### PR TITLE
tests that make their own logctx need to clean it up on success

### DIFF
--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -184,6 +184,7 @@ mod test {
             "expected unauthenticated user not to be able to query database",
         );
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -224,5 +225,6 @@ mod test {
             to create organization",
             );
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/sled-agent/src/bootstrap/spdm/mod.rs
+++ b/sled-agent/src/bootstrap/spdm/mod.rs
@@ -75,8 +75,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_recv_timeout() {
-        let log =
-            omicron_test_utils::dev::test_setup_log("test_recv_timeout").log;
+        let logctx =
+            omicron_test_utils::dev::test_setup_log("test_recv_timeout");
+        let log = logctx.log.clone();
         let addr: SocketAddr = "127.0.0.1:9898".parse().unwrap();
         let listener = TcpListener::bind(addr.clone()).await.unwrap();
 
@@ -89,5 +90,6 @@ mod tests {
         let _ = TcpStream::connect(addr).await.unwrap();
 
         assert!(handle.await.unwrap().is_err());
+        logctx.cleanup_successful();
     }
 }

--- a/sled-agent/src/bootstrap/spdm/requester.rs
+++ b/sled-agent/src/bootstrap/spdm/requester.rs
@@ -153,7 +153,8 @@ mod tests {
 
     #[tokio::test]
     async fn negotiation() {
-        let log = omicron_test_utils::dev::test_setup_log("negotiation").log;
+        let logctx = omicron_test_utils::dev::test_setup_log("negotiation");
+        let log = logctx.log.clone();
         let log2 = log.clone();
         let log3 = log.clone();
 
@@ -172,5 +173,6 @@ mod tests {
         run(log3, transport).await.unwrap();
 
         handle.await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/sled-agent/src/bootstrap/trust_quorum/server.rs
+++ b/sled-agent/src/bootstrap/trust_quorum/server.rs
@@ -115,9 +115,9 @@ mod test {
         let (shares, verifier) = secret.split(2, 2).unwrap();
 
         // Start a trust quorum server, but only accept one connection
-        let log =
-            omicron_test_utils::dev::test_setup_log("trust_quorum::send_share")
-                .log;
+        let logctx =
+            omicron_test_utils::dev::test_setup_log("trust_quorum::send_share");
+        let log = logctx.log.clone();
         let mut server = Server::new(&log, shares[0].clone()).unwrap();
         let join_handle = tokio::spawn(async move { server.accept().await });
 
@@ -127,5 +127,6 @@ mod test {
         assert_eq!(share, shares[0]);
 
         join_handle.await.unwrap().unwrap();
+        logctx.cleanup_successful();
     }
 }


### PR DESCRIPTION
We could really use a macro like @teisenbe did in #502 but for things that only use a LogContext.  In the meantime, this cleans up the cases that were added since #499.   @jclulow noticed these in #542.