### PR TITLE
a lot of tests leave detritus in $TMPDIR

### DIFF
--- a/nexus/src/db/collection_insert.rs
+++ b/nexus/src/db/collection_insert.rs
@@ -693,6 +693,7 @@ mod test {
         assert!(*not_found.lock().unwrap());
 
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -757,5 +758,6 @@ mod test {
         assert_eq!(collection_rcgen, 2);
 
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2077,6 +2077,7 @@ mod test {
         assert!(organization_after_project_create.rcgen > organization.rcgen);
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -2133,5 +2134,6 @@ mod test {
         assert_eq!(delete_again, Ok(()));
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/src/db/saga_recovery.rs
+++ b/nexus/src/db/saga_recovery.rs
@@ -474,7 +474,7 @@ mod test {
         // Test setup
         let logctx =
             dev::test_setup_log("test_failure_during_saga_can_be_recovered");
-        let log = logctx.log;
+        let log = logctx.log.new(o!());
         let (mut db, db_datastore) = new_db(&log).await;
         let sec_id = db::SecId(uuid::Uuid::new_v4());
         let (storage, sec_client, uctx) =
@@ -539,6 +539,7 @@ mod test {
         let sec_client = Arc::try_unwrap(sec_client).unwrap();
         sec_client.shutdown().await;
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -547,7 +548,7 @@ mod test {
         let logctx = dev::test_setup_log(
             "test_successful_saga_does_not_replay_during_recovery",
         );
-        let log = logctx.log;
+        let log = logctx.log.new(o!());
         let (mut db, db_datastore) = new_db(&log).await;
         let sec_id = db::SecId(uuid::Uuid::new_v4());
         let (storage, sec_client, uctx) =
@@ -601,5 +602,6 @@ mod test {
         let sec_client = Arc::try_unwrap(sec_client).unwrap();
         sec_client.shutdown().await;
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -211,6 +211,7 @@ async fn test_absolute_static_dir() {
         .expect("failed to get existing file");
 
     assert_eq!(resp.body, "hello there".as_bytes());
+    cptestctx.teardown().await;
 }
 
 fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -268,4 +268,5 @@ async fn test_oximeter_reregistration() {
         timeseries.measurements,
         new_timeseries.measurements[..timeseries.measurements.len()]
     );
+    context.teardown().await;
 }

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -138,6 +138,7 @@ async fn test_vpc_firewall() {
             StatusCode::NOT_FOUND,
         )
         .await;
+    cptestctx.teardown().await;
 }
 
 fn is_default_firewall_rules(rules: &Vec<VpcFirewallRule>) -> bool {

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -443,6 +443,7 @@ mod test {
             assert!(rx.try_next().is_err());
             rprev = rnext;
         }
+        logctx.cleanup_successful();
     }
 
     /**
@@ -556,6 +557,7 @@ mod test {
         instance.transition_finish();
         let rnext = instance.object.current().clone();
         assert_eq!(rprev.gen, rnext.gen);
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -868,6 +870,7 @@ mod test {
             assert_eq!(rnext.disk_state, next);
             rprev = rnext;
         }
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -967,6 +970,7 @@ mod test {
         );
         disk.transition_finish();
         assert_eq!(disk.object.current().disk_state, DiskState::Destroyed);
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]


### PR DESCRIPTION
There are two common problems:

* Tests create a `LogContext` and never invoke `cleanup_successful()`.  This leaves log files hanging around in $TMPDIR.
* Tests create a `ControlPlaneTestContext` and never invoke `teardown()`.  This also leaves log files hanging around in $TMPDIR.  The `Drop` impls on `CockroachInstance` and `ClickHouseInstance` _should_ cause those programs to shut down and their storage directories to be cleaned up, but it's not a guarantee.  If not, we might leak them, using up memory in the process.

This change fixes them.  I did this by looking at all the log files in $TMPDIR, which are named by what test created them, finding the test, and adding the appropriate cleanup call.

---

Obviously, this pattern is easy to mis-use.  I'd welcome improvements here.  The design goal is:

* On success, these resources (temp directories and child processes) are automatically cleaned up.
* On failure, the log files are kept around for post hoc debugging.  (A key goal was that if a test fails in some rare case, we should still be able to debug it.  This feels important for eliminating flaky tests.)

Because we want to keep these around on failure, we can't have the `Drop` impls clean up these files.  We want to do that _only_ if the test fails.  The only way we know if it succeeds or fails is if the programmer tells us they succeeded by calling `teardown()`/`cleanup_successful()`.  We could flip the default assumption so that you have to tell us when it failed, but that seems much harder to use and more error-prone.