### PR TITLE
Require both IPv4 and IPv6 blocks on VPC subnets

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -1090,9 +1090,7 @@ impl DataStore {
             }
             // Insert and allocate an IP address
             None => {
-                let block = interface.subnet.ipv4_block.ok_or_else(|| {
-                    Error::internal_error("assuming subnets all have v4 block")
-                })?;
+                let block = interface.subnet.ipv4_block;
                 let allocation_query = AllocateIpQuery {
                     block: ipnetwork::IpNetwork::V4(block.0 .0),
                     interface,

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1162,8 +1162,8 @@ pub struct VpcSubnet {
     identity: VpcSubnetIdentity,
 
     pub vpc_id: Uuid,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
+    pub ipv4_block: Ipv4Net,
+    pub ipv6_block: Ipv6Net,
 }
 
 impl VpcSubnet {
@@ -1176,8 +1176,8 @@ impl VpcSubnet {
         Self {
             identity,
             vpc_id,
-            ipv4_block: params.ipv4_block.map(Ipv4Net),
-            ipv6_block: params.ipv6_block.map(Ipv6Net),
+            ipv4_block: Ipv4Net(params.ipv4_block),
+            ipv6_block: Ipv6Net(params.ipv6_block),
         }
     }
 }
@@ -1198,8 +1198,8 @@ impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
             name: params.identity.name.map(Name),
             description: params.identity.description,
             time_modified: Utc::now(),
-            ipv4_block: params.ipv4_block.map(Ipv4Net),
-            ipv6_block: params.ipv6_block.map(Ipv6Net),
+            ipv4_block: Some(Ipv4Net(params.ipv4_block)),
+            ipv6_block: Some(Ipv6Net(params.ipv6_block)),
         }
     }
 }

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -233,8 +233,8 @@ table! {
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
         vpc_id -> Uuid,
-        ipv4_block -> Nullable<Inet>,
-        ipv6_block -> Nullable<Inet>,
+        ipv4_block -> Inet,
+        ipv6_block -> Inet,
     }
 }
 

--- a/nexus/src/db/subnet_allocation.rs
+++ b/nexus/src/db/subnet_allocation.rs
@@ -231,7 +231,7 @@ mod test {
     use diesel::pg::Pg;
     use diesel::prelude::*;
     use omicron_common::api::external::{
-        IdentityMetadataCreateParams, Ipv4Net, MacAddr,
+        IdentityMetadataCreateParams, Ipv4Net, Ipv6Net, MacAddr,
     };
     use std::convert::TryInto;
 
@@ -249,7 +249,8 @@ mod test {
         let subnet_id =
             uuid::Uuid::parse_str("223cb7f7-0d3a-4a4e-a5e1-ad38ecb785d3")
                 .unwrap();
-        let block: ipnetwork::Ipv4Network = "192.168.1.0/24".parse().unwrap();
+        let ipv4_block = "192.168.1.0/24".parse().unwrap();
+        let ipv6_block = "fd12:3456::/64".parse().unwrap();
         let subnet = VpcSubnet::new(
             subnet_id,
             vpc_id,
@@ -258,8 +259,8 @@ mod test {
                     name: "test-subnet".to_string().try_into().unwrap(),
                     description: "subnet description".to_string(),
                 },
-                ipv4_block: Some(Ipv4Net(block.clone()).into()),
-                ipv6_block: None,
+                ipv4_block: Ipv4Net(ipv4_block),
+                ipv6_block: Ipv6Net(ipv6_block),
             },
         );
         let mac =
@@ -281,7 +282,7 @@ mod test {
         );
         let select = AllocateIpQuery {
             interface,
-            block: block.into(),
+            block: ipv4_block.into(),
             now: DateTime::<Utc>::from_utc(
                 NaiveDateTime::from_timestamp(0, 0),
                 Utc,

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -127,8 +127,8 @@ pub struct VpcUpdate {
 pub struct VpcSubnetCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
+    pub ipv4_block: Ipv4Net,
+    pub ipv6_block: Ipv6Net,
 }
 
 /**
@@ -139,8 +139,8 @@ pub struct VpcSubnetCreate {
 pub struct VpcSubnetUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
+    pub ipv4_block: Ipv4Net,
+    pub ipv6_block: Ipv6Net,
 }
 
 /*

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -119,10 +119,10 @@ pub struct VpcSubnet {
     // how to do the validation of user-specified CIDR blocks, or how to create a block if one is
     // not given.
     /** The IPv4 subnet CIDR block. */
-    pub ipv4_block: Option<Ipv4Net>,
+    pub ipv4_block: Ipv4Net,
 
     /** The IPv6 subnet CIDR block. */
-    pub ipv6_block: Option<Ipv6Net>,
+    pub ipv6_block: Ipv6Net,
 }
 
 impl Into<VpcSubnet> for model::VpcSubnet {
@@ -130,8 +130,8 @@ impl Into<VpcSubnet> for model::VpcSubnet {
         VpcSubnet {
             identity: self.identity(),
             vpc_id: self.vpc_id,
-            ipv4_block: self.ipv4_block.map(|ip| ip.into()),
-            ipv6_block: self.ipv6_block.map(|ip| ip.into()),
+            ipv4_block: self.ipv4_block.into(),
+            ipv6_block: self.ipv6_block.into(),
         }
     }
 }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1592,14 +1592,14 @@ impl Nexus {
                         params.identity.name
                     ),
                 },
-                ipv4_block: Some(Ipv4Net(
+                ipv4_block: Ipv4Net(
                     // TODO: This value should be replaced with the correct ipv4 range for a default subnet
                     "10.1.9.32/16".parse::<Ipv4Network>().unwrap(),
-                )),
-                ipv6_block: Some(Ipv6Net(
+                ),
+                ipv6_block: Ipv6Net(
                     // TODO: This value should be replaced w/ the first `/64` ipv6 from the address block
                     "2001:db8::0/64".parse::<Ipv6Network>().unwrap(),
-                )),
+                ),
             },
         );
         self.db_datastore.vpc_create_subnet(subnet).await?;

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -11,7 +11,7 @@ use http::method::Method;
 use http::StatusCode;
 use omicron_common::api::external::{
     ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams,
-    Instance, InstanceCpuCount, Ipv4Net, NetworkInterface,
+    Instance, InstanceCpuCount, Ipv4Net, Ipv6Net, NetworkInterface,
 };
 use omicron_nexus::external_api::params;
 use std::net::IpAddr;
