### PR TITLE
Add install instructions for json in oxapi_demo

### DIFF
--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -56,7 +56,7 @@ function main
 	local cmd
 
 	type curl > /dev/null 2>&1 || fail "curl not found in PATH."
-	type json > /dev/null 2>&1 || fail "json not found in PATH."
+	type json > /dev/null 2>&1 || fail "json not found in PATH. Install it with npm i -g json."
 
 	[[ $# -gt 0 ]] || usage "command not specified"
 


### PR DESCRIPTION
Was going to put it in the readme, but in the error message you really can't miss it.