### PR TITLE
Simplifies target strings as used in network resources

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1277,19 +1277,15 @@ pub struct VpcRouter {
     JsonSchema,
 )]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
-#[display(style = "lowercase")]
+#[display("{}:{0}", style = "lowercase")]
 pub enum RouteTarget {
     /// Forward traffic to a particular IP address.
-    #[display("{}:{0}")]
     Ip(IpAddr),
-    /// Forward traffic a VPC
-    #[display("{}:{0}")]
+    /// Forward traffic to a VPC
     Vpc(Name),
-    /// Forward traffic a VPC Subnet
-    #[display("{}:{0}")]
+    /// Forward traffic to a VPC Subnet
     Subnet(Name),
-    /// Forward traffic a specific instance
-    #[display("{}:{0}")]
+    /// Forward traffic to a specific instance
     Instance(Name),
     #[display("inetgw:{0}")]
     /// Forward traffic to an internet gateway
@@ -1556,21 +1552,17 @@ pub enum VpcFirewallRuleTarget {
     JsonSchema,
 )]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
-#[display(style = "lowercase")]
+#[display("{}:{0}", style = "lowercase")]
 pub enum VpcFirewallRuleHostFilter {
     /// The rule applies to traffic from/to all instances in the VPC
-    #[display("{}:{0}")]
     Vpc(Name),
     /// The rule applies to traffic from/to all instances in the VPC Subnet
-    #[display("{}:{0}")]
     Subnet(Name),
     /// The rule applies to traffic from/to this specific instance
-    #[display("{}:{0}")]
     Instance(Name),
     // Tags not yet implemented
     // Tag(Name),
     /// The rule applies to traffic from/to a specific IP address or IP subnet
-    #[display("{}:{0}")]
     Ip(IpNet),
     // TODO: Internet gateways not yet implemented
     // #[display("inetgw:{0}")]

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1311,9 +1311,10 @@ pub enum RouteTarget {
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 #[display("{}:{0}", style = "lowercase")]
 pub enum RouteDestination {
-    /// Route applies to traffic destined for a specific IP address or IP
-    /// subnet.
-    Ip(IpNet),
+    /// Route applies to traffic destined for a specific IP address
+    Ip(IpAddr),
+    /// Route applies to traffic destined for a specific IP subnet
+    IpNet(IpNet),
     /// Route applies to traffic destined for the given VPC.
     Vpc(Name),
     /// Route applies to traffic
@@ -1533,8 +1534,10 @@ pub enum VpcFirewallRuleTarget {
     Subnet(Name),
     /// The rule applies to this specific instance
     Instance(Name),
-    /// The rule applies to a specific IP address or IP subnet
-    Ip(IpNet),
+    /// The rule applies to a specific IP address
+    Ip(IpAddr),
+    /// The rule applies to a specific IP subnet
+    IpNet(IpNet),
     // Tags not yet implemented
     //Tag(Name),
 }
@@ -1562,8 +1565,10 @@ pub enum VpcFirewallRuleHostFilter {
     Instance(Name),
     // Tags not yet implemented
     // Tag(Name),
-    /// The rule applies to traffic from/to a specific IP address or IP subnet
-    Ip(IpNet),
+    /// The rule applies to traffic from/to a specific IP address
+    Ip(IpAddr),
+    /// The rule applies to traffic from/to a specific IP subnet
+    IpNet(IpNet),
     // TODO: Internet gateways not yet implemented
     // #[display("inetgw:{0}")]
     // InternetGateway(Name),
@@ -2211,8 +2216,8 @@ mod test {
             "ip:192.168.0.10".parse().unwrap()
         );
         assert_eq!(
-            RouteDestination::Ip(network),
-            "ip:fd00::/64".parse().unwrap()
+            RouteDestination::IpNet(network),
+            "ipnet:fd00::/64".parse().unwrap()
         );
         assert!("foo:foo".parse::<RouteDestination>().is_err());
         assert!("foo".parse::<RouteDestination>().is_err());
@@ -2240,8 +2245,8 @@ mod test {
             "ip:192.168.0.10".parse().unwrap()
         );
         assert_eq!(
-            VpcFirewallRuleTarget::Ip(network),
-            "ip:fd00::/64".parse().unwrap()
+            VpcFirewallRuleTarget::IpNet(network),
+            "ipnet:fd00::/64".parse().unwrap()
         );
         assert!("foo:foo".parse::<VpcFirewallRuleTarget>().is_err());
         assert!("foo".parse::<VpcFirewallRuleTarget>().is_err());
@@ -2269,8 +2274,8 @@ mod test {
             "ip:192.168.0.10".parse().unwrap()
         );
         assert_eq!(
-            VpcFirewallRuleHostFilter::Ip(network),
-            "ip:fd00::/64".parse().unwrap()
+            VpcFirewallRuleHostFilter::IpNet(network),
+            "ipnet:fd00::/64".parse().unwrap()
         );
         assert!("foo:foo".parse::<VpcFirewallRuleHostFilter>().is_err());
         assert!("foo".parse::<VpcFirewallRuleHostFilter>().is_err());

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -35,6 +35,8 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FormatResult;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::str::FromStr;
 use uuid::Uuid;
@@ -1039,7 +1041,7 @@ impl From<steno::SagaStateView> for SagaState {
 }
 
 /// An `Ipv4Net` represents a IPv4 subnetwork, including the address and network mask.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Serialize)]
 pub struct Ipv4Net(pub ipnetwork::Ipv4Network);
 
 impl Ipv4Net {
@@ -1088,11 +1090,11 @@ impl JsonSchema for Ipv4Net {
                     pattern: Some(
                         concat!(
                             // 10.x.x.x/8
-                            r#"^(10\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9]\.){2}(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[0-9]|2[0-8]|[8-9]))$"#,
+                            r#"(^(10\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9]\.){2}(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[0-9]|2[0-8]|[8-9]))$)|"#,
                             // 172.16.x.x/12
-                            r#"^(172\.16\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[2-9]|2[0-8]))$"#,
+                            r#"(^(172\.16\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[2-9]|2[0-8]))$)|"#,
                             // 192.168.x.x/16
-                            r#"^(192\.168\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[6-9]|2[0-8]))$"#,
+                            r#"(^(192\.168\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[6-9]|2[0-8]))$)"#,
                         ).to_string(),
                     ),
                 })),
@@ -1103,7 +1105,7 @@ impl JsonSchema for Ipv4Net {
 }
 
 /// An `Ipv6Net` represents a IPv6 subnetwork, including the address and network mask.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Serialize)]
 pub struct Ipv6Net(pub ipnetwork::Ipv6Network);
 
 impl Ipv6Net {
@@ -1186,6 +1188,61 @@ impl JsonSchema for Ipv6Net {
     }
 }
 
+/// An `IpNet` represents an IP network, either IPv4 or IPv6.
+#[derive(
+    Clone, Copy, Debug, Deserialize, PartialEq, Hash, JsonSchema, Serialize,
+)]
+pub enum IpNet {
+    V4(Ipv4Net),
+    V6(Ipv6Net),
+}
+
+impl From<Ipv4Net> for IpNet {
+    fn from(n: Ipv4Net) -> IpNet {
+        IpNet::V4(n)
+    }
+}
+
+impl From<Ipv4Addr> for IpNet {
+    fn from(n: Ipv4Addr) -> IpNet {
+        IpNet::V4(Ipv4Net(ipnetwork::Ipv4Network::from(n)))
+    }
+}
+
+impl From<Ipv6Net> for IpNet {
+    fn from(n: Ipv6Net) -> IpNet {
+        IpNet::V6(n)
+    }
+}
+
+impl From<Ipv6Addr> for IpNet {
+    fn from(n: Ipv6Addr) -> IpNet {
+        IpNet::V6(Ipv6Net(ipnetwork::Ipv6Network::from(n)))
+    }
+}
+
+impl std::fmt::Display for IpNet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpNet::V4(inner) => write!(f, "{}", inner),
+            IpNet::V6(inner) => write!(f, "{}", inner),
+        }
+    }
+}
+
+impl FromStr for IpNet {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net =
+            s.parse::<ipnetwork::IpNetwork>().map_err(|e| e.to_string())?;
+        match net {
+            ipnetwork::IpNetwork::V4(net) => Ok(IpNet::from(Ipv4Net(net))),
+            ipnetwork::IpNetwork::V6(net) => Ok(IpNet::from(Ipv6Net(net))),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum VpcRouterKind {
@@ -1207,160 +1264,64 @@ pub struct VpcRouter {
     pub vpc_id: Uuid,
 }
 
-/// Represents all possible network target strings as defined in RFD-21
-/// This enum itself isn't intended to be used directly but rather as a
-/// delegate for subset enums to not have to re-implement all the base type conversions.
-///
-/// See <https://rfd.shared.oxide.computer/rfd/0021#api-target-strings>
-#[derive(Debug, PartialEq, Display, FromStr)]
-pub enum NetworkTarget {
-    #[display("vpc:{0}")]
-    Vpc(Name),
-    #[display("subnet:{0}")]
-    Subnet(Name),
-    #[display("instance:{0}")]
-    Instance(Name),
-    #[display("tag:{0}")]
-    Tag(Name),
-    #[display("ip:{0}")]
-    Ip(IpAddr),
-    #[display("inetgw:{0}")]
-    InternetGateway(Name),
-    #[display("fip:{0}")]
-    FloatingIp(Name),
-}
-
-/// A subset of [`NetworkTarget`], `RouteTarget` specifies all
-/// possible targets that a route can forward to.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+/// A `RouteTarget` describes the possible locations that traffic matching a
+/// route destination can be sent.
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Display,
+    FromStr,
+    Serialize,
+    PartialEq,
+    JsonSchema,
+)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
+#[display(style = "lowercase")]
 pub enum RouteTarget {
+    /// Forward traffic to a particular IP address.
+    #[display("{}:{0}")]
     Ip(IpAddr),
+    /// Forward traffic a VPC
+    #[display("{}:{0}")]
     Vpc(Name),
+    /// Forward traffic a VPC Subnet
+    #[display("{}:{0}")]
     Subnet(Name),
+    /// Forward traffic a specific instance
+    #[display("{}:{0}")]
     Instance(Name),
+    #[display("inetgw:{0}")]
+    /// Forward traffic to an internet gateway
     InternetGateway(Name),
 }
 
-impl TryFrom<String> for RouteTarget {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        RouteTarget::try_from(
-            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
-        )
-    }
-}
-
-impl FromStr for RouteTarget {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        RouteTarget::try_from(String::from(value))
-    }
-}
-
-impl From<RouteTarget> for NetworkTarget {
-    fn from(target: RouteTarget) -> Self {
-        match target {
-            RouteTarget::Ip(ip) => NetworkTarget::Ip(ip),
-            RouteTarget::Vpc(name) => NetworkTarget::Vpc(name),
-            RouteTarget::Subnet(name) => NetworkTarget::Subnet(name),
-            RouteTarget::Instance(name) => NetworkTarget::Instance(name),
-            RouteTarget::InternetGateway(name) => {
-                NetworkTarget::InternetGateway(name)
-            }
-        }
-    }
-}
-
-impl TryFrom<NetworkTarget> for RouteTarget {
-    type Error = String;
-
-    fn try_from(value: NetworkTarget) -> Result<Self, Self::Error> {
-        match value {
-            NetworkTarget::Ip(ip) => Ok(RouteTarget::Ip(ip)),
-            NetworkTarget::Vpc(name) => Ok(RouteTarget::Vpc(name)),
-            NetworkTarget::Subnet(name) => Ok(RouteTarget::Subnet(name)),
-            NetworkTarget::Instance(name) => Ok(RouteTarget::Instance(name)),
-            NetworkTarget::InternetGateway(name) => {
-                Ok(RouteTarget::InternetGateway(name))
-            }
-            _ => Err(format!(
-                "Invalid RouteTarget {}, only ip, vpc, subnet, instance, and inetgw are allowed",
-                value
-            )),
-        }
-    }
-}
-
-impl Display for RouteTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        let target = NetworkTarget::from(self.clone());
-        write!(f, "{}", target)
-    }
-}
-
-/// A subset of [`NetworkTarget`], `RouteDestination` specifies
-/// the kind of network traffic that will be matched to be forwarded
-/// to the [`RouteTarget`].
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+/// A `RouteDestination` is used to match traffic with a routing rule, on the
+/// destination of that traffic.
+///
+/// When traffic is to be sent to a destination that is within a given
+/// `RouteDestination`, the corresponding [`RouterRoute`] applies, and traffic
+/// will be forward to the [`RouteTarget`] for that rule.
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Display,
+    FromStr,
+    Serialize,
+    PartialEq,
+    JsonSchema,
+)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
+#[display("{}:{0}", style = "lowercase")]
 pub enum RouteDestination {
-    Ip(IpAddr),
+    /// Route applies to traffic destined for a specific IP address or IP
+    /// subnet.
+    Ip(IpNet),
+    /// Route applies to traffic destined for the given VPC.
     Vpc(Name),
+    /// Route applies to traffic
     Subnet(Name),
-}
-
-impl TryFrom<NetworkTarget> for RouteDestination {
-    type Error = String;
-
-    fn try_from(value: NetworkTarget) -> Result<Self, Self::Error> {
-        match value {
-            NetworkTarget::Ip(ip) => Ok(RouteDestination::Ip(ip)),
-            NetworkTarget::Vpc(name) => Ok(RouteDestination::Vpc(name)),
-            NetworkTarget::Subnet(name) => Ok(RouteDestination::Subnet(name)),
-            _ => Err(format!(
-                "Invalid RouteTarget {}, only ip, vpc, and subnets are allowed",
-                value
-            )),
-        }
-    }
-}
-
-impl TryFrom<String> for RouteDestination {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        RouteDestination::try_from(
-            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
-        )
-    }
-}
-
-impl FromStr for RouteDestination {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        RouteDestination::try_from(String::from(value))
-    }
-}
-
-impl From<RouteDestination> for NetworkTarget {
-    fn from(target: RouteDestination) -> Self {
-        match target {
-            RouteDestination::Ip(ip) => NetworkTarget::Ip(ip),
-            RouteDestination::Vpc(name) => NetworkTarget::Vpc(name),
-            RouteDestination::Subnet(name) => NetworkTarget::Subnet(name),
-        }
-    }
-}
-
-impl Display for RouteDestination {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        let target = NetworkTarget::from(self.clone());
-        write!(f, "{}", target)
-    }
 }
 
 /// The classification of a [`RouterRoute`] as defined by the system.
