### PR TITLE
VPC-related nexus functions return models, not views

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1598,7 +1598,10 @@ async fn routers_routes_get(
                 &data_page_params_for(&rqctx, &query)?
                     .map_name(|n| Name::ref_cast(n)),
             )
-            .await?;
+            .await?
+            .into_iter()
+            .map(|route| route.into())
+            .collect();
         Ok(HttpResponseOk(ScanByName::results_page(&query, routes)?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1640,7 +1643,7 @@ async fn routers_routes_get_route(
                 &path.route_name,
             )
             .await?;
-        Ok(HttpResponseOk(route))
+        Ok(HttpResponseOk(route.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1661,7 +1664,7 @@ async fn routers_routes_post(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
-        let router = nexus
+        let route = nexus
             .router_create_route(
                 &path.organization_name,
                 &path.project_name,
@@ -1671,7 +1674,7 @@ async fn routers_routes_post(
                 &create_params.into_inner(),
             )
             .await?;
-        Ok(HttpResponseCreated(router))
+        Ok(HttpResponseCreated(route.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }


### PR DESCRIPTION
Move the `into()` that converts from model to view from the service layer into the endpoint handler.

All the other types of resources already work this way. I'm just bringing the networking stuff into alignment.