### PR TITLE
authz: protect VPC endpoints

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -479,3 +479,4 @@ impl ApiResourceError for ProjectChild {
 
 pub type Disk = ProjectChild;
 pub type Instance = ProjectChild;
+pub type Vpc = ProjectChild;

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -170,6 +170,7 @@ pub use api_resources::FleetChild;
 pub use api_resources::Instance;
 pub use api_resources::Organization;
 pub use api_resources::Project;
+pub use api_resources::Vpc;
 pub use api_resources::FLEET;
 
 mod context;

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2012,18 +2012,74 @@ impl DataStore {
 
     // VPCs
 
+    /// Fetches a Vpc from the database and returns both the database row
+    /// and an [`authz::Vpc`] for doing authz checks
+    ///
+    /// See [`DataStore::organization_lookup_noauthz()`] for intended use cases
+    /// and caveats.
+    // TODO-security See the note on organization_lookup_noauthz().
+    async fn vpc_lookup_noauthz(
+        &self,
+        authz_project: &authz::Project,
+        vpc_name: &Name,
+    ) -> LookupResult<(authz::Vpc, Vpc)> {
+        use db::schema::vpc::dsl;
+        dsl::vpc
+            .filter(dsl::time_deleted.is_null())
+            .filter(dsl::project_id.eq(authz_project.id()))
+            .filter(dsl::name.eq(vpc_name.clone()))
+            .select(Vpc::as_select())
+            .first_async(self.pool())
+            .await
+            .map_err(|e| {
+                public_error_from_diesel_pool(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::Vpc,
+                        LookupType::ByName(vpc_name.as_str().to_owned()),
+                    ),
+                )
+            })
+            .map(|d| {
+                (
+                    authz_project.child_generic(
+                        ResourceType::Vpc,
+                        d.id(),
+                        LookupType::from(&vpc_name.0),
+                    ),
+                    d,
+                )
+            })
+    }
+
+    /// Lookup a Vpc by name and return the full database record, along
+    /// with an [`authz::Vpc`] for subsequent authorization checks
+    pub async fn vpc_fetch(
+        &self,
+        opctx: &OpContext,
+        authz_project: &authz::Project,
+        name: &Name,
+    ) -> LookupResult<(authz::Vpc, Vpc)> {
+        let (authz_vpc, db_vpc) =
+            self.vpc_lookup_noauthz(authz_project, name).await?;
+        opctx.authorize(authz::Action::Read, &authz_vpc).await?;
+        Ok((authz_vpc, db_vpc))
+    }
+
     pub async fn project_list_vpcs(
         &self,
-        project_id: &Uuid,
+        opctx: &OpContext,
+        authz_project: &authz::Project,
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<Vpc> {
-        use db::schema::vpc::dsl;
+        opctx.authorize(authz::Action::ListChildren, authz_project).await?;
 
+        use db::schema::vpc::dsl;
         paginated(dsl::vpc, dsl::name, &pagparams)
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::project_id.eq(*project_id))
+            .filter(dsl::project_id.eq(authz_project.id()))
             .select(Vpc::as_select())
-            .load_async(self.pool())
+            .load_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
     }
@@ -2073,6 +2129,7 @@ impl DataStore {
         Ok(())
     }
 
+    // XXX remove
     pub async fn vpc_fetch_by_name(
         &self,
         project_id: &Uuid,

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2153,7 +2153,8 @@ impl DataStore {
             })
     }
 
