### PR TITLE
try limiting concurrency on MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,10 @@ jobs:
         os: [ ubuntu-18.04, macos-10.15 ]
         # See rust-toolchain for why we're using nightly here.
         toolchain: [ nightly-2021-11-24 ]
+        include:
+          - os: macos-10.15
+            toolchain: nightly-2021-11-24
+            extra_test_args: "-- --test-threads 1"
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -123,4 +127,4 @@ jobs:
       # rebuild here.
       # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
       # suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} test --workspace --locked --verbose
+      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} test --workspace --locked --verbose ${{matrix.extra_test_args }}


### PR DESCRIPTION
Mitigates #461.

One hypothesis for the issue in #461 is that we're out of memory.  I'll put more analysis in #461 about this.  In the meantime, this is a fairly innocuous change: it limits concurrency on OS X in hopes of reducing the memory usage, since many tests spin up CockroachDB, Nexus, and other processes.

This change is only applied to Mac because that's where we're seeing the problem.  I don't totally want to eliminate concurrency in CI because there are legitimate concurrency bugs in the test suite.  I think it's important that the test suite continue to work at increased concurrency (aside from resource exhaustion).