### PR TITLE
WIP: Adding general-purpose metric query endpoints to nexus

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -474,6 +474,7 @@ pub enum ResourceType {
     RouterRoute,
     Oximeter,
     MetricProducer,
+    Timeseries,
 }
 
 impl Display for ResourceType {
@@ -496,6 +497,7 @@ impl Display for ResourceType {
                 ResourceType::RouterRoute => "vpc router route",
                 ResourceType::Oximeter => "oximeter",
                 ResourceType::MetricProducer => "metric producer",
+                ResourceType::Timeseries => "timeseries",
             }
         )
     }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -58,6 +58,10 @@ path = "../sled-agent"
 version = "0.1.0"
 path = "../oximeter/oximeter"
 
+[dependencies.oximeter-db]
+version = "0.1.0"
+path = "../oximeter/db"
+
 [dependencies.oximeter-instruments]
 version = "0.1.0"
 path = "../oximeter/instruments"

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -20,6 +20,10 @@ session_absolute_timeout_minutes = 480
 # URL for connecting to the database
 url = "postgresql://root@127.0.0.1:32221/omicron?sslmode=disable"
 
+[timeseries_db]
+# IP address and TCP port at which to reach the timeseries database
+address = "127.0.0.1:8123"
+
 [dropshot_external]
 # IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12220"

--- a/nexus/src/config.rs
+++ b/nexus/src/config.rs
@@ -9,9 +9,12 @@ use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::serde_as;
 use serde_with::DeserializeFromStr;
+use serde_with::DisplayFromStr;
 use serde_with::SerializeDisplay;
 use std::fmt;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 /*
@@ -29,6 +32,13 @@ pub struct AuthnConfig {
     pub session_absolute_timeout_minutes: u32,
 }
 
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TimeseriesDbConfig {
+    #[serde_as(as = "DisplayFromStr")]
+    pub address: SocketAddr,
+}
+
 /**
  * Configuration for a nexus server
  */
@@ -44,6 +54,8 @@ pub struct Config {
     pub log: ConfigLogging,
     /** Database parameters */
     pub database: db::Config,
+    /** Timeseries database parameters */
+    pub timeseries_db: TimeseriesDbConfig,
     /** Authentication-related configuration */
     pub authn: AuthnConfig,
 }
