### PR TITLE
Fix oxapi_demo shebang

### DIFF
--- a/nexus/tests/test_commands.rs
+++ b/nexus/tests/test_commands.rs
@@ -165,23 +165,3 @@ fn test_nexus_openapi_internal() {
      */
     assert_contents("../openapi/nexus-internal.json", &stdout_text);
 }
-
-#[test]
-fn test_oxapi_demo_no_args() {
-    let exec = Exec::cmd("../tools/oxapi_demo");
-    let (exit_status, stdout_text, stderr_text) = dbg!(run_command(exec));
-
-    assert_exit_code(exit_status, EXIT_USAGE);
-    assert!(stdout_text.contains("usage:"));
-    assert_eq!(stderr_text, "oxapi_demo: command not specified\n");
-}
-
-#[test]
-fn test_oxapi_demo() {
-    let exec = Exec::cmd("../tools/oxapi_demo").arg("organizations_list");
-    let (exit_status, stdout_text, stderr_text) = dbg!(run_command(exec));
-
-    assert_exit_code(exit_status, EXIT_SUCCESS);
-    assert_eq!(stdout_text, "");
-    assert!(stderr_text.contains("Failed to connect"));
-}

--- a/nexus/tests/test_commands.rs
+++ b/nexus/tests/test_commands.rs
@@ -165,3 +165,23 @@ fn test_nexus_openapi_internal() {
      */
     assert_contents("../openapi/nexus-internal.json", &stdout_text);
 }
+
+#[test]
+fn test_oxapi_demo_no_args() {
+    let exec = Exec::cmd("../tools/oxapi_demo");
+    let (exit_status, stdout_text, stderr_text) = run_command(exec);
+
+    assert_exit_code(exit_status, EXIT_USAGE);
+    assert!(stdout_text.contains("usage:"));
+    assert_eq!(stderr_text, "oxapi_demo: command not specified\n");
+}
+
+#[test]
+fn test_oxapi_demo() {
+    let exec = Exec::cmd("../tools/oxapi_demo").arg("organizations_list");
+    let (exit_status, stdout_text, stderr_text) = run_command(exec);
+
+    assert_exit_code(exit_status, EXIT_SUCCESS);
+    assert_eq!(stdout_text, "");
+    assert!(stderr_text.contains("Failed to connect"));
+}

--- a/nexus/tests/test_commands.rs
+++ b/nexus/tests/test_commands.rs
@@ -169,7 +169,7 @@ fn test_nexus_openapi_internal() {
 #[test]
 fn test_oxapi_demo_no_args() {
     let exec = Exec::cmd("../tools/oxapi_demo");
-    let (exit_status, stdout_text, stderr_text) = run_command(exec);
+    let (exit_status, stdout_text, stderr_text) = dbg!(run_command(exec));
 
     assert_exit_code(exit_status, EXIT_USAGE);
     assert!(stdout_text.contains("usage:"));
@@ -179,7 +179,7 @@ fn test_oxapi_demo_no_args() {
 #[test]
 fn test_oxapi_demo() {
     let exec = Exec::cmd("../tools/oxapi_demo").arg("organizations_list");
-    let (exit_status, stdout_text, stderr_text) = run_command(exec);
+    let (exit_status, stdout_text, stderr_text) = dbg!(run_command(exec));
 
     assert_exit_code(exit_status, EXIT_SUCCESS);
     assert_eq!(stdout_text, "");

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 #
 # oxapi_demo: wrapper around curl(1) to run basic requests against the Oxide API


### PR DESCRIPTION
Decided against testing because the script relies on the `npm` package `json`, which doesn't seem worth setting up for a tool we're eventually going to throw out.