### PR TITLE
Update async-bb8 to use flexible error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?branch=errors#9b361fa6b3886c2b642f638a9887b343866c318b"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=c849b717be#c849b717be1e33528c7c3950fefcb431a65ef469"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=22c26ef#22c26ef840075a57b18ac2eae3ead989b992773e"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?branch=errors#9b361fa6b3886c2b642f638a9887b343866c318b"
 dependencies = [
  "async-trait",
  "bb8",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -11,7 +11,8 @@ path = "../rpaths"
 anyhow = "1.0"
 async-trait = "0.1.51"
 bb8 = "0.7.1"
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "22c26ef" }
+# TODO: Replace custom branch with rev+master before merging
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", branch = "errors" }
 cookie = "0.15"
 # Tracking pending 2.0 version.
 diesel = { git = "https://github.com/diesel-rs/diesel", rev = "ce77c382", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -11,8 +11,7 @@ path = "../rpaths"
 anyhow = "1.0"
 async-trait = "0.1.51"
 bb8 = "0.7.1"
-# TODO: Replace custom branch with rev+master before merging
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", branch = "errors" }
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "c849b717be" }
 cookie = "0.15"
 # Tracking pending 2.0 version.
 diesel = { git = "https://github.com/diesel-rs/diesel", rev = "ce77c382", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }


### PR DESCRIPTION
Updates async-bb8-diesel to include https://github.com/oxidecomputer/async-bb8-diesel/pull/9

See that PR for more context, but TL;DR: we can now propagate user-defined errors from Diesel transaction functions.
