### PR TITLE
return 404 rather than 401/403 when user can't even see the object

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -20,7 +20,7 @@
 // parts we need for authorization.
 
 use super::actor::AnyActor;
-use super::context::Authorize;
+use super::context::AuthorizedResource;
 use super::roles::{
     load_roles_for_resource, load_roles_for_resource_tree, RoleSet,
 };
@@ -37,9 +37,7 @@ use uuid::Uuid;
 
 /// Describes an authz resource that corresponds to an API resource that has a
 /// corresponding ResourceType and is stored in the database
-///
-/// This is a helper trait used to impl [`AuthzResource`].
-pub trait AuthzApiResource: Clone + Send + Sync + 'static {
+pub trait ApiResource: Clone + Send + Sync + 'static {
     /// If roles can be assigned to this resource, return the type and id of the
     /// database record describing this resource
     ///
@@ -49,14 +47,14 @@ pub trait AuthzApiResource: Clone + Send + Sync + 'static {
     /// If this resource has a parent in the API hierarchy whose assigned roles
     /// can affect access to this resource, return the parent resource.
     /// Otherwise, returns `None`.
-    fn parent(&self) -> Option<&dyn Authorize>;
+    fn parent(&self) -> Option<&dyn AuthorizedResource>;
 
     /// Returns an error as though this resource were not found, suitable for
     /// use when an actor should not be able to see that this resource exists
     fn not_found(&self) -> Error;
 }
 
-impl<T: AuthzApiResource + oso::PolarClass> Authorize for T {
+impl<T: ApiResource + oso::PolarClass> AuthorizedResource for T {
     fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
         opctx: &'b OpContext,
@@ -81,21 +79,21 @@ impl<T: AuthzApiResource + oso::PolarClass> Authorize for T {
         error: Error,
         actor: AnyActor,
         action: Action,
-    ) -> Result<(), Error> {
+    ) -> Error {
         if action == Action::Read {
-            return Err(self.not_found());
+            return self.not_found();
         }
 
         // If the user failed an authz check, and they can't even read this
         // resource, then we should produce a 404 rather than a 401/403.
         match authz.is_allowed(&actor, Action::Read, self) {
-            Err(error) => Err(Error::internal_error(&format!(
+            Err(error) => Error::internal_error(&format!(
                 "failed to compute read authorization to determine visibility: \
                 {:#}",
                 error
-            ))),
-            Ok(false) => Err(self.not_found()),
-            Ok(true) => Err(error),
+            )),
+            Ok(false) => self.not_found(),
+            Ok(true) => error,
         }
     }
 }
@@ -163,13 +161,13 @@ impl oso::PolarClass for Fleet {
     }
 }
 
-impl Authorize for Fleet {
+impl AuthorizedResource for Fleet {
     fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
-        opctx: &'b crate::context::OpContext,
-        datastore: &'c crate::db::DataStore,
-        authn: &'d crate::authn::Context,
-        roleset: &'e mut super::roles::RoleSet,
+        opctx: &'b OpContext,
+        datastore: &'c DataStore,
+        authn: &'d authn::Context,
+        roleset: &'e mut RoleSet,
     ) -> futures::future::BoxFuture<'f, Result<(), Error>>
     where
         'a: 'f,
@@ -195,8 +193,8 @@ impl Authorize for Fleet {
         error: Error,
         _: AnyActor,
         _: Action,
-    ) -> Result<(), Error> {
-        Err(error)
+    ) -> Error {
+        error
     }
 }
 
@@ -232,12 +230,12 @@ impl oso::PolarClass for FleetChild {
     }
 }
 
-impl AuthzApiResource for FleetChild {
+impl ApiResource for FleetChild {
     fn db_resource(&self) -> Option<(ResourceType, Uuid)> {
         None
     }
 
-    fn parent(&self) -> Option<&dyn Authorize> {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&FLEET)
     }
 
@@ -303,12 +301,12 @@ impl oso::PolarClass for Organization {
     }
 }
 
-impl AuthzApiResource for Organization {
+impl ApiResource for Organization {
     fn db_resource(&self) -> Option<(ResourceType, Uuid)> {
         Some((ResourceType::Organization, self.organization_id))
     }
 
-    fn parent(&self) -> Option<&dyn Authorize> {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&FLEET)
     }
 
@@ -382,12 +380,12 @@ impl oso::PolarClass for Project {
     }
 }
 
