### PR TITLE
cockroachdb: Fix download script for illumos

### DIFF
--- a/tools/ci_download_cockroachdb
+++ b/tools/ci_download_cockroachdb
@@ -151,6 +151,7 @@ function do_assemble_official
 
 function do_assemble_illumos
 {
+	rm -r "$CIDL_ASSEMBLE_DIR" || true
 	cp -r "cockroach-$CIDL_VERSION" "$CIDL_ASSEMBLE_DIR"
 }
 


### PR DESCRIPTION
This was previously copying the new version into
`cockroachdb/cockroachdb-<newver>` instead of replacing
the `cockroachdb` directory.

Fixes #475