### PR TITLE
prototype OpContext

### DIFF
--- a/nexus/src/authn/mod.rs
+++ b/nexus/src/authn/mod.rs
@@ -58,6 +58,11 @@ impl Context {
     pub fn schemes_tried(&self) -> &[SchemeName] {
         &self.schemes_tried
     }
+
+    /// Returns an unauthenticated context for use internally
+    pub fn internal_unauthenticated() -> Context {
+        Context { kind: Kind::Unauthenticated, schemes_tried: vec![] }
+    }
 }
 
 /// Describes whether the user is authenticated and provides more information

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -20,6 +20,7 @@
 
 use super::identity::{Asset, Resource};
 use super::Pool;
+use crate::context::OpContext;
 use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager};
 use chrono::Utc;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
@@ -237,6 +238,7 @@ impl DataStore {
 
     pub async fn organizations_list_by_id(
         &self,
+        opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<Organization> {
         use db::schema::organization::dsl;
@@ -256,6 +258,7 @@ impl DataStore {
 
     pub async fn organizations_list_by_name(
         &self,
+        opctx: &OpContext,
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<Organization> {
         use db::schema::organization::dsl;

--- a/nexus/src/http_entrypoints_external.rs
+++ b/nexus/src/http_entrypoints_external.rs
@@ -3,6 +3,7 @@
  */
 
 use super::ServerContext;
+use crate::context::OpContext;
 use crate::db;
 use crate::db::model::Name;
 
@@ -185,6 +186,7 @@ async fn organizations_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByNameOrId>,
 ) -> Result<HttpResponseOk<ResultsPage<Organization>>, HttpError> {
+    let opctx = OpContext::for_external_api(&rqctx).await?;
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let handler = async {
@@ -195,14 +197,14 @@ async fn organizations_get(
         let organizations = match field {
             PagField::Id => {
                 let page_selector = data_page_params_nameid_id(&rqctx, &query)?;
-                nexus.organizations_list_by_id(&page_selector).await?
+                nexus.organizations_list_by_id(&opctx, &page_selector).await?
             }
 
             PagField::Name => {
                 let page_selector =
                     data_page_params_nameid_name(&rqctx, &query)?
                         .map_name(|n| Name::ref_cast(n));
-                nexus.organizations_list_by_name(&page_selector).await?
+                nexus.organizations_list_by_name(&opctx, &page_selector).await?
             }
         }
         .into_iter()

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -3,6 +3,7 @@
  */
 
 use crate::config;
+use crate::context::OpContext;
 use crate::db;
 use crate::db::identity::{Asset, Resource};
 use crate::db::model::Name;
@@ -410,16 +411,18 @@ impl Nexus {
 
     pub async fn organizations_list_by_name(
         &self,
+        opctx: &OpContext,
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<db::model::Organization> {
-        self.db_datastore.organizations_list_by_name(pagparams).await
+        self.db_datastore.organizations_list_by_name(opctx, pagparams).await
     }
 
     pub async fn organizations_list_by_id(
         &self,
+        opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Organization> {
-        self.db_datastore.organizations_list_by_id(pagparams).await
+        self.db_datastore.organizations_list_by_id(opctx, pagparams).await
     }
 
     pub async fn organization_delete(&self, name: &Name) -> DeleteResult {


### PR DESCRIPTION
This PR is experimental.  I'd like feedback about how this looks.  If it's promising, I can go make the rest of the changes (which will be extensive) to plumb this through in more places.

## Motivation

There are a bunch of things that I think we might want to do in the middle of virtually any code path in Nexus:

- Log a message with key-value pairs related to whatever operation we're doing.  For example, it would be really nice if async-bb8-diesel's `load_async` could log a message that includes the current HTTP request id.  Of course, it doesn't _know_ anything about HTTP requests today, so this needs to be baked into whatever logger it gets.  Slog already has a good pattern for this.  This whole thing is kind of a generalization of that pattern.
- Bump a counter (or any other Oximeter metric) with key-value pairs related to whatever operation we're doing.  Similarly, we could imagine bumping a counter for queries executed inside `async-bb8-diesel`.  Like with logging, we might want that to use key-value pairs related to things async-bb8-diesel doesn't know anything about.
- Fire DTrace probes.  Again, these might want access to current key-value pairs like loggers.
- Do an authorization check.  We don't do these today, but it'd be nice to get to a point where we're able to easily check these anywhere.  I think it's important to get these deep in the stack.  For example, datastore operations could require that the caller has checked that the user is allowed to do something that interacts with the database.

## Proposal

This PR prototypes a unified `OpContext` that bundles this stuff together.  I've seen and used similar patterns a bunch in other places but this is the first time it's been unified and the first time I'm trying to apply it to Rust.

The basic idea is that you create an `OpContext` when you start an operation:

- implemented here: a background task (like saga recovery)
- implemented here: handling an external API request (I only did this for "list organizations" so far)
- not yet implemented: handling an internal API request
- not yet implemented: applying this to sagas

The OpContext includes:

- a `slog::Logger` so that you can always log a message, and it will include whatever key-value pairs are specific to this operation (e.g., request id)
- an `authn::Context` so that you can always do an authz check (not yet implemented -- this is kind of a first step)
- a creation `Instant` (which we can use to measure latency of the overall operation or to any point in the request)
- a creation wall time (this can be useful in the debugger or in logs when correlating events across machines)
- arbitrary key-value metadata.  This is intended for the same reason you can put key-value pairs into slog::Loggers.  But instead of going to the log, these could be used in DTrace probes or tracing spans
- `kind`, which describes what operation we're doing (currently either handling an external API request or running a background operation)

The idea is that we pass the `OpContext` around basically everywhere.  Think of passing this to every Datastore function so that it could log messages and record metrics.  Maybe even down to `async-bb8-diesel`'s `load_async()` and having it log the query in a message that includes the current `request_id`.  This particular example is tricky though -- see below.

## Lots of context

We already have a bunch of contexts in Nexus:

- While handling an HTTP request, `dropshot::RequestContext` gives you information related to the current HTTP request
- While handling an HTTP request, `omicron_nexus::context::Context` gives you access to server-wide state (like a reference to `Nexus` itself)
- While inside a saga action, `steno::ActionContext` gives you information related to the current saga action and some control interfaces
- In any authenticated code path, `authn::Context` tells you about the actor that's currently authenticated.  Eventually this will provide a handle for doing authorization checks.

I think this pattern basically makes sense -- there's just a lot of different state, it's organized by its scope, and different scopes might have different combinations of context.  I could also see the naming being confusing though.

## Things I'm punting on

I want to defer all of this because I think we need experience with a prototype to make informed decisions here.  But if folks think this stuff is important to nail down first (maybe because this feels like a bad direction), please say so.

- Would it be useful to have child contexts?  Slog and distributed tracing already have notions of this and it seems pretty useful.  I hope this would be pretty straightforward to add but I haven't done it here because I wanted to start as small as possible.
- How should this integrate with the existing contexts above?  I toyed with the idea of putting the other contexts _into_ `OpContext`.  That way, you'd only need one object to reach all the others that were relevant for what you were doing.  The ugly thing about this: either `OpContext` takes type parameter(s) describing the contexts inside it -- in which case all the general-purpose functions that accept an `OpContext` need to be parameterized, which feels annoying -- or else the other contexts are only available sometimes (e.g., if `kind == ExternalApiRequest`, you get a dropshot::RequestContext), in which case it feels like a lot of code is going to be doing `unwrap()` because it knows its handling, say, an external API request, but that's not reflected in the type signature.
- How will this work with DTrace probes?  I'm hoping at the very least, code could use the metadata inside the OpContext in probe arguments if they want.
- How will this work with Oximeter-collected metrics?  I'm hoping at the very least, we could provide handles to things like `LatencyTracker` in global `Context` (like we do today) and use key-value pairs from the metadata.
- How will this work with distributed tracing?  I haven't looked into this much at all, but I hope it doesn't look a lot worse than DTrace probes or metrics.
- How does this work with components outside of Omicron?  Right now, OpContext includes the authn context, which is Nexus-specific.  In principle, we might want similar functionality for very general-purpose crates.  You could imagine passing this to `reqwest` so that it can log and record metrics about client requests.  But obviously it won't know about authn.  So do we create some kind of general-purpose thing that can also store special-purpose data?  This problem is very theoretical at this point because most general-purpose crates don't even accept a slog Logger today, let alone something else for metrics, etc.  So I want to punt on it.

Trying to solve all of these simultaneously seems really hard.  I'm just looking to take a step in a useful direction here.