### PR TITLE
Add a simulated gimlet SP that can send serial console data to the MGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "dropshot",
  "gateway-messages",
  "omicron-common",
+ "ringbuffer",
  "schemars",
  "serde",
  "slog",

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -136,7 +136,7 @@ pub struct SerialConsole {
 }
 
 impl SerialConsole {
-    const MAX_DATA_PER_PACKET: usize = 32;
+    pub const MAX_DATA_PER_PACKET: usize = 32;
 }
 
 #[cfg(test)]

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -34,14 +34,6 @@ pub enum RequestKind {
     IgnitionCommand { target: u8, command: IgnitionCommand },
 }
 
-/// Messages from an SP to a gateway, specifically responding to a [Request].
-#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
-pub struct Response {
-    pub version: u32,
-    pub request_id: u32,
-    pub kind: ResponseKind,
-}
-
 // TODO: Not all SPs are capable of crafting all these response kinds, but the
 // way we're using hubpack requires everyone to allocate Response::MAX_SIZE. Is
 // that okay, or should we break this up more?
@@ -60,26 +52,25 @@ pub enum ResponseError {
     RequestUnsupported,
 }
 
-/* IGNORE - treat these as notes; will flesh this out in the near future
-
-/// Messages from an SP to a gateway, prompted by the SP itself; e.g., ignition
-/// state change or serial console output.
+/// Messages from an SP to a gateway. Includes both responses to [`Request`]s as
+/// well as SP-initiated messages like serial console output.
 #[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub struct SpMessage {
-    // TODO: expections on this field? E.g. for serial console, does it imply
-    // ordering, or can we live with "wait to send more console data until we
-    // get an ack" with just a single outstanding message?
-    pub msg_id: u32,
+    pub version: u32,
     pub kind: SpMessageKind,
 }
 
 #[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub enum SpMessageKind {
     // TODO: Is only sending the new state sufficient?
-    IgnitionChange { target: u8, new_state: IgnitionState },
+    // IgnitionChange { target: u8, new_state: IgnitionState },
+    /// Response to a [`Request`] from MGS.
+    Response { request_id: u32, kind: ResponseKind },
+
+    /// Data traveling from an SP-attached component (in practice, a CPU) on the
+    /// component's serial console.
     SerialConsole(SerialConsole),
 }
-*/
 
 #[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub struct IgnitionState {
@@ -110,19 +101,42 @@ pub enum IgnitionCommand {
     PowerOff,
 }
 
-/* IGNORE - treat these as notes; will flesh this out in the near future
-#[derive(
-    Debug, Clone, Copy, Default, SerializedSize, Serialize, Deserialize,
-)]
+/// Identifier for a single component managed by an SP.
+#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
+pub struct SpComponent {
+    /// The ID of the component.
+    ///
+    /// TODO This needs some thought/polish. Is this "up to 16 bytes of human
+    /// readable data" (my current thought)? If so, should we add a length field
+    /// or specify padding?
+    pub id: [u8; 16],
+}
+
+#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub struct SerialConsole {
-    len: u8,
-    // TODO: What's a reasonable chunk size? Or do we want some variability
-    // here (subject to hubpack limitations or outside-of-hubpack encoding)?
-    //
-    // Another minor annoyance - serde doesn't support arbitrary array sizes,
-    // and only implements up to [T; 32], so we'd need a wrapper of some kind to
-    // go higher. See https://github.com/serde-rs/serde/issues/1937
-    data: [u8; 32],
+    /// Source component of this serial console data.
+    pub component: SpComponent,
+
+    /// Offset of this chunk of data relative to all console ouput this
+    /// SP+component has seen since it booted. MGS can determine if it's missed
+    /// data and reconstruct out-of-order packets based on this value plus
+    /// `len`.
+    pub offset: u64,
+
+    /// Number of bytes in `data`.
+    pub len: u8,
+
+    /// TODO: What's a reasonable chunk size? Or do we want some variability
+    /// here (subject to hubpack limitations or outside-of-hubpack encoding)?
+    ///
+    /// Another minor annoyance - serde doesn't support arbitrary array sizes
+    /// and only implements up to [T; 32], so we'd need a wrapper of some kind to
+    /// go higher. See https://github.com/serde-rs/serde/issues/1937
+    pub data: [u8; Self::MAX_DATA_PER_PACKET],
+}
+
+impl SerialConsole {
+    const MAX_DATA_PER_PACKET: usize = 32;
 }
 
 #[cfg(test)]
@@ -132,8 +146,12 @@ mod tests {
     #[test]
     fn roundtrip_serial_console() {
         let line = "hello world\n";
-        let mut console = SerialConsole::default();
-        console.len = line.len() as u8;
+        let mut console = SerialConsole {
+            component: SpComponent { id: *b"0000111122223333" },
+            offset: 12345,
+            len: line.len() as u8,
+            data: [0xff; 32],
+        };
         console.data[..line.len()].copy_from_slice(line.as_bytes());
 
         let mut serialized = [0; SerialConsole::MAX_SIZE];
@@ -145,4 +163,3 @@ mod tests {
         assert_eq!(deserialized.data, console.data);
     }
 }
-*/

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#![cfg_attr(not(test), no_std)]
+
 pub mod sp_impl;
 
 use bitflags::bitflags;

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     version, IgnitionCommand, Request, RequestKind, ResponseKind,
-    SerialConsole, SpMessage, SpMessageKind, SpComponent,
+    SerialConsole, SpComponent, SpMessage, SpMessageKind,
 };
 use hubpack::SerializedSize;
 
