### PR TITLE
Allow authn spoofing

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -11,7 +11,8 @@ id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
 # working on authentication or authorization.  Neither is really implemented
 # yet.
 [authn]
-schemes_external = []
+# TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
+schemes_external = ["spoof"]
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480
 

--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -6,7 +6,8 @@
 id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
 
 [authn]
-schemes_external = []
+# TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
+schemes_external = ["spoof"]
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480
 


### PR DESCRIPTION
This is necessary for examples to be runnable. 

https://github.com/oxidecomputer/omicron/issues/372 tracks removal when we have a replacement.