-    // XXX remove
+    // TODO-security TODO-cleanup Remove this function.  Update callers to use
+    // vpc_lookup_by_path() or vpc_fetch() instead.
     pub async fn vpc_fetch_by_name(
         &self,
         project_id: &Uuid,

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2185,6 +2185,8 @@ impl DataStore {
         opctx: &OpContext,
         authz_vpc: &authz::Vpc,
     ) -> DeleteResult {
+        opctx.authorize(authz::Action::Delete, authz_vpc).await?;
+
         use db::schema::vpc::dsl;
 
         // Note that we don't ensure the firewall rules are empty here, because

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1238,8 +1238,10 @@ async fn project_vpcs_put_vpc(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         nexus
             .project_update_vpc(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1207,8 +1207,10 @@ async fn project_vpcs_post(
     let project_name = &path.project_name;
     let new_vpc_params = &new_vpc.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let vpc = nexus
             .project_create_vpc(
+                &opctx,
                 &organization_name,
                 &project_name,
                 &new_vpc_params,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1130,8 +1130,10 @@ async fn project_vpcs_get(
     let organization_name = &path.organization_name;
     let project_name = &path.project_name;
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let vpcs = nexus
             .project_list_vpcs(
+                &opctx,
                 &organization_name,
                 &project_name,
                 &data_page_params_for(&rqctx, &query)?
@@ -1176,8 +1178,9 @@ async fn project_vpcs_get_vpc(
     let project_name = &path.project_name;
     let vpc_name = &path.vpc_name;
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let vpc = nexus
-            .project_lookup_vpc(&organization_name, &project_name, &vpc_name)
+            .vpc_fetch(&opctx, &organization_name, &project_name, &vpc_name)
             .await?;
         Ok(HttpResponseOk(vpc.into()))
     };

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1233,13 +1233,13 @@ async fn project_vpcs_put_vpc(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<VpcPathParam>,
     updated_vpc: TypedBody<params::VpcUpdate>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+) -> Result<HttpResponseOk<Vpc>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        nexus
+        let newvpc = nexus
             .project_update_vpc(
                 &opctx,
                 &path.organization_name,
@@ -1248,7 +1248,7 @@ async fn project_vpcs_put_vpc(
                 &updated_vpc.into_inner(),
             )
             .await?;
-        Ok(HttpResponseUpdatedNoContent())
+        Ok(HttpResponseOk(newvpc.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1272,8 +1272,14 @@ async fn project_vpcs_delete_vpc(
     let project_name = &path.project_name;
     let vpc_name = &path.vpc_name;
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         nexus
-            .project_delete_vpc(&organization_name, &project_name, &vpc_name)
+            .project_delete_vpc(
+                &opctx,
+                &organization_name,
+                &project_name,
+                &vpc_name,
+            )
             .await?;
         Ok(HttpResponseDeleted())
     };

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1763,7 +1763,9 @@ impl Nexus {
             .1)
     }
 
-    // XXX revisit this function and its callers
+    // TODO-security TODO-cleanup Remove this function.  Callers should use
+    // vpc_lookup_by_path() / vpc_fetch() instead, or we should create a more
+    // useful pattern for looking up records by path (e.g., *_fetch_by_path()).
     pub async fn project_lookup_vpc(
         &self,
         organization_name: &Name,

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1780,21 +1780,19 @@ impl Nexus {
 
     pub async fn project_update_vpc(
         &self,
+        opctx: &OpContext,
         organization_name: &Name,
         project_name: &Name,
         vpc_name: &Name,
         params: &params::VpcUpdate,
     ) -> UpdateResult<()> {
-        let project_id = self
+        let authz_vpc = self
             .db_datastore
-            .project_lookup_by_path(organization_name, project_name)
-            .await?
-            .id();
-        let vpc =
-            self.db_datastore.vpc_fetch_by_name(&project_id, vpc_name).await?;
+            .vpc_lookup_by_path(organization_name, project_name, vpc_name)
+            .await?;
         Ok(self
             .db_datastore
-            .project_update_vpc(&vpc.id(), params.clone().into())
+            .project_update_vpc(opctx, &authz_vpc, params.clone().into())
             .await?)
     }
 

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1785,15 +1785,14 @@ impl Nexus {
         project_name: &Name,
         vpc_name: &Name,
         params: &params::VpcUpdate,
-    ) -> UpdateResult<()> {
+    ) -> UpdateResult<db::model::Vpc> {
         let authz_vpc = self
             .db_datastore
             .vpc_lookup_by_path(organization_name, project_name, vpc_name)
             .await?;
-        Ok(self
-            .db_datastore
+        self.db_datastore
             .project_update_vpc(opctx, &authz_vpc, params.clone().into())
-            .await?)
+            .await
     }
 
     pub async fn project_delete_vpc(

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -1541,55 +1541,6 @@ impl Nexus {
             .map(|_| ())
     }
 
-    /**
-     * Creates a new network interface for this instance
-     */
-    pub async fn instance_create_network_interface(
-        &self,
-        organization_name: &Name,
-        project_name: &Name,
-        instance_name: &Name,
-        vpc_name: &Name,
-        subnet_name: &Name,
-        params: &params::NetworkInterfaceCreate,
-    ) -> CreateResult<db::model::NetworkInterface> {
-        let authz_instance = self
-            .db_datastore
-            .instance_lookup_by_path(
-                organization_name,
-                project_name,
-                instance_name,
-            )
-            .await?;
-        let vpc = self
-            .db_datastore
-            .vpc_fetch_by_name(&authz_instance.project().id(), vpc_name)
-            .await?;
-        let subnet = self
-            .db_datastore
-            .vpc_subnet_fetch_by_name(&vpc.id(), subnet_name)
-            .await?;
-
-        let mac = db::model::MacAddr::new()?;
-
-        let interface_id = Uuid::new_v4();
-        // Request an allocation
-        let ip = None;
-        let interface = db::model::IncompleteNetworkInterface::new(
-            interface_id,
-            authz_instance.id(),
-            // TODO-correctness: vpc_id here is used for name uniqueness. Should
-            // interface names be unique to the subnet's VPC or to the
-            // VPC associated with the instance's default interface?
-            vpc.id(),
-            subnet,
-            mac,
-            ip,
-            params.clone(),
-        );
-        self.db_datastore.instance_create_network_interface(interface).await
-    }
-
     pub async fn project_list_vpcs(
         &self,
         opctx: &OpContext,

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -107,6 +107,11 @@ lazy_static! {
             url: &*DEMO_ORG_PROJECTS_URL,
             body: serde_json::to_value(&*DEMO_PROJECT_CREATE).unwrap(),
         },
+        // Create a VPC in the Project
+        SetupReq {
+            url: &*DEMO_PROJECT_URL_VPCS,
+            body: serde_json::to_value(&*DEMO_VPC_CREATE).unwrap(),
+        },
         // Create a Disk in the Project
         SetupReq {
             url: &*DEMO_PROJECT_URL_DISKS,
@@ -141,12 +146,28 @@ lazy_static! {
         format!("{}/disks", *DEMO_PROJECT_URL);
     static ref DEMO_PROJECT_URL_INSTANCES: String =
         format!("{}/instances", *DEMO_PROJECT_URL);
+    static ref DEMO_PROJECT_URL_VPCS: String =
+        format!("{}/vpcs", *DEMO_PROJECT_URL);
     static ref DEMO_PROJECT_CREATE: params::ProjectCreate =
         params::ProjectCreate {
             identity: IdentityMetadataCreateParams {
                 name: DEMO_PROJECT_NAME.clone(),
                 description: "".parse().unwrap(),
             },
+        };
+
+    // VPC used for testing
+    static ref DEMO_VPC_NAME: Name = "demo-vpc".parse().unwrap();
+    static ref DEMO_VPC_URL: String =
+        format!("{}/{}", *DEMO_PROJECT_URL_VPCS, *DEMO_VPC_NAME);
+    static ref DEMO_VPC_CREATE: params::VpcCreate =
+        params::VpcCreate {
+            identity: IdentityMetadataCreateParams {
+                name: DEMO_VPC_NAME.clone(),
+                description: "".parse().unwrap(),
+            },
+            ipv6_prefix: None,
+            dns_name: DEMO_VPC_NAME.clone(),
         };
 
     // Disk used for testing
@@ -350,6 +371,36 @@ lazy_static! {
                         },
                     }).unwrap()
                 ),
+            ],
+        },
+
+        /* VPCs */
+        VerifyEndpoint {
+            url: &*DEMO_PROJECT_URL_VPCS,
+            visibility: Visibility::Protected,
+            allowed_methods: vec![
+                AllowedMethod::Get,
+                AllowedMethod::Post(
+                    serde_json::to_value(&*DEMO_VPC_CREATE).unwrap()
+                ),
+            ],
+        },
+
+        VerifyEndpoint {
+            url: &*DEMO_VPC_URL,
+            visibility: Visibility::Protected,
+            allowed_methods: vec![
+                AllowedMethod::Get,
+                AllowedMethod::Put(
+                    serde_json::to_value(&params::VpcUpdate {
+                        identity: IdentityMetadataUpdateParams {
+                            name: None,
+                            description: Some("different".to_string())
+                        },
+                        dns_name: None,
+                    }).unwrap()
+                ),
+                AllowedMethod::Delete,
             ],
         },
 

--- a/nexus/tests/integration_tests/vpcs.rs
+++ b/nexus/tests/integration_tests/vpcs.rs
@@ -2,23 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use dropshot::test_util::ClientTestContext;
+use dropshot::HttpErrorResponseBody;
 use http::method::Method;
 use http::StatusCode;
-use omicron_common::api::external::IdentityMetadataCreateParams;
-use omicron_common::api::external::IdentityMetadataUpdateParams;
-use omicron_common::api::external::Ipv6Net;
-use omicron_nexus::external_api::{params, views::Vpc};
-
-use dropshot::test_util::object_get;
-use dropshot::test_util::objects_list_page;
-use dropshot::test_util::ClientTestContext;
-
+use nexus_test_utils::http_testing::AuthnMode;
+use nexus_test_utils::http_testing::NexusRequest;
+use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::identity_eq;
+use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::resource_helpers::{
     create_organization, create_project, create_vpc, create_vpc_with_error,
 };
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
+use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_common::api::external::IdentityMetadataUpdateParams;
+use omicron_common::api::external::Ipv6Net;
+use omicron_nexus::external_api::{params, views::Vpc};
 
 #[nexus_test]
 async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
@@ -35,6 +36,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     let project_name2 = "pokemon";
     let _ = create_project(&client, &org_name, &project_name2).await;
 
+    // XXX Lots of these need fixing
     /* List vpcs.  We see the default VPC, and nothing else. */
     let mut vpcs = vpcs_list(&client, &vpcs_url).await;
     assert_eq!(vpcs.len(), 1);
@@ -42,40 +44,48 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(vpcs[0].dns_name, "default");
     let default_vpc = vpcs.remove(0);
 
-    /* Make sure we get a 404 if we fetch one. */
+    /* Make sure we get a 404 if we fetch or delete one. */
     let vpc_url = format!("{}/just-rainsticks", vpcs_url);
-
-    let error = client
-        .make_request_error(Method::GET, &vpc_url, StatusCode::NOT_FOUND)
-        .await;
-    assert_eq!(error.message, "not found: vpc with name \"just-rainsticks\"");
-
-    /* Ditto if we try to delete one. */
-    let error = client
-        .make_request_error(Method::DELETE, &vpc_url, StatusCode::NOT_FOUND)
-        .await;
-    assert_eq!(error.message, "not found: vpc with name \"just-rainsticks\"");
+    for method in &[Method::GET, Method::DELETE] {
+        let error: HttpErrorResponseBody = NexusRequest::expect_failure(
+            client,
+            StatusCode::NOT_FOUND,
+            method.clone(),
+            &vpc_url,
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .unwrap()
+        .parsed_body()
+        .unwrap();
+        assert_eq!(
+            error.message,
+            "not found: vpc with name \"just-rainsticks\""
+        );
+    }
 
     /*
      * Make sure creating a VPC fails if we specify an IPv6 prefix that is
      * not a valid ULA range.
      */
     let bad_prefix = Ipv6Net("2000:1000::/48".parse().unwrap());
-    let _ = client
-        .make_request_error_body(
-            Method::POST,
-            &vpcs_url,
-            params::VpcCreate {
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &vpcs_url)
+            .expect_status(Some(StatusCode::BAD_REQUEST))
+            .body(Some(&params::VpcCreate {
                 identity: IdentityMetadataCreateParams {
                     name: "just-rainsticks".parse().unwrap(),
                     description: String::from("vpc description"),
                 },
                 ipv6_prefix: Some(bad_prefix),
                 dns_name: "abc".parse().unwrap(),
-            },
-            StatusCode::BAD_REQUEST,
-        )
-        .await;
+            })),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
 
     /* Create a VPC. */
     let vpc_name = "just-rainsticks";
@@ -127,12 +137,24 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
         },
         dns_name: Some("def".parse().unwrap()),
     };
-    vpc_put(&client, &vpc_url, update_params).await;
+    let updated_vpc = vpc_put(&client, &vpc_url, update_params).await;
+    assert_eq!(updated_vpc.identity.name, "new-name");
+    assert_eq!(updated_vpc.identity.description, "another description");
+    assert_eq!(updated_vpc.dns_name, "def");
 
     // fetching by old name fails
-    let error = client
-        .make_request_error(Method::GET, &vpc_url, StatusCode::NOT_FOUND)
-        .await;
+    let error: HttpErrorResponseBody = NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &vpc_url,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
     assert_eq!(error.message, "not found: vpc with name \"just-rainsticks\"");
 
     // new url with new name
@@ -145,15 +167,25 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(vpc.dns_name, "def");
 
     /* Delete the VPC. */
-    client
-        .make_request_no_body(Method::DELETE, &vpc_url, StatusCode::NO_CONTENT)
+    NexusRequest::object_delete(client, &vpc_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
         .await
         .unwrap();
 
     /* Now we expect a 404 on fetch */
-    let error = client
-        .make_request_error(Method::GET, &vpc_url, StatusCode::NOT_FOUND)
-        .await;
+    let error: HttpErrorResponseBody = NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &vpc_url,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
     assert_eq!(error.message, "not found: vpc with name \"new-name\"");
 
     /* And the list should be empty (aside from default VPC) again */
@@ -163,27 +195,31 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
 }
 
 async fn vpcs_list(client: &ClientTestContext, vpcs_url: &str) -> Vec<Vpc> {
-    objects_list_page::<Vpc>(client, vpcs_url).await.items
+    objects_list_page_authz::<Vpc>(client, vpcs_url).await.items
 }
 
 async fn vpc_get(client: &ClientTestContext, vpc_url: &str) -> Vpc {
-    object_get::<Vpc>(client, vpc_url).await
+    NexusRequest::object_get(client, vpc_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .unwrap()
+        .parsed_body()
+        .unwrap()
 }
 
 async fn vpc_put(
     client: &ClientTestContext,
     vpc_url: &str,
     params: params::VpcUpdate,
-) {
-    client
-        .make_request(
-            Method::PUT,
-            &vpc_url,
-            Some(params),
-            StatusCode::NO_CONTENT,
-        )
+) -> Vpc {
+    NexusRequest::object_put(client, vpc_url, Some(&params))
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
         .await
-        .unwrap();
+        .unwrap()
+        .parsed_body()
+        .unwrap()
 }
 
 fn vpcs_eq(vpc1: &Vpc, vpc2: &Vpc) {

--- a/nexus/tests/integration_tests/vpcs.rs
+++ b/nexus/tests/integration_tests/vpcs.rs
@@ -36,7 +36,6 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     let project_name2 = "pokemon";
     let _ = create_project(&client, &org_name, &project_name2).await;
 
-    // XXX Lots of these need fixing
     /* List vpcs.  We see the default VPC, and nothing else. */
     let mut vpcs = vpcs_list(&client, &vpcs_url).await;
     assert_eq!(vpcs.len(), 1);

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1889,8 +1889,15 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "resource updated"
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vpc"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -365,7 +365,7 @@ function cmd_vpc_get
 function cmd_vpc_delete
 {
 	[[ $# != 3 ]] && usage "expected ORGANIZATION_NAME PROJECT_NAME VPC_NAME"
-	do_curl "/organizations/$1/projects/$2/vpcs/$3" -X DELETE
+	do_curl_authn "/organizations/$1/projects/$2/vpcs/$3" -X DELETE
 }
 
 function cmd_vpc_subnets_list

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -353,7 +353,7 @@ function cmd_vpc_create_demo
 {
 	[[ $# != 4 ]] && usage "expected ORGANIZATION_NAME PROJECT_NAME VPC_NAME DNS_NAME"
 	mkjson name="$3" dns_name="$4" description="a vpc called $3" |
-		do_curl "/organizations/$1/projects/$2/vpcs" -X POST -T -
+		do_curl_authn "/organizations/$1/projects/$2/vpcs" -X POST -T -
 }
 
 function cmd_vpc_get

--- a/tools/oxapi_demo
+++ b/tools/oxapi_demo
@@ -260,7 +260,7 @@ function cmd_project_list_disks
 function cmd_project_list_vpcs
 {
 	[[ $# != 2 ]] && usage "expected ORGANIZATION_NAME PROJECT_NAME"
-	do_curl "/organizations/$1/projects/$2/vpcs"
+	do_curl_authn "/organizations/$1/projects/$2/vpcs"
 }
 
 function cmd_instance_create_demo
@@ -356,11 +356,10 @@ function cmd_vpc_create_demo
 		do_curl "/organizations/$1/projects/$2/vpcs" -X POST -T -
 }
 
-
 function cmd_vpc_get
 {
 	[[ $# != 3 ]] && usage "expected ORGANIZATION_NAME PROJECT_NAME VPC_NAME"
-	do_curl "/organizations/$1/projects/$2/vpcs/$3"
+	do_curl_authn "/organizations/$1/projects/$2/vpcs/$3"
 }
 
 function cmd_vpc_delete


### PR DESCRIPTION
See #419 for context.  This change adds authz protection for VPC create/delete/update/get and the "list VPCs" endpoint.  This does not affect any of the resources underneath VPCs (subnets, routers, firewalls, etc.).

I ran into #742 and fixed that here as well.