### PR TITLE
Use OS-assigned port in oximeter DB client tests

### DIFF
--- a/oximeter/oximeter/src/db/client.rs
+++ b/oximeter/oximeter/src/db/client.rs
@@ -359,10 +359,13 @@ mod tests {
     #[tokio::test]
     async fn test_build_client() {
         let log = slog::Logger::root(slog::Discard, o!());
-        let address: SocketAddr = "[::1]:8123".parse().unwrap();
-        let mut db = dev::clickhouse::ClickHouseInstance::new(address.port())
+
+        // Let the OS assign a port and discover it after ClickHouse starts
+        let mut db = dev::clickhouse::ClickHouseInstance::new(0)
             .await
             .expect("Failed to start ClickHouse");
+        let address = SocketAddr::new("::1".parse().unwrap(), db.port());
+
         Client::new(address, log).await.unwrap().wipe_db().await.unwrap();
         db.cleanup().await.expect("Failed to cleanup ClickHouse server");
     }
@@ -370,10 +373,13 @@ mod tests {
     #[tokio::test]
     async fn test_client_insert() {
         let log = slog::Logger::root(slog::Discard, o!());
-        let address: SocketAddr = "[::1]:8124".parse().unwrap();
-        let mut db = dev::clickhouse::ClickHouseInstance::new(address.port())
+
+        // Let the OS assign a port and discover it after ClickHouse starts
+        let mut db = dev::clickhouse::ClickHouseInstance::new(0)
             .await
             .expect("Failed to start ClickHouse");
+        let address = SocketAddr::new("::1".parse().unwrap(), db.port());
+
         let client = Client::new(address, log).await.unwrap();
         let samples = {
             let mut s = Vec::with_capacity(8);
@@ -409,10 +415,13 @@ mod tests {
     #[tokio::test]
     async fn test_schema_mismatch() {
         let log = slog::Logger::root(slog::Discard, o!());
-        let address: SocketAddr = "[::1]:8125".parse().unwrap();
-        let mut db = dev::clickhouse::ClickHouseInstance::new(address.port())
+
+        // Let the OS assign a port and discover it after ClickHouse starts
+        let mut db = dev::clickhouse::ClickHouseInstance::new(0)
             .await
             .expect("Failed to start ClickHouse");
+        let address = SocketAddr::new("::1".parse().unwrap(), db.port());
+
         let client = Client::new(address, log).await.unwrap();
         let sample = test_util::make_sample();
         client.insert_samples(&vec![sample]).await.unwrap();
@@ -436,10 +445,13 @@ mod tests {
     #[tokio::test]
     async fn test_schema_update() {
         let log = slog::Logger::root(slog::Discard, o!());
-        let address: SocketAddr = "[::1]:8126".parse().unwrap();
-        let mut db = dev::clickhouse::ClickHouseInstance::new(address.port())
+
+        // Let the OS assign a port and discover it after ClickHouse starts
+        let mut db = dev::clickhouse::ClickHouseInstance::new(0)
             .await
             .expect("Failed to start ClickHouse");
+        let address = SocketAddr::new("::1".parse().unwrap(), db.port());
+
         let client = Client::new(address, log).await.unwrap();
         let sample = test_util::make_sample();
 


### PR DESCRIPTION
- Removes hard-coded port numbers in tests of the oximeter ClickHouse
client, opting for OS-assigned ports to really avoid collisions.
- Simplifies internals of ClickHouse runner. Previously, we checked for
the a "status" file, which the ClickHouse binary spits out with
information like the PID. But this is _before_ the server(s) start,
which means it was possible that the server's socket is not
bound/listening by the time we actually query it, _in the case that we
start it with a known port_. If we use an OS-assigned port, we wait for
the log-file to tell us the actual bound port, which means the server
has to actually be listening at that point. This change now
unconditionally parses the log file for the port, meaning that we're
always guaranteed that the server is ready for connections when we
return from `ClickHouseInstance::new`. This avoids _yet another_ race in
the startup/management of the ClickHouse subprocess.