### PR TITLE
initial pass at adding tags

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -46,6 +46,7 @@ pub struct LoginParams {
    path = "/login",
    // TODO: this should be unpublished, but for now it's convenient for the
    // console to use the generated client for this request
+   tags = ["hidden"],
 }]
 pub async fn spoof_login(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -90,6 +91,7 @@ pub async fn spoof_login(
    path = "/logout",
    // TODO: this should be unpublished, but for now it's convenient for the
    // console to use the generated client for this request
+   tags = ["hidden"],
 }]
 pub async fn logout(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -202,6 +204,7 @@ pub async fn login_redirect(
 #[endpoint {
    method = GET,
    path = "/session/me",
+   tags = ["hidden"],
 }]
 pub async fn session_me(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -205,8 +205,9 @@ pub fn external_api() -> NexusApiDescription {
  * List all organizations.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations",
+    method = GET,
+    path = "/organizations",
+    tags = ["organizations"],
  }]
 async fn organizations_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -246,7 +247,8 @@ async fn organizations_get(
  */
 #[endpoint {
     method = POST,
-    path = "/organizations"
+    path = "/organizations",
+    tags = ["organizations"],
 }]
 async fn organizations_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -279,6 +281,7 @@ struct OrganizationPathParam {
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}",
+    tags = ["organizations"],
 }]
 async fn organizations_get_organization(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -299,9 +302,10 @@ async fn organizations_get_organization(
  * Delete a specific organization.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}",
+    tags = ["organizations"],
+}]
 async fn organizations_delete_organization(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<OrganizationPathParam>,
@@ -327,9 +331,10 @@ async fn organizations_delete_organization(
  * "application/json-patch")?  We should see what other APIs do.
  */
 #[endpoint {
-     method = PUT,
-     path = "/organizations/{organization_name}",
- }]
+    method = PUT,
+    path = "/organizations/{organization_name}",
+    tags = ["organizations"],
+}]
 async fn organizations_put_organization(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<OrganizationPathParam>,
@@ -355,9 +360,10 @@ async fn organizations_put_organization(
  * List all projects.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects",
+    tags = ["projects"],
+}]
 async fn organization_projects_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByNameOrId>,
@@ -402,7 +408,8 @@ async fn organization_projects_get(
  */
 #[endpoint {
     method = POST,
-    path = "/organizations/{organization_name}/projects"
+    path = "/organizations/{organization_name}/projects",
+    tags = ["projects"],
 }]
 async fn organization_projects_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -444,6 +451,7 @@ struct ProjectPathParam {
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}/projects/{project_name}",
+    tags = ["projects"],
 }]
 async fn organization_projects_get_project(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -466,9 +474,10 @@ async fn organization_projects_get_project(
  * Delete a specific project.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}/projects/{project_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}/projects/{project_name}",
+    tags = ["projects"],
+}]
 async fn organization_projects_delete_project(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
@@ -495,9 +504,10 @@ async fn organization_projects_delete_project(
  * "application/json-patch")?  We should see what other APIs do.
  */
 #[endpoint {
-     method = PUT,
-     path = "/organizations/{organization_name}/projects/{project_name}",
- }]
+    method = PUT,
+    path = "/organizations/{organization_name}/projects/{project_name}",
+    tags = ["organizations"],
+}]
 async fn organization_projects_put_project(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
@@ -529,9 +539,10 @@ async fn organization_projects_put_project(
  * List disks in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/disks",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/disks",
+    tags = ["projects"]
+}]
 async fn project_disks_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -566,9 +577,10 @@ async fn project_disks_get(
  * TODO-correctness See note about instance create.  This should be async.
  */
 #[endpoint {
-     method = POST,
-     path = "/organizations/{organization_name}/projects/{project_name}/disks",
- }]
+    method = POST,
+    path = "/organizations/{organization_name}/projects/{project_name}/disks",
+    tags = ["projects"]
+}]
 async fn project_disks_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
@@ -607,9 +619,10 @@ struct DiskPathParam {
  * Fetch a single disk in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}",
+    tags = ["projects"],
+}]
 async fn project_disks_get_disk(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<DiskPathParam>,
@@ -633,9 +646,10 @@ async fn project_disks_get_disk(
  * Delete a disk from a project.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}",
+    tags = ["projects"],
+}]
 async fn project_disks_delete_disk(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<DiskPathParam>,
@@ -669,9 +683,10 @@ async fn project_disks_delete_disk(
  * List instances in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/instances",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/instances",
+    tags = ["instances"],
+}]
 async fn project_instances_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -712,9 +727,10 @@ async fn project_instances_get(
  * resource created?
  */
 #[endpoint {
-     method = POST,
+    method = POST,
      path = "/organizations/{organization_name}/projects/{project_name}/instances",
- }]
+    tags = ["instances"],
+}]
 async fn project_instances_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
