### PR TITLE
[nexus] Add the notion of 'volume' to the DB

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -573,6 +573,7 @@ pub enum ResourceType {
     Rack,
     Sled,
     SagaDbg,
+    Volume,
     Vpc,
     VpcFirewallRule,
     VpcSubnet,

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -169,7 +169,7 @@ CREATE TABLE omicron.public.volume (
      * consumed by some Upstairs code to perform the volume creation. The Rust
      * type of this column should be Crucible::VolumeConstructionRequest.
      */
-    data TEXT NOT NULL /* JSONB */
+    data TEXT NOT NULL
 );
 
 /*

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -135,8 +135,8 @@ CREATE TABLE omicron.public.Region (
     /* FK into the Dataset table */
     dataset_id UUID NOT NULL,
 
-    /* FK into the (Guest-visible, Virtual) Disk table */
-    disk_id UUID NOT NULL,
+    /* FK into the volume table */
+    volume_id UUID NOT NULL,
 
     /* Metadata describing the region */
     block_size INT NOT NULL,
@@ -148,7 +148,28 @@ CREATE TABLE omicron.public.Region (
  * Allow all regions belonging to a disk to be accessed quickly.
  */
 CREATE INDEX on omicron.public.Region (
-    disk_id
+    volume_id
+);
+
+/*
+ * A volume within Crucible
+ */
+CREATE TABLE omicron.public.volume (
+    id UUID PRIMARY KEY,
+    time_created TIMESTAMPTZ NOT NULL,
+    time_modified TIMESTAMPTZ NOT NULL,
+    time_deleted TIMESTAMPTZ,
+
+    /* child resource generation number, per RFD 192 */
+    rcgen INT NOT NULL,
+
+    /*
+     * A JSON document describing the construction of the volume, including all
+     * sub volumes. This is what will be POSTed to propolis, and eventually
+     * consumed by some Upstairs code to perform the volume creation. The Rust
+     * type of this column should be Crucible::VolumeConstructionRequest.
+     */
+    data TEXT NOT NULL /* JSONB */
 );
 
 /*
@@ -314,6 +335,9 @@ CREATE TABLE omicron.public.disk (
 
     /* Every Disk is in exactly one Project at a time. */
     project_id UUID NOT NULL,
+
+    /* Every disk consists of a root volume */
+    volume_id UUID NOT NULL,
 
     /*
      * TODO Would it make sense for the runtime state to live in a separate

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -73,8 +73,8 @@ use crate::db::{
         Name, NetworkInterface, Organization, OrganizationUpdate, OximeterInfo,
         ProducerEndpoint, Project, ProjectUpdate, Region,
         RoleAssignmentBuiltin, RoleBuiltin, RouterRoute, RouterRouteUpdate,
-        Sled, UpdateArtifactKind, UpdateAvailableArtifact, UserBuiltin, Vpc,
-        VpcFirewallRule, VpcRouter, VpcRouterUpdate, VpcSubnet,
+        Sled, UpdateArtifactKind, UpdateAvailableArtifact, UserBuiltin, Volume,
+        Vpc, VpcFirewallRule, VpcRouter, VpcRouterUpdate, VpcSubnet,
         VpcSubnetUpdate, VpcUpdate, Zpool,
     },
     pagination::paginated,
@@ -270,12 +270,12 @@ impl DataStore {
     }
 
     fn get_allocated_regions_query(
-        disk_id: Uuid,
+        volume_id: Uuid,
     ) -> impl RunnableQuery<(Dataset, Region)> {
         use db::schema::dataset::dsl as dataset_dsl;
         use db::schema::region::dsl as region_dsl;
         region_dsl::region
-            .filter(region_dsl::disk_id.eq(disk_id))
+            .filter(region_dsl::volume_id.eq(volume_id))
             .inner_join(
                 dataset_dsl::dataset
                     .on(region_dsl::dataset_id.eq(dataset_dsl::id)),
@@ -290,9 +290,9 @@ impl DataStore {
     /// may be used in a context where the disk is being deleted.
     pub async fn get_allocated_regions(
         &self,
-        disk_id: Uuid,
+        volume_id: Uuid,
     ) -> Result<Vec<(Dataset, Region)>, Error> {
-        Self::get_allocated_regions_query(disk_id)
+        Self::get_allocated_regions_query(volume_id)
             .get_results_async::<(Dataset, Region)>(self.pool())
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
@@ -324,7 +324,7 @@ impl DataStore {
     /// belong.
     pub async fn region_allocate(
         &self,
-        disk_id: Uuid,
+        volume_id: Uuid,
         params: &params::DiskCreate,
     ) -> Result<Vec<(Dataset, Region)>, Error> {
         use db::schema::dataset::dsl as dataset_dsl;
@@ -363,10 +363,9 @@ impl DataStore {
                 //
                 // If they are, return those regions and the associated
                 // datasets.
-                let datasets_and_regions = Self::get_allocated_regions_query(
-                    disk_id,
-                )
-                .get_results::<(Dataset, Region)>(conn)?;
+                let datasets_and_regions =
+                    Self::get_allocated_regions_query(volume_id)
+                        .get_results::<(Dataset, Region)>(conn)?;
                 if !datasets_and_regions.is_empty() {
                     return Ok(datasets_and_regions);
                 }
@@ -389,7 +388,7 @@ impl DataStore {
                     .map(|dataset| {
                         Region::new(
                             dataset.id(),
-                            disk_id,
+                            volume_id,
                             params.block_size().into(),
                             params.blocks_per_extent(),
                             params.extent_count(),
@@ -442,13 +441,13 @@ impl DataStore {
     /// Deletes all regions backing a disk.
     ///
     /// Also updates the storage usage on their corresponding datasets.
-    pub async fn regions_hard_delete(&self, disk_id: Uuid) -> DeleteResult {
+    pub async fn regions_hard_delete(&self, volume_id: Uuid) -> DeleteResult {
         use db::schema::dataset::dsl as dataset_dsl;
         use db::schema::region::dsl as region_dsl;
 
         // Remove the regions, collecting datasets they're from.
         let (dataset_id, size) = diesel::delete(region_dsl::region)
-            .filter(region_dsl::disk_id.eq(disk_id))
+            .filter(region_dsl::volume_id.eq(volume_id))
             .returning((
                 region_dsl::dataset_id,
                 region_dsl::block_size
@@ -478,6 +477,60 @@ impl DataStore {
             })?;
 
         Ok(())
+    }
+
+    pub async fn volume_create(&self, volume: Volume) -> CreateResult<Volume> {
+        use db::schema::volume::dsl;
+
+        diesel::insert_into(dsl::volume)
+            .values(volume.clone())
+            .on_conflict(dsl::id)
+            .do_nothing()
+            .returning(Volume::as_returning())
+            .get_result_async(self.pool())
+            .await
+            .map_err(|e| {
+                public_error_from_diesel_pool(
+                    e,
+                    ErrorHandler::Conflict(
+                        ResourceType::Volume,
+                        volume.id().to_string().as_str(),
+                    ),
+                )
+            })
+    }
+
+    pub async fn volume_delete(&self, volume_id: Uuid) -> DeleteResult {
+        use db::schema::volume::dsl;
+
+        let now = Utc::now();
+        diesel::update(dsl::volume)
+            .filter(dsl::id.eq(volume_id))
+            .set(dsl::time_deleted.eq(now))
+            .check_if_exists::<Volume>(volume_id)
+            .execute_and_check(self.pool())
+            .await
+            .map_err(|e| {
+                public_error_from_diesel_pool(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::Volume,
+                        LookupType::ById(volume_id),
+                    ),
+                )
+            })?;
+        Ok(())
+    }
+
+    pub async fn volume_get(&self, volume_id: Uuid) -> LookupResult<Volume> {
+        use db::schema::volume::dsl;
+
+        dsl::volume
+            .filter(dsl::id.eq(volume_id))
+            .select(Volume::as_select())
+            .get_result_async(self.pool())
+            .await
+            .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
     }
 
     /// Create a organization
@@ -1548,6 +1601,8 @@ impl DataStore {
 
     /// Updates a disk record to indicate it has been deleted.
     ///
+    /// Returns the volume ID of associated with the deleted disk.
+    ///
     /// Does not attempt to modify any resources (e.g. regions) which may
     /// belong to the disk.
     // TODO: Delete me (this function, not the disk!), ensure all datastore
@@ -1570,7 +1625,7 @@ impl DataStore {
     pub async fn project_delete_disk_no_auth(
         &self,
         disk_id: &Uuid,
-    ) -> Result<(), Error> {
+    ) -> Result<Uuid, Error> {
         use db::schema::disk::dsl;
         let pool = self.pool();
         let now = Utc::now();
@@ -1605,7 +1660,7 @@ impl DataStore {
             })?;
 
         match result.status {
-            UpdateStatus::Updated => Ok(()),
+            UpdateStatus::Updated => Ok(result.found.volume_id),
             UpdateStatus::NotUpdatedButExists => {
                 let disk = result.found;
                 let disk_state = disk.state();
@@ -1615,7 +1670,7 @@ impl DataStore {
                 {
                     // To maintain idempotency, if the disk has already been
                     // destroyed, don't throw an error.
-                    return Ok(());
+                    return Ok(disk.volume_id);
                 } else if !ok_to_delete_states.contains(disk_state.state()) {
                     return Err(Error::InvalidRequest {
                         message: format!(
@@ -3204,18 +3259,18 @@ mod test {
             "disk1",
             ByteCount::from_mebibytes_u32(500),
         );
-        let disk1_id = Uuid::new_v4();
-        // Currently, we only allocate one Region Set per disk.
+        let volume1_id = Uuid::new_v4();
+        // Currently, we only allocate one Region Set per volume.
         let expected_region_count = REGION_REDUNDANCY_THRESHOLD;
         let dataset_and_regions =
-            datastore.region_allocate(disk1_id, &params).await.unwrap();
+            datastore.region_allocate(volume1_id, &params).await.unwrap();
 
         // Verify the allocation.
         assert_eq!(expected_region_count, dataset_and_regions.len());
         let mut disk1_datasets = HashSet::new();
         for (dataset, region) in dataset_and_regions {
             assert!(disk1_datasets.insert(dataset.id()));
-            assert_eq!(disk1_id, region.disk_id());
+            assert_eq!(volume1_id, region.volume_id());
             assert_eq!(params.block_size(), region.block_size());
             assert_eq!(params.blocks_per_extent(), region.blocks_per_extent());
             assert_eq!(params.extent_count(), region.extent_count());
@@ -3227,14 +3282,14 @@ mod test {
             "disk2",
             ByteCount::from_mebibytes_u32(500),
         );
-        let disk2_id = Uuid::new_v4();
+        let volume2_id = Uuid::new_v4();
         let dataset_and_regions =
-            datastore.region_allocate(disk2_id, &params).await.unwrap();
+            datastore.region_allocate(volume2_id, &params).await.unwrap();
         assert_eq!(expected_region_count, dataset_and_regions.len());
         let mut disk2_datasets = HashSet::new();
         for (dataset, region) in dataset_and_regions {
             assert!(disk2_datasets.insert(dataset.id()));
-            assert_eq!(disk2_id, region.disk_id());
+            assert_eq!(volume2_id, region.volume_id());
             assert_eq!(params.block_size(), region.block_size());
             assert_eq!(params.blocks_per_extent(), region.blocks_per_extent());
             assert_eq!(params.extent_count(), region.extent_count());
@@ -3275,16 +3330,16 @@ mod test {
             datastore.dataset_upsert(dataset).await.unwrap();
         }
 
-        // Allocate regions from the datasets for this disk.
+        // Allocate regions from the datasets for this volume.
         let params = create_test_disk_create_params(
             "disk",
             ByteCount::from_mebibytes_u32(500),
         );
-        let disk_id = Uuid::new_v4();
+        let volume_id = Uuid::new_v4();
         let mut dataset_and_regions1 =
-            datastore.region_allocate(disk_id, &params).await.unwrap();
+            datastore.region_allocate(volume_id, &params).await.unwrap();
         let mut dataset_and_regions2 =
-            datastore.region_allocate(disk_id, &params).await.unwrap();
+            datastore.region_allocate(volume_id, &params).await.unwrap();
 
         // Give them a consistent order so we can easily compare them.
         let sort_vec = |v: &mut Vec<(Dataset, Region)>| {
@@ -3336,14 +3391,14 @@ mod test {
             datastore.dataset_upsert(dataset).await.unwrap();
         }
 
-        // Allocate regions from the datasets for this disk.
+        // Allocate regions from the datasets for this volume.
         let params = create_test_disk_create_params(
             "disk1",
             ByteCount::from_mebibytes_u32(500),
         );
-        let disk1_id = Uuid::new_v4();
+        let volume1_id = Uuid::new_v4();
         let err =
-            datastore.region_allocate(disk1_id, &params).await.unwrap_err();
+            datastore.region_allocate(volume1_id, &params).await.unwrap_err();
         assert!(err
             .to_string()
             .contains("Not enough datasets to allocate disks"));
@@ -3390,10 +3445,10 @@ mod test {
         // so we shouldn't have space for redundancy.
         let disk_size = test_zpool_size();
         let params = create_test_disk_create_params("disk1", disk_size);
-        let disk1_id = Uuid::new_v4();
+        let volume1_id = Uuid::new_v4();
 
         // NOTE: This *should* be an error, rather than succeeding.
-        datastore.region_allocate(disk1_id, &params).await.unwrap();
+        datastore.region_allocate(volume1_id, &params).await.unwrap();
 
         let _ = db.cleanup().await;
     }

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -764,7 +764,7 @@ pub struct Volume {
 
     rcgen: Generation,
 
-    pub data: String, // XXX serde_json::Value,
+    data: String,
 }
 
 impl Volume {

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -10,7 +10,7 @@ use crate::db::schema::{
     console_session, dataset, disk, instance, metric_producer,
     network_interface, organization, oximeter, project, rack, region,
     role_assignment_builtin, role_builtin, router_route, sled,
-    update_available_artifact, user_builtin, vpc, vpc_firewall_rule,
+    update_available_artifact, user_builtin, volume, vpc, vpc_firewall_rule,
     vpc_router, vpc_subnet, zpool,
 };
 use crate::defaults;
@@ -670,12 +670,12 @@ impl DatastoreCollection<Region> for Dataset {
     type CollectionIdColumn = region::dsl::dataset_id;
 }
 
-// Virtual disks contain regions
-impl DatastoreCollection<Region> for Disk {
+// Volumes contain regions
+impl DatastoreCollection<Region> for Volume {
     type CollectionId = Uuid;
-    type GenerationNumberColumn = disk::dsl::rcgen;
-    type CollectionTimeDeletedColumn = disk::dsl::time_deleted;
-    type CollectionIdColumn = region::dsl::disk_id;
+    type GenerationNumberColumn = volume::dsl::rcgen;
+    type CollectionTimeDeletedColumn = volume::dsl::time_deleted;
+    type CollectionIdColumn = region::dsl::volume_id;
 }
 
 /// Database representation of a Region.
@@ -699,7 +699,7 @@ pub struct Region {
     identity: RegionIdentity,
 
     dataset_id: Uuid,
-    disk_id: Uuid,
+    volume_id: Uuid,
 
     block_size: ByteCount,
     blocks_per_extent: i64,
@@ -709,7 +709,7 @@ pub struct Region {
 impl Region {
     pub fn new(
         dataset_id: Uuid,
-        disk_id: Uuid,
+        volume_id: Uuid,
         block_size: ByteCount,
         blocks_per_extent: i64,
         extent_count: i64,
@@ -717,15 +717,15 @@ impl Region {
         Self {
             identity: RegionIdentity::new(Uuid::new_v4()),
             dataset_id,
-            disk_id,
+            volume_id,
             block_size,
             blocks_per_extent,
             extent_count,
         }
     }
 
-    pub fn disk_id(&self) -> Uuid {
-        self.disk_id
+    pub fn volume_id(&self) -> Uuid {
+        self.volume_id
     }
     pub fn dataset_id(&self) -> Uuid {
         self.dataset_id
@@ -743,6 +743,38 @@ impl Region {
         // Per RFD 29, data is always encrypted at rest, and support for
         // external, customer-supplied keys is a non-requirement.
         true
+    }
+}
+
+#[derive(
+    Asset,
+    Queryable,
+    Insertable,
+    Debug,
+    Selectable,
+    Serialize,
+    Deserialize,
+    Clone,
+)]
+#[table_name = "volume"]
+pub struct Volume {
+    #[diesel(embed)]
+    identity: VolumeIdentity,
+    time_deleted: Option<DateTime<Utc>>,
+
+    rcgen: Generation,
+
+    pub data: String, // XXX serde_json::Value,
+}
+
+impl Volume {
+    pub fn new(id: Uuid, data: String) -> Self {
+        Self {
+            identity: VolumeIdentity::new(id),
+            time_deleted: None,
+            rcgen: Generation::new(),
+            data,
+        }
     }
 }
 
@@ -1021,6 +1053,9 @@ pub struct Disk {
     /// id for the project containing this Disk
     pub project_id: Uuid,
 
+    /// Root volume of the disk
+    pub volume_id: Uuid,
+
     /// runtime state of the Disk
     #[diesel(embed)]
     pub runtime_state: DiskRuntimeState,
@@ -1038,6 +1073,7 @@ impl Disk {
     pub fn new(
         disk_id: Uuid,
         project_id: Uuid,
+        volume_id: Uuid,
         params: params::DiskCreate,
         runtime_initial: DiskRuntimeState,
     ) -> Self {
@@ -1046,6 +1082,7 @@ impl Disk {
             identity,
             rcgen: external::Generation::new().into(),
             project_id,
+            volume_id,
             runtime_state: runtime_initial,
             size: params.size.into(),
             create_snapshot_id: params.snapshot_id,

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -16,6 +16,7 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
         rcgen -> Int8,
         project_id -> Uuid,
+        volume_id -> Uuid,
         disk_state -> Text,
         attach_instance_id -> Nullable<Uuid>,
         state_generation -> Int8,
@@ -207,11 +208,24 @@ table! {
         time_modified -> Timestamptz,
 
         dataset_id -> Uuid,
-        disk_id -> Uuid,
+        volume_id -> Uuid,
 
         block_size -> Int8,
         blocks_per_extent -> Int8,
         extent_count -> Int8,
+    }
+}
+
+table! {
+    volume (id) {
+        id -> Uuid,
+        time_created -> Timestamptz,
+        time_modified -> Timestamptz,
+        time_deleted -> Nullable<Timestamptz>,
+        rcgen -> Int8,
+
+        data -> Text, /* TODO Jsonb */
+        /* TODO: some sort of refcount? */
     }
 }
 

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -224,7 +224,7 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
         rcgen -> Int8,
 
