### PR TITLE
authz: protect GET for Projects (and prepare for more)

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -331,6 +331,11 @@ pub struct Project {
 }
 
 impl Project {
+    // TODO-cleanup see note on Organization::id above.
+    pub fn id(&self) -> Uuid {
+        self.project_id
+    }
+
     /// Returns an authz resource representing any child of this Project (e.g.,
     /// an Instance or Disk)
     ///

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -325,7 +325,7 @@ impl DataStore {
     ///
     /// This function does no authz checks because it is not possible to know
     /// just by looking up an Organization's id what privileges are required.
-    pub async fn organization_lookup_id(
+    pub async fn organization_lookup_path(
         &self,
         name: &Name,
     ) -> LookupResult<authz::Organization> {
@@ -340,8 +340,6 @@ impl DataStore {
     ) -> LookupResult<(authz::Organization, Organization)> {
         let (authz_org, db_org) =
             self.organization_lookup_noauthz(name).await?;
-        // TODO-security See the note in authz::authorize().  This needs to
-        // return a 404, not a 403.
         opctx.authorize(authz::Action::Read, &authz_org).await?;
         Ok((authz_org, db_org))
     }
@@ -475,7 +473,7 @@ impl DataStore {
     ) -> UpdateResult<Organization> {
         use db::schema::organization::dsl;
 
-        let authz_org = self.organization_lookup_id(name).await?;
+        let authz_org = self.organization_lookup_path(name).await?;
         opctx.authorize(authz::Action::Modify, &authz_org).await?;
 
         diesel::update(dsl::organization)
@@ -528,17 +526,22 @@ impl DataStore {
         })
     }
 
-    /// Lookup a project by name.
-    pub async fn project_fetch(
+    /// Fetches a Project from the database and returns both the database row
+    /// and an authz::Project for doing authz checks
+    ///
+    /// See [`DataStore::organization_lookup_noauthz()`] for intended use cases
+    /// and caveats.
+    // TODO-security See the note on organization_lookup_noauthz().
+    async fn project_lookup_noauthz(
         &self,
-        organization_id: &Uuid,
-        name: &Name,
-    ) -> LookupResult<Project> {
+        authz_org: &authz::Organization,
+        project_name: &Name,
+    ) -> LookupResult<(authz::Project, Project)> {
         use db::schema::project::dsl;
         dsl::project
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::organization_id.eq(*organization_id))
-            .filter(dsl::name.eq(name.clone()))
+            .filter(dsl::organization_id.eq(authz_org.id()))
+            .filter(dsl::name.eq(project_name.clone()))
             .select(Project::as_select())
             .first_async(self.pool())
             .await
@@ -546,9 +549,47 @@ impl DataStore {
                 public_error_from_diesel_pool(
                     e,
                     ResourceType::Project,
-                    LookupType::ByName(name.as_str().to_owned()),
+                    LookupType::ByName(project_name.as_str().to_owned()),
                 )
             })
+            .map(|p| {
+                (
+                    authz_org
+                        .project(p.id(), LookupType::from(&project_name.0)),
+                    p,
+                )
+            })
+    }
+
+    /// Look up the id for a Project based on its name
+    ///
+    /// Returns an [`authz::Project`] (which makes the id available).
+    ///
+    /// This function does no authz checks because it is not possible to know
+    /// just by looking up an Project's id what privileges are required.
+    pub async fn project_lookup_path(
+        &self,
+        organization_name: &Name,
+        project_name: &Name,
+    ) -> LookupResult<authz::Project> {
+        let authz_org =
+            self.organization_lookup_path(organization_name).await?;
+        self.project_lookup_noauthz(&authz_org, project_name)
+            .await
+            .map(|(p, _)| p)
+    }
+
+    /// Lookup a project by name.
+    pub async fn project_fetch(
+        &self,
+        opctx: &OpContext,
+        authz_org: &authz::Organization,
+        name: &Name,
+    ) -> LookupResult<(authz::Project, Project)> {
+        let (authz_org, db_org) =
+            self.project_lookup_noauthz(authz_org, name).await?;
+        opctx.authorize(authz::Action::Read, &authz_org).await?;
+        Ok((authz_org, db_org))
     }
 
     /// Delete a project
@@ -580,29 +621,6 @@ impl DataStore {
                 )
             })?;
         Ok(())
