### PR TITLE
Adds IPv6 prefix to VPC objects

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1135,9 +1135,9 @@ impl JsonSchema for Ipv6Net {
                     max_length: Some(43),
                     min_length: None,
                     pattern: Some(
-                        // Conforming to unique local addressing scheme, `fd00::/8`
+                        // Conforming to unique local addressing scheme, `fd00::/8`.
                         concat!(
-                            r#"^(fd|FD)00:((([0-9a-fA-F]{1,4}\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$"#,
+                            r#"^(fd|FD)[0-9a-fA-F]{2}:((([0-9a-fA-F]{1,4}\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$"#,
                         ).to_string(),
                     ),
                 })),

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -387,6 +387,9 @@ CREATE TABLE omicron.public.vpc (
     system_router_id UUID NOT NULL,
     dns_name STRING(63) NOT NULL,
 
+    /* The IPv6 prefix allocated to subnets. */
+    ipv6_prefix INET NOT NULL,
+
     /* Used to ensure that two requests do not concurrently modify the
        VPC's firewall */
     firewall_gen INT NOT NULL

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -12,6 +12,7 @@ use crate::db::schema::{
     role_assignment_builtin, role_builtin, router_route, sled, user_builtin,
     vpc, vpc_firewall_rule, vpc_router, vpc_subnet, zpool,
 };
+use crate::defaults;
 use crate::external_api::params;
 use crate::internal_api;
 use chrono::{DateTime, Utc};
@@ -1213,6 +1214,7 @@ pub struct Vpc {
 
     pub project_id: Uuid,
     pub system_router_id: Uuid,
+    pub ipv6_prefix: Ipv6Net,
     pub dns_name: Name,
 
     /// firewall generation number, used as a child resource generation number
@@ -1226,15 +1228,33 @@ impl Vpc {
         project_id: Uuid,
         system_router_id: Uuid,
         params: params::VpcCreate,
-    ) -> Self {
+    ) -> Result<Self, external::Error> {
         let identity = VpcIdentity::new(vpc_id, params.identity);
-        Self {
+        let ipv6_prefix = match params.ipv6_prefix {
+            None => defaults::random_unique_local_ipv6(),
+            Some(prefix) => {
+                // TODO: Delegate to `Ipv6Addr::is_unique_local()` when stabilized.
+                if prefix.0.prefix() == 48
+                    && prefix.0.ip().segments()[0] == 0xfd00
+                {
+                    Ok(prefix)
+                } else {
+                    Err(external::Error::invalid_request(
+                        "VPC IPv6 address prefixes must be in the 
+                            Unique Local Address range `fd00::/48` (RFD 4193)",
+                    ))
+                }
+            }
+        }?
+        .into();
+        Ok(Self {
             identity,
             project_id,
             system_router_id,
+            ipv6_prefix,
             dns_name: params.dns_name.into(),
             firewall_gen: Generation::new(),
-        }
+        })
     }
 }
 
@@ -1694,7 +1714,7 @@ where
     }
 }
 
