### PR TITLE
Remove unsafe unwraps

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1403,7 +1403,9 @@ impl TryFrom<String> for RouteTarget {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        RouteTarget::try_from(value.parse::<NetworkTarget>().unwrap())
+        RouteTarget::try_from(
+            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
+        )
     }
 }
 
@@ -1468,7 +1470,9 @@ impl TryFrom<String> for RouteDestination {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        RouteDestination::try_from(value.parse::<NetworkTarget>().unwrap())
+        RouteDestination::try_from(
+            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
+        )
     }
 }
 


### PR DESCRIPTION
These can fail from user input, so we should propagate them as errors