### PR TITLE
Make test-utils buildable on their own

### DIFF
--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -30,7 +30,7 @@ features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.tokio]
 version = "1.14"
-features = [ "full" ]
+features = [ "full", "test-util" ]
 
 [dependencies.tokio-postgres]
 version = "0.7"


### PR DESCRIPTION
Without this PR, running:

```bash
$  cargo test -p omicron-test-utils --lib
```

Fails to build - `tokio::time::pause` is not found.

I think `cargo test` still works because of feature resolution in the workspace, but this change lets the tests be buildable on their own.