@@ -753,9 +769,10 @@ struct InstancePathParam {
  * Get an instance in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
+    tags = ["instances"],
+}]
 async fn project_instances_get_instance(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
@@ -783,9 +800,10 @@ async fn project_instances_get_instance(
  * Delete an instance from a project.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
+    tags = ["instances"],
+}]
 async fn project_instances_delete_instance(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
@@ -815,6 +833,7 @@ async fn project_instances_delete_instance(
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot",
+    tags = ["instances"],
 }]
 async fn project_instances_instance_reboot(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -841,6 +860,7 @@ async fn project_instances_instance_reboot(
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start",
+    tags = ["instances"],
 }]
 async fn project_instances_instance_start(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -867,6 +887,7 @@ async fn project_instances_instance_start(
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop",
+    tags = ["instances"],
 }]
 /* Our naming convention kind of falls apart here. */
 async fn project_instances_instance_stop(
@@ -894,7 +915,8 @@ async fn project_instances_instance_stop(
 /* TODO-scalability needs to be paginated */
 #[endpoint {
     method = GET,
-    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks"
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks",
+    tags = ["instances"],
 }]
 async fn instance_disks_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -928,7 +950,8 @@ async fn instance_disks_get(
 
 #[endpoint {
     method = POST,
-    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach"
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach",
+    tags = ["instances"],
 }]
 async fn instance_disks_attach(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -957,7 +980,8 @@ async fn instance_disks_attach(
 
 #[endpoint {
     method = POST,
-    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach"
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach",
+    tags = ["instances"],
 }]
 async fn instance_disks_detach(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -992,9 +1016,10 @@ async fn instance_disks_detach(
  * List VPCs in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs",
+    tags = ["networking"],
+}]
 async fn project_vpcs_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1038,9 +1063,10 @@ struct VpcPathParam {
  * Get a VPC in a project.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
+    tags = ["networking"],
+}]
 async fn project_vpcs_get_vpc(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
@@ -1064,9 +1090,10 @@ async fn project_vpcs_get_vpc(
  * Create a VPC in a project.
  */
 #[endpoint {
-     method = POST,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs",
- }]
+    method = POST,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs",
+    tags = ["networking"],
+}]
 async fn project_vpcs_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
@@ -1095,9 +1122,10 @@ async fn project_vpcs_post(
  * Update a VPC.
  */
 #[endpoint {
-     method = PUT,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
- }]
+    method = PUT,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
+    tags = ["networking"],
+}]
 async fn project_vpcs_put_vpc(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
@@ -1124,9 +1152,10 @@ async fn project_vpcs_put_vpc(
  * Delete a vpc from a project.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}",
+    tags = ["networking"],
+}]
 async fn project_vpcs_delete_vpc(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
@@ -1150,9 +1179,10 @@ async fn project_vpcs_delete_vpc(
  * List subnets in a VPC.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets",
+    tags = ["networking"],
+}]
 async fn vpc_subnets_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1195,9 +1225,10 @@ struct VpcSubnetPathParam {
  * Get subnet in a VPC.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
+    tags = ["networking"],
+}]
 async fn vpc_subnets_get_subnet(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcSubnetPathParam>,
@@ -1223,9 +1254,10 @@ async fn vpc_subnets_get_subnet(
  * Create a subnet in a VPC.
  */
 #[endpoint {
-     method = POST,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets",
- }]
+    method = POST,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets",
+    tags = ["networking"],
+}]
 async fn vpc_subnets_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
@@ -1252,9 +1284,10 @@ async fn vpc_subnets_post(
  * Delete a subnet from a VPC.
  */
 #[endpoint {
-     method = DELETE,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
- }]
+    method = DELETE,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
+    tags = ["networking"],
+}]
 async fn vpc_subnets_delete_subnet(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcSubnetPathParam>,
@@ -1280,9 +1313,10 @@ async fn vpc_subnets_delete_subnet(
  * Update a VPC Subnet.
  */
 #[endpoint {
-     method = PUT,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
- }]
+    method = PUT,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}",
+    tags = ["networking"],
+}]
 async fn vpc_subnets_put_subnet(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcSubnetPathParam>,
@@ -1313,9 +1347,10 @@ async fn vpc_subnets_put_subnet(
 // may not actually be what we want. It is being implemented here to give our
 // testing introspection into network interfaces.
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips",
+    tags = ["networking"],
+}]
 async fn subnets_ips_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1352,9 +1387,10 @@ async fn subnets_ips_get(
  * List firewall rules for a VPC.
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules",
+    tags = ["networking"],
+}]
 async fn vpc_firewall_rules_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1391,6 +1427,7 @@ async fn vpc_firewall_rules_get(
 #[endpoint {
     method = PUT,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules",
+    tags = ["networking"],
 }]
 async fn vpc_firewall_rules_put(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1423,9 +1460,10 @@ async fn vpc_firewall_rules_put(
  * List VPC Custom and System Routers
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers",
+    tags = ["networking"],
+}]
 async fn vpc_routers_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1469,7 +1507,8 @@ struct VpcRouterPathParam {
  */
 #[endpoint {
     method = GET,
-    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}",
+    tags = ["networking"],
 }]
 async fn vpc_routers_get_router(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1498,6 +1537,7 @@ async fn vpc_routers_get_router(
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers",
+    tags = ["networking"],
 }]
 async fn vpc_routers_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1528,6 +1568,7 @@ async fn vpc_routers_post(
 #[endpoint {
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}",
+    tags = ["networking"],
 }]
 async fn vpc_routers_delete_router(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1556,6 +1597,7 @@ async fn vpc_routers_delete_router(
 #[endpoint {
     method = PUT,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}",
+    tags = ["networking"],
 }]
 async fn vpc_routers_put_router(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1588,9 +1630,10 @@ async fn vpc_routers_put_router(
  * List a Router's routes
  */
 #[endpoint {
-     method = GET,
-     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes",
- }]
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes",
+    tags = ["networking"],
+}]
 async fn routers_routes_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedByName>,
