### PR TITLE
Add a traceable Diesel connection structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=1a5c55d#1a5c55d9e31210fd7dfff944798e89578e3a0dfc"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=22c26ef#22c26ef840075a57b18ac2eae3ead989b992773e"
 dependencies = [
  "async-trait",
  "bb8",
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel?rev=a39dd2e#a39dd2ebc5acccb8cde73d40b0d81dde3e073170"
+source = "git+https://github.com/diesel-rs/diesel?rev=ce77c382#ce77c382d2836f6b385225991cf58cb2d2dd65d6"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel?rev=a39dd2e#a39dd2ebc5acccb8cde73d40b0d81dde3e073170"
+source = "git+https://github.com/diesel-rs/diesel?rev=ce77c382#ce77c382d2836f6b385225991cf58cb2d2dd65d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -10,9 +10,9 @@ path = "../rpaths"
 anyhow = "1.0"
 async-trait = "0.1.51"
 bb8 = "0.7.1"
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "1a5c55d" }
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "22c26ef" }
 # Tracking pending 2.0 version.
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "ce77c382", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 futures = "0.3.15"
 http = "0.2.5"
 hyper = "0.14"

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -20,6 +20,7 @@
 
 use super::identity::{Asset, Resource};
 use super::Pool;
+use super::TracedPgConnection;
 use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager};
 use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
@@ -62,7 +63,7 @@ impl DataStore {
         DataStore { pool }
     }
 