@@ -1555,158 +1516,65 @@ pub enum VpcFirewallRuleAction {
     Deny,
 }
 
-/// A subset of [`NetworkTarget`], `VpcFirewallRuleTarget` specifies all
-/// possible targets that a firewall rule can be attached to.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+/// A `VpcFirewallRuleTarget` is used to specify the set of [`Instance`]s to
+/// which a firewall rule applies.
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Display,
+    FromStr,
+    Serialize,
+    PartialEq,
+    JsonSchema,
+)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
+#[display("{}:{0}", style = "lowercase")]
 pub enum VpcFirewallRuleTarget {
+    /// The rule applies to all instances in the VPC
     Vpc(Name),
+    /// The rule applies to all instances in the VPC Subnet
     Subnet(Name),
+    /// The rule applies to this specific instance
     Instance(Name),
+    /// The rule applies to a specific IP address or IP subnet
+    Ip(IpNet),
     // Tags not yet implemented
     //Tag(Name),
 }
 
-impl TryFrom<String> for VpcFirewallRuleTarget {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        VpcFirewallRuleTarget::try_from(
-            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
-        )
-    }
-}
-
-impl FromStr for VpcFirewallRuleTarget {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        VpcFirewallRuleTarget::try_from(String::from(value))
-    }
-}
-
-impl From<VpcFirewallRuleTarget> for NetworkTarget {
-    fn from(target: VpcFirewallRuleTarget) -> Self {
-        match target {
-            VpcFirewallRuleTarget::Vpc(name) => NetworkTarget::Vpc(name),
-            VpcFirewallRuleTarget::Subnet(name) => NetworkTarget::Subnet(name),
-            VpcFirewallRuleTarget::Instance(name) => {
-                NetworkTarget::Instance(name)
-            }
-        }
-    }
-}
-
-impl TryFrom<NetworkTarget> for VpcFirewallRuleTarget {
-    type Error = String;
-
-    fn try_from(value: NetworkTarget) -> Result<Self, Self::Error> {
-        match value {
-            NetworkTarget::Vpc(name) => Ok(VpcFirewallRuleTarget::Vpc(name)),
-            NetworkTarget::Subnet(name) => {
-                Ok(VpcFirewallRuleTarget::Subnet(name))
-            }
-            NetworkTarget::Instance(name) => {
-                Ok(VpcFirewallRuleTarget::Instance(name))
-            }
-            _ => Err(format!(
-                "Invalid VpcFirewallRuleTarget {}, only vpc, subnet, and instance, \
-                are allowed",
-                value
-            )),
-        }
-    }
-}
-
-impl Display for VpcFirewallRuleTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        let target = NetworkTarget::from(self.clone());
-        write!(f, "{}", target)
-    }
-}
-
-/// A subset of [`NetworkTarget`], `VpcFirewallRuleHostFilter` specifies all
-/// possible targets that a route can forward to.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+/// The `VpcFirewallRuleHostFilter` is used to filter traffic on the basis of
+/// its source or destination host.
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Display,
+    FromStr,
+    Serialize,
+    PartialEq,
+    JsonSchema,
+)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
+#[display(style = "lowercase")]
 pub enum VpcFirewallRuleHostFilter {
+    /// The rule applies to traffic from/to all instances in the VPC
+    #[display("{}:{0}")]
     Vpc(Name),
+    /// The rule applies to traffic from/to all instances in the VPC Subnet
+    #[display("{}:{0}")]
     Subnet(Name),
+    /// The rule applies to traffic from/to this specific instance
+    #[display("{}:{0}")]
     Instance(Name),
     // Tags not yet implemented
     // Tag(Name),
-    Ip(IpAddr),
-    InternetGateway(Name),
-}
-
-impl TryFrom<String> for VpcFirewallRuleHostFilter {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        VpcFirewallRuleHostFilter::try_from(
-            value.parse::<NetworkTarget>().map_err(|e| e.to_string())?,
-        )
-    }
-}
-
-impl FromStr for VpcFirewallRuleHostFilter {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        VpcFirewallRuleHostFilter::try_from(String::from(value))
-    }
-}
-
-impl From<VpcFirewallRuleHostFilter> for NetworkTarget {
-    fn from(target: VpcFirewallRuleHostFilter) -> Self {
-        match target {
-            VpcFirewallRuleHostFilter::Vpc(name) => NetworkTarget::Vpc(name),
-            VpcFirewallRuleHostFilter::Subnet(name) => {
-                NetworkTarget::Subnet(name)
-            }
-            VpcFirewallRuleHostFilter::Instance(name) => {
-                NetworkTarget::Instance(name)
-            }
-            VpcFirewallRuleHostFilter::Ip(ip) => NetworkTarget::Ip(ip),
-            VpcFirewallRuleHostFilter::InternetGateway(name) => {
-                NetworkTarget::InternetGateway(name)
-            }
-        }
-    }
-}
-
-impl TryFrom<NetworkTarget> for VpcFirewallRuleHostFilter {
-    type Error = String;
-
-    fn try_from(value: NetworkTarget) -> Result<Self, Self::Error> {
-        match value {
-            NetworkTarget::Vpc(name) => {
-                Ok(VpcFirewallRuleHostFilter::Vpc(name))
-            }
-            NetworkTarget::Subnet(name) => {
-                Ok(VpcFirewallRuleHostFilter::Subnet(name))
-            }
-            NetworkTarget::Instance(name) => {
-                Ok(VpcFirewallRuleHostFilter::Instance(name))
-            }
-            NetworkTarget::Ip(ip) => Ok(VpcFirewallRuleHostFilter::Ip(ip)),
-            NetworkTarget::InternetGateway(name) => {
-                Ok(VpcFirewallRuleHostFilter::InternetGateway(name))
-            }
-            _ => Err(format!(
-                "Invalid VpcFirewallRuleHostFilter {}, only vpc, subnet, \
-                instance, ip, and inetgw are allowed",
-                value
-            )),
-        }
-    }
-}
-
-impl Display for VpcFirewallRuleHostFilter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        let target = NetworkTarget::from(self.clone());
-        write!(f, "{}", target)
-    }
+    /// The rule applies to traffic from/to a specific IP address or IP subnet
+    #[display("{}:{0}")]
+    Ip(IpNet),
+    // TODO: Internet gateways not yet implemented
+    // #[display("inetgw:{0}")]
+    // InternetGateway(Name),
 }
 
 /// Port number used in a transport-layer protocol like TCP or UDP
