### PR TITLE
Update async-bb8-diesel revision, handle more errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,11 +38,12 @@ dependencies = [
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=0a6d535#0a6d535f8ac21b407879e6d7dc5214186a187e08"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=1a5c55d#1a5c55d9e31210fd7dfff944798e89578e3a0dfc"
 dependencies = [
  "async-trait",
  "bb8",
  "diesel",
+ "thiserror",
  "tokio",
 ]
 

--- a/omicron-common/src/api/external/error.rs
+++ b/omicron-common/src/api/external/error.rs
@@ -6,8 +6,6 @@
 
 use crate::api::external::Name;
 use crate::api::external::ResourceType;
-use diesel::result::DatabaseErrorKind as DieselErrorKind;
-use diesel::result::Error as DieselError;
 use dropshot::HttpError;
 use dropshot::HttpErrorResponseBody;
 use serde::Deserialize;
@@ -161,46 +159,6 @@ impl Error {
                     error_message_base, error_response
                 ),
             },
-        }
-    }
-
-    /// Converts a Diesel error to an external type error.
-    pub fn from_diesel(
-        error: DieselError,
-        resource_type: ResourceType,
-        lookup_type: LookupType,
-    ) -> Error {
-        match error {
-            DieselError::NotFound => {
-                Error::ObjectNotFound { type_name: resource_type, lookup_type }
-            }
-            DieselError::DatabaseError(kind, _info) => {
-                Error::unavail(format!("Database error: {:?}", kind).as_str())
-            }
-            _ => Error::internal_error("Unknown diesel error"),
-        }
-    }
-
-    /// Converts a Diesel error to an external type error, when requested as
-    /// part of a creation operation.
-    pub fn from_diesel_create(
-        error: DieselError,
-        resource_type: ResourceType,
-        object_name: &str,
-    ) -> Error {
-        match error {
-            DieselError::DatabaseError(kind, _info) => match kind {
-                DieselErrorKind::UniqueViolation => {
-                    Error::ObjectAlreadyExists {
-                        type_name: resource_type,
-                        object_name: object_name.to_string(),
-                    }
-                }
-                _ => Error::unavail(
-                    format!("Database error: {:?}", kind).as_str(),
-                ),
-            },
-            _ => Error::internal_error("Unknown diesel error"),
         }
     }
 }

--- a/omicron-nexus/Cargo.toml
+++ b/omicron-nexus/Cargo.toml
@@ -10,7 +10,7 @@ path = "../omicron-rpaths"
 anyhow = "1.0"
 async-trait = "0.1.51"
 bb8 = "0.7.1"
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "0a6d535" }
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "1a5c55d" }
 # Tracking pending 2.0 version.
 diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 futures = "0.3.15"

--- a/omicron-nexus/src/db/datastore.rs
+++ b/omicron-nexus/src/db/datastore.rs
@@ -19,7 +19,7 @@
  */
 
 use super::Pool;
-use async_bb8_diesel::{AsyncRunQueryDsl, DieselConnectionManager};
+use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager};
 use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use omicron_common::api;
