### PR TITLE
clean up use of `public_error_from_diesel*`

### DIFF
--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -163,6 +163,7 @@
 mod actor;
 
 mod api_resources;
+pub use api_resources::ApiResource;
 pub use api_resources::Fleet;
 pub use api_resources::FleetChild;
 pub use api_resources::Organization;

--- a/nexus/src/db/error.rs
+++ b/nexus/src/db/error.rs
@@ -81,14 +81,35 @@ pub fn diesel_pool_result_optional<T>(
 }
 
 /// Converts a Diesel pool error to an external error when operating on a
-/// particular resource
-pub fn public_error_from_diesel_pool(
+/// particular resource, identified by resource type and lookup type
+/// NOTE: If you already have an `authz::ApiResource`, you should use
+/// [`public_error_from_diesel_pool_authz()`] instead.  Eventually, the only
+/// uses of this function should be in the DataStore functions that actually
+/// look up a record for the first time.
+pub fn public_error_from_diesel_pool_lookup(
     error: PoolError,
     resource_type: ResourceType,
     lookup_type: LookupType,
 ) -> PublicError {
-    public_error_from_diesel_pool_helper(error, |error| {
-        public_error_from_diesel(error, resource_type, lookup_type)
+    public_error_from_diesel_pool_lookup_helper(error, |error| {
+        public_error_from_diesel(error, || PublicError::ObjectNotFound {
+            type_name: resource_type,
+            lookup_type,
+        })
+    })
+}
+
+/// Converts a Diesel pool error to an external error when operating on a
+/// particular resource, identified by ApiResource
+pub fn public_error_from_diesel_pool_authz<R>(
+    error: PoolError,
+    resource: &R,
+) -> PublicError
+where
+    R: crate::authz::ApiResource,
+{
+    public_error_from_diesel_pool_lookup_helper(error, |error| {
+        public_error_from_diesel(error, || resource.not_found())
     })
 }
 
@@ -99,7 +120,7 @@ pub fn public_error_from_diesel_pool_create(
     resource_type: ResourceType,
     object_name: &str,
 ) -> PublicError {
-    public_error_from_diesel_pool_helper(error, |error| {
+    public_error_from_diesel_pool_lookup_helper(error, |error| {
         public_error_from_diesel_create(error, resource_type, object_name)
     })
 }
@@ -110,7 +131,7 @@ pub fn public_error_from_diesel_pool_create(
 pub fn public_error_from_diesel_pool_shouldnt_fail(
     error: PoolError,
 ) -> PublicError {
-    public_error_from_diesel_pool_helper(error, |diesel_error| {
+    public_error_from_diesel_pool_lookup_helper(error, |diesel_error| {
         PublicError::internal_error(&format!(
             "unexpected database error: {:#}",
             diesel_error
@@ -123,7 +144,7 @@ pub fn public_error_from_diesel_pool_shouldnt_fail(
 /// `PoolError::Connection(ConnectionError::Query(diesel_error))` to
 /// `make_query_error(diesel_error)`, allowing the caller to decide how to
 /// format a message for that case.
-fn public_error_from_diesel_pool_helper<F>(
+fn public_error_from_diesel_pool_lookup_helper<F>(
     error: PoolError,
     make_query_error: F,
 ) -> PublicError
@@ -145,16 +166,15 @@ where
 }
 
 /// Converts a Diesel error to an external error.
-fn public_error_from_diesel(
+fn public_error_from_diesel<F>(
     error: DieselError,
-    resource_type: ResourceType,
-    lookup_type: LookupType,
-) -> PublicError {
+    make_not_found_error: F,
+) -> PublicError
+where
+    F: FnOnce() -> PublicError,
+{
     match error {
-        DieselError::NotFound => PublicError::ObjectNotFound {
-            type_name: resource_type,
-            lookup_type,
-        },
+        DieselError::NotFound => make_not_found_error(),
         DieselError::DatabaseError(kind, info) => {
             PublicError::internal_error(&format_database_error(kind, &*info))
         }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1295,14 +1295,7 @@ impl Nexus {
             }
         }
 
-        Err(Error::not_found_other(
-            ResourceType::Disk,
-            format!(
-                "disk \"{}\" is not attached to instance \"{}\"",
-                disk_name.as_str(),
-                instance_name.as_str()
-            ),
-        ))
+        Err(Error::not_found_by_name(ResourceType::Disk, disk_name))
     }
 
     /**


### PR DESCRIPTION
When running database queries in datastore.rs, we use the `public_error_from_diesel*` family of functions from `nexus/src/db/error.rs` to translate database errors into appropriate external API errors.  There are a lot of possible cases.

Every database query can result in:

* a 503 error (for a connection problem or a problem running the query at the database)
* a 500 error (if we've run into some unknown problem, which should never happen unless there's a bug -- an example might be if we fail to deserialize a record from the database)

If those are the only two errors that can happen, callers can use `public_error_from_diesel_pool_shouldnt_fail()` to handle errors.  This function explicitly checks for the 503 case and turns anything else into a 500.

Other errors are also possible.  These depend on the kind of query we're running.  Most queries fall into one of these buckets:

1. INSERT statements that are associated with a "create" operation.  These can usually produce a 400-level error indicating a validation problem (e.g., a Project already exists with that name).  Errors are handled for these queries using `public_error_from_diesel_pool_create`, which takes extra arguments that are used to construct a useful "name already exists" message.
2. SELECT statements that are expected to return exactly one item (e.g., lookup of any resource, like an Instance), UPDATE statements that are expected to update one item, and DELETE statements that are expected to delete one item.  These produce a 404 when the expected item isn't found.  Errors are handled for these queries using `public_error_from_diesel_pool`, which takes extra arguments that are used to construct a useful "not found" message.
3. SELECT statements that list a page of items (e.g., listing Instances in a Project).  These generally don't produce any 400-level error.  (You could argue that they should produce a 404 if you, say, try to list Instances in a Project that doesn't exist.  But that's generally handled before you get to this query -- some _other_ query already had to map a Project name to an id, and _that_ would have failed if the Project didn't exist.  We could check it here also, but it doesn't buy us anything.  If you somehow hit this case, that means the Project did exist at one point in your request, so it's valid for us to report 0 Instances found inside it rather than a 404 error.)

I've left out INSERT, UPDATE, and DELETE statements that may affect 0 or more rows because they're not relevant here.

Today, case 3 (SELECTs that can return 0 or more results and still be valid) tend to use `public_error_from_diesel_pool` with a special `LookupType::Other` argument with the string "Listing All" or something like that.  I don't believe this case can ever happen.  For us to produce a 404, we need to get back `DieselError::NotFound`, which means we've used `first_async()` or `get_result_async()` when running the query, which is the way we tell Diesel that we expect one result.  Naturally, we never do this when we're expecting 0 or more results.

This change:

* changes most of the list functions in datastore.rs to use `public_error_from_diesel_pool_shouldnt_fail` rather than `public_error_from_diesel_pool`.  To summarize what I said above: the `shouldnt_fail` version is intended for cases where a 500 or 503 can still happen, but 400-level errors can't.  On the other hand, `public_error_from_diesel_pool` is structured for cases that can return a 404, which these cannot.
* removes `LookupType::Other`, since it's no longer used.  This makes sense: all lookups are either by id or name.  With one exception, the only cases where `LookupType::Other` was used were cases that couldn't produce a 404 anyway and so shouldn't need to construct a `LookupType`.  In the exceptional case, it was easy to make the appropriate 404 directly.
* renames `public_error_from_diesel_pool` to `public_error_from_diesel_pool_lookup`, which I think better reflects that this function is intended for the specific case where you expect exactly one result.
* adds a variant of this function called `public_error_from_diesel_pool_authz`.  Rather than accepting a `LookupType`, this accepts an `authz::ApiResource`, which can be used to construct the appropriate 404 error.  (Implementors of `ApiResource` know their own LookupType already.  This function avoids callers having to specify it again.)