### PR TITLE
[nexus] [oximeter] Uses DB for storing Oximeter instances

### DIFF
--- a/omicron-nexus/src/db/datastore.rs
+++ b/omicron-nexus/src/db/datastore.rs
@@ -651,6 +651,43 @@ impl DataStore {
         Ok(())
     }
 
+    // Fetch a record for an Oximeter instance, by its ID.
+    pub async fn oximeter_fetch(
+        &self,
+        id: Uuid,
+    ) -> Result<db::model::OximeterInfo, Error> {
+        use db::schema::oximeter::dsl;
+        dsl::oximeter
+            .filter(dsl::id.eq(id))
+            .first_async::<db::model::OximeterInfo>(self.pool())
+            .await
+            .map_err(|e| {
+                Error::from_diesel(
+                    e,
+                    ResourceType::Oximeter,
+                    LookupType::ById(id),
+                )
+            })
+    }
+
+    // List the oximeter collector instances
+    pub async fn oximeter_list(
+        &self,
+        page_params: &DataPageParams<'_, Uuid>,
+    ) -> ListResultVec<db::model::OximeterInfo> {
+        use db::schema::oximeter::dsl;
+        paginated(dsl::oximeter, dsl::id, page_params)
+            .load_async::<db::model::OximeterInfo>(self.pool())
+            .await
+            .map_err(|e| {
+                Error::from_diesel(
+                    e,
+                    ResourceType::Oximeter,
+                    LookupType::Other("Listing All".to_string()),
+                )
+            })
+    }
+
     // Create a record for a new producer endpoint
     pub async fn producer_endpoint_create(
         &self,

--- a/oximeter/oximeter/examples/producer.rs
+++ b/oximeter/oximeter/examples/producer.rs
@@ -81,7 +81,7 @@ impl Producer for CpuBusyProducer {
 
 #[tokio::main]
 async fn main() {
-    let address = "[::1]:12225".parse().unwrap();
+    let address = "[::1]:0".parse().unwrap();
     let dropshot_config =
         ConfigDropshot { bind_address: address, request_body_max_bytes: 2048 };
     let logging_config =


### PR DESCRIPTION
- Removes in-memory map of registered Oximeter instances from Nexus
  object
- Adds methods for fetching and listing records of Oximeter instances
  from the database
- Uses database records to build an Oximeter client when requested, and
  to select an instance when assigning an Oximeter instance to a metric
  producer on registration