### PR TITLE
Fixes some oddities dealing with ClickHouse

### DIFF
--- a/oximeter/oximeter/src/db/model.rs
+++ b/oximeter/oximeter/src/db/model.rs
@@ -1,19 +1,17 @@
 //! Models for timeseries data in ClickHouse
 // Copyright 2021 Oxide Computer Company
 
-use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv6Addr};
-
-use bytes::Bytes;
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
 use crate::histogram;
 use crate::types::{
     self, Cumulative, Datum, DatumType, FieldType, FieldValue, Measurement,
     Sample,
 };
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv6Addr};
+use uuid::Uuid;
 
 /// The name of the database storing all metric information.
 pub const DATABASE_NAME: &str = "oximeter";
@@ -539,8 +537,8 @@ pub(crate) fn schema_for(sample: &Sample) -> TimeseriesSchema {
 
 // A scalar timestamped sample from a gauge timeseries, as extracted from a query to the database.
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct DbTimeseriesScalarGaugeSample<'a, T> {
-    pub timeseries_key: &'a str,
+pub(crate) struct DbTimeseriesScalarGaugeSample<T> {
+    pub timeseries_key: String,
     #[serde(with = "serde_timestamp")]
     pub timestamp: DateTime<Utc>,
     pub datum: T,
@@ -549,8 +547,8 @@ pub(crate) struct DbTimeseriesScalarGaugeSample<'a, T> {
 // A scalar timestamped sample from a cumulative timeseries, as extracted from a query to the
 // database.
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct DbTimeseriesScalarCumulativeSample<'a, T> {
-    pub timeseries_key: &'a str,
+pub(crate) struct DbTimeseriesScalarCumulativeSample<T> {
+    pub timeseries_key: String,
     #[serde(with = "serde_timestamp")]
     pub start_time: DateTime<Utc>,
     #[serde(with = "serde_timestamp")]
@@ -560,14 +558,55 @@ pub(crate) struct DbTimeseriesScalarCumulativeSample<'a, T> {
 
 // A histogram timestamped sample from a timeseries, as extracted from a query to the database.
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct DbTimeseriesHistogramSample<'a, T> {
-    pub timeseries_key: &'a str,
+pub(crate) struct DbTimeseriesHistogramSample<T> {
+    pub timeseries_key: String,
     #[serde(with = "serde_timestamp")]
     pub start_time: DateTime<Utc>,
     #[serde(with = "serde_timestamp")]
     pub timestamp: DateTime<Utc>,
     pub bins: Vec<T>,
     pub counts: Vec<u64>,
+}
+
+impl<T> From<DbTimeseriesScalarGaugeSample<T>> for Measurement
+where
+    Datum: From<T>,
+{
+    fn from(sample: DbTimeseriesScalarGaugeSample<T>) -> Measurement {
+        let datum = Datum::from(sample.datum);
+        Measurement::with_timestamp(sample.timestamp, datum)
+    }
+}
+
+impl<T> From<DbTimeseriesScalarCumulativeSample<T>> for Measurement
+where
+    Datum: From<Cumulative<T>>,
+    T: types::CumulativeType,
+{
+    fn from(sample: DbTimeseriesScalarCumulativeSample<T>) -> Measurement {
+        let cumulative =
+            Cumulative::with_start_time(sample.start_time, sample.datum);
+        let datum = Datum::from(cumulative);
+        Measurement::with_timestamp(sample.timestamp, datum)
+    }
+}
+
+impl<T> From<DbTimeseriesHistogramSample<T>> for Measurement
+where
+    Datum: From<histogram::Histogram<T>>,
+    T: histogram::HistogramSupport,
+{
+    fn from(sample: DbTimeseriesHistogramSample<T>) -> Measurement {
+        let datum = Datum::from(
+            histogram::Histogram::from_arrays(
+                sample.start_time,
+                sample.bins,
+                sample.counts,
+            )
+            .unwrap(),
+        );
+        Measurement::with_timestamp(sample.timestamp, datum)
+    }
 }
 
 fn parse_timeseries_scalar_gauge_measurement<'a, T>(
@@ -578,11 +617,8 @@ where
     Datum: From<T>,
 {
     let sample =
-        serde_json::from_str::<DbTimeseriesScalarGaugeSample<'a, T>>(line)
-            .unwrap();
-    let datum = Datum::from(sample.datum);
-    let measurement = Measurement::with_timestamp(sample.timestamp, datum);
-    (sample.timeseries_key.to_string(), measurement)
+        serde_json::from_str::<DbTimeseriesScalarGaugeSample<T>>(line).unwrap();
+    (sample.timeseries_key.to_string(), sample.into())
 }
 
 fn parse_timeseries_scalar_cumulative_measurement<'a, T>(
@@ -593,37 +629,21 @@ where
     Datum: From<Cumulative<T>>,
 {
     let sample =
-        serde_json::from_str::<DbTimeseriesScalarCumulativeSample<'a, T>>(line)
+        serde_json::from_str::<DbTimeseriesScalarCumulativeSample<T>>(line)
             .unwrap();
-    let cumulative =
-        Cumulative::with_start_time(sample.start_time, sample.datum);
-    let datum = Datum::from(cumulative);
-    let measurement = Measurement::with_timestamp(sample.timestamp, datum);
-    (sample.timeseries_key.to_string(), measurement)
+    (sample.timeseries_key.to_string(), sample.into())
 }
 
-fn parse_timeseries_histogram_measurement<'a, T>(
-    line: &'a str,
+fn parse_timeseries_histogram_measurement<T>(
+    line: &str,
 ) -> (String, Measurement)
 where
     T: Into<Datum> + histogram::HistogramSupport,
     Datum: From<histogram::Histogram<T>>,
 {
     let sample =
-        serde_json::from_str::<DbTimeseriesHistogramSample<'a, T>>(line)
-            .unwrap();
-    let datum = Datum::from(
-        histogram::Histogram::from_arrays(
-            sample.start_time,
-            sample.bins,
-            sample.counts,
-        )
-        .unwrap(),
-    );
-    (
-        sample.timeseries_key.to_string(),
-        Measurement::with_timestamp(sample.timestamp, datum),
-    )
+        serde_json::from_str::<DbTimeseriesHistogramSample<T>>(line).unwrap();
+    (sample.timeseries_key.to_string(), sample.into())
 }
 
 // Parse a line of JSON from the database resulting from `as_select_query`, into a measurement of
@@ -643,7 +663,7 @@ pub(crate) fn parse_measurement_from_row(
             parse_timeseries_scalar_gauge_measurement::<f64>(line)
         }
         DatumType::String => {
-            parse_timeseries_scalar_gauge_measurement::<&str>(line)
+            parse_timeseries_scalar_gauge_measurement::<String>(line)
         }
         DatumType::Bytes => {
             parse_timeseries_scalar_gauge_measurement::<Bytes>(line)
@@ -844,5 +864,21 @@ mod tests {
         } else {
             panic!("Expected a histogram sample");
         }
+    }
+
+    // A regression test for parsing a timeseries key which requires escaping.
+    #[test]
+    fn test_parse_timeseries_key_requiring_escape() {
+        let line = "{\"timeseries_key\": \"foo:\\/some\\/path\", \"timestamp\": \"2021-01-01 01:00:00.123456789\", \"datum\": 2.0 }";
+        let (key, _) = parse_measurement_from_row(line, DatumType::F64);
+        assert_eq!(key, "foo:/some/path");
+    }
+
+    #[test]
+    fn test_parse_string_datum_requiring_escape() {
+        let line = "{\"timeseries_key\": \"foo:bar\", \"timestamp\": \"2021-01-01 01:00:00.123456789\", \"datum\": \"\\/some\\/path\"}";
+        let (_, measurement) =
+            parse_measurement_from_row(line, DatumType::String);
+        assert_eq!(measurement.datum(), &Datum::from("/some/path"));
     }
 }


### PR DESCRIPTION
This commit fixes two bugs dealing with ClickHouse, and adds regressions
for them.

The first is about deserialization of structs which have a `&str` field.
`serde_json` is generally fine about zero-copy, except if the string
requires escaping. In that case, it can no longer deserialize the data
into a `&str`, since it must take ownership and manipulate the returned
buffer. This requires replacing `&'a str` with `Cow<'a, str>` in the DB
model types, specifically for the timeseries key fields. See
https://github.com/serde-rs/serde/issues/1413 for more details. Note
that we also parse all string datum from the DB as `String` directly,
rather than as `&str`, again to avoid this (and because we'll be
converting it to an owned representation soon anyway).

The second bug is handling a ClickHouse oddity. By default, 64-bit
integer types are returned as _quoted_ strings. As in, `"1"` instead of
`1`. This is apparently to support JavaScript's JSON implementation, but
in any case it's not the behavior we expect or want. There is thankfully
a setting to turn this off, which the database client object now sets
when it makes requests returning JSON data. See
https://github.com/ClickHouse/ClickHouse/issues/2375 for more details.