@@ -1636,7 +1679,8 @@ struct RouterRoutePathParam {
  */
 #[endpoint {
     method = GET,
-    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"
+    path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}",
+    tags = ["networking"],
 }]
 async fn routers_routes_get_route(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1666,6 +1710,7 @@ async fn routers_routes_get_route(
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes",
+    tags = ["networking"],
 }]
 async fn routers_routes_post(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1697,6 +1742,7 @@ async fn routers_routes_post(
 #[endpoint {
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}",
+    tags = ["networking"],
 }]
 async fn routers_routes_delete_route(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1726,6 +1772,7 @@ async fn routers_routes_delete_route(
 #[endpoint {
     method = PUT,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}",
+    tags = ["networking"],
 }]
 async fn routers_routes_put_route(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1759,9 +1806,10 @@ async fn routers_routes_put_route(
  * List racks in the system.
  */
 #[endpoint {
-     method = GET,
-     path = "/hardware/racks",
- }]
+    method = GET,
+    path = "/hardware/racks",
+    tags = ["hardware"],
+}]
 async fn hardware_racks_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedById>,
@@ -1793,6 +1841,7 @@ struct RackPathParam {
 #[endpoint {
     method = GET,
     path = "/hardware/racks/{rack_id}",
+    tags = ["hardware"],
 }]
 async fn hardware_racks_get_rack(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1816,9 +1865,10 @@ async fn hardware_racks_get_rack(
  * List sleds in the system.
  */
 #[endpoint {
-     method = GET,
-     path = "/hardware/sleds",
- }]
+    method = GET,
+    path = "/hardware/sleds",
+    tags = ["hardware"],
+}]
 async fn hardware_sleds_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedById>,
@@ -1851,9 +1901,10 @@ struct SledPathParam {
  * Fetch information about a sled in the system.
  */
 #[endpoint {
-     method = GET,
-     path = "/hardware/sleds/{sled_id}",
- }]
+    method = GET,
+    path = "/hardware/sleds/{sled_id}",
+    tags = ["hardware"],
+}]
 async fn hardware_sleds_get_sled(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SledPathParam>,
@@ -1876,9 +1927,10 @@ async fn hardware_sleds_get_sled(
  * List all sagas (for debugging)
  */
 #[endpoint {
-     method = GET,
-     path = "/sagas",
- }]
+    method = GET,
+    path = "/sagas",
+    tags = ["sagas"],
+}]
 async fn sagas_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     query_params: Query<PaginatedById>,
