### PR TITLE
Distinguishes between IPv4 and v6 subnet overlap when creating VPC

### DIFF
--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -157,6 +157,10 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
         ipv4_block,
         ipv6_block,
     };
+    let expected_error = format!(
+        "IP address range '{}' conflicts with an existing subnet",
+        ipv4_block,
+    );
     let error: dropshot::HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &subnets_url)
             .expect_status(Some(StatusCode::BAD_REQUEST))
@@ -168,7 +172,7 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
     .unwrap()
     .parsed_body()
     .unwrap();
-    assert!(error.message.starts_with("IPv4 block '"));
+    assert_eq!(error.message, expected_error);
 
     // creating another subnet in the same VPC with the same name, but different
     // IP address ranges also fails.


### PR DESCRIPTION
Subnets

- Extends `SubnetError` variant for communicating overlapping address
  ranges to contain the actual subnet that caused the problem. This can
  be used to determine if it was a V4 or V6, client-provided or
  auto-generated subnet.
- Reworks the SQL for checking this case. It now tries to insert NULL
  for a subnet if that's been found to overlap with an existing range,
  which violates a not-NULL constraint on the `vpc_subnet` table. By
  inspecting which constraint failed, we can learn which input caused
  the issue.
- Updates tests to verify, ensuring we get the actual bad subnet back