### PR TITLE
Add endpoint to MGS to post serial console data to an SP component

### DIFF
--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -5,7 +5,6 @@
 # Identifier for this instance of MGS
 id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
 udp_bind_address = "127.0.0.1:22222"
-ignition_controller_timeout_milliseconds = 1_000
 
 [known_sps]
 # TODO we repeat the ignition_controller IP as a switch; should we specify it as
@@ -15,6 +14,10 @@ ignition_controller = "127.0.0.1:23456"
 switches = ["127.0.0.1:23456"]
 sleds = ["127.0.0.1:23457"]
 power_controllers = []
+
+[timeouts]
+ignition_controller_milliseconds = 1_000
+sp_request_milliseconds = 1_000
 
 [dropshot]
 # IP address and TCP port on which to listen for the external API

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -13,6 +13,7 @@ use std::{sync::Arc, time::Duration};
 pub struct ServerContext {
     pub sp_comms: SpCommunicator,
     pub ignition_controller_timeout: Duration,
+    pub sp_request_timeout: Duration,
 }
 
 impl ServerContext {
@@ -29,7 +30,10 @@ impl ServerContext {
         Ok(Arc::new(ServerContext {
             sp_comms,
             ignition_controller_timeout: Duration::from_millis(
-                config.ignition_controller_timeout_milliseconds,
+                config.timeouts.ignition_controller_milliseconds,
+            ),
+            sp_request_timeout: Duration::from_millis(
+                config.timeouts.sp_request_milliseconds,
             ),
         }))
     }

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -13,7 +13,7 @@ use crate::ServerContext;
 use dropshot::{
     endpoint, ApiDescription, EmptyScanParams, HttpError, HttpResponseOk,
     HttpResponseUpdatedNoContent, PaginationParams, Path, Query,
-    RequestContext, ResultsPage, TypedBody,
+    RequestContext, ResultsPage, TypedBody, UntypedBody,
 };
 use gateway_messages::SpComponent;
 use schemars::JsonSchema;
@@ -319,8 +319,9 @@ async fn sp_component_serial_console_get(
 
     let sp = comms
         .placeholder_known_sps()
-        .ip_for(&sp)
-        .ok_or(Error::SpDoesNotExist(sp))?;
+        .addr_for(&sp)
+        .ok_or(Error::SpDoesNotExist(sp))?
+        .ip();
     let component = SpComponent::try_from(component.as_str())
         .map_err(|_| Error::InvalidSpComponentId(component))?;
     let contents = comms.serial_console_get(sp, &component)?;
@@ -332,6 +333,51 @@ async fn sp_component_serial_console_get(
     // more gracefully, we will need to know which components have a serial
     // console.
     Ok(HttpResponseOk(contents.unwrap_or_default()))
+}
+
+/// Send data to an SP component's serial console.
+///
+/// If this request returns successfully, the SP acknowledged that the data
+/// arrived. If it fails, we do not know whether or not the data arrived (or
+/// will eventually arrive).
+#[endpoint {
+    method = POST,
+    path = "/sp/{type}/{slot}/component/{component}/serial_console",
+}]
+async fn sp_component_serial_console_post(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path: Path<PathSpComponent>,
+    data: UntypedBody,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let apictx = rqctx.context();
+    let comms = &apictx.sp_comms;
+    let PathSpComponent { sp, component } = path.into_inner();
+
+    let sp = comms
+        .placeholder_known_sps()
+        .addr_for(&sp)
+        .ok_or(Error::SpDoesNotExist(sp))?;
+    let component = SpComponent::try_from(component.as_str())
+        .map_err(|_| Error::InvalidSpComponentId(component))?;
+
+    // TODO What is our recourse if we hit a timeout here? We don't know whether
+    // the SP received none, some, or all of the data we sent, only that it
+    // failed to ack (at least) the last packet in time. Hopefully the user can
+    // manually detect this by inspecting the serial console output from this
+    // component (if whatever they sent triggers some kind of output)? But maybe
+    // we should try to do a little better - if we had to packetize `data`, for
+    // example, we could at least report how much data was ack'd and how much we
+    // sent that hasn't been ack'd yet?
+    comms
+        .serial_console_post(
+            sp,
+            component,
+            data.as_bytes(),
+            apictx.sp_request_timeout,
+        )
+        .await?;
+
+    Ok(HttpResponseUpdatedNoContent {})
 }
 
 // TODO: how can we make this generic enough to support any update mechanism?
@@ -486,6 +532,7 @@ pub fn api() -> GatewayApiDescription {
         api.register(sp_component_list)?;
         api.register(sp_component_get)?;
         api.register(sp_component_serial_console_get)?;
+        api.register(sp_component_serial_console_post)?;
         api.register(sp_component_update)?;
         api.register(sp_component_power_on)?;
         api.register(sp_component_power_off)?;

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -191,12 +191,12 @@ impl SpCommunicator {
             .sp_state
             .all_sps
             .get(&sp.ip())
-            .ok_or(Error::SpDoesNotExist(sp.ip()))?;
+            .ok_or_else(|| Error::SpDoesNotExist(sp.ip()))?;
 
         let mut packetizers = sp_state.serial_console_to_sp.lock().await;
         let packetizer = packetizers
             .entry(component)
-            .or_insert(SerialConsolePacketizer::new(component));
+            .or_insert_with(|| SerialConsolePacketizer::new(component));
 
         for packet in packetizer.packetize(data) {
             let request = RequestKind::SerialConsoleWrite(packet);

--- a/sp-sim/src/bin/sp-sim.rs
+++ b/sp-sim/src/bin/sp-sim.rs
@@ -6,10 +6,12 @@ use anyhow::Result;
 use omicron_common::cmd::{fatal, CmdError};
 use sp_sim::config::{Config, SpType};
 use sp_sim::{Gimlet, Sidecar};
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::io::AsyncReadExt;
+use tokio::select;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "sp-sim", about = "See README.adoc for more information")]
@@ -58,15 +60,24 @@ async fn run_gimlet(config: &Config) -> Result<(), CmdError> {
     // tokio docs warn against using its stdin handle for user-interactive
     // input; we'll live dangerously in this simulator
     let mut stdin = tokio::io::stdin();
+    let mut stdout = std::io::stdout();
     let mut buf = [0; 512];
 
     loop {
-        let n = stdin.read(&mut buf).await.map_err(|e| {
-            CmdError::Failure(format!("failed to read stdin: {}", e))
-        })?;
-        gimlet
-            .send_serial_console(&buf[..n])
-            .await
-            .map_err(|e| CmdError::Failure(e.to_string()))?;
+        select! {
+            res = stdin.read(&mut buf) => {
+                let n = res.map_err(|e| {
+                    CmdError::Failure(format!("failed to read stdin: {}", e))
+                })?;
+                gimlet
+                    .send_serial_console(&buf[..n])
+                    .await
+                    .map_err(|e| CmdError::Failure(e.to_string()))?;
+            }
+            incoming = gimlet.incoming_serial_console() => {
+                write!(stdout, "{}", String::from_utf8_lossy(&incoming)).unwrap();
+                stdout.flush().unwrap();
+            }
+        }
     }
 }


### PR DESCRIPTION
The provides the other direction of serial console transfers (MGS -> SP), building off of #703 which provided the initial SP -> MGS direction. It keeps the same style of "chop data up into at-most 32-byte packets", which is not what we want but good enough for the time being while we decide what we want.