### PR TITLE
Move more easy views and params into Nexus

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -737,34 +737,6 @@ pub struct Instance {
     pub runtime: InstanceRuntimeState,
 }
 
-/**
- * Create-time parameters for an [`Instance`]
- */
-/*
- * TODO We're ignoring "type" for now because no types are specified by the API.
- * Presumably this will need to be its own kind of API object that can be
- * created, modified, removed, etc.
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct InstanceCreateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataCreateParams,
-    pub ncpus: InstanceCpuCount,
-    pub memory: ByteCount,
-    pub hostname: String, /* TODO-cleanup different type? */
-}
-
-/**
- * Updateable properties of an [`Instance`]
- */
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InstanceUpdateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataUpdateParams,
-}
-
 /*
  * DISKS
  */

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -888,21 +888,6 @@ impl DiskState {
 }
 
 /**
- * Create-time parameters for an [`Disk`]
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct DiskCreateParams {
-    /** common identifying metadata */
-    #[serde(flatten)]
-    pub identity: IdentityMetadataCreateParams,
-    /** id for snapshot from which the Disk should be created, if any */
-    pub snapshot_id: Option<Uuid>, /* TODO should be a name? */
-    /** size of the Disk */
-    pub size: ByteCount,
-}
-
-/**
  * Describes a Disk's attachment to an Instance
  */
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1085,54 +1085,6 @@ impl JsonSchema for Ipv6Net {
     }
 }
 
