### PR TITLE
[nexus][db] Return 503 when insufficient datasets exist for disk creation

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -428,9 +428,7 @@ impl DataStore {
             .map_err(|e| match e {
                 TxnError::CustomError(
                     RegionAllocateError::NotEnoughDatasets(_),
-                ) => Error::unavail(&format!(
-                    "Not enough datasets to allocate disks"
-                )),
+                ) => Error::unavail("Not enough datasets to allocate disks"),
                 _ => {
                     Error::internal_error(&format!("Transaction error: {}", e))
                 }


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/659