-    fn pool(&self) -> &bb8::Pool<ConnectionManager<diesel::PgConnection>> {
+    fn pool(&self) -> &bb8::Pool<ConnectionManager<TracedPgConnection>> {
         self.pool.pool()
     }
 

--- a/nexus/src/db/mod.rs
+++ b/nexus/src/db/mod.rs
@@ -10,6 +10,7 @@ mod pool;
 mod saga_recovery;
 mod saga_types;
 mod sec_store;
+mod traced_pg_connection;
 mod update_and_check;
 
 #[cfg(test)]
@@ -25,3 +26,4 @@ pub use pool::Pool;
 pub use saga_recovery::{recover, RecoveryTask};
 pub use saga_types::SecId;
 pub use sec_store::CockroachDbSecStore;
+pub(crate) use traced_pg_connection::TracedPgConnection;

--- a/nexus/src/db/pool.rs
+++ b/nexus/src/db/pool.rs
@@ -25,26 +25,28 @@
  */
 
 use super::Config as DbConfig;
+use super::TracedPgConnection;
 use async_bb8_diesel::ConnectionManager;
-use diesel::PgConnection;
 
 /// Wrapper around a database connection pool.
 ///
 /// Expected to be used as the primary interface to the database.
 pub struct Pool {
-    pool: bb8::Pool<ConnectionManager<diesel::PgConnection>>,
+    pool: bb8::Pool<ConnectionManager<TracedPgConnection>>,
 }
 
 impl Pool {
     pub fn new(db_config: &DbConfig) -> Self {
         let manager =
-            ConnectionManager::<PgConnection>::new(&db_config.url.url());
+            ConnectionManager::<TracedPgConnection>::new(&db_config.url.url());
         let pool = bb8::Builder::new().build_unchecked(manager);
         Pool { pool }
     }
 
     /// Returns a reference to the underlying pool.
-    pub fn pool(&self) -> &bb8::Pool<ConnectionManager<diesel::PgConnection>> {
+    pub(crate) fn pool(
+        &self,
+    ) -> &bb8::Pool<ConnectionManager<TracedPgConnection>> {
         &self.pool
     }
 }

--- a/nexus/src/db/traced_pg_connection.rs
+++ b/nexus/src/db/traced_pg_connection.rs
@@ -24,6 +24,7 @@ pub(crate) struct TracedPgConnection(PgConnection);
 impl SimpleConnection for TracedPgConnection {
     fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
         // TODO: We should trace this. We have a query string here.
+        println!("batch_execute: {}", query);
         self.0.batch_execute(query)
     }
 }
@@ -43,6 +44,7 @@ impl Connection for TracedPgConnection {
 
     fn execute(&mut self, query: &str) -> QueryResult<usize> {
         // TODO: We should trace this. We have a query string here.
+        println!("execute: {}", query);
         self.0.execute(query)
     }
 
@@ -58,7 +60,9 @@ impl Connection for TracedPgConnection {
         // TODO: This is also worth tracing - it appears to issue a call to the
         // underlying DB using the "raw connection" - so it doesn't call
         // 'execute'.
-        self.0.load(source)
+        let query = source.as_query();
+        println!("load: {}", diesel::debug_query::<Self::Backend, _>(&query));
+        self.0.load(query)
     }
 
     fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>

--- a/nexus/src/db/traced_pg_connection.rs
+++ b/nexus/src/db/traced_pg_connection.rs
@@ -1,0 +1,89 @@
+//! Wrapper around [`diesel::PgConnection`] which adds tracing.
+
+use diesel::connection::{
+    AnsiTransactionManager, ConnectionGatWorkaround, SimpleConnection,
+};
+use diesel::expression::QueryMetadata;
+use diesel::pg::{GetPgMetadataCache, Pg, PgMetadataCache};
+use diesel::prelude::*;
+use diesel::query_builder::{AsQuery, QueryFragment, QueryId};
+use diesel::PgConnection;
+
+/// A wrapper around [`diesel::PgConnection`] enabling tracing.
+///
+/// This struct attempts to mimic nearly the entire public API
+/// of PgConnection - and should be usable in the same spots -
+/// but provides hooks for tracing and logging functions to inspect
+/// operations as they are issued to the database.
+///
+/// NOTE: This function effectively relies on implementation details
+/// of Diesel, and as such, is highly unstable. Modifications beyond
+/// "changes for instrumentation and observability" are not recommended.
+pub(crate) struct TracedPgConnection(PgConnection);
+
+impl SimpleConnection for TracedPgConnection {
+    fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
+        // TODO: We should trace this. We have a query string here.
+        self.0.batch_execute(query)
+    }
+}
+
+impl<'a> ConnectionGatWorkaround<'a, Pg> for TracedPgConnection {
+    type Cursor = <PgConnection as ConnectionGatWorkaround<'a, Pg>>::Cursor;
+    type Row = <PgConnection as ConnectionGatWorkaround<'a, Pg>>::Row;
+}
+
+impl Connection for TracedPgConnection {
+    type Backend = Pg;
+    type TransactionManager = AnsiTransactionManager;
+
+    fn establish(database_url: &str) -> ConnectionResult<TracedPgConnection> {
+        Ok(TracedPgConnection(PgConnection::establish(database_url)?))
+    }
+
+    fn execute(&mut self, query: &str) -> QueryResult<usize> {
+        // TODO: We should trace this. We have a query string here.
+        self.0.execute(query)
+    }
+
+    fn load<T>(
+        &mut self,
+        source: T,
+    ) -> QueryResult<<Self as ConnectionGatWorkaround<Pg>>::Cursor>
+    where
+        T: AsQuery,
+        T::Query: QueryFragment<Self::Backend> + QueryId,
+        Self::Backend: QueryMetadata<T::SqlType>,
+    {
+        // TODO: This is also worth tracing - it appears to issue a call to the
+        // underlying DB using the "raw connection" - so it doesn't call
+        // 'execute'.
+        self.0.load(source)
+    }
+
+    fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>
+    where
+        T: QueryFragment<Pg> + QueryId,
+    {
+        self.0.execute_returning_count(source)
+    }
+
+    fn transaction_state(&mut self) -> &mut AnsiTransactionManager
+    where
+        Self: Sized,
+    {
+        self.0.transaction_state()
+    }
+}
+
+impl GetPgMetadataCache for TracedPgConnection {
+    fn get_metadata_cache(&mut self) -> &mut PgMetadataCache {
+        self.0.get_metadata_cache()
+    }
+}
+
+impl diesel::r2d2::R2D2Connection for TracedPgConnection {
+    fn ping(&mut self) -> QueryResult<()> {
+        self.0.ping()
+    }
+}


### PR DESCRIPTION
FYI @bnaecker - this might be an alternative to the issues we had in https://github.com/oxidecomputer/async-bb8-diesel/pull/7. 

I believe all the "Span" fundamentals mentioned in that PR are still relevant, but this attempts to expose the "raw DB interface to Diesel" a little more explicitly.