### PR TITLE
[nexus] Create a default VPC on project creation

### DIFF
--- a/omicron-nexus/src/nexus.rs
+++ b/omicron-nexus/src/nexus.rs
@@ -312,16 +312,19 @@ impl Nexus {
 
         // Create a default VPC associated with the project.
         let vpc_id = Uuid::new_v4();
-        let _ = self.db_datastore.project_create_vpc(
-            &vpc_id,
-            &project_id,
-            &VpcCreateParams {
-                identity: IdentityMetadataCreateParams {
-                    name: Name::try_from("default").unwrap(),
-                    description: "Default VPC".to_string(),
+        let _ = self
+            .db_datastore
+            .project_create_vpc(
+                &vpc_id,
+                &project_id,
+                &VpcCreateParams {
+                    identity: IdentityMetadataCreateParams {
+                        name: Name::try_from("default").unwrap(),
+                        description: "Default VPC".to_string(),
+                    },
                 },
-            },
-        );
+            )
+            .await?;
 
         Ok(project)
     }


### PR DESCRIPTION
There is room to improve here - the default VPC could be made immutable, and probably *should* be made within a saga, but this allows other APIs to operate on the default unless something more specific is specified.