### PR TITLE
add authz checks for top-level Organization endpoints

### DIFF
--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -21,6 +21,8 @@ use authn::external::spoof::HttpAuthnSpoof;
 use authn::external::HttpAuthnScheme;
 use chrono::{DateTime, Duration, Utc};
 use omicron_common::api::external::Error;
+use omicron_common::api::external::LookupType;
+use omicron_common::api::external::ResourceType;
 use oximeter::types::ProducerRegistry;
 use oximeter_instruments::http::{HttpService, LatencyTracker};
 use slog::Logger;
@@ -333,6 +335,36 @@ impl OpContext {
         );
         result
     }
+
+    /// Check whether the actor performing this request is authorized for a read
+    /// operation on this resource.  This is similar to `authorize()`, but
+    /// produces a "NotFound" error when authorization fails.
+    // TODO It would be nice if authorize() only accepted non-read operations so
+    // that people couldn't accidentally call the wrong function without
+    // realizing it.
+    // TODO Alternatively, and maybe better: each authz struct could contain the
+    // the LookupType that produced it, plus its ResourceType.  Then authorize()
+    // could do the logic that we really want, which is on failure, re-check the
+    // Read action and generate an error if that doesn't work.
+    pub async fn authorize_read<Resource>(
+        &self,
+        resource: Resource,
+        type_name: ResourceType,
+        lookup_type: LookupType,
+    ) -> Result<(), Error>
+    where
+        Resource: oso::ToPolar + AuthzResource + Debug + Clone,
+    {
+        self.authorize(authz::Action::Read, resource).await.map_err(|e| {
+            // XXX TODO-security Should we replace 401 as well?
+            if let Error::Forbidden = e {
+                Error::ObjectNotFound { type_name, lookup_type }
+            } else {
+                e
+            }
+        })
+    }
+
 }
 
 #[cfg(test)]

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -331,13 +331,13 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         name: &Name,
-    ) -> LookupResult<Organization> {
+    ) -> LookupResult<(authz::Organization, Organization)> {
         let (authz_org, db_org) =
             self.organization_lookup_noauthz(name).await?;
         // TODO-security See the note in authz::authorize().  This needs to
         // return a 404, not a 403.
         opctx.authorize(authz::Action::Read, authz_org).await?;
-        Ok(db_org)
+        Ok((authz_org, db_org))
     }
 
     /// Delete a organization
@@ -2419,7 +2419,7 @@ mod test {
         );
         let org = authz::FLEET.organization(organization.id());
         datastore.project_create(&opctx, &org, project).await.unwrap();
-        let organization_after_project_create = datastore
+        let (_, organization_after_project_create) = datastore
             .organization_fetch(&opctx, organization.name())
             .await
             .unwrap();

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -326,7 +326,7 @@ impl DataStore {
         self.organization_lookup_noauthz(name).await.map(|(o, _)| o)
     }
 