@@ -149,7 +161,10 @@ impl Config {
 
 #[cfg(test)]
 mod test {
-    use super::{AuthnConfig, Config, LoadError, LoadErrorKind, SchemeName};
+    use super::{
+        AuthnConfig, Config, LoadError, LoadErrorKind, SchemeName,
+        TimeseriesDbConfig,
+    };
     use crate::db;
     use dropshot::ConfigDropshot;
     use dropshot::ConfigLogging;
@@ -269,6 +284,8 @@ mod test {
             request_body_max_bytes = 1024
             [database]
             url = "postgresql://127.0.0.1?sslmode=disable"
+            [timeseries_db]
+            address = "127.0.0.1:8123"
             [log]
             mode = "file"
             level = "debug"
@@ -309,6 +326,9 @@ mod test {
                         .parse()
                         .unwrap()
                 },
+                timeseries_db: TimeseriesDbConfig {
+                    address: "127.0.0.1:8123".parse().unwrap(),
+                },
             }
         );
 
@@ -328,6 +348,8 @@ mod test {
             request_body_max_bytes = 1024
             [database]
             url = "postgresql://127.0.0.1?sslmode=disable"
+            [timeseries_db]
+            address = "127.0.0.1:8123"
             [log]
             mode = "file"
             level = "debug"
@@ -363,6 +385,8 @@ mod test {
             request_body_max_bytes = 1024
             [database]
             url = "postgresql://127.0.0.1?sslmode=disable"
+            [timeseries_db]
+            address = "127.0.0.1:8123"
             [log]
             mode = "file"
             level = "debug"

--- a/nexus/tests/common/mod.rs
+++ b/nexus/tests/common/mod.rs
@@ -97,6 +97,7 @@ pub async fn test_setup_with_config(
     let clickhouse = dev::clickhouse::ClickHouseInstance::new(0).await.unwrap();
 
     config.database.url = database.pg_config().clone();
+    config.timeseries_db.address.set_port(clickhouse.port());
     let server = omicron_nexus::Server::start(&config, &rack_id, &logctx.log)
         .await
         .unwrap();

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -19,6 +19,9 @@ session_absolute_timeout_minutes = 480
 [database]
 url = "postgresql://root@127.0.0.1:0/omicron?sslmode=disable"
 
+[timeseries_db]
+address = "127.0.0.1:0"
+
 #
 # NOTE: for the test suite, the port MUST be 0 (in order to bind to any
 # available port) because the test suite will be running many servers

--- a/nexus/tests/test_oximeter.rs
+++ b/nexus/tests/test_oximeter.rs
@@ -3,6 +3,7 @@
 pub mod common;
 
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
+use oximeter_db::DbWrite;
 use std::net;
 use std::time::Duration;
 use uuid::Uuid;
@@ -101,9 +102,8 @@ async fn test_oximeter_reregistration() {
         0,
     );
     let client =
-        oximeter_db::Client::new(ch_address.into(), context.logctx.log.clone())
-            .await
-            .unwrap();
+        oximeter_db::Client::new(ch_address.into(), context.logctx.log.clone());
+    client.init_db().await.expect("Failed to initialize timeseries database");
 
     // Helper to retrieve the timeseries from ClickHouse
     let timeseries_name = "integration_target:integration_metric";

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -174,6 +174,118 @@
         }
       }
     },
+    "/metrics/schema": {
+      "get": {
+        "description": "Fetch all timeseries schema.",
+        "operationId": "metrics_get_schemas",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_TimeseriesSchema",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TimeseriesSchema"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/schema/{target}/{metric}": {
+      "get": {
+        "description": "Fetch the schema for a metric timeseries by name.",
+        "operationId": "metrics_get_schema",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "metric",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "target",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeseriesSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/timeseries/{target}/{metric}": {
+      "get": {
+        "description": "Fetch a specific metric timeseries by name.",
+        "operationId": "metrics_get_timeseries",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "metric",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "target",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TimeseriesFilters"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_Timeseries",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Timeseries"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/organizations": {
       "get": {
         "description": "List all organizations.",
@@ -2552,11 +2664,350 @@
   },
   "components": {
     "schemas": {
+      "BinRange_for_double": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "RangeTo": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "RangeTo"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "Range": {
+                "type": "object",
+                "properties": {
+                  "end": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "start": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "required": [
+                  "end",
+                  "start"
+                ]
+              }
+            },
+            "required": [
+              "Range"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "A range bounded inclusively below and unbouned above, `start..`.",
+            "type": "object",
+            "properties": {
+              "RangeFrom": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "RangeFrom"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "BinRange_for_int64": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "RangeTo": {
+                "type": "integer",
+                "format": "int64"
+              }
+            },
+            "required": [
+              "RangeTo"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "Range": {
+                "type": "object",
+                "properties": {
+                  "end": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "start": {
+                    "type": "integer",
+                    "format": "int64"
+                  }
+                },
+                "required": [
+                  "end",
+                  "start"
+                ]
+              }
+            },
+            "required": [
+              "Range"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "A range bounded inclusively below and unbouned above, `start..`.",
+            "type": "object",
+            "properties": {
+              "RangeFrom": {
+                "type": "integer",
+                "format": "int64"
+              }
+            },
+            "required": [
+              "RangeFrom"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Bin_for_double": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRange_for_double"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Bin_for_int64": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRange_for_int64"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
       "ByteCount": {
         "description": "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience.",
         "type": "integer",
         "format": "uint64",
         "minimum": 0
+      },
+      "Cumulative_for_double": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
+      "Cumulative_for_int64": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
+      "Datum": {
+        "description": "A `Datum` is a single sampled data point from a metric.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "Bool": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "Bool"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "I64": {
+                "type": "integer",
+                "format": "int64"
+              }
+            },
+            "required": [
+              "I64"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "F64": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "F64"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "String": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "String"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Bytes": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0
+                }
+              }
+            },
+            "required": [
+              "Bytes"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "CumulativeI64": {
+                "$ref": "#/components/schemas/Cumulative_for_int64"
+              }
+            },
+            "required": [
+              "CumulativeI64"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "CumulativeF64": {
+                "$ref": "#/components/schemas/Cumulative_for_double"
+              }
+            },
+            "required": [
+              "CumulativeF64"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "HistogramI64": {
+                "$ref": "#/components/schemas/Histogram_for_int64"
+              }
+            },
+            "required": [
+              "HistogramI64"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "HistogramF64": {
+                "$ref": "#/components/schemas/Histogram_for_double"
+              }
+            },
+            "required": [
+              "HistogramF64"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "DatumType": {
+        "description": "The type of an individual datum of a metric.",
+        "type": "string",
+        "enum": [
+          "Bool",
+          "I64",
+          "F64",
+          "String",
+          "Bytes",
+          "CumulativeI64",
+          "CumulativeF64",
+          "HistogramI64",
+          "HistogramF64"
+        ]
       },
       "Disk": {
         "description": "Client view of an [`Disk`]",
@@ -2823,6 +3274,115 @@
           }
         ]
       },
+      "Field": {
+        "description": "Information about a target or metric field as contained in a schema.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/FieldSource"
+          },
+          "ty": {
+            "$ref": "#/components/schemas/FieldType"
+          }
+        },
+        "required": [
+          "name",
+          "source",
+          "ty"
+        ]
+      },
+      "FieldSource": {
+        "description": "The source, target or metric, from which a field is derived.",
+        "type": "string",
+        "enum": [
+          "Target",
+          "Metric"
+        ]
+      },
+      "FieldType": {
+        "description": "The `FieldType` identifies the data type of a target or metric field.",
+        "type": "string",
+        "enum": [
+          "String",
+          "I64",
+          "IpAddr",
+          "Uuid",
+          "Bool"
+        ]
+      },
+      "Filter": {
+        "description": "A string-typed filter, used to build filters on timeseries fields from external input.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the field.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the field as a string.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "Histogram_for_double": {
+        "description": "A simple type for managing a histogram metric.\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.\n\nExample ------- ```rust use oximeter::histogram::{BinRange, Histogram};\n\nlet edges = [0i64, 10, 20]; let mut hist = Histogram::new(&edges).unwrap(); assert_eq!(hist.n_bins(), 4); // One additional bin for the range (20..) assert_eq!(hist.n_samples(), 0); hist.sample(4); hist.sample(100); assert_eq!(hist.n_samples(), 2);\n\nlet data = hist.iter().collect::<Vec<_>>(); assert_eq!(data[0].range, BinRange::range(i64::MIN, 0)); // An additional bin for `..0` assert_eq!(data[0].count, 0); // Nothing is in this bin\n\nassert_eq!(data[1].range, BinRange::range(0, 10)); // The range `0..10` assert_eq!(data[1].count, 1); // 4 is sampled into this bin ```\n\nNotes -----\n\nHistograms may be constructed either from their left bin edges, or from a sequence of ranges. In either case, the left-most bin may be converted upon construction. In particular, if the left-most value is not equal to the minimum of the support, a new bin will be added from the minimum to that provided value. If the left-most value _is_ the support's minimum, because the provided bin was unbounded below, such as `(..0)`, then that bin will be converted into one bounded below, `(MIN..0)` in this case.\n\nThe short of this is that, most of the time, it shouldn't matter. If one specifies the extremes of the support as their bins, be aware that the left-most may be converted from a `BinRange::RangeTo` into a `BinRange::Range`. In other words, the first bin of a histogram is _always_ a `Bin::Range` or a `Bin::RangeFrom` after construction. In fact, every bin is one of those variants, the `BinRange::RangeTo` is only provided as a convenience during construction.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bin_for_double"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogram_for_int64": {
+        "description": "A simple type for managing a histogram metric.\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.\n\nExample ------- ```rust use oximeter::histogram::{BinRange, Histogram};\n\nlet edges = [0i64, 10, 20]; let mut hist = Histogram::new(&edges).unwrap(); assert_eq!(hist.n_bins(), 4); // One additional bin for the range (20..) assert_eq!(hist.n_samples(), 0); hist.sample(4); hist.sample(100); assert_eq!(hist.n_samples(), 2);\n\nlet data = hist.iter().collect::<Vec<_>>(); assert_eq!(data[0].range, BinRange::range(i64::MIN, 0)); // An additional bin for `..0` assert_eq!(data[0].count, 0); // Nothing is in this bin\n\nassert_eq!(data[1].range, BinRange::range(0, 10)); // The range `0..10` assert_eq!(data[1].count, 1); // 4 is sampled into this bin ```\n\nNotes -----\n\nHistograms may be constructed either from their left bin edges, or from a sequence of ranges. In either case, the left-most bin may be converted upon construction. In particular, if the left-most value is not equal to the minimum of the support, a new bin will be added from the minimum to that provided value. If the left-most value _is_ the support's minimum, because the provided bin was unbounded below, such as `(..0)`, then that bin will be converted into one bounded below, `(MIN..0)` in this case.\n\nThe short of this is that, most of the time, it shouldn't matter. If one specifies the extremes of the support as their bins, be aware that the left-most may be converted from a `BinRange::RangeTo` into a `BinRange::Range`. In other words, the first bin of a histogram is _always_ a `Bin::Range` or a `Bin::RangeFrom` after construction. In fact, every bin is one of those variants, the `BinRange::RangeTo` is only provided as a convenience during construction.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bin_for_int64"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
       "IdentityMetadata": {
         "description": "Identity-related metadata that's included in nearly all public API objects",
         "type": "object",
@@ -3024,6 +3584,46 @@
         "type": "string",
         "pattern": "^(fd|FD)00:((([0-9a-fA-F]{1,4}\\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$",
         "maxLength": 43
+      },
+      "Measurement": {
+        "description": "A `Measurement` is a timestamped datum from a single metric",
+        "type": "object",
+        "properties": {
+          "datum": {
+            "$ref": "#/components/schemas/Datum"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "datum",
+          "timestamp"
+        ]
+      },
+      "Metric": {
+        "description": "Information about a metric, returned to clients in a query",
+        "type": "object",
+        "properties": {
+          "datum_type": {
+            "$ref": "#/components/schemas/DatumType"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "datum_type",
+          "fields",
+          "name"
+        ]
       },
       "Name": {
         "title": "A name used in the API",
@@ -3781,6 +4381,108 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "Target": {
+        "description": "Information about a target, returned to clients in a query",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fields",
+          "name"
+        ]
+      },
+      "Timeseries": {
+        "description": "A list of timestamped measurements from a timeseries.",
+        "type": "object",
+        "properties": {
+          "measurements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Measurement"
+            }
+          },
+          "metric": {
+            "$ref": "#/components/schemas/Metric"
+          },
+          "target": {
+            "$ref": "#/components/schemas/Target"
+          },
+          "timeseries_key": {
+            "type": "string"
+          },
+          "timeseries_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "measurements",
+          "metric",
+          "target",
+          "timeseries_key",
+          "timeseries_name"
+        ]
+      },
+      "TimeseriesFilters": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "before": {
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "field_filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Filter"
+            }
+          }
+        },
+        "required": [
+          "field_filters"
+        ]
+      },
+      "TimeseriesSchema": {
+        "description": "The `TimeseriesSchema` struct represents the schema of a timeseries.",
+        "type": "object",
+        "properties": {
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "datum_type": {
+            "$ref": "#/components/schemas/DatumType"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            }
+          },
+          "timeseries_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "created",
+          "datum_type",
+          "fields",
+          "timeseries_name"
         ]
       },
       "Vpc": {

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -263,7 +263,8 @@ impl OximeterAgent {
         let client_log = log.new(o!("component" => "clickhouse-client"));
 
         // Construct the ClickHouse client first, to propagate an error if needed.
-        let client = Client::new(db_config.address, client_log).await?;
+        let client = Client::new(db_config.address, client_log);
+        client.init_db().await?;
 
         // Spawn the task for aggregating and inserting all metrics
         tokio::spawn(async move {

--- a/oximeter/db/src/bin/oxdb.rs
+++ b/oximeter/db/src/bin/oxdb.rs
@@ -125,7 +125,12 @@ enum Subcommand {
 async fn make_client(port: u16, log: &Logger) -> Result<Client, anyhow::Error> {
     let client_log = log.new(o!("component" => "oximeter_client"));
     let address = SocketAddr::new("::1".parse().unwrap(), port);
-    Client::new(address, client_log).await.context("Failed to connect to DB")
+    let client = Client::new(address, client_log);
+    client
+        .init_db()
+        .await
+        .context("Failed to initialize timeseries database")?;
+    Ok(client)
 }
 
 fn describe_data() {

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -21,26 +21,10 @@ pub struct Client {
 
 impl Client {
     /// Construct a new ClickHouse client of the database at `address`.
-    pub async fn new(address: SocketAddr, log: Logger) -> Result<Self, Error> {
+    pub fn new(address: SocketAddr, log: Logger) -> Self {
         let client = reqwest::Client::new();
         let url = format!("http://{}", address);
-        let out =
-            Self { log, url, client, schema: Mutex::new(BTreeMap::new()) };
-        // TODO-robustness: We may want to remove this init_db call.
-        //
-        // The call will always succeed (assuming the DB can be reached), since the statements for
-        // creating the database and tables have `IF NOT EXISTS` everywhere. It may be preferable
-        // to remove this call and change the statements to _fail_ if the DB is already
-        // initialized. This removes some of the "magic", and allows clients to know if the DB is
-        // already populated or not. It also means we can connect and do stuff (such as wipe)
-        // without first creating a bunch of data.
-        //
-        // For example, we really want to know if the DB is populated when we cold-start the rack,
-        // as that would indicate a serious problem. This should probably trigger an obvious error,
-        // rather than silently succeeding.
-        out.init_db().await?;
-        out.get_schema().await?;
-        Ok(out)
+        Self { log, url, client, schema: Mutex::new(BTreeMap::new()) }
     }
 
     /// Ping the ClickHouse server to verify connectivitiy.
@@ -170,6 +154,14 @@ impl Client {
         Ok(self.schema.lock().unwrap().get(name.as_ref()).map(Clone::clone))
     }
 
+    /// Return all timeseries schema.
+    pub async fn all_schema(
+        &self,
+    ) -> Result<Vec<model::TimeseriesSchema>, Error> {
+        self.get_schema().await?;
+        Ok(self.schema.lock().unwrap().values().cloned().collect())
+    }
+
     // Verifies that the schema for a sample matches the schema in the database.
     //
     // If the schema does not match, an Err is returned (the caller skips the sample in this case).
@@ -207,25 +199,6 @@ impl Client {
             serde_json::to_string(&model::DbTimeseriesSchema::from(schema))
                 .unwrap()
         }))
-    }
-
-    // Initialize ClickHouse with the database and metric table schema.
-    pub(crate) async fn init_db(&self) -> Result<(), Error> {
-        // The HTTP client doesn't support multiple statements per query, so we break them out here
-        // manually.
-        debug!(self.log, "initializing ClickHouse database");
-        let sql = include_str!("./db-init.sql");
-        for query in sql.split("\n--\n") {
-            self.execute(query.to_string()).await?;
-        }
-        Ok(())
-    }
-
-    // Wipe the ClickHouse database entirely.
-    pub async fn wipe_db(&self) -> Result<(), Error> {
-        debug!(self.log, "wiping ClickHouse database");
-        let sql = include_str!("./db-wipe.sql").to_string();
-        self.execute(sql).await
     }
 
     // Execute a generic SQL statement.
@@ -291,6 +264,12 @@ impl Client {
 pub trait DbWrite {
     /// Insert the given samples into the database.
     async fn insert_samples(&self, samples: &[Sample]) -> Result<(), Error>;
+
+    /// Initialize ClickHouse with the database and metric table schema.
+    async fn init_db(&self) -> Result<(), Error>;
+
+    /// Wipe the ClickHouse database entirely.
+    async fn wipe_db(&self) -> Result<(), Error>;
 }
 
 #[async_trait]
@@ -386,6 +365,25 @@ impl DbWrite for Client {
         // many as one per sample. It's not clear how to structure this in a way that's useful.
         Ok(())
     }
+
+    /// Initialize ClickHouse with the database and metric table schema.
+    async fn init_db(&self) -> Result<(), Error> {
+        // The HTTP client doesn't support multiple statements per query, so we break them out here
+        // manually.
+        debug!(self.log, "initializing ClickHouse database");
+        let sql = include_str!("./db-init.sql");
+        for query in sql.split("\n--\n") {
+            self.execute(query.to_string()).await?;
+        }
+        Ok(())
+    }
+
+    /// Wipe the ClickHouse database entirely.
+    async fn wipe_db(&self) -> Result<(), Error> {
+        debug!(self.log, "wiping ClickHouse database");
+        let sql = include_str!("./db-wipe.sql").to_string();
+        self.execute(sql).await
+    }
 }
 
 // Return Ok if the response indicates success, otherwise return either the reqwest::Error, if this
@@ -437,6 +435,7 @@ fn reconstitute_from_schema(
     let (target_fields, metric_fields): (Vec<_>, Vec<_>) = schema
         .fields
         .iter()
+        // TODO-correctness: We need to handle keys with a literal ":" in the name.
         .zip(timeseries_key.split(':'))
         .map(|(field, value_str)| {
             FieldValue::parse_as_type(value_str, field.ty)
@@ -493,7 +492,7 @@ mod tests {
             .expect("Failed to start ClickHouse");
         let address = SocketAddr::new("::1".parse().unwrap(), db.port());
 
-        Client::new(address, log).await.unwrap().wipe_db().await.unwrap();
+        Client::new(address, log).wipe_db().await.unwrap();
         db.cleanup().await.expect("Failed to cleanup ClickHouse server");
     }
 
@@ -507,7 +506,11 @@ mod tests {
             .expect("Failed to start ClickHouse");
         let address = SocketAddr::new("::1".parse().unwrap(), db.port());
 
-        let client = Client::new(address, log).await.unwrap();
+        let client = Client::new(address, log);
+        client
+            .init_db()
+            .await
+            .expect("Failed to initialize timeseries database");
         let samples = {
             let mut s = Vec::with_capacity(8);
             for _ in 0..s.capacity() {
@@ -549,7 +552,11 @@ mod tests {
             .expect("Failed to start ClickHouse");
         let address = SocketAddr::new("::1".parse().unwrap(), db.port());
 
-        let client = Client::new(address, log).await.unwrap();
+        let client = Client::new(address, log);
+        client
+            .init_db()
+            .await
+            .expect("Failed to initialize timeseries database");
         let sample = test_util::make_sample();
         client.insert_samples(&vec![sample]).await.unwrap();
 
@@ -579,7 +586,11 @@ mod tests {
             .expect("Failed to start ClickHouse");
         let address = SocketAddr::new("::1".parse().unwrap(), db.port());
 
-        let client = Client::new(address, log).await.unwrap();
+        let client = Client::new(address, log);
+        client
+            .init_db()
+            .await
+            .expect("Failed to initialize timeseries database");
         let sample = test_util::make_sample();
 
         // Verify that this sample is considered new, i.e., we return rows to update the timeseries
@@ -732,7 +743,11 @@ mod tests {
             .expect("Failed to start ClickHouse");
         let address = SocketAddr::new("::1".parse().unwrap(), db.port());
 
-        let client = Client::new(address, log).await.unwrap();
+        let client = Client::new(address, log);
+        client
+            .init_db()
+            .await
+            .expect("Failed to initialize timeseries database");
 
         // Create sample data
         let (n_projects, n_instances, n_cpus, n_samples) = (2, 2, 2, 2);

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -10,6 +10,8 @@ mod client;
 pub mod model;
 pub mod query;
 pub use client::{Client, DbWrite};
+pub use model::{Metric, Target, Timeseries, TimeseriesSchema};
+pub use query::{FieldFilter, Filter, TimeFilter};
 
 #[derive(Clone, Debug, Error)]
 pub enum Error {

--- a/oximeter/db/src/model.rs
+++ b/oximeter/db/src/model.rs
@@ -9,6 +9,7 @@ use oximeter::types::{
     self, Cumulative, Datum, DatumType, FieldType, FieldValue, Measurement,
     Sample,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv6Addr};
@@ -55,14 +56,14 @@ impl From<DbBool> for Datum {
 }
 
 /// The source, target or metric, from which a field is derived.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum FieldSource {
     Target,
     Metric,
 }
 
 /// Information about a target or metric field as contained in a schema.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Field {
     pub name: String,
     pub ty: FieldType,
@@ -115,7 +116,7 @@ impl From<Vec<Field>> for DbFieldList {
 }
 
 /// The `TimeseriesSchema` struct represents the schema of a timeseries.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct TimeseriesSchema {
     pub timeseries_name: String,
     pub fields: Vec<Field>,
@@ -685,14 +686,14 @@ pub(crate) fn parse_measurement_from_row(
 }
 
 /// Information about a target, returned to clients in a query
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Target {
     pub name: String,
     pub fields: Vec<types::Field>,
 }
 
 /// Information about a metric, returned to clients in a query
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Metric {
     pub name: String,
     pub fields: Vec<types::Field>,
@@ -700,7 +701,7 @@ pub struct Metric {
 }
 
 /// A list of timestamped measurements from a timeseries.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Timeseries {
     pub timeseries_name: String,
     pub timeseries_key: String,

--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -5,6 +5,7 @@ use crate::model::DATABASE_NAME;
 use crate::Error;
 use chrono::{DateTime, Utc};
 use oximeter::types::{DatumType, FieldValue};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
@@ -12,7 +13,7 @@ use std::net::IpAddr;
 ///
 /// Note that the endpoints are interpreted as inclusive, so a timestamp matching the endpoints is
 /// also returned.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub enum TimeFilter {
     /// Passes timestamps before the contained value
     Before(DateTime<Utc>),
@@ -77,7 +78,7 @@ impl TimeFilter {
 }
 
 /// A string-typed filter, used to build filters on timeseries fields from external input.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Filter {
     /// The name of the field.
     pub name: String,

--- a/oximeter/oximeter/src/lib.rs
+++ b/oximeter/oximeter/src/lib.rs
@@ -111,3 +111,29 @@ pub use traits::{Metric, Producer, Target};
 pub use types::{
     Datum, DatumType, Error, Field, FieldType, FieldValue, Measurement, Sample,
 };
+
+/// Format the name of a timeseries, from the names of its target and metric
+pub fn timeseries_name<S>(target_name: S, metric_name: S) -> String
+where
+    S: AsRef<str> + std::fmt::Display,
+{
+    format!("{}:{}", target_name, metric_name)
+}
+
+/// Format the name of a timeseries, from its target and metric objects.
+pub fn timeseries_name_for<T, M>(target: &T, metric: &M) -> String
+where
+    T: Target,
+    M: Metric,
+{
+    timeseries_name(target.name(), metric.name())
+}
+
+/// Format the full timeseries key for a target and metric.
+pub fn timeseries_key<T, M>(target: &T, metric: &M) -> String
+where
+    T: Target,
+    M: Metric,
+{
+    format!("{}:{}", target.key(), metric.key())
+}

--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -15,6 +15,10 @@ session_absolute_timeout_minutes = 480
 # URL for connecting to the database
 url = "postgresql://root@127.0.0.1:32221/omicron?sslmode=disable"
 
+[timeseries_db]
+# IP address and TCP port at which to reach the timeseries database
+address = "127.0.0.1:8123"
+
 [dropshot_external]
 # IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12220"


### PR DESCRIPTION
- Adds endpoint for getting a single timeseries schema by name
- Adds endpoint for getting all timeseries schema
- Adds endpoint for querying for timeseries
- Moves the initialization of the ClickHouse database to a separate
  method, so consumers can make a client object without first requiring
  a connection to the DB. These are now part of the `DbWrite` trait,
  which provides some amount of separation between reading clients and
  the writable client that the oximeter collector has.
- Update tests/config for new ClickHouse database client structure