### PR TITLE
Cleans up Oximeter macros

### DIFF
--- a/oximeter/oximeter/src/traits.rs
+++ b/oximeter/oximeter/src/traits.rs
@@ -61,7 +61,7 @@ pub trait Target {
     fn field_names(&self) -> &'static [&'static str];
 
     /// Return the types of the target's fields.
-    fn field_types(&self) -> &'static [FieldType];
+    fn field_types(&self) -> Vec<FieldType>;
 
     /// Return the values of the target's fields.
     fn field_values(&self) -> Vec<FieldValue>;
@@ -142,7 +142,7 @@ pub trait Metric {
     fn field_names(&self) -> &'static [&'static str];
 
     /// Return the types of the metric's fields.
-    fn field_types(&self) -> &'static [FieldType];
+    fn field_types(&self) -> Vec<FieldType>;
 
     /// Return the values of the metric's fields.
     fn field_values(&self) -> Vec<FieldValue>;

--- a/oximeter/oximeter/src/types.rs
+++ b/oximeter/oximeter/src/types.rs
@@ -37,6 +37,22 @@ impl std::fmt::Display for FieldType {
     }
 }
 
+macro_rules! impl_field_type_from {
+    ($ty:ty, $variant:path) => {
+        impl From<&$ty> for FieldType {
+            fn from(_: &$ty) -> FieldType {
+                $variant
+            }
+        }
+    };
+}
+
+impl_field_type_from! { String, FieldType::String }
+impl_field_type_from! { i64, FieldType::I64 }
+impl_field_type_from! { IpAddr, FieldType::IpAddr }
+impl_field_type_from! { Uuid, FieldType::Uuid }
+impl_field_type_from! { bool, FieldType::Bool }
+
 /// The `FieldValue` contains the value of a target or metric field.
 #[derive(Clone, Debug, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
 pub enum FieldValue {


### PR DESCRIPTION
- Removes string-based type checking for field types. Relies on the
  types that have `impl<T> From<T> for FieldType` instead, similar to
  how the datum type is now handled
- Some code reuse between target/metric macro implementations