### PR TITLE
Paginate instances get disk

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -471,7 +471,6 @@ pub enum ResourceType {
     Project,
     Dataset,
     Disk,
-    DiskAttachment,
     Instance,
     NetworkInterface,
     Rack,
@@ -498,7 +497,6 @@ impl Display for ResourceType {
                 ResourceType::Project => "project",
                 ResourceType::Dataset => "dataset",
                 ResourceType::Disk => "disk",
-                ResourceType::DiskAttachment => "disk attachment",
                 ResourceType::Instance => "instance",
                 ResourceType::NetworkInterface => "network interface",
                 ResourceType::Rack => "rack",
@@ -865,18 +863,6 @@ impl DiskState {
             DiskState::Faulted => None,
         }
     }
-}
-
-/**
- * Describes a Disk's attachment to an Instance
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct DiskAttachment {
-    pub instance_id: Uuid,
-    pub disk_id: Uuid,
-    pub disk_name: Name,
-    pub disk_state: DiskState,
 }
 
 /*

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -65,9 +65,9 @@ use crate::db::{
         public_error_from_diesel_pool_shouldnt_fail,
     },
     model::{
-        ConsoleSession, Dataset, Disk, DiskAttachment, DiskRuntimeState,
-        Generation, IncompleteNetworkInterface, Instance, InstanceRuntimeState,
-        Name, NetworkInterface, Organization, OrganizationUpdate, OximeterInfo,
+        ConsoleSession, Dataset, Disk, DiskRuntimeState, Generation,
+        IncompleteNetworkInterface, Instance, InstanceRuntimeState, Name,
+        NetworkInterface, Organization, OrganizationUpdate, OximeterInfo,
         ProducerEndpoint, Project, ProjectUpdate, RouterRoute,
         RouterRouteUpdate, Sled, UserBuiltin, Vpc, VpcFirewallRule, VpcRouter,
         VpcRouterUpdate, VpcSubnet, VpcSubnetUpdate, VpcUpdate, Zpool,
@@ -858,7 +858,7 @@ impl DataStore {
         &self,
         instance_id: &Uuid,
         pagparams: &DataPageParams<'_, Name>,
-    ) -> ListResultVec<DiskAttachment> {
+    ) -> ListResultVec<Disk> {
         use db::schema::disk::dsl;
 
         paginated(dsl::disk, dsl::name, &pagparams)
@@ -867,13 +867,6 @@ impl DataStore {
             .select(Disk::as_select())
             .load_async::<Disk>(self.pool())
             .await
-            .map(|disks| {
-                disks
-                    .into_iter()
-                    // Unwrap safety: filtered by instance_id in query.
-                    .map(|disk| disk.attachment().unwrap())
-                    .collect()
-            })
             .map_err(|e| {
                 public_error_from_diesel_pool(
                     e,

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -901,19 +901,6 @@ impl Disk {
     pub fn runtime(&self) -> DiskRuntimeState {
         self.runtime_state.clone()
     }
-
-    pub fn attachment(&self) -> Option<DiskAttachment> {
-        if let Some(instance_id) = self.runtime_state.attach_instance_id {
-            Some(DiskAttachment {
-                instance_id,
-                disk_id: self.id(),
-                disk_name: self.name().clone(),
-                disk_state: self.state(),
-            })
-        } else {
-            None
-        }
-    }
 }
 
 /// Conversion to the external API type.
@@ -1037,26 +1024,6 @@ impl From<external::DiskState> for DiskState {
 impl Into<external::DiskState> for DiskState {
     fn into(self) -> external::DiskState {
         self.0
-    }
-}
-
-/// Type which describes the attachment status of a disk.
-#[derive(Clone, Debug)]
-pub struct DiskAttachment {
-    pub instance_id: Uuid,
-    pub disk_id: Uuid,
-    pub disk_name: Name,
-    pub disk_state: DiskState,
-}
-
-impl Into<external::DiskAttachment> for DiskAttachment {
-    fn into(self) -> external::DiskAttachment {
-        external::DiskAttachment {
-            instance_id: self.instance_id,
-            disk_id: self.disk_id,
-            disk_name: self.disk_name.0,
-            disk_state: self.disk_state.0,
-        }
     }
 }
 

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -95,7 +95,6 @@ pub fn external_api() -> NexusApiDescription {
         api.register(instance_disks_get)?;
         api.register(instance_disks_attach)?;
         api.register(instance_disks_detach)?;
-        api.register(instance_disks_get_disk)?;
 
         api.register(project_vpcs_get)?;
         api.register(project_vpcs_post)?;
@@ -983,38 +982,6 @@ struct InstanceDiskPathParam {
     project_name: Name,
     instance_name: Name,
     disk_name: Name,
-}
-
-/**
- * Fetch a description of the attachment of this disk to this instance.
- */
-#[endpoint {
-    method = GET,
-    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}"
-}]
-async fn instance_disks_get_disk(
-    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path_params: Path<InstanceDiskPathParam>,
-) -> Result<HttpResponseOk<Disk>, HttpError> {
-    let apictx = rqctx.context();
-    let nexus = &apictx.nexus;
-    let path = path_params.into_inner();
-    let organization_name = &path.organization_name;
-    let project_name = &path.project_name;
-    let instance_name = &path.instance_name;
-    let disk_name = &path.disk_name;
-    let handler = async {
-        let disk = nexus
-            .instance_get_disk(
-                &organization_name,
-                &project_name,
-                &instance_name,
-                &disk_name,
-            )
-            .await?;
-        Ok(HttpResponseOk(disk))
-    };
-    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
 /*

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -968,7 +968,7 @@ async fn instance_disks_detach(
                 &disk_to_detach.into_inner().disk.into(),
             )
             .await?;
-        Ok(HttpResponseAccepted(disk))
+        Ok(HttpResponseAccepted(disk.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -973,17 +973,6 @@ async fn instance_disks_detach(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/**
- * Path parameters for requests that access Disks attached to an Instance
- */
-#[derive(Deserialize, JsonSchema)]
-struct InstanceDiskPathParam {
-    organization_name: Name,
-    project_name: Name,
-    instance_name: Name,
-    disk_name: Name,
-}
-
 /*
  * VPCs
  */

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -922,7 +922,7 @@ async fn instance_disks_get(
 async fn instance_disks_attach(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
-    disk_to_attach: TypedBody<params::DiskReference>,
+    disk_to_attach: TypedBody<params::DiskIdentifier>,
 ) -> Result<HttpResponseAccepted<Disk>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -951,7 +951,7 @@ async fn instance_disks_attach(
 async fn instance_disks_detach(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
-    disk_to_detach: TypedBody<params::DiskReference>,
+    disk_to_detach: TypedBody<params::DiskIdentifier>,
 ) -> Result<HttpResponseAccepted<Disk>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -187,7 +187,7 @@ pub struct DiskCreate {
  */
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct DiskReference {
+pub struct DiskIdentifier {
     pub disk: Name,
 }
 

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -182,6 +182,15 @@ pub struct DiskCreate {
     pub size: ByteCount,
 }
 
+/**
+ * Parameters for the [`Disk`] to be attached or detached to an instance
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DiskReference {
+    pub disk: Name,
+}
+
 /*
  * BUILT-IN USERS
  *

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1174,7 +1174,7 @@ impl Nexus {
         project_name: &Name,
         instance_name: &Name,
         pagparams: &DataPageParams<'_, Name>,
-    ) -> ListResultVec<db::model::DiskAttachment> {
+    ) -> ListResultVec<db::model::Disk> {
         let instance = self
             .project_lookup_instance(
                 organization_name,

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -229,12 +229,6 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         },
     )
     .await;
-    let url_instance2_disks = format!(
-        "/organizations/{}/projects/{}/instances/{}/disks",
-        org_name,
-        project_name,
-        instance2.identity.name.as_str(),
-    );
     let url_instance2_attach_disk = format!(
         "/organizations/{}/projects/{}/instances/{}/disks/attach",
         org_name,
@@ -250,7 +244,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
     let error = client
         .make_request_error_body(
             Method::POST,
-            &url_instance2_disks,
+            &url_instance2_attach_disk,
             params::DiskReference { disk: disk.identity.name.clone() },
             StatusCode::BAD_REQUEST,
         )

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -10,7 +10,6 @@ use http::method::Method;
 use http::StatusCode;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Disk;
-use omicron_common::api::external::DiskAttachment;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
@@ -176,63 +175,55 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         error.message
     );
 
+    let url_instance_attach_disk = format!(
+        "/organizations/{}/projects/{}/instances/{}/disks/attach",
+        org_name,
+        project_name,
+        instance.identity.name.as_str(),
+    );
+    let url_instance_detach_disk = format!(
+        "/organizations/{}/projects/{}/instances/{}/disks/detach",
+        org_name,
+        project_name,
+        instance.identity.name.as_str(),
+    );
+
     /* Start attaching the disk to the instance. */
     let mut response = client
-        .make_request_no_body(
-            Method::PUT,
-            &url_instance_disk,
-            StatusCode::CREATED,
+        .make_request(
+            Method::POST,
+            &url_instance_attach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
-    let attachment: DiskAttachment = read_json(&mut response).await;
+    let attached_disk: Disk = read_json(&mut response).await;
     let instance_id = &instance.identity.id;
-    assert_eq!(attachment.instance_id, *instance_id);
-    assert_eq!(attachment.disk_name, disk.identity.name);
-    assert_eq!(attachment.disk_id, disk.identity.id);
-    assert_eq!(
-        attachment.disk_state,
-        DiskState::Attaching(instance_id.clone())
-    );
-
-    let attachment: DiskAttachment =
-        object_get(&client, &url_instance_disk).await;
-    assert_eq!(attachment.instance_id, instance.identity.id);
-    assert_eq!(attachment.disk_name, disk.identity.name);
-    assert_eq!(attachment.disk_id, disk.identity.id);
-    assert_eq!(
-        attachment.disk_state,
-        DiskState::Attaching(instance_id.clone())
-    );
-
-    /* Check the state of the disk, too. */
-    let disk = disk_get(&client, &disk_url).await;
-    assert_eq!(disk.state, DiskState::Attaching(instance_id.clone()));
+    assert_eq!(attached_disk.identity.name, disk.identity.name);
+    assert_eq!(attached_disk.identity.id, disk.identity.id);
+    assert_eq!(attached_disk.state, DiskState::Attaching(instance_id.clone()));
 
     /*
      * Finish simulation of the attachment and verify the new state, both on the
      * attachment and the disk itself.
      */
     disk_simulate(nexus, &disk.identity.id).await;
-    let attachment: DiskAttachment =
-        object_get(&client, &url_instance_disk).await;
-    assert_eq!(attachment.instance_id, instance.identity.id);
-    assert_eq!(attachment.disk_name, disk.identity.name);
-    assert_eq!(attachment.disk_id, disk.identity.id);
-    assert_eq!(attachment.disk_state, DiskState::Attached(instance_id.clone()));
-
-    let disk = disk_get(&client, &disk_url).await;
-    assert_eq!(disk.state, DiskState::Attached(instance_id.clone()));
+    let attached_disk: Disk = object_get(&client, &url_instance_disk).await;
+    assert_eq!(attached_disk.identity.name, disk.identity.name);
+    assert_eq!(attached_disk.identity.id, disk.identity.id);
+    assert_eq!(attached_disk.state, DiskState::Attached(instance_id.clone()));
 
     /*
      * Attach the disk to the same instance.  This should complete immediately
      * with no state change.
      */
     client
-        .make_request_no_body(
-            Method::PUT,
-            &url_instance_disk,
-            StatusCode::CREATED,
+        .make_request(
+            Method::POST,
+            &url_instance_attach_disk,
+            Some(params::DiskReference { disk: disk.identity.name }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
@@ -257,18 +248,37 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         },
     )
     .await;
+    let url_instance2_disks = format!(
+        "/organizations/{}/projects/{}/instances/{}/disks",
+        org_name,
+        project_name,
+        instance2.identity.name.as_str(),
+    );
     let url_instance2_disk = format!(
         "/organizations/{}/projects/{}/instances/{}/disks/{}",
         org_name,
         project_name,
         instance2.identity.name.as_str(),
-        disk.identity.name.as_str()
+        disk.identity.name.as_str(),
+    );
+    let url_instance2_attach_disk = format!(
+        "/organizations/{}/projects/{}/instances/{}/disks/attach",
+        org_name,
+        project_name,
+        instance2.identity.name.as_str(),
+    );
+    let url_instance2_detach_disk = format!(
+        "/organizations/{}/projects/{}/instances/{}/disks/detach",
+        org_name,
+        project_name,
+        instance2.identity.name.as_str(),
     );
     let error = client
-        .make_request_error(
-            Method::PUT,
-            &url_instance2_disk,
-            StatusCode::BAD_REQUEST,
+        .make_request_error_body(
+            Method::POST,
+            &url_instance2_disks,
+            params::DiskReference { disk: disk.identity.name.clone() },
+            StatusCode::CONFLICT,
         )
         .await;
     assert_eq!(
@@ -277,8 +287,8 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
          instance"
     );
 
-    let disk = disk_get(&client, &disk_url).await;
-    assert_eq!(disk.state, DiskState::Attached(instance_id.clone()));
+    let attached_disk = disk_get(&client, &disk_url).await;
+    assert_eq!(attached_disk.state, DiskState::Attached(instance_id.clone()));
 
     let error = client
         .make_request_error(
@@ -296,30 +306,24 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
      * Begin detaching the disk.
      */
     client
-        .make_request_no_body(
-            Method::DELETE,
-            &url_instance_disk,
-            StatusCode::NO_CONTENT,
+        .make_request(
+            Method::POST,
+            &url_instance_detach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
-    let attachment: DiskAttachment =
-        object_get(&client, &url_instance_disk).await;
-    assert_eq!(
-        attachment.disk_state,
-        DiskState::Detaching(instance_id.clone())
-    );
-
-    /* Check the state of the disk, too. */
-    let disk = disk_get(&client, &disk_url).await;
-    assert_eq!(disk.state, DiskState::Detaching(instance_id.clone()));
+    let detached_disk: Disk = object_get(&client, &url_instance_disk).await;
+    assert_eq!(detached_disk.state, DiskState::Detaching(instance_id.clone()));
 
     /* It's still illegal to attach this disk elsewhere. */
     let error = client
-        .make_request_error(
-            Method::PUT,
-            &url_instance2_disk,
-            StatusCode::BAD_REQUEST,
+        .make_request_error_body(
+            Method::POST,
+            &url_instance2_attach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::CONFLICT,
         )
         .await;
     assert_eq!(
@@ -330,10 +334,11 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
 
     /* It's even illegal to attach this disk back to the same instance. */
     let error = client
-        .make_request_error(
-            Method::PUT,
-            &url_instance_disk,
-            StatusCode::BAD_REQUEST,
+        .make_request_error_body(
+            Method::POST,
+            &url_instance_attach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::CONFLICT,
         )
         .await;
     /* TODO-debug the error message here is misleading. */
@@ -345,10 +350,11 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
 
     /* However, there's no problem attempting to detach it again. */
     client
-        .make_request_no_body(
-            Method::DELETE,
-            &url_instance_disk,
-            StatusCode::NO_CONTENT,
+        .make_request(
+            Method::POST,
+            &url_instance_detach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
@@ -374,40 +380,39 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
 
     /* Since delete is idempotent, we can detach it again -- from either one. */
     client
-        .make_request_no_body(
-            Method::DELETE,
-            &url_instance_disk,
-            StatusCode::NO_CONTENT,
+        .make_request(
+            Method::POST,
+            &url_instance_detach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
     client
-        .make_request_no_body(
-            Method::DELETE,
-            &url_instance2_disk,
-            StatusCode::NO_CONTENT,
+        .make_request(
+            Method::POST,
+            &url_instance2_detach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
 
     /* Now, start attaching it again to the second instance. */
     let mut response = client
-        .make_request_no_body(
-            Method::PUT,
-            &url_instance2_disk,
-            StatusCode::CREATED,
+        .make_request(
+            Method::POST,
+            &url_instance2_attach_disk,
+            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            StatusCode::ACCEPTED,
         )
         .await
         .unwrap();
-    let attachment: DiskAttachment = read_json(&mut response).await;
+    let attached_disk: Disk = read_json(&mut response).await;
     let instance2_id = &instance2.identity.id;
-    assert_eq!(attachment.instance_id, *instance2_id);
-    assert_eq!(attachment.disk_name, disk.identity.name);
-    assert_eq!(attachment.disk_id, disk.identity.id);
-    assert_eq!(
-        attachment.disk_state,
-        DiskState::Attaching(instance2_id.clone())
-    );
+    assert_eq!(attached_disk.identity.name, disk.identity.name);
+    assert_eq!(attached_disk.identity.id, disk.identity.id);
+    assert_eq!(attached_disk.state, DiskState::Attaching(instance2_id.clone()));
 
     let disk = disk_get(&client, &disk_url).await;
     assert_eq!(disk.state, DiskState::Attaching(instance2_id.clone()));
@@ -456,12 +461,9 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         )
         .await
         .unwrap();
-    let attachment: DiskAttachment =
-        object_get(&client, &url_instance2_disk).await;
-    assert_eq!(
-        attachment.disk_state,
-        DiskState::Detaching(instance2_id.clone())
-    );
+    let detached_disk: Disk = object_get(&client, &url_instance2_disk).await;
+    assert_eq!(detached_disk.state, DiskState::Detaching(instance2_id.clone()));
+
     let disk = disk_get(&client, &disk_url).await;
     assert_eq!(disk.state, DiskState::Detaching(instance2_id.clone()));
 

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -174,7 +174,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -203,7 +203,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name }),
+            Some(params::DiskIdentifier { disk: disk.identity.name }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -245,7 +245,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request_error_body(
             Method::POST,
             &url_instance2_attach_disk,
-            params::DiskReference { disk: disk.identity.name.clone() },
+            params::DiskIdentifier { disk: disk.identity.name.clone() },
             StatusCode::BAD_REQUEST,
         )
         .await;
@@ -265,7 +265,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance_detach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -278,7 +278,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request_error_body(
             Method::POST,
             &url_instance2_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::BAD_REQUEST,
         )
         .await;
@@ -293,7 +293,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request_error_body(
             Method::POST,
             &url_instance_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::BAD_REQUEST,
         )
         .await;
@@ -309,7 +309,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance_detach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -327,7 +327,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance_detach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -336,7 +336,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance2_detach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -347,7 +347,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance2_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -369,7 +369,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request_error_body(
             Method::POST,
             &url_instance_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::BAD_REQUEST,
         )
         .await;
@@ -384,7 +384,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance2_attach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await
@@ -403,7 +403,7 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         .make_request(
             Method::POST,
             &url_instance2_detach_disk,
-            Some(params::DiskReference { disk: disk.identity.name.clone() }),
+            Some(params::DiskIdentifier { disk: disk.identity.name.clone() }),
             StatusCode::ACCEPTED,
         )
         .await

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -161,9 +161,8 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
         instance.identity.name.as_str(),
         disk.identity.name.as_str(),
     );
-    let attachments =
-        object_get::<Vec<DiskAttachment>>(&client, &url_instance_disks).await;
-    assert_eq!(attachments.len(), 0);
+    let disks = objects_list_page::<Disk>(&client, &url_instance_disks).await;
+    assert_eq!(disks.items.len(), 0);
     let error = client
         .make_request_error(
             Method::GET,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -975,6 +975,36 @@
         "operationId": "instance_disks_get",
         "parameters": [
           {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
             "in": "path",
             "name": "instance_name",
             "required": true,
@@ -1008,16 +1038,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Array_of_DiskAttachment",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DiskAttachment"
-                  }
+                  "$ref": "#/components/schemas/DiskResultsPage"
                 }
               }
             }
           }
-        }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1047,20 +1047,10 @@
         "x-dropshot-pagination": true
       }
     },
-    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}": {
-      "get": {
-        "description": "Fetch a description of the attachment of this disk to this instance.",
-        "operationId": "instance_disks_get_disk",
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach": {
+      "post": {
+        "operationId": "instance_disks_attach",
         "parameters": [
-          {
-            "in": "path",
-            "name": "disk_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
           {
             "in": "path",
             "name": "instance_name",
@@ -1089,32 +1079,34 @@
             "style": "simple"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiskIdentifier"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
-          "200": {
-            "description": "successful operation",
+          "202": {
+            "description": "successfully enqueued operation",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DiskAttachment"
+                  "$ref": "#/components/schemas/Disk"
                 }
               }
             }
           }
         }
-      },
-      "put": {
-        "description": "Attach a disk to this instance.",
-        "operationId": "instance_disks_put_disk",
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach": {
+      "post": {
+        "operationId": "instance_disks_detach",
         "parameters": [
-          {
-            "in": "path",
-            "name": "disk_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
           {
             "in": "path",
             "name": "instance_name",
@@ -1143,63 +1135,26 @@
             "style": "simple"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiskIdentifier"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
-          "201": {
-            "description": "successful creation",
+          "202": {
+            "description": "successfully enqueued operation",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DiskAttachment"
+                  "$ref": "#/components/schemas/Disk"
                 }
               }
             }
-          }
-        }
-      },
-      "delete": {
-        "description": "Detach a disk from this instance.",
-        "operationId": "instance_disks_delete_disk",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "disk_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "instance_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "organization_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "project_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "successful deletion"
           }
         }
       }
@@ -2969,32 +2924,6 @@
           "timeModified"
         ]
       },
-      "DiskAttachment": {
-        "description": "Describes a Disk's attachment to an Instance",
-        "type": "object",
-        "properties": {
-          "diskId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "diskName": {
-            "$ref": "#/components/schemas/Name"
-          },
-          "diskState": {
-            "$ref": "#/components/schemas/DiskState"
-          },
-          "instanceId": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "diskId",
-          "diskName",
-          "diskState",
-          "instanceId"
-        ]
-      },
       "DiskCreate": {
         "description": "Create-time parameters for a [`Disk`]",
         "type": "object",
@@ -3024,6 +2953,18 @@
           "description",
           "name",
           "size"
+        ]
+      },
+      "DiskIdentifier": {
+        "description": "Parameters for the [`Disk`] to be attached or detached to an instance",
+        "type": "object",
+        "properties": {
+          "disk": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "disk"
         ]
       },
       "DiskResultsPage": {


### PR DESCRIPTION
As we build out table interfaces in Console we'd like to see that all list endpoints we're wired up to are properly paginated. We've had a todo for a while to paginate instance disks which is the intend behind this PR. As I was digging into it though, it seems potentially a bit more involved.

Prior to this PR we have a notion of a `DiskAttachment`. It's just an instance id and a few fields (id, name, state) from the disk. That's the data structure we're currently exposing from `/instances/:instance/disks`. As I understand it, this route is just the project lists endpoint filtered down to the current `attached_instance_id`. As I was going through the work to paginated that it was notable that the `DiskAttachment` data structure pre-dates a lot of our pagination work and thereby lacks a lot of prerequisite fields (like `identity`) that are typically required for pagination. I was considering updating it to have those fields when I realized it probably makes more sense for these fields just to return a `Disk` structure instead. 

The biggest hiccup to this approach is the `PUT` method. When doing a `GET` it feels right to get an entire disk representation back. When doing a `PUT` the question becomes are we updating a disk or just attaching a disk? The answer to that has ramifications about how we expose the API. From a strictly consistency perspective it would seem that if a `GET` returns a `Disk` then a `PUT` should take a `Disk`... perhaps with a limited subset of fields (i.e. you don't _have_ to provide the `attached_instance_id` because that's directly implied from the route being `PUT` to. 

I'd like some feedback on the above. 