### PR TITLE
Use Vec instead of HashMap for firewall rules, don't paginate

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1415,6 +1415,14 @@ pub struct VpcFirewallRule {
     pub vpc_id: Uuid,
 }
 
+/**
+ * Collection of a [`Vpc`]'s firewall rules
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct VpcFirewallRules {
+    pub rules: Vec<VpcFirewallRule>,
+}
+
 /// A single rule in a VPC firewall
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleUpdate {
@@ -1446,15 +1454,7 @@ pub struct VpcFirewallRuleUpdateParams {
     pub rules: Vec<VpcFirewallRuleUpdate>,
 }
 
-/**
- * Response to an update replacing `Vpc`'s firewall
- */
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct VpcFirewallRuleUpdateResult {
-    pub rules: Vec<VpcFirewallRule>,
-}
-
-impl FromIterator<VpcFirewallRule> for VpcFirewallRuleUpdateResult {
+impl FromIterator<VpcFirewallRule> for VpcFirewallRules {
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = VpcFirewallRule>,

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -34,7 +34,6 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FormatResult;
-use std::iter::FromIterator;
 use std::net::IpAddr;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::str::FromStr;
@@ -1452,15 +1451,6 @@ pub struct VpcFirewallRuleUpdate {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleUpdateParams {
     pub rules: Vec<VpcFirewallRuleUpdate>,
-}
-
-impl FromIterator<VpcFirewallRule> for VpcFirewallRules {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = VpcFirewallRule>,
-    {
-        Self { rules: iter.into_iter().collect() }
-    }
 }
 
 /// Firewall rule priority. This is a value from 0 to 65535, with rules with

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2043,13 +2043,13 @@ impl DataStore {
     pub async fn vpc_list_firewall_rules(
         &self,
         vpc_id: &Uuid,
-        pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<VpcFirewallRule> {
         use db::schema::vpc_firewall_rule::dsl;
 
-        paginated(dsl::vpc_firewall_rule, dsl::name, &pagparams)
+        dsl::vpc_firewall_rule
             .filter(dsl::time_deleted.is_null())
             .filter(dsl::vpc_id.eq(*vpc_id))
+            .order(dsl::name.asc())
             .select(VpcFirewallRule::as_select())
             .load_async(self.pool())
             .await

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1761,13 +1761,12 @@ impl VpcFirewallRule {
     pub fn new(
         rule_id: Uuid,
         vpc_id: Uuid,
-        rule_name: external::Name,
         rule: &external::VpcFirewallRuleUpdate,
     ) -> Self {
         let identity = VpcFirewallRuleIdentity::new(
             rule_id,
             external::IdentityMetadataCreateParams {
-                name: rule_name,
+                name: rule.name.clone(),
                 description: rule.description.clone(),
             },
         );
@@ -1805,9 +1804,7 @@ impl VpcFirewallRule {
         params
             .rules
             .iter()
-            .map(|(name, rule)| {
-                VpcFirewallRule::new(Uuid::new_v4(), vpc_id, name.clone(), rule)
-            })
+            .map(|rule| VpcFirewallRule::new(Uuid::new_v4(), vpc_id, rule))
             .collect()
     }
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1474,11 +1474,10 @@ async fn vpc_firewall_rules_get(
                 &path.project_name,
                 &path.vpc_name,
             )
-            .await?
-            .into_iter()
-            .map(|rule| rule.into())
-            .collect();
-        Ok(HttpResponseOk(rules))
+            .await?;
+        Ok(HttpResponseOk(VpcFirewallRules {
+            rules: rules.into_iter().map(|rule| rule.into()).collect(),
+        }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1510,7 +1509,9 @@ async fn vpc_firewall_rules_put(
                 &router_params.into_inner(),
             )
             .await?;
-        Ok(HttpResponseOk(rules))
+        Ok(HttpResponseOk(VpcFirewallRules {
+            rules: rules.into_iter().map(|rule| rule.into()).collect(),
+        }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -52,9 +52,8 @@ use omicron_common::api::external::RouterRouteCreateParams;
 use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::Saga;
-use omicron_common::api::external::VpcFirewallRule;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
-use omicron_common::api::external::VpcFirewallRuleUpdateResult;
+use omicron_common::api::external::VpcFirewallRules;
 use omicron_common::api::external::VpcRouter;
 use omicron_common::api::external::VpcRouterKind;
 use ref_cast::RefCast;
@@ -1460,15 +1459,13 @@ async fn subnets_ips_get(
 }]
 async fn vpc_firewall_rules_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    query_params: Query<PaginatedByName>,
     path_params: Path<VpcPathParam>,
-) -> Result<HttpResponseOk<ResultsPage<VpcFirewallRule>>, HttpError> {
+) -> Result<HttpResponseOk<VpcFirewallRules>, HttpError> {
     // TODO: Check If-Match and fail if the ETag doesn't match anymore.
     // Without this check, if firewall rules change while someone is listing
     // the rules, they will see a mix of the old and new rules.
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
-    let query = query_params.into_inner();
     let path = path_params.into_inner();
     let handler = async {
         let rules = nexus
@@ -1476,14 +1473,12 @@ async fn vpc_firewall_rules_get(
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
-                &data_page_params_for(&rqctx, &query)?
-                    .map_name(|n| Name::ref_cast(n)),
             )
             .await?
             .into_iter()
             .map(|rule| rule.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, rules)?))
+        Ok(HttpResponseOk(rules))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1500,8 +1495,9 @@ async fn vpc_firewall_rules_put(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
     router_params: TypedBody<VpcFirewallRuleUpdateParams>,
-) -> Result<HttpResponseOk<VpcFirewallRuleUpdateResult>, HttpError> {
+) -> Result<HttpResponseOk<VpcFirewallRules>, HttpError> {
     // TODO: Check If-Match and fail if the ETag doesn't match anymore.
+    // TODO: limit size of the ruleset because the GET endpoint is not paginated
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -2516,41 +2516,47 @@ impl TestInterfaces for Nexus {
 lazy_static! {
     static ref DEFAULT_FIREWALL_RULES: external::VpcFirewallRuleUpdateParams =
         serde_json::from_str(r#"{
-            "allow-internal-inbound": {
-                "status": "enabled",
-                "direction": "inbound",
-                "targets": [ { "type": "vpc", "value": "default" } ],
-                "filters": { "hosts": [ { "type": "vpc", "value": "default" } ] },
-                "action": "allow",
-                "priority": 65534,
-                "description": "allow inbound traffic to all instances within the VPC if originated within the VPC"
-            },
-            "allow-ssh": {
-                "status": "enabled",
-                "direction": "inbound",
-                "targets": [ { "type": "vpc", "value": "default" } ],
-                "filters": { "ports": [ "22" ], "protocols": [ "TCP" ] },
-                "action": "allow",
-                "priority": 65534,
-                "description": "allow inbound TCP connections on port 22 from anywhere"
-            },
-            "allow-icmp": {
-                "status": "enabled",
-                "direction": "inbound",
-                "targets": [ { "type": "vpc", "value": "default" } ],
-                "filters": { "protocols": [ "ICMP" ] },
-                "action": "allow",
-                "priority": 65534,
-                "description": "allow inbound ICMP traffic from anywhere"
-            },
-            "allow-rdp": {
-                "status": "enabled",
-                "direction": "inbound",
-                "targets": [ { "type": "vpc", "value": "default" } ],
-                "filters": { "ports": [ "3389" ], "protocols": [ "TCP" ] },
-                "action": "allow",
-                "priority": 65534,
-                "description": "allow inbound TCP connections on port 3389 from anywhere"
-            }
+            "rules": [
+                {
+                    "name": "allow-internal-inbound",
+                    "status": "enabled",
+                    "direction": "inbound",
+                    "targets": [ { "type": "vpc", "value": "default" } ],
+                    "filters": { "hosts": [ { "type": "vpc", "value": "default" } ] },
+                    "action": "allow",
+                    "priority": 65534,
+                    "description": "allow inbound traffic to all instances within the VPC if originated within the VPC"
+                },
+                {
+                    "name": "allow-ssh",
+                    "status": "enabled",
+                    "direction": "inbound",
+                    "targets": [ { "type": "vpc", "value": "default" } ],
+                    "filters": { "ports": [ "22" ], "protocols": [ "TCP" ] },
+                    "action": "allow",
+                    "priority": 65534,
+                    "description": "allow inbound TCP connections on port 22 from anywhere"
+                },
+                {
+                    "name": "allow-icmp",
+                    "status": "enabled",
+                    "direction": "inbound",
+                    "targets": [ { "type": "vpc", "value": "default" } ],
+                    "filters": { "protocols": [ "ICMP" ] },
+                    "action": "allow",
+                    "priority": 65534,
+                    "description": "allow inbound ICMP traffic from anywhere"
+                },
+                {
+                    "name": "allow-rdp",
+                    "status": "enabled",
+                    "direction": "inbound",
+                    "targets": [ { "type": "vpc", "value": "default" } ],
+                    "filters": { "ports": [ "3389" ], "protocols": [ "TCP" ] },
+                    "action": "allow",
+                    "priority": 65534,
+                    "description": "allow inbound TCP connections on port 3389 from anywhere"
+                }
+            ]
         }"#).unwrap();
 }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -51,7 +51,6 @@ use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
-use omicron_common::api::external::VpcFirewallRules;
 use omicron_common::api::external::VpcRouterKind;
 use omicron_common::api::internal::nexus;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
@@ -1750,7 +1749,7 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         params: &VpcFirewallRuleUpdateParams,
-    ) -> UpdateResult<VpcFirewallRules> {
+    ) -> UpdateResult<Vec<db::model::VpcFirewallRule>> {
         let vpc = self
             .project_lookup_vpc(organization_name, project_name, vpc_name)
             .await?;
@@ -1758,14 +1757,7 @@ impl Nexus {
             vpc.id(),
             params.clone(),
         );
-        let result = self
-            .db_datastore
-            .vpc_update_firewall_rules(&vpc.id(), rules)
-            .await?
-            .into_iter()
-            .map(|rule| rule.into())
-            .collect();
-        Ok(result)
+        self.db_datastore.vpc_update_firewall_rules(&vpc.id(), rules).await
     }
 
     pub async fn vpc_list_subnets(

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -51,7 +51,7 @@ use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
-use omicron_common::api::external::VpcFirewallRuleUpdateResult;
+use omicron_common::api::external::VpcFirewallRules;
 use omicron_common::api::external::VpcRouterKind;
 use omicron_common::api::internal::nexus;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
@@ -1735,16 +1735,13 @@ impl Nexus {
         organization_name: &Name,
         project_name: &Name,
         vpc_name: &Name,
-        pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<db::model::VpcFirewallRule> {
         let vpc = self
             .project_lookup_vpc(organization_name, project_name, vpc_name)
             .await?;
-        let subnets = self
-            .db_datastore
-            .vpc_list_firewall_rules(&vpc.id(), pagparams)
-            .await?;
-        Ok(subnets)
+        let rules =
+            self.db_datastore.vpc_list_firewall_rules(&vpc.id()).await?;
+        Ok(rules)
     }
 
     pub async fn vpc_update_firewall_rules(
@@ -1753,7 +1750,7 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         params: &VpcFirewallRuleUpdateParams,
-    ) -> UpdateResult<VpcFirewallRuleUpdateResult> {
+    ) -> UpdateResult<VpcFirewallRules> {
         let vpc = self
             .project_lookup_vpc(organization_name, project_name, vpc_name)
             .await?;

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -12,7 +12,6 @@ use omicron_common::api::external::{
     VpcFirewallRuleUpdate, VpcFirewallRuleUpdateParams,
 };
 use omicron_nexus::external_api::views::Vpc;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
@@ -61,10 +60,9 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
     assert!(is_default_firewall_rules(&rules));
 
     // Modify one VPC's firewall
-    let mut new_rules = HashMap::new();
-    new_rules.insert(
-        "deny-all-incoming".parse().unwrap(),
+    let new_rules = vec![
         VpcFirewallRuleUpdate {
+            name: "deny-all-incoming".parse().unwrap(),
             action: VpcFirewallRuleAction::Deny,
             description: "test desc".to_string(),
             status: VpcFirewallRuleStatus::Disabled,
@@ -79,10 +77,8 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
             direction: VpcFirewallRuleDirection::Inbound,
             priority: VpcFirewallRulePriority(100),
         },
-    );
-    new_rules.insert(
-        "allow-icmp".parse().unwrap(),
         VpcFirewallRuleUpdate {
+            name: "allow-icmp".parse().unwrap(),
             action: VpcFirewallRuleAction::Allow,
             description: "allow icmp".to_string(),
             status: VpcFirewallRuleStatus::Enabled,
@@ -97,7 +93,7 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
             direction: VpcFirewallRuleDirection::Inbound,
             priority: VpcFirewallRulePriority(10),
         },
-    );
+    ];
     let update_params =
         VpcFirewallRuleUpdateParams { rules: new_rules.clone() };
     client

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5277,6 +5277,14 @@
               }
             ]
           },
+          "name": {
+            "description": "name of the rule, unique to this VPC",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
           "priority": {
             "description": "the relative priority of this rule",
             "type": "integer",
@@ -5304,6 +5312,7 @@
           "description",
           "direction",
           "filters",
+          "name",
           "priority",
           "status",
           "targets"
@@ -5312,16 +5321,32 @@
       "VpcFirewallRuleUpdateParams": {
         "description": "Updateable properties of a `Vpc`'s firewall Note that VpcFirewallRules are implicitly created along with a Vpc, so there is no explicit creation.",
         "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/VpcFirewallRuleUpdate"
-        }
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleUpdate"
+            }
+          }
+        },
+        "required": [
+          "rules"
+        ]
       },
       "VpcFirewallRuleUpdateResult": {
         "description": "Response to an update replacing `Vpc`'s firewall",
         "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/VpcFirewallRule"
-        }
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRule"
+            }
+          }
+        },
+        "required": [
+          "rules"
+        ]
       },
       "VpcResultsPage": {
         "description": "A single page of results",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1730,36 +1730,6 @@
         "operationId": "vpc_firewall_rules_get",
         "parameters": [
           {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "nullable": true,
-              "description": "Maximum number of items returned by a single call",
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "schema": {
-              "nullable": true,
-              "description": "Token returned by previous call to retreive the subsequent page",
-              "type": "string"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "sort_by",
-            "schema": {
-              "$ref": "#/components/schemas/NameSortMode"
-            },
-            "style": "form"
-          },
-          {
             "in": "path",
             "name": "organization_name",
             "required": true,
@@ -1793,13 +1763,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VpcFirewallRuleResultsPage"
+                  "$ref": "#/components/schemas/VpcFirewallRules"
                 }
               }
             }
           }
-        },
-        "x-dropshot-pagination": true
+        }
       },
       "put": {
         "tags": [
@@ -1852,7 +1821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VpcFirewallRuleUpdateResult"
+                  "$ref": "#/components/schemas/VpcFirewallRules"
                 }
               }
             }
@@ -5158,27 +5127,6 @@
           "ICMP"
         ]
       },
