### PR TITLE
remove unneeded diesel config

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -1,5 +1,0 @@
-# For documentation on how to configure this file,
-# see diesel.rs/guides/configuring-diesel-cli
-
-[print_schema]
-file = "omicron-nexus/src/db/diesel_schema.rs"


### PR DESCRIPTION
This file was left over from early experiments with the Diesel CLI.