### PR TITLE
Implement ignition power on/off in simulated sidecar

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -54,6 +54,8 @@ pub enum ResponseError {
     /// The [RequestKind] is not supported by the receiving SP; e.g., asking an
     /// SP without an attached ignition controller for ignition state.
     RequestUnsupported,
+    /// The specified ignition target does not exist.
+    IgnitionTargetDoesNotExist(u8),
 }
 
 /// Messages from an SP to a gateway. Includes both responses to [`Request`]s as
@@ -76,7 +78,9 @@ pub enum SpMessageKind {
     SerialConsole(SerialConsole),
 }
 
-#[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, SerializedSize, Serialize, Deserialize,
+)]
 pub struct IgnitionState {
     pub id: u16,
     pub flags: IgnitionFlags,

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -491,10 +491,21 @@ async fn ignition_get(
     path = "/sp/{type}/{slot}/power_on",
 }]
 async fn ignition_power_on(
-    _rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    _path: Path<PathSp>,
-) -> Result<HttpResponseOk<SpIgnitionInfo>, HttpError> {
-    todo!()
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path: Path<PathSp>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let apictx = rqctx.context();
+    let sp = path.into_inner().sp;
+
+    let target =
+        sp.placeholder_map_to_target(apictx.sp_comms.placeholder_known_sps())?;
+
+    apictx
+        .sp_comms
+        .ignition_power_on(target, apictx.ignition_controller_timeout)
+        .await?;
+
+    Ok(HttpResponseUpdatedNoContent {})
 }
 
 /// Power off an SP via Ignition
@@ -503,10 +514,21 @@ async fn ignition_power_on(
     path = "/sp/{type}/{slot}/power_off",
 }]
 async fn ignition_power_off(
-    _rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    _path: Path<PathSp>,
-) -> Result<HttpResponseOk<SpIgnitionInfo>, HttpError> {
-    todo!()
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path: Path<PathSp>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let apictx = rqctx.context();
+    let sp = path.into_inner().sp;
+
+    let target =
+        sp.placeholder_map_to_target(apictx.sp_comms.placeholder_known_sps())?;
+
+    apictx
+        .sp_comms
+        .ignition_power_off(target, apictx.ignition_controller_timeout)
+        .await?;
+
+    Ok(HttpResponseUpdatedNoContent {})
 }
 
 // TODO

--- a/sp-sim/examples/gimlet.toml
+++ b/sp-sim/examples/gimlet.toml
@@ -2,9 +2,11 @@
 # SP simulator: example config file
 #
 
-sp_type = "gimlet"
 bind_address = "127.0.0.1:23457"
 gateway_address = "127.0.0.1:22222"
+
+[sp_type]
+type = "gimlet"
 
 [components]
 serial_console = ["sp3"]

--- a/sp-sim/examples/sidecar.toml
+++ b/sp-sim/examples/sidecar.toml
@@ -2,9 +2,17 @@
 # SP simulator: example config file
 #
 
-sp_type = "sidecar"
 bind_address = "127.0.0.1:23456"
 gateway_address = "127.0.0.1:22222"
+
+[sp_type]
+type = "sidecar"
+ignition_targets = [
+    # sidecar, power | ctrl_detect_0
+    { id = 0b01_0010, flags = { bits = 0b000_0011 } },
+    # gimlet, power | ctrl_detect_0
+    { id = 0b01_0001, flags = { bits = 0b000_0011 } },
+]
 
 [components]
 serial_console = []

--- a/sp-sim/src/bin/sp-sim.rs
+++ b/sp-sim/src/bin/sp-sim.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use omicron_common::cmd::{fatal, CmdError};
-use sp_sim::config::{Config, SpType};
+use sp_sim::config::{Config, SidecarConfig, SpType};
 use sp_sim::{Gimlet, Sidecar};
 use std::io::Write;
 use std::path::PathBuf;
@@ -34,14 +34,19 @@ async fn do_run() -> Result<(), CmdError> {
     let config = Config::from_file(args.config_file_path)
         .map_err(|e| CmdError::Failure(e.to_string()))?;
 
-    match config.sp_type {
-        SpType::Sidecar => run_sidecar(&config).await,
+    match &config.sp_type {
+        SpType::Sidecar(sidecar_config) => {
+            run_sidecar(&config, sidecar_config).await
+        }
         SpType::Gimlet => run_gimlet(&config).await,
     }
 }
 
-async fn run_sidecar(config: &Config) -> Result<(), CmdError> {
-    let _sidecar = Sidecar::spawn(config)
+async fn run_sidecar(
+    config: &Config,
+    sidecar_config: &SidecarConfig,
+) -> Result<(), CmdError> {
+    let _sidecar = Sidecar::spawn(config, sidecar_config)
         .await
         .map_err(|e| CmdError::Failure(e.to_string()))?;
 

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -8,6 +8,7 @@
 //!
 
 use dropshot::ConfigLogging;
+use gateway_messages::IgnitionState;
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
@@ -15,10 +16,15 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct SidecarConfig {
+    pub ignition_targets: Vec<IgnitionState>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
 pub enum SpType {
-    Sidecar,
+    Sidecar(SidecarConfig),
     Gimlet,
 }
 


### PR DESCRIPTION
The simulated sidecar does not talk to other simulated SPs to actually start or stop them; it merely flips its "powered on" ignition flag in its corresponding ignition target state.

I think I shortly want to move to running a single `sp-sim` binary that simulates a set of SPs, which would give an easy path for the simulated sidecar to actually "power on/off" other simulated SPs (by killing or starting the tokio tasks providing them).