### PR TITLE
update README to set RUSTDOCFLAGS too

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ We use Diesel's PostgreSQL support to connect to CockroachDB (which is wire-comp
 
 After doing this, you should have the `pg_config` command on your PATH.  For example, on Helios, you'd want `/opt/ooce/bin` on your PATH.
 
-See the note about setting RUSTFLAGS at build time below.
+See the note about setting RUSTFLAGS and RUSTDOCFLAGS at build time below.
 --
 . CockroachDB v20.2.5.
 +
@@ -106,10 +106,11 @@ the database files will be deleted when you stop the program.
 
 The easiest way to start the required databases is to use the built-in `omicron-dev` tool.  This tool assumes that the `cockroach` and `clickhouse` executables are on your PATH, and match the versions above.
 
-. Set `RUSTFLAGS` in your environment so that built binaries will be able to find your local copy of libpq.  A typical example might look like this:
+. Set `RUSTFLAGS` and `RUSTDOCFLAGS` in your environment so that built binaries will be able to find your local copy of libpq.  A typical example might look like this:
 +
 ----
 $ export RUSTFLAGS="-Clink-args=-R$(pg_config --libdir)"
+$ export RUSTDOCFLAGS="$RUSTFLAGS"
 ----
 + Note that this might be wrong in some configurations or if you're using environment variables to control how the `pq-sys` crate finds libpq.  See https://github.com/oxidecomputer/omicron/issues/213[#213] for details.
 +


### PR DESCRIPTION
See #213.  I somehow missed that if you try to work around this by setting RUSTFLAGS at build time but not RUSTDOCFLAGS, then the oximeter doc-tests fail as well:

```
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests oximeter

running 8 tests
test src/traits.rs - traits::Metric (line 117) ... ok
test src/traits.rs - traits::Target (line 50) ... ok
test src/traits.rs - traits::Metric (line 124) ... ok
test src/traits.rs - traits::Target (line 24) ... FAILED
test src/traits.rs - traits::Producer (line 202) ... FAILED
test src/histogram.rs - histogram::Histogram<T>::with_bins (line 246) ... FAILED
test src/traits.rs - traits::Metric (line 99) ... FAILED
test src/histogram.rs - histogram::Histogram (line 191) ... FAILED

failures:

---- src/traits.rs - traits::Target (line 24) stdout ----
Test executable failed (terminated by signal).

stderr:
ld.so.1: rust_out: fatal: libpq.so.5: open failed: No such file or directory


---- src/traits.rs - traits::Producer (line 202) stdout ----
Test executable failed (terminated by signal).

stderr:
ld.so.1: rust_out: fatal: libpq.so.5: open failed: No such file or directory


---- src/histogram.rs - histogram::Histogram<T>::with_bins (line 246) stdout ----
Test executable failed (terminated by signal).

stderr:
ld.so.1: rust_out: fatal: libpq.so.5: open failed: No such file or directory


---- src/traits.rs - traits::Metric (line 99) stdout ----
Test executable failed (terminated by signal).

stderr:
ld.so.1: rust_out: fatal: libpq.so.5: open failed: No such file or directory


---- src/histogram.rs - histogram::Histogram (line 191) stdout ----
Test executable failed (terminated by signal).

stderr:
ld.so.1: rust_out: fatal: libpq.so.5: open failed: No such file or directory



failures:
    src/histogram.rs - histogram::Histogram (line 191)
    src/histogram.rs - histogram::Histogram<T>::with_bins (line 246)
    src/traits.rs - traits::Metric (line 99)
    src/traits.rs - traits::Producer (line 202)
    src/traits.rs - traits::Target (line 24)

test result: FAILED. 3 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 14.66s

error: test failed, to rerun pass '--doc'
```