### PR TITLE
Use fewer features for the diesel dependency in omicron-common

### DIFF
--- a/omicron-common/Cargo.toml
+++ b/omicron-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1.0"
 async-trait = "0.1.51"
 # Tracking pending 2.0 version.
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e", features = ["postgres", "r2d2", "chrono", "uuid"] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e" }
 futures = "0.3.15"
 http = "0.2.0"
 hyper = "0.14"


### PR DESCRIPTION
These features aren't needed - our usage of Diesel in `omicron-common` is limited to errors and single column conversions (name, generation, bytecount, etc).