### PR TITLE
Reduce 'test_projects_list' length

### DIFF
--- a/nexus/tests/test_basic.rs
+++ b/nexus/tests/test_basic.rs
@@ -531,9 +531,10 @@ async fn test_projects_list() {
     assert_eq!(projects_list(&client, &projects_url).await.len(), 0);
 
     /* Create a large number of projects that we can page through. */
-    let nprojects = 1000;
-    let mut projects_created = Vec::with_capacity(nprojects);
-    for _ in 0..nprojects {
+    let projects_total = 10;
+    let projects_subset = 3;
+    let mut projects_created = Vec::with_capacity(projects_total);
+    for _ in 0..projects_total {
         /*
          * We'll use uuids for the names to make sure that works, and that we
          * can paginate through by _name_ even though the names happen to be
@@ -565,7 +566,7 @@ async fn test_projects_list() {
      * increasing order of name.
      */
     let found_projects_by_name =
-        iter_collection::<Project>(&client, projects_url, "", 99).await.0;
+        iter_collection::<Project>(&client, projects_url, "", projects_subset).await.0;
     assert_eq!(found_projects_by_name.len(), project_names_by_name.len());
     assert_eq!(
         project_names_by_name,
@@ -583,7 +584,7 @@ async fn test_projects_list() {
         &client,
         projects_url,
         "sort_by=name-ascending",
-        99,
+        projects_subset,
     )
     .await
     .0;
@@ -604,7 +605,7 @@ async fn test_projects_list() {
         &client,
         projects_url,
         "sort_by=name-descending",
-        99,
+        projects_subset,
     )
     .await
     .0;
@@ -625,7 +626,7 @@ async fn test_projects_list() {
         &client,
         projects_url,
         "sort_by=id-ascending",
-        99,
+        projects_subset,
     )
     .await
     .0;

--- a/nexus/tests/test_basic.rs
+++ b/nexus/tests/test_basic.rs
@@ -566,7 +566,9 @@ async fn test_projects_list() {
      * increasing order of name.
      */
     let found_projects_by_name =
-        iter_collection::<Project>(&client, projects_url, "", projects_subset).await.0;
+        iter_collection::<Project>(&client, projects_url, "", projects_subset)
+            .await
+            .0;
     assert_eq!(found_projects_by_name.len(), project_names_by_name.len());
     assert_eq!(
         project_names_by_name,


### PR DESCRIPTION
I believe we still have coverage of pagination with smaller constants, and this prevents the test from taking 60+ seconds on my development machine.