### PR TITLE
dropshot_endpoint: reuse fn docs and remove dependency on http::Method

### DIFF
--- a/dropshot/examples/basic.rs
+++ b/dropshot/examples/basic.rs
@@ -13,7 +13,6 @@ use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::HttpServer;
 use dropshot::Json;
 use dropshot::RequestContext;
-use http::Method; /* TODO-cleanup should not be required for endpoint */
 use serde::Deserialize;
 use serde::Serialize;
 use std::any::Any;

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -325,6 +325,11 @@ pub use logging::ConfigLoggingIfExists;
 pub use logging::ConfigLoggingLevel;
 pub use server::HttpServer;
 
+/*
+ * Users of the `endpoint` macro need `http::Method` available.
+ */
+pub use http::Method;
+
 extern crate dropshot_endpoint;
 pub use dropshot_endpoint::endpoint;
 pub use dropshot_endpoint::ExtractedParameter;

--- a/src/oxide_controller/http_entrypoints_external.rs
+++ b/src/oxide_controller/http_entrypoints_external.rs
@@ -33,7 +33,6 @@ use dropshot::Json;
 use dropshot::Path;
 use dropshot::Query;
 use dropshot::RequestContext;
-use http::Method;
 use serde::Deserialize;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/src/oxide_controller/http_entrypoints_internal.rs
+++ b/src/oxide_controller/http_entrypoints_internal.rs
@@ -16,7 +16,6 @@ use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Json;
 use dropshot::Path;
 use dropshot::RequestContext;
-use http::Method;
 use serde::Deserialize;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/src/sled_agent/http_entrypoints.rs
+++ b/src/sled_agent/http_entrypoints.rs
@@ -15,7 +15,6 @@ use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Json;
 use dropshot::Path;
 use dropshot::RequestContext;
-use http::Method;
 use serde::Deserialize;
 use std::any::Any;
 use std::sync::Arc;


### PR DESCRIPTION
This PR has two changes.

**Rustdoc comments:** The first change is something I noticed when I went to fill in more rustdocs in this repo.  I've found we can get pretty useful internal developer documentation by writing rustdoc comments and running rustdoc with `--document-private-items`.  When I do this, I see all the structs and constants generated by the `endpoint` macro, which is nice, but they don't have any docs.  I figured it'd be useful to add the rustdoc that the user had on the original function, if any.

This is what it looks like now:

![funcs-with-docs](https://user-images.githubusercontent.com/532688/83951927-0a95d980-a7ea-11ea-8e10-0e65267a1177.png)

This is what it looks like for a function that doesn't have any docs (look at `api_hardware_racks_get`):

![func-without-docs](https://user-images.githubusercontent.com/532688/83951964-5183cf00-a7ea-11ea-9086-bbda8600323a.png)

I'm interested in your thoughts @ahl -- if this seems like a bad idea, or if the "API endpoint" prefix is weird.  I thought it made things a little clearer.

**Use of `http::Method`**: The second change is that I found in order to use the `endpoint` macro, you had to have done `use http::Method` already.  I think that consumers otherwise wouldn't need a dependency on `http`.  I've changed Dropshot to re-export `http::Method` (as `dropshot::Method`) and I've changed `endpoint` to use this with a fully-qualified name.  (I couldn't quite remove the dependency on `http` in `oxide_api_prototype` because of the HTTP clients that it uses.)