### PR TITLE
save test outputs from GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,8 +145,8 @@ jobs:
       uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: test_outputs
+        retention-days: 7
         path: |
           ${{ env.OMICRON_TMP }}
           !${{ env.OMICRON_TMP }}/crdb-base
           !${{ env.OMICRON_TMP }}/rustc*
-          retention-days: 7

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,7 +144,7 @@ jobs:
       # actions/upload-artifact@v2.3.1
       uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
-        name: test_outputs
+        name: failed_test_outputs_${{ runner.os }}
         retention-days: 7
         path: |
           ${{ env.OMICRON_TMP }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-and-test:
     env:
-      OMICRON_TMP=/tmp/omicron_tmp
+      OMICRON_TMP: /tmp/omicron_tmp
     needs: skip_duplicate_jobs
     if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,6 +140,7 @@ jobs:
       # suite.
       run: TMPDIR=$OMICRON_TMP PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --workspace --locked --verbose
     - name: Archive any failed test results
+      if: ${{ failure() }}
       # actions/upload-artifact@v2.3.1
       uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,8 @@ jobs:
       run: cargo doc
 
   build-and-test:
+    env:
+      OMICRON_TMP=/tmp/omicron_tmp
     needs: skip_duplicate_jobs
     if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
@@ -114,6 +116,8 @@ jobs:
     - name: Download CockroachDB binary
       if: steps.cache-cockroachdb.outputs.cache-hit != 'true'
       run: bash ./tools/ci_download_cockroachdb
+    - name: Create temporary directory for test outputs
+      run: mkdir -p $OMICRON_TMP
     - name: Build
       # We build with:
       # - RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings": disallow warnings
@@ -125,10 +129,23 @@ jobs:
       #   also gives us a record of which dependencies were used for each CI
       #   run.  Building with `--locked` ensures that the checked-in Cargo.lock
       #   is up to date.
-      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo build --locked --all-targets --verbose
+      # - TMPDIR=$OMICRON_TMP: we specify a specific temporary directory so that
+      #   failed test outputs will be in a known place that we can grab at the
+      #   end without also grabbing random other temporary files.
+      run: TMPDIR=$OMICRON_TMP PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo build --locked --all-targets --verbose
     - name: Run tests
       # Use the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid having to
       # rebuild here.
       # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
       # suite.
-      run: PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --workspace --locked --verbose
+      run: TMPDIR=$OMICRON_TMP PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --workspace --locked --verbose
+    - name: Archive any failed test results
+      # actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+      with:
+        name: test_outputs
+        path: |
+          ${{ env.OMICRON_TMP }}
+          !${{ env.OMICRON_TMP }}/crdb-base
+          !${{ env.OMICRON_TMP }}/rustc*
+          retention-days: 7

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -224,9 +224,12 @@ mod test {
                 "expected unauthenticated user not to be able \
             to create organization",
             );
-        #[allow(unreachable_code)]
-        panic!("injected error (dap)");
+        dummy();
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
+    }
+
+    fn dummy() {
+        panic!("injected error (dap)");
     }
 }

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -224,6 +224,7 @@ mod test {
                 "expected unauthenticated user not to be able \
             to create organization",
             );
+        #[allow(unreachable_code)]
         panic!("injected error (dap)");
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -224,12 +224,7 @@ mod test {
                 "expected unauthenticated user not to be able \
             to create organization",
             );
-        dummy();
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
-    }
-
-    fn dummy() {
-        panic!("injected error (dap)");
     }
 }

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -189,7 +189,7 @@ mod test {
 
     #[tokio::test]
     async fn test_organization() {
-        let logctx = dev::test_setup_log("test_database");
+        let logctx = dev::test_setup_log("test_organization");
         let mut db = dev::test_setup_database(&logctx.log).await;
         let (opctx, datastore) =
             crate::db::datastore::datastore_test(&logctx, &db).await;
@@ -224,6 +224,7 @@ mod test {
                 "expected unauthenticated user not to be able \
             to create organization",
             );
+        panic!("injected error (dap)");
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
     }

--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -572,7 +572,14 @@ impl Drop for CockroachInstance {
             }
             #[allow(unused_must_use)]
             if let Some(temp_dir) = self.temp_dir.take() {
-                temp_dir.close();
+                /*
+                 * Do NOT clean up the temporary directory in this case.
+                 */
+                let path = temp_dir.into_path();
+                eprintln!(
+                    "WARN: temporary directory leaked: {}",
+                    path.display()
+                );
             }
         }
     }

--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -1246,13 +1246,13 @@ mod test {
      */
     #[tokio::test]
     async fn test_database_concurrent() {
-        let db1 = new_builder()
+        let mut db1 = new_builder()
             .build()
             .expect("failed to create starter for the first database")
             .start()
             .await
             .expect("failed to start first database");
-        let db2 = new_builder()
+        let mut db2 = new_builder()
             .build()
             .expect("failed to create starter for the second database")
             .start()
@@ -1281,6 +1281,9 @@ mod test {
             client2.query("SELECT v FROM foo", &[]).await.expect("list rows");
         assert_eq!(rows.len(), 0);
         client2.cleanup().await.expect("second connection closed ungracefully");
+
+        db1.cleanup().await.expect("failed to clean up first database");
+        db2.cleanup().await.expect("failed to clean up second database");
     }
 
     /* Success case for make_pg_config() */


### PR DESCRIPTION
Related to #542.  Do this for GitHub Actions too.

I haven't tested this yet.