@@ -48,10 +48,7 @@ pub struct SerialConsolePacketizer {
 
 impl SerialConsolePacketizer {
     pub fn new(component: SpComponent) -> Self {
-        Self {
-            component,
-            offset: 0,
-        }
+        Self { component, offset: 0 }
     }
 
     pub fn packetize<'a, 'b>(
@@ -100,7 +97,7 @@ impl SerialConsolePackets<'_, '_> {
 
         // We know `out` is big enough for any `SpMessage`, so no need to bubble
         // up an error here.
-        let n = match hubpack::serialize(&mut out[..], &message){
+        let n = match hubpack::serialize(&mut out[..], &message) {
             Ok(n) => n,
             Err(_) => panic!(),
         };

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -57,6 +57,12 @@ impl SerialConsolePacketizer {
     ) -> SerialConsolePackets<'a, 'b> {
         SerialConsolePackets { parent: self, data }
     }
+
+    // TODO this function exists only to allow callers to inject artifical gaps
+    // in the data they're sending; should we gate it behind a cargo feature?
+    pub fn danger_emulate_dropped_packets(&mut self, bytes_to_skip: u64) {
+        self.offset += bytes_to_skip;
+    }
 }
 
 #[derive(Debug)]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 clap = { version = "3.0", features = ["derive"] }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
+ringbuffer = "0.8"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 slog-dtrace = "0.2"

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -13,7 +13,7 @@ ignition_controller_timeout_milliseconds = 1_000
 # our known SPs anyway.
 ignition_controller = "127.0.0.1:23456"
 switches = ["127.0.0.1:23456"]
-sleds = []
+sleds = ["127.0.0.1:23457"]
 power_controllers = []
 
 [dropshot]

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -19,6 +19,10 @@ pub(crate) enum Error {
     #[error("SP {} (of type {:?}) does not exist", .0.slot, .0.typ)]
     SpDoesNotExist(SpIdentifier),
 
+    /// The requested SP component ID is invalid (i.e., too long).
+    #[error("invalid SP component ID `{0}`")]
+    InvalidSpComponentId(String),
+
     /// The system encountered an unhandled operational error.
     #[error("internal error: {internal_message}")]
     InternalError { internal_message: String },
@@ -29,6 +33,10 @@ impl From<Error> for HttpError {
         match err {
             Error::SpDoesNotExist(_) => HttpError::for_bad_request(
                 Some(String::from("SpDoesNotExist")),
+                err.to_string(),
+            ),
+            Error::InvalidSpComponentId(_) => HttpError::for_bad_request(
+                Some(String::from("InvalidSpComponentId")),
                 err.to_string(),
             ),
             Error::InternalError { internal_message } => {

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -325,12 +325,13 @@ async fn sp_component_serial_console_get(
         .map_err(|_| Error::InvalidSpComponentId(component))?;
     let contents = comms.serial_console_get(sp, &component)?;
 
-    // TODO we can't tell the difference between "this component has no serial
-    // console" and "we haven't received any serial console data for this
-    // component". Is that okay? For now both cases send back empty contents.
-    Ok(HttpResponseOk(
-        contents.unwrap_or_else(|| SerialConsoleContents::default()),
-    ))
+    // TODO With `unwrap_or_default()`, our caller can't tell the difference
+    // between "this component hasn't sent us any console information yet" and
+    // "this component does not have a serial console and will never send data"
+    // - both cases send back an empty `SerialConsoleContents`. To handle this
+    // more gracefully, we will need to know which components have a serial
+    // console.
+    Ok(HttpResponseOk(contents.unwrap_or_default()))
 }
 
 // TODO: how can we make this generic enough to support any update mechanism?

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -201,8 +201,6 @@ impl SpCommunicator {
 /// dropped. When the communicator wants to send a request on behalf of an HTTP
 /// request:
 ///
-/// TODO update for non-response messages
-///
 /// 1. `SpCommunicator` creates a tokio oneshot channel for this task to use to
 ///    send the response.
 /// 2. `SpCommunicator` inserts the sending half of that channel into
@@ -221,6 +219,10 @@ impl SpCommunicator {
 /// If a timeout or other error occurs between step 2 and the end of step 4, the
 /// `ResponseReceiver` wrapper below is responsible for cleaning up the entry in
 /// `outstanding_requests` (via its `Drop` impl).
+///
+/// We can also receive messages from SPs that are not responses to oustanding
+/// requests. These are handled on a case-by-case basis; e.g., serial console
+/// data is pushed into the in-memory ringbuffer corresponding to the source.
 struct RecvTask {
     socket: Arc<UdpSocket>,
     sp_state: Arc<SpState>,

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -192,10 +192,10 @@ impl SpCommunicator {
 /// Handle for the background tokio task responsible for receiving incoming UDP
 /// messages.
 ///
-/// We currently assume that we know (before this task is spawned) the IP
+/// TODO We currently assume that we know (before this task is spawned) the IP
 /// address of all SPs with which we want to communicate, and that those IP
-/// addresses will not change while we're running. Either or both of those may
-/// end up being wrong.
+/// addresses will not change while we're running. These assumptions are wrong -
+/// hot swapping sleds will lead to both being violated.
 ///
 /// This task is spawned when `SpCommunicator` is created, and runs until it is
 /// dropped. When the communicator wants to send a request on behalf of an HTTP

--- a/gateway/src/sp_comms/serial_console_history.rs
+++ b/gateway/src/sp_comms/serial_console_history.rs
@@ -93,10 +93,7 @@ impl SerialConsoleHistory {
             chunks.push(SerialConsoleChunk::Data { bytes: buf });
         }
 
-        Some(SerialConsoleContents {
-            start: start.unwrap_or(0),
-            chunks,
-        })
+        Some(SerialConsoleContents { start: start.unwrap_or(0), chunks })
     }
 
     pub(super) fn push(&mut self, packet: SerialConsole, log: &Logger) {

--- a/gateway/src/sp_comms/serial_console_history.rs
+++ b/gateway/src/sp_comms/serial_console_history.rs
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use gateway_messages::SerialConsole;
+use ringbuffer::{AllocRingBuffer, RingBufferExt, RingBufferWrite};
+use slog::{warn, Logger};
+use std::cmp::Ordering;
+
+/// Current in-memory contents of an SP component's serial console.
+///
+/// Note that we currently embed a placeholder string for missing data, which
+/// adds some nuance around what the "length" of this buffer means: We have both
+/// the length in bytes of the buffer itself, but also the nominal length of
+/// what range of data from the SP it covers. If we haven't missed any packets,
+/// these lengths will be the same. If we have, they will probably be different;
+/// typically the nominal length will be longer, but it could be shorter if we
+/// missed packets containing chunks shorter than the placeholder string we drop
+/// in in their place(s).
+///
+/// If we have not received any serial console data from this SP component,
+/// `start` and `end` will both be `0`, and `buf` will be empty.
+#[derive(Debug)]
+pub(crate) struct SerialConsoleContents {
+    /// Position since SP component start of the first byte of `buf`.
+    ///
+    /// This is equal to the number of bytes that we've discarded due to
+    /// dropping out of our internal ring buffer.
+    pub(crate) start: u64,
+
+    /// Nominal end of the data covered by `buf`.
+    ///
+    /// If we have not missed any packets since `start`, this will be equal to
+    /// `start + data.len()`. If we _have_ missed at least one packet, those
+    /// lengths are likely different.
+    pub(crate) end: u64,
+
+    /// Contents of the serial console buffer.
+    pub(crate) buf: Vec<u8>,
+}
+
+// We currently store serial console packets from an SP more or less "as is" in
+// a ringbuffer. It might be better to keep a ringbuffer backed by a `Vec<u8>`
+// to make querying the current serial console state simpler, but (a) I'm not
+// aware of a nice ringbuffer API that would let us push in chunks of data, and
+// (b) it makes managing gaps in the data more complicated. This seems good
+// enough for now (and possibly for the foreseeable future).
+#[derive(Debug)]
+pub(super) struct SerialConsoleHistory {
+    slots: AllocRingBuffer<Slot>,
+}
+
+impl Default for SerialConsoleHistory {
+    fn default() -> Self {
+        Self {
+            // TODO do we want this capacity to be configurable, or just pick
+            // something small but reasonable?
+            slots: AllocRingBuffer::with_capacity(32),
+        }
+    }
+}
+
+impl SerialConsoleHistory {
+    pub(super) fn contents(&self) -> SerialConsoleContents {
+        let mut buf = Vec::new();
+        let mut start = None;
+        let mut end = None;
+
+        for slot in self.slots.iter() {
+            match slot {
+                Slot::MissingData { offset, len } => {
+                    buf.extend_from_slice(
+                        format!("... MISSING {} BYTES ...", len).as_bytes(),
+                    );
+                    if start.is_none() {
+                        start = Some(*offset);
+                    }
+                    end = Some(offset + len);
+                }
+                Slot::Valid { offset, len, data } => {
+                    buf.extend_from_slice(&data[..usize::from(*len)]);
+                    if start.is_none() {
+                        start = Some(*offset);
+                    }
+                    end = Some(offset + u64::from(*len));
+                }
+            }
+        }
+
+        SerialConsoleContents {
+            start: start.unwrap_or(0),
+            end: end.unwrap_or(0),
+            buf,
+        }
+    }
+
+    pub(super) fn push(&mut self, packet: SerialConsole, log: &Logger) {
+        // detect dropped packets - see what we expect `packet.offset` to be
+        // based on the end of our most-recently-received packet.
+        let expected_offset =
+            self.slots.back().map_or(0, |slot| slot.end_pos());
+
+        match packet.offset.cmp(&expected_offset) {
+            Ordering::Less => {
+                // TODO We're currently assuming that a packet offset earlier
+                // than what we expect implies we're now receiving an
+                // out-of-order back that we missed earlier. This is
+                // demonstrably wrong in at least one case (the SP has
+                // restarted), but we're punting on that problem for now. It
+                // seems likely that an SP restarting is going to end up
+                // triggering a lot of state reset (reestablish an authorized
+                // connection, for one) which would give us a chance to reset
+                // our serial console state too.
+                warn!(
+                    log,
+                    "dropping serial console packet with out-of-order offset"
+                );
+            }
+            Ordering::Greater => {
+                // we have a gap; push a "missing data" entry
+                self.slots.push(Slot::MissingData {
+                    offset: expected_offset,
+                    len: packet.offset - expected_offset,
+                });
+            }
+            Ordering::Equal => (), // nothing to do; this is expected
+        }
+
+        self.slots.push(Slot::Valid {
+            offset: packet.offset,
+            len: packet.len,
+            data: packet.data,
+        });
+
+        // TODO FIX THIS - expose in API
+        let contents = self.contents();
+        dbg!((contents.start, contents.end));
+        dbg!(String::from_utf8(contents.buf).unwrap());
+    }
+}
+
+#[derive(Debug)]
+enum Slot {
+    // we had dropped our out-of-order packets amounting to this number of bytes
+    MissingData {
+        offset: u64,
+        len: u64,
+    },
+    // an in-order serial console packet
+    Valid {
+        offset: u64,
+        len: u8,
+        data: [u8; SerialConsole::MAX_DATA_PER_PACKET],
+    },
+}
+
+impl Slot {
+    fn end_pos(&self) -> u64 {
+        match self {
+            Slot::MissingData { offset, len } => offset + len,
+            Slot::Valid { offset, len, .. } => offset + u64::from(*len),
+        }
+    }
+}

--- a/sp-sim/examples/gimlet.toml
+++ b/sp-sim/examples/gimlet.toml
@@ -6,6 +6,9 @@ sp_type = "gimlet"
 bind_address = "127.0.0.1:23457"
 gateway_address = "127.0.0.1:22222"
 
+[components]
+serial_console = ["sp3"]
+
 [log]
 # Show log messages of this level and more severe
 level = "debug"

--- a/sp-sim/examples/gimlet.toml
+++ b/sp-sim/examples/gimlet.toml
@@ -2,8 +2,8 @@
 # SP simulator: example config file
 #
 
-sp_type = "sidecar"
-bind_address = "127.0.0.1:23456"
+sp_type = "gimlet"
+bind_address = "127.0.0.1:23457"
 gateway_address = "127.0.0.1:22222"
 
 [log]

--- a/sp-sim/examples/sidecar.toml
+++ b/sp-sim/examples/sidecar.toml
@@ -6,6 +6,9 @@ sp_type = "sidecar"
 bind_address = "127.0.0.1:23456"
 gateway_address = "127.0.0.1:22222"
 
+[components]
+serial_console = []
+
 [log]
 # Show log messages of this level and more severe
 level = "debug"

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -15,11 +15,22 @@ use std::{
 };
 use thiserror::Error;
 
-/// Configuration for a gateway server
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SpType {
+    Sidecar,
+    Gimlet,
+}
+
+/// Configuration for a simulated SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
+    /// Type of SP to simulate.
+    pub sp_type: SpType,
     /// UDP listen address.
     pub bind_address: SocketAddr,
+    /// UDP address of MGS.
+    pub gateway_address: SocketAddr,
     /// Server-wide logging configuration.
     pub log: ConfigLogging,
 }

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -22,11 +22,23 @@ pub enum SpType {
     Gimlet,
 }
 
+/// Description of a simulated SP's components.
+// TODO should reorganize this once we have more to do with components than just
+// a serial console - maybe a list of components with flags for which operations
+// they support (serial console, power on/off, etc)
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct SpComponents {
+    /// List of components with a serial console.
+    pub serial_console: Vec<String>,
+}
+
 /// Configuration for a simulated SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
     /// Type of SP to simulate.
     pub sp_type: SpType,
+    /// Components to simulate.
+    pub components: SpComponents,
     /// UDP listen address.
     pub bind_address: SocketAddr,
     /// UDP address of MGS.

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -132,8 +132,6 @@ impl Inner {
 
                     let resp = match self.server.dispatch(data) {
                         Ok(resp) => resp,
-                        // TODO: should we send back an error here? may not be
-                        // able to say anything meaningful, depending on `err`
                         Err(err) => {
                             error!(
                                 self.server.handler().log,

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -2,9 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod config;
+pub mod config;
+mod gimlet;
 mod server;
 mod sidecar;
 
-pub use config::Config;
+pub use gimlet::Gimlet;
 pub use sidecar::Sidecar;

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -95,8 +95,6 @@ impl Inner {
 
                     let resp = match self.server.dispatch(data) {
                         Ok(resp) => resp,
-                        // TODO: should we send back an error here? may not be
-                        // able to say anything meaningful, depending on `err`
                         Err(err) => {
                             error!(
                                 self.server.handler().log,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::server::{self, UdpServer};
 use crate::config::Config;
+use crate::server::{self, UdpServer};
 use anyhow::Result;
 use gateway_messages::sp_impl::{SpHandler, SpServer};
 use gateway_messages::{IgnitionFlags, IgnitionState, ResponseKind};


### PR DESCRIPTION
The most interesting part of this PR is the new endpoint in `gateway` and the collection of machinery that backs it: primarily `gateway/src/sp_comms/serial_console_history.rs`, which stores incoming serial console messages in a ring buffer, checks for gaps, and collapses contiguous packets on demand (when the endpoint to get the data is called).

A lot of this is still very rough in an attempt to get @ahl something he can work with; to see the new functionality in this PR, start both the gateway:

```
$ cargo run --bin gateway -- gateway/examples/config.toml
```

and a simulated gimlet:

```
$ cargo run --bin sp-sim -- sp-sim/examples/gimlet.toml
```

The gimlet simulator currently unconditionally reads on stdin and forwards all messages to the gateway. If the line begins with `SKIP `, the gimlet will lie about it the remainder of the line, making MGS thinks it missed a dropped packet of length 10. E.g.,

```
$ cargo run --bin sp-sim -- sp-sim/examples/gimlet.toml
hello
SKIP 123
```

leads to MGS reporting the serial console data

```
$ curl -s http://127.0.0.1:12222/sp/sled/0/component/sp3/serial_console
{"start":0,"chunks":[{"kind":"data","bytes":[104,101,108,108,111,10]},{"kind":"missing","len":10},{"kind":"data","bytes":[49,50,51,10]}]}
```