@@ -1907,9 +1959,10 @@ struct SagaPathParam {
  * Fetch information about a single saga (for debugging)
  */
 #[endpoint {
-     method = GET,
-     path = "/sagas/{saga_id}",
- }]
+    method = GET,
+    path = "/sagas/{saga_id}",
+    tags = ["sagas"],
+}]
 async fn sagas_get_saga(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SagaPathParam>,
@@ -1934,6 +1987,7 @@ async fn sagas_get_saga(
 #[endpoint {
     method = GET,
     path = "/users",
+    tags = ["users"],
 }]
 async fn users_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1972,6 +2026,7 @@ struct UserPathParam {
 #[endpoint {
     method = GET,
     path = "/users/{user_name}",
+    tags = ["users"],
 }]
 async fn users_get_user(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -1995,6 +2050,7 @@ async fn users_get_user(
 #[endpoint {
     method = GET,
     path = "/timeseries/schema",
+    tags = ["metrics"],
 }]
 async fn timeseries_schema_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2030,6 +2086,7 @@ struct RolePage {
 #[endpoint {
     method = GET,
     path = "/roles",
+    tags = ["roles"],
 }]
 async fn roles_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2087,6 +2144,7 @@ struct RolePathParam {
 #[endpoint {
     method = GET,
     path = "/roles/{role_name}",
+    tags = ["roles"],
 }]
 async fn roles_get_role(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -22,6 +22,7 @@ use omicron_test_utils::dev::test_cmds::EXIT_FAILURE;
 use omicron_test_utils::dev::test_cmds::EXIT_SUCCESS;
 use omicron_test_utils::dev::test_cmds::EXIT_USAGE;
 use openapiv3::OpenAPI;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use subprocess::Exec;
@@ -139,11 +140,56 @@ fn test_nexus_openapi() {
     assert!(errors.is_empty(), "{}", errors.join("\n\n"));
 
     /*
+     * Construct a string that helps us identify the organization of tags and
+     * operations.
+     */
+    let mut ops_by_tag = BTreeMap::<String, Vec<(String, String)>>::new();
+    for (path, _, op) in spec.operations() {
+        /*
+         * Make sure each operation has exactly one tag. Note, we intentionally
+         * do this before validating the OpenAPI output as fixing an error here
+         * would necessitate refreshing the spec file again.
+         */
+        assert_eq!(
+            op.tags.len(),
+            1,
+            "operation '{}' has {} tags rather than 1",
+            op.operation_id.as_ref().unwrap(),
+            op.tags.len()
+        );
+
+        ops_by_tag
+            .entry(op.tags.first().unwrap().to_string())
+            .or_default()
+            .push((
+                op.operation_id.as_ref().unwrap().to_string(),
+                path.to_string(),
+            ));
+    }
+
+    let mut tags = String::new();
+    for (tag, mut ops) in ops_by_tag {
+        ops.sort();
+        tags.push_str(&tag);
+        tags.push('\n');
+        for (operation_id, path) in ops {
+            tags.push_str(&format!("{:40} {}\n", operation_id, path));
+        }
+        tags.push('\n');
+    }
+
+    /*
      * Confirm that the output hasn't changed. It's expected that we'll change
      * this file as the API evolves, but pay attention to the diffs to ensure
      * that the changes match your expectations.
      */
     assert_contents("../openapi/nexus.json", &stdout_text);
+
+    /*
+     * When this fails, verify that operations on which you're adding,
+     * renaming, or changing the tags are what you intend.
+     */
+    assert_contents("tests/output/nexus_tags.txt", &tags);
 }
 
 #[test]

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -171,7 +171,7 @@ fn test_nexus_openapi() {
     for (tag, mut ops) in ops_by_tag {
         ops.sort();
         tags.push_str(&format!(r#"API operations found with tag "{}""#, tag));
-        tags.push('\n');
+        tags.push_str(&format!("\n{:40} {}\n", "OPERATION ID", "URL PATH"));
         for (operation_id, path) in ops {
             tags.push_str(&format!("{:40} {}\n", operation_id, path));
         }

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -170,7 +170,7 @@ fn test_nexus_openapi() {
     let mut tags = String::new();
     for (tag, mut ops) in ops_by_tag {
         ops.sort();
-        tags.push_str(&tag);
+        tags.push_str(&format!(r#"API operations found with tag "{}""#, tag));
         tags.push('\n');
         for (operation_id, path) in ops {
             tags.push_str(&format!("{:40} {}\n", operation_id, path));

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -1,0 +1,81 @@
+hardware
+hardware_racks_get                       /hardware/racks
+hardware_racks_get_rack                  /hardware/racks/{rack_id}
+hardware_sleds_get                       /hardware/sleds
+hardware_sleds_get_sled                  /hardware/sleds/{sled_id}
+
+hidden
+logout                                   /logout
+session_me                               /session/me
+spoof_login                              /login
+
+instances
+instance_disks_attach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach
+instance_disks_detach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach
+instance_disks_get                       /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks
+project_instances_delete_instance        /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}
+project_instances_get                    /organizations/{organization_name}/projects/{project_name}/instances
+project_instances_get_instance           /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}
+project_instances_instance_reboot        /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot
+project_instances_instance_start         /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start
+project_instances_instance_stop          /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop
+project_instances_post                   /organizations/{organization_name}/projects/{project_name}/instances
+
+metrics
+timeseries_schema_get                    /timeseries/schema
+
+networking
+project_vpcs_delete_vpc                  /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
+project_vpcs_get                         /organizations/{organization_name}/projects/{project_name}/vpcs
+project_vpcs_get_vpc                     /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
+project_vpcs_post                        /organizations/{organization_name}/projects/{project_name}/vpcs
+project_vpcs_put_vpc                     /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
+routers_routes_delete_route              /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}
+routers_routes_get                       /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes
+routers_routes_get_route                 /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}
+routers_routes_post                      /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes
+routers_routes_put_route                 /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}
+subnets_ips_get                          /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips
+vpc_firewall_rules_get                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules
+vpc_firewall_rules_put                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules
+vpc_routers_delete_router                /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}
+vpc_routers_get                          /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers
+vpc_routers_get_router                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}
+vpc_routers_post                         /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers
+vpc_routers_put_router                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}
+vpc_subnets_delete_subnet                /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
+vpc_subnets_get                          /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets
+vpc_subnets_get_subnet                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
+vpc_subnets_post                         /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets
+vpc_subnets_put_subnet                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
+
+organizations
+organization_projects_put_project        /organizations/{organization_name}/projects/{project_name}
+organizations_delete_organization        /organizations/{organization_name}
+organizations_get                        /organizations
+organizations_get_organization           /organizations/{organization_name}
+organizations_post                       /organizations
+organizations_put_organization           /organizations/{organization_name}
+
+projects
+organization_projects_delete_project     /organizations/{organization_name}/projects/{project_name}
+organization_projects_get                /organizations/{organization_name}/projects
+organization_projects_get_project        /organizations/{organization_name}/projects/{project_name}
+organization_projects_post               /organizations/{organization_name}/projects
+project_disks_delete_disk                /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}
+project_disks_get                        /organizations/{organization_name}/projects/{project_name}/disks
+project_disks_get_disk                   /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}
+project_disks_post                       /organizations/{organization_name}/projects/{project_name}/disks
+
+roles
+roles_get                                /roles
+roles_get_role                           /roles/{role_name}
+
+sagas
+sagas_get                                /sagas
+sagas_get_saga                           /sagas/{saga_id}
+
+users
+users_get                                /users
+users_get_user                           /users/{user_name}
+

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -1,15 +1,15 @@
-hardware
+API operations found with tag "hardware"
 hardware_racks_get                       /hardware/racks
 hardware_racks_get_rack                  /hardware/racks/{rack_id}
 hardware_sleds_get                       /hardware/sleds
 hardware_sleds_get_sled                  /hardware/sleds/{sled_id}
 