@@ -1926,18 +1794,20 @@ pub struct NetworkInterface {
 
 #[cfg(test)]
 mod test {
+    use super::RouteDestination;
+    use super::RouteTarget;
+    use super::VpcFirewallRuleHostFilter;
+    use super::VpcFirewallRuleTarget;
     use super::{
-        ByteCount, L4Port, L4PortRange, Name, NetworkTarget, RoleName,
-        VpcFirewallRuleAction, VpcFirewallRuleDirection, VpcFirewallRuleFilter,
-        VpcFirewallRuleHostFilter, VpcFirewallRulePriority,
-        VpcFirewallRuleProtocol, VpcFirewallRuleStatus, VpcFirewallRuleTarget,
-        VpcFirewallRuleUpdate, VpcFirewallRuleUpdateParams,
+        ByteCount, L4Port, L4PortRange, Name, RoleName, VpcFirewallRuleAction,
+        VpcFirewallRuleDirection, VpcFirewallRuleFilter,
+        VpcFirewallRulePriority, VpcFirewallRuleProtocol,
+        VpcFirewallRuleStatus, VpcFirewallRuleUpdate,
+        VpcFirewallRuleUpdateParams,
     };
     use crate::api::external::Error;
     use crate::api::external::ResourceType;
     use std::convert::TryFrom;
-    use std::net::IpAddr;
-    use std::net::Ipv4Addr;
 
     #[test]
     fn test_name_parse() {
@@ -2289,48 +2159,6 @@ mod test {
     }
 
     #[test]
-    fn test_networktarget_parsing() {
-        assert_eq!(
-            "vpc:my-vital-vpc".parse(),
-            Ok(NetworkTarget::Vpc("my-vital-vpc".parse().unwrap()))
-        );
-        assert_eq!(
-            "subnet:my-slick-subnet".parse(),
-            Ok(NetworkTarget::Subnet("my-slick-subnet".parse().unwrap()))
-        );
-        assert_eq!(
-            "instance:my-intrepid-instance".parse(),
-            Ok(NetworkTarget::Instance(
-                "my-intrepid-instance".parse().unwrap()
-            ))
-        );
-        assert_eq!(
-            "tag:my-turbid-tag".parse(),
-            Ok(NetworkTarget::Tag("my-turbid-tag".parse().unwrap()))
-        );
-        assert_eq!(
-            "ip:127.0.0.1".parse(),
-            Ok(NetworkTarget::Ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))))
-        );
-        assert_eq!(
-            "inetgw:my-gregarious-internet-gateway".parse(),
-            Ok(NetworkTarget::InternetGateway(
-                "my-gregarious-internet-gateway".parse().unwrap()
-            ))
-        );
-        assert_eq!(
-            "fip:my-fickle-floating-ip".parse(),
-            Ok(NetworkTarget::FloatingIp(
-                "my-fickle-floating-ip".parse().unwrap()
-            ))
-        );
-        assert_eq!(
-            "nope:this-should-error".parse::<NetworkTarget>().unwrap_err(),
-            parse_display::ParseError::new()
-        );
-    }
-
-    #[test]
     fn test_ipv6_net_operations() {
         use super::Ipv6Net;
         assert!(Ipv6Net("fd00::/8".parse().unwrap()).is_unique_local());
@@ -2350,5 +2178,109 @@ mod test {
         assert!(
             !Ipv6Net("fd00::/63".parse().unwrap()).is_vpc_subnet(&vpc_prefix)
         );
+    }
+
+    #[test]
+    fn test_route_target_parse() {
+        let name: Name = "foo".parse().unwrap();
+        let address = "192.168.0.10".parse().unwrap();
+        assert_eq!(RouteTarget::Vpc(name.clone()), "vpc:foo".parse().unwrap());
+        assert_eq!(
+            RouteTarget::Subnet(name.clone()),
+            "subnet:foo".parse().unwrap()
+        );
+        assert_eq!(
+            RouteTarget::Instance(name),
+            "instance:foo".parse().unwrap()
+        );
+        assert_eq!(
+            RouteTarget::Ip(address),
+            "ip:192.168.0.10".parse().unwrap()
+        );
+        assert!("foo:foo".parse::<RouteTarget>().is_err());
+        assert!("foo".parse::<RouteTarget>().is_err());
+    }
+
+    #[test]
+    fn test_route_destination_parse() {
+        let name: Name = "foo".parse().unwrap();
+        let address = "192.168.0.10".parse().unwrap();
+        let network = "fd00::/64".parse().unwrap();
+        assert_eq!(
+            RouteDestination::Vpc(name.clone()),
+            "vpc:foo".parse().unwrap()
+        );
+        assert_eq!(
+            RouteDestination::Subnet(name.clone()),
+            "subnet:foo".parse().unwrap()
+        );
+        assert_eq!(
+            RouteDestination::Ip(address),
+            "ip:192.168.0.10".parse().unwrap()
+        );
+        assert_eq!(
+            RouteDestination::Ip(network),
+            "ip:fd00::/64".parse().unwrap()
+        );
+        assert!("foo:foo".parse::<RouteDestination>().is_err());
+        assert!("foo".parse::<RouteDestination>().is_err());
+    }
+
+    #[test]
+    fn test_firewall_rule_target_parse() {
+        let name: Name = "foo".parse().unwrap();
+        let address = "192.168.0.10".parse().unwrap();
+        let network = "fd00::/64".parse().unwrap();
+        assert_eq!(
+            VpcFirewallRuleTarget::Vpc(name.clone()),
+            "vpc:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleTarget::Subnet(name.clone()),
+            "subnet:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleTarget::Instance(name),
+            "instance:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleTarget::Ip(address),
+            "ip:192.168.0.10".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleTarget::Ip(network),
+            "ip:fd00::/64".parse().unwrap()
+        );
+        assert!("foo:foo".parse::<VpcFirewallRuleTarget>().is_err());
+        assert!("foo".parse::<VpcFirewallRuleTarget>().is_err());
+    }
+
+    #[test]
+    fn test_firewall_rule_host_filter_parse() {
+        let name: Name = "foo".parse().unwrap();
+        let address = "192.168.0.10".parse().unwrap();
+        let network = "fd00::/64".parse().unwrap();
+        assert_eq!(
+            VpcFirewallRuleHostFilter::Vpc(name.clone()),
+            "vpc:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleHostFilter::Subnet(name.clone()),
+            "subnet:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleHostFilter::Instance(name),
+            "instance:foo".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleHostFilter::Ip(address),
+            "ip:192.168.0.10".parse().unwrap()
+        );
+        assert_eq!(
+            VpcFirewallRuleHostFilter::Ip(network),
+            "ip:fd00::/64".parse().unwrap()
+        );
+        assert!("foo:foo".parse::<VpcFirewallRuleHostFilter>().is_err());
+        assert!("foo".parse::<VpcFirewallRuleHostFilter>().is_err());
     }
 }