-      "VpcFirewallRuleResultsPage": {
-        "description": "A single page of results",
-        "type": "object",
-        "properties": {
-          "items": {
-            "description": "list of items on this page of results",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VpcFirewallRule"
-            }
-          },
-          "next_page": {
-            "nullable": true,
-            "description": "token used to fetch the next page of results (if any)",
-            "type": "string"
-          }
-        },
-        "required": [
-          "items"
-        ]
-      },
       "VpcFirewallRuleStatus": {
         "type": "string",
         "enum": [
@@ -5333,8 +5281,8 @@
           "rules"
         ]
       },
-      "VpcFirewallRuleUpdateResult": {
-        "description": "Response to an update replacing `Vpc`'s firewall",
+      "VpcFirewallRules": {
+        "description": "Collection of a [`Vpc`]'s firewall rules",
         "type": "object",
         "properties": {
           "rules": {


### PR DESCRIPTION
As discussed in the 2/4/22 control plane huddle, after working on the firewall rules UI, I found some issues that are orthogonal to and less controversial than the PUT vs. POST debate in #623.

### Issues

* Firewall rules are the only collection in the API that we represent as a hashmap instead of a list
* The GET endpoint returns a list but the PUT endpoint expects a hashmap. These should be the same, one or the other.
* The GET endpoint is paginated, which would require the client to pull all the pages before doing a PUT

### Fixes proposed here

* Standardize on using a list of rules in both GET response body and PUT request/response body
* Don't paginate GET