-hidden
+API operations found with tag "hidden"
 logout                                   /logout
 session_me                               /session/me
 spoof_login                              /login
 
-instances
+API operations found with tag "instances"
 instance_disks_attach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach
 instance_disks_detach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach
 instance_disks_get                       /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks
@@ -21,10 +21,10 @@ project_instances_instance_start         /organizations/{organization_name}/proj
 project_instances_instance_stop          /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop
 project_instances_post                   /organizations/{organization_name}/projects/{project_name}/instances
 
-metrics
+API operations found with tag "metrics"
 timeseries_schema_get                    /timeseries/schema
 
-networking
+API operations found with tag "networking"
 project_vpcs_delete_vpc                  /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
 project_vpcs_get                         /organizations/{organization_name}/projects/{project_name}/vpcs
 project_vpcs_get_vpc                     /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
@@ -49,7 +49,7 @@ vpc_subnets_get_subnet                   /organizations/{organization_name}/proj
 vpc_subnets_post                         /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets
 vpc_subnets_put_subnet                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
 
-organizations
+API operations found with tag "organizations"
 organization_projects_put_project        /organizations/{organization_name}/projects/{project_name}
 organizations_delete_organization        /organizations/{organization_name}
 organizations_get                        /organizations
@@ -57,7 +57,7 @@ organizations_get_organization           /organizations/{organization_name}
 organizations_post                       /organizations
 organizations_put_organization           /organizations/{organization_name}
 
-projects
+API operations found with tag "projects"
 organization_projects_delete_project     /organizations/{organization_name}/projects/{project_name}
 organization_projects_get                /organizations/{organization_name}/projects
 organization_projects_get_project        /organizations/{organization_name}/projects/{project_name}
@@ -67,15 +67,15 @@ project_disks_get                        /organizations/{organization_name}/proj
 project_disks_get_disk                   /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}
 project_disks_post                       /organizations/{organization_name}/projects/{project_name}/disks
 
-roles
+API operations found with tag "roles"
 roles_get                                /roles
 roles_get_role                           /roles/{role_name}
 
-sagas
+API operations found with tag "sagas"
 sagas_get                                /sagas
 sagas_get_saga                           /sagas/{saga_id}
 
-users
+API operations found with tag "users"
 users_get                                /users
 users_get_user                           /users/{user_name}
 

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -1,15 +1,18 @@
 API operations found with tag "hardware"
+OPERATION ID                             URL PATH
 hardware_racks_get                       /hardware/racks
 hardware_racks_get_rack                  /hardware/racks/{rack_id}
 hardware_sleds_get                       /hardware/sleds
 hardware_sleds_get_sled                  /hardware/sleds/{sled_id}
 
 API operations found with tag "hidden"
+OPERATION ID                             URL PATH
 logout                                   /logout
 session_me                               /session/me
 spoof_login                              /login
 
 API operations found with tag "instances"
+OPERATION ID                             URL PATH
 instance_disks_attach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach
 instance_disks_detach                    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach
 instance_disks_get                       /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks
@@ -22,9 +25,11 @@ project_instances_instance_stop          /organizations/{organization_name}/proj
 project_instances_post                   /organizations/{organization_name}/projects/{project_name}/instances
 
 API operations found with tag "metrics"
