### PR TITLE
Bump the unlock threshold back down to one

### DIFF
--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use tar::Archive;
 use thiserror::Error;
 
-const UNLOCK_THRESHOLD: usize = 2;
+const UNLOCK_THRESHOLD: usize = 1;
 const BOOTSTRAP_PORT: u16 = 12346;
 
 /// Describes errors which may occur while operating the bootstrap service.


### PR DESCRIPTION
This fixes an issue caused by https://github.com/oxidecomputer/omicron/pull/404

Basically, the "unlock threshold" is the number of sleds that must share (placeholder) secrets before unlocking the sled.

This *should* be hardcoded to one for the moment, as it allows developers to unlock sleds running solo.

Longer-term, this will be a configurable option, but this unblocks sled agent development.