### PR TITLE
Adds timeseries name to oximeter query implementation

### DIFF
--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -234,12 +234,13 @@ impl TimeseriesFilter {
                     "{timeseries_name},\n",
                     "{timeseries_key}\n",
                     "FROM {table_name}\n",
-                    "WHERE ({where_fragment})",
+                    "WHERE ({where_fragment} AND (timeseries_name = '{ts_name}'))",
                 ),
                 timeseries_name = indent("timeseries_name", 4),
                 timeseries_key = indent("timeseries_key", 4),
                 table_name = table_name,
                 where_fragment = filter.as_where_fragment(),
+                ts_name = self.timeseries_name,
             )
         };
         self.table_names()
@@ -320,7 +321,7 @@ impl TimeseriesFilter {
             WHERE ({filter_columns}) IN (\n\
             {query}\n\
             ){timestamp_filter}\n\
-            ORDER BY (timeseries_key, timestamp)\n\
+            ORDER BY (timeseries_name, timeseries_key, timestamp)\n\
             FORMAT JSONEachRow;",
             db_name = DATABASE_NAME,
             data_type = db_type_name_for_datum(&datum_type),
@@ -465,7 +466,7 @@ mod tests {
         let query = filter.as_select_query(DatumType::F64);
         let expected = "SELECT * FROM oximeter.measurements_f64 \
             WHERE (timeseries_name) IN ('virtual_machine:cpu_busy') \
-            ORDER BY (timeseries_key, timestamp) \
+            ORDER BY (timeseries_name, timeseries_key, timestamp) \
             FORMAT JSONEachRow;"
             .replace(" ", "");
         assert_eq!(query.replace(|c| c == '\n' || c == ' ', ""), expected);
@@ -484,7 +485,7 @@ mod tests {
             "SELECT * FROM oximeter.measurements_f64 \
             WHERE (timeseries_name) IN ('virtual_machine:cpu_busy') \
             AND {} \
-            ORDER BY (timeseries_key, timestamp) \
+            ORDER BY (timeseries_name, timeseries_key, timestamp) \
             FORMAT JSONEachRow;",
             time.as_where_fragment(),
         )
@@ -504,8 +505,9 @@ mod tests {
             WHERE (timeseries_name, timeseries_key) IN ( \
                 SELECT timeseries_name, timeseries_key \
                 FROM oximeter.fields_i64 \
-                WHERE (field_name = 'cpu_id' AND ((field_value = 0)))) \
-            ORDER BY (timeseries_key, timestamp) \
+                WHERE (field_name = 'cpu_id' AND ((field_value = 0)) AND \
+                    (timeseries_name = 'virtual_machine:cpu_busy'))) \
+            ORDER BY (timeseries_name, timeseries_key, timestamp) \
             FORMAT JSONEachRow;"
             .replace(" ", "");
         assert_eq!(query.replace(|c| c == '\n' || c == ' ', ""), expected,);


### PR DESCRIPTION
The previous implementation incorrectly filtered timeseries on the basis
of their timeseries keys and field names/values only. This isn't quite
right, as many timeseries can share the same key if they happen to have
the same values for the fields. What is unique is the combination of
timeseries name and timeseries key. This adds the timeseries name to the
internal WHERE clause when selecting samples, and the other places
timeseries are expected to be unique. The returned samples are also
ordered by the name, in addition to the key and timestamp as before.