### PR TITLE
Update "skip-duplicate-actions" revision to fix "skip runs" bug

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - id: skip_check
         # fkirc/skip-duplicate-actions@v3.4.0 (plus a bit)
-        uses: fkirc/skip-duplicate-actions@98d1dc89f43a47f8e4fba8e1c1fb8d6c5fc515ee
+        uses: fkirc/skip-duplicate-actions@867de26591aa7542d65bc38f576c5a244c3c6034
         with:
           # For workflows which are triggered concurrently with the same
           # contents, attempt to execute them exactly once.


### PR DESCRIPTION
- Update to include https://github.com/fkirc/skip-duplicate-actions/pull/116 ...
- ... which is fixed by https://github.com/fkirc/skip-duplicate-actions/pull/116


TL;DR: Our usage of the action seems correct, but this update fixes a bug in the implementation which could skip jobs.