### PR TITLE
Updates diesel-dtrace dep and adds a few DTrace scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,10 +730,12 @@ dependencies = [
 [[package]]
 name = "diesel-dtrace"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#dfeff3201eb8180220542b29021f0b5f71e50b46"
+source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#2e586f1424baf02ca6991d8ea63c4dd84c81a0ef"
 dependencies = [
  "diesel",
+ "serde",
  "usdt",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
- "usdt",
+ "usdt 0.2.1",
  "uuid",
  "xts-mode",
 ]
@@ -730,11 +730,11 @@ dependencies = [
 [[package]]
 name = "diesel-dtrace"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#2e586f1424baf02ca6991d8ea63c4dd84c81a0ef"
+source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#f74c1db52e86f53d9234969541673d1d9aecb101"
 dependencies = [
  "diesel",
  "serde",
- "usdt",
+ "usdt 0.3.1",
  "uuid",
 ]
 
@@ -861,7 +861,7 @@ dependencies = [
  "syn",
  "tokio",
  "toml",
- "usdt",
+ "usdt 0.2.1",
  "uuid",
 ]
 
@@ -1925,7 +1925,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "toml",
- "usdt",
+ "usdt 0.3.1",
  "uuid",
 ]
 
@@ -2730,7 +2730,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "usdt",
+ "usdt 0.2.1",
  "viona_api",
 ]
 
@@ -3521,7 +3521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "usdt",
+ "usdt 0.2.1",
 ]
 
 [[package]]
@@ -4342,9 +4342,23 @@ dependencies = [
  "dof",
  "dtrace-parser",
  "serde",
- "usdt-attr-macro",
- "usdt-impl",
- "usdt-macro",
+ "usdt-attr-macro 0.2.1",
+ "usdt-impl 0.2.1",
+ "usdt-macro 0.2.1",
+]
+
+[[package]]
+name = "usdt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3877c300bc107d8d05455e8e2bec271ca9e1d24fbc17e3ef27d18b9b53c684e2"
+dependencies = [
+ "dof",
+ "dtrace-parser",
+ "serde",
+ "usdt-attr-macro 0.3.1",
+ "usdt-impl 0.3.1",
+ "usdt-macro 0.3.1",
 ]
 
 [[package]]
@@ -4358,7 +4372,21 @@ dependencies = [
  "quote",
  "serde_tokenstream",
  "syn",
- "usdt-impl",
+ "usdt-impl 0.2.1",
+]
+
+[[package]]
+name = "usdt-attr-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedf62a6eab9c6da23fa64353382ef2b73dce8891eadda8755bfed179cb2103d"
+dependencies = [
+ "dtrace-parser",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream",
+ "syn",
+ "usdt-impl 0.3.1",
 ]
 
 [[package]]