+OPERATION ID                             URL PATH
 timeseries_schema_get                    /timeseries/schema
 
 API operations found with tag "networking"
+OPERATION ID                             URL PATH
 project_vpcs_delete_vpc                  /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
 project_vpcs_get                         /organizations/{organization_name}/projects/{project_name}/vpcs
 project_vpcs_get_vpc                     /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}
@@ -50,6 +55,7 @@ vpc_subnets_post                         /organizations/{organization_name}/proj
 vpc_subnets_put_subnet                   /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
 
 API operations found with tag "organizations"
+OPERATION ID                             URL PATH
 organization_projects_put_project        /organizations/{organization_name}/projects/{project_name}
 organizations_delete_organization        /organizations/{organization_name}
 organizations_get                        /organizations
@@ -58,6 +64,7 @@ organizations_post                       /organizations
 organizations_put_organization           /organizations/{organization_name}
 
 API operations found with tag "projects"
+OPERATION ID                             URL PATH
 organization_projects_delete_project     /organizations/{organization_name}/projects/{project_name}
 organization_projects_get                /organizations/{organization_name}/projects
 organization_projects_get_project        /organizations/{organization_name}/projects/{project_name}
@@ -68,14 +75,17 @@ project_disks_get_disk                   /organizations/{organization_name}/proj
 project_disks_post                       /organizations/{organization_name}/projects/{project_name}/disks
 
 API operations found with tag "roles"
+OPERATION ID                             URL PATH
 roles_get                                /roles
 roles_get_role                           /roles/{role_name}
 
 API operations found with tag "sagas"
+OPERATION ID                             URL PATH
 sagas_get                                /sagas
 sagas_get_saga                           /sagas/{saga_id}
 
 API operations found with tag "users"
