### PR TITLE
Removes implicit ordering in materialized targets and metrics

### DIFF
--- a/oximeter/oximeter/src/lib.rs
+++ b/oximeter/oximeter/src/lib.rs
@@ -22,4 +22,6 @@ pub mod types;
 pub use oximeter_server::Oximeter;
 pub use producer_server::ProducerServer;
 pub use traits::{Metric, Producer, Target};
-pub use types::{Error, FieldType, FieldValue, Measurement, MeasurementType};
+pub use types::{
+    Error, Field, FieldType, FieldValue, Measurement, MeasurementType,
+};

--- a/oximeter/oximeter/src/traits.rs
+++ b/oximeter/oximeter/src/traits.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 
 use crate::histogram::Histogram;
 use crate::types::{Cumulative, Measurement, Sample};
-use crate::{Error, FieldType, FieldValue, MeasurementType};
+use crate::{Error, Field, FieldType, FieldValue, MeasurementType};
 
 /// The `Target` trait identifies a source of metric data by a sequence of fields.
 ///
@@ -65,6 +65,15 @@ pub trait Target {
 
     /// Return the values of the target's fields.
     fn field_values(&self) -> Vec<FieldValue>;
+
+    /// Return the target's fields, both name and value.
+    fn fields(&self) -> Vec<Field> {
+        self.field_names()
+            .iter()
+            .zip(self.field_values().into_iter())
+            .map(|(name, value)| Field { name: name.to_string(), value })
+            .collect()
+    }
 
     /// Return the key for this target.
     ///
@@ -133,6 +142,15 @@ pub trait Metric {
 
     /// Return the values of the metric's fields.
     fn field_values(&self) -> Vec<FieldValue>;
+
+    /// Return the metrics's fields, both name and value.
+    fn fields(&self) -> Vec<Field> {
+        self.field_names()
+            .iter()
+            .zip(self.field_values().into_iter())
+            .map(|(name, value)| Field { name: name.to_string(), value })
+            .collect()
+    }
 
     /// Return the key for this metric.
     ///


### PR DESCRIPTION
The `oximeter::types::{Target,Metric}` structs previously stored a
B-tree mapping field names to field values. This collection sorts its
keys, so there's possibly a different ordering between the definition of
the fields (which is how they're stored in the DB) and the fields as
stored in those structs. This came up while implementing
filtering/querying on the DB, in which case, rebuilding a `Target` or
`Metric` struct from the values in the timeseries key no longer works,
since it requires the ordering be preserved.

This commit removes any B-trees used to store name/value pairs of a
field, and introduces the `oximeter::types::Field` struct which combines
the name and value into one. Linear sequences of these (vectors, slices,
etc) are used in place of maps.