### PR TITLE
Fix some tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "http",
  "hyper",
  "indexmap",
+ "libc",
  "openapiv3",
  "schemars",
  "serde",
@@ -501,9 +502,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "linked-hash-map"
@@ -693,6 +694,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
+ "libc",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tokio = { version = "0.2", features = [ "full" ] }
 toml = "0.5.6"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 
+[dev-dependencies]
+libc = "0.2.71"
+
 [dependencies.slog]
 version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]

--- a/dropshot/Cargo.toml
+++ b/dropshot/Cargo.toml
@@ -30,3 +30,6 @@ uuid = { version = "0.8", features = [ "serde", "v4" ] }
 [dependencies.slog]
 version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]
+
+[dev-dependencies]
+libc = "0.2.71"

--- a/dropshot/src/lib.rs
+++ b/dropshot/src/lib.rs
@@ -63,7 +63,8 @@
  *         ConfigLogging::StderrTerminal {
  *             level: ConfigLoggingLevel::Info,
  *         }
- *         .to_logger("minimal-example")?;
+ *         .to_logger("minimal-example")
+ *         .map_err(|e| e.to_string())?;
  *
  *     // Describe the API.
  *     let mut api = ApiDescription::new();

--- a/dropshot/src/test_util.rs
+++ b/dropshot/src/test_util.rs
@@ -625,9 +625,8 @@ pub fn log_file_for_test(test_name: &str) -> PathBuf {
 pub fn read_config<T: DeserializeOwned + Debug>(
     label: &str,
     contents: &str,
-) -> Result<T, String> {
-    let result: Result<T, String> =
-        toml::from_str(contents).map_err(|error| format!("{}", error));
+) -> Result<T, toml::de::Error> {
+    let result = toml::from_str(contents);
     eprintln!("config \"{}\": {:?}", label, result);
     result
 }
@@ -653,7 +652,7 @@ pub struct BunyanLogRecord {
 /**
  * Read a file containing a Bunyan-format log, returning an array of records.
  */
-pub fn read_bunyan_log(logpath: &str) -> Vec<BunyanLogRecord> {
+pub fn read_bunyan_log(logpath: &Path) -> Vec<BunyanLogRecord> {
     let log_contents = fs::read_to_string(logpath).unwrap();
     let log_records = log_contents
         .split("\n")

--- a/dropshot/tests/test_config.rs
+++ b/dropshot/tests/test_config.rs
@@ -19,7 +19,8 @@ fn test_config_bad_bind_address_port_too_small() {
         "bad_bind_address_port_too_small",
         "bind_address = \"127.0.0.1:-3\"",
     )
-    .unwrap_err();
+    .unwrap_err()
+    .to_string();
     assert!(
         error.starts_with("invalid IP address syntax for key `bind_address`")
     );
@@ -31,7 +32,8 @@ fn test_config_bad_bind_address_port_too_large() {
         "bad_bind_address_port_too_large",
         "bind_address = \"127.0.0.1:65536\"",
     )
-    .unwrap_err();
+    .unwrap_err()
+    .to_string();
     assert!(
         error.starts_with("invalid IP address syntax for key `bind_address`")
     );
@@ -43,7 +45,8 @@ fn test_config_bad_bind_address_garbage() {
         "bad_bind_address_garbage",
         "bind_address = \"garbage\"",
     )
-    .unwrap_err();
+    .unwrap_err()
+    .to_string();
     assert!(
         error.starts_with("invalid IP address syntax for key `bind_address`")
     );

--- a/src/bin/oxide_controller.rs
+++ b/src/bin/oxide_controller.rs
@@ -44,7 +44,8 @@ async fn do_run() -> Result<(), String> {
 
     let config_file = matches.value_of("CONFIG_FILE_PATH").unwrap();
     let config_file_path = Path::new(config_file);
-    let config = ConfigController::from_file(config_file_path)?;
+    let config = ConfigController::from_file(config_file_path)
+        .map_err(|e| e.to_string())?;
 
     if matches.is_present("openapi") {
         Ok(controller_run_openapi_external())


### PR DESCRIPTION
These tests would fail on Windows, because Windows paths contain \s,
which are interpreted by TOML as Unicode escapes. This commit fixes that
issue, as well as removes the dependence on the specific text of the
error. These strings are platform dependent, and so these tests will be
very fragile. Because the errors are only Strings anyway, I changed the
tests to verify an Err was returned, but not which one. A more robust
test would require a more robust error type, and I wasn't sure that was
worth actually doing yet.