### PR TITLE
Add an Explainable trait to EXPLAIN Diesel statements

### DIFF
--- a/nexus/src/db/explain.rs
+++ b/nexus/src/db/explain.rs
@@ -5,9 +5,7 @@
 //! Utility allowing Diesel to EXPLAIN queries.
 
 use super::pool::DbConnection;
-use async_bb8_diesel::{
-    AsyncRunQueryDsl, ConnectionManager, PoolError,
-};
+use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager, PoolError};
 use async_trait::async_trait;
 use diesel::pg::Pg;
 use diesel::prelude::*;
@@ -30,12 +28,13 @@ impl<Q> Explainable<Q> for Q
 where
     Q: QueryFragment<Pg> + RunQueryDsl<DbConnection> + Sized,
 {
-    fn explain(self, conn: &mut DbConnection) -> Result<String, diesel::result::Error> {
-        Ok(
-            ExplainStatement {
-                query: self,
-            }.get_results::<String>(conn)?.join("\n")
-        )
+    fn explain(
+        self,
+        conn: &mut DbConnection,
+    ) -> Result<String, diesel::result::Error> {
+        Ok(ExplainStatement { query: self }
+            .get_results::<String>(conn)?
+            .join("\n"))
     }
 }
 
@@ -58,11 +57,10 @@ where
         self,
         pool: &bb8::Pool<ConnectionManager<DbConnection>>,
     ) -> Result<String, PoolError> {
-        Ok(
-            ExplainStatement {
-                query: self,
-            }.get_results_async::<String>(pool).await?.join("\n")
-        )
+        Ok(ExplainStatement { query: self }
+            .get_results_async::<String>(pool)
+            .await?
+            .join("\n"))
     }
 }
 
@@ -91,7 +89,7 @@ impl<Q> RunQueryDsl<DbConnection> for ExplainStatement<Q> {}
 
 impl<Q> QueryFragment<Pg> for ExplainStatement<Q>
 where
-    Q: QueryFragment<Pg>
+    Q: QueryFragment<Pg>,
 {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.push_sql("EXPLAIN (");

--- a/nexus/src/db/explain.rs
+++ b/nexus/src/db/explain.rs
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Utility allowing Diesel to EXPLAIN queries.
+
+use super::pool::DbConnection;
+use async_bb8_diesel::{
+    AsyncRunQueryDsl, ConnectionManager, PoolError,
+};
+use async_trait::async_trait;
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::query_builder::*;
+
+/// A wrapper around a runnable Diesel query, which EXPLAINs what it is doing.
+///
+/// Q: The Query we're explaining.
+///
+/// EXPLAIN: https://www.cockroachlabs.com/docs/stable/explain.html
+pub trait Explainable<Q> {
+    /// Syncronously issues an explain statement.
+    fn explain(
+        self,
+        conn: &mut DbConnection,
+    ) -> Result<String, diesel::result::Error>;
+}
+
+impl<Q> Explainable<Q> for Q
+where
+    Q: QueryFragment<Pg> + RunQueryDsl<DbConnection> + Sized,
+{
+    fn explain(self, conn: &mut DbConnection) -> Result<String, diesel::result::Error> {
+        Ok(
+            ExplainStatement {
+                query: self,
+            }.get_results::<String>(conn)?.join("\n")
+        )
+    }
+}
+
+/// An async variant of [`Explainable`].
+#[async_trait]
+pub trait ExplainableAsync<Q> {
+    /// Asynchronously issues an explain statement.
+    async fn explain_async(
+        self,
+        pool: &bb8::Pool<ConnectionManager<DbConnection>>,
+    ) -> Result<String, PoolError>;
+}
+
+#[async_trait]
+impl<Q> ExplainableAsync<Q> for Q
+where
+    Q: QueryFragment<Pg> + RunQueryDsl<DbConnection> + Sized + Send + 'static,
+{
+    async fn explain_async(
+        self,
+        pool: &bb8::Pool<ConnectionManager<DbConnection>>,
+    ) -> Result<String, PoolError> {
+        Ok(
+            ExplainStatement {
+                query: self,
+            }.get_results_async::<String>(pool).await?.join("\n")
+        )
+    }
+}
+
+// An EXPLAIN statement, wrapping an underlying query.
+//
+// This isn't `pub` because it's kinda weird to access "part" of the EXPLAIN
+// output, which would be possible by calling "get_result" instead of
+// "get_results". We'd like to be able to constrain callers such that they get
+// all of the output or none of it.
+//
+// See the [`Explainable`] trait for why this exists.
+struct ExplainStatement<Q> {
+    query: Q,
+}
+
+impl<Q> QueryId for ExplainStatement<Q> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<Q> Query for ExplainStatement<Q> {
+    type SqlType = diesel::sql_types::Text;
+}
+
+impl<Q> RunQueryDsl<DbConnection> for ExplainStatement<Q> {}
+
+impl<Q> QueryFragment<Pg> for ExplainStatement<Q>
+where
+    Q: QueryFragment<Pg>
+{
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("EXPLAIN (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(")");
+        Ok(())
+    }
+}

--- a/nexus/src/db/mod.rs
+++ b/nexus/src/db/mod.rs
@@ -14,6 +14,7 @@ mod config;
 // This is marked public for use by the integration tests
 pub mod datastore;
 mod error;
+mod explain;
 pub mod fixed_data;
 mod pagination;
 mod pool;


### PR DESCRIPTION
Here's a situation I find myself in often:

- I write a Diesel statement
- I'd like to figure out how indices are used for this statement (e.g., are we doing full table scans?)
- I try to figure out how to map the "Diesel statement" to "raw SQL". This often means manually printing the statement, or just trying to eyeball it and recreate something similar by hand.
- I pop open CockroachDB's CLI, populate the tables in a way that matches our DB structure, try to `EXPLAIN` the SQL statement, and hope it was aligned with the Diesel statement.

That workflow is... fine. But this intends to make it a little simpler.

For any runnable diesel statement, rather than executing it using the typical [RunQueryDsl](https://docs.diesel.rs/master/diesel/prelude/trait.RunQueryDsl.html#) methods, it may be "explained" instead, producing a string of the raw [EXPLAIN](https://www.cockroachlabs.com/docs/stable/explain.html) output.

The intent of this statement is to assist debugging, but it could also potentially be used for automated testing (e.g., checking for / / disallowing `spans: FULL SCAN`)