### PR TITLE
Adds packaging for oximeter

### DIFF
--- a/omicron-bootstrap-agent/src/bootstrap_agent.rs
+++ b/omicron-bootstrap-agent/src/bootstrap_agent.rs
@@ -109,7 +109,10 @@ impl BootstrapAgent {
         // Presumably, we'd try to contact a Nexus elsewhere
         // on the rack, or use the unlocked local storage to remember
         // a decision from the previous boot.
-        self.launch(&digests, &tar_source, &destination, "nexus")
+        self.launch(&digests, &tar_source, &destination, "nexus")?;
+
+        // TODO-correctness: The same note as above applies to oximeter.
+        self.launch(&digests, &tar_source, &destination, "oximeter")
     }
 
     // Verify, unpack, and enable a service.

--- a/omicron-common/src/bin/omicron-package.rs
+++ b/omicron-common/src/bin/omicron-package.rs
@@ -56,6 +56,7 @@ fn main() -> Result<()> {
         &Package::new("bootstrap-agent"),
         &Package::new("nexus"),
         &Package::new("sled-agent"),
+        &Package::new("oximeter"),
     ];
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);

--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -1,9 +1,30 @@
+#
+# Oxide API: example configuration file
+#
+
+# Identifier for this instance of Nexus
+id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
+
+[database]
+# URL for connecting to the database
+url = "postgresql://root@127.0.0.1:32221/omicron?sslmode=disable"
+
 [dropshot_external]
+# IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12220"
 
 [dropshot_internal]
+# IP address and TCP port on which to listen for the internal API
 bind_address = "127.0.0.1:12221"
 
 [log]
+# Show log messages of this level and more severe
 level = "info"
+
+# Example output to a terminal (with colors)
 mode = "stderr-terminal"
+
+# Example output to a file, appending if it already exists.
+#mode = "file"
+#path = "logs/server.log"
+#if_exists = "append"

--- a/smf/oximeter/manifest.xml
+++ b/smf/oximeter/manifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='oximeter'>
+
+<service name='system/illumos/oximeter' type='service' version='1'>
+  <create_default_instance enabled='false' />
+  <single_instance />
+
+  <dependency name='bootstrap-agent' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/system/illumos/bootstrap-agent' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/oximeter/oximeter --address %{config/address} --nexus %{config/nexus_address} --clickhouse %{config/clickhouse_address} &amp;'
+    timeout_seconds='0' />
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
+
+  <property_group name='config' type='application'>
+    <propval name='address' type='astring' value='127.0.0.1:12223' />
+    <propval name='nexus_address' type='astring' value='127.0.0.1:12221' />
+    <propval name='clickhouse_address' type='astring' value='127.0.0.1:9000' />
+  </property_group>
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='contract' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Metric Collector</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Server for collecting metrics from the Oxide rack</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>


### PR DESCRIPTION
Adds the main `oximeter` binary to the list of those packaged by
`omicron-package`, along with an SMF manifest for it. Also updates the
`config.toml` file that's bundled with `nexus`, which seems to have been
stale (missing fields like ID, etc). This all unpacks and runs as
expected under /opt/oxide.