### PR TITLE
MGS: Implement "get ignition state of all SPs" endpoint

### DIFF
--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -5,9 +5,9 @@
 //! Behavior implemented by both real and simulated SPs.
 
 use crate::{
-    version, IgnitionCommand, IgnitionState, Request, RequestKind,
-    ResponseError, ResponseKind, SerialConsole, SpComponent, SpMessage,
-    SpMessageKind, SpState,
+    version, BulkIgnitionState, IgnitionCommand, IgnitionState, Request,
+    RequestKind, ResponseError, ResponseKind, SerialConsole, SpComponent,
+    SpMessage, SpMessageKind, SpState,
 };
 use hubpack::SerializedSize;
 
@@ -18,6 +18,10 @@ pub trait SpHandler {
         &mut self,
         target: u8,
     ) -> Result<IgnitionState, ResponseError>;
+
+    fn bulk_ignition_state(
+        &mut self,
+    ) -> Result<BulkIgnitionState, ResponseError>;
 
     fn ignition_command(
         &mut self,
@@ -157,6 +161,9 @@ impl SpServer {
             RequestKind::IgnitionState { target } => {
                 handler.ignition_state(target).map(ResponseKind::IgnitionState)
             }
+            RequestKind::BulkIgnitionState => handler
+                .bulk_ignition_state()
+                .map(ResponseKind::BulkIgnitionState),
             RequestKind::IgnitionCommand { target, command } => handler
                 .ignition_command(target, command)
                 .map(|()| ResponseKind::IgnitionCommandAck),

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -101,7 +101,7 @@ impl Iterator for SerialConsolePackets<'_, '_> {
         let mut packet = SerialConsole {
             component: self.parent.component,
             offset: self.parent.offset,
-            len: this_packet.len() as u8,
+            len: this_packet.len() as u16,
             data: [0; SerialConsole::MAX_DATA_PER_PACKET],
         };
         packet.data[..this_packet.len()].copy_from_slice(this_packet);

--- a/gateway-messages/src/variable_packet.rs
+++ b/gateway-messages/src/variable_packet.rs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Helper trait to write serde `Serialize`/`Deserialize` implementations that
+//! traffic in a header followed by a variable number of elements (the count of
+//! which is described by the header). This allows us to live within `hubpack`'s
+//! static world with a fixed max size without sending padding for
+//! underpopulated messages.
+
+use std::marker::PhantomData;
+
+use serde::de::{DeserializeOwned, Error, Visitor};
+use serde::ser::SerializeTuple;
+use serde::Serialize;
+
+pub(crate) trait VariablePacket {
+    type Header: DeserializeOwned + Serialize;
+    type Element: DeserializeOwned + Serialize;
+
+    const MAX_ELEMENTS: usize;
+    const DESERIALIZE_NAME: &'static str;
+
+    // construct a header from this instance
+    fn header(&self) -> Self::Header;
+
+    // number of elements actually contained in this instance
+    fn num_elements(&self) -> u16;
+
+    // `elements` and `elements_mut` can return slices up to
+    // `Self::MAX_ELEMENTS` long; the `serialize`/`deserialize` implementations
+    // will shorten them to `num_elements()` as needed
+    fn elements(&self) -> &[Self::Element];
+    fn elements_mut(&mut self) -> &mut [Self::Element];
+
+    // construct an instance from `header` with empty/zero'd elements that
+    // `deserialize` will populate before returning
+    fn from_header(header: Self::Header) -> Self;
+
+    // We can't `impl<T: VariablePacket> Serialize for T { .. }` due to
+    // coherence rules, so instead we'll plop the implementation here, and all
+    // our types that implement `VariablePacket` can now have 1-line
+    // `Serialize`/`Deserialize` implementations.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let header = self.header();
+        let num_elements = usize::from(self.num_elements());
+
+        // serialize ourselves as a tuple containing our header + each element
+        let mut tup = serializer.serialize_tuple(1 + num_elements)?;
+        tup.serialize_element(&header)?;
+        for element in &self.elements()[..num_elements] {
+            tup.serialize_element(element)?;
+        }
+
+        tup.end()
+    }
+
+    fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        Self: Sized,
+    {
+        struct TupleVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for TupleVisitor<T>
+        where
+            T: VariablePacket,
+        {
+            type Value = T;
+
+            fn expecting(
+                &self,
+                formatter: &mut std::fmt::Formatter,
+            ) -> std::fmt::Result {
+                write!(formatter, "{}", T::DESERIALIZE_NAME)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let header: T::Header = match seq.next_element()? {
+                    Some(header) => header,
+                    None => {
+                        return Err(A::Error::custom("missing packet header"))
+                    }
+                };
+                let mut out = T::from_header(header);
+                let num_elements = usize::from(out.num_elements());
+                if num_elements > T::MAX_ELEMENTS {
+                    return Err(A::Error::custom("packet length too long"));
+                }
+                for element in &mut out.elements_mut()[..num_elements] {
+                    *element = match seq.next_element()? {
+                        Some(element) => element,
+                        None => {
+                            return Err(A::Error::custom(
+                                "invalid packet length",
+                            ))
+                        }
+                    };
+                }
+                Ok(out)
+            }
+        }
+
+        let visitor = TupleVisitor(PhantomData);
+        deserializer.deserialize_tuple(1 + Self::MAX_ELEMENTS, visitor)
+    }
+}

--- a/gateway-messages/src/variable_packet.rs
+++ b/gateway-messages/src/variable_packet.rs
@@ -53,6 +53,11 @@ pub(crate) trait VariablePacket {
         // serialize ourselves as a tuple containing our header + each element
         let mut tup = serializer.serialize_tuple(1 + num_elements)?;
         tup.serialize_element(&header)?;
+
+        // This is the same as what serde's default serialize implementation
+        // does, but we should confirm this generates reasonable code if
+        // `Self::Element == u8`. Ideally rustc/llvm will reduce this loop to
+        // something approximating memcpy; TODO check this on the stm32.
         for element in &self.elements()[..num_elements] {
             tup.serialize_element(element)?;
         }

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -22,7 +22,7 @@ sp_request_milliseconds = 1_000
 [dropshot]
 # IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12222"
-#request_body_max_bytes = 1048576
+request_body_max_bytes = 1048576
 
 [log]
 # Show log messages of this level and more severe

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -252,7 +252,7 @@ impl SpCommunicator {
     async fn bulk_ignition_get_impl(
         &self,
     ) -> Result<Vec<IgnitionState>, Error> {
-        // XXX We currently assume we're know which ignition controller is our
+        // XXX We currently assume we know which ignition controller is our
         // local one, and only use it for ignition interactions.
         let controller = self.known_sps.ignition_controller;
 

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -287,7 +287,7 @@ impl SpCommunicator {
         &self,
         target: u8,
     ) -> Result<IgnitionState, Error> {
-        // XXX We currently assume we're know which ignition controller is our
+        // XXX We currently assume we know which ignition controller is our
         // local one, and only use it for ignition interactions.
         let controller = self.known_sps.ignition_controller;
 
@@ -333,7 +333,7 @@ impl SpCommunicator {
         target: u8,
         command: IgnitionCommand,
     ) -> Result<(), Error> {
-        // XXX We currently assume we're know which ignition controller is our
+        // XXX We currently assume we know which ignition controller is our
         // local one, and only use it for ignition interactions.
         let controller = self.known_sps.ignition_controller;
         let request = RequestKind::IgnitionCommand { target, command };

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -78,6 +78,9 @@ impl Error {
             ResponseKind::IgnitionState(_) => {
                 response_kind_names::IGNITION_STATE
             }
+            ResponseKind::BulkIgnitionState(_) => {
+                response_kind_names::BULK_IGNITION_STATE
+            }
             ResponseKind::IgnitionCommandAck => {
                 response_kind_names::IGNITION_COMMAND_ACK
             }
@@ -95,6 +98,7 @@ impl Error {
 mod response_kind_names {
     pub(super) const PONG: &str = "pong";
     pub(super) const IGNITION_STATE: &str = "ignition_state";
+    pub(super) const BULK_IGNITION_STATE: &str = "bulk_ignition_state";
     pub(super) const IGNITION_COMMAND_ACK: &str = "ignition_command_ack";
     pub(super) const SP_STATE: &str = "sp_state";
     pub(super) const SERIAL_CONSOLE_WRITE_ACK: &str =
@@ -236,6 +240,37 @@ impl SpCommunicator {
         }
 
         Ok(())
+    }
+
+    pub async fn bulk_ignition_get(
+        &self,
+        timeout: Duration,
+    ) -> Result<Vec<IgnitionState>, Error> {
+        tokio::time::timeout(timeout, self.bulk_ignition_get_impl()).await?
+    }
+
+    async fn bulk_ignition_get_impl(
+        &self,
+    ) -> Result<Vec<IgnitionState>, Error> {
+        // XXX We currently assume we're know which ignition controller is our
+        // local one, and only use it for ignition interactions.
+        let controller = self.known_sps.ignition_controller;
+
+        let request = RequestKind::BulkIgnitionState;
+
+        match self.request_response(controller, request).await? {
+            ResponseKind::BulkIgnitionState(state) => Ok(state.targets
+                [..usize::from(state.num_targets)]
+                .iter()
+                .copied()
+                .collect()),
+            other => {
+                return Err(Error::from_unhandled_response_kind(
+                    &other,
+                    response_kind_names::BULK_IGNITION_STATE,
+                ))
+            }
+        }
     }
 
     // How do we want to describe ignition targets? Currently we want to

--- a/gateway/src/sp_comms/serial_console_history.rs
+++ b/gateway/src/sp_comms/serial_console_history.rs
@@ -157,7 +157,7 @@ enum Slot {
     // an in-order serial console packet
     Valid {
         offset: u64,
-        len: u8,
+        len: u16,
         data: [u8; SerialConsole::MAX_DATA_PER_PACKET],
     },
 }

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -282,6 +282,16 @@ impl SpHandler for Handler {
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
+    fn bulk_ignition_state(
+        &mut self,
+    ) -> Result<gateway_messages::BulkIgnitionState, ResponseError> {
+        warn!(
+            &self.log,
+            "received bulk ignition state request; not supported by gimlet",
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
     fn ignition_command(
         &mut self,
         target: u8,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -160,8 +160,7 @@ impl SpHandler for Handler {
             BulkIgnitionState::MAX_IGNITION_TARGETS
         );
         let mut out = BulkIgnitionState {
-            num_targets: u16::try_from(num_targets)
-                .expect("more than 65535 ignition targets"),
+            num_targets: u16::try_from(num_targets).unwrap(),
             targets: [IgnitionState::default();
                 BulkIgnitionState::MAX_IGNITION_TARGETS],
         };

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -7,8 +7,8 @@ use crate::server::UdpServer;
 use anyhow::Result;
 use gateway_messages::sp_impl::{SpHandler, SpServer};
 use gateway_messages::{
-    IgnitionCommand, IgnitionFlags, IgnitionState, ResponseError, SerialNumber,
-    SpState,
+    BulkIgnitionState, IgnitionCommand, IgnitionFlags, IgnitionState,
+    ResponseError, SerialNumber, SpState,
 };
 use slog::{debug, error, info, warn, Logger};
 use tokio::{
@@ -148,6 +148,31 @@ impl SpHandler for Handler {
             state
         );
         Ok(*state)
+    }
+
+    fn bulk_ignition_state(
+        &mut self,
+    ) -> Result<BulkIgnitionState, ResponseError> {
+        let num_targets = self.ignition_targets.len();
+        assert!(
+            num_targets <= BulkIgnitionState::MAX_IGNITION_TARGETS,
+            "too many configured ignition targets (max is {})",
+            BulkIgnitionState::MAX_IGNITION_TARGETS
+        );
+        let mut out = BulkIgnitionState {
+            num_targets: u16::try_from(num_targets)
+                .expect("more than 65535 ignition targets"),
+            targets: [IgnitionState::default();
+                BulkIgnitionState::MAX_IGNITION_TARGETS],
+        };
+        out.targets[..num_targets].copy_from_slice(&self.ignition_targets);
+
+        debug!(
+            &self.log,
+            "received bulk ignition state request; sending state for {} targets",
+            num_targets,
+        );
+        Ok(out)
     }
 
     fn ignition_command(


### PR DESCRIPTION
Couple comments for folks based on conversations last week:

@ahl I dropped the pagination from this endpoint based on rolling in a single "ignition state of all SPs" message (I assume the pagination on this endpoint was originally because you were thinking we'd have to send the sidecar SP multiple messages, but please correct me if that's wrong!). I still plan to implement the timeout/pagination stuff we chatted about on Friday for the "get the state of all SPs" endpoint; I hope to have that in PR tomorrow or Wednesday.

@andrewjstone This implements the serde tweak you suggested at the beginning of the week where we have a fixed max size (to support both hubpack and no_std), but on the wire we only serialize the number of elements actually present. This may present a minor wrinkle to versioning, but that's a conversation we still need to have.