### PR TITLE
Set session cookie path to /

### DIFF
--- a/nexus/src/authn/external/session_cookie.rs
+++ b/nexus/src/authn/external/session_cookie.rs
@@ -56,7 +56,7 @@ pub const SESSION_COOKIE_SCHEME_NAME: authn::SchemeName =
 /// Generate session cookie header
 pub fn session_cookie_header_value(token: &str, max_age: Duration) -> String {
     format!(
-        "{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={}",
+        "{}={}; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age={}",
         SESSION_COOKIE_COOKIE_NAME,
         token,
         max_age.num_seconds()
@@ -380,17 +380,17 @@ mod test {
     fn test_session_cookie_value() {
         assert_eq!(
             session_cookie_header_value("abc", Duration::seconds(5)),
-            "session=abc; Secure; HttpOnly; SameSite=Lax; Max-Age=5"
+            "session=abc; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=5"
         );
 
         assert_eq!(
             session_cookie_header_value("abc", Duration::seconds(-5)),
-            "session=abc; Secure; HttpOnly; SameSite=Lax; Max-Age=-5"
+            "session=abc; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=-5"
         );
 
         assert_eq!(
             session_cookie_header_value("", Duration::zero()),
-            "session=; Secure; HttpOnly; SameSite=Lax; Max-Age=0"
+            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0"
         );
     }
 }

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -25,7 +25,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
         .expect_status(Some(StatusCode::NO_CONTENT))
         .expect_response_header(
             header::SET_COOKIE,
-            "session=; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
+            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
         )
         .execute()
         .await
@@ -80,7 +80,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
         // logout also clears the cookie client-side
         .expect_response_header(
             header::SET_COOKIE,
-            "session=; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
+            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
         )
         .execute()
         .await
@@ -222,7 +222,7 @@ async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let (session_token, rest) = session_cookie.split_once("; ").unwrap();
 
     assert!(session_token.starts_with("session="));
-    assert_eq!(rest, "Secure; HttpOnly; SameSite=Lax; Max-Age=3600");
+    assert_eq!(rest, "Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=3600");
 
     session_token.to_string()
 }


### PR DESCRIPTION
Ran into a double puzzle after helping @jmpesp get his demo SAML server working with the console.

The first was that James was posting to `/login/saml` (I think) but the cookie was getting set to `path=/login` in the browser. That is explained [here](https://stackoverflow.com/a/64515458): the spec says basically that when a `set-cookie` doesn't specify a path, you automatically get a `path` that takes all but the last segment of the requested path.

The other part was that when I tested it myself locally and on GCP, I saw a path of `/api`. That is also explained by the above, with the additional context that both locally and on GCP, API requests are going through a proxy server and all API routes have a prefix of `/api`, so even `/login` becomes `/api/login`. So when I posted to `/api/login` to log in, I got a cookie path of `/api`.

Specifying `Path="/"` on the server is a general solution. It would be nice if we could get a more restricted path that would work, but we can't: we need to work for console page routes as well as API routes.

> It is recommended to use a narrow or restricted scope for these two attributes. In this way, the Domain attribute should not be set (restricting the cookie just to the origin server) and the Path attribute should be set as restrictive as possible to the web application path that makes use of the session ID.

— [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)