### PR TITLE
Fixes api-identity derive macro tests

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -52,4 +52,4 @@ export PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse"
 # having to rebuild here.
 #
 banner test
-ptime -m cargo +'nightly-2021-09-03' test --locked --verbose
+ptime -m cargo +'nightly-2021-09-03' test --workspace --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,4 +123,4 @@ jobs:
       # rebuild here.
       # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
       # suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} test --locked --verbose
+      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} test --workspace --locked --verbose

--- a/common/src/api/external/api_identity/Cargo.toml
+++ b/common/src/api/external/api_identity/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.0"
 quote = "1.0.0"
-syn = "1.0.17"
+syn = { version = "1.0.17", features = [ "full" ] }

--- a/common/src/api/external/api_identity/src/lib.rs
+++ b/common/src/api/external/api_identity/src/lib.rs
@@ -68,8 +68,8 @@ mod test {
         );
 
         let expected = quote! {
-            impl ApiObjectIdentity for Foo {
-                fn identity(&self) -> &IdentityMetadata {
+            impl crate::api::external::ObjectIdentity for Foo {
+                fn identity(&self) -> &crate::api::external::IdentityMetadata {
                     &self.identity
                 }
             }
@@ -88,6 +88,6 @@ mod test {
         );
 
         let error = ret.unwrap_err();
-        assert!(error.to_string().starts_with("deriving ApiObjectIdentity"));
+        assert!(error.to_string().starts_with("deriving ObjectIdentity"));
     }
 }


### PR DESCRIPTION
- Fixes some mis-merge history in the api-identity derive macro tests
- Adds a `--workspace` flag to the invocation of tests on CI. The cargo
  docs indicate that running in the workspace root, but without the
  `--workspace` flag, is the same as running with the `--workspace`
  flag. However, it looks like the API identity tests haven't been
  running in CI, and invoking locally with the flag and without results
  in running the tests in the former case but not the latter.