### PR TITLE
update nightly to 2021-11-24

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build-and-test"
 #: variety = "basic"
 #: target = "helios"
-#: rust_toolchain = "nightly-2021-09-03"
+#: rust_toolchain = "nightly-2021-11-24"
 #: output_rules = []
 #:
 
@@ -28,12 +28,10 @@ rustc --version
 #   run.  Building with `--locked` ensures that the checked-in Cargo.lock
 #   is up to date.
 #
-# - Work-around for cargo#9895 via RUSTDOCFLAGS also.
-#
 banner build
 export RUSTFLAGS="-D warnings"
-export RUSTDOCFLAGS="-D warnings -Clink-args=-Wl,-R$(pg_config --libdir)"
-ptime -m cargo +'nightly-2021-09-03' build --locked --all-targets --verbose
+export RUSTDOCFLAGS="-D warnings"
+ptime -m cargo +'nightly-2021-11-24' build --locked --all-targets --verbose
 
 banner clickhouse
 ptime -m ./tools/ci_download_clickhouse
@@ -52,4 +50,4 @@ export PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse"
 # having to rebuild here.
 #
 banner test
-ptime -m cargo +'nightly-2021-09-03' test --workspace --locked --verbose
+ptime -m cargo +'nightly-2021-11-24' test --workspace --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         os: [ ubuntu-18.04, macos-10.15 ]
         # See rust-toolchain for why we're using nightly here.
-        toolchain: [ nightly-2021-09-03 ]
+        toolchain: [ nightly-2021-11-24 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b

--- a/README.adoc
+++ b/README.adoc
@@ -69,8 +69,6 @@ We use Diesel's PostgreSQL support to connect to CockroachDB (which is wire-comp
 * Mac: `brew install postgresql`
 
 After doing this, you should have the `pg_config` command on your PATH.  For example, on Helios, you'd want `/opt/ooce/bin` on your PATH.
-
-See the note about setting RUSTDOCFLAGS at build time below.
 --
 . pkg-config, a tool for querying installed libraries
 +
@@ -117,14 +115,6 @@ the database files will be deleted when you stop the program.
 
 The easiest way to start the required databases is to use the built-in `omicron-dev` tool.  This tool assumes that the `cockroach` and `clickhouse` executables are on your PATH, and match the versions above.
 
-. Work around https://github.com/rust-lang/cargo/issues/9895[rust-lang/cargo#9895]: set `RUSTDOCFLAGS` in your environment so that built test binaries will be able to find your local copy of libpq.  A typical example might look like this:
-+
-----
-$ export RUSTDOCFLAGS="-Clink-args=-Wl,-R$(pg_config --libdir)"
-----
-+ Note that this might be wrong in some configurations or if you're using environment variables to control how the `pq-sys` crate finds libpq.  See https://github.com/oxidecomputer/omicron/issues/213[#213] for details.
-+
-NOTE: You may be able to skip this step if your libpq is in a directory that's already part of the runtime linker's default search path, which may be the case if you've installed libpq using the system package manager.  This step is necessarily on Helios because the package manager does not put libpq on the default ld.so search path.
 . Start CockroachDB using `omicron-dev db-run`:
 +
 [source,text]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,16 +1,14 @@
 #
-# We use nightly for a few unstable features:
-#
-# 1. the "asm" unstable Rust feature, used within Propolis for dtrace probes
-# 2. the "extra-link-arg" unstable Cargo feature, used in omicron-rpaths.  This
-#    will be stable in 1.56.
+# We use nightly for the "asm" unstable Rust feature, used within Propolis for
+# dtrace probes.
 #
 # We specify a specific, known-good nightly to avoid regular breakage.
-# Once the above features stabilize, we should switch back to "stable".
+# Once all unstable features that we use are stabilized, we should switch back
+# to "stable".
 #
 
 [toolchain]
 # NOTE: This toolchain is also specified within .github/workflows/rust.yml
 # If you update it here, update that file too.
-channel = "nightly-2021-09-03"
+channel = "nightly-2021-11-24"
 profile = "default"


### PR DESCRIPTION
This resolves #327.

According to the note in rust-toolchain.toml, the "extra-link-arg" flag became stable in 1.56.  Between these two things, the only (documented) reason that omicron uses "nightly" is for asm, which is on track for stabilization soon.