-/// A VPC subnet represents a logical grouping for instances that allows network traffic between
-/// them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.
-#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct VpcSubnet {
-    /** common identifying metadata */
-    pub identity: IdentityMetadata,
-
-    /** The VPC to which the subnet belongs. */
-    pub vpc_id: Uuid,
-
-    // TODO-design: RFD 21 says that V4 subnets are currently required, and V6 are optional. If a
-    // V6 address is _not_ specified, one is created with a prefix that depends on the VPC and a
-    // unique subnet-specific portion of the prefix (40 and 16 bits for each, respectively).
-    //
-    // We're leaving out the "view" types here for the external HTTP API for now, so it's not clear
-    // how to do the validation of user-specified CIDR blocks, or how to create a block if one is
-    // not given.
-    /** The IPv4 subnet CIDR block. */
-    pub ipv4_block: Option<Ipv4Net>,
-
-    /** The IPv6 subnet CIDR block. */
-    pub ipv6_block: Option<Ipv6Net>,
-}
-
-/**
- * Create-time parameters for a [`VpcSubnet`]
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct VpcSubnetCreateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataCreateParams,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
-}
-
-/**
- * Updateable properties of a [`VpcSubnet`]
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct VpcSubnetUpdateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataUpdateParams,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum VpcRouterKind {

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -35,7 +35,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FormatResult;
 use std::iter::FromIterator;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::str::FromStr;
 use uuid::Uuid;
@@ -897,34 +897,6 @@ pub struct DiskAttachment {
     pub disk_id: Uuid,
     pub disk_name: Name,
     pub disk_state: DiskState,
-}
-
-/*
- * RACKS
- */
-
-/**
- * Client view of an [`Rack`]
- */
-#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Rack {
-    pub identity: IdentityMetadata,
-}
-
-/*
- * SLEDS
- */
-
-/**
- * Client view of an [`Sled`]
- */
-#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Sled {
-    #[serde(flatten)]
-    pub identity: IdentityMetadata,
-    pub service_address: SocketAddr,
 }
 
 /*

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1105,22 +1105,6 @@ pub struct VpcRouter {
     pub vpc_id: Uuid,
 }
 
-/// Create-time parameters for a [`VpcRouter`]
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct VpcRouterCreateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataCreateParams,
-}
-
-/// Updateable properties of a [`VpcRouter`]
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct VpcRouterUpdateParams {
-    #[serde(flatten)]
-    pub identity: IdentityMetadataUpdateParams,
-}
-
 /// Represents all possible network target strings as defined in RFD-21
 /// This enum itself isn't intended to be used directly but rather as a
 /// delegate for subset enums to not have to re-implement all the base type conversions.

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -650,7 +650,7 @@ impl Disk {
     pub fn new(
         disk_id: Uuid,
         project_id: Uuid,
-        params: external::DiskCreateParams,
+        params: params::DiskCreate,
         runtime_initial: DiskRuntimeState,
     ) -> Self {
         let identity = DiskIdentity::new(disk_id, params.identity);

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1083,7 +1083,7 @@ impl VpcRouter {
         router_id: Uuid,
         vpc_id: Uuid,
         kind: external::VpcRouterKind,
-        params: external::VpcRouterCreateParams,
+        params: params::VpcRouterCreate,
     ) -> Self {
         let identity = VpcRouterIdentity::new(router_id, params.identity);
         Self {
@@ -1120,8 +1120,8 @@ pub struct VpcRouterUpdate {
     pub time_modified: DateTime<Utc>,
 }
 
-impl From<external::VpcRouterUpdateParams> for VpcRouterUpdate {
-    fn from(params: external::VpcRouterUpdateParams) -> Self {
+impl From<params::VpcRouterUpdate> for VpcRouterUpdate {
+    fn from(params: params::VpcRouterUpdate) -> Self {
         Self {
             name: params.identity.name.map(Name),
             description: params.identity.description,

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -959,7 +959,7 @@ impl VpcSubnet {
     pub fn new(
         subnet_id: Uuid,
         vpc_id: Uuid,
-        params: external::VpcSubnetCreateParams,
+        params: params::VpcSubnetCreate,
     ) -> Self {
         let identity = VpcSubnetIdentity::new(subnet_id, params.identity);
         Self {
@@ -967,17 +967,6 @@ impl VpcSubnet {
             vpc_id,
             ipv4_block: params.ipv4_block.map(Ipv4Net),
             ipv6_block: params.ipv6_block.map(Ipv6Net),
-        }
-    }
-}
-
-impl Into<external::VpcSubnet> for VpcSubnet {
-    fn into(self) -> external::VpcSubnet {
-        external::VpcSubnet {
-            identity: self.identity(),
-            vpc_id: self.vpc_id,
-            ipv4_block: self.ipv4_block.map(|ip| ip.into()),
-            ipv6_block: self.ipv6_block.map(|ip| ip.into()),
         }
     }
 }
@@ -992,8 +981,8 @@ pub struct VpcSubnetUpdate {
     pub ipv6_block: Option<Ipv6Net>,
 }
 
-impl From<external::VpcSubnetUpdateParams> for VpcSubnetUpdate {
-    fn from(params: external::VpcSubnetUpdateParams) -> Self {
+impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
+    fn from(params: params::VpcSubnetUpdate) -> Self {
         Self {
             name: params.identity.name.map(Name),
             description: params.identity.description,

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -472,7 +472,7 @@ impl Instance {
     pub fn new(
         instance_id: Uuid,
         project_id: Uuid,
-        params: &external::InstanceCreateParams,
+        params: &params::InstanceCreate,
         runtime: InstanceRuntimeState,
     ) -> Self {
         let identity =

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -338,12 +338,6 @@ pub struct Rack {
     pub identity: RackIdentity,
 }
 
-impl Into<external::Rack> for Rack {
-    fn into(self) -> external::Rack {
-        external::Rack { identity: self.identity() }
-    }
-}
-
 /// Database representation of a Sled.
 #[derive(Queryable, Insertable, Debug, Clone, Selectable, Asset)]
 #[table_name = "sled"]
@@ -369,13 +363,6 @@ impl Sled {
     pub fn address(&self) -> SocketAddr {
         // TODO: avoid this unwrap
         SocketAddr::new(self.ip.ip(), u16::try_from(self.port).unwrap())
-    }
-}
-
-impl Into<external::Sled> for Sled {
-    fn into(self) -> external::Sled {
-        let service_address = self.address();
-        external::Sled { identity: self.identity(), service_address }
     }
 }
 

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -44,7 +44,6 @@ use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Disk;
 use omicron_common::api::external::DiskAttachment;
 use omicron_common::api::external::Instance;
-use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::PaginationOrder;
 use omicron_common::api::external::RouterRoute;
 use omicron_common::api::external::RouterRouteCreateParams;
@@ -706,7 +705,7 @@ async fn project_instances_get(
 async fn project_instances_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
-    new_instance: TypedBody<InstanceCreateParams>,
+    new_instance: TypedBody<params::InstanceCreate>,
 ) -> Result<HttpResponseCreated<Instance>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -12,7 +12,7 @@ use crate::ServerContext;
 
 use super::{
     console_api, params,
-    views::{Organization, Project, Vpc},
+    views::{Organization, Project, Rack, Sled, Vpc},
 };
 use crate::context::OpContext;
 use dropshot::endpoint;
@@ -46,13 +46,11 @@ use omicron_common::api::external::DiskAttachment;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::PaginationOrder;
-use omicron_common::api::external::Rack;
 use omicron_common::api::external::RouterRoute;
 use omicron_common::api::external::RouterRouteCreateParams;
 use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::Saga;
-use omicron_common::api::external::Sled;
 use omicron_common::api::external::VpcFirewallRule;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRuleUpdateResult;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -54,9 +54,7 @@ use omicron_common::api::external::VpcFirewallRule;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRuleUpdateResult;
 use omicron_common::api::external::VpcRouter;
-use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_common::api::external::VpcRouterKind;
-use omicron_common::api::external::VpcRouterUpdateParams;
 use ref_cast::RefCast;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -1499,7 +1497,7 @@ async fn vpc_routers_get_router(
 async fn vpc_routers_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
-    create_params: TypedBody<VpcRouterCreateParams>,
+    create_params: TypedBody<params::VpcRouterCreate>,
 ) -> Result<HttpResponseCreated<VpcRouter>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -1557,7 +1555,7 @@ async fn vpc_routers_delete_router(
 async fn vpc_routers_put_router(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcRouterPathParam>,
-    router_params: TypedBody<VpcRouterUpdateParams>,
+    router_params: TypedBody<params::VpcRouterUpdate>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -12,7 +12,7 @@ use crate::ServerContext;
 
 use super::{
     console_api, params,
-    views::{Organization, Project, Rack, Sled, Vpc},
+    views::{Organization, Project, Rack, Sled, Vpc, VpcSubnet},
 };
 use crate::context::OpContext;
 use dropshot::endpoint;
@@ -57,9 +57,6 @@ use omicron_common::api::external::VpcRouter;
 use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_common::api::external::VpcRouterKind;
 use omicron_common::api::external::VpcRouterUpdateParams;
-use omicron_common::api::external::VpcSubnet;
-use omicron_common::api::external::VpcSubnetCreateParams;
-use omicron_common::api::external::VpcSubnetUpdateParams;
 use ref_cast::RefCast;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -1267,7 +1264,7 @@ async fn vpc_subnets_get_subnet(
 async fn vpc_subnets_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
-    create_params: TypedBody<VpcSubnetCreateParams>,
+    create_params: TypedBody<params::VpcSubnetCreate>,
 ) -> Result<HttpResponseCreated<VpcSubnet>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -1324,7 +1321,7 @@ async fn vpc_subnets_delete_subnet(
 async fn vpc_subnets_put_subnet(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcSubnetPathParam>,
-    subnet_params: TypedBody<VpcSubnetUpdateParams>,
+    subnet_params: TypedBody<params::VpcSubnetUpdate>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -43,7 +43,6 @@ use omicron_common::api::external::to_list;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Disk;
 use omicron_common::api::external::DiskAttachment;
-use omicron_common::api::external::DiskCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::PaginationOrder;
@@ -563,7 +562,7 @@ async fn project_disks_get(
 async fn project_disks_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
-    new_disk: TypedBody<DiskCreateParams>,
+    new_disk: TypedBody<params::DiskCreate>,
 ) -> Result<HttpResponseCreated<Disk>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -135,6 +135,26 @@ pub struct VpcSubnetUpdate {
 }
 
 /*
+ * VPC ROUTERS
+ */
+
+/// Create-time parameters for a [`VpcRouter`]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VpcRouterCreate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataCreateParams,
+}
+
+/// Updateable properties of a [`VpcRouter`]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VpcRouterUpdate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataUpdateParams,
+}
+
+/*
  * DISKS
  */
 

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -7,7 +7,8 @@
  */
 
 use omicron_common::api::external::{
-    ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams, Name,
+    ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams,
+    InstanceCpuCount, Name,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,28 @@ pub struct ProjectCreate {
 pub struct ProjectUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
+}
+
+/*
+ * INSTANCES
+ */
+
+/**
+ * Create-time parameters for an [`Instance`]
+ */
+/*
+ * TODO We're ignoring "type" for now because no types are specified by the API.
+ * Presumably this will need to be its own kind of API object that can be
+ * created, modified, removed, etc.
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceCreate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataCreateParams,
+    pub ncpus: InstanceCpuCount,
+    pub memory: ByteCount,
+    pub hostname: String, /* TODO-cleanup different type? */
 }
 
 /*

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -69,11 +69,6 @@ pub struct ProjectUpdate {
 /**
  * Create-time parameters for an [`Instance`]
  */
