### PR TITLE
Simplifies types used in metric producer descriptions

### DIFF
--- a/omicron-common/src/model.rs
+++ b/omicron-common/src/model.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FormatResult;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::time::Duration;
 use thiserror::Error;
@@ -1395,132 +1395,23 @@ pub struct BootstrapAgentShareResponse {
  */
 
 /**
- * Idenitifier for a producer.
- */
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Eq,
-    JsonSchema,
-    Serialize,
-    Deserialize,
-)]
-pub struct ProducerId {
-    pub producer_id: Uuid,
-}
-
-impl ProducerId {
-    /**
-     * Construct a new producer ID.
-     */
-    pub fn new() -> Self {
-        Self { producer_id: Uuid::new_v4() }
-    }
-}
-
-impl Default for ProducerId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl std::fmt::Display for ProducerId {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.producer_id.to_string())
-    }
-}
-
-/**
  * Information announced by a metric server, used so that clients can contact it and collect
  * available metric data from it.
  */
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 pub struct ProducerEndpoint {
-    producer_id: ProducerId,
-    address: SocketAddr,
-    collection_route: String,
-    interval: Duration,
+    pub id: Uuid,
+    pub address: SocketAddr,
+    pub base_route: String,
+    pub interval: Duration,
 }
 
 impl ProducerEndpoint {
     /**
-     * Generate info for a metric server listening on the given address and route.
-     *
-     * This will generate a new, random [`ProducerId`] for the server. The `base_route` should be
-     * a route stem, to which the producer ID will be appended. `interval` is the desired initial
-     * collection interval for the producers metrics.
-     *
-     * Example
-     * -------
-     * ```rust
-     * use std::time::Duration;
-     * use omicron_common::model::ProducerEndpoint;
-     *
-     * let info = ProducerEndpoint::new("127.0.0.1:4444", "/collect", Duration::from_secs(10));
-     * assert_eq!(info.collection_route(), format!("/collect/{}", info.producer_id()));
-     * ```
-     */
-    pub fn new<T>(address: T, base_route: &str, interval: Duration) -> Self
-    where
-        T: ToSocketAddrs,
-    {
-        Self::with_id(ProducerId::new(), address, base_route, interval)
-    }
-
-    /**
-     * Generate info for a metric server, listening on the given address and route, with a known
-     * ID.
-     */
-    pub fn with_id<T>(
-        producer_id: ProducerId,
-        address: T,
-        base_route: &str,
-        interval: Duration,
-    ) -> Self
-    where
-        T: ToSocketAddrs,
-    {
-        Self {
-            producer_id,
-            address: address.to_socket_addrs().unwrap().next().unwrap(),
-            collection_route: format!(
-                "{}/{}",
-                base_route, producer_id.producer_id
-            ),
-            interval,
-        }
-    }
-
-    /**
-     * Return the producer ID for this server.
-     */
-    pub fn producer_id(&self) -> ProducerId {
-        self.producer_id
-    }
-
-    /**
-     * Return the address on which this server listens.
-     */
-    pub fn address(&self) -> SocketAddr {
-        self.address
-    }
-
-    /**
      * Return the route that can be used to request metric data.
      */
-    pub fn collection_route(&self) -> &str {
-        &self.collection_route
-    }
-
-    /**
-     * Return the interval on which metrics should be collected.
-     */
-    pub fn interval(&self) -> &Duration {
-        &self.interval
+    pub fn collection_route(&self) -> String {
+        format!("{}/{}", &self.base_route, &self.id)
     }
 }
 

--- a/omicron-nexus/src/nexus.rs
+++ b/omicron-nexus/src/nexus.rs
@@ -1244,7 +1244,7 @@ impl Nexus {
         info!(
             self.log,
             "assigned collector to new producer";
-            "producer_id" => ?producer_info.producer_id(),
+            "producer_id" => ?producer_info.id,
             "collector_id" => ?collector.id,
         );
         Ok(())

--- a/oximeter/oximeter/examples/producer.rs
+++ b/oximeter/oximeter/examples/producer.rs
@@ -88,8 +88,12 @@ async fn main() {
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug };
     let registration_info =
         RegistrationInfo::new("127.0.0.1:12221", "/metrics/producers");
-    let server_info =
-        ProducerEndpoint::new(address, "/collect", Duration::from_secs(10));
+    let server_info = ProducerEndpoint {
+        id: Uuid::new_v4().into(),
+        address,
+        base_route: "/collect".to_string(),
+        interval: Duration::from_secs(10),
+    };
     let config = ProducerServerConfig {
         server_info,
         registration_info,


### PR DESCRIPTION
- Removes the `ProducerId` type entirely. This was mostly there due to a
misunderstanding of how Dropshot deserializes path types. It's been
replaced with a Uuid
- Makes most fields of the `ProducerEndpoint` type public. This now
stores the base collection route and the ID, and concats them on-demand,
rather than storing the joined path and splitting it on demand.