### PR TITLE
Adding tools to manage ClickHouse during development

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,16 +95,21 @@ jobs:
       with:
         key: ${{ runner.os }}-cockroach-binary-v2
         path: "cockroachdb"
-    - name: Install ClickHouse
-      # Workflow environment variables are not propagated to the script by default
-      run: sudo CI=$CI ./tools/ci_download_clickhouse
+    - name: Configure GitHub cache for ClickHouse binaries
+      id: cache-clickhouse
+      # actions/cache@v2.1.4
+      uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6
+      with:
+        key: ${{ runner.os }}-clickhouse-binary
+        path: "clickhouse"
     - name: Build
       run: cargo +${{ matrix.toolchain }} build --locked --all-targets --verbose
+    - name: Download ClickHouse
+      if: steps.cache-clickhouse.outputs.cache-hit != 'true'
+      run: ./tools/ci_download_clickhouse
     - name: Download CockroachDB binary
       if: steps.cache-cockroachdb.outputs.cache-hit != 'true'
       run: bash ./tools/ci_download_cockroachdb
     - name: Run tests
-      # Put "./cockroachdb/bin" on the PATH for the test suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin" cargo +${{ matrix.toolchain }} test --locked --verbose
-    - name: Run ClickHouse client tests
-      run: cargo test --locked --verbose --features clickhouse-tests --package oximeter -- --test-threads 1 db::client
+      # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test suite.
+      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" cargo +${{ matrix.toolchain }} test --locked --verbose

--- a/README.adoc
+++ b/README.adoc
@@ -56,23 +56,26 @@ See TODO.adoc for more info.
 1. CockroachDB v20.2.5.  The test suite expects to be able to start a single-node CockroachDB cluster using the `cockroach` executable on your PATH.  On illumos, MacOS, and Linux, you should be able to use the `tools/ci_download_cockroachdb` script to fetch the official CockroachDB binary.  It will be put into `./cockroachdb/bin/cockroach`.  Alternatively, you can follow the https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html[official CockroachDB installation instructions for your platform].
 With `cockroach` on your PATH, you can **build and run the whole test suite** with `cargo test`.  The test suite runs cleanly and should remain clean.
 
-2. ClickHouse >= v21.5.5. The test suite expects a running instance of the ClickHouse database server.
+2. ClickHouse >= v21.7.1. The test suite expects a running instance of the ClickHouse database server.
 (It currently _does not_ start the server automatically.) The script `./tools/ci_download_clickhouse`
-can be used to download and install the server on Linux platforms only. It's not currently possible
-to validate the downloaded binaries automatically on other platforms, so it must be done manually.
-Instructions can be found https://clickhouse.tech/docs/en/getting-started/install/#from-binaries-non-linux[here].
+can be used to download a pre-built binary for illumos, Linux, or macOS platforms. You may also install
+ClickHouse manually; instructions can be found https://clickhouse.tech/docs/en/getting-started/install[here].
 
 You can **format the code** using `cargo fmt`.  Make sure to run this before pushing changes.  The CI checks that the code is correctly formatted.
 
 You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy \-- -D warnings -A clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.
 
-To **run Omicron** you need to run three programs:
+To **run Omicron** you need to run four programs:
 
 * a CockroachDB cluster.  For development, you can use the `omicron-dev` tool in this repository to start a single-node CockroachDB cluster **that will delete the database when you shut it down.**
+* a ClickHouse server. You may use the `omicron-dev` tool for this as well, see below, and as with CockroachDB,
+the database files will be deleted when you stop the program.
 * `nexus`: the guts of the control plane
 * `sled-agent-sim`: a simulator for the component that manages a single sled
 
-The easiest way to start a CockroachDB cluster is to use the built in `omicron-dev` tool.  This tool assumes that the `cockroach` executable on your PATH comes from CockroachDB v20.2.5.
+The easiest way to start the required databases is to use the built in `omicron-dev` tool.
+This tool assumes that the `cockroach` and `clickhouse` executables are on your PATH,
+and match the versions above.
 
 1. Start CockroachDB using `omicron-dev db-run`:
 +
@@ -129,7 +132,18 @@ omicron-dev: populated database
 +
 Note that as the output indicates, this cluster will be available to anybody that can reach 127.0.0.1.
 