-    /// Lookup a organization by name.
+    /// Lookup an organization by name.
     pub async fn organization_fetch(
         &self,
         opctx: &OpContext,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -289,7 +289,9 @@ async fn organizations_get_organization(
     let path = path_params.into_inner();
     let organization_name = &path.organization_name;
     let handler = async {
-        let organization = nexus.organization_fetch(&organization_name).await?;
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let organization =
+            nexus.organization_fetch(&opctx, &organization_name).await?;
         Ok(HttpResponseOk(organization.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -311,7 +313,8 @@ async fn organizations_delete_organization(
     let params = path_params.into_inner();
     let organization_name = &params.organization_name;
     let handler = async {
-        nexus.organization_delete(&organization_name).await?;
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        nexus.organization_delete(&opctx, &organization_name).await?;
         Ok(HttpResponseDeleted())
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -340,8 +343,10 @@ async fn organizations_put_organization(
     let path = path_params.into_inner();
     let organization_name = &path.organization_name;
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let new_organization = nexus
             .organization_update(
+                &opctx,
                 &organization_name,
                 &updated_organization.into_inner(),
             )

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -492,7 +492,7 @@ impl Nexus {
         opctx: &OpContext,
         name: &Name,
     ) -> LookupResult<db::model::Organization> {
-        self.db_datastore.organization_fetch(opctx, name).await
+        Ok(self.db_datastore.organization_fetch(opctx, name).await?.1)
     }
 
     pub async fn organizations_list_by_name(

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -540,10 +540,8 @@ impl Nexus {
         organization_name: &Name,
         new_project: &params::ProjectCreate,
     ) -> CreateResult<db::model::Project> {
-        let org = self
-            .db_datastore
-            .organization_lookup_id_authz(organization_name)
-            .await?;
+        let org =
+            self.db_datastore.organization_lookup_id(organization_name).await?;
 
         // Create a project.
         let db_project = db::model::Project::new(org.id(), new_project.clone());
@@ -565,8 +563,9 @@ impl Nexus {
                         name: "default".parse().unwrap(),
                         description: "Default VPC".to_string(),
                     },
-                    // TODO-robustness this will need to be None if we decide to handle
-                    // the logic around name and dns_name by making dns_name optional
+                    // TODO-robustness this will need to be None if we decide to
+                    // handle the logic around name and dns_name by making
+                    // dns_name optional
                     dns_name: "default".parse().unwrap(),
                 },
             )
@@ -582,8 +581,9 @@ impl Nexus {
     ) -> LookupResult<db::model::Project> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         self.db_datastore.project_fetch(&organization_id, project_name).await
     }
 
@@ -594,8 +594,9 @@ impl Nexus {
     ) -> ListResultVec<db::model::Project> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         self.db_datastore
             .projects_list_by_name(&organization_id, pagparams)
             .await
@@ -608,8 +609,9 @@ impl Nexus {
     ) -> ListResultVec<db::model::Project> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         self.db_datastore.projects_list_by_id(&organization_id, pagparams).await
     }
 
@@ -620,8 +622,9 @@ impl Nexus {
     ) -> DeleteResult {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         self.db_datastore.project_delete(&organization_id, project_name).await
     }
 
@@ -633,8 +636,9 @@ impl Nexus {
     ) -> UpdateResult<db::model::Project> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         self.db_datastore
             .project_update(
                 &organization_id,
@@ -656,8 +660,9 @@ impl Nexus {
     ) -> ListResultVec<db::model::Disk> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -727,8 +732,9 @@ impl Nexus {
     ) -> LookupResult<(db::model::Disk, authz::ProjectChild)> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -824,8 +830,9 @@ impl Nexus {
     ) -> ListResultVec<db::model::Instance> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -841,8 +848,9 @@ impl Nexus {
     ) -> CreateResult<db::model::Instance> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -929,8 +937,9 @@ impl Nexus {
          */
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -950,8 +959,9 @@ impl Nexus {
     ) -> LookupResult<db::model::Instance> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -1513,8 +1523,9 @@ impl Nexus {
     ) -> ListResultVec<db::model::Vpc> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -1532,8 +1543,9 @@ impl Nexus {
     ) -> CreateResult<db::model::Vpc> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -1636,8 +1648,9 @@ impl Nexus {
     ) -> LookupResult<db::model::Vpc> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)
@@ -1654,8 +1667,9 @@ impl Nexus {
     ) -> UpdateResult<()> {
         let organization_id = self
             .db_datastore
-            .organization_lookup_id_by_name(organization_name)
-            .await?;
+            .organization_lookup_id(organization_name)
+            .await?
+            .id();
         let project_id = self
             .db_datastore
             .project_lookup_id_by_name(&organization_id, project_name)

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -489,9 +489,10 @@ impl Nexus {
 
     pub async fn organization_fetch(
         &self,
+        opctx: &OpContext,
         name: &Name,
     ) -> LookupResult<db::model::Organization> {
-        self.db_datastore.organization_fetch(name).await
+        self.db_datastore.organization_fetch(opctx, name).await
     }
 
     pub async fn organizations_list_by_name(
@@ -510,17 +511,22 @@ impl Nexus {
         self.db_datastore.organizations_list_by_id(opctx, pagparams).await
     }
 
-    pub async fn organization_delete(&self, name: &Name) -> DeleteResult {
-        self.db_datastore.organization_delete(name).await
+    pub async fn organization_delete(
+        &self,
+        opctx: &OpContext,
+        name: &Name,
+    ) -> DeleteResult {
+        self.db_datastore.organization_delete(opctx, name).await
     }
 
     pub async fn organization_update(
         &self,
+        opctx: &OpContext,
         name: &Name,
         new_params: &params::OrganizationUpdate,
     ) -> UpdateResult<db::model::Organization> {
         self.db_datastore
-            .organization_update(name, new_params.clone().into())
+            .organization_update(opctx, name, new_params.clone().into())
             .await
     }
 
@@ -534,8 +540,10 @@ impl Nexus {
         organization_name: &Name,
         new_project: &params::ProjectCreate,
     ) -> CreateResult<db::model::Project> {
-        let org =
-            self.db_datastore.organization_lookup(organization_name).await?;
+        let org = self
+            .db_datastore
+            .organization_lookup_id_authz(organization_name)
+            .await?;
 
         // Create a project.
         let db_project = db::model::Project::new(org.id(), new_project.clone());

--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -479,6 +479,19 @@ impl<'a> NexusRequest<'a> {
         )
     }
 
+    /// Convenience constructor for failure cases
+    pub fn expect_failure(
+        testctx: &'a ClientTestContext,
+        expected_status: http::StatusCode,
+        method: http::Method,
+        uri: &str,
+    ) -> Self {
+        NexusRequest::new(
+            RequestBuilder::new(testctx, method, uri)
+                .expect_status(Some(expected_status)),
+        )
+    }
+
     /// Iterates a collection (like `dropshot::test_util::iter_collection`)
     /// using authenticated requests.
     pub async fn iter_collection_authn<T>(

--- a/nexus/tests/integration_tests/organizations.rs
+++ b/nexus/tests/integration_tests/organizations.rs
@@ -25,8 +25,6 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
     create_organization(&client, &o1_name).await;
     create_organization(&client, &o2_name).await;
 
-    // XXX test 401 if not authenticated?
-
     // Verify GET /organizations/{org} works
     let o1_url = format!("/organizations/{}", o1_name);
     let organization: Organization = NexusRequest::object_get(&client, &o1_url)

--- a/nexus/tests/integration_tests/organizations.rs
+++ b/nexus/tests/integration_tests/organizations.rs
@@ -2,9 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use nexus_test_utils::http_testing::{AuthnMode, NexusRequest};
 use omicron_nexus::external_api::views::Organization;
 
-use dropshot::test_util::{object_delete, object_get};
+use dropshot::test_util::object_delete;
 
 use http::method::Method;
 use http::StatusCode;
@@ -24,13 +25,27 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
     create_organization(&client, &o1_name).await;
     create_organization(&client, &o2_name).await;
 
-    let o1_url = format!("/organizations/{}", o1_name);
+    // XXX test 401 if not authenticated?
+
     // Verify GET /organizations/{org} works
-    let organization: Organization = object_get(&client, &o1_url).await;
+    let o1_url = format!("/organizations/{}", o1_name);
+    let organization: Organization = NexusRequest::object_get(&client, &o1_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request")
+        .parsed_body()
+        .unwrap();
     assert_eq!(organization.identity.name, o1_name);
 
     let o2_url = format!("/organizations/{}", o2_name);
-    let organization: Organization = object_get(&client, &o2_url).await;
+    let organization: Organization = NexusRequest::object_get(&client, &o2_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request")
+        .parsed_body()
+        .unwrap();
     assert_eq!(organization.identity.name, o2_name);
 
     // Verifying requesting a non-existent organization fails
@@ -54,12 +69,23 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
 
     // Verify DELETE /organization/{org} works
     let o1_old_id = organizations[1].identity.id;
-    object_delete(&client, &o1_url).await;
+    NexusRequest::object_delete(&client, &o1_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request");
 
     // Verify the org now returns a 404
-    client
-        .make_request_error(Method::GET, &o1_url, StatusCode::NOT_FOUND)
-        .await;
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &o1_url,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make request");
 
     // Verify the org is gone from the organizations list
     let organizations =
@@ -71,7 +97,13 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
 
     // Verify the org's name can be reused
     create_organization(&client, &o1_name).await;
-    let organization: Organization = object_get(&client, &o1_url).await;
+    let organization: Organization = NexusRequest::object_get(&client, &o1_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request")
+        .parsed_body()
+        .unwrap();
     assert_eq!(organization.identity.name, o1_name);
     // It should have a different UUID now
     assert_ne!(organization.identity.id, o1_old_id);
@@ -80,11 +112,22 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
     let project_name = "p1";
     let project_url = format!("{}/projects/{}", o2_url, project_name);
     create_project(&client, &o2_name, &project_name).await;
-    client
-        .make_request_error(Method::DELETE, &o2_url, StatusCode::BAD_REQUEST)
-        .await;
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::BAD_REQUEST,
+        Method::DELETE,
+        &o2_url,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make request");
 
     // Delete the project, then delete the organization
     object_delete(&client, &project_url).await;
-    object_delete(&client, &o2_url).await;
+    NexusRequest::object_delete(&client, &o2_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request");
 }

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -205,13 +205,13 @@ function cmd_organization_create_demo
 function cmd_organization_delete
 {
 	[[ $# != 1 ]] && usage "expected ORGANIZATION_NAME"
-	do_curl "/organizations/$1" -X DELETE
+	do_curl_authn "/organizations/$1" -X DELETE
 }
 
 function cmd_organization_get
 {
 	[[ $# != 1 ]] && usage "expected ORGANIZATION_NAME"
-	do_curl "/organizations/$1"
+	do_curl_authn "/organizations/$1"
 }
 
 function cmd_projects_list


### PR DESCRIPTION
This change adds authz checks for:

* `GET /organizations/$org`
* `PUT /organizations/$org`
* `DELETE /organizations/$org`

(`POST /organizations` and `GET /organizations` already have authz checks.)

In doing this, I've refactored the DataStore's functions for looking up an organization.  From first principles, there are a few different use cases:

* I'm looking up an Organization in order to do something with it directly (i.e., read all its properties, update it, or delete it).  This requires an appropriate authorization check on the Organization resource itself.
* I'm looking up an Organization solely as part of looking up some more deeply nested resource (e.g., a Project, Disk, Instance, etc.).  In this case, there's no authz check to be done at the Organization level.  You're always allowed to do this lookup, provided that you're eventually going to look up something inside the Organization.  If _that_ lookup fails (e.g., the Project wasn't found), then the client should get back a 404 and they shouldn't be able to tell if it was the Organization or Project that was missing.

I found the existing functions confusing.  I'll note details inline in the code.  To summarize:

* `organization_fetch(name)` fetches the whole `db::model::Organization`, does an authz check, _and_ returns an `authz::Organization` so that you can do more authz checks as needed.  This is intended for the case where you're doing something directly with the Organization (see above).  
* `organization_lookup_id(name)` now fetches the organization's id as an `authz::Organization` for subsequent authz checks.  This is intended for the use case where you're looking up the Organization in order to look up something _else_ inside it (see above).
* `organization_lookup_noauthz(name)`: internal function that fetches the `db::model::Organization` and produces an `authz::Organization`, but which does no authz check of its own.  This is private to the DataStore -- it's exposed through these other two functions instead, which make it easier to do the appropriate authz checks.

I'm planning to use this same pattern for other kinds of objects.  Eventually, I hope to refactor the `_noauthz()` versions of these functions in a way that will make it harder to misuse them.  But that's hard to do while there are still so many callers that haven't been updated for authz.