### PR TITLE
authz: add OpContext::for_saga_action

### DIFF
--- a/nexus/src/authn/mod.rs
+++ b/nexus/src/authn/mod.rs
@@ -25,6 +25,7 @@
 //! authentication, but they'd all produce the same [`Context`] struct.
 
 pub mod external;
+pub mod saga;
 
 pub use crate::db::fixed_data::user_builtin::USER_DB_INIT;
 pub use crate::db::fixed_data::user_builtin::USER_INTERNAL_API;
@@ -32,6 +33,8 @@ pub use crate::db::fixed_data::user_builtin::USER_SAGA_RECOVERY;
 pub use crate::db::fixed_data::user_builtin::USER_TEST_PRIVILEGED;
 pub use crate::db::fixed_data::user_builtin::USER_TEST_UNPRIVILEGED;
 
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 /// Describes how the actor performing the current operation is authenticated
@@ -156,8 +159,8 @@ mod test {
 
 /// Describes whether the user is authenticated and provides more information
 /// that's specific to whether they're authenticated (or not)
-#[derive(Debug)]
-pub enum Kind {
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum Kind {
     /// Client successfully authenticated
     Authenticated(Details),
     /// Client did not attempt to authenticate
@@ -168,14 +171,14 @@ pub enum Kind {
 ///
 /// This could eventually include other information used during authorization,
 /// like a remote IP, the time of authentication, etc.
-#[derive(Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Details {
     /// the actor performing the request
     actor: Actor,
 }
 
 /// Who is performing an operation
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Actor(pub Uuid);
 
 /// Label for a particular authentication scheme (used in log messages and

--- a/nexus/src/authn/saga.rs
+++ b/nexus/src/authn/saga.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Serialization of authentication context for sagas
+// TODO-security: This is not fully baked.  Right now, we serialize the actor
+// id.  We should think through that a little more.  Should we instead preload a
+// bunch of roles and then serialize that, for example?
+
+use crate::authn;
+use crate::context::OpContext;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Serialized form of an `OpContext`
+// NOTE: This structure must be versioned carefully.  (That's true of all saga
+// structures, but this one has a particularly large blast radius.)
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Serialized {
+    kind: authn::Kind,
+}
+
+impl Serialized {
+    pub fn for_opctx(opctx: &OpContext) -> Serialized {
+        Serialized { kind: opctx.authn.kind.clone() }
+    }
+
+    pub fn to_authn(&self) -> authn::Context {
+        authn::Context { kind: self.kind.clone(), schemes_tried: vec![] }
+    }
+}

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -1376,13 +1376,23 @@ impl DataStore {
 
     /// See `disk_update_runtime()`.  This version should only be used from
     /// sagas, which do not currently have authn contexts.
-    // TODO-security Like project_delete_disk_no_auth(), this should be removed
-    // once we have support for authz checks from sagas.
-    pub async fn disk_update_runtime_no_auth(
+    pub async fn disk_update_runtime(
         &self,
+        opctx: &OpContext,
         authz_disk: &authz::Disk,
         new_runtime: &DiskRuntimeState,
     ) -> Result<bool, Error> {
+        // TODO-security This permission might be overloaded here.  The way disk
+        // runtime updates work is that the caller in Nexus first updates the
+        // Sled Agent to make a change, then updates to the database to reflect
+        // that change.  So by the time we get here, we better have already done
+        // an authz check, or we will have already made some unauthorized change
+        // to the system!  At the same time, we don't want just anybody to be
+        // able to modify the database state.  So we _do_ still want an authz
+        // check here.  Arguably it's for a different kind of action, but it
+        // doesn't seem that useful to split it out right now.
+        opctx.authorize(authz::Action::Modify, authz_disk).await?;
+
         let disk_id = authz_disk.id();
         use db::schema::disk::dsl;
         let updated = diesel::update(dsl::disk)
@@ -1405,25 +1415,6 @@ impl DataStore {
             })?;
 
         Ok(updated)
-    }
-
-    pub async fn disk_update_runtime(
-        &self,
-        opctx: &OpContext,
-        authz_disk: &authz::Disk,
-        new_runtime: &DiskRuntimeState,
-    ) -> Result<bool, Error> {
-        // TODO-security This permission might be overloaded here.  The way disk
-        // runtime updates work is that the caller in Nexus first updates the
-        // Sled Agent to make a change, then updates to the database to reflect
-        // that change.  So by the time we get here, we better have already done
-        // an authz check, or we will have already made some unauthorized change
-        // to the system!  At the same time, we don't want just anybody to be
-        // able to modify the database state.  So we _do_ still want an authz
-        // check here.  Arguably it's for a different kind of action, but it
-        // doesn't seem that useful to split it out right now.
-        opctx.authorize(authz::Action::Modify, authz_disk).await?;
-        self.disk_update_runtime_no_auth(authz_disk, new_runtime).await
     }
 
     /// Fetches information about a Disk that the caller has previously fetched

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -6,9 +6,9 @@
  * Interfaces available to saga actions and undo actions
  */
 
-use crate::db;
 use crate::external_api::params;
 use crate::Nexus;
+use crate::{authz, db};
 use omicron_common::api::external::Error;
 use sled_agent_client::Client as SledAgentClient;
 use slog::Logger;
@@ -24,6 +24,7 @@ use uuid::Uuid;
 pub struct SagaContext {
     nexus: Arc<Nexus>,
     log: Logger,
+    authz: Arc<authz::Authz>,
 }
 
 impl fmt::Debug for SagaContext {
@@ -33,8 +34,12 @@ impl fmt::Debug for SagaContext {
 }
 
 impl SagaContext {
-    pub fn new(nexus: Arc<Nexus>, log: Logger) -> SagaContext {
-        SagaContext { nexus, log }
+    pub fn new(
+        nexus: Arc<Nexus>,
+        log: Logger,
+        authz: Arc<authz::Authz>,
+    ) -> SagaContext {
+        SagaContext { authz, nexus, log }
     }
 
     pub fn log(&self) -> &Logger {
@@ -57,6 +62,10 @@ impl SagaContext {
         _params: &params::InstanceCreate,
     ) -> Result<Uuid, Error> {
         self.nexus.sled_allocate().await
+    }
+
+    pub fn authz(&self) -> &Arc<authz::Authz> {
+        &self.authz
     }
 
     pub fn nexus(&self) -> &Arc<Nexus> {


### PR DESCRIPTION
This change takes a first cut at adding the ability to make authz checks from saga actions.

It works like this:

- When an API call creates a saga, it includes in the saga's parameters a new struct called `authn::saga::Serialized`.  This represents a serialized `authn::Context`.  There's a `authn::saga::Serialized::for_opctx` that serializes the `authn::Context` of the currently-authenticated user.  (In other words: we take the user that's authenticated for the current HTTP request and store that in the saga's parameters.)
- Within a saga action, you use `OpContext::for_saga_action` to reconstruct an `OpContext` from the `authn::saga::Serialized` that's stored in the saga's parameters.

I implemented this end-to-end for one of the datastore functions that was being used by a saga action (`disk_update_runtime`).

The motivation for this is that I want to start doing authz checks in datastore methods that are invoked from saga actions.  With this change, those authz checks will be done against whatever user made the HTTP request that created the saga.  This seemed like a reasonable first cut.

There's an additional benefit which is that `OpContext::for_saga_action` crates a `slog::Logger` with metadata from steno about the name of the current saga action.  Thus, all saga actions now get a logger that includes that metadata.  We should update Steno to make more information available here (like the current saga template name and saga id, or even a logger that we can start from). 

Some design thoughts:

* It's worth noting that serializing just the user's identity isn't necessarily the long-term plan.
    * We may want something more cryptographically verifiable -- e.g., some token that proves the user actually created the saga in question, or that a trusted Nexus instance did, or whatever.  I'm not sure.  But right now we trust whatever's in the database record.
    * A different approach would be to pre-execute any authorization checks that would be needed in the saga and store some token into the saga parameters that proves we did those authz checks up front.
    * Yet a different approach would be to store the current user's _roles_ into the saga parameters and do authz checks against those roles.
* Critically, we can change the contents of `authn::saga::Serialized` to store whatever we want and change how this works later.
* `authn::saga::Serialized` _could_ just be an `authn::Context` right now.  I'm reluctant to make `authn::Context` impl `Serialize` because I don't want us to accidentally try to serialize it some place without thinking through the implications (like the ones I mentioned above).

In summary: I know this isn't fully baked but I think it's a step in the right direction, and lacking even a crude facility here is blocking the work to protect more endpoints with authz.