-/*
- * TODO We're ignoring "type" for now because no types are specified by the API.
- * Presumably this will need to be its own kind of API object that can be
- * created, modified, removed, etc.
- */
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct InstanceCreate {

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -7,10 +7,11 @@
  */
 
 use omicron_common::api::external::{
-    IdentityMetadataCreateParams, IdentityMetadataUpdateParams, Name,
+    ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams, Name,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /*
  * ORGANIZATIONS
@@ -61,7 +62,7 @@ pub struct ProjectUpdate {
 }
 
 /*
- * VPCs
+ * VPCS
  */
 
 /**
@@ -84,4 +85,23 @@ pub struct VpcUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
     pub dns_name: Option<Name>,
+}
+
+/*
+ * DISKS
+ */
+
+/**
+ * Create-time parameters for a [`Disk`]
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiskCreate {
+    /** common identifying metadata */
+    #[serde(flatten)]
+    pub identity: IdentityMetadataCreateParams,
+    /** id for snapshot from which the Disk should be created, if any */
+    pub snapshot_id: Option<Uuid>, /* TODO should be a name? */
+    /** size of the Disk */
+    pub size: ByteCount,
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -8,7 +8,7 @@
 
 use omicron_common::api::external::{
     ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams,
-    InstanceCpuCount, Name,
+    InstanceCpuCount, Ipv4Net, Ipv6Net, Name,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -108,6 +108,30 @@ pub struct VpcUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
     pub dns_name: Option<Name>,
+}
+
+/**
+ * Create-time parameters for a [`VpcSubnet`]
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VpcSubnetCreate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataCreateParams,
+    pub ipv4_block: Option<Ipv4Net>,
+    pub ipv6_block: Option<Ipv6Net>,
+}
+
+/**
+ * Updateable properties of a [`VpcSubnet`]
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VpcSubnetUpdate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataUpdateParams,
+    pub ipv4_block: Option<Ipv4Net>,
+    pub ipv6_block: Option<Ipv6Net>,
 }
 
 /*

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -9,7 +9,9 @@
 use crate::db::identity::{Asset, Resource};
 use crate::db::model;
 use api_identity::ObjectIdentity;
-use omicron_common::api::external::{IdentityMetadata, Name, ObjectIdentity};
+use omicron_common::api::external::{
+    IdentityMetadata, Ipv4Net, Ipv6Net, Name, ObjectIdentity,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -94,6 +96,41 @@ impl Into<Vpc> for model::Vpc {
             project_id: self.project_id,
             system_router_id: self.system_router_id,
             dns_name: self.dns_name.0,
+        }
+    }
+}
+
+/// A VPC subnet represents a logical grouping for instances that allows network traffic between
+/// them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.
+#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct VpcSubnet {
+    /** common identifying metadata */
+    pub identity: IdentityMetadata,
+
+    /** The VPC to which the subnet belongs. */
+    pub vpc_id: Uuid,
+
+    // TODO-design: RFD 21 says that V4 subnets are currently required, and V6 are optional. If a
+    // V6 address is _not_ specified, one is created with a prefix that depends on the VPC and a
+    // unique subnet-specific portion of the prefix (40 and 16 bits for each, respectively).
+    //
+    // We're leaving out the "view" types here for the external HTTP API for now, so it's not clear
+    // how to do the validation of user-specified CIDR blocks, or how to create a block if one is
+    // not given.
+    /** The IPv4 subnet CIDR block. */
+    pub ipv4_block: Option<Ipv4Net>,
+
+    /** The IPv6 subnet CIDR block. */
+    pub ipv6_block: Option<Ipv6Net>,
+}
+
+impl Into<VpcSubnet> for model::VpcSubnet {
+    fn into(self) -> VpcSubnet {
+        VpcSubnet {
+            identity: self.identity(),
+            vpc_id: self.vpc_id,
+            ipv4_block: self.ipv4_block.map(|ip| ip.into()),
+            ipv6_block: self.ipv6_block.map(|ip| ip.into()),
         }
     }
 }

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -6,12 +6,13 @@
  * Views are response bodies, most of which are public lenses onto DB models.
  */
 
-use crate::db::identity::Resource;
+use crate::db::identity::{Asset, Resource};
 use crate::db::model;
 use api_identity::ObjectIdentity;
 use omicron_common::api::external::{IdentityMetadata, Name, ObjectIdentity};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use uuid::Uuid;
 
 /*
@@ -94,5 +95,45 @@ impl Into<Vpc> for model::Vpc {
             system_router_id: self.system_router_id,
             dns_name: self.dns_name.0,
         }
+    }
+}
+
+/*
+ * RACKS
+ */
+
+/**
+ * Client view of an [`Rack`]
+ */
+#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Rack {
+    pub identity: IdentityMetadata,
+}
+
+impl Into<Rack> for model::Rack {
+    fn into(self) -> Rack {
+        Rack { identity: self.identity() }
+    }
+}
+
+/*
+ * SLEDS
+ */
+
+/**
+ * Client view of an [`Sled`]
+ */
+#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Sled {
+    #[serde(flatten)]
+    pub identity: IdentityMetadata,
+    pub service_address: SocketAddr,
+}
+
+impl Into<Sled> for model::Sled {
+    fn into(self) -> Sled {
+        Sled { identity: self.identity(), service_address: self.address() }
     }
 }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -32,7 +32,6 @@ use omicron_common::api::external::DiskAttachment;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
