### PR TITLE
Fixes usdt feature dependency resolution bug

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -33,6 +33,12 @@ export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 ptime -m cargo +'nightly-2021-11-24' build --locked --all-targets --verbose
 
+#
+# Check that building individual packages as when deploying Omicron succeeds
+#
+banner deploy-check
+ptime -m cargo run --bin omicron-package -- check
+
 banner clickhouse
 ptime -m ./tools/ci_download_clickhouse
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,19 +89,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macos-11 ]
-        # See rust-toolchain for why we're using nightly here.
-        toolchain: [ nightly-2021-11-24 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
-    - name: Install Toolchain
-    # actions-rs/toolchain@v1.0.6
-      uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f
-      with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
     - name: Report cargo version
-      run: cargo +${{ matrix.toolchain }} --version
+      run: cargo --version
     - name: Configure GitHub cache for CockroachDB binaries
       id: cache-cockroachdb
       # actions/cache@v2.1.4
@@ -127,7 +119,7 @@ jobs:
       #   also gives us a record of which dependencies were used for each CI
       #   run.  Building with `--locked` ensures that the checked-in Cargo.lock
       #   is up to date.
-      run: RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} build --locked --all-targets --verbose
+      run: RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo build --locked --all-targets --verbose
     - name: Download ClickHouse
       if: steps.cache-clickhouse.outputs.cache-hit != 'true'
       run: ./tools/ci_download_clickhouse
@@ -139,4 +131,4 @@ jobs:
       # rebuild here.
       # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
       # suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo +${{ matrix.toolchain }} test --workspace --locked --verbose
+      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --workspace --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,22 @@ jobs:
     - name: Check style
       run: cargo fmt -- --check
 
+  check-omicron-deployment:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macos-11 ]
+    steps:
+    # actions/checkout@v2
+    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+    - name: Report cargo version
+      run: cargo --version
+    - name: Check build of deployed Omicron packages
+      run: cargo run --bin omicron-package -- check
+
   clippy-lint:
     needs: skip_duplicate_jobs
     if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 [[package]]
 name = "dropshot"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff33033ad3d7fcf32caa352d76fc243bd20db176"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#5a80ca53df78b5ee11dc97a252864c6c86046a0b"
 dependencies = [
  "async-trait",
  "base64",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff33033ad3d7fcf32caa352d76fc243bd20db176"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#5a80ca53df78b5ee11dc97a252864c6c86046a0b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,34 @@ See TODO.adoc for more info.
 
 == Build and run
 
+Briefly, the steps to run each component of the control plane manually are:
+
++
+[source,text]
+----
+$ cargo run --bin omicron-dev -- db-run # Start CockroachDB
+$ cargo run --bin omicron-dev -- ch-run # Start ClickHouse
+$ cargo run --bin nexus -- nexus/examples/config.toml
+$ cargo run --bin oximeter -- oximeter/collector/config.toml
+$ cargo run --bin sled-agent -- $(uuidgen) [::1]:12223 [::1]:12222 127.0.0.1:12221
+----
+
+To run the control plane components as SMF services, first run the two databases
+manually, and then:
+
++
+[source,text]
+----
+$ cargo run --bin omicron-dev -- db-run # Start CockroachDB
+$ cargo run --bin omicron-dev -- ch-run # Start ClickHouse
+$ cargo run --bin omicron-package -- package # Build and package up SMF services
+$ cargo run --bin omicron-package -- install # Install and start SMF services
+----
+
+For more detailed information about the build and development process, read on.
+
+== Building and running, in detail
+
 You can **format the code** using `cargo fmt`.  Make sure to run this before pushing changes.  The CI checks that the code is correctly formatted.
 
 You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy \-- -D warnings -A clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 api_identity = { path = "../api_identity" }
 backoff = { version = "0.3.0", features = [ "tokio" ] }
 chrono = { version = "0.4", features = [ "serde" ] }
-dropshot = {  git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+dropshot = {  git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.18"
 http = "0.2.5"
 hyper = "0.14"

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -6,7 +6,7 @@ description = "The oximeter metric collection server"
 license = "MPL-2.0"
 
 [dependencies]
-dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 nexus-client = { path = "../../nexus-client" }
 omicron-common = { path = "../../common" }
 oximeter = { path = "../oximeter" }

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 chrono = { version = "0.4", features = [ "serde" ] }
-dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.18"
 oximeter = { path = "../oximeter" }
 http = { version = "0.2.5", optional = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,5 +8,7 @@
 #
 
 [toolchain]
+# NOTE: This toolchain is also specified within .github/buildomat/jobs/build-and-test.sh.
+# If you update it here, update that file too.
 channel = "nightly-2021-11-24"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,7 +8,5 @@
 #
 
 [toolchain]
-# NOTE: This toolchain is also specified within .github/workflows/rust.yml
-# If you update it here, update that file too.
 channel = "nightly-2021-11-24"
 profile = "default"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -11,7 +11,7 @@ bincode = "1.3.3"
 bytes = "1.1"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
-dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.18"
 ipnetwork = "0.18"
 nexus-client = { path = "../nexus-client" }


### PR DESCRIPTION
- Adds the Dropshot `usdt-probes` feature to every crate depending on
  both Dropshot and `slog-dtrace`. Leaving this feature out causes build
  failures when compiling packages individually, as the selected `usdt`
  feature actually includes inline assembly, but Dropshot does not
  include the right feature-selection crate attribute. This works when
  building the whole workspace, since all features are unioned.
- Adds a `check` subcommand to `omicron-package`, that runs `cargo
  check` instead of `cargo build`. This is also run during CI now, to
  catch regressions here, at least for the crates that we package via
  `omicron-package`.