### PR TITLE
buildomat: retain log files from test failures

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -4,7 +4,9 @@
 #: variety = "basic"
 #: target = "helios"
 #: rust_toolchain = "nightly-2021-11-24"
-#: output_rules = []
+#: output_rules = [
+#:	"/tmp/omicron*.log",
+#: ]
 #:
 
 set -o errexit


### PR DESCRIPTION
As seen in omicron#540, sometimes a test run under buildomat fails.  We see in the stdio output of the job the path of a log file; viz., `/tmp/omicron_nexus-af7cc18609452f5b-test_paginated_single_column_descending.3657.7.log`.  We don't currently preserve the contents of the log file, though.

This PR adds a buildomat output rule to save any file that matches the glob `/tmp/omicron*.log` which would have caught this log file.  Buildomat will save any matching files, including links to their contents, whether the job succeeds or fails.  As long as successful tests clean up their log files, but failures do not, we will only preserve the failures.