### PR TITLE
WIP: build internal docs for prototype, public docs for dropshot

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+#
+# Build private documentation for this package to serve as internal developer
+# documentation.  (The "library" in this package only exists to implement the
+# binaries and the test suite.  There's no need for typical library
+# documentation of public interfaces.)
+#
+[build]
+rustdocflags = "--document-private-items"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,17 @@ features = [ "max_level_trace", "release_max_level_debug" ]
 members = [".", "dropshot", "dropshot/dropshot_endpoint" ]
 default-members = [".", "dropshot", "dropshot/dropshot_endpoint" ]
 
+#
+# Disable doc builds by default for our binaries to work around issue
+# rust-lang/cargo#8373.  These docs would not be very useful anyway.
+#
+[[bin]]
+name = "oxide_controller"
+doc = false
+[[bin]]
+name = "sled_agent"
+doc = false
+
 [profile.dev]
 panic = "abort"
 [profile.release]

--- a/dropshot/.cargo/config
+++ b/dropshot/.cargo/config
@@ -1,0 +1,9 @@
+#
+# Override the rustdoc flags that are set for the parent crate in this
+# workspace.  (This is kind of an unfortunate way to do this -- all we really
+# want to do here is to turn off --document-private-items so that this crate
+# gets documented like a normal library crate.  However, the only way we can do
+# this is to remove all configured rustdoc flags.)
+#
+[build]
+rustdocflags = ""


### PR DESCRIPTION
What I'm trying to do here is:

- for oxide_api_prototype: generate docs with private items so that we can use this as internal developer documentation
- for dropshot (a crate within oxide_api_prototype): generate docs without private items (intended for dropshot consumers) -- this is the usual default for library crates

There are 4 contexts we might care about:

- `cargo +nightly doc` in oxide_api_prototype (particularly for new developers to get useful docs if they do the obvious thing)
- `cargo +nightly doc` in oxide_api_prototype/dropshot (though I don't think people are likely to do this)
- `oxide_api_prototype` docs on https://rust.docs.corp.oxide.computer/
- `dropshot` docs on https://rust.docs.corp.oxide.computer/

(Note that `+nightly` is needed to use intra-document links, which seem pretty ubiquitous -- docs.rs builds with nightly as well, apparently for this reason.)

https://rust.docs.corp.oxide.computer/ basically just runs `cargo doc` on the repo using the nightly toolchain and then copies docs for each package within the workspace.  So we can basically think of it the same as `cargo +nightly doc`.

I haven't figured out a way to make all these do what we want.

With the change I have here:

- good: if you `cargo doc` in oxide_api_prototype: you get good developer docs with the private stuff
- bad: if you look at the dropshot docs you just generated, you have a bunch of irrelevant private stuff
- good: if you `cargo doc` inside oxide_api_prototype/dropshot (which you'd probably never do): you get consumer docs without the private stuff
- good: I expect (but haven't tested) that the `oxide_api_prototype` docs on https://rust.docs.corp.oxide.computer/ will include the private items
- bad: I expect (but haven't tested) that the `dropshot` docs on https://rust.docs.corp.oxide.computer/ will include the private items.

The only way I can think to make all of these work properly is if we pull dropshot into its own repo.  That way, its docs are always built separately from `oxide_api_prototype`.  Dropshot will look just like any other Rust library crate: a stock `cargo +nightly doc` will generate public docs only and that's what will show up on https://rust.docs.corp.oxide.computer/.  We can still use the config override in this repo to have `oxide_api_prototype` docs include private items, but for a stock `cargo +nightly doc` and also on https://rust.docs.corp.oxide.computer/.

@ahl do you think we're ready to move dropshot to its own crate?

Any thoughts on all this from folks with more Rust experience (@cbiffle @steveklabnik @kc8apf ?)