-impl AuthzApiResource for Project {
+impl ApiResource for Project {
     fn db_resource(&self) -> Option<(ResourceType, Uuid)> {
         Some((ResourceType::Project, self.project_id))
     }
 
-    fn parent(&self) -> Option<&dyn Authorize> {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&self.parent)
     }
 
@@ -438,13 +436,13 @@ impl oso::PolarClass for ProjectChild {
     }
 }
 
-impl AuthzApiResource for ProjectChild {
+impl ApiResource for ProjectChild {
     fn db_resource(&self) -> Option<(ResourceType, Uuid)> {
         // We do not support assigning roles to children of Projects.
         None
     }
 
-    fn parent(&self) -> Option<&dyn Authorize> {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&self.parent)
     }
 

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -88,8 +88,7 @@ impl<T: AuthzApiResource + oso::PolarClass> Authorize for T {
 
         // If the user failed an authz check, and they can't even read this
         // resource, then we should produce a 404 rather than a 401/403.
-        let can_read = authz.oso.is_allowed(actor, Action::Read, self.clone());
-        match can_read {
+        match authz.is_allowed(&actor, Action::Read, self) {
             Err(error) => Err(Error::internal_error(&format!(
                 "failed to compute read authorization to determine visibility: \
                 {:#}",

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -77,7 +77,7 @@ impl Context {
         resource: Resource,
     ) -> Result<(), Error>
     where
-        Resource: oso::ToPolar + Authorize + Clone,
+        Resource: AuthorizedResource + Clone,
     {
         let mut roles = RoleSet::new();
         resource
@@ -105,13 +105,13 @@ impl Context {
                     }
                 };
 
-                resource.on_unauthorized(&self.authz, error, actor, action)
+                Err(resource.on_unauthorized(&self.authz, error, actor, action))
             }
         }
     }
 }
 
-pub trait Authorize: Send + Sync + 'static {
+pub trait AuthorizedResource: oso::ToPolar + Send + Sync + 'static {
     /// Find all roles for the user described in `authn` that might be used to
     /// make an authorization decision on `self` (a resource)
     ///
@@ -148,7 +148,7 @@ pub trait Authorize: Send + Sync + 'static {
         error: Error,
         actor: AnyActor,
         action: Action,
-    ) -> Result<(), Error>;
+    ) -> Error;
 }
 
 #[cfg(test)]

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -35,9 +35,6 @@ impl Authz {
     }
 
     // TODO-cleanup This should not be exposed outside the `authz` module.
-    // One way might be if `Authz` itself weren't exposed.  We'd just have
-    // `Context::new()` create one.  (There's only one way to create one
-    // anyway.)
     pub fn is_allowed<R>(
         &self,
         actor: &AnyActor,

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -180,4 +180,3 @@ pub use oso_generic::Action;
 pub use oso_generic::DATABASE;
 
 mod roles;
-pub use roles::AuthzApiResource;

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -171,7 +171,7 @@ pub use api_resources::ProjectChild;
 pub use api_resources::FLEET;
 
 mod context;
-pub use context::Authorize;
+pub use context::AuthorizedResource;
 pub use context::Authz;
 pub use context::Context;
 

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -171,6 +171,7 @@ pub use api_resources::ProjectChild;
 pub use api_resources::FLEET;
 
 mod context;
+pub use context::Authorize;
 pub use context::Authz;
 pub use context::Context;
 
@@ -179,4 +180,4 @@ pub use oso_generic::Action;
 pub use oso_generic::DATABASE;
 
 mod roles;
-pub use roles::AuthzResource;
+pub use roles::AuthzApiResource;

--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -4,6 +4,7 @@
 
 //! Oso integration
 
+use super::Authz;
 use super::actor::AnyActor;
 use super::actor::AuthenticatedActor;
 use super::api_resources::Fleet;
@@ -11,7 +12,7 @@ use super::api_resources::FleetChild;
 use super::api_resources::Organization;
 use super::api_resources::Project;
 use super::api_resources::ProjectChild;
-use super::roles::AuthzResource;
+use super::context::Authorize;
 use super::roles::RoleSet;
 use crate::authn;
 use crate::context::OpContext;
@@ -149,8 +150,8 @@ impl oso::PolarClass for Database {
     }
 }
 