@@ -4366,6 +4394,25 @@ name = "usdt-impl"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6e158f113f80db319e54f62c59ea4329a31190a43ed7db07578982021209014"
+dependencies = [
+ "byteorder",
+ "dof",
+ "dtrace-parser",
+ "libc",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "thread-id",
+]
+
+[[package]]
+name = "usdt-impl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dda9311a9f1452ebc752d264e9d1e3c2dac9807219e19471bcef3bd1b7f90cb"
 dependencies = [
  "byteorder",
  "dof",
@@ -4391,7 +4438,21 @@ dependencies = [
  "quote",
  "serde_tokenstream",
  "syn",
- "usdt-impl",
+ "usdt-impl 0.2.1",
+]
+
+[[package]]
+name = "usdt-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64160eb8f7ee61fcaef542b2f75fa807e8c3ed4b4f075e6ca0b17ea6fcea6f8"
+dependencies = [
+ "dtrace-parser",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream",
+ "syn",
+ "usdt-impl 0.3.1",
 ]
 
 [[package]]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -41,7 +41,7 @@ slog-dtrace = "0.2"
 structopt = "0.3"
 thiserror = "1.0"
 toml = "0.5.6"
-usdt = "0.2"
+usdt = "0.3.1"
 
 [dependencies.api_identity]
 path = "../api_identity"

--- a/tools/dtrace/aggregate-query-latency.d
+++ b/tools/dtrace/aggregate-query-latency.d
@@ -1,0 +1,34 @@
+#!/usr/sbin/dtrace -qZs
+
+/* Aggregate database query latency by connection, printing every 10 seconds. */
+uint64_t total_queries;
+
+dtrace:::BEGIN
+{
+    printf("Tracing database query latency by connection ID for nexus PID %d, use Ctrl-C to exit\n", $target);
+    total_queries = 0;
+}
+
+diesel_db$target:::query_start
+{
+    total_queries++;
+    this->conn_id = json(copyinstr(arg1), "ok");
+    self->ts[this->conn_id] = timestamp;
+}
+
+
+diesel_db$target:::query_end
+/self->ts[json(copyinstr(arg1), "ok")] != 0/
+{
+    this->conn_id = json(copyinstr(arg1), "ok");
+    @latency[this->conn_id] = quantize((timestamp - self->ts[this->conn_id]) / 1000);
+    self->ts[this->conn_id] = 0;
+}
+
+tick-10s
+{
+    printf("%Y\n", walltimestamp);
+    printf("%d total queries\n", total_queries);
+    printa(@latency);
+    printf("\n");
+}

--- a/tools/dtrace/aggregate-query-latency.d
+++ b/tools/dtrace/aggregate-query-latency.d
@@ -1,23 +1,20 @@
-#!/usr/sbin/dtrace -qZs
+#!/usr/sbin/dtrace -qs
 
 /* Aggregate database query latency by connection, printing every 10 seconds. */
-uint64_t total_queries;
 
 dtrace:::BEGIN
 {
     printf("Tracing database query latency by connection ID for nexus PID %d, use Ctrl-C to exit\n", $target);
-    total_queries = 0;
 }
 
-diesel_db$target:::query_start
+diesel-db$target:::query-start
 {
-    total_queries++;
+    @total_queries = count();
     this->conn_id = json(copyinstr(arg1), "ok");
     self->ts[this->conn_id] = timestamp;
 }
 
-
-diesel_db$target:::query_end
+diesel-db$target:::query-done
 /self->ts[json(copyinstr(arg1), "ok")] != 0/
 {
     this->conn_id = json(copyinstr(arg1), "ok");
@@ -28,7 +25,7 @@ diesel_db$target:::query_end
 tick-10s
 {
     printf("%Y\n", walltimestamp);
-    printf("%d total queries\n", total_queries);
+    printa("%@d total queries\n", @total_queries);
     printa(@latency);
     printf("\n");
 }

--- a/tools/dtrace/slowest-queries.d
+++ b/tools/dtrace/slowest-queries.d
@@ -1,0 +1,53 @@
+#!/usr/sbin/dtrace -qZs
+
+#pragma strsize=4k
+
+/* Print out the slowest query every 10 seconds. */
+
+struct query_info {
+    string conn_id;
+    string query;
+    uint64_t latency;
+};
+
+struct query_info slowest_query;
+self struct query_info queries[string];
+
+dtrace:::BEGIN
+{
+    printf("Tracing slowest queries for nexus PID %d, use Ctrl-C to exit\n", $target);
+}
+
+diesel_db$target:::query_start
+{
+    this->conn_id = json(copyinstr(arg1), "ok");
+    self->queries[this->conn_id].conn_id = json(copyinstr(arg1), "ok");
+    self->queries[this->conn_id].query = copyinstr(arg2);
+    self->queries[this->conn_id].latency = timestamp;
+}
+
+
+diesel_db$target:::query_end
+/self->queries[json(copyinstr(arg1), "ok")].latency != 0/
+{
+    this->conn_id = json(copyinstr(arg1), "ok");
+    this->latency = timestamp - self->queries[this->conn_id].latency;
+    if (this->latency > slowest_query.latency) {
+        slowest_query.conn_id = self->queries[this->conn_id].conn_id;
+        slowest_query.query = self->queries[this->conn_id].query;
+        slowest_query.latency = this->latency;
+    }
+}
+
+tick-10s
+{
+    printf("%Y\n", walltimestamp);
+    if (strlen(slowest_query.query) > 0) {
+        printf("latency: %lu us, conn_id: %s, query: '%s'\n", slowest_query.latency / 1000, slowest_query.conn_id, slowest_query.query);
+        slowest_query.query = "";
+        slowest_query.conn_id = "";
+        slowest_query.latency = 0;
+    } else {
+        printf("No new queries\n");
+    }
+}

--- a/tools/dtrace/slowest-queries.d
+++ b/tools/dtrace/slowest-queries.d
@@ -1,53 +1,41 @@
-#!/usr/sbin/dtrace -qZs
+#!/usr/sbin/dtrace -qs
 
 #pragma strsize=4k
 
-/* Print out the slowest query every 10 seconds. */
-
-struct query_info {
-    string conn_id;
-    string query;
-    uint64_t latency;
-};
-
-struct query_info slowest_query;
-self struct query_info queries[string];
+/* Print out the slowest 5 queries every 10 seconds. */
 
 dtrace:::BEGIN
 {
     printf("Tracing slowest queries for nexus PID %d, use Ctrl-C to exit\n", $target);
 }
 
-diesel_db$target:::query_start
+diesel-db$target:::query-start
 {
     this->conn_id = json(copyinstr(arg1), "ok");
-    self->queries[this->conn_id].conn_id = json(copyinstr(arg1), "ok");
-    self->queries[this->conn_id].query = copyinstr(arg2);
-    self->queries[this->conn_id].latency = timestamp;
+    ts[this->conn_id] = timestamp;
+    query[this->conn_id] = copyinstr(arg2);
 }
 
 
-diesel_db$target:::query_end
-/self->queries[json(copyinstr(arg1), "ok")].latency != 0/
+diesel-db$target:::query-done
 {
     this->conn_id = json(copyinstr(arg1), "ok");
-    this->latency = timestamp - self->queries[this->conn_id].latency;
-    if (this->latency > slowest_query.latency) {
-        slowest_query.conn_id = self->queries[this->conn_id].conn_id;
-        slowest_query.query = self->queries[this->conn_id].query;
-        slowest_query.latency = this->latency;
-    }
 }
 
-tick-10s
+diesel-db$target:::query-done
+/ts[this->conn_id]/
 {
-    printf("%Y\n", walltimestamp);
-    if (strlen(slowest_query.query) > 0) {
-        printf("latency: %lu us, conn_id: %s, query: '%s'\n", slowest_query.latency / 1000, slowest_query.conn_id, slowest_query.query);
-        slowest_query.query = "";
-        slowest_query.conn_id = "";
-        slowest_query.latency = 0;
-    } else {
-        printf("No new queries\n");
-    }
+    this->latency = timestamp - ts[this->conn_id];
+    @[this->conn_id, query[this->conn_id]] = max(this->latency);
+    ts[this->conn_id] = 0;
+    query[this->conn_id] = NULL;
+}
+
+tick-5s
+{
+    printf("\n%Y\n", walltimestamp);
+    trunc(@, 5);
+    normalize(@, 1000);
+    printa("latency: %@ld us, conn_id: %s, query: '%s'\n", @);
+    trunc(@);
 }

--- a/tools/dtrace/slowest-queries.d
+++ b/tools/dtrace/slowest-queries.d
@@ -26,6 +26,10 @@ diesel-db$target:::query-done
 /ts[this->conn_id]/
 {
     this->latency = timestamp - ts[this->conn_id];
+    /* There's only a single value here, so `max` is just used to "convert"
+     * the latency as an integer to an aggregation. `min`, or any other scalar
+     * aggregation function, would be equivalent.
+     */
     @[this->conn_id, query[this->conn_id]] = max(this->latency);
     ts[this->conn_id] = 0;
     query[this->conn_id] = NULL;

--- a/tools/dtrace/trace-db-queries.d
+++ b/tools/dtrace/trace-db-queries.d
@@ -1,15 +1,36 @@
-#!/usr/sbin/dtrace -qZs
+#!/usr/sbin/dtrace -qs
 
 #pragma strsize=16k
 
-/* Trace all queries to the control plane database */
+/* Trace all queries to the control plane database with their latency */
 
 dtrace:::BEGIN
 {
     printf("Tracing all database queries for nexus PID %d, use Ctrl-C to exit\n", $target);
 }
 
-diesel_db$target:::query_start
+diesel-db$target:::query-start
 {
-    printf("conn_id: %s, query: '%s'\n", json(copyinstr(arg1), "ok"), copyinstr(arg2));
+    this->conn_id = json(copyinstr(arg1), "ok");
+    ts[this->conn_id] = timestamp;
+    query[this->conn_id] = copyinstr(arg2);
+}
+
+diesel-db$target:::query-done
+{
+    this->conn_id = json(copyinstr(arg1), "ok");
+}
+
+diesel-db$target:::query-done
+/ts[this->conn_id]/
+{
+    this->latency = (timestamp - ts[this->conn_id]) / 1000;
+    printf(
+        "conn_id: %s, latency: %lu us, query: '%s'\n",
+        this->conn_id,
+        this->latency,
+        query[this->conn_id]
+    );
+    ts[this->conn_id] = 0;
+    query[this->conn_id] = NULL;
 }

--- a/tools/dtrace/trace-db-queries.d
+++ b/tools/dtrace/trace-db-queries.d
@@ -1,0 +1,15 @@
+#!/usr/sbin/dtrace -qZs
+
+#pragma strsize=16k
+
+/* Trace all queries to the control plane database */
+
+dtrace:::BEGIN
+{
+    printf("Tracing all database queries for nexus PID %d, use Ctrl-C to exit\n", $target);
+}
+
+diesel_db$target:::query_start
+{
+    printf("conn_id: %s, query: '%s'\n", json(copyinstr(arg1), "ok"), copyinstr(arg2));
+}


### PR DESCRIPTION
Adds the `tools/dtrace` directory, with a few scripts for tracing
connections of a given nexus process.

- aggregate-query-latency.d: distribution of query latency by connection
- slowest-queries.d: display slowest query of the last 10 seconds
- trace-db-queries.d: display all queries with connection id