@@ -88,14 +88,15 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
         "/organizations/{}/projects/{}/vpcs/default/subnets/default",
         organization_name, project_name
     );
-    let subnet = "192.168.42.0/29".parse().unwrap();
+    let ipv4_block = "192.168.42.0/29".parse().unwrap();
+    let ipv6_block = "fd12:3456::/64".parse().unwrap();
     let subnet_update = params::VpcSubnetUpdate {
         identity: IdentityMetadataUpdateParams {
             name: Some("default".parse().unwrap()),
             description: None,
         },
-        ipv4_block: Some(Ipv4Net(subnet)),
-        ipv6_block: None,
+        ipv4_block: Ipv4Net(ipv4_block),
+        ipv6_block: Ipv6Net(ipv6_block),
     };
     client
         .make_request(

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -72,10 +72,8 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(error.message, "not found: vpc-subnet with name \"subnet1\"");
 
     /* Create a VPC Subnet. */
-    let ipv4_block =
-        Some(Ipv4Net("10.1.9.32/16".parse::<Ipv4Network>().unwrap()));
-    let ipv6_block =
-        Some(Ipv6Net("2001:db8::0/96".parse::<Ipv6Network>().unwrap()));
+    let ipv4_block = Ipv4Net("10.1.9.32/16".parse::<Ipv4Network>().unwrap());
+    let ipv6_block = Ipv6Net("2001:db8::0/96".parse::<Ipv6Network>().unwrap());
     let new_subnet = params::VpcSubnetCreate {
         identity: IdentityMetadataCreateParams {
             name: subnet_name.parse().unwrap(),
@@ -146,16 +144,16 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
             name: subnet2_name.parse().unwrap(),
             description: "it's also below the net".to_string(),
         },
-        ipv4_block: None,
-        ipv6_block: None,
+        ipv4_block,
+        ipv6_block,
     };
     let subnet2: VpcSubnet =
         objects_post(&client, &subnets_url, new_subnet.clone()).await;
     assert_eq!(subnet2.identity.name, subnet2_name);
     assert_eq!(subnet2.identity.description, "it's also below the net");
     assert_eq!(subnet2.vpc_id, vpc.identity.id);
-    assert_eq!(subnet2.ipv4_block, None);
-    assert_eq!(subnet2.ipv6_block, None);
+    assert_eq!(subnet2.ipv4_block, ipv4_block);
+    assert_eq!(subnet2.ipv6_block, ipv6_block);
 
     // subnets list should now have two in it
     let subnets =
@@ -165,13 +163,17 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
     subnets_eq(&subnets[1], &subnet2);
 
     // update first subnet
+    let new_ipv4_block =
+        Ipv4Net("10.1.9.33/16".parse::<Ipv4Network>().unwrap());
+    let new_ipv6_block =
+        Ipv6Net("2001:db9::0/96".parse::<Ipv6Network>().unwrap());
     let update_params = params::VpcSubnetUpdate {
         identity: IdentityMetadataUpdateParams {
             name: Some("new-name".parse().unwrap()),
             description: Some("another description".to_string()),
         },
-        ipv4_block: None,
-        ipv6_block: None,
+        ipv4_block: new_ipv4_block,
+        ipv6_block: new_ipv6_block,
     };
     client
         .make_request(
@@ -245,8 +247,8 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
         "it's also below the net"
     );
     assert_eq!(subnet_same_name.vpc_id, vpc2.identity.id);
-    assert_eq!(subnet_same_name.ipv4_block, None);
-    assert_eq!(subnet_same_name.ipv6_block, None);
+    assert_eq!(subnet_same_name.ipv4_block, ipv4_block);
+    assert_eq!(subnet_same_name.ipv6_block, ipv6_block);
 }
 
 fn subnets_eq(sn1: &VpcSubnet, sn2: &VpcSubnet) {


### PR DESCRIPTION
Leaving as a draft because I'm not sure whether we want to do this, but I wanted to see how it would look. @rmustacc's says [here](https://github.com/oxidecomputer/rfd/issues/274#issuecomment-1006163082):

> So IIRC we had some discussion around this earlier, I think when @teisenbe was working on the nexus/Omicron end. So hopefully what I'm about to say will agree with what I talked about then. The long term goal is to allow someone to have an entire VPC or an individual VPC subnet with only one of IPv4 or IPv6; however, to simplify the initial implementation we're requiring that both an IPv4 and IPv6 subnet be present at this time.

@teisenbe how does this comport with your memory of the conversation?

@bnaecker it looks like you originally [wrote](https://github.com/oxidecomputer/omicron/pull/163/files#diff-fa1a683dc9c0f71347ffbf6f1488706fccd37a65065e5df8f01d766793cdfe0eR1443-R1445) this comment, what do you remember?

https://github.com/oxidecomputer/omicron/blob/939adec4de865caf4c0339fced7fdc75f8bfa5b0/nexus/src/external_api/views.rs#L114-L116