-2. `nexus` requires a configuration file to run.  You can use `omicron-nexus/examples/config.toml` to start with.  Build and run it like this:
+2. Start the ClickHouse database server:
++
+[source,text]
+----
+$ cargo run --bin omicron-dev -- ch-run
+    Finished dev [unoptimized + debuginfo] target(s) in 0.47s
+     Running `target/debug/omicron-dev ch-run`
+omicron-dev: running ClickHouse (PID: 2463), full command is "clickhouse server --log-file /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot/clickhouse-server.log --errorlog-file /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot/clickhouse-server.errlog -- --http_port 8123 --path /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot"
+omicron-dev: using /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot for ClickHouse data storage
+----
+
+3. `nexus` requires a configuration file to run.  You can use `omicron-nexus/examples/config.toml` to start with.  Build and run it like this:
 +
 [source,text]
 ----
@@ -138,11 +152,11 @@ $ cargo run --bin=nexus -- omicron-nexus/examples/config.toml
 listening: http://127.0.0.1:12220
 ----
 
-3. `sled-agent-sim` only accepts configuration on the command line.  Run it with a uuid identifying itself (this would be a uuid for the sled it's managing), an IP:port for itself, and the IP:port of `nexus`'s _internal_ interface.  Using default config, this might look like this:
+4. `sled-agent` only accepts configuration on the command line.  Run it with a uuid identifying itself (this would be a uuid for the sled it's managing), an IP:port for itself, and the IP:port of `nexus`'s _internal_ interface.  Using default config, this might look like this:
 +
 [source,text]
 ----
-$ cargo run --bin=sled-agent-sim -- $(uuidgen) 127.0.0.1:12345 127.0.0.1:12221
+$ cargo run --bin=sled-agent -- $(uuidgen) 127.0.0.1:12345 127.0.0.1:12221
 ...
 Jun 02 12:21:50.989 INFO listening, local_addr: 127.0.0.1:12345, component: dropshot
 ----

--- a/omicron-common/src/bin/omicron-dev.rs
+++ b/omicron-common/src/bin/omicron-dev.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
         OmicronDb::DbRun { ref args } => cmd_db_run(args).await,
         OmicronDb::DbPopulate { ref args } => cmd_db_populate(args).await,
         OmicronDb::DbWipe { ref args } => cmd_db_wipe(args).await,
+        OmicronDb::ChRun { ref args } => cmd_clickhouse_run(args).await,
     };
     if let Err(error) = result {
         fatal(CmdError::Failure(format!("{:#}", error)));
@@ -49,6 +50,12 @@ enum OmicronDb {
     DbWipe {
         #[structopt(flatten)]
         args: DbWipeArgs,
+    },
+
+    /// Run a ClickHouse database server for development
+    ChRun {
+        #[structopt(flatten)]
+        args: ChRunArgs,
     },
 }
 
@@ -225,5 +232,56 @@ async fn cmd_db_wipe(args: &DbWipeArgs) -> Result<(), anyhow::Error> {
     dev::db::wipe(&client).await?;
     println!("omicron-dev: wiped");
     client.cleanup().await.expect("connection failed");
+    Ok(())
+}
+
+#[derive(Debug, StructOpt)]
+struct ChRunArgs {
+    /// The HTTP port on which the server will listen
+    #[structopt(short, long, default_value = "8123")]
+    port: u16,
+}
+
+async fn cmd_clickhouse_run(args: &ChRunArgs) -> Result<(), anyhow::Error> {
+    // Start a stream listening for SIGINT
+    let signals = Signals::new(&[SIGINT]).expect("failed to wait for SIGINT");
+    let mut signal_stream = signals.fuse();
+
+    // Start the database server process, possibly on a specific port
+    let mut db_instance =
+        dev::clickhouse::ClickHouseInstance::new(args.port).await?;
+    println!(
+        "omicron-dev: running ClickHouse (PID: {}), full command is \"clickhouse {}\"",
+        db_instance.pid().expect("Failed to get process PID, it may not have started"),
+        db_instance.cmdline().join(" ")
+    );
+    println!(
+        "omicron-dev: using {} for ClickHouse data storage",
+        db_instance.data_path().display()
+    );
+
+    // Wait for the DB to exit itself (an error), or for SIGINT
+    tokio::select! {
+        _ = db_instance.wait_for_shutdown() => {
+            db_instance.cleanup().await.context("clean up after shutdown")?;
+            bail!("omicron-dev: ClickHouse shutdown unexpectedly");
+        }
+        caught_signal = signal_stream.next() => {
+            assert_eq!(caught_signal.unwrap(), SIGINT);
+
+            // As above, we don't need to explicitly kill the DB process, since
+            // the shell will have delivered the signal to the whole process group.
+            eprintln!(
+                "omicron-dev: caught signal, shutting down and removing \
+                temporary directory"
+            );
+
+            // Remove the data directory.
+            db_instance
+                .wait_for_shutdown()
+                .await
+                .context("clean up after SIGINT shutdown")?;
+        }
+    }
     Ok(())
 }

--- a/omicron-common/src/dev/clickhouse.rs
+++ b/omicron-common/src/dev/clickhouse.rs
@@ -1,0 +1,154 @@
+//! Tools for managing ClickHouse during development
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Context;
+use tempfile::TempDir;
+
+use crate::dev::poll;
+
+/// A `ClickHouseInstance` is used to start and manage a ClickHouse server process.
+#[derive(Debug)]
+pub struct ClickHouseInstance {
+    // Directory in which all data, logs, etc are stored.
+    data_dir: Option<TempDir>,
+    data_path: PathBuf,
+    // The HTTP port the server is listening on
+    port: u16,
+    // Full list of command-line arguments
+    args: Vec<String>,
+    // Subprocess handle
+    child: Option<tokio::process::Child>,
+}
+
+impl ClickHouseInstance {
+    /// Start a new ClickHouse server
+    pub async fn new(port: u16) -> Result<Self, anyhow::Error> {
+        let data_dir = TempDir::new()?;
+        let log_path = data_dir.path().join("clickhouse-server.log");
+        let err_log_path = data_dir.path().join("clickhouse-server.errlog");
+        let args = vec![
+            "server".to_string(),
+            "--log-file".to_string(),
+            log_path.display().to_string(),
+            "--errorlog-file".to_string(),
+            err_log_path.display().to_string(),
+            "--".to_string(),
+            "--http_port".to_string(),
+            format!("{}", port),
+            "--path".to_string(),
+            data_dir.path().display().to_string(),
+        ];
+
+        let child = tokio::process::Command::new("clickhouse")
+            .args(&args)
+            // ClickHouse internall tees its logs to a file, so we throw away std{in,out,err}
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            // By default ClickHouse forks a child if it's been explicitly requested via the
+            // following environment variable, _or_ if it's not attached to a TTY. Avoid this
+            // behavior, so that we can correctly deliver SIGINT. The "watchdog" masks SIGINT,
+            // meaning we'd have to deliver that to the _child_, which is more complicated.
+            .env("CLICKHOUSE_WATCHDOG_ENABLE", "0")
+            .spawn()?;
+
+        // Wait for the "status" file to become available, at least with a newline.
+        let data_path = data_dir.path().to_path_buf();
+        let status_file = data_path.join("status");
+        poll::wait_for_condition(
+            || async {
+                let contents =
+                    match tokio::fs::read_to_string(&status_file).await {
+                        Ok(contents) => contents,
+                        Err(e) => match e.kind() {
+                            std::io::ErrorKind::NotFound => {
+                                return Err(poll::CondCheckError::NotYet)
+                            }
+                            _ => return Err(poll::CondCheckError::from(e)),
+                        },
+                    };
+                if !contents.is_empty() && contents.contains('\n') {
+                    Ok(())
+                } else {
+                    Err(poll::CondCheckError::NotYet)
+                }
+            },
+            &Duration::from_millis(500),
+            &Duration::from_secs(30),
+        )
+        .await?;
+
+        Ok(Self {
+            data_dir: Some(data_dir),
+            data_path,
+            port,
+            args,
+            child: Some(child),
+        })
+    }
+
+    /// Wait for the ClickHouse server process to shutdown, after it's been killed.
+    pub async fn wait_for_shutdown(&mut self) -> Result<(), anyhow::Error> {
+        if let Some(mut child) = self.child.take() {
+            child.wait().await?;
+        }
+        self.cleanup().await
+    }
+
+    /// Kill the ClickHouse server process and cleanup the data directory.
+    pub async fn cleanup(&mut self) -> Result<(), anyhow::Error> {
+        if let Some(mut child) = self.child.take() {
+            child.start_kill().context("Sending SIGKILL to child")?;
+            child.wait().await.context("waiting for child")?;
+        }
+        if let Some(dir) = self.data_dir.take() {
+            dir.close().context("Cleaning up temporary directory")?;
+
+            // ClickHouse doesn't fully respect the `--path` flag, and still seems
+            // to put the `preprocessed_configs` directory in $CWD.
+            let _ = std::fs::remove_dir_all("./preprocessed_configs");
+        }
+        Ok(())
+    }
+
+    /// Return the full path to the directory used for the server's data.
+    pub fn data_path(&self) -> &Path {
+        &self.data_path
+    }
+
+    /// Return the command-line used to start the ClickHouse server process
+    pub fn cmdline(&self) -> &Vec<String> {
+        &self.args
+    }
+
+    /// Return the child PID, if any
+    pub fn pid(&self) -> Option<u32> {
+        self.child.as_ref().and_then(|child| child.id())
+    }
+
+    /// Return the HTTP port the server is listening on.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for ClickHouseInstance {
+    fn drop(&mut self) {
+        if self.child.is_some() || self.data_dir.is_some() {
+            eprintln!(
+                "WARN: dropped CockroachInstance without cleaning it up first \
+                (there may still be a child process running and a \
+                temporary directory leaked)"
+            );
+            if let Some(child) = self.child.as_mut() {
+                let _ = child.start_kill();
+            }
+            if let Some(dir) = self.data_dir.take() {
+                let _ = dir.close();
+            }
+        }
+    }
+}

--- a/omicron-common/src/dev/mod.rs
+++ b/omicron-common/src/dev/mod.rs
@@ -8,6 +8,7 @@
  */
 #![cfg_attr(not(test), allow(dead_code))]
 
+pub mod clickhouse;
 pub mod db;
 pub mod poll;
 pub mod test_cmds;

--- a/omicron-common/tests/output/cmd-omicron-dev-noargs-stderr
+++ b/omicron-common/tests/output/cmd-omicron-dev-noargs-stderr
@@ -9,6 +9,7 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
+    ch-run         Run a ClickHouse database server for development
     db-populate    Populate an existing CockroachDB cluster with the Omicron schema
     db-run         Start a CockroachDB cluster for development
     db-wipe        Wipe the Omicron schema (and all data) from an existing CockroachDB cluster

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -25,6 +25,3 @@ uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
 trybuild = "1.0.42"
-
-[features]
-clickhouse-tests = []

--- a/tools/ci_download_clickhouse
+++ b/tools/ci_download_clickhouse
@@ -1,69 +1,124 @@
 #!/bin/bash
 
-# This is used _only within GitHub CI_ to install the ClickHouse server
-# To install in any other context, see https://clickhouse.tech/docs/en/getting-started/install
+#
+# ci_download_clickhouse: fetches the appropriate ClickHouse binary tarball
+# based on the currently running operating system, unpacks it, and creates a
+# copy called "clickhouse", all in the current directory.
+#
 
-function main() {
-    set -o xtrace
-    set -o pipefail
-    set -o errexit
-    verify_github_ci
-    verify_linux
-    verify_root
-    add_clickhouse_apt_sources
-    install_clickhouse
-    sudo systemctl start clickhouse-server.service
+set -o pipefail
+set -o xtrace
+set -o errexit
+
+ARG0="$(basename ${BASH_SOURCE[0]})"
+
+# If you change this, you must also update the md5sums below
+CIDL_VERSION="v21.7"
+CIDL_MD5_DARWIN="501dafb3cf0b134832d0719dfefdd851"
+CIDL_MD5_LINUX=""95e3d042cec0a1c03edea01c5ee009ee
+CIDL_MD5_ILLUMOS="53c9417619cb84c8ed1e1a1bc0510a89"
+CIDL_ASSEMBLE_DIR="./clickhouse"
+
+# Download from manually-populated S3 bucket for now
+CIDL_URL_BASE="https://oxide-clickhouse-build.s3.us-west-2.amazonaws.com"
+
+function main
+{
+	#
+	# Process command-line arguments.  We generally don't expect any, but
+	# we allow callers to specify a value to override OSTYPE, just for
+	# testing.
+	#
+	if [[ $# != 0 ]]; then
+		CIDL_OS="$1"
+		shift
+	else
+		CIDL_OS="$OSTYPE"
+	fi
+
+	if [[ $# != 0 ]]; then
+		echo "unexpected arguments" >&2
+		exit 2
+	fi
+
+	# Configure this program
+	configure_os "$CIDL_OS"
+	CIDL_URL="$CIDL_URL_BASE/$CIDL_FILE"
+
+	# Download the file.
+	echo "URL: $CIDL_URL"
+	echo "Local file: $CIDL_FILE"
+	do_download_curl "$CIDL_URL" "$CIDL_FILE" || \
+	    fail "failed to download file"
+
+	# Verify the md5sum.
+	calculated_md5="$($CIDL_MD5FUNC "$CIDL_FILE")" || \
+	    fail "failed to calculate md5sum"
+	if [[ "$calculated_md5" != "$CIDL_MD5" ]]; then
+		fail "md5sum mismatch \
+		    (expected $CIDL_MD5, found $calculated_md5)"
+	fi
+
+	# Unpack the tarball into a local directory
+	do_untar "$CIDL_FILE" "$CIDL_ASSEMBLE_DIR"
+
+	# Run the binary as a sanity-check.
+	"$CIDL_ASSEMBLE_DIR/clickhouse" server --version
 }
 
-function verify_github_ci() {
-    if ! [ "$CI" ]; then
-        echo "This script can only be used to install ClickHouse"
-        echo "within GitHub's CI. Please see the link below for"
-        echo "directions to install ClickHouse"
-        echo ""
-        echo "https://clickhouse.tech/docs/en/getting-started/install/"
-        exit 1
-    fi
+function fail
+{
+	echo "$ARG0: $@" >&2
+	exit 1
 }
 
-function verify_linux() {
-    case "$OSTYPE" in
-        linux*)
-            ;;
-        *)
-            echo "This script can only be used to install ClickHouse on"
-            echo "Linux platforms. See https://clickhouse.tech/docs/en/getting-started/install/#from-binaries-non-linux"
-            echo "for instructions to install manually on non-Linux platforms"
-            exit 0 # Return 0 to avoid erroring out on CI
-            ;;
-    esac
+function configure_os
+{
+	echo "current directory: $PWD"
+	echo "configuring based on OS: \"$1\""
+	case "$1" in
+		darwin*)
+            CIDL_PLATFORM="macos"
+			CIDL_MD5="$CIDL_MD5_DARWIN"
+			CIDL_MD5FUNC="do_md5"
+			;;
+		linux-gnu*) 
+            CIDL_PLATFORM="linux"
+			CIDL_MD5="$CIDL_MD5_LINUX"
+			CIDL_MD5FUNC="do_md5sum"
+			;;
+		solaris*)
+            CIDL_PLATFORM="illumos"
+			CIDL_MD5="$CIDL_MD5_ILLUMOS"
+			CIDL_MD5FUNC="do_md5sum"
+			;;
+		*)
+			fail "unsupported OS: $1"
+			;;
+	esac
+
+	CIDL_DIR="clickhouse-$CIDL_VERSION"
+	CIDL_FILE="$CIDL_DIR.$CIDL_PLATFORM.tar.gz"
 }
 
-function verify_root() {
-    if [ $(id -u) -ne 0 ]; then
-        echo "This script must be run as root"
-        exit 1
-    fi
+function do_download_curl
+{
+	curl --silent --show-error --fail --location --output "$2" "$1"
 }
 
-function add_clickhouse_apt_sources() {
-    apt-get install apt-transport-https ca-certificates dirmngr
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4
-    echo "deb https://repo.clickhouse.tech/deb/stable/ main/" | \
-            tee /etc/apt/sources.list.d/clickhouse.list
-    apt-get update
+function do_md5
+{
+	md5 < "$1"
 }
 
-function install_clickhouse() {
-    # ClickHouse clearly expects this to be installed by a human,
-    # since they prompt in the middle of installation to ask for
-    # the default users password.
-    apt-get install -y --no-install-recommends expect
-    expect -f - <<-EOI
-        spawn apt-get install -y --no-install-recommends clickhouse-server
-        expect "Enter password for default user:" { send "\r" }
-        wait
-EOI
+function do_md5sum
+{
+	md5sum < "$1" | awk '{print $1}'
 }
 
-main
+function do_untar
+{
+    mkdir -p "$2" && tar xzf "$1" -C "$2"
+}
+
+main "$@"


### PR DESCRIPTION
- Updates tool for downloading ClickHouse, now using prebuilt binaries
from S3.
- Adds the `omicron_common::dev::clickhouse::ClickHouseInstance` object.
This is modeled after the existing `CockroachInstance` object, and is
used to start and manage a ClickHouse server sub-process. It currently
is quite constrained, only allowing users to specify the HTTP port the
server listens on. This is for simplicity, and further options may be
needed in the future.
- Updates the Oximeter client tests. These now spawn their own
`ClickHouseInstance` in each test, so they can be run in parallel. This
also removes the feature flag used to hide the tests on non-linux
platforms.
- Updates the GitHub workflow to use the new tool to download ClickHouse