### PR TITLE
clean up build warnings

### DIFF
--- a/omicron-nexus/tests/test_disks.rs
+++ b/omicron-nexus/tests/test_disks.rs
@@ -32,9 +32,6 @@ use common::identity_eq;
 use common::resource_helpers::create_project;
 use common::test_setup;
 
-#[macro_use]
-extern crate slog;
-
 /*
  * TODO-cleanup the mess of URLs used here and in test_instances.rs ought to
  * come from common code.

--- a/omicron-nexus/tests/test_instances.rs
+++ b/omicron-nexus/tests/test_instances.rs
@@ -29,9 +29,6 @@ use common::identity_eq;
 use common::resource_helpers::create_project;
 use common::test_setup;
 
-#[macro_use]
-extern crate slog;
-
 #[tokio::test]
 async fn test_instances() {
     let cptestctx = test_setup("test_instances").await;

--- a/omicron-nexus/tests/test_oximeter.rs
+++ b/omicron-nexus/tests/test_oximeter.rs
@@ -1,6 +1,6 @@
 //! Integration tests for oximeter collectors and producers.
 
-mod common;
+pub mod common;
 
 use uuid::Uuid;
 


### PR DESCRIPTION
This change cleans up several warnings in the build.

This depends on #225.  That one changes the toolchain, and so changes the warnings around.