@@ -38,9 +38,14 @@ use omicron_common::bail_unless;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::db;
-use crate::db::pagination::paginated;
-use crate::db::update_and_check::{UpdateAndCheck, UpdateStatus};
+use crate::db::{
+    self,
+    error::{
+        public_error_from_diesel_pool, public_error_from_diesel_pool_create,
+    },
+    pagination::paginated,
+    update_and_check::{UpdateAndCheck, UpdateStatus},
+};
 
 pub struct DataStore {
     pool: Arc<Pool>,
@@ -51,9 +56,7 @@ impl DataStore {
         DataStore { pool }
     }
 
-    fn pool(
-        &self,
-    ) -> &bb8::Pool<DieselConnectionManager<diesel::PgConnection>> {
+    fn pool(&self) -> &bb8::Pool<ConnectionManager<diesel::PgConnection>> {
         self.pool.pool()
     }
 
@@ -70,7 +73,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::Project,
                     name.as_str(),
@@ -90,7 +93,7 @@ impl DataStore {
             .first_async::<db::model::Project>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::ByName(name.as_str().to_owned()),
@@ -114,7 +117,7 @@ impl DataStore {
             .get_result_async::<db::model::Project>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::ByName(name.as_str().to_owned()),
@@ -136,7 +139,7 @@ impl DataStore {
             .get_result_async::<Uuid>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::ByName(name.as_str().to_owned()),
@@ -154,7 +157,7 @@ impl DataStore {
             .load_async::<db::model::Project>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::Other("Listing All".to_string()),
@@ -172,7 +175,7 @@ impl DataStore {
             .load_async::<db::model::Project>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::Other("Listing All".to_string()),
@@ -196,7 +199,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
                     LookupType::ByName(name.as_str().to_owned()),
@@ -255,7 +258,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::Instance,
                     name.as_str(),
@@ -290,7 +293,7 @@ impl DataStore {
             .load_async::<db::model::Instance>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Instance,
                     LookupType::Other("Listing All".to_string()),
@@ -311,7 +314,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Instance,
                     LookupType::ById(*instance_id),
@@ -334,7 +337,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Instance,
                     LookupType::ByName(instance_name.as_str().to_owned()),
@@ -371,7 +374,7 @@ impl DataStore {
                 UpdateStatus::NotUpdatedButExists => false,
             })
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Instance,
                     LookupType::ById(*instance_id),
@@ -413,7 +416,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Instance,
                     LookupType::ById(*instance_id),
@@ -450,7 +453,7 @@ impl DataStore {
                     .collect()
             })
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::Other("Listing All".to_string()),
@@ -482,7 +485,11 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(e, ResourceType::Disk, name.as_str())
+                public_error_from_diesel_pool_create(
+                    e,
+                    ResourceType::Disk,
+                    name.as_str(),
+                )
             })?;
 
         let runtime = disk.runtime();
@@ -513,7 +520,7 @@ impl DataStore {
             .load_async::<db::model::Disk>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::Other("Listing All".to_string()),
@@ -541,7 +548,7 @@ impl DataStore {
                 UpdateStatus::NotUpdatedButExists => false,
             })
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::ById(*disk_id),
@@ -564,7 +571,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::ById(*disk_id),
@@ -587,7 +594,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::ByName(disk_name.as_str().to_owned()),
@@ -612,7 +619,7 @@ impl DataStore {
             .execute_and_check(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Disk,
                     LookupType::ById(*disk_id),
@@ -642,7 +649,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::Oximeter,
                     "Oximeter Info",
@@ -663,7 +670,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::Oximeter,
                     "Producer Endpoint",
@@ -687,7 +694,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::Oximeter,
                     "Oximeter Assignment",
@@ -712,7 +719,11 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(e, ResourceType::SagaDbg, &name)
+                public_error_from_diesel_pool_create(
+                    e,
+                    ResourceType::SagaDbg,
+                    &name,
+                )
             })?;
         Ok(())
     }
@@ -730,7 +741,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::SagaDbg,
                     "Saga Event",
@@ -758,7 +769,7 @@ impl DataStore {
             .execute_and_check(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::SagaDbg,
                     LookupType::ById(saga_id.0.into()),
@@ -797,7 +808,7 @@ impl DataStore {
             .load_async::<db::model::Vpc>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Vpc,
                     LookupType::Other("Listing All".to_string()),
@@ -822,7 +833,11 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(e, ResourceType::Vpc, name.as_str())
+                public_error_from_diesel_pool_create(
+                    e,
+                    ResourceType::Vpc,
+                    name.as_str(),
+                )
             })?;
         Ok(vpc)
     }
@@ -842,7 +857,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Vpc,
                     LookupType::ById(*vpc_id),
@@ -865,7 +880,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Vpc,
                     LookupType::ByName(vpc_name.as_str().to_owned()),
@@ -884,7 +899,7 @@ impl DataStore {
             .get_result_async::<db::model::Vpc>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::Vpc,
                     LookupType::ById(*vpc_id),
@@ -906,7 +921,7 @@ impl DataStore {
             .load_async::<db::model::VpcSubnet>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::VpcSubnet,
                     LookupType::Other("Listing All".to_string()),
@@ -927,7 +942,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::VpcSubnet,
                     LookupType::ByName(subnet_name.as_str().to_owned()),
@@ -953,7 +968,7 @@ impl DataStore {
             .get_result_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel_create(
+                public_error_from_diesel_pool_create(
                     e,
                     ResourceType::VpcSubnet,
                     name.as_str(),
@@ -973,7 +988,7 @@ impl DataStore {
             .get_result_async::<db::model::VpcSubnet>(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::VpcSubnet,
                     LookupType::ById(*subnet_id),
@@ -997,7 +1012,7 @@ impl DataStore {
             .execute_async(self.pool())
             .await
             .map_err(|e| {
-                Error::from_diesel(
+                public_error_from_diesel_pool(
                     e,
                     ResourceType::VpcSubnet,
                     LookupType::ById(*subnet_id),

--- a/omicron-nexus/src/db/error.rs
+++ b/omicron-nexus/src/db/error.rs
@@ -1,0 +1,104 @@
+//! Error handling and conversions.
+
+use async_bb8_diesel::{ConnectionError, PoolError};
+use diesel::result::DatabaseErrorKind as DieselErrorKind;
+use diesel::result::Error as DieselError;
+use omicron_common::api::external::{
+    Error as PublicError, LookupType, ResourceType,
+};
+
+/// Converts a Diesel pool error to an external error.
+pub fn public_error_from_diesel_pool(
+    error: PoolError,
+    resource_type: ResourceType,
+    lookup_type: LookupType,
+) -> PublicError {
+    match error {
+        PoolError::Connection(error) => match error {
+            ConnectionError::Checkout(error) => {
+                PublicError::ServiceUnavailable {
+                    message: format!(
+                        "Failed to access connection pool: {}",
+                        error
+                    ),
+                }
+            }
+            ConnectionError::Query(error) => {
+                public_error_from_diesel(error, resource_type, lookup_type)
+            }
+        },
+        PoolError::Timeout => {
+            PublicError::unavail("Timeout accessing connection pool")
+        }
+    }
+}
+
+/// Converts a Diesel pool error to an external error,
+/// when requested as part of a creation operation
+pub fn public_error_from_diesel_pool_create(
+    error: PoolError,
+    resource_type: ResourceType,
+    object_name: &str,
+) -> PublicError {
+    match error {
+        PoolError::Connection(error) => match error {
+            ConnectionError::Checkout(error) => {
+                PublicError::ServiceUnavailable {
+                    message: format!(
+                        "Failed to access connection pool: {}",
+                        error
+                    ),
+                }
+            }
+            ConnectionError::Query(error) => public_error_from_diesel_create(
+                error,
+                resource_type,
+                object_name,
+            ),
+        },
+        PoolError::Timeout => {
+            PublicError::unavail("Timeout accessing connection pool")
+        }
+    }
+}
+
+/// Converts a Diesel error to an external error.
+pub fn public_error_from_diesel(
+    error: DieselError,
+    resource_type: ResourceType,
+    lookup_type: LookupType,
+) -> PublicError {
+    match error {
+        DieselError::NotFound => PublicError::ObjectNotFound {
+            type_name: resource_type,
+            lookup_type,
+        },
+        DieselError::DatabaseError(kind, _info) => {
+            PublicError::unavail(format!("Database error: {:?}", kind).as_str())
+        }
+        _ => PublicError::internal_error("Unknown diesel error"),
+    }
+}
+
+/// Converts a Diesel error to an external error, when requested as
+/// part of a creation operation.
+pub fn public_error_from_diesel_create(
+    error: DieselError,
+    resource_type: ResourceType,
+    object_name: &str,
+) -> PublicError {
+    match error {
+        DieselError::DatabaseError(kind, _info) => match kind {
+            DieselErrorKind::UniqueViolation => {
+                PublicError::ObjectAlreadyExists {
+                    type_name: resource_type,
+                    object_name: object_name.to_string(),
+                }
+            }
+            _ => PublicError::unavail(
+                format!("Database error: {:?}", kind).as_str(),
+            ),
+        },
+        _ => PublicError::internal_error("Unknown diesel error"),
+    }
+}

--- a/omicron-nexus/src/db/mod.rs
+++ b/omicron-nexus/src/db/mod.rs
@@ -4,6 +4,7 @@
 
 mod config;
 mod datastore;
+mod error;
 mod pagination;
 mod pool;
 mod saga_recovery;

--- a/omicron-nexus/src/db/pool.rs
+++ b/omicron-nexus/src/db/pool.rs
@@ -25,28 +25,26 @@
  */
 
 use super::Config as DbConfig;
-use async_bb8_diesel::DieselConnectionManager;
+use async_bb8_diesel::ConnectionManager;
 use diesel::PgConnection;
 
 /// Wrapper around a database connection pool.
 ///
 /// Expected to be used as the primary interface to the database.
 pub struct Pool {
-    pool: bb8::Pool<DieselConnectionManager<diesel::PgConnection>>,
+    pool: bb8::Pool<ConnectionManager<diesel::PgConnection>>,
 }
 
 impl Pool {
     pub fn new(db_config: &DbConfig) -> Self {
         let manager =
-            DieselConnectionManager::<PgConnection>::new(&db_config.url.url());
+            ConnectionManager::<PgConnection>::new(&db_config.url.url());
         let pool = bb8::Builder::new().build_unchecked(manager);
         Pool { pool }
     }
 
     /// Returns a reference to the underlying pool.
-    pub fn pool(
-        &self,
-    ) -> &bb8::Pool<DieselConnectionManager<diesel::PgConnection>> {
+    pub fn pool(&self) -> &bb8::Pool<ConnectionManager<diesel::PgConnection>> {
         &self.pool
     }
 }

--- a/omicron-nexus/src/db/saga_recovery.rs
+++ b/omicron-nexus/src/db/saga_recovery.rs
@@ -2,7 +2,7 @@
  * Handles recovery of sagas
  */
 
-use crate::db;
+use crate::db::{self, error::public_error_from_diesel_pool};
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::{ExpressionMethods, QueryDsl};
 use omicron_common::api::external::Error;
@@ -147,7 +147,7 @@ async fn list_unfinished_sagas(
         .load_async(pool.pool())
         .await
         .map_err(|e| {
-            Error::from_diesel(
+            public_error_from_diesel_pool(
                 e,
                 ResourceType::SagaDbg,
                 LookupType::ById(sec_id.0),
@@ -235,7 +235,7 @@ pub async fn load_saga_log(
         .load_async::<db::saga_types::SagaNodeEvent>(pool.pool())
         .await
         .map_err(|e| {
-            Error::from_diesel(
+            public_error_from_diesel_pool(
                 e,
                 ResourceType::SagaDbg,
                 LookupType::ById(saga.id.0 .0),

--- a/omicron-nexus/src/db/update_and_check.rs
+++ b/omicron-nexus/src/db/update_and_check.rs
@@ -1,6 +1,6 @@
 //! CTE implementation for "UPDATE with extended return status".
 
-use async_bb8_diesel::{AsyncRunQueryDsl, DieselConnectionManager};
+use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager, PoolError};
 use diesel::associations::HasTable;
 use diesel::helper_types::*;
 use diesel::pg::Pg;
@@ -138,8 +138,8 @@ where
     /// - Error (row doesn't exist, or other diesel error)
     pub async fn execute_and_check(
         self,
-        pool: &bb8::Pool<DieselConnectionManager<PgConnection>>,
-    ) -> Result<UpdateAndQueryResult<Q>, diesel::result::Error>
+        pool: &bb8::Pool<ConnectionManager<PgConnection>>,
+    ) -> Result<UpdateAndQueryResult<Q>, PoolError>
     where
         // We require this bound to ensure that "Self" is runnable as query.
         Self: LoadQuery<PgConnection, (Option<K>, Option<K>, Q)>,


### PR DESCRIPTION
- Renamed `async_bb8_diesel::DieselConnectionManager` to `async_bb8_diesel::ConnectionManager`.
- Migrated error conversion from `omicron-common` into `omicron-nexus/src/db/errors.rs`. This pushes us
  closer in the direction of "only Nexus depends on diesel", but requires conversion functions be implemented
  as free functions.
- Add handling for "inability to check out connection from connection pool" errors. The handling should
  be contained within `errors.rs`, so this should mostly appear the same at the callsites in `datastore.rs`.

This new revision of `async-bb8-diesel` also supports the async Diesel operations on the direct connections, in
addition to the pool itself. This should allow callers to customize their individual connections as they
see fit.