### PR TITLE
Make assets_directory optional. if undefined, assets 404

### DIFF
--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -57,7 +57,7 @@ pub struct ConsoleConfig {
     /** how long browsers can cache static assets */
     pub cache_control_max_age: Duration,
     /** directory containing static assets */
-    pub assets_directory: PathBuf,
+    pub assets_directory: Option<PathBuf>,
 }
 
 impl ServerContext {
@@ -107,18 +107,16 @@ impl ServerContext {
             .register_producer(external_latencies.clone())
             .unwrap();
 
-        let assets_directory = PathBuf::from(
-            env::var("CARGO_MANIFEST_DIR")
-            .map_err(|_e| "env var CARGO_MANIFEST_DIR must be defined because the path for static assets is relative to it")?,
-        )
-        .join(config.console.assets_directory.to_owned());
+        let assets_directory = env::var("CARGO_MANIFEST_DIR")
+            .map(|root| {
+                PathBuf::from(root)
+                    .join(config.console.assets_directory.to_owned())
+            })
+            .ok();
 
-        if !assets_directory.exists() {
-            return Err("assets_directory must exist at start time".to_string());
-        }
-
-        // TODO: check for particular assets, like console index.html
-        // leaving that out for now so we don't break nexus in dev for everyone
+        // TODO: check that asset directory exists, check for particular assets
+        // like console index.html. leaving that out for now so we don't break
+        // nexus in dev for everyone
 
         Ok(Arc::new(ServerContext {
             nexus: Nexus::new_with_id(

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -185,7 +185,10 @@ pub async fn asset(
     let apictx = rqctx.context();
     let path = path_params.into_inner().path;
 
-    let file = find_file(path, &apictx.console_config.assets_directory)?;
+    let file = match &apictx.console_config.assets_directory {
+        Some(assets_directory) => find_file(path, assets_directory),
+        _ => Err(not_found("assets_directory undefined")),
+    }?;
     let file_contents =
         tokio::fs::read(&file).await.map_err(|_| not_found("EBADF"))?;
 
@@ -211,10 +214,13 @@ fn cache_control_header_value(apictx: &Arc<ServerContext>) -> String {
 async fn serve_console_index(
     apictx: &Arc<ServerContext>,
 ) -> Result<Response<Body>, HttpError> {
-    let file = apictx
-        .console_config
-        .assets_directory
-        .join(PathBuf::from("index.html"));
+    let assets_directory =
+        &apictx
+            .console_config
+            .assets_directory
+            .to_owned()
+            .ok_or_else(|| not_found("assets_directory undefined"))?;
+    let file = assets_directory.join(PathBuf::from("index.html"));
     let file_contents =
         tokio::fs::read(&file).await.map_err(|_| not_found("EBADF"))?;
     Ok(Response::builder()


### PR DESCRIPTION
No need to be so strict when we don't even know how we're going to get the assets in there.