### PR TITLE
run a test build of `cargo doc` in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,18 @@ jobs:
       #
       run: cargo clippy -- -D warnings -A clippy::style
 
+  # This is just a test build of docs.  Publicly available docs are built via
+  # the separate "rustdocs" repo.
+  build-docs:
+    runs-on: ubuntu-18.04
+    steps:
+    # actions/checkout@v2
+    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+    - name: Report cargo version
+      run: cargo --version
+    - name: Test build documentation
+      run: cargo doc
+
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
The separate rustdoc repo generates documentation, but it seems useful to do a doc build in CI as well.  At the very least, we can look for warnings in the generated docs.