### PR TITLE
Update api spec in oxide.ts, start daisy chain of updates on spec push

### DIFF
--- a/.github/workflows/trigger-update-spec-everywhere.yml
+++ b/.github/workflows/trigger-update-spec-everywhere.yml
@@ -1,0 +1,60 @@
+# This workflow starts the Rube Goldberg machine of updating the spec everywhere
+# by making a PR to the oxide.ts repo.
+# In the future, once we have real releases and versioning we will likely only
+# want to run this on a tag push, but for now we will run it on pushes to main
+# since then the docs and clients will be updated for any changes to the omicron
+# nexus external API.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - openapi/nexus.json
+  pull_request:
+    paths:
+      - .github/workflows/trigger-update-spec-everywhere.yml
+  workflow_dispatch:
+name: update spec everywhere
+concurrency:
+  group: update-spec-everywhere-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  update-spec:
+    name: update-spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Checkout the oxide.ts repo since we will want to update the file there.
+      # After ts has updated it will pull request the next language client and
+      # so on and so forth before terminating with the docs repo.
+      - uses: actions/checkout@v2
+        with:
+          repository: 'oxidecomputer/oxide.ts'
+          path: 'oxide.ts'
+          token: ${{secrets.GLOBAL_GITHUB_PAT}}
+      - name: move spec to ts repo
+        shell: bash
+        run: |
+          rm oxide.ts/spec.json || true
+          cp openapi/nexus.json oxide.ts/spec.json
+      - name: commit the changes in the oxide.ts repo
+        shell: bash
+        run: |
+          cd oxide.ts
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -am "YOYO NEW API SPEC!" || exit 0
+          git fetch origin
+          git rebase origin/main || exit 0
+          export NEW_BRANCH="update-spec"
+          git checkout -b "$NEW_BRANCH"
+          git push -f origin "$NEW_BRANCH"
+          gh pr create --title "Update api spec from omicron" \
+              --body "Updating the spec from that in the omicron repo" \
+              --head "$NEW_BRANCH" \
+              --base main || true
+        env:
+          GITHUB_TOKEN: ${{secrets.GLOBAL_GITHUB_PAT}}
+
+

--- a/.github/workflows/trigger-update-spec-everywhere.yml
+++ b/.github/workflows/trigger-update-spec-everywhere.yml
@@ -20,7 +20,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   update-spec:
-    name: update-spec
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
In the future we will likely only want to do this on tag push, but for
now while changes are being made frequently for dev purposes, let's do
it on every push to main, and of course if someone makes a PR to the
workflow so we can test.

Closes #597

Do not merge til after #751 

I'm open to changing the name of the action, I didn't spend much time thinking about it.