### PR TITLE
Add configuration - with defaults - to enable virtualized sled storage

### DIFF
--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -11,6 +11,7 @@ use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
 use omicron_common::api::external::IdentityMetadata;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
 use oximeter_collector::Oximeter;
 use oximeter_producer::Server as ProducerServer;
@@ -37,7 +38,7 @@ pub struct ControlPlaneTestContext {
     pub database: dev::db::CockroachInstance,
     pub clickhouse: dev::clickhouse::ClickHouseInstance,
     pub logctx: LogContext,
-    pub sled_agent: omicron_sled_agent::sim::Server,
+    pub sled_agent: sim::Server,
     pub oximeter: Oximeter,
     pub producer: ProducerServer,
 }
@@ -171,10 +172,10 @@ pub async fn start_sled_agent(
     log: Logger,
     nexus_address: SocketAddr,
     id: Uuid,
-) -> Result<omicron_sled_agent::sim::Server, String> {
-    let config = omicron_sled_agent::sim::Config {
+) -> Result<sim::Server, String> {
+    let config = sim::Config {
         id,
-        sim_mode: omicron_sled_agent::sim::SimMode::Explicit,
+        sim_mode: sim::SimMode::Explicit,
         nexus_address,
         dropshot: ConfigDropshot {
             bind_address: SocketAddr::new("127.0.0.1".parse().unwrap(), 0),
@@ -182,9 +183,10 @@ pub async fn start_sled_agent(
         },
         /* TODO-cleanup this is unused */
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug },
+        storage: sim::ConfigStorage::default(),
     };
 
-    omicron_sled_agent::sim::Server::start(&config, &log).await
+    sim::Server::start(&config, &log).await
 }
 
 pub async fn start_oximeter(

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -15,7 +15,9 @@ use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
-use omicron_sled_agent::sim::{run_server, Config, SimMode};
+use omicron_sled_agent::sim::{
+    run_server, Config, ConfigStorage, ConfigZpool, SimMode,
+};
 use std::net::SocketAddr;
 use structopt::StructOpt;
 use uuid::Uuid;
@@ -73,6 +75,10 @@ async fn do_run() -> Result<(), CmdError> {
             ..Default::default()
         },
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info },
+        storage: ConfigStorage {
+            // Create 10 "virtual" U.2s, with 1 TB of storage.
+            zpools: vec![ConfigZpool { size: 1 << 40 }; 10],
+        },
     };
 
     run_server(&config).await.map_err(CmdError::Failure)

--- a/sled-agent/src/sim/config.rs
+++ b/sled-agent/src/sim/config.rs
@@ -43,7 +43,7 @@ pub struct ConfigZpool {
 }
 
 /// Configuration describing simulated storage.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ConfigStorage {
     pub zpools: Vec<ConfigZpool>,
 }

--- a/sled-agent/src/sim/config.rs
+++ b/sled-agent/src/sim/config.rs
@@ -33,6 +33,21 @@ pub enum SimMode {
     Explicit,
 }
 
+/// Configuration for a simulated zpool.
+///
+/// Currently, each zpool will receive a single Crucible Dataset.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConfigZpool {
+    /// The size of the Zpool in bytes.
+    pub size: u64,
+}
+
+/// Configuration describing simulated storage.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConfigStorage {
+    pub zpools: Vec<ConfigZpool>,
+}
+
 /**
  * Configuration for a sled agent
  */
@@ -48,4 +63,6 @@ pub struct Config {
     pub dropshot: ConfigDropshot,
     /** configuration for the sled agent debug log */
     pub log: ConfigLogging,
+    /** configuration for the sled agent's storage */
+    pub storage: ConfigStorage,
 }

--- a/sled-agent/src/sim/mod.rs
+++ b/sled-agent/src/sim/mod.rs
@@ -17,6 +17,6 @@ mod simulatable;
 mod sled_agent;
 mod storage;
 
-pub use config::{Config, SimMode};
+pub use config::{Config, ConfigStorage, ConfigZpool, SimMode};
 pub use server::{run_server, Server};
 pub use sled_agent::SledAgent;

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -66,6 +66,16 @@ impl Server {
         .map_err(|error| format!("initializing server: {}", error))?
         .start();
 
+        // Create all the Zpools requested by the config, and allocate a single
+        // Crucible dataset for each. This emulates the setup we expect to have
+        // on the physical rack.
+        for zpool in &config.storage.zpools {
+            let zpool_id = uuid::Uuid::new_v4();
+            sled_agent.create_zpool(zpool_id, zpool.size).await;
+            let dataset_id = uuid::Uuid::new_v4();
+            sled_agent.create_crucible_dataset(zpool_id, dataset_id).await;
+        }
+
         /*
          * Notify the control plane that we're up, and continue trying this
          * until it succeeds. We retry with an randomized, capped exponential


### PR DESCRIPTION
https://github.com/oxidecomputer/omicron/pull/511 made disk allocation more "real" - disks are allocated from a group of datasets.

Even for the Simulated Sled Agent, Crucible Regions may be allocated atop a Crucible Dataset (though the data plane won't exist).

However, this wasn't the default when running the "simulated sled agent" binary. This PR adds a default for the simulated sled agent: "pretend you have 10 zpools (representing U.2 storage), each with 1 TB".