### PR TITLE
bump command timeout

### DIFF
--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -32,7 +32,7 @@ pub const EXIT_USAGE: u32 = 2;
  * This is important because a bug might actually cause this test to start one
  * of the servers and run it indefinitely.
  */
-const TIMEOUT: Duration = Duration::from_millis(10000);
+const TIMEOUT: Duration = Duration::from_millis(60000);
 
 pub fn path_to_executable(cmd_name: &str) -> PathBuf {
     let mut rv = PathBuf::from(cmd_name);
@@ -79,7 +79,7 @@ pub fn run_command(exec: Exec) -> (ExitStatus, String, String) {
         .unwrap_or_else(|_| panic!("failed to start command: {}", cmdline));
 
     let exit_status = subproc
-        .wait_timeout(TIMEOUT)
+        .wait_timeout(timeout)
         .unwrap_or_else(|_| panic!("failed to wait for command: {}", cmdline))
         .unwrap_or_else(|| {
             panic!(


### PR DESCRIPTION
Mitigates #461.

I hate bumping timeouts in tests.  But in this case: the timeout exists primarily to prevent the test from hanging if some erroneous command invocation actually starts a server to run indefinitely.  There's not much harm in waiting 60 seconds instead of 10 except potentially for papering over whatever problem is causing these simple commands to take over 10 seconds.  That's covered by #461.