### PR TITLE
Adds a basic ClickHouse client and methods to insert samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -1084,6 +1084,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
+ "serde_json",
  "slog",
  "structopt",
  "thiserror",

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -4,55 +4,20 @@ version = "0.1.0"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 
-[dependencies.bytes]
-version = "1.0.1"
-features = [ "serde" ]
-
-[dependencies.chrono]
-version = "0.4.19"
-features = [ "serde" ]
-
-[dependencies.dropshot]
-git = "https://github.com/oxidecomputer/dropshot"
-branch = "main"
-
-[dependencies.num-traits]
-version = "0.2.14"
-
-[dependencies.hyper]
-version = "0.14.7"
-
-[dependencies.oximeter-macro-impl]
-path = "../oximeter-macro-impl"
-
-[dependencies.omicron-common]
-path = "../../omicron-common"
-
-[dependencies.reqwest]
-version = "0.11.3"
-features = [ "json" ]
-
-[dependencies.schemars]
-version = "0.8.3"
-features = [ "uuid", "bytes", "chrono" ]
-
-[dependencies.serde]
-version = "1"
-features = [ "derive" ]
-
-[dependencies.slog]
-version = "2.5"
-features = [ "max_level_trace", "release_max_level_debug" ]
-
-[dependencies.structopt]
-version = "0.3"
-
-[dependencies.thiserror]
-version = "1.0.24"
-
-[dependencies.tokio]
-version = "1.6"
-
-[dependencies.uuid]
-version = "0.8.2"
-features = [ "v4", "serde" ]
+[dependencies]
+bytes = { version = "1.0.1", features = [ "serde" ] }
+chrono = { version = "0.4.19", features = [ "serde" ] }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+num-traits = "0.2.14"
+hyper = "0.14.7"
+oximeter-macro-impl = { path = "../oximeter-macro-impl" }
+omicron-common = { path = "../../omicron-common" }
+reqwest = { version = "0.11.3", features = [ "json" ] }
+schemars = { version = "0.8.3", features = [ "uuid", "bytes", "chrono" ] }
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1.0.0"
+slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
+structopt = "0.3"
+thiserror = "1.0.24"
+tokio = "1.6"
+uuid = { version = "0.8.2", features = [ "v4", "serde" ] }