-use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::InstanceState;
 use omicron_common::api::external::Ipv4Net;
 use omicron_common::api::external::Ipv6Net;
@@ -751,7 +750,7 @@ impl Nexus {
         self: &Arc<Self>,
         organization_name: &Name,
         project_name: &Name,
-        params: &InstanceCreateParams,
+        params: &params::InstanceCreate,
     ) -> CreateResult<db::model::Instance> {
         let organization_id = self
             .db_datastore

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -51,8 +51,6 @@ use omicron_common::api::external::VpcFirewallRuleUpdateResult;
 use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_common::api::external::VpcRouterKind;
 use omicron_common::api::external::VpcRouterUpdateParams;
-use omicron_common::api::external::VpcSubnetCreateParams;
-use omicron_common::api::external::VpcSubnetUpdateParams;
 use omicron_common::api::internal::nexus;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::sled_agent::InstanceRuntimeStateRequested;
@@ -1481,7 +1479,7 @@ impl Nexus {
         let subnet = db::model::VpcSubnet::new(
             default_subnet_id,
             vpc_id,
-            VpcSubnetCreateParams {
+            params::VpcSubnetCreate {
                 identity: IdentityMetadataCreateParams {
                     name: "default".parse().unwrap(),
                     description: format!(
@@ -1655,7 +1653,7 @@ impl Nexus {
         organization_name: &Name,
         project_name: &Name,
         vpc_name: &Name,
-        params: &VpcSubnetCreateParams,
+        params: &params::VpcSubnetCreate,
     ) -> CreateResult<db::model::VpcSubnet> {
         let vpc = self
             .project_lookup_vpc(organization_name, project_name, vpc_name)
@@ -1691,7 +1689,7 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         subnet_name: &Name,
-        params: &VpcSubnetUpdateParams,
+        params: &params::VpcSubnetUpdate,
     ) -> UpdateResult<()> {
         let subnet = self
             .vpc_lookup_subnet(

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -29,7 +29,6 @@ use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::DiskAttachment;
-use omicron_common::api::external::DiskCreateParams;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -591,7 +590,7 @@ impl Nexus {
         &self,
         organization_name: &Name,
         project_name: &Name,
-        params: &DiskCreateParams,
+        params: &params::DiskCreate,
     ) -> CreateResult<db::model::Disk> {
         let project =
             self.project_fetch(organization_name, project_name).await?;

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -48,9 +48,7 @@ use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRuleUpdateResult;
-use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_common::api::external::VpcRouterKind;
-use omicron_common::api::external::VpcRouterUpdateParams;
 use omicron_common::api::internal::nexus;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::sled_agent::InstanceRuntimeStateRequested;
@@ -1437,7 +1435,7 @@ impl Nexus {
             system_router_id,
             vpc_id,
             VpcRouterKind::System,
-            VpcRouterCreateParams {
+            params::VpcRouterCreate {
                 identity: IdentityMetadataCreateParams {
                     name: "system".parse().unwrap(),
                     description: "Routes are automatically added to this router as vpc subnets are created".into()
@@ -1742,7 +1740,7 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         kind: &VpcRouterKind,
-        params: &VpcRouterCreateParams,
+        params: &params::VpcRouterCreate,
     ) -> CreateResult<db::model::VpcRouter> {
         let vpc = self
             .project_lookup_vpc(organization_name, project_name, vpc_name)
@@ -1786,7 +1784,7 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         router_name: &Name,
-        params: &VpcRouterUpdateParams,
+        params: &params::VpcRouterUpdate,
     ) -> UpdateResult<()> {
         let router = self
             .vpc_lookup_router(

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -7,9 +7,9 @@
  */
 
 use crate::db;
+use crate::external_api::params;
 use crate::Nexus;
 use omicron_common::api::external::Error;
-use omicron_common::api::external::InstanceCreateParams;
 use sled_agent_client::Client as SledAgentClient;
 use std::fmt;
 use std::sync::Arc;
@@ -48,7 +48,7 @@ impl SagaContext {
      */
     pub async fn alloc_server(
         &self,
-        _params: &InstanceCreateParams,
+        _params: &params::InstanceCreate,
     ) -> Result<Uuid, Error> {
         self.nexus.sled_allocate().await
     }

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -14,11 +14,11 @@
  */
 
 use crate::db;
+use crate::external_api::params;
 use crate::saga_interface::SagaContext;
 use chrono::Utc;
 use lazy_static::lazy_static;
 use omicron_common::api::external::Generation;
-use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::InstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use omicron_common::api::internal::sled_agent::InstanceHardware;
@@ -67,7 +67,7 @@ fn all_templates(
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ParamsInstanceCreate {
     pub project_id: Uuid,
-    pub create_params: InstanceCreateParams,
+    pub create_params: params::InstanceCreate,
 }
 
 #[derive(Debug)]

--- a/nexus/tests/common/resource_helpers.rs
+++ b/nexus/tests/common/resource_helpers.rs
@@ -11,7 +11,6 @@ use dropshot::Method;
 use http::StatusCode;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::VpcRouter;
-use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_nexus::external_api::params;
 use omicron_nexus::external_api::views::{Organization, Project, Vpc};
 
@@ -135,7 +134,7 @@ pub async fn create_router(
             &organization_name, &project_name, &vpc_name
         )
         .as_str(),
-        VpcRouterCreateParams {
+        params::VpcRouterCreate {
             identity: IdentityMetadataCreateParams {
                 name: router_name.parse().unwrap(),
                 description: String::from("router description"),

--- a/nexus/tests/test_basic.rs
+++ b/nexus/tests/test_basic.rs
@@ -20,8 +20,10 @@ use http::StatusCode;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::Name;
-use omicron_common::api::external::Sled;
-use omicron_nexus::external_api::{params, views::Project};
+use omicron_nexus::external_api::{
+    params,
+    views::{Project, Sled},
+};
 use uuid::Uuid;
 
 pub mod common;

--- a/nexus/tests/test_disks.rs
+++ b/nexus/tests/test_disks.rs
@@ -11,14 +11,13 @@ use http::StatusCode;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Disk;
 use omicron_common::api::external::DiskAttachment;
-use omicron_common::api::external::DiskCreateParams;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
 use omicron_common::api::external::InstanceCreateParams;
-use omicron_nexus::Nexus;
 use omicron_nexus::TestInterfaces as _;
+use omicron_nexus::{external_api::params, Nexus};
 use sled_agent_client::TestInterfaces as _;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -82,7 +81,7 @@ async fn test_disks() {
     assert_eq!(error.message, "not found: disk with name \"just-rainsticks\"");
 
     /* Create a disk. */
-    let new_disk = DiskCreateParams {
+    let new_disk = params::DiskCreate {
         identity: IdentityMetadataCreateParams {
             name: "just-rainsticks".parse().unwrap(),
             description: String::from("sells rainsticks"),

--- a/nexus/tests/test_disks.rs
+++ b/nexus/tests/test_disks.rs
@@ -15,7 +15,6 @@ use omicron_common::api::external::DiskState;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
-use omicron_common::api::external::InstanceCreateParams;
 use omicron_nexus::TestInterfaces as _;
 use omicron_nexus::{external_api::params, Nexus};
 use sled_agent_client::TestInterfaces as _;
@@ -134,7 +133,7 @@ async fn test_disks() {
     let instance: Instance = objects_post(
         &client,
         &url_instances,
-        InstanceCreateParams {
+        params::InstanceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "just-rainsticks".parse().unwrap(),
                 description: String::from("sells rainsticks"),
@@ -249,7 +248,7 @@ async fn test_disks() {
     let instance2: Instance = objects_post(
         &client,
         &url_instances,
-        InstanceCreateParams {
+        params::InstanceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "instance2".parse().unwrap(),
                 description: "instance2".to_string(),

--- a/nexus/tests/test_instances.rs
+++ b/nexus/tests/test_instances.rs
@@ -12,10 +12,9 @@ use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
-use omicron_common::api::external::InstanceCreateParams;
 use omicron_common::api::external::InstanceState;
-use omicron_nexus::Nexus;
 use omicron_nexus::TestInterfaces as _;
+use omicron_nexus::{external_api::params, Nexus};
 use sled_agent_client::TestInterfaces as _;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -96,7 +95,7 @@ async fn test_instances_create_reboot_halt() {
 
     /* Create an instance. */
     let instance_url = format!("{}/just-rainsticks", url_instances);
-    let new_instance = InstanceCreateParams {
+    let new_instance = params::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: "just-rainsticks".parse().unwrap(),
             description: "sells rainsticks".to_string(),
@@ -379,7 +378,7 @@ async fn test_instances_delete_fails_when_running_succeeds_when_stopped() {
 
     // Create an instance.
     let instance_url = format!("{}/just-rainsticks", url_instances);
-    let new_instance = InstanceCreateParams {
+    let new_instance = params::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: "just-rainsticks".parse().unwrap(),
             description: "sells rainsticks".to_string(),

--- a/nexus/tests/test_vpc_routers.rs
+++ b/nexus/tests/test_vpc_routers.rs
@@ -7,9 +7,8 @@ use http::StatusCode;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::VpcRouter;
-use omicron_common::api::external::VpcRouterCreateParams;
 use omicron_common::api::external::VpcRouterKind;
-use omicron_common::api::external::VpcRouterUpdateParams;
+use omicron_nexus::external_api::params;
 
 use dropshot::test_util::object_get;
 use dropshot::test_util::objects_list_page;
@@ -63,7 +62,7 @@ async fn test_vpc_routers() {
     assert_eq!(error.message, "not found: vpc router with name \"router1\"");
 
     /* Create a VPC Router. */
-    let new_router = VpcRouterCreateParams {
+    let new_router = params::VpcRouterCreate {
         identity: IdentityMetadataCreateParams {
             name: router_name.parse().unwrap(),
             description: "it's not really a router".to_string(),
@@ -107,7 +106,7 @@ async fn test_vpc_routers() {
     assert_eq!(error.message, "not found: vpc router with name \"router2\"");
 
     // create second custom router
-    let new_router = VpcRouterCreateParams {
+    let new_router = params::VpcRouterCreate {
         identity: IdentityMetadataCreateParams {
             name: router2_name.parse().unwrap(),
             description: "it's also not really a router".to_string(),
@@ -128,7 +127,7 @@ async fn test_vpc_routers() {
     routers_eq(&routers[1], &router2);
 
     // update first router
-    let update_params = VpcRouterUpdateParams {
+    let update_params = params::VpcRouterUpdate {
         identity: IdentityMetadataUpdateParams {
             name: Some("new-name".parse().unwrap()),
             description: Some("another description".to_string()),

--- a/nexus/tests/test_vpc_subnets.rs
+++ b/nexus/tests/test_vpc_subnets.rs
@@ -9,9 +9,7 @@ use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::Ipv4Net;
 use omicron_common::api::external::Ipv6Net;
-use omicron_common::api::external::VpcSubnet;
-use omicron_common::api::external::VpcSubnetCreateParams;
-use omicron_common::api::external::VpcSubnetUpdateParams;
+use omicron_nexus::external_api::{params, views::VpcSubnet};
 
 use dropshot::test_util::object_get;
 use dropshot::test_util::objects_list_page;
@@ -81,7 +79,7 @@ async fn test_vpc_subnets() {
         Some(Ipv4Net("10.1.9.32/16".parse::<Ipv4Network>().unwrap()));
     let ipv6_block =
         Some(Ipv6Net("2001:db8::0/96".parse::<Ipv6Network>().unwrap()));
-    let new_subnet = VpcSubnetCreateParams {
+    let new_subnet = params::VpcSubnetCreate {
         identity: IdentityMetadataCreateParams {
             name: subnet_name.parse().unwrap(),
             description: "it's below the net".to_string(),
@@ -146,7 +144,7 @@ async fn test_vpc_subnets() {
     assert_eq!(error.message, "not found: vpc subnet with name \"subnet2\"");
 
     // create second subnet
-    let new_subnet = VpcSubnetCreateParams {
+    let new_subnet = params::VpcSubnetCreate {
         identity: IdentityMetadataCreateParams {
             name: subnet2_name.parse().unwrap(),
             description: "it's also below the net".to_string(),
@@ -170,7 +168,7 @@ async fn test_vpc_subnets() {
     subnets_eq(&subnets[1], &subnet2);
 
     // update first subnet
-    let update_params = VpcSubnetUpdateParams {
+    let update_params = params::VpcSubnetUpdate {
         identity: IdentityMetadataUpdateParams {
             name: Some("new-name".parse().unwrap()),
             description: Some("another description".to_string()),

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -864,7 +864,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InstanceCreateParams"
+                "$ref": "#/components/schemas/InstanceCreate"
               }
             }
           },
@@ -2443,7 +2443,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VpcSubnetCreateParams"
+                "$ref": "#/components/schemas/VpcSubnetCreate"
               }
             }
           },
@@ -2563,7 +2563,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VpcSubnetUpdateParams"
+                "$ref": "#/components/schemas/VpcSubnetUpdate"
               }
             }
           },
@@ -3102,7 +3102,7 @@
         "format": "uint16",
         "minimum": 0
       },
-      "InstanceCreateParams": {
+      "InstanceCreate": {
         "description": "Create-time parameters for an [`Instance`]",
         "type": "object",
         "properties": {
@@ -4571,7 +4571,7 @@
           "vpc_id"
         ]
       },
-      "VpcSubnetCreateParams": {
+      "VpcSubnetCreate": {
         "description": "Create-time parameters for a [`VpcSubnet`]",
         "type": "object",
         "properties": {
@@ -4624,7 +4624,7 @@
           "items"
         ]
       },
-      "VpcSubnetUpdateParams": {
+      "VpcSubnetUpdate": {
         "description": "Updateable properties of a [`VpcSubnet`]",
         "type": "object",
         "properties": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1812,7 +1812,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VpcRouterCreateParams"
+                "$ref": "#/components/schemas/VpcRouterCreate"
               }
             }
           },
@@ -1932,7 +1932,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VpcRouterUpdateParams"
+                "$ref": "#/components/schemas/VpcRouterUpdate"
               }
             }
           },
@@ -4468,7 +4468,7 @@
           "vpc_id"
         ]
       },
-      "VpcRouterCreateParams": {
+      "VpcRouterCreate": {
         "description": "Create-time parameters for a [`VpcRouter`]",
         "type": "object",
         "properties": {
@@ -4512,7 +4512,7 @@
           "items"
         ]
       },
-      "VpcRouterUpdateParams": {
+      "VpcRouterUpdate": {
         "description": "Updateable properties of a [`VpcRouter`]",
         "type": "object",
         "properties": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -664,7 +664,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DiskCreateParams"
+                "$ref": "#/components/schemas/DiskCreate"
               }
             }
           },
@@ -2801,8 +2801,8 @@
           "instanceId"
         ]
       },
-      "DiskCreateParams": {
-        "description": "Create-time parameters for an [`Disk`]",
+      "DiskCreate": {
+        "description": "Create-time parameters for a [`Disk`]",
         "type": "object",
         "properties": {
           "description": {


### PR DESCRIPTION
More that are only used in Nexus and therefore are just shuffling code and renaming: Rack, Sled, VpcSubnet, InstanceCreate, InstanceUpdate, DiskCreate.