### PR TITLE
Add mandatory authn_schemes_external array to config

### DIFF
--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -5,6 +5,8 @@
 # Identifier for this instance of Nexus
 id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
 
+authn_schemes_external = []
+
 [database]
 # URL for connecting to the database
 url = "postgresql://root@127.0.0.1:32221/omicron?sslmode=disable"


### PR DESCRIPTION
Without this, the SMF Nexus service crashed on boot in Helios