### PR TITLE
update README and CONTRIBUTING guidelines about expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,16 +22,17 @@ manage your expectations.
   themselves are undergoing a similar development churn.
 
 - These points together mean that we may not have enough bandwidth to review and
-  integrate outside PRs right now. This will change in the future.
+  integrate outside PRs right now.  We hope this will change in the future.
 
-You're welcome to send PRs! If we have time, or if the PRs are very small or fix
-bugs, we may even integrate them in the near future. But be aware that we might
-not get to it for a while, by which time it might no longer be relevant.
+You're welcome to send PRs, but we want to set expectations right: if we have
+time, or if the PRs are very small or fix bugs, we may integrate them in the
+near future.  But we might also not get to any PR for a while, by which time it
+might no longer be relevant.
 
 We've all dealt with those open source projects that feel open in name only, and
 have big patches and history-free source drops appearing from behind the walls
 of some large organization. We don't like that, and we're not going to do that.
-But please bear with us while we're scaling up.
+But it will take some time for us to scale up -- please bear with us.
 
 If you want to ask about whether a PR is consistent with our short-term plan
 _before_ you put in the work -- and you should! -- hit us up on the repo

--- a/README.adoc
+++ b/README.adoc
@@ -4,20 +4,13 @@
 
 = Oxide Control Plane
 
-This repo houses the Oxide Rack control plane prototype.
+This repo houses the work-in-progress Oxide Rack control plane.
 
 image::https://github.com/oxidecomputer/omicron/workflows/Rust/badge.svg[]
 
+Omicron is open-source.  But we're pretty focused on our own goals for the foreseeable future and not able to help external contributors.  Please see CONTRIBUTING.md for more information.
+
 == Documentation
-
-Several Oxide RFDs are relevant:
-
-* https://48.rfd.oxide.computer[RFD 48 Control Plane Requirements]
-* https://61.rfd.oxide.computer[RFD 61 Control Plane Architecture and Design]
-* https://4.rfd.oxide.computer[RFD 4 User Facing API Design]
-* https://10.rfd.oxide.computer[RFD 10 API Prototype and Simulated Implementation]
-
-For documentation on the control plane architecture, see https://61.rfd.oxide.computer[RFD 61].
 
 For design and API docs, see the https://rust.docs.corp.oxide.computer/omicron/[generated documentation].  You can generate this yourself with:
 
@@ -28,26 +21,7 @@ $ cargo doc --document-private-items
 
 Note that `--document-private-items` is configured by default, so you can actually just use `cargo doc`.
 
-== Status
-
-The code here is still rough, but the following are implemented:
-
-* actual API:
-** projects: CRUD
-** instances: CRUD + boot/halt/reboot.
-** disks: CRD + attach/detach (simulated)
-** racks: list + get
-** sleds: list + get
-* architecture:
-** nexus: manages a fleet of Oxide racks
-** sled agent: manages a single compute sled in an Oxide fleet
-** bootstrap agent: launches sled agent and Nexus.
-* basic server infrastructure: configuration, logging
-* test coverage for most of the above
-
-Nexus uses CockroachDB for persistent state.  Resources like Instances and Disks are simulated in the sled agent.
-
-See TODO.adoc for more info.
+Folks with access to Oxide RFDs may find RFD 48 ("Control Plane Requirements") and other control plane RFDs relevant.  These are not currently publicly available.
 
 == Build and run
 


### PR DESCRIPTION
Omicron is not really in a state where external contributors could be expected to come up to speed and participate substantially in its development.  (RFDs are private, for one thing; we heavily use Oxide-internal meetings to communicate about ongoing work, customer goals, etc.)  Being open-source still provides a lot of benefits: people _can_ build, run, fork, and even use the software in a business; partners and participants in other OSS communities (like Diesel and Oso) can see how we're using their work and if anything we're doing is useful to them; people interested in the company can see what we're doing; etc.  But we should be candid and transparent about the fact that we're not really willing to spend a lot of time right now developing an OSS community and accepting contributions that don't contribute to our existing business goals.

(I also removed the outdated "Status" section of the README.)