### PR TITLE
Unify diesel error conversions under 'public_error_from_diesel_pool'

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -48,13 +48,17 @@ pub trait ApiResource: Clone + Send + Sync + 'static {
     /// can affect access to this resource, return the parent resource.
     /// Otherwise, returns `None`.
     fn parent(&self) -> Option<&dyn AuthorizedResource>;
+}
 
+pub trait ApiResourceError {
     /// Returns an error as though this resource were not found, suitable for
     /// use when an actor should not be able to see that this resource exists
     fn not_found(&self) -> Error;
 }
 
-impl<T: ApiResource + oso::PolarClass> AuthorizedResource for T {
+impl<T: ApiResource + ApiResourceError + oso::PolarClass> AuthorizedResource
+    for T
+{
     fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
         &'a self,
         opctx: &'b OpContext,
@@ -238,7 +242,9 @@ impl ApiResource for FleetChild {
     fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&FLEET)
     }
+}
 
+impl ApiResourceError for FleetChild {
     fn not_found(&self) -> Error {
         self.lookup_type.clone().into_not_found(self.resource_type)
     }
@@ -309,7 +315,9 @@ impl ApiResource for Organization {
     fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&FLEET)
     }
+}
 
+impl ApiResourceError for Organization {
     fn not_found(&self) -> Error {
         self.lookup_type.clone().into_not_found(ResourceType::Organization)
     }
@@ -393,7 +401,9 @@ impl ApiResource for Project {
     fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&self.parent)
     }
+}
 
+impl ApiResourceError for Project {
     fn not_found(&self) -> Error {
         self.lookup_type.clone().into_not_found(ResourceType::Project)
     }
@@ -450,7 +460,9 @@ impl ApiResource for ProjectChild {
     fn parent(&self) -> Option<&dyn AuthorizedResource> {
         Some(&self.parent)
     }
+}
 
+impl ApiResourceError for ProjectChild {
     fn not_found(&self) -> Error {
         self.lookup_type.clone().into_not_found(self.resource_type)
     }

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -164,6 +164,7 @@ mod actor;
 
 mod api_resources;
 pub use api_resources::ApiResource;
+pub use api_resources::ApiResourceError;
 pub use api_resources::Fleet;
 pub use api_resources::FleetChild;
 pub use api_resources::Organization;

--- a/nexus/src/db/error.rs
+++ b/nexus/src/db/error.rs
@@ -101,9 +101,9 @@ pub enum OpKind<'a> {
 ///
 /// [`OpKind`] may be used to add additional context to the error
 /// being returned.
-pub fn public_error_from_diesel_pool<'a>(
+pub fn public_error_from_diesel_pool(
     error: PoolError,
-    kind: OpKind<'a>,
+    kind: OpKind<'_>,
 ) -> PublicError {
     public_error_from_diesel_pool_helper(error, |error| match kind {
         OpKind::Authz(resource) => {

--- a/nexus/src/db/error.rs
+++ b/nexus/src/db/error.rs
@@ -83,8 +83,9 @@ pub fn diesel_pool_result_optional<T>(
 /// Allows the caller to handle user-facing errors, and provide additional
 /// context which may be used to populate more informative errors.
 ///
-/// Note that all operations may return a "Service Unavailable" error if the
-/// database cannot be contacted.
+/// Note that all operations may return server-level errors for a variety
+/// of reasons, including being unable to contact the database, I/O errors,
+/// etc.
 pub enum ErrorHandler<'a> {
     /// The operation expected to fetch, update, or delete exactly one resource
     /// identified by the [`crate::authz::ApiResourceError`].


### PR DESCRIPTION
This follows-up a conversation from https://github.com/oxidecomputer/omicron/pull/644 , and exposes only a single function for performing the error conversion. An enum named `OpKind`, indicating which operation was issued against the DB, allows callers to supply additional context to their errors.