### PR TITLE
update dependabot config and build with --locked

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,6 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "omicron-bootstrap-agent"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "omicron-common"
-    schedule:
-      interval: "weekly"
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "omicron-nexus"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "omicron-sled-agent"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,10 @@ jobs:
         key: ${{ runner.os }}-cockroach-binary-v2
         path: "cockroachdb"
     - name: Build
-      run: cargo build --all-targets --verbose
+      run: cargo build --locked --all-targets --verbose
     - name: Download CockroachDB binary
       if: steps.cache-cockroachdb.outputs.cache-hit != 'true'
       run: bash ./tools/ci_download_cockroachdb
     - name: Run tests
       # Put "./cockroachdb/bin" on the PATH for the test suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin" cargo test --verbose
+      run: PATH="$PATH:$PWD/cockroachdb/bin" cargo test --locked --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,9 +1498,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smf"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d3e8846949a0eab4b74c2b1f83e2eb50232beb5d64382e2ecfa889f8c6daca"
+checksum = "836e990d5a6ca0b31510a9405692ea8a90666f6f3d5fd5c7a26c4bc71874ebe0"
 dependencies = [
  "thiserror",
 ]


### PR DESCRIPTION
This change does three things:

- updates Cargo.lock based on the most recent Dependabot update to the "smf" dependency
- updates the Dependabot config to look at the whole workspace instead of the individual packages within it
- changes CI to build and run test with cargo's `--locked` flag

Prior to this change, we had configured Dependabot to separately look at each of the packages in this repo.  A side effect of that was that it did not find the Cargo.lock file in the workspace and so wouldn't update it.  These changes fix the Cargo.lock file after the last missed update, update the Dependabot config so that it will update Cargo.lock files in the future, and update the CI builds so that the build will fail if the same sort of thing happens again.

There's another impact of the Dependabot config change: because we were pointing Dependabot at the individual packages in this repo, it assumed it was looking at a library and only updated Cargo.toml files when a dependency had a new package available that was not compatible with the semver expression in the Cargo.toml file.  More concretely, if we had a dependency of "0.6.0", it would not create a PR if 0.6.1 was released (because that satisfies 0.6.0), but it would create one if 0.7.0 were released.  After this change, I expect Dependabot to treat the whole repo as an application, which means it will be more aggressive about submitting PRs to increase versions when new packages are available.  If this is a problem, we can configure the versioning-policy to only update when the semver in Cargo.toml is not compatible with the latest released version.