-// Deserialize the "L4PortRange" object from SQL TEXT.
+// Deserialize the "L4PortRange" object from SQL INT4.
 impl<DB> FromSql<sql_types::Text, DB> for L4PortRange
 where
     DB: Backend,

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1234,8 +1234,7 @@ impl Vpc {
             None => defaults::random_unique_local_ipv6(),
             Some(prefix) => {
                 // TODO: Delegate to `Ipv6Addr::is_unique_local()` when stabilized.
-                if prefix.0.prefix() == 48
-                    && prefix.0.ip().segments()[0] == 0xfd00
+                if prefix.0.prefix() == 48 && prefix.0.ip().octets()[0] == 0xfd
                 {
                     Ok(prefix)
                 } else {

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -223,6 +223,7 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
         project_id -> Uuid,
         system_router_id -> Uuid,
+        ipv6_prefix -> Inet,
         dns_name -> Text,
         firewall_gen -> Int8,
     }

--- a/nexus/src/defaults.rs
+++ b/nexus/src/defaults.rs
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Default values for data in the Nexus API, when not provided explicitly in a request.
+
+use ipnetwork::Ipv6Network;
+use lazy_static::lazy_static;
+use omicron_common::api::external;
+use omicron_common::api::external::Ipv6Net;
+use std::net::Ipv6Addr;
+
+lazy_static! {
+    pub static ref DEFAULT_FIREWALL_RULES: external::VpcFirewallRuleUpdateParams =
+        serde_json::from_str(r#"{
+            "allow-internal-inbound": {
+                "status": "enabled",
+                "direction": "inbound",
+                "targets": [ { "type": "vpc", "value": "default" } ],
+                "filters": { "hosts": [ { "type": "vpc", "value": "default" } ] },
+                "action": "allow",
+                "priority": 65534,
+                "description": "allow inbound traffic to all instances within the VPC if originated within the VPC"
+            },
+            "allow-ssh": {
+                "status": "enabled",
+                "direction": "inbound",
+                "targets": [ { "type": "vpc", "value": "default" } ],
+                "filters": { "ports": [ "22" ], "protocols": [ "TCP" ] },
+                "action": "allow",
+                "priority": 65534,
+                "description": "allow inbound TCP connections on port 22 from anywhere"
+            },
+            "allow-icmp": {
+                "status": "enabled",
+                "direction": "inbound",
+                "targets": [ { "type": "vpc", "value": "default" } ],
+                "filters": { "protocols": [ "ICMP" ] },
+                "action": "allow",
+                "priority": 65534,
+                "description": "allow inbound ICMP traffic from anywhere"
+            },
+            "allow-rdp": {
+                "status": "enabled",
+                "direction": "inbound",
+                "targets": [ { "type": "vpc", "value": "default" } ],
+                "filters": { "ports": [ "3389" ], "protocols": [ "TCP" ] },
+                "action": "allow",
+                "priority": 65534,
+                "description": "allow inbound TCP connections on port 3389 from anywhere"
+            }
+        }"#).unwrap();
+}
+
+pub fn random_unique_local_ipv6() -> Result<Ipv6Net, external::Error> {
+    use rand::Rng;
+    let mut bytes = [0u16; 8];
+    bytes[0] = 0xfd00;
+    rand::thread_rng().try_fill(&mut bytes[1..4]).map_err(|_| {
+        external::Error::internal_error(
+            "Unable to allocate random IPv6 address range",
+        )
+    })?;
+    Ok(Ipv6Net(Ipv6Network::new(Ipv6Addr::from(bytes), 48).unwrap()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_random_unique_local_ipv6() {
+        let network = random_unique_local_ipv6().unwrap().0;
+        assert_eq!(network.prefix(), 48);
+        let segments = network.network().segments();
+        assert_eq!(segments[0], 0xfd00);
+        assert!(segments[4..].iter().all(|x| *x == 0));
+    }
+}

--- a/nexus/src/defaults.rs
+++ b/nexus/src/defaults.rs
@@ -54,9 +54,9 @@ lazy_static! {
 
 pub fn random_unique_local_ipv6() -> Result<Ipv6Net, external::Error> {
     use rand::Rng;
-    let mut bytes = [0u16; 8];
-    bytes[0] = 0xfd00;
-    rand::thread_rng().try_fill(&mut bytes[1..4]).map_err(|_| {
+    let mut bytes = [0u8; 16];
+    bytes[0] = 0xfd;
+    rand::thread_rng().try_fill(&mut bytes[1..6]).map_err(|_| {
         external::Error::internal_error(
             "Unable to allocate random IPv6 address range",
         )
@@ -72,8 +72,8 @@ mod tests {
     fn test_random_unique_local_ipv6() {
         let network = random_unique_local_ipv6().unwrap().0;
         assert_eq!(network.prefix(), 48);
-        let segments = network.network().segments();
-        assert_eq!(segments[0], 0xfd00);
-        assert!(segments[4..].iter().all(|x| *x == 0));
+        let octets = network.network().octets();
+        assert_eq!(octets[0], 0xfd);
+        assert!(octets[6..].iter().all(|x| *x == 0));
     }
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -107,6 +107,7 @@ pub struct InstanceMigrate {
 pub struct VpcCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
+    pub ipv6_prefix: Option<Ipv6Net>,
     pub dns_name: Name,
 }
 

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -82,6 +82,9 @@ pub struct Vpc {
     /// id for the system router where subnet default routes are registered
     pub system_router_id: Uuid,
 
+    /// The unique local IPv6 address range for subnets in this VPC
+    pub ipv6_prefix: Ipv6Net,
+
     // TODO-design should this be optional?
     /** The name used for the VPC in DNS. */
     pub dns_name: Name,
@@ -93,6 +96,7 @@ impl Into<Vpc> for model::Vpc {
             identity: self.identity(),
             project_id: self.project_id,
             system_router_id: self.system_router_id,
+            ipv6_prefix: *self.ipv6_prefix,
             dns_name: self.dns_name.0,
         }
     }

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -21,6 +21,7 @@ pub mod authz;
 mod config;
 mod context;
 pub mod db; // Public only for some documentation examples
+mod defaults;
 pub mod external_api; // public for testing
 pub mod internal_api; // public for testing
 mod nexus;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -135,6 +135,7 @@ pub async fn create_vpc(
                 name: vpc_name.parse().unwrap(),
                 description: "vpc description".to_string(),
             },
+            ipv6_prefix: None,
             dns_name: "abc".parse().unwrap(),
         },
     )
@@ -163,6 +164,7 @@ pub async fn create_vpc_with_error(
                     name: vpc_name.parse().unwrap(),
                     description: String::from("vpc description"),
                 },
+                ipv6_prefix: None,
                 dns_name: "abc".parse().unwrap(),
             },
             status,

--- a/nexus/tests/integration_tests/vpcs.rs
+++ b/nexus/tests/integration_tests/vpcs.rs
@@ -89,8 +89,8 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
         "Expected a 48-bit ULA IPv6 address prefix"
     );
     assert_eq!(
-        vpc.ipv6_prefix.ip().segments()[0],
-        0xfd00,
+        vpc.ipv6_prefix.ip().octets()[0],
+        0xfd,
         "Expected a ULA IPv6 address prefix"
     );
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4852,6 +4852,14 @@
             "type": "string",
             "format": "uuid"
           },
+          "ipv6_prefix": {
+            "description": "The unique local IPv6 address range for subnets in this VPC",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
           "name": {
             "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
@@ -4885,6 +4893,7 @@
           "description",
           "dns_name",
           "id",
+          "ipv6_prefix",
           "name",
           "project_id",
           "system_router_id",
@@ -4901,6 +4910,14 @@
           },
           "dns_name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "ipv6_prefix": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
           },
           "name": {
             "$ref": "#/components/schemas/Name"

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -3725,7 +3725,7 @@
         "title": "An IPv6 subnet",
         "description": "An IPv6 subnet, including prefix and subnet mask",
         "type": "string",
-        "pattern": "^(fd|FD)00:((([0-9a-fA-F]{1,4}\\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$",
+        "pattern": "^(fd|FD)[0-9a-fA-F]{2}:((([0-9a-fA-F]{1,4}\\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$",
         "maxLength": 43
       },
       "L4PortRange": {


### PR DESCRIPTION
- Adds an optional IPv6 prefix to the request to create a VPC. Validated
  if provided, otherwise a random RFD 4139 address is created.
- Adds the prefix to the database and views
- Adds some integration tests verifying this behavior