### PR TITLE
Connects oximeter collector server to ClickHouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
+ "toml",
  "uuid",
 ]
 

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -20,4 +20,5 @@ slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_deb
 structopt = "0.3"
 thiserror = "1.0.24"
 tokio = "1.6"
+toml = "0.5.8"
 uuid = { version = "0.8.2", features = [ "v4", "serde" ] }

--- a/oximeter/oximeter/examples/config.toml
+++ b/oximeter/oximeter/examples/config.toml
@@ -1,0 +1,16 @@
+# Example configuration file for running an oximeter collector server
+
+id = "1da65e5b-210c-4859-a7d7-200c1e659972"
+nexus_address = "127.0.0.1:12221"
+
+[db]
+address = "[::1]:8123"
+batch_size = 1000
+batch_interval = 5 # In seconds
+
+[log]
+level = "debug"
+mode = "stderr-terminal"
+
+[dropshot]
+bind_address = "[::1]:12223"

--- a/oximeter/oximeter/src/bin/oximeter.rs
+++ b/oximeter/oximeter/src/bin/oximeter.rs
@@ -1,9 +1,6 @@
 //! Main entry point to run an `oximeter` server in the control plane.
 // Copyright 2021 Oxide Computer Company
 
-use std::net::SocketAddr;
-
-use dropshot::{ConfigDropshot, ConfigLogging, ConfigLoggingLevel};
 use structopt::StructOpt;
 
 use oximeter::{oximeter_server::Config, Oximeter};
@@ -11,29 +8,13 @@ use oximeter::{oximeter_server::Config, Oximeter};
 /// Run an oximeter metric collection server in the Oxide Control Plane.
 #[derive(StructOpt)]
 struct Args {
-    /// Address on which to serve internal API request
-    #[structopt(short, long, default_value = "[::1]:12223")]
-    address: SocketAddr,
-
-    /// Address at which to connect to Nexus
-    #[structopt(short, long, default_value = "127.0.0.1:12221")]
-    nexus: SocketAddr,
-
-    /// Address at which to connect to ClickHouse
-    #[structopt(short, long, default_value = "[::1]:9000")]
-    _clickhouse: SocketAddr,
+    /// Path to TOML file with configuration for the server
+    config_file: String,
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::from_args();
-    let config = Config {
-        nexus_address: args.nexus,
-        dropshot: ConfigDropshot {
-            bind_address: args.address,
-            ..Default::default()
-        },
-        log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info },
-    };
+    let config = Config::from_file(args.config_file).unwrap();
     Oximeter::new(&config).await.unwrap().serve_forever().await.unwrap();
 }

--- a/oximeter/oximeter/src/db/mod.rs
+++ b/oximeter/oximeter/src/db/mod.rs
@@ -1,8 +1,10 @@
 //! Tools for interacting with the timeseries database.
 // Copyright 2021 Oxide Computer Company
 
-pub mod client;
+mod client;
 mod model;
+
+pub use client::Client;
 
 #[cfg(test)]
 pub(crate) mod test_util {

--- a/smf/oximeter/config.toml
+++ b/smf/oximeter/config.toml
@@ -1,0 +1,16 @@
+# Example configuration file for running an oximeter collector server
+
+id = "1da65e5b-210c-4859-a7d7-200c1e659972"
+nexus_address = "127.0.0.1:12221"
+
+[db]
+address = "[::1]:8123"
+batch_size = 1000
+batch_interval = 5 # In seconds
+
+[log]
+level = "debug"
+mode = "stderr-terminal"
+
+[dropshot]
+bind_address = "[::1]:12223"

--- a/smf/oximeter/manifest.xml
+++ b/smf/oximeter/manifest.xml
@@ -13,15 +13,9 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/oximeter/oximeter --address %{config/address} --nexus %{config/nexus_address} --clickhouse %{config/clickhouse_address} &amp;'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/oximeter/oximeter ./config.toml &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
-
-  <property_group name='config' type='application'>
-    <propval name='address' type='astring' value='127.0.0.1:12223' />
-    <propval name='nexus_address' type='astring' value='127.0.0.1:12221' />
-    <propval name='clickhouse_address' type='astring' value='127.0.0.1:9000' />
-  </property_group>
 
   <property_group name='startd' type='framework'>
     <propval name='duration' type='astring' value='contract' />


### PR DESCRIPTION
- Uses the new clickhouse client internally in Oximeter to actually push
  aggregated results into the database
- Sprinkles some logging throughout
- Updates oximeter CLI to use a TOML configuration file for its
  parameters, rather than CLI args. The goal here is more reproducible
  assignment of these parameters, especially things like UUIDs which may
  otherwise be random
- Updates the oximeter SMF manifest to refer to a default config file,
  which is also now included in the `./smf` directory for packaging