### PR TITLE
Modifies some oximeter types to be compatible with OpenAPI

### DIFF
--- a/oximeter/oximeter/src/histogram.rs
+++ b/oximeter/oximeter/src/histogram.rs
@@ -57,17 +57,11 @@ pub enum HistogramError {
 
     /// Error returned when two neighboring bins are not adjoining (there's space between them)
     #[error("Neigboring bins {left} and {right} are not adjoining")]
-    NonAdjoiningBins {
-        left: String,
-        right: String,
-    },
+    NonAdjoiningBins { left: String, right: String },
 
     /// Bin and count arrays are of different sizes.
     #[error("Bin and count arrays must have the same size, found {n_bins} and {n_counts}")]
-    ArraySizeMismatch {
-        n_bins: usize,
-        n_counts: usize
-    },
+    ArraySizeMismatch { n_bins: usize, n_counts: usize },
 }
 
 /// A type storing a range over `T`.
@@ -80,7 +74,7 @@ pub enum BinRange<T> {
     RangeTo(T),
 
     /// A range bounded inclusively below and exclusively above, `start..end`.
-    Range { start: T, end: T},
+    Range { start: T, end: T },
 
     /// A range bounded inclusively below and unbouned above, `start..`.
     RangeFrom(T),

--- a/oximeter/oximeter/src/types.rs
+++ b/oximeter/oximeter/src/types.rs
@@ -80,8 +80,10 @@ impl FieldValue {
         s: &str,
         field_type: FieldType,
     ) -> Result<Self, Error> {
-        let make_err =
-            || Error::ParseError { src: s.to_string(), typ: field_type.to_string() };
+        let make_err = || Error::ParseError {
+            src: s.to_string(),
+            typ: field_type.to_string(),
+        };
         match field_type {
             FieldType::String => Ok(FieldValue::String(s.to_string())),
             FieldType::I64 => {
@@ -370,10 +372,7 @@ pub enum Error {
 
     /// An error parsing a field or measurement from a string.
     #[error("String '{src}' could not be parsed as type '{typ}'")]
-    ParseError {
-        src: String,
-        typ: String
-    },
+    ParseError { src: String, typ: String },
 }
 
 /// A cumulative or counter data type.


### PR DESCRIPTION
The OpenAPI spec emitted by Dropshot doesn't currently handle tuples,
nor is it clear that this is desirable. This modifies some internal
oximeter types so that they can be more cleanly represented in the
OpenAPI spec.