--- a/nexus/tests/integration_tests/router_routes.rs
+++ b/nexus/tests/integration_tests/router_routes.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use dropshot::test_util::{
     object_delete, object_get, objects_list_page, objects_post,
@@ -107,7 +108,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
                 name: route_name.parse().unwrap(),
                 description: "It's a route, what else can I say?".to_string(),
             },
-            target: RouteTarget::Ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            target: RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(127, 0, 0, 1))),
             destination: RouteDestination::Subnet("loopback".parse().unwrap()),
         },
     )
@@ -119,7 +120,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(route.kind, RouterRouteKind::Custom);
     assert_eq!(
         route.target,
-        RouteTarget::Ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(127, 0, 0, 1)))
     );
     assert_eq!(
         route.destination,
@@ -136,7 +137,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
                     name: Some(route_name.parse().unwrap()),
                     description: None,
                 },
-                target: RouteTarget::Ip(IpAddr::V4(Ipv4Addr::new(
+                target: RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(
                     192, 168, 1, 1,
                 ))),
                 destination: RouteDestination::Subnet(
@@ -152,7 +153,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(route.identity.name, route_name);
     assert_eq!(
         route.target,
-        RouteTarget::Ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1,)))
+        RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(192, 168, 1, 1,)))
     );
 
     object_delete(client, route_url.as_str()).await;

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4675,7 +4675,7 @@
             ]
           },
           {
-            "description": "Forward traffic a VPC",
+            "description": "Forward traffic to a VPC",
             "type": "object",
             "properties": {
               "type": {
@@ -4694,7 +4694,7 @@
             ]
           },
           {
-            "description": "Forward traffic a VPC Subnet",
+            "description": "Forward traffic to a VPC Subnet",
             "type": "object",
             "properties": {
               "type": {
@@ -4713,7 +4713,7 @@
             ]
           },
           {
-            "description": "Forward traffic a specific instance",
+            "description": "Forward traffic to a specific instance",
             "type": "object",
             "properties": {
               "type": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4593,13 +4593,33 @@
         "description": "A `RouteDestination` is used to match traffic with a routing rule, on the destination of that traffic.\n\nWhen traffic is to be sent to a destination that is within a given `RouteDestination`, the corresponding [`RouterRoute`] applies, and traffic will be forward to the [`RouteTarget`] for that rule.",
         "oneOf": [
           {
-            "description": "Route applies to traffic destined for a specific IP address or IP subnet.",
+            "description": "Route applies to traffic destined for a specific IP address",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
                   "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Route applies to traffic destined for a specific IP subnet",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip_net"
                 ]
               },
               "value": {
@@ -5572,13 +5592,33 @@
             ]
           },
           {
-            "description": "The rule applies to traffic from/to a specific IP address or IP subnet",
+            "description": "The rule applies to traffic from/to a specific IP address",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
                   "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The rule applies to traffic from/to a specific IP subnet",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip_net"
                 ]
               },
               "value": {
@@ -5669,13 +5709,33 @@
             ]
           },
           {
-            "description": "The rule applies to a specific IP address or IP subnet",
+            "description": "The rule applies to a specific IP address",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
                   "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The rule applies to a specific IP subnet",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip_net"
                 ]
               },
               "value": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4118,11 +4118,40 @@
           "destroyed"
         ]
       },
