### PR TITLE
cargo test --no-fail-fast in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,7 +138,7 @@ jobs:
       # rebuild here.
       # Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
       # suite.
-      run: TMPDIR=$OMICRON_TMP PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --workspace --locked --verbose
+      run: TMPDIR=$OMICRON_TMP PATH="$PATH:$PWD/cockroachdb/bin:$PWD/clickhouse" RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo test --no-fail-fast --workspace --locked --verbose
     - name: Archive any failed test results
       if: ${{ failure() }}
       # actions/upload-artifact@v2.3.1


### PR DESCRIPTION
In an initial version of #581, I forgot to update the sled agent OpenAPI JSON, but I did not see a test failure in CI that would have made that obvious because `cargo test` by default bails on the remaining targets if it gets failures in one target. It took a bunch of work to figure out the issue and fix it in #589.

`--no-fail-fast`, which turns off that bailing behavior, seems like an obvious improvement. The longest it can make the tests take is however long they take when they pass.