### PR TITLE
Unifies targets and metrics early in the sampling process

### DIFF
--- a/oximeter/oximeter-macro-impl/src/lib.rs
+++ b/oximeter/oximeter-macro-impl/src/lib.rs
@@ -137,9 +137,9 @@ fn build_target_trait_impl(
     let refs = names.iter().map(|name| format_ident!("{}", name));
     let name = to_snake_case(&format!("{}", item_name));
 
-    // "target-name:field:field:..."
-    let fmt = format!("{{}}{}", ":{}".repeat(values.len()));
-    let key_formatter = quote! { format!(#fmt, #name, #(self.#refs),*) };
+    // key format: "field0_value:field1_value:..."
+    let fmt = vec!["{}"; values.len()].join(":");
+    let key_formatter = quote! { format!(#fmt, #(self.#refs),*) };
     quote! {
         impl ::oximeter::Target for #item_name {
             fn name(&self) -> &'static str {
@@ -177,12 +177,10 @@ fn build_metric_trait_impl(
     let refs =
         names.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
     let name = to_snake_case(&format!("{}", item_name));
-    let fmt = format!("{}{{}}", "{}:".repeat(values.len()));
-    let key_formatter = if refs.is_empty() {
-        quote! { format!(#fmt, #name) }
-    } else {
-        quote! { format!(#fmt, #(self.#refs),*, #name) }
-    };
+
+    // key format: "field0_value:field1_value:..."
+    let fmt = vec!["{}"; values.len()].join(":");
+    let key_formatter = quote! { format!(#fmt, #(self.#refs),*) };
     let measurement_type =
         syn::parse_str::<syn::Expr>(&format!("{}", measurement_type)).unwrap();
     quote! {

--- a/oximeter/oximeter/src/db/db-init.sql
+++ b/oximeter/oximeter/src/db/db-init.sql
@@ -2,108 +2,154 @@ CREATE DATABASE IF NOT EXISTS oximeter;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value UInt8
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value Int64
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value Float64
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value String
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value Array(UInt8)
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value Int64
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     value Float64
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     bins Array(Int64),
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
 (
-    target_name String,
-    metric_name String,
+    timeseries_name String,
     timeseries_key String,
     timestamp DateTime64(6, 'UTC'),
     bins Array(Float64),
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-ORDER BY (target_name, metric_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp);
 --
-CREATE TABLE IF NOT EXISTS oximeter.metric_schema
+CREATE TABLE IF NOT EXISTS oximeter.fields_bool
 (
-    metric_name String,
+    timeseries_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UInt8,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+ORDER BY (field_name, field_value, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_i64
+(
+    timeseries_name String,
+    timeseries_key String,
+    field_name String,
+    field_value Int64,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+ORDER BY (field_value, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr
+(
+    timeseries_name String,
+    timeseries_key String,
+    field_name String,
+    field_value IPv6,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+ORDER BY (field_name, field_value, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_string
+(
+    timeseries_name String,
+    timeseries_key String,
+    field_name String,
+    field_value String,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+ORDER BY (field_name, field_value, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_uuid
+(
+    timeseries_name String,
+    timeseries_key String,
+    field_name String,
+    field_value UUID,
+    timestamp DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree()
+ORDER BY (field_name, field_value, timestamp);
+--
+CREATE TABLE IF NOT EXISTS oximeter.timeseries_schema
+(
+    timeseries_name String,
     fields Nested(
         name String,
         type Enum(
@@ -112,7 +158,12 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_schema
             'IpAddr' = 3,
             'String' = 4,
             'Uuid' = 6
-    )),
+        ),
+        source Enum(
+            'Target' = 1,
+            'Metric' = 2
+        )
+    ),
     measurement_type Enum(
         'Bool' = 1,
         'I64' = 2,
@@ -127,131 +178,4 @@ CREATE TABLE IF NOT EXISTS oximeter.metric_schema
     created DateTime64(6, 'UTC')
 )
 ENGINE = MergeTree()
-ORDER BY (metric_name, fields.name);
---
-CREATE TABLE IF NOT EXISTS oximeter.metric_fields_bool
-(
-    metric_name String,
-    timeseries_key String,
-    field_name String,
-    field_value UInt8,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (metric_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.metric_fields_i64
-(
-    metric_name String,
-    timeseries_key String,
-    field_name String,
-    field_value Int64,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (metric_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.metric_fields_ipaddr
-(
-    metric_name String,
-    timeseries_key String,
-    field_name String,
-    field_value IPv6,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (metric_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.metric_fields_string
-(
-    metric_name String,
-    timeseries_key String,
-    field_name String,
-    field_value String,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (metric_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.metric_fields_uuid
-(
-    metric_name String,
-    timeseries_key String,
-    field_name String,
-    field_value UUID,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (metric_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_schema
-(
-    target_name String,
-    fields Nested(
-        name String,
-        type Enum(
-            'Bool' = 1,
-            'I64' = 2,
-            'IpAddr' = 3,
-            'String' = 4,
-            'Uuid' = 6
-    )),
-    created DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, fields.name);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_fields_bool
-(
-    target_name String,
-    timeseries_key String,
-    field_name String,
-    field_value UInt8,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_fields_i64
-(
-    target_name String,
-    timeseries_key String,
-    field_name String,
-    field_value Int64,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_fields_ipaddr
-(
-    target_name String,
-    timeseries_key String,
-    field_name String,
-    field_value IPv6,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_fields_string
-(
-    target_name String,
-    timeseries_key String,
-    field_name String,
-    field_value String,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, field_name, field_value, timestamp);
---
-CREATE TABLE IF NOT EXISTS oximeter.target_fields_uuid
-(
-    target_name String,
-    timeseries_key String,
-    field_name String,
-    field_value UUID,
-    timestamp DateTime64(6, 'UTC')
-)
-ENGINE = MergeTree()
-ORDER BY (target_name, field_name, field_value, timestamp);
+ORDER BY (timeseries_name, fields.name);


### PR DESCRIPTION
Metrics and targets are used to distinguish the features we're measuring
from the resources we're monitoring. But the distinction between targets
and metrics gets less important when querying, which I discovered during
the process of actually implementing querying and filtering. For
example, when searching for a timeseries, we want to filter by
field=value pairs, but we don't particularly care whether those fields
apply to the target or metric.

This commit collapses the distinction between targets and metrics during
the process of generating a `Sample`, transforming them into a name and
an ordered sequence of field name/value pairs. The representation in the
database has also been simplified a lot, as there are no longer tables
for each type of field, for _both_ targets and metrics, only a single
field table for each type. The tables for target and metric schema have
also been reduced to just one table for timeseries schema. This really
reduces the code size and complexity -- there was a lot of dispatching
on targets vs. metrics, often in confusing or obtuse ways.

Another important change is introduced here. The timeseries key was
previously constructed as `target_name:field1:field2:...:metric_name`.
The target and metric names have been removed from the key. A timeseries
is identified by its name, which is `target_name:metric_name`, and its
key which is `field1:field2:...`. This should also help lookup in the
database, as the keys and names are orthogonal. Since the metric name
was previously at the _end_ of the timeseries key, this really reduces
the usefulness of the key as a sorting criterion, especially when we're
also sorting by the target/metric name. Keeping them separate reduces
duplicate information in the key, and improves sorting, compression, and
lookup by timeseries key.