### PR TITLE
Extract get/post resource helpers for tests

### DIFF
--- a/omicron-nexus/tests/common/mod.rs
+++ b/omicron-nexus/tests/common/mod.rs
@@ -17,6 +17,8 @@ use std::path::Path;
 use std::time::Duration;
 use uuid::Uuid;
 
+pub mod resource_helpers;
+
 const SLED_AGENT_UUID: &str = "b6d65341-167c-41df-9b5c-41cded99c229";
 const RACK_UUID: &str = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc";
 pub const OXIMETER_UUID: &str = "39e6175b-4df2-4730-b11d-cbc1e60a2e78";

--- a/omicron-nexus/tests/common/resource_helpers.rs
+++ b/omicron-nexus/tests/common/resource_helpers.rs
@@ -1,0 +1,25 @@
+use dropshot::test_util::objects_post;
+use dropshot::test_util::ClientTestContext;
+
+use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_common::api::external::Name;
+use omicron_common::api::external::Project;
+use omicron_common::api::external::ProjectCreateParams;
+use std::convert::TryFrom;
+
+pub async fn create_project(
+    client: &ClientTestContext,
+    project_name: &str,
+) -> Project {
+    objects_post(
+        &client,
+        "/projects",
+        ProjectCreateParams {
+            identity: IdentityMetadataCreateParams {
+                name: Name::try_from(project_name).unwrap(),
+                description: "a pier".to_string(),
+            },
+        },
+    )
+    .await
+}

--- a/omicron-nexus/tests/test_disks.rs
+++ b/omicron-nexus/tests/test_disks.rs
@@ -14,8 +14,6 @@ use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
 use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::Name;
-use omicron_common::api::external::Project;
-use omicron_common::api::external::ProjectCreateParams;
 use omicron_common::SledAgentTestInterfaces as _;
 use omicron_nexus::Nexus;
 use omicron_nexus::TestInterfaces as _;
@@ -31,6 +29,7 @@ use dropshot::test_util::ClientTestContext;
 
 pub mod common;
 use common::identity_eq;
+use common::resource_helpers::create_project;
 use common::test_setup;
 
 #[macro_use]
@@ -50,17 +49,7 @@ async fn test_disks() {
     /* Create a project for testing. */
     let project_name = "springfield-squidport-disks";
     let url_disks = format!("/projects/{}/disks", project_name);
-    let project: Project = objects_post(
-        &client,
-        "/projects",
-        ProjectCreateParams {
-            identity: IdentityMetadataCreateParams {
-                name: Name::try_from(project_name).unwrap(),
-                description: "a pier".to_string(),
-            },
-        },
-    )
-    .await;
+    let project = create_project(client, &project_name).await;
 
     /* List disks.  There aren't any yet. */
     let disks = disks_list(&client, &url_disks).await;

--- a/omicron-nexus/tests/test_instances.rs
+++ b/omicron-nexus/tests/test_instances.rs
@@ -11,8 +11,6 @@ use omicron_common::api::external::InstanceCpuCount;
 use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::InstanceState;
 use omicron_common::api::external::Name;
-use omicron_common::api::external::Project;
-use omicron_common::api::external::ProjectCreateParams;
 use omicron_common::SledAgentTestInterfaces as _;
 use omicron_nexus::Nexus;
 use omicron_nexus::TestInterfaces as _;
@@ -28,6 +26,7 @@ use dropshot::test_util::ClientTestContext;
 
 pub mod common;
 use common::identity_eq;
+use common::resource_helpers::create_project;
 use common::test_setup;
 
 #[macro_use]
@@ -43,17 +42,7 @@ async fn test_instances() {
     /* Create a project that we'll use for testing. */
     let project_name = "springfield-squidport";
     let url_instances = format!("/projects/{}/instances", project_name);
-    let _: Project = objects_post(
-        &client,
-        "/projects",
-        ProjectCreateParams {
-            identity: IdentityMetadataCreateParams {
-                name: Name::try_from(project_name).unwrap(),
-                description: "a pier".to_string(),
-            },
-        },
-    )
-    .await;
+    let _ = create_project(&client, &project_name).await;
 
     /* List instances.  There aren't any yet. */
     let instances = instances_list(&client, &url_instances).await;

--- a/omicron-nexus/tests/test_projects.rs
+++ b/omicron-nexus/tests/test_projects.rs
@@ -1,15 +1,10 @@
-use omicron_common::api::external::IdentityMetadataCreateParams;
-use omicron_common::api::external::Name;
 use omicron_common::api::external::Project;
-use omicron_common::api::external::ProjectCreateParams;
-use std::convert::TryFrom;
 
 use dropshot::test_util::object_get;
 use dropshot::test_util::objects_list_page;
-use dropshot::test_util::objects_post;
-use dropshot::test_util::ClientTestContext;
 
 pub mod common;
+use common::resource_helpers::create_project;
 use common::test_setup;
 
 extern crate slog;
@@ -41,21 +36,4 @@ async fn test_projects() {
     assert_eq!(projects[1].identity.name, p1_name);
 
     cptestctx.teardown().await;
-}
-
-async fn create_project(
-    client: &ClientTestContext,
-    project_name: &str,
-) -> Project {
-    objects_post(
-        &client,
-        "/projects",
-        ProjectCreateParams {
-            identity: IdentityMetadataCreateParams {
-                name: Name::try_from(project_name).unwrap(),
-                description: "a pier".to_string(),
-            },
-        },
-    )
-    .await
 }

--- a/omicron-nexus/tests/test_vpcs.rs
+++ b/omicron-nexus/tests/test_vpcs.rs
@@ -3,8 +3,6 @@ use http::StatusCode;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::Name;
-use omicron_common::api::external::Project;
-use omicron_common::api::external::ProjectCreateParams;
 use omicron_common::api::external::Vpc;
 use omicron_common::api::external::VpcCreateParams;
 use omicron_common::api::external::VpcUpdateParams;
@@ -17,6 +15,7 @@ use dropshot::test_util::ClientTestContext;
 
 pub mod common;
 use common::identity_eq;
+use common::resource_helpers::create_project;
 use common::test_setup;
 
 extern crate slog;
@@ -161,21 +160,4 @@ async fn vpc_put(
 fn vpcs_eq(vpc1: &Vpc, vpc2: &Vpc) {
     identity_eq(&vpc1.identity, &vpc2.identity);
     assert_eq!(vpc1.project_id, vpc2.project_id);
-}
-
-async fn create_project(
-    client: &ClientTestContext,
-    project_name: &str,
-) -> Project {
-    objects_post(
-        &client,
-        "/projects",
-        ProjectCreateParams {
-            identity: IdentityMetadataCreateParams {
-                name: Name::try_from(project_name).unwrap(),
-                description: "a pier".to_string(),
-            },
-        },
-    )
-    .await
 }


### PR DESCRIPTION
The ergonomics in our test files could be a bit better. This is just a start on that bigger idea. We have identical `create_project` functions in the project, instance, and VPC test files. Soon it will be used in the VPC subnets test as well.

I realize if we pull a lot of these out, it starts looking like yet another API client, at which point it almost starts to feel like we should be using a generated client in the tests. Is that a weird thing to do? I'm not sure.