+      "IpNet": {
+        "description": "An `IpNet` represents an IP network, either IPv4 or IPv6.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "V4": {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            },
+            "required": [
+              "V4"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "V6": {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            },
+            "required": [
+              "V6"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
       "Ipv4Net": {
         "title": "An IPv4 subnet",
         "description": "An IPv4 subnet, including prefix and subnet mask",
         "type": "string",
-        "pattern": "^(10\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9]\\.){2}(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[0-9]|2[0-8]|[8-9]))$^(172\\.16\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[2-9]|2[0-8]))$^(192\\.168\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[6-9]|2[0-8]))$",
+        "pattern": "(^(10\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9]\\.){2}(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[0-9]|2[0-8]|[8-9]))$)|(^(172\\.16\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[2-9]|2[0-8]))$)|(^(192\\.168\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[6-9]|2[0-8]))$)",
         "maxLength": 18
       },
       "Ipv6Net": {
@@ -4561,9 +4590,10 @@
         ]
       },
       "RouteDestination": {
-        "description": "A subset of [`NetworkTarget`], `RouteDestination` specifies the kind of network traffic that will be matched to be forwarded to the [`RouteTarget`].",
+        "description": "A `RouteDestination` is used to match traffic with a routing rule, on the destination of that traffic.\n\nWhen traffic is to be sent to a destination that is within a given `RouteDestination`, the corresponding [`RouterRoute`] applies, and traffic will be forward to the [`RouteTarget`] for that rule.",
         "oneOf": [
           {
+            "description": "Route applies to traffic destined for a specific IP address or IP subnet.",
             "type": "object",
             "properties": {
               "type": {
@@ -4573,8 +4603,7 @@
                 ]
               },
               "value": {
-                "type": "string",
-                "format": "ip"
+                "$ref": "#/components/schemas/IpNet"
               }
             },
             "required": [
@@ -4583,6 +4612,7 @@
             ]
           },
           {
+            "description": "Route applies to traffic destined for the given VPC.",
             "type": "object",
             "properties": {
               "type": {
@@ -4601,6 +4631,7 @@
             ]
           },
           {
+            "description": "Route applies to traffic",
             "type": "object",
             "properties": {
               "type": {
@@ -4621,9 +4652,10 @@
         ]
       },
       "RouteTarget": {
-        "description": "A subset of [`NetworkTarget`], `RouteTarget` specifies all possible targets that a route can forward to.",
+        "description": "A `RouteTarget` describes the possible locations that traffic matching a route destination can be sent.",
         "oneOf": [
           {
+            "description": "Forward traffic to a particular IP address.",
             "type": "object",
             "properties": {
               "type": {
@@ -4643,6 +4675,7 @@
             ]
           },
           {
+            "description": "Forward traffic a VPC",
             "type": "object",
             "properties": {
               "type": {
@@ -4661,6 +4694,7 @@
             ]
           },
           {
+            "description": "Forward traffic a VPC Subnet",
             "type": "object",
             "properties": {
               "type": {
@@ -4679,6 +4713,7 @@
             ]
           },
           {
+            "description": "Forward traffic a specific instance",
             "type": "object",
             "properties": {
               "type": {
@@ -4697,6 +4732,7 @@
             ]
           },
           {
+            "description": "Forward traffic to an internet gateway",
             "type": "object",
             "properties": {
               "type": {
@@ -5476,9 +5512,10 @@
         }
       },
       "VpcFirewallRuleHostFilter": {
-        "description": "A subset of [`NetworkTarget`], `VpcFirewallRuleHostFilter` specifies all possible targets that a route can forward to.",
+        "description": "The `VpcFirewallRuleHostFilter` is used to filter traffic on the basis of its source or destination host.",
         "oneOf": [
           {
+            "description": "The rule applies to traffic from/to all instances in the VPC",
             "type": "object",
             "properties": {
               "type": {
@@ -5497,6 +5534,7 @@
             ]
           },
           {
+            "description": "The rule applies to traffic from/to all instances in the VPC Subnet",
             "type": "object",
             "properties": {
               "type": {
@@ -5515,6 +5553,7 @@
             ]
           },
           {
+            "description": "The rule applies to traffic from/to this specific instance",
             "type": "object",
             "properties": {
               "type": {
@@ -5533,6 +5572,7 @@
             ]
           },
           {
+            "description": "The rule applies to traffic from/to a specific IP address or IP subnet",
             "type": "object",
             "properties": {
               "type": {
@@ -5542,26 +5582,7 @@
                 ]
               },
               "value": {
-                "type": "string",
-                "format": "ip"
-              }
-            },
-            "required": [
-              "type",
-              "value"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "internet_gateway"
-                ]
-              },
-              "value": {
-                "$ref": "#/components/schemas/Name"
+                "$ref": "#/components/schemas/IpNet"
               }
             },
             "required": [
@@ -5588,9 +5609,10 @@
         ]
       },
       "VpcFirewallRuleTarget": {
-        "description": "A subset of [`NetworkTarget`], `VpcFirewallRuleTarget` specifies all possible targets that a firewall rule can be attached to.",
+        "description": "A `VpcFirewallRuleTarget` is used to specify the set of [`Instance`]s to which a firewall rule applies.",
         "oneOf": [
           {
+            "description": "The rule applies to all instances in the VPC",
             "type": "object",
             "properties": {
               "type": {
@@ -5609,6 +5631,7 @@
             ]
           },
           {
+            "description": "The rule applies to all instances in the VPC Subnet",
             "type": "object",
             "properties": {
               "type": {
@@ -5627,6 +5650,7 @@
             ]
           },
           {
+            "description": "The rule applies to this specific instance",
             "type": "object",
             "properties": {
               "type": {
@@ -5637,6 +5661,25 @@
               },
               "value": {
                 "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The rule applies to a specific IP address or IP subnet",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/IpNet"
               }
             },
             "required": [


### PR DESCRIPTION
- Removes the "base class" network target. The underlying conversion
  code is all done in a derived trait, so this actually ended up adding
  code, not removing it. The other problem is that the targets are not
  all the same in every context. IPs is the most obvious case. That can
  be a single IP address or an IP subnet, depending on the context. This
  uses the right type (`std::net::IpAddr` or `ipnetwork::IpNetwork`) in
  those different contexts, rather than forcing everything to be an
  address or a network.
- Derives the `parse_display` traits for other targets.
- Adds tests for all enums.
- Fixes some comments, adds more clarity