### PR TITLE
Plumbs through endpoints for returning (empty) VM instance metrics

### DIFF
--- a/omicron-common/src/sled_agent_client.rs
+++ b/omicron-common/src/sled_agent_client.rs
@@ -9,6 +9,7 @@ use crate::error::ApiError;
 use crate::http_client::HttpClient;
 use crate::model::ApiDiskRuntimeState;
 use crate::model::ApiDiskStateRequested;
+use crate::model::ApiInstanceMetrics;
 use crate::model::ApiInstanceRuntimeState;
 use crate::model::ApiInstanceRuntimeStateRequested;
 use crate::model::DiskEnsureBody;
@@ -102,6 +103,29 @@ impl Client {
             .client
             .read_json::<ApiDiskRuntimeState>(
                 &self.client.error_message_base(&Method::PUT, path.as_str()),
+                &mut response,
+            )
+            .await?;
+        Ok(value)
+    }
+
+    /**
+     * Retrieves the current metrics associated with the given instance.
+     */
+    pub async fn metrics_get(
+        self: &Arc<Self>,
+        instance_id: Uuid,
+    ) -> Result<ApiInstanceMetrics, ApiError> {
+        let path = format!("/instances/{}/metrics", instance_id);
+        let mut response = self
+            .client
+            .request(Method::GET, path.as_str(), Body::from(""))
+            .await?;
+        assert!(response.status().is_success());
+        let value = self
+            .client
+            .read_json::<ApiInstanceMetrics>(
+                &self.client.error_message_base(&Method::GET, path.as_str()),
                 &mut response,
             )
             .await?;

--- a/omicron-nexus/src/nexus.rs
+++ b/omicron-nexus/src/nexus.rs
@@ -22,6 +22,7 @@ use omicron_common::model::ApiGeneration;
 use omicron_common::model::ApiIdentityMetadata;
 use omicron_common::model::ApiInstance;
 use omicron_common::model::ApiInstanceCreateParams;
+use omicron_common::model::ApiInstanceMetrics;
 use omicron_common::model::ApiInstanceRuntimeState;
 use omicron_common::model::ApiInstanceRuntimeStateRequested;
 use omicron_common::model::ApiInstanceState;
@@ -659,6 +660,22 @@ impl Nexus {
             .instance_update_runtime(&instance.identity.id, &new_runtime)
             .await
             .map(|_| ())
+    }
+
+    /**
+     * Gets the current metrics for the instance.
+     */
+    pub async fn instance_get_metrics(
+        &self,
+        project_name: &ApiName,
+        instance_name: &ApiName,
+    ) -> Result<ApiInstanceMetrics, ApiError> {
+        let instance =
+            self.project_lookup_instance(project_name, instance_name).await?;
+        self.instance_sled(&instance)
+            .await?
+            .metrics_get(instance.identity.id)
+            .await
     }
 
     /**

--- a/omicron-sled-agent/src/http_entrypoints.rs
+++ b/omicron-sled-agent/src/http_entrypoints.rs
@@ -11,6 +11,7 @@ use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
 use omicron_common::model::ApiDiskRuntimeState;
+use omicron_common::model::ApiInstanceMetrics;
 use omicron_common::model::ApiInstanceRuntimeState;
 use omicron_common::model::DiskEnsureBody;
 use omicron_common::model::InstanceEnsureBody;
@@ -32,6 +33,7 @@ pub fn api() -> SledApiDescription {
         api.register(instance_poke_post)?;
         api.register(disk_put)?;
         api.register(disk_poke_post)?;
+        api.register(instance_get_metrics)?;
         Ok(())
     }
 
@@ -128,4 +130,17 @@ async fn disk_poke_post(
     let disk_id = path_params.into_inner().disk_id;
     sa.disk_poke(disk_id).await;
     Ok(HttpResponseUpdatedNoContent())
+}
+
+#[endpoint {
+    method = GET,
+    path = "/instances/{instance_id}/metrics",
+}]
+async fn instance_get_metrics(
+    rqctx: Arc<RequestContext<Arc<SledAgent>>>,
+    path_params: Path<InstancePathParam>,
+) -> Result<HttpResponseOk<ApiInstanceMetrics>, HttpError> {
+    let sa = rqctx.context();
+    let instance_id = path_params.into_inner().instance_id;
+    Ok(HttpResponseOk(sa.instance_get_metrics(instance_id).await?))
 }

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -30,6 +30,7 @@ INSTANCES
     instance_detach_disk PROJECT_NAME INSTANCE_NAME DISK_NAME
     instance_list_disks  PROJECT_NAME INSTANCE_NAME
     instance_get_disk    PROJECT_NAME INSTANCE_NAME DISK_NAME
+    instance_get_metrics PROJECT_NAME INSTANCE_NAME
 
 DISKS
 
@@ -218,6 +219,12 @@ function cmd_instance_get_disk
 {
 	[[ $# != 3 ]] && usage "expected PROJECT_NAME INSTANCE_NAME DISK_NAME"
 	do_curl "/projects/$1/instances/$2/disks/$3"
+}
+
+function cmd_instance_get_metrics
+{
+	[[ $# != 2 ]] && usage "expected PROJECT_NAME INSTANCE_NAME"
+	do_curl "/projects/$1/instances/$2/metrics"
 }
 
 function cmd_disk_create_demo


### PR DESCRIPTION
- Adds model types for representing the current metrics for a virtual
  machine, including vCPU, disk, network, and memory utilization, and
  top-level types representing these in the public API.
- Adds endpoints in Nexus for retrieving the metrics for an instance by
  name, forwarding this to new endpoints and handlers in the sled agent
  for actually extracting these.
- Adds cmds to the demo shell script

It should be noted that the metrics returned here are completely empty.
The SA knows very little about intances now, as we currently simulate
only their runtime state. Extracting metrics with even the right
_structure_ (even if the data is all zeros), requires pushing the full
instance state, including cpu count, attached disks, etc, from Nexus the
agent. This commit puts the API pipeline in place only.