### PR TITLE
[smf] Update Propolis service dependencies

### DIFF
--- a/smf/propolis-server/manifest.xml
+++ b/smf/propolis-server/manifest.xml
@@ -4,9 +4,9 @@
 <service_bundle type='manifest' name='propolis-server'>
 
 <service name='system/illumos/propolis-server' type='service' version='1'>
-  <dependency name='sled-agent' grouping='require_all' restart_on='none'
+  <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
-  <service_fmri value='svc:/system/illumos/sled-agent' />
+  <service_fmri value='svc:/milestone/network:default' />
   </dependency>
 
   <exec_method type='method' name='start'


### PR DESCRIPTION
- Propolis will no longer depend on the Sled Agent: soon,
Sled Agent will launch Propolis in a dedicated zone. As such,
it won't even be visible to Propolis.
- Instead, a dependency is added on the network milestone.
Propolis communicates using an IP address allocated on a
VNIC specifically created for the Zone.