--- a/oximeter/oximeter/src/db/client.rs
+++ b/oximeter/oximeter/src/db/client.rs
@@ -1,0 +1,144 @@
+//! Rust client to ClickHouse database
+// Copyright 2021 Oxide Computer Company
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+
+use crate::db::model;
+use crate::{types::Sample, Error};
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    address: SocketAddr,
+    url: String,
+    client: reqwest::Client,
+}
+
+impl Client {
+    /// Construct a new ClickHouse client of the database at `address`.
+    pub async fn new(address: SocketAddr) -> Result<Self, Error> {
+        let client = reqwest::Client::new();
+        let url = format!("http://{}", address);
+        let out = Self { address, url, client };
+        out.ping().await?;
+        Ok(out)
+    }
+
+    /// Ping the ClickHouse server to verify connectivitiy.
+    pub async fn ping(&self) -> Result<(), Error> {
+        self.client
+            .get(format!("{}/ping", self.url))
+            .send()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| Error::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Insert the given samples into the database.
+    pub async fn insert_samples(
+        &self,
+        samples: &[Sample],
+    ) -> Result<(), Error> {
+        let mut rows = BTreeMap::new();
+        for sample in samples.iter() {
+            for (table_name, table_rows) in model::unroll_field_rows(sample) {
+                rows.entry(table_name)
+                    .or_insert_with(Vec::new)
+                    .extend(table_rows);
+            }
+            let (table_name, measurement_row) =
+                model::unroll_measurement_row(sample);
+            rows.entry(table_name)
+                .or_insert_with(Vec::new)
+                .push(measurement_row);
+        }
+        for (table_name, rows) in rows {
+            let body = format!(
+                "INSERT INTO {table_name} FORMAT JSONEachRow\n{row_data}\n",
+                table_name = table_name,
+                row_data = rows.join("\n")
+            );
+            // TODO-robustness If this fails, it's likely that we'll have partially inserted
+            // data. ClickHouse doesn't really support transactions or deleting data, so we
+            // will probably have to validate this data against the schema prior to inserting
+            // it. We should be doing that anyway, but there may be other considerations here
+            // in the case that there's another kind of error, like a network outage, database
+            // failure, ZooKeeper error, etc.
+            self.execute(body).await?;
+        }
+        Ok(())
+    }
+
+    // Initialize ClickHouse with the database and metric table schema.
+    #[allow(dead_code)]
+    pub(crate) async fn init_db(&self) -> Result<(), Error> {
+        // The HTTP client doesn't support multiple statements per query, so we break them out here
+        // manually.
+        let sql = include_str!("./db-init.sql");
+        for query in sql.split("\n--\n") {
+            self.execute(query.to_string()).await?;
+        }
+        Ok(())
+    }
+
+    // Wipe the ClickHouse database entirely.
+    #[allow(dead_code)]
+    pub(crate) async fn wipe_db(&self) -> Result<(), Error> {
+        let sql = include_str!("./db-wipe.sql").to_string();
+        self.execute(sql).await
+    }
+
+    // Execute a generic SQL statement.
+    //
+    // TODO-robustness This currently does no validation of the statement.
+    async fn execute(&self, sql: String) -> Result<(), Error> {
+        let response = self
+            .client
+            .post(&self.url)
+            .body(sql)
+            .send()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let text = response.text().await.unwrap_or_else(|e| e.to_string());
+            Err(Error::Database(text))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_util;
+
+    // This test is intentionally skipped for now, as we don't have ClickHouse set up in our CI
+    // infrastructure yet. Uncomment the attribute line to enable it.
+    //
+    // #[tokio::test]
+    async fn test_build_client() {
+        Client::new("[::1]:8123".parse().unwrap()).await.unwrap();
+    }
+
+    // This test is intentionally skipped for now, as we don't have ClickHouse set up in our CI
+    // infrastructure yet. Uncomment the attribute line to enable it.
+    //
+    // #[tokio::test]
+    async fn test_client_insert() {
+        let client = Client::new("[::1]:8123".parse().unwrap()).await.unwrap();
+        client.wipe_db().await.unwrap();
+        client.init_db().await.unwrap();
+        let samples = {
+            let mut s = Vec::with_capacity(8);
+            for _ in 0..s.capacity() {
+                s.push(test_util::make_hist_sample())
+            }
+            s
+        };
+        client.insert_samples(&samples).await.unwrap();
+        client.wipe_db().await.unwrap();
+    }
+}

--- a/oximeter/oximeter/src/db/db-init.sql
+++ b/oximeter/oximeter/src/db/db-init.sql
@@ -1,0 +1,276 @@
+CREATE DATABASE IF NOT EXISTS oximeter;
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value UInt8
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value Int64
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value Float64
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_string
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value String
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value Array(UInt8)
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value Int64
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    value Float64
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    bins Array(Int64),
+    counts Array(UInt64)
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
+(
+    target_name String,
+    metric_name String,
+    timeseries_key String,
+    timestamp DateTime64(6, 'UTC'),
+    bins Array(Float64),
+    counts Array(UInt64)
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, metric_name, timeseries_key)
+ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_schema
+(
+    metric_name String,
+    field_names Array(String),
+    field_types Array(Enum(
+        'Bool' = 1,
+        'I64' = 2,
+        'IpAddr' = 3,
+        'String' = 4,
+        'Bytes' = 5,
+        'Uuid' = 6
+    )),
+    measurement_type Enum(
+        'Bool' = 1,
+        'I64' = 2,
+        'F64' = 3,
+        'String' = 4,
+        'Bytes' = 5,
+        'CumulativeI64' = 6,
+        'CumulativeF64' = 7,
+        'HistogramI64' = 8,
+        'HistogramF64' = 9
+    ),
+    created DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_names);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_fields_bool
+(
+    metric_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UInt8,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_name, timeseries_key)
+ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_fields_i64
+(
+    metric_name String,
+    timeseries_key String,
+    field_name String,
+    field_value Int64,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_name, timeseries_key)
+ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_fields_ipaddr
+(
+    metric_name String,
+    timeseries_key String,
+    field_name String,
+    field_value IPv6,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_name, timeseries_key)
+ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_fields_string
+(
+    metric_name String,
+    timeseries_key String,
+    field_name String,
+    field_value String,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_name, timeseries_key)
+ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.metric_fields_uuid
+(
+    metric_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UUID,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (metric_name, field_name, timeseries_key)
+ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_schema
+(
+    target_name String,
+    field_names Array(String),
+    field_types Array(Enum(
+        'Bool' = 1,
+        'I64' = 2,
+        'IpAddr' = 3,
+        'String' = 4,
+        'Bytes' = 5,
+        'Uuid' = 6
+    )),
+    created DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_names);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_fields_bool
+(
+    target_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UInt8,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_name, timeseries_key)
+ORDER BY (target_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_fields_i64
+(
+    target_name String,
+    timeseries_key String,
+    field_name String,
+    field_value Int64,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_name, timeseries_key)
+ORDER BY (target_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_fields_ipaddr
+(
+    target_name String,
+    timeseries_key String,
+    field_name String,
+    field_value IPv6,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_name, timeseries_key)
+ORDER BY (target_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_fields_string
+(
+    target_name String,
+    timeseries_key String,
+    field_name String,
+    field_value String,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_name, timeseries_key)
+ORDER BY (target_name, field_name, timeseries_key, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.target_fields_uuid
+(
+    target_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UUID,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+PRIMARY KEY (target_name, field_name, timeseries_key)
+ORDER BY (target_name, field_name, timeseries_key, timestamp);

--- a/oximeter/oximeter/src/db/db-wipe.sql
+++ b/oximeter/oximeter/src/db/db-wipe.sql
@@ -1,0 +1,1 @@
+DROP DATABASE IF EXISTS oximeter;

--- a/oximeter/oximeter/src/db/mod.rs
+++ b/oximeter/oximeter/src/db/mod.rs
@@ -1,0 +1,57 @@
+//! Tools for interacting with the timeseries database.
+// Copyright 2021 Oxide Computer Company
+
+pub mod client;
+mod model;
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use crate::histogram;
+    use crate::types::Sample;
+    use uuid::Uuid;
+
+    #[derive(oximeter::Target)]
+    struct TestTarget {
+        pub name1: String,
+        pub name2: String,
+        pub num: i64,
+    }
+
+    #[oximeter::metric(I64)]
+    pub struct TestMetric {
+        pub id: Uuid,
+        pub good: bool,
+    }
+
+    #[oximeter::metric(HistogramF64)]
+    pub struct TestHistogram {
+        pub id: Uuid,
+        pub good: bool,
+    }
+
+    pub fn make_sample() -> Sample {
+        let target = TestTarget {
+            name1: "first_name".into(),
+            name2: "second_name".into(),
+            num: 2,
+        };
+        let metric = TestMetric { id: Uuid::new_v4(), good: true };
+        let sample = Sample::new(&target, &metric, 1, None);
+        sample
+    }
+
+    pub fn make_hist_sample() -> Sample {
+        let target = TestTarget {
+            name1: "first_name".into(),
+            name2: "second_name".into(),
+            num: 2,
+        };
+        let metric = TestHistogram { id: Uuid::new_v4(), good: true };
+        let mut hist = histogram::Histogram::new(&[0.0, 5.0, 10.0]).unwrap();
+        hist.sample(1.0).unwrap();
+        hist.sample(2.0).unwrap();
+        hist.sample(6.0).unwrap();
+        let sample = Sample::new(&target, &metric, hist, None);
+        sample
+    }
+}

--- a/oximeter/oximeter/src/db/model.rs
+++ b/oximeter/oximeter/src/db/model.rs
@@ -1,0 +1,511 @@
+//! Models for timeseries data in ClickHouse
+// Copyright 2021 Oxide Computer Company
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv6Addr};
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::histogram;
+use crate::types::{FieldValue, Measurement, Sample};
+
+// TODO-completeness This module implements and tests paths for inserting data into ClickHouse, but
+// not for reading it out. It's not yet clear how we'll be querying the database, but this is a
+// large open area.
+
+/// The name of the database storing all metric information.
+pub const DATABASE_NAME: &str = "oximeter";
+
+/// Wrapper type to represent a boolean in the database.
+///
+/// ClickHouse's type system lacks a boolean, and using `u8` to represent them. This a safe wrapper
+/// type around that for serializing to/from the database.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct DbBool {
+    inner: u8,
+}
+
+impl From<bool> for DbBool {
+    fn from(b: bool) -> Self {
+        DbBool { inner: b as _ }
+    }
+}
+
+impl From<DbBool> for bool {
+    fn from(b: DbBool) -> bool {
+        match b.inner {
+            0 => false,
+            1 => true,
+            x => {
+                unreachable!(
+                    "A boolean can only be represented by 0 or 1 in the database, but found {}",
+                    x
+                );
+            }
+        }
+    }
+}
+
+/// The source, target or metric, to which a field corresponds.
+///
+/// Tables with field information, whether from a target or metric, are largely the same. This enum
+/// indicates which of these this field row derives from, and is used to populate the
+/// `{target,metric}_name` column of the corresponding field tables.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum FieldSource {
+    #[serde(rename = "target_name")]
+    Target(String),
+    #[serde(rename = "metric_name")]
+    Metric(String),
+}
+
+impl FieldSource {
+    /// Return the stem of the table name for the corresponding row.
+    pub fn table_stem(&self) -> &'static str {
+        match self {
+            FieldSource::Target(_) => "target_fields",
+            FieldSource::Metric(_) => "metric_fields",
+        }
+    }
+}
+// Internal module used to serialize datetime's to the database.
+//
+// Serde by default includes the timezone when serializing at `DateTime`. However, the `DateTime64`
+// type in ClickHouse already includes the timezone, and so times are always assumed relative to
+// that timezone. So it doesn't accept the default serialization format.
+//
+// ClickHouse also accepts integers, in the tick resolution of the `DateTime64` type, which is
+// microseconds in our case. We opt for strings here, since we're using that anyway in the
+// input/output format for ClickHouse.
+mod serde_timestamp {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    const FORMAT: &str = "%Y-%m-%d %H:%M:%S%.6f";
+
+    pub fn serialize<S>(
+        date: &DateTime<Utc>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}", date.format(FORMAT));
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Utc.datetime_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
+    }
+}
+
+macro_rules! define_field_row {
+    {$name:ident, $value_type:ty, $table_suffix:literal} => {
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct $name {
+            #[serde(flatten)]
+            pub source: FieldSource,
+            pub timeseries_key: String,
+            pub field_name: String,
+            pub field_value: $value_type,
+            #[serde(with = "serde_timestamp")]
+            pub timestamp: DateTime<Utc>,
+        }
+
+        impl $name {
+            pub fn table_name(&self) -> String {
+                format!(
+                    "{db_name}.{stem}_{type_}",
+                    db_name = DATABASE_NAME,
+                    stem = self.source.table_stem(),
+                    type_ = $table_suffix,
+                )
+            }
+        }
+    }
+}
+
+define_field_row! {BoolFieldRow, DbBool, "bool"}
+define_field_row! {I64FieldRow, i64, "i64"}
+define_field_row! {StringFieldRow, String, "string"}
+define_field_row! {IpAddrFieldRow, Ipv6Addr, "ipaddr"}
+define_field_row! {UuidFieldRow, Uuid, "uuid"}
+
+macro_rules! define_measurement_row {
+    {$name:ident, $value_type:ty, $table_suffix:literal} => {
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct $name {
+            pub target_name: String,
+            pub metric_name: String,
+            pub timeseries_key: String,
+            #[serde(with = "serde_timestamp")]
+            pub timestamp: DateTime<Utc>,
+            pub value: $value_type,
+        }
+
+        impl $name {
+            pub fn table_name(&self) -> String {
+                format!(
+                    "{db_name}.measurements_{type_}",
+                    db_name = DATABASE_NAME,
+                    type_ = $table_suffix,
+                )
+            }
+        }
+    };
+}
+
+define_measurement_row! { BoolMeasurementRow, DbBool, "bool" }
+define_measurement_row! { I64MeasurementRow, i64, "i64" }
+define_measurement_row! { F64MeasurementRow, f64, "f64" }
+define_measurement_row! { StringMeasurementRow, String, "string" }
+define_measurement_row! { BytesMeasurementRow, Bytes, "bytes" }
+define_measurement_row! { CumulativeI64MeasurementRow, i64, "cumulativei64" }
+define_measurement_row! { CumulativeF64MeasurementRow, f64, "cumulativef64" }
+
+/// Representation of a histogram in ClickHouse.
+///
+/// The tables storing measurements of a histogram metric use a pair of arrays to represent them,
+/// for the bins and counts, respectively. This handles conversion between the type used to
+/// represent histograms in Rust, [`histogram::Histogram`], and this in-database representation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DbHistogram<T> {
+    pub bins: Vec<T>,
+    pub counts: Vec<u64>,
+}
+
+impl<T> From<&histogram::Histogram<T>> for DbHistogram<T>
+where
+    T: histogram::HistogramSupport,
+{
+    fn from(hist: &histogram::Histogram<T>) -> Self {
+        let (bins, counts) = hist.to_arrays();
+        Self { bins, counts }
+    }
+}
+
+impl<T> From<DbHistogram<T>> for histogram::Histogram<T>
+where
+    T: histogram::HistogramSupport,
+{
+    fn from(hist: DbHistogram<T>) -> Self {
+        Self::from_arrays(hist.bins, hist.counts).unwrap()
+    }
+}
+
+macro_rules! define_histogram_measurement_row {
+    {$name:ident, $value_type:ty, $table_suffix:literal} => {
+        #[derive(Clone, Debug, Deserialize, Serialize)]
+        pub struct $name {
+            pub target_name: String,
+            pub metric_name: String,
+            pub timeseries_key: String,
+            #[serde(with = "serde_timestamp")]
+            pub timestamp: DateTime<Utc>,
+            #[serde(flatten)]
+            pub value: $value_type,
+        }
+
+        impl $name {
+            pub fn table_name(&self) -> String {
+                format!(
+                    "{db_name}.measurements_{type_}",
+                    db_name = DATABASE_NAME,
+                    type_ = $table_suffix,
+                )
+            }
+        }
+    };
+}
+
+define_histogram_measurement_row! { HistogramI64MeasurementRow, DbHistogram<i64>, "histogrami64" }
+define_histogram_measurement_row! { HistogramF64MeasurementRow, DbHistogram<f64>, "histogramf64" }
+
+// Helper to collect the field rows, for either the targets or metrics, from a sample.
+fn unroll_from_source(
+    sample: &Sample,
+    source: FieldSource,
+) -> BTreeMap<String, Vec<String>> {
+    let mut out = BTreeMap::new();
+    let fields = match source {
+        FieldSource::Target(_) => &sample.target.fields,
+        FieldSource::Metric(_) => &sample.metric.fields,
+    };
+    for (field_name, field_value) in fields.iter() {
+        let (table_name, row_string) = match field_value {
+            FieldValue::Bool(inner) => {
+                let row = BoolFieldRow {
+                    source: source.clone(),
+                    timeseries_key: sample.key.clone(),
+                    field_name: field_name.clone(),
+                    field_value: DbBool::from(*inner),
+                    timestamp: sample.timestamp,
+                };
+                (row.table_name(), serde_json::to_string(&row).unwrap())
+            }
+            FieldValue::I64(inner) => {
+                let row = I64FieldRow {
+                    source: source.clone(),
+                    timeseries_key: sample.key.clone(),
+                    field_name: field_name.clone(),
+                    field_value: *inner,
+                    timestamp: sample.timestamp,
+                };
+                (row.table_name(), serde_json::to_string(&row).unwrap())
+            }
+            FieldValue::String(inner) => {
+                let row = StringFieldRow {
+                    source: source.clone(),
+                    timeseries_key: sample.key.clone(),
+                    field_name: field_name.clone(),
+                    field_value: inner.clone(),
+                    timestamp: sample.timestamp,
+                };
+                (row.table_name(), serde_json::to_string(&row).unwrap())
+            }
+            FieldValue::IpAddr(inner) => {
+                // TODO-completeness Be sure to map IPV6 back to IPV4 if possible when reading.
+                //
+                // We're using the IPV6 type in ClickHouse to store all addresses. This code maps
+                // IPV4 into IPV6 in with an invertible mapping. The inversion method
+                // `to_ipv4_mapped` is currently unstable, so when we get to implementing _reading_
+                // of these types from the database, we can just copy that implementation. See
+                // https://github.com/rust-lang/rust/issues/27709 for the tracking issue for
+                // stabilizing that function, which looks like it'll happen in the near future.
+                let addr = match inner {
+                    IpAddr::V4(addr) => addr.to_ipv6_mapped(),
+                    IpAddr::V6(addr) => *addr,
+                };
+                let row = IpAddrFieldRow {
+                    source: source.clone(),
+                    timeseries_key: sample.key.clone(),
+                    field_name: field_name.clone(),
+                    field_value: addr,
+                    timestamp: sample.timestamp,
+                };
+                (row.table_name(), serde_json::to_string(&row).unwrap())
+            }
+            FieldValue::Uuid(inner) => {
+                let row = UuidFieldRow {
+                    source: source.clone(),
+                    timeseries_key: sample.key.clone(),
+                    field_name: field_name.clone(),
+                    field_value: *inner,
+                    timestamp: sample.timestamp,
+                };
+                (row.table_name(), serde_json::to_string(&row).unwrap())
+            }
+        };
+        out.entry(table_name).or_insert_with(Vec::new).push(row_string);
+    }
+    out
+}
+
+/// Collect and serialize the unrolled target and metric rows from a [`Sample`].
+///
+/// This method performs the main "unrolling" of a `Sample`, generating one record in the field
+/// tables for each field in the sample itself. The rows are returned in a map, which stores the
+/// table into which the rows should be inserted, and the string (JSON) representation of those
+/// rows appropriate for actually sending to ClickHouse.
+pub(crate) fn unroll_field_rows(
+    sample: &Sample,
+) -> BTreeMap<String, Vec<String>> {
+    let mut out = BTreeMap::new();
+    for (table, rows) in unroll_from_source(
+        sample,
+        FieldSource::Target(sample.target.name.clone()),
+    ) {
+        out.entry(table).or_insert_with(Vec::new).extend(rows);
+    }
+    for (table, rows) in unroll_from_source(
+        sample,
+        FieldSource::Metric(sample.metric.name.clone()),
+    ) {
+        out.entry(table).or_insert_with(Vec::new).extend(rows);
+    }
+    out
+}
+
+/// Return the table name and serialized measurement row for a [`Sample`], to insert into
+/// ClickHouse.
+pub(crate) fn unroll_measurement_row(sample: &Sample) -> (String, String) {
+    match sample.measurement {
+        Measurement::Bool(inner) => {
+            let row = BoolMeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: DbBool::from(inner),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::I64(inner) => {
+            let row = I64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner,
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::F64(inner) => {
+            let row = F64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner,
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::String(ref inner) => {
+            let row = StringMeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner.clone(),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::Bytes(ref inner) => {
+            let row = BytesMeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner.clone(),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::CumulativeI64(inner) => {
+            let row = CumulativeI64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner.value(),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::CumulativeF64(inner) => {
+            let row = CumulativeF64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: inner.value(),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::HistogramI64(ref inner) => {
+            let row = HistogramI64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: DbHistogram::from(inner),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+        Measurement::HistogramF64(ref inner) => {
+            let row = HistogramF64MeasurementRow {
+                target_name: sample.target.name.clone(),
+                metric_name: sample.metric.name.clone(),
+                timeseries_key: sample.key.clone(),
+                timestamp: sample.timestamp,
+                value: DbHistogram::from(inner),
+            };
+            (row.table_name(), serde_json::to_string(&row).unwrap())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_util;
+
+    #[test]
+    fn test_db_bool() {
+        assert!(matches!(DbBool::from(false), DbBool { inner: 0 }));
+        assert!(matches!(DbBool::from(true), DbBool { inner: 1 }));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_db_bool_bad() {
+        let _ = bool::from(DbBool { inner: 10 });
+    }
+
+    #[test]
+    fn test_db_histogram() {
+        let mut hist = histogram::Histogram::new(&[0i64, 10, 20]).unwrap();
+        hist.sample(1).unwrap();
+        hist.sample(10).unwrap();
+        let dbhist = DbHistogram::from(&hist);
+        let (bins, counts) = hist.to_arrays();
+        assert_eq!(dbhist.bins, bins);
+        assert_eq!(dbhist.counts, counts);
+    }
+
+    #[test]
+    fn test_unroll_from_source() {
+        let sample = test_util::make_sample();
+        let out = unroll_from_source(
+            &sample,
+            FieldSource::Target(sample.target.name.clone()),
+        );
+        assert_eq!(out["oximeter.target_fields_string"].len(), 2);
+        assert_eq!(out["oximeter.target_fields_i64"].len(), 1);
+        let unpacked: StringFieldRow =
+            serde_json::from_str(&out["oximeter.target_fields_string"][0])
+                .unwrap();
+        if let FieldSource::Target(name) = unpacked.source {
+            assert_eq!(name, sample.target.name);
+        } else {
+            panic!("Expected the packed row to have a source matching FieldSource::Target");
+        }
+        let (key, value) = sample.target.fields.iter().nth(0).unwrap();
+        assert_eq!(&unpacked.field_name, key);
+        if let FieldValue::String(v) = value {
+            assert_eq!(v, &unpacked.field_value);
+        } else {
+            panic!("Expected the packed row to have a field_value matching FieldValue::String");
+        }
+    }
+
+    #[test]
+    fn test_unroll_measurement_row() {
+        let sample = test_util::make_hist_sample();
+        let (table_name, row) = unroll_measurement_row(&sample);
+        assert_eq!(table_name, "oximeter.measurements_histogramf64");
+        let unpacked: HistogramF64MeasurementRow =
+            serde_json::from_str(&row).unwrap();
+        let unpacked_hist = histogram::Histogram::from_arrays(
+            unpacked.value.bins,
+            unpacked.value.counts,
+        )
+        .unwrap();
+        if let Measurement::HistogramF64(hist) = sample.measurement {
+            assert_eq!(
+                hist, unpacked_hist,
+                "Unpacking histogram from database representation failed"
+            );
+        } else {
+            panic!("Expected a histogram measurement");
+        }
+    }
+}

--- a/oximeter/oximeter/src/lib.rs
+++ b/oximeter/oximeter/src/lib.rs
@@ -12,6 +12,7 @@ pub use oximeter_macro_impl::*;
 extern crate self as oximeter;
 
 pub mod collect;
+pub mod db;
 pub mod histogram;
 pub mod oximeter_server;
 pub mod traits;


### PR DESCRIPTION
- Adds some SQL files for initializing the database (setting up schema)
  and wiping it.
- Adds a minimal set of types to model the tables in ClickHouse. There
  are some unfortunate interactions between Rust and ClickHouse's type
  system, and between the types and the JSON spec, which is what we're
  using for inserting data at this point. For example, the `DbBool` type
  is needed because ClickHouse lacks a true boolean type. We use a
  newtype around a u8 instead. As for JSON, it turns out the spec
  doesn't support non-finite floating point values (e.g., infty), which
  means we have to restrict our histogram to purely finite values. Note
  that we've _not_ yet done this for the other f64-based metrics.
- Adds code to unroll a list of samples, generating a row in the target
  or metric field tables for each field name/value in the sample. These
  are all packed up into strings, and the client makes one request per
  table at this point.
- Updates the histogram to support only finite values, both in its
  support and the sampled data.
- Adds methods for converting to/from a pair of bin and count arrays,
  which is how the histogram is represented in ClickHouse.
- Adds basic tests of the conversion to the model types and the client
  itself. Note that these tests are compiled, but not actually run
  automatically, since we don't yet have the database set up in our CI
  infrastructure.