### PR TITLE
Improves telemetry database schema for querying

### DIFF
--- a/oximeter/oximeter/src/db/db-init.sql
+++ b/oximeter/oximeter/src/db/db-init.sql
@@ -9,7 +9,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
     value UInt8
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
@@ -21,7 +20,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
     value Int64
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
@@ -33,7 +31,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
     value Float64
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string
@@ -45,7 +42,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_string
     value String
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
@@ -57,7 +53,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
     value Array(UInt8)
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
@@ -69,7 +64,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
     value Int64
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
@@ -81,7 +75,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
     value Float64
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
@@ -94,7 +87,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
@@ -107,7 +99,6 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, metric_name, timeseries_key)
 ORDER BY (target_name, metric_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_schema
@@ -120,7 +111,6 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_schema
             'I64' = 2,
             'IpAddr' = 3,
             'String' = 4,
-            'Bytes' = 5,
             'Uuid' = 6
     )),
     measurement_type Enum(
@@ -137,7 +127,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_schema
     created DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, fields.name);
+ORDER BY (metric_name, fields.name);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_fields_bool
 (
@@ -148,8 +138,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_fields_bool
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, field_name, timeseries_key)
-ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+ORDER BY (metric_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_fields_i64
 (
@@ -160,8 +149,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_fields_i64
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, field_name, timeseries_key)
-ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+ORDER BY (metric_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_fields_ipaddr
 (
@@ -172,8 +160,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_fields_ipaddr
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, field_name, timeseries_key)
-ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+ORDER BY (metric_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_fields_string
 (
@@ -184,8 +171,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_fields_string
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, field_name, timeseries_key)
-ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+ORDER BY (metric_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.metric_fields_uuid
 (
@@ -196,8 +182,7 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_fields_uuid
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (metric_name, field_name, timeseries_key)
-ORDER BY (metric_name, field_name, timeseries_key, timestamp);
+ORDER BY (metric_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_schema
 (
@@ -209,13 +194,12 @@ CREATE TABLE IF NOT EXISTS oximeter.target_schema
             'I64' = 2,
             'IpAddr' = 3,
             'String' = 4,
-            'Bytes' = 5,
             'Uuid' = 6
     )),
     created DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, fields.name);
+ORDER BY (target_name, fields.name);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_fields_bool
 (
@@ -226,8 +210,7 @@ CREATE TABLE IF NOT EXISTS oximeter.target_fields_bool
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, field_name, timeseries_key)
-ORDER BY (target_name, field_name, timeseries_key, timestamp);
+ORDER BY (target_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_fields_i64
 (
@@ -238,8 +221,7 @@ CREATE TABLE IF NOT EXISTS oximeter.target_fields_i64
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, field_name, timeseries_key)
-ORDER BY (target_name, field_name, timeseries_key, timestamp);
+ORDER BY (target_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_fields_ipaddr
 (
@@ -250,8 +232,7 @@ CREATE TABLE IF NOT EXISTS oximeter.target_fields_ipaddr
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, field_name, timeseries_key)
-ORDER BY (target_name, field_name, timeseries_key, timestamp);
+ORDER BY (target_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_fields_string
 (
@@ -262,8 +243,7 @@ CREATE TABLE IF NOT EXISTS oximeter.target_fields_string
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, field_name, timeseries_key)
-ORDER BY (target_name, field_name, timeseries_key, timestamp);
+ORDER BY (target_name, field_name, field_value, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.target_fields_uuid
 (
@@ -274,5 +254,4 @@ CREATE TABLE IF NOT EXISTS oximeter.target_fields_uuid
     timestamp DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-PRIMARY KEY (target_name, field_name, timeseries_key)
-ORDER BY (target_name, field_name, timeseries_key, timestamp);
+ORDER BY (target_name, field_name, field_value, timestamp);


### PR DESCRIPTION
This commit changes the sorting key for many of the telemetry database
tables, most notably those storing field names/values. Querying will be
implemented by writing clauses like `WHERE field_name = 'foo' and
field_value = 'bar'`. However, the `field_value` column was not
previously in the sorting key, which forces ClickHouse to scan the
entire table for matching records. The new key includes the field value,
which enables the DB to skip records quickly. Example queries can reduce
the number of rows scanned by many orders of magnitude.

Note that while the timeseries key is still part of the index for the
measurement tables, it's also been removed from the field tables. The
key is the concatenation of the field values, which means that the
sorting implied by individual field values often conflicts with the
sorting implied by the timeseries key. At the same time, we're only
_reading_ the timeseries key of matching columns, to then select
measurements with that key, and not really using the key directly when
searching the field tables. So it's at best unhelpful, but more likely
an impediment to an efficient sort order for the way we'll be using the
tables.