### PR TITLE
better macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "hostname 0.3.1",
  "http",
  "hyper",
+ "impl-trait-for-tuples",
  "indexmap",
  "openapiv3",
  "schemars",
@@ -456,6 +457,15 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.1.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -26,6 +26,7 @@ slog-term = "2.5"
 tokio = { version = "0.2", features = [ "full" ] }
 toml = "0.5.6"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
+impl-trait-for-tuples = { path = "../../impl-trait-for-tuples" }
 
 [dependencies.slog]
 version = "2.5"


### PR DESCRIPTION
@davepacheco this is sort of a cute one that I'm not sure is worth integrating, but I wanted to share. I had been thinking about this tuple macro thing and wondering why there wasn't a more generic form. I found a macro crate (not well used) and adapted it to handle the somewhat odd case of an `Fn` with tuple elements as the arguments.

The only real advantage over the macros you put together is that the code is out of macro context and therefore interpreted by stuff like rustfmt and the IDE.