### PR TITLE
Add #[serde(flatten)] to identity on some views that were missing it

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1161,6 +1161,7 @@ pub enum VpcRouterKind {
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcRouter {
     /// common identifying metadata
+    #[serde(flatten)]
     pub identity: IdentityMetadata,
 
     pub kind: VpcRouterKind,
@@ -1364,6 +1365,7 @@ pub enum RouterRouteKind {
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct RouterRoute {
     /// common identifying metadata
+    #[serde(flatten)]
     pub identity: IdentityMetadata,
 
     /// The VPC Router to which the route belongs.
@@ -1400,6 +1402,7 @@ pub struct RouterRouteUpdateParams {
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRule {
     /// common identifying metadata
+    #[serde(flatten)]
     pub identity: IdentityMetadata,
     /// whether this rule is in effect
     pub status: VpcFirewallRuleStatus,

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -106,6 +106,7 @@ impl Into<Vpc> for model::Vpc {
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcSubnet {
     /** common identifying metadata */
+    #[serde(flatten)]
     pub identity: IdentityMetadata,
 
     /** The VPC to which the subnet belongs. */
@@ -146,6 +147,7 @@ impl Into<VpcSubnet> for model::VpcSubnet {
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Rack {
+    #[serde(flatten)]
     pub identity: IdentityMetadata,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -3815,12 +3815,40 @@
         "description": "Client view of an [`Rack`]",
         "type": "object",
         "properties": {
-          "identity": {
-            "$ref": "#/components/schemas/IdentityMetadata"
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
-          "identity"
+          "description",
+          "id",
+          "name",
+          "timeCreated",
+          "timeModified"
         ]
       },
       "RackResultsPage": {
@@ -4048,22 +4076,31 @@
         "description": "A route defines a rule that governs where traffic should be sent based on its destination.",
         "type": "object",
         "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
           "destination": {
             "$ref": "#/components/schemas/RouteDestination"
           },
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "kind": {
             "description": "Describes the kind of router. Set at creation. `read-only`",
             "allOf": [
               {
                 "$ref": "#/components/schemas/RouterRouteKind"
+              }
+            ]
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
               }
             ]
           },
@@ -4074,14 +4111,28 @@
           },
           "target": {
             "$ref": "#/components/schemas/RouteTarget"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
+          "description",
           "destination",
-          "identity",
+          "id",
           "kind",
+          "name",
           "router_id",
-          "target"
+          "target",
+          "timeCreated",
+          "timeModified"
         ]
       },
       "RouterRouteCreateParams": {
@@ -4633,6 +4684,10 @@
               }
             ]
           },
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
           "direction": {
             "description": "whether this rule is for incoming or outgoing traffic",
             "allOf": [
@@ -4649,11 +4704,16 @@
               }
             ]
           },
-          "identity": {
-            "description": "common identifying metadata",
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
               {
-                "$ref": "#/components/schemas/IdentityMetadata"
+                "$ref": "#/components/schemas/Name"
               }
             ]
           },
@@ -4677,16 +4737,30 @@
             "items": {
               "$ref": "#/components/schemas/VpcFirewallRuleTarget"
             }
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
           "action",
+          "description",
           "direction",
           "filters",
-          "identity",
+          "id",
+          "name",
           "priority",
           "status",
-          "targets"
+          "targets",
+          "timeCreated",
+          "timeModified"
         ]
       },
       "VpcFirewallRuleAction": {
@@ -5028,16 +5102,35 @@
         "description": "A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination.",
         "type": "object",
         "properties": {
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "kind": {
             "$ref": "#/components/schemas/VpcRouterKind"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           },
           "vpc_id": {
             "description": "The VPC to which the router belongs.",
@@ -5046,8 +5139,12 @@
           }
         },
         "required": [
-          "identity",
+          "description",
+          "id",
           "kind",
+          "name",
+          "timeCreated",
+          "timeModified",
           "vpc_id"
         ]
       },
@@ -5117,13 +5214,14 @@
         "description": "A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.",
         "type": "object",
         "properties": {
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "ipv4_block": {
             "nullable": true,
@@ -5143,6 +5241,24 @@
               }
             ]
           },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
           "vpc_id": {
             "description": "The VPC to which the subnet belongs.",
             "type": "string",
@@ -5150,7 +5266,11 @@
           }
         },
         "required": [
-          "identity",
+          "description",
+          "id",
+          "name",
+          "timeCreated",
+          "timeModified",
           "vpc_id"
         ]
       },


### PR DESCRIPTION
Noticed this while working with VPC subnets, then found a few others.

Left out `NetworkInterface` because it's used by sled agent as a model rather than a view, so changing it causes tests to fail in mysterious ways that I think are 400s when Nexus calls Sled Agent.

https://github.com/oxidecomputer/omicron/blob/939adec4de865caf4c0339fced7fdc75f8bfa5b0/common/src/api/internal/sled_agent.rs#L12-L17