+OPERATION ID                             URL PATH
 users_get                                /users
 users_get_user                           /users/{user_name}
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -188,6 +188,9 @@
     },
     "/login": {
       "post": {
+        "tags": [
+          "hidden"
+        ],
         "operationId": "spoof_login",
         "requestBody": {
           "content": {
@@ -208,6 +211,9 @@
     },
     "/logout": {
       "post": {
+        "tags": [
+          "hidden"
+        ],
         "operationId": "logout",
         "responses": {
           "default": {
@@ -3021,6 +3027,9 @@
     },
     "/session/me": {
       "get": {
+        "tags": [
+          "hidden"
+        ],
         "description": "Fetch the user associated with the current session",
         "operationId": "session_me",
         "responses": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12,6 +12,9 @@
   "paths": {
     "/hardware/racks": {
       "get": {
+        "tags": [
+          "hardware"
+        ],
         "description": "List racks in the system.",
         "operationId": "hardware_racks_get",
         "parameters": [
@@ -63,6 +66,9 @@
     },
     "/hardware/racks/{rack_id}": {
       "get": {
+        "tags": [
+          "hardware"
+        ],
         "description": "Fetch information about a particular rack.",
         "operationId": "hardware_racks_get_rack",
         "parameters": [
@@ -94,6 +100,9 @@
     },
     "/hardware/sleds": {
       "get": {
+        "tags": [
+          "hardware"
+        ],
         "description": "List sleds in the system.",
         "operationId": "hardware_sleds_get",
         "parameters": [
@@ -145,6 +154,9 @@
     },
     "/hardware/sleds/{sled_id}": {
       "get": {
+        "tags": [
+          "hardware"
+        ],
         "description": "Fetch information about a sled in the system.",
         "operationId": "hardware_sleds_get_sled",
         "parameters": [
@@ -206,6 +218,9 @@
     },
     "/organizations": {
       "get": {
+        "tags": [
+          "organizations"
+        ],
         "description": "List all organizations.",
         "operationId": "organizations_get",
         "parameters": [
@@ -255,6 +270,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "organizations"
+        ],
         "description": "Create a new organization.",
         "operationId": "organizations_post",
         "requestBody": {
@@ -283,6 +301,9 @@
     },
     "/organizations/{organization_name}": {
       "get": {
+        "tags": [
+          "organizations"
+        ],
         "description": "Fetch a specific organization",
         "operationId": "organizations_get_organization",
         "parameters": [
@@ -310,6 +331,9 @@
         }
       },
       "put": {
+        "tags": [
+          "organizations"
+        ],
         "description": "Update a specific organization.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
         "operationId": "organizations_put_organization",
         "parameters": [
@@ -347,6 +371,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "organizations"
+        ],
         "description": "Delete a specific organization.",
         "operationId": "organizations_delete_organization",
         "parameters": [
@@ -369,6 +396,9 @@
     },
     "/organizations/{organization_name}/projects": {
       "get": {
+        "tags": [
+          "projects"
+        ],
         "description": "List all projects.",
         "operationId": "organization_projects_get",
         "parameters": [
@@ -427,6 +457,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "projects"
+        ],
         "description": "Create a new project.",
         "operationId": "organization_projects_post",
         "parameters": [
@@ -466,6 +499,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}": {
       "get": {
+        "tags": [
+          "projects"
+        ],
         "description": "Fetch a specific project",
         "operationId": "organization_projects_get_project",
         "parameters": [
@@ -502,6 +538,9 @@
         }
       },
       "put": {
+        "tags": [
+          "organizations"
+        ],
         "description": "Update a specific project.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
         "operationId": "organization_projects_put_project",
         "parameters": [
@@ -548,6 +587,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "projects"
+        ],
         "description": "Delete a specific project.",
         "operationId": "organization_projects_delete_project",
         "parameters": [
@@ -579,6 +621,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/disks": {
       "get": {
+        "tags": [
+          "projects"
+        ],
         "description": "List disks in a project.",
         "operationId": "project_disks_get",
         "parameters": [
@@ -646,6 +691,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "projects"
+        ],
         "description": "Create a disk in a project.\n * TODO-correctness See note about instance create.  This should be async.",
         "operationId": "project_disks_post",
         "parameters": [
@@ -694,6 +742,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}": {
       "get": {
+        "tags": [
+          "projects"
+        ],
         "description": "Fetch a single disk in a project.",
         "operationId": "project_disks_get_disk",
         "parameters": [
@@ -739,6 +790,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "projects"
+        ],
         "description": "Delete a disk from a project.",
         "operationId": "project_disks_delete_disk",
         "parameters": [
@@ -779,6 +833,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances": {
       "get": {
+        "tags": [
+          "instances"
+        ],
         "description": "List instances in a project.",
         "operationId": "project_instances_get",
         "parameters": [
@@ -846,6 +903,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "instances"
+        ],
         "description": "Create an instance in a project.\n * TODO-correctness This is supposed to be async.  Is that right?  We can create the instance immediately -- it's just not booted yet.  Maybe the boot operation is what's a separate operation_id.  What about the response code (201 Created vs 202 Accepted)?  Is that orthogonal?  Things can return a useful response, including an operation id, with either response code.  Maybe a \"reboot\" operation would return a 202 Accepted because there's no actual resource created?",
         "operationId": "project_instances_post",
         "parameters": [
@@ -894,6 +954,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}": {
       "get": {
+        "tags": [
+          "instances"
+        ],
         "description": "Get an instance in a project.",
         "operationId": "project_instances_get_instance",
         "parameters": [
@@ -939,6 +1002,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "instances"
+        ],
         "description": "Delete an instance from a project.",
         "operationId": "project_instances_delete_instance",
         "parameters": [
@@ -979,6 +1045,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks": {
       "get": {
+        "tags": [
+          "instances"
+        ],
         "description": "List disks attached to this instance.",
         "operationId": "instance_disks_get",
         "parameters": [
@@ -1057,6 +1126,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "operationId": "instance_disks_attach",
         "parameters": [
           {
@@ -1113,6 +1185,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "operationId": "instance_disks_detach",
         "parameters": [
           {
@@ -1169,6 +1244,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "description": "Reboot an instance.",
         "operationId": "project_instances_instance_reboot",
         "parameters": [
@@ -1216,6 +1294,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "description": "Boot an instance.",
         "operationId": "project_instances_instance_start",
         "parameters": [
@@ -1263,6 +1344,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "description": "Halt an instance.",
         "operationId": "project_instances_instance_stop",
         "parameters": [
@@ -1310,6 +1394,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List VPCs in a project.",
         "operationId": "project_vpcs_get",
         "parameters": [
@@ -1377,6 +1464,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "networking"
+        ],
         "description": "Create a VPC in a project.",
         "operationId": "project_vpcs_post",
         "parameters": [
@@ -1425,6 +1515,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "Get a VPC in a project.",
         "operationId": "project_vpcs_get_vpc",
         "parameters": [
@@ -1470,6 +1563,9 @@
         }
       },
       "put": {
+        "tags": [
+          "networking"
+        ],
         "description": "Update a VPC.",
         "operationId": "project_vpcs_put_vpc",
         "parameters": [
@@ -1518,6 +1614,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "networking"
+        ],
         "description": "Delete a vpc from a project.",
         "operationId": "project_vpcs_delete_vpc",
         "parameters": [
@@ -1558,6 +1657,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List firewall rules for a VPC.",
         "operationId": "vpc_firewall_rules_get",
         "parameters": [
@@ -1634,6 +1736,9 @@
         "x-dropshot-pagination": true
       },
       "put": {
+        "tags": [
+          "networking"
+        ],
         "description": "Replace the firewall rules for a VPC",
         "operationId": "vpc_firewall_rules_put",
         "parameters": [
@@ -1691,6 +1796,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List VPC Custom and System Routers",
         "operationId": "vpc_routers_get",
         "parameters": [
@@ -1767,6 +1875,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "networking"
+        ],
         "description": "Create a VPC Router",
         "operationId": "vpc_routers_post",
         "parameters": [
@@ -1824,6 +1935,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "Get a VPC Router",
         "operationId": "vpc_routers_get_router",
         "parameters": [
@@ -1878,6 +1992,9 @@
         }
       },
       "put": {
+        "tags": [
+          "networking"
+        ],
         "description": "Update a VPC Router",
         "operationId": "vpc_routers_put_router",
         "parameters": [
@@ -1935,6 +2052,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "networking"
+        ],
         "description": "Delete a router from its VPC",
         "operationId": "vpc_routers_delete_router",
         "parameters": [
@@ -1984,6 +2104,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List a Router's routes",
         "operationId": "routers_routes_get",
         "parameters": [
@@ -2069,6 +2192,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "networking"
+        ],
         "description": "Create a VPC Router",
         "operationId": "routers_routes_post",
         "parameters": [
@@ -2135,6 +2261,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "Get a VPC Router route",
         "operationId": "routers_routes_get_route",
         "parameters": [
@@ -2198,6 +2327,9 @@
         }
       },
       "put": {
+        "tags": [
+          "networking"
+        ],
         "description": "Update a Router route",
         "operationId": "routers_routes_put_route",
         "parameters": [
@@ -2264,6 +2396,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "networking"
+        ],
         "description": "Delete a route from its router",
         "operationId": "routers_routes_delete_route",
         "parameters": [
@@ -2322,6 +2457,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List subnets in a VPC.",
         "operationId": "vpc_subnets_get",
         "parameters": [
@@ -2398,6 +2536,9 @@
         "x-dropshot-pagination": true
       },
       "post": {
+        "tags": [
+          "networking"
+        ],
         "description": "Create a subnet in a VPC.",
         "operationId": "vpc_subnets_post",
         "parameters": [
@@ -2455,6 +2596,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "Get subnet in a VPC.",
         "operationId": "vpc_subnets_get_subnet",
         "parameters": [
@@ -2509,6 +2653,9 @@
         }
       },
       "put": {
+        "tags": [
+          "networking"
+        ],
         "description": "Update a VPC Subnet.",
         "operationId": "vpc_subnets_put_subnet",
         "parameters": [
@@ -2566,6 +2713,9 @@
         }
       },
       "delete": {
+        "tags": [
+          "networking"
+        ],
         "description": "Delete a subnet from a VPC.",
         "operationId": "vpc_subnets_delete_subnet",
         "parameters": [
@@ -2615,6 +2765,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips": {
       "get": {
+        "tags": [
+          "networking"
+        ],
         "description": "List IP addresses on a VPC subnet.",
         "operationId": "subnets_ips_get",
         "parameters": [
@@ -2702,6 +2855,9 @@
     },
     "/roles": {
       "get": {
+        "tags": [
+          "roles"
+        ],
         "description": "List the built-in roles",
         "operationId": "roles_get",
         "parameters": [
@@ -2745,6 +2901,9 @@
     },
     "/roles/{role_name}": {
       "get": {
+        "tags": [
+          "roles"
+        ],
         "description": "Fetch a specific built-in role",
         "operationId": "roles_get_role",
         "parameters": [
@@ -2775,6 +2934,9 @@
     },
     "/sagas": {
       "get": {
+        "tags": [
+          "sagas"
+        ],
         "description": "List all sagas (for debugging)",
         "operationId": "sagas_get",
         "parameters": [
@@ -2826,6 +2988,9 @@
     },
     "/sagas/{saga_id}": {
       "get": {
+        "tags": [
+          "sagas"
+        ],
         "description": "Fetch information about a single saga (for debugging)",
         "operationId": "sagas_get_saga",
         "parameters": [
@@ -2874,6 +3039,9 @@
     },
     "/timeseries/schema": {
       "get": {
+        "tags": [
+          "metrics"
+        ],
         "description": "List all timeseries schema",
         "operationId": "timeseries_schema_get",
         "parameters": [
@@ -2917,6 +3085,9 @@
     },
     "/users": {
       "get": {
+        "tags": [
+          "users"
+        ],
         "description": "List the built-in system users",
         "operationId": "users_get",
         "parameters": [
@@ -2968,6 +3139,9 @@
     },
     "/users/{user_name}": {
       "get": {
+        "tags": [
+          "users"
+        ],
         "description": "Fetch a specific built-in system user",
         "operationId": "users_get_user",
         "parameters": [


### PR DESCRIPTION
closes #535 

This adds tags and a mechanism to verify that there's exactly one per endpoint. This also creates a file of tags and endpoints to help people see how endpoints are organized when adding new ones.

@jessfraz I picked not very good names for the tags; if you have opinions about better names, let me know.

If we want the `tags` property of the `openapi` header to be populated with a list of these, we can make that change in Dropshot, but it's not required by the spec so we didn't bother.