### PR TITLE
Prevent Nexus from initializing until CRDB is populated

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -829,9 +829,16 @@ CREATE TABLE omicron.public.role_assignment_builtin (
 
 CREATE TABLE omicron.public.db_metadata (
     name  STRING(63) NOT NULL,
-    value STRING(1023) NOT NULL
+    value STRING(1023) NOT NULL,
+
+    PRIMARY KEY(name, value)
 );
 
+/*
+ * This must be the last value inserted in the database when populating.
+ * Nexus checks for this value as a sign that initialization has completed
+ * successfully.
+ */
 INSERT INTO omicron.public.db_metadata (
     name,
     value

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -7,7 +7,7 @@
 use crate::db::collection_insert::DatastoreCollection;
 use crate::db::identity::{Asset, Resource};
 use crate::db::schema::{
-    console_session, dataset, disk, instance, metric_producer,
+    console_session, dataset, db_metadata, disk, instance, metric_producer,
     network_interface, organization, oximeter, project, rack, region,
     role_assignment_builtin, role_builtin, router_route, sled, user_builtin,
     vpc, vpc_firewall_rule, vpc_router, vpc_subnet, zpool,
@@ -2082,6 +2082,13 @@ impl RoleAssignmentBuiltin {
             role_name: String::from(role_name),
         }
     }
+}
+
+#[derive(Queryable, Debug, Selectable)]
+#[table_name = "db_metadata"]
+pub struct DbMetadata {
+    pub name: String,
+    pub value: String,
 }
 
 #[cfg(test)]

--- a/nexus/src/db/pool.rs
+++ b/nexus/src/db/pool.rs
@@ -29,9 +29,13 @@
  */
 
 use super::Config as DbConfig;
-use async_bb8_diesel::ConnectionManager;
-use diesel::PgConnection;
+use crate::db::model::DbMetadata;
+use anyhow::anyhow;
+use async_bb8_diesel::{AsyncRunQueryDsl, ConnectionManager};
+use diesel::{ExpressionMethods, PgConnection, QueryDsl, SelectableHelper};
 use diesel_dtrace::DTraceConnection;
+use omicron_common::backoff;
+use slog::Logger;
 
 pub type DbConnection = DTraceConnection<PgConnection>;
 
@@ -53,5 +57,36 @@ impl Pool {
     /// Returns a reference to the underlying pool.
     pub fn pool(&self) -> &bb8::Pool<ConnectionManager<DbConnection>> {
         &self.pool
+    }
+
+    /// Contact CockroachDB using exponential backoff until it appears alive.
+    ///
+    /// Although liveness of CRDB is not guaranteed generally (such is the
+    /// nature of distributed systems), this check lets a caller avoid a
+    /// race condition during initialization, where Nexus may boot before
+    /// the database.
+    pub async fn wait_for_cockroachdb(&self, log: &Logger) {
+        let check_health = || async {
+            use crate::db::schema::db_metadata::dsl;
+
+            dsl::db_metadata
+                .filter(dsl::name.eq("schema_version"))
+                .select(DbMetadata::as_select())
+                .first_async(self.pool())
+                .await
+                .map_err(|e| backoff::BackoffError::Transient(anyhow!(e)))
+        };
+        let log_failure = |_, _| {
+            warn!(log, "cockroachdb not yet alive");
+        };
+        backoff::retry_notify(
+            backoff::internal_service_policy(),
+            check_health,
+            log_failure,
+        )
+        .await
+        .expect("expected an infinite retry loop waiting for crdb");
+
+        info!(log, "CockroachDB appears online");
     }
 }

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -329,6 +329,13 @@ table! {
     }
 }
 
+table! {
+    db_metadata (name, value) {
+        name -> Text,
+        value -> Text,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(
     dataset,
     disk,

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -98,6 +98,8 @@ impl Server {
 
         let ctxlog = log.new(o!("component" => "ServerContext"));
         let pool = db::Pool::new(&config.database);
+        pool.wait_for_cockroachdb(&log).await;
+
         let apictx = ServerContext::new(rack_id, ctxlog, pool, &config)?;
 
         let http_server_starter_external = dropshot::HttpServerStarter::new(


### PR DESCRIPTION
Stops Nexus from booting until CRDB appears initialized, at least once.

This change allows other bootstrapping aspects of the control plane to initialize Nexus and CRDB concurrently, as Nexus will await CRDB formatting before launching itself.
