### PR TITLE
Use MacOS 11 CI runner instead of 10.15

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-10.15 ]
+        os: [ ubuntu-18.04, macos-11 ]
         # See rust-toolchain for why we're using nightly here.
         toolchain: [ nightly-2021-11-24 ]
     steps:


### PR DESCRIPTION
[GitHub Actions: macOS 11 Big Sur is generally available on GitHub-hosted runners ](https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/)

We might as well be on the latest version. MacOS 10.15 is over two years old.

It seems to work. It doesn't speed anything up dramatically (28m is typical) which is not surprising because we know from local dev that the slow CRDB thing afflicts MacOS 11.