-    }
-
-    /// Look up the id for a project based on its name
-    pub async fn project_lookup_id_by_name(
-        &self,
-        organization_id: &Uuid,
-        name: &Name,
-    ) -> Result<Uuid, Error> {
-        use db::schema::project::dsl;
-        dsl::project
-            .filter(dsl::time_deleted.is_null())
-            .filter(dsl::organization_id.eq(*organization_id))
-            .filter(dsl::name.eq(name.clone()))
-            .select(dsl::id)
-            .get_result_async::<Uuid>(self.pool())
-            .await
-            .map_err(|e| {
-                public_error_from_diesel_pool(
-                    e,
-                    ResourceType::Project,
-                    LookupType::ByName(name.as_str().to_owned()),
-                )
-            })
     }
 
     pub async fn projects_list_by_id(

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -477,8 +477,10 @@ async fn organization_projects_get_project(
     let organization_name = &path.organization_name;
     let project_name = &path.project_name;
     let handler = async {
-        let project =
-            nexus.project_fetch(&organization_name, &project_name).await?;
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let project = nexus
+            .project_fetch(&opctx, &organization_name, &project_name)
+            .await?;
         Ok(HttpResponseOk(project.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -148,3 +148,16 @@ pub async fn create_router(
     )
     .await
 }
+
+pub async fn project_get(
+    client: &ClientTestContext,
+    project_url: &str,
+) -> Project {
+    NexusRequest::object_get(client, project_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to get project")
+        .parsed_body()
+        .expect("failed to parse Project")
+}

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -4,9 +4,8 @@
 
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
+use nexus_test_utils::resource_helpers::project_get;
 use omicron_nexus::external_api::views::Project;
-
-use dropshot::test_util::object_get;
 
 use nexus_test_utils::resource_helpers::{create_organization, create_project};
 use nexus_test_utils::ControlPlaneTestContext;
@@ -28,11 +27,11 @@ async fn test_projects(cptestctx: &ControlPlaneTestContext) {
     create_project(&client, &org_name, &p2_name).await;
 
     let p1_url = format!("/organizations/{}/projects/{}", org_name, p1_name);
-    let project: Project = object_get(&client, &p1_url).await;
+    let project: Project = project_get(&client, &p1_url).await;
     assert_eq!(project.identity.name, p1_name);
 
     let p2_url = format!("/organizations/{}/projects/{}", org_name, p2_name);
-    let project: Project = object_get(&client, &p2_url).await;
+    let project: Project = project_get(&client, &p2_url).await;
     assert_eq!(project.identity.name, p2_name);
 
     /*

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -236,7 +236,7 @@ function cmd_project_delete
 function cmd_project_get
 {
 	[[ $# != 2 ]] && usage "expected ORGANIZATION_NAME PROJECT_NAME"
-	do_curl "/organizations/$1/projects/$2"
+	do_curl_authn "/organizations/$1/projects/$2"
 }
 
 function cmd_project_list_instances


### PR DESCRIPTION
This change does a few things:

* adds authz checks for the "GET Project" API endpoint
* refactors the Project fetch/lookup functions, exactly analogously to what I did under #592 for Organizations.  This lays groundwork for protecting the rest of the project-level API endpoints as well as the endpoints for Instances, Disks, VPCs, etc.
* renames `organization_lookup_id()` (which was created in #592) to `organization_lookup_path()` for consistency with `project_lookup_path()`.  The idea here is that for every resource we'll eventually have a `$resource_lookup_path()` function that takes the (API) path of names that identify it.  For example:
    * `organization_lookup_path(organization_name)` (in this change, renamed from organization_lookup_id)
    * `project_lookup_path(organization_name, project_name)` (new in this change, this simplifies a bunch of call sites in nexus.rs)
    * `disk_lookup_path(organization_name, project_name, disk_name)` (future change)
    * etc
* rewraps some comments and string literals that were over 80 columns

This is all a lot simpler than it sounds.  Most of the changes are pretty mechanical.

Hopefully those examples explain why I called these `*_lookup_path`, and why I renamed the Organization lookup function to match, even though it only has one name in its argument list.

I'm trying to keep these PRs small and manageable.  As a result, this is still an intermediate state.  There will be more cleanup to be done as I get to the more deeply-nested endpoints.  (As an example: in functions like `Nexus::project_update_vpc`, we used to first look up the Organization id, then the Project id, then the Vpc id.  Now we use the new `DataStore::project_lookup_path` to directly fetch the project id, then we do a separate lookup for the Vpc id.  In a follow on change I expect this to be simplified further using a new `DataStore::vpc_lookup_path`.)