-        data -> Text, /* TODO Jsonb */
+        data -> Text,
         /* TODO: some sort of refcount? */
     }
 }

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -816,8 +816,8 @@ async fn sdc_create_volume_record_undo(
 ) -> Result<(), anyhow::Error> {
     let osagactx = sagactx.user_data();
 
-    let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
-    osagactx.datastore().project_delete_disk_no_auth(&disk_id).await?;
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
+    osagactx.datastore().volume_delete(volume_id).await?;
     Ok(())
 }
 

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -539,6 +539,12 @@ fn saga_disk_create() -> SagaTemplate<SagaDiskCreate> {
     );
 
     template_builder.append(
+        "volume_id",
+        "GenerateVolumeId",
+        new_action_noop_undo(saga_generate_uuid),
+    );
+
+    template_builder.append(
         "created_disk",
         "CreateDiskRecord",
         ActionFunc::new_action(
@@ -560,6 +566,15 @@ fn saga_disk_create() -> SagaTemplate<SagaDiskCreate> {
     );
 
     template_builder.append(
+        "created_volume",
+        "CreateVolumeRecord",
+        ActionFunc::new_action(
+            sdc_create_volume_record,
+            sdc_create_volume_record_undo,
+        ),
+    );
+
+    template_builder.append(
         "disk_runtime",
         "FinalizeDiskRecord",
         new_action_noop_undo(sdc_finalize_disk_record),
@@ -575,9 +590,14 @@ async fn sdc_create_disk_record(
     let params = sagactx.saga_params();
 
     let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
+    // We admittedly reference the volume before it has been allocated,
+    // but this should be acceptable because the disk remains in a "Creating"
+    // state until the saga has completed.
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
     let disk = db::model::Disk::new(
         disk_id,
         params.project_id,
+        volume_id,
         params.create_params.clone(),
         db::model::DiskRuntimeState::new(),
     );
@@ -604,7 +624,7 @@ async fn sdc_alloc_regions(
 ) -> Result<Vec<(db::model::Dataset, db::model::Region)>, ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params();
-    let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
     // Ensure the disk is backed by appropriate regions.
     //
     // This allocates regions in the database, but the disk state is still
@@ -618,7 +638,7 @@ async fn sdc_alloc_regions(
     // returning all of them at once.
     let datasets_and_regions = osagactx
         .datastore()
-        .region_allocate(disk_id, &params.create_params)
+        .region_allocate(volume_id, &params.create_params)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(datasets_and_regions)
@@ -629,8 +649,8 @@ async fn sdc_alloc_regions_undo(
 ) -> Result<(), anyhow::Error> {
     let osagactx = sagactx.user_data();
 
-    let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
-    osagactx.datastore().regions_hard_delete(disk_id).await?;
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
+    osagactx.datastore().regions_hard_delete(volume_id).await?;
     Ok(())
 }
 
@@ -649,7 +669,7 @@ async fn ensure_region_in_dataset(
         // TODO: Can we avoid casting from UUID to string?
         // NOTE: This'll require updating the crucible agent client.
         id: RegionId(region.id().to_string()),
-        volume_id: region.disk_id().to_string(),
+        volume_id: region.volume_id().to_string(),
         encrypted: region.encrypted(),
         cert_pem: None,
         key_pem: None,
@@ -772,6 +792,35 @@ async fn sdc_regions_ensure_undo(
     Ok(())
 }
 
+async fn sdc_create_volume_record(
+    sagactx: ActionContext<SagaDiskCreate>,
+) -> Result<db::model::Volume, ActionError> {
+    let osagactx = sagactx.user_data();
+
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
+    let volume = db::model::Volume::new(
+        volume_id,
+        // TODO: Patch this up with serialized contents that Crucible can use.
+        "Some Data".to_string(),
+    );
+    let volume_created = osagactx
+        .datastore()
+        .volume_create(volume)
+        .await
+        .map_err(ActionError::action_failed)?;
+    Ok(volume_created)
+}
+
+async fn sdc_create_volume_record_undo(
+    sagactx: ActionContext<SagaDiskCreate>,
+) -> Result<(), anyhow::Error> {
+    let osagactx = sagactx.user_data();
+
+    let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
+    osagactx.datastore().project_delete_disk_no_auth(&disk_id).await?;
+    Ok(())
+}
+
 async fn sdc_finalize_disk_record(
     sagactx: ActionContext<SagaDiskCreate>,
 ) -> Result<(), ActionError> {
@@ -823,7 +872,7 @@ fn saga_disk_delete() -> SagaTemplate<SagaDiskDelete> {
     let mut template_builder = SagaTemplateBuilder::new();
 
     template_builder.append(
-        "no_result",
+        "volume_id",
         "DeleteDiskRecord",
         // TODO: See the comment on the "DeleteRegions" step,
         // we may want to un-delete the disk if we cannot remove
@@ -852,32 +901,37 @@ fn saga_disk_delete() -> SagaTemplate<SagaDiskDelete> {
         new_action_noop_undo(sdd_delete_region_records),
     );
 
+    template_builder.append(
+        "no_result",
+        "DeleteVolumeRecord",
+        new_action_noop_undo(sdd_delete_volume_record),
+    );
+
     template_builder.build()
 }
 
 async fn sdd_delete_disk_record(
     sagactx: ActionContext<SagaDiskDelete>,
-) -> Result<(), ActionError> {
+) -> Result<Uuid, ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params();
 
-    osagactx
+    let volume_id = osagactx
         .datastore()
         .project_delete_disk_no_auth(&params.disk_id)
         .await
         .map_err(ActionError::action_failed)?;
-    Ok(())
+    Ok(volume_id)
 }
 
 async fn sdd_delete_regions(
     sagactx: ActionContext<SagaDiskDelete>,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
-    let params = sagactx.saga_params();
-
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
     let datasets_and_regions = osagactx
         .datastore()
-        .get_allocated_regions(params.disk_id)
+        .get_allocated_regions(volume_id)
         .await
         .map_err(ActionError::action_failed)?;
     delete_regions(datasets_and_regions)
@@ -890,10 +944,23 @@ async fn sdd_delete_region_records(
     sagactx: ActionContext<SagaDiskDelete>,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
-    let params = sagactx.saga_params();
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
     osagactx
         .datastore()
-        .regions_hard_delete(params.disk_id)
+        .regions_hard_delete(volume_id)
+        .await
+        .map_err(ActionError::action_failed)?;
+    Ok(())
+}
+
+async fn sdd_delete_volume_record(
+    sagactx: ActionContext<SagaDiskDelete>,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let volume_id = sagactx.lookup::<Uuid>("volume_id")?;
+    osagactx
+        .datastore()
+        .volume_delete(volume_id)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())


### PR DESCRIPTION
Credit to jmpesp's branch at

  https://github.com/jmpesp/omicron/tree/volumes

for providing the initial framwork.

This change:
- Adds Volume table to CRDB
- Modifies regions to point to Volumes
- Modifies disks to point to Volumes
- Allocates volume records during disk creation
- Removes volume records during saga unwinding / disk deletion

There are known shortcomings of this PR:
- Volume data is "made up", and not yet being supplied to Crucible
- This PR assumes the relationship between volumes and disks is 1:1
for the purposes of deletion. In the future, many objects may hold
references to volumes, which may change the accounting regarding
"when should a volume be deleted".