### PR TITLE
Add parent vpc_id to VpcFirewallRule

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1411,6 +1411,8 @@ pub struct VpcFirewallRule {
     pub action: VpcFirewallRuleAction,
     /// the relative priority of this rule
     pub priority: VpcFirewallRulePriority,
+    /// the VPC to which this rule belongs
+    pub vpc_id: Uuid,
 }
 
 /// A single rule in a VPC firewall

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1836,6 +1836,7 @@ impl Into<external::VpcFirewallRule> for VpcFirewallRule {
             },
             action: self.action.into(),
             priority: self.priority.into(),
+            vpc_id: self.vpc_id,
         }
     }
 }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4987,6 +4987,11 @@
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
+          },
+          "vpc_id": {
+            "description": "the VPC to which this rule belongs",
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
@@ -5000,7 +5005,8 @@
           "status",
           "targets",
           "time_created",
-          "time_modified"
+          "time_modified",
+          "vpc_id"
         ]
       },
       "VpcFirewallRuleAction": {


### PR DESCRIPTION
Noticed while working on the firewall rules UI that these don't have VPC IDs, and I'm pretty sure they should.