-impl AuthzResource for Database {
-    fn fetch_all_related_roles_for_user<'a, 'b, 'c, 'd, 'e, 'f>(
+impl Authorize for Database {
+    fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
         _: &'b OpContext,
         _: &'c DataStore,
@@ -174,5 +175,15 @@ impl AuthzResource for Database {
         // for roles on database objects -- it assumes they have a ResourceType
         // and id, neither of which is true for `Database`.
         futures::future::ready(Ok(())).boxed()
+    }
+
+    fn on_unauthorized(
+        &self,
+        _: &Authz,
+        error: Error,
+        _: AnyActor,
+        _: Action,
+    ) -> Result<(), Error> {
+        Err(error)
     }
 }

--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -4,7 +4,6 @@
 
 //! Oso integration
 
-use super::Authz;
 use super::actor::AnyActor;
 use super::actor::AuthenticatedActor;
 use super::api_resources::Fleet;
@@ -14,6 +13,7 @@ use super::api_resources::Project;
 use super::api_resources::ProjectChild;
 use super::context::Authorize;
 use super::roles::RoleSet;
+use super::Authz;
 use crate::authn;
 use crate::context::OpContext;
 use crate::db::DataStore;

--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -11,7 +11,7 @@ use super::api_resources::FleetChild;
 use super::api_resources::Organization;
 use super::api_resources::Project;
 use super::api_resources::ProjectChild;
-use super::context::Authorize;
+use super::context::AuthorizedResource;
 use super::roles::RoleSet;
 use super::Authz;
 use crate::authn;
@@ -150,7 +150,7 @@ impl oso::PolarClass for Database {
     }
 }
 
-impl Authorize for Database {
+impl AuthorizedResource for Database {
     fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
         _: &'b OpContext,
@@ -183,7 +183,7 @@ impl Authorize for Database {
         error: Error,
         _: AnyActor,
         _: Action,
-    ) -> Result<(), Error> {
-        Err(error)
+    ) -> Error {
+        error
     }
 }

--- a/nexus/src/authz/roles.rs
+++ b/nexus/src/authz/roles.rs
@@ -45,6 +45,11 @@ use omicron_common::api::external::ResourceType;
 use std::collections::BTreeSet;
 use uuid::Uuid;
 
+use super::actor::AnyActor;
+use super::context::Authorize;
+use super::Action;
+use super::Authz;
+
 /// A set of built-in roles, used for quickly checking whether a particular role
 /// is contained within the set
 ///
@@ -86,40 +91,12 @@ impl RoleSet {
     }
 }
 
-/// Describes how to fetch the roles for an authz resource
-pub trait AuthzResource: Send + Sync + 'static {
-    /// Find all roles for the user described in `authn` that might be used to
-    /// make an authorization decision on `self` (a resource)
-    ///
-    /// You can imagine that this function would first find roles that are
-    /// explicitly associated with this resource in the database.  Then it would
-    /// also find roles associated with its parent, since, for example, an
-    /// Organization Administrator can access things within Projects in the
-    /// organization.  This process continues up the hierarchy.
-    ///
-    /// That's how this works for most resources.  There are other kinds of
-    /// resources (like the Database itself) that aren't stored in the database
-    /// and for which a different mechanism might be used.
-    fn fetch_all_related_roles_for_user<'a, 'b, 'c, 'd, 'e, 'f>(
-        &'a self,
-        opctx: &'b OpContext,
-        datastore: &'c DataStore,
-        authn: &'d authn::Context,
-        roleset: &'e mut RoleSet,
-    ) -> BoxFuture<'f, Result<(), Error>>
-    where
-        'a: 'f,
-        'b: 'f,
-        'c: 'f,
-        'd: 'f,
-        'e: 'f;
-}
-
+/// XXX consider moving this to authz/context.rs
 /// Describes an authz resource that corresponds to an API resource that has a
 /// corresponding ResourceType and is stored in the database
 ///
 /// This is a helper trait used to impl [`AuthzResource`].
