### PR TITLE
[sled-agent] Propolis "destroyed" now means "stopped" to the Sled Agent

### DIFF
--- a/omicron-sled-agent/src/sim/collection.rs
+++ b/omicron-sled-agent/src/sim/collection.rs
@@ -542,7 +542,7 @@ mod test {
         assert!(rnext.time_updated >= rprev.time_updated);
         assert!(instance.object.desired().is_none());
         assert_eq!(rprev.run_state, ApiInstanceState::Stopping);
-        assert_eq!(rnext.run_state, ApiInstanceState::Destroyed);
+        assert_eq!(rnext.run_state, ApiInstanceState::Stopped);
         rprev = rnext;
         instance.transition_finish();
         let rnext = instance.object.current().clone();
@@ -626,7 +626,7 @@ mod test {
         assert!(rnext.time_updated >= rprev.time_updated);
         assert!(instance.object.desired().is_none());
         assert_eq!(rprev.run_state, ApiInstanceState::Stopping);
-        assert_eq!(rnext.run_state, ApiInstanceState::Destroyed);
+        assert_eq!(rnext.run_state, ApiInstanceState::Stopped);
         rprev = rnext;
         instance.transition_finish();
         let rnext = instance.object.current().clone();


### PR DESCRIPTION
When Propolis self-reports that local state has been destroyed,
the Sled Agent should report to Nexus that the state has been
stopped.

This is a matter of semantics, but the distinction is important:
when an instance is stopped within Propolis, it will never again
run on that specific server. However, the instance (and associated
virtual resources) may be re-allocated elsewhere - so they are
"stopped" from a client perspective.