### PR TITLE
Separate Instance and propolis UUIDs.

### DIFF
--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -36,6 +36,8 @@ pub struct InstanceRuntimeState {
     pub run_state: InstanceState,
     /// which sled is running this Instance
     pub sled_uuid: Uuid,
+    /// which propolis-server is running this Instance
+    pub propolis_uuid: Uuid,
     /// number of CPUs allocated for this Instance
     pub ncpus: InstanceCpuCount,
     /// memory allocated for this Instance

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -166,6 +166,8 @@ CREATE TABLE omicron.public.instance (
      * servers involved in the migration.
      */
     active_server_id UUID,
+    /* Identifies the underlying propolis-server backing the instance. */
+    active_propolis_id UUID,
 
     /* Instance configuration */
     ncpus INT NOT NULL,

--- a/nexus-client/src/lib.rs
+++ b/nexus-client/src/lib.rs
@@ -66,6 +66,7 @@ impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
         Self {
             run_state: s.run_state.into(),
             sled_uuid: s.sled_uuid,
+            propolis_uuid: s.propolis_uuid,
             ncpus: s.ncpus.into(),
             memory: s.memory.into(),
             hostname: s.hostname,
@@ -84,6 +85,7 @@ impl From<&omicron_common::api::internal::nexus::InstanceRuntimeState>
         Self {
             run_state: s.run_state.into(),
             sled_uuid: s.sled_uuid,
+            propolis_uuid: s.propolis_uuid,
             ncpus: s.ncpus.into(),
             memory: s.memory.into(),
             hostname: s.hostname.clone(),

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -520,6 +520,8 @@ pub struct InstanceRuntimeState {
     // TODO: should this be optional?
     #[column_name = "active_server_id"]
     pub sled_uuid: Uuid,
+    #[column_name = "active_propolis_id"]
+    pub propolis_uuid: Uuid,
     #[column_name = "ncpus"]
     pub ncpus: InstanceCpuCount,
     #[column_name = "memory"]
@@ -545,6 +547,7 @@ impl From<internal::nexus::InstanceRuntimeState> for InstanceRuntimeState {
         Self {
             state: InstanceState::new(state.run_state),
             sled_uuid: state.sled_uuid,
+            propolis_uuid: state.propolis_uuid,
             ncpus: state.ncpus.into(),
             memory: state.memory.into(),
             hostname: state.hostname,
@@ -560,6 +563,7 @@ impl Into<internal::nexus::InstanceRuntimeState> for InstanceRuntimeState {
         internal::nexus::InstanceRuntimeState {
             run_state: *self.state.state(),
             sled_uuid: self.sled_uuid,
+            propolis_uuid: self.propolis_uuid,
             ncpus: self.ncpus.into(),
             memory: self.memory.into(),
             hostname: self.hostname,

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -37,6 +37,7 @@ table! {
         time_state_updated -> Timestamptz,
         state_generation -> Int8,
         active_server_id -> Uuid,
+        active_propolis_id -> Uuid,
         ncpus -> Int8,
         memory -> Int8,
         hostname -> Text,

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -83,7 +83,13 @@ pub fn saga_instance_create() -> SagaTemplate<SagaInstanceCreate> {
     template_builder.append(
         "instance_id",
         "GenerateInstanceId",
-        new_action_noop_undo(sic_generate_instance_id),
+        new_action_noop_undo(sic_generate_uuid),
+    );
+
+    template_builder.append(
+        "propolis_id",
+        "GeneratePropolisId",
+        new_action_noop_undo(sic_generate_uuid),
     );
 
     template_builder.append(
@@ -110,7 +116,7 @@ pub fn saga_instance_create() -> SagaTemplate<SagaInstanceCreate> {
     template_builder.build()
 }
 
-async fn sic_generate_instance_id(
+async fn sic_generate_uuid(
     _: ActionContext<SagaInstanceCreate>,
 ) -> Result<Uuid, ActionError> {
     Ok(Uuid::new_v4())
@@ -134,10 +140,12 @@ async fn sic_create_instance_record(
     let params = sagactx.saga_params();
     let sled_uuid = sagactx.lookup::<Uuid>("server_id");
     let instance_id = sagactx.lookup::<Uuid>("instance_id");
+    let propolis_uuid = sagactx.lookup::<Uuid>("propolis_id");
 
     let runtime = InstanceRuntimeState {
         run_state: InstanceState::Creating,
         sled_uuid: sled_uuid?,
+        propolis_uuid: propolis_uuid?,
         hostname: params.create_params.hostname.clone(),
         memory: params.create_params.memory,
         ncpus: params.create_params.ncpus,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1105,6 +1105,11 @@
               }
             ]
           },
+          "propolis_uuid": {
+            "description": "which propolis-server is running this Instance",
+            "type": "string",
+            "format": "uuid"
+          },
           "run_state": {
             "description": "runtime state of the Instance",
             "allOf": [
@@ -1129,6 +1134,7 @@
           "hostname",
           "memory",
           "ncpus",
+          "propolis_uuid",
           "run_state",
           "sled_uuid",
           "time_updated"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -475,6 +475,11 @@
               }
             ]
           },
+          "propolis_uuid": {
+            "description": "which propolis-server is running this Instance",
+            "type": "string",
+            "format": "uuid"
+          },
           "run_state": {
             "description": "runtime state of the Instance",
             "allOf": [
@@ -499,6 +504,7 @@
           "hostname",
           "memory",
           "ncpus",
+          "propolis_uuid",
           "run_state",
           "sled_uuid",
           "time_updated"

--- a/sled-agent-client/src/lib.rs
+++ b/sled-agent-client/src/lib.rs
@@ -22,6 +22,7 @@ impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
         Self {
             run_state: s.run_state.into(),
             sled_uuid: s.sled_uuid,
+            propolis_uuid: s.propolis_uuid,
             ncpus: s.ncpus.into(),
             memory: s.memory.into(),
             hostname: s.hostname,
@@ -119,6 +120,7 @@ impl From<types::InstanceRuntimeState>
         Self {
             run_state: s.run_state.into(),
             sled_uuid: s.sled_uuid,
+            propolis_uuid: s.propolis_uuid,
             ncpus: s.ncpus.into(),
             memory: s.memory.into(),
             hostname: s.hostname,

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -275,6 +275,7 @@ mod test {
         InstanceStates::new(InstanceRuntimeState {
             run_state: State::Creating,
             sled_uuid: uuid::Uuid::new_v4(),
+            propolis_uuid: uuid::Uuid::new_v4(),
             ncpus: InstanceCpuCount(2),
             memory: ByteCount::from_mebibytes_u32(512),
             hostname: "myvm".to_string(),

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -665,9 +665,14 @@ mod test {
     use tokio::sync::watch;
 
     static INST_UUID_STR: &str = "e398c5d5-5059-4e55-beac-3a1071083aaa";
+    static PROPOLIS_UUID_STR: &str = "ed895b13-55d5-4e0b-88e9-3f4e74d0d936";
 
     fn test_uuid() -> Uuid {
         INST_UUID_STR.parse().unwrap()
+    }
+
+    fn test_propolis_uuid() -> Uuid {
+        PROPOLIS_UUID_STR.parse().unwrap()
     }
 
     // Endpoints for a fake Propolis server.
@@ -876,7 +881,7 @@ mod test {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|_, zone, vnics| {
-                assert_eq!(zone, zone_name(&test_uuid()));
+                assert_eq!(zone, zone_name(&test_propolis_uuid()));
                 assert_eq!(vnics.len(), 1);
                 assert_eq!(vnics[0], vnic_name(0));
                 Ok(())
@@ -888,14 +893,14 @@ mod test {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|zone| {
-                assert_eq!(zone, zone_name(&test_uuid()));
+                assert_eq!(zone, zone_name(&test_propolis_uuid()));
                 Ok(())
             });
 
         let zone_boot_ctx = MockZones::boot_context();
         zone_boot_ctx.expect().times(1).in_sequence(&mut seq).returning(
             |zone| {
-                assert_eq!(zone, zone_name(&test_uuid()));
+                assert_eq!(zone, zone_name(&test_propolis_uuid()));
                 Ok(())
             },
         );
@@ -904,7 +909,7 @@ mod test {
             crate::illumos::svc::wait_for_service_context();
         wait_for_service_ctx.expect().times(1).in_sequence(&mut seq).returning(
             |zone, fmri| {
-                assert_eq!(zone.unwrap(), zone_name(&test_uuid()));
+                assert_eq!(zone.unwrap(), zone_name(&test_propolis_uuid()));
                 assert_eq!(fmri, "svc:/milestone/network:default");
                 Ok(())
             },
@@ -916,7 +921,7 @@ mod test {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|zone, iface| {
-                assert_eq!(zone, zone_name(&test_uuid()));
+                assert_eq!(zone, zone_name(&test_propolis_uuid()));
                 assert_eq!(iface, interface_name(&vnic_name(0)));
                 Ok("127.0.0.1/24".parse().unwrap())
             });
@@ -927,8 +932,8 @@ mod test {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|zone, id, addr| {
-                assert_eq!(zone, zone_name(&test_uuid()));
-                assert_eq!(id, &test_uuid());
+                assert_eq!(zone, zone_name(&test_propolis_uuid()));
+                assert_eq!(id, &test_propolis_uuid());
                 assert_eq!(
                     addr,
                     &"127.0.0.1:12400".parse::<SocketAddr>().unwrap()
@@ -940,7 +945,7 @@ mod test {
             crate::illumos::svc::wait_for_service_context();
         wait_for_service_ctx.expect().times(1).in_sequence(&mut seq).returning(
             |zone, fmri| {
-                let id = test_uuid();
+                let id = test_propolis_uuid();
                 assert_eq!(zone.unwrap(), zone_name(&id));
                 assert_eq!(
                     fmri,
@@ -994,7 +999,7 @@ mod test {
             runtime: InstanceRuntimeState {
                 run_state: InstanceState::Creating,
                 sled_uuid: Uuid::new_v4(),
-                propolis_uuid: Uuid::new_v4(),
+                propolis_uuid: test_propolis_uuid(),
                 ncpus: InstanceCpuCount(2),
                 memory: ByteCount::from_mebibytes_u32(512),
                 hostname: "myvm".to_string(),

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -251,6 +251,7 @@ mod test {
             runtime: InstanceRuntimeState {
                 run_state: InstanceState::Creating,
                 sled_uuid: Uuid::new_v4(),
+                propolis_uuid: Uuid::new_v4(),
                 ncpus: InstanceCpuCount(2),
                 memory: ByteCount::from_mebibytes_u32(512),
                 hostname: "myvm".to_string(),

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -360,6 +360,7 @@ mod test {
             InstanceRuntimeState {
                 run_state: InstanceState::Creating,
                 sled_uuid: uuid::Uuid::new_v4(),
+                propolis_uuid: uuid::Uuid::new_v4(),
                 ncpus: InstanceCpuCount(2),
                 memory: ByteCount::from_mebibytes_u32(512),
                 hostname: "myvm".to_string(),

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 #
 # oxapi_demo: wrapper around curl(1) to run basic requests against the Oxide API
 # prototype server.


### PR DESCRIPTION
As prep for the live migration work, we want to use a separate UUID for the underlying propolis-server rather than the instance's own UUID. During a migration, we'll be spinning up a new propolis but want to keep the user-visible instance id the same.