-pub trait AuthzApiResource: Send + Sync + 'static {
+pub trait AuthzApiResource: Clone + Send + Sync + 'static {
     /// If roles can be assigned to this resource, return the type and id of the
     /// database record describing this resource
     ///
@@ -129,11 +106,15 @@ pub trait AuthzApiResource: Send + Sync + 'static {
     /// If this resource has a parent in the API hierarchy whose assigned roles
     /// can affect access to this resource, return the parent resource.
     /// Otherwise, returns `None`.
-    fn parent(&self) -> Option<Box<dyn AuthzResource>>;
+    fn parent(&self) -> Option<Box<dyn Authorize>>;
+
+    /// Returns an error as though this resource were not found, suitable for
+    /// use when an actor should not be able to see that this resource exists
+    fn not_found(&self) -> Error;
 }
 
-impl<T: AuthzApiResource> AuthzResource for T {
-    fn fetch_all_related_roles_for_user<'a, 'b, 'c, 'd, 'e, 'f>(
+impl<T: AuthzApiResource + oso::PolarClass> Authorize for T {
+    fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
         opctx: &'b OpContext,
         datastore: &'c DataStore,
@@ -148,59 +129,105 @@ impl<T: AuthzApiResource> AuthzResource for T {
         'e: 'f,
     {
         async move {
-            // If the user is authenticated ...
-            if let Some(actor_id) = authn.actor() {
-                // ... and if roles can be assigned directly on this resource ...
-                if let Some((resource_type, resource_id)) = self.db_resource() {
-                    // ... then start by fetching all the roles for this user
-                    // that are associated with this resource.
-                    trace!(opctx.log, "loading roles";
-                        "actor_id" => actor_id.0.to_string(),
-                        "resource_type" => ?resource_type,
-                        "resource_id" => resource_id.to_string(),
-                    );
-                    let roles = datastore
-                        .role_asgn_builtin_list_for(
-                            opctx,
-                            actor_id.0,
-                            resource_type,
-                            resource_id,
-                        )
-                        .await?;
-                    // Add each role to the output roleset.
-                    for role_asgn in roles {
-                        assert_eq!(
-                            resource_type.to_string(),
-                            role_asgn.resource_type
-                        );
-                        roleset.insert(
-                            resource_type,
-                            resource_id,
-                            &role_asgn.role_name,
-                        );
-                    }
-                }
+            // If roles can be assigned directly on this resource, load them.
+            if let Some((resource_type, resource_id)) = self.db_resource() {
+                load_roles_for_resource(
+                    opctx,
+                    datastore,
+                    authn,
+                    resource_type,
+                    resource_id,
+                    roleset,
+                )
+                .await?;
+            }
 
-                // If this resource has a parent, the user's roles on the parent
-                // might grant them access to this resource.  We have to fetch
-                // those, too.  This process is recursive up to the root.
-                //
-                // (In general, there could be another resource with _any_ kind
-                // of relationship to this one that grants them a role that
-                // grants access to this resource.  In practice, we only use
-                // "parent", and it's clearer to just call this "parent" than
-                // "related_resources_whose_roles_might_grant_access_to_this".)
-                if let Some(parent) = self.parent() {
-                    parent
-                        .fetch_all_related_roles_for_user(
-                            opctx, datastore, authn, roleset,
-                        )
-                        .await?;
-                }
+            // If this resource has a parent, the user's roles on the parent
+            // might grant them access to this resource.  We have to fetch
+            // those, too.  This process is recursive up to the root.
+            //
+            // (In general, there could be another resource with _any_ kind of
+            // relationship to this one that grants them a role that grants
+            // access to this resource.  In practice, we only use "parent", and
+            // it's clearer to just call this "parent" than
+            // "related_resources_whose_roles_might_grant_access_to_this".)
+            if let Some(parent) = self.parent() {
+                parent.load_roles(opctx, datastore, authn, roleset).await?;
             }
 
             Ok(())
         }
         .boxed()
     }
+
+    // XXX this is no longer really part of roles
+    fn on_unauthorized(
+        &self,
+        authz: &Authz,
+        error: Error,
+        actor: AnyActor,
+        action: Action,
+    ) -> Result<(), Error> {
+        if action == Action::Read {
+            return Err(self.not_found());
+        }
+        let can_read = authz.oso.is_allowed(actor, Action::Read, self.clone());
+        match can_read {
+            Err(error) => Err(Error::internal_error(&format!(
+                "failed to compute read authorization to determine visibility: \
+                {:#}",
+                error
+            ))),
+            Ok(false) => Err(self.not_found()),
+            Ok(true) => Err(error),
+        }
+    }
+}
+
+pub fn load_roles_for_resource<'a, 'b, 'c, 'd, 'e, 'f>(
+    opctx: &'b OpContext,
+    datastore: &'c DataStore,
+    authn: &'d authn::Context,
+    resource_type: ResourceType,
+    resource_id: Uuid,
+    roleset: &'e mut RoleSet,
+) -> BoxFuture<'f, Result<(), Error>>
+where
+    'a: 'f,
+    'b: 'f,
+    'c: 'f,
+    'd: 'f,
+    'e: 'f,
+{
+    async move {
+        // If the user is authenticated ...
+        if let Some(actor_id) = authn.actor() {
+            // ... then start by fetching all the roles for this user
+            // that are associated with this resource.
+            trace!(opctx.log, "loading roles";
+                "actor_id" => actor_id.0.to_string(),
+                "resource_type" => ?resource_type,
+                "resource_id" => resource_id.to_string(),
+            );
+            let roles = datastore
+                .role_asgn_builtin_list_for(
+                    opctx,
+                    actor_id.0,
+                    resource_type,
+                    resource_id,
+                )
+                .await?;
+            // Add each role to the output roleset.
+            for role_asgn in roles {
+                assert_eq!(resource_type.to_string(), role_asgn.resource_type);
+                roleset.insert(
+                    resource_type,
+                    resource_id,
+                    &role_asgn.role_name,
+                );
+            }
+        }
+        Ok(())
+    }
+    .boxed()
 }

--- a/nexus/src/authz/roles.rs
+++ b/nexus/src/authz/roles.rs
@@ -17,8 +17,7 @@
 //! its parent Organization or the parent Fleet.  This isn't as large as it
 //! might sound, since the hierarchy is not _that_ deep, but we do have to make
 //! multiple database queries to load all this.  This is all done by
-//! [`AuthzResource::fetch_all_related_roles_for_user()`].  This is really done
-//! by the impl of [`AuthzResource`] for [`AuthzApiResource`].
+//! [`load_roles_for_resource_tree`].
 //!
 //! Once we've got the complete list of roles, we include that in the data
 //! structure we pass into Oso.   When it asks whether an actor has a role on a
@@ -35,7 +34,7 @@
 //! request, and we don't want that thread to block while we hit the database.
 //! Both of these issues could be addressed with considerably more work.
 
-use super::api_resources::AuthzApiResource;
+use super::api_resources::ApiResource;
 use crate::authn;
 use crate::context::OpContext;
 use crate::db::DataStore;
@@ -93,7 +92,7 @@ pub async fn load_roles_for_resource_tree<R>(
     roleset: &mut RoleSet,
 ) -> Result<(), Error>
 where
-    R: AuthzApiResource,
+    R: ApiResource,
 {
     // If roles can be assigned directly on this resource, load them.
     if let Some((resource_type, resource_id)) = resource.db_resource() {

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -12,7 +12,7 @@ use super::db;
 use super::Nexus;
 use crate::authn::external::session_cookie::{Session, SessionStore};
 use crate::authn::Actor;
-use crate::authz::Authorize;
+use crate::authz::AuthorizedResource;
 use crate::db::model::ConsoleSession;
 use crate::db::DataStore;
 use async_trait::async_trait;
@@ -311,7 +311,7 @@ impl OpContext {
         resource: &Resource,
     ) -> Result<(), Error>
     where
-        Resource: oso::ToPolar + Authorize + Debug + Clone,
+        Resource: AuthorizedResource + Debug + Clone,
     {
         /*
          * TODO-cleanup In an ideal world, Oso would consume &Action and

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -12,7 +12,7 @@ use super::db;
 use super::Nexus;
 use crate::authn::external::session_cookie::{Session, SessionStore};
 use crate::authn::Actor;
-use crate::authz::AuthzResource;
+use crate::authz::Authorize;
 use crate::db::model::ConsoleSession;
 use crate::db::DataStore;
 use async_trait::async_trait;
@@ -308,10 +308,10 @@ impl OpContext {
     pub async fn authorize<Resource>(
         &self,
         action: authz::Action,
-        resource: Resource,
+        resource: &Resource,
     ) -> Result<(), Error>
     where
-        Resource: oso::ToPolar + AuthzResource + Debug + Clone,
+        Resource: oso::ToPolar + Authorize + Debug + Clone,
     {
         /*
          * TODO-cleanup In an ideal world, Oso would consume &Action and
@@ -322,13 +322,13 @@ impl OpContext {
         trace!(self.log, "authorize begin";
             "actor" => ?self.authn.actor(),
             "action" => ?action,
-            "resource" => ?resource
+            "resource" => ?*resource
         );
         let result = self.authz.authorize(self, action, resource.clone()).await;
         debug!(self.log, "authorize result";
             "actor" => ?self.authn.actor(),
             "action" => ?action,
-            "resource" => ?resource,
+            "resource" => ?*resource,
             "result" => ?result,
         );
         result
@@ -370,7 +370,7 @@ mod test {
         // For now, we check what we currently expect, which is that this
         // context has no official privileges.
         let error = opctx
-            .authorize(Action::Query, authz::DATABASE)
+            .authorize(Action::Query, &authz::DATABASE)
             .await
             .expect_err("expected authorization error");
         assert!(matches!(error, Error::Unauthenticated { .. }));
@@ -392,7 +392,7 @@ mod test {
         // themselves do that -- but it's useful to have a basic santiy test
         // that we can construct such a context it's authorized to do something.
         opctx
-            .authorize(Action::Query, authz::DATABASE)
+            .authorize(Action::Query, &authz::DATABASE)
             .await
             .expect("expected authorization to succeed");
         db.cleanup().await.unwrap();

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -43,6 +43,7 @@ use omicron_common::api::external::Ipv6Net;
 use omicron_common::api::external::ListResult;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::LookupType;
 use omicron_common::api::external::PaginationOrder;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::RouteDestination;
@@ -747,9 +748,16 @@ impl Nexus {
         Ok((
             disk,
             authz::FLEET
-                .organization(organization_id)
-                .project(project_id)
-                .child_generic(ResourceType::Disk, disk_id),
+                .organization(
+                    organization_id,
+                    LookupType::from(&organization_name.0),
+                )
+                .project(project_id, LookupType::from(&project_name.0))
+                .child_generic(
+                    ResourceType::Disk,
+                    disk_id,
+                    LookupType::from(&disk_name.0),
+                ),
         ))
     }
 
@@ -790,7 +798,7 @@ impl Nexus {
          * before actually beginning the attach process.  Sagas can maybe
          * address that.
          */
-        self.db_datastore.project_delete_disk(opctx, authz_disk).await
+        self.db_datastore.project_delete_disk(opctx, &authz_disk).await
     }
 
     /*

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -424,18 +424,23 @@ async fn test_disks(cptestctx: &ControlPlaneTestContext) {
 
     /*
      * If we're not authenticated, or authenticated as an unprivileged user, we
-     * shouldn't be able to delete this disk.
+     * shouldn't be able to delete this disk.  (We shouldn't be able to even see
+     * it if we try.)
      */
-    NexusRequest::new(
-        RequestBuilder::new(client, Method::DELETE, &disk_url)
-            .expect_status(Some(StatusCode::UNAUTHORIZED)),
+    NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::DELETE,
+        &disk_url,
     )
     .execute()
     .await
     .expect("expected request to fail");
-    NexusRequest::new(
-        RequestBuilder::new(client, Method::DELETE, &disk_url)
-            .expect_status(Some(StatusCode::FORBIDDEN)),
+    NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::DELETE,
+        &disk_url,
     )
     .authn_as(AuthnMode::UnprivilegedUser)
     .execute()

--- a/nexus/tests/integration_tests/organizations.rs
+++ b/nexus/tests/integration_tests/organizations.rs
@@ -36,6 +36,29 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
     assert_eq!(organization.identity.name, o1_name);
 
+    // You should get a 404 if not authenticated.
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &o1_url,
+    )
+    .execute()
+    .await
+    .expect("failed to make request");
+
+    // Same if you're authenticated but not authorized to see it.
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &o1_url,
+    )
+    .authn_as(AuthnMode::UnprivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make request");
+
     let o2_url = format!("/organizations/{}", o2_name);
     let organization: Organization = NexusRequest::object_get(&client, &o2_url)
         .authn_as(AuthnMode::PrivilegedUser)
@@ -46,7 +69,7 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
     assert_eq!(organization.identity.name, o2_name);
 
-    // Verifying requesting a non-existent organization fails
+    // Verify requesting a non-existent organization fails
     client
         .make_request_error(
             Method::GET,
@@ -64,6 +87,29 @@ async fn test_organizations(cptestctx: &ControlPlaneTestContext) {
     // alphabetical order for now
     assert_eq!(organizations[0].identity.name, o2_name);
     assert_eq!(organizations[1].identity.name, o1_name);
+
+    // You should get a 404 if you attempt to delete an organization if you are
+    // unauthenticated or unauthorized.
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::NOT_FOUND,
+        Method::DELETE,
+        &o1_url,
+    )
+    .execute()
+    .await
+    .expect("failed to make request");
+
+    NexusRequest::expect_failure(
+        &client,
+        StatusCode::NOT_FOUND,
+        Method::DELETE,
+        &o1_url,
+    )
+    .authn_as(AuthnMode::UnprivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make request");
 
     // Verify DELETE /organization/{org} works
     let o1_old_id = organizations[1].identity.id;

--- a/nexus/tests/integration_tests/roles_builtin.rs
+++ b/nexus/tests/integration_tests/roles_builtin.rs
@@ -18,15 +18,21 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
     // Standard authn / authz checks
-    RequestBuilder::new(testctx, Method::GET, "/roles")
-        .expect_status(Some(StatusCode::UNAUTHORIZED))
-        .execute()
-        .await
-        .unwrap();
+    NexusRequest::expect_failure(
+        testctx,
+        StatusCode::UNAUTHORIZED,
+        Method::GET,
+        "/roles",
+    )
+    .execute()
+    .await
+    .unwrap();
 
-    NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/roles")
-            .expect_status(Some(StatusCode::FORBIDDEN)),
+    NexusRequest::expect_failure(
+        testctx,
+        StatusCode::FORBIDDEN,
+        Method::GET,
+        "/roles",
     )
     .authn_as(AuthnMode::UnprivilegedUser)
     .execute()
@@ -88,14 +94,16 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
 
     // Standard authnn/authz checks
     RequestBuilder::new(testctx, Method::GET, "/roles/fleet.admin")
-        .expect_status(Some(StatusCode::UNAUTHORIZED))
+        .expect_status(Some(StatusCode::NOT_FOUND))
         .execute()
         .await
         .unwrap();
 
-    NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/roles/fleet.admin")
-            .expect_status(Some(StatusCode::FORBIDDEN)),
+    NexusRequest::expect_failure(
+        testctx,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        "/roles/fleet.admin",
     )
     .authn_as(AuthnMode::UnprivilegedUser)
     .execute()


### PR DESCRIPTION
When a user attempts to perform some action on an object, and they shouldn't even see that the object exists, they should get a 404 rather than a 401 or 403.  (If we return a 403, then we're leaking information to a potential attacker: they can find out whether an Organization exists based on whether they get a 404 or 403 when they try to create a Project inside it.)

I think this is widely understood, but for a reference, see the [Enforcement chapter of Oso's Authorization Academy](https://www.osohq.com/academy/authorization-enforcement), which says:

> The default strategy for handling an authorization failure is to return an HTTP 403 Forbidden message, along with any details that might be helpful for the client.
> However, in some cases returning an error message would be revealing information that the user should not otherwise know. For example, suppose a GitClub user visits /org/acme/repo/secret_project – a private repository – then a 403 Forbidden message might reveal to the user that such a repository exists.
> Therefore, it is best practice to return an HTTP 404 NotFound message whenever the user is not even allowed to read the resource, regardless of what action they are attempting.

That's essentially what this change does.  It took some refactoring to make this work well, especially because our 404 errors have type information about what you're looking up.