### PR TITLE
Overhaul the packaging process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -348,6 +348,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
 ]
 
 [[package]]
@@ -897,6 +912,12 @@ checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1489,6 +1510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e540eeecee89ed4391cbbe2c86a9df6c061fc93f7710e2af69cbfccdc6564eae"
+dependencies = [
+ "console",
+ "number_prefix",
+ "rayon",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2078,8 @@ dependencies = [
  "anyhow",
  "crossbeam",
  "flate2",
+ "futures",
+ "indicatif",
  "omicron-common",
  "omicron-zone-package",
  "rayon",
@@ -2136,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd2e4dbdcf6781c86cee71b7d30a7fed585fd1653dd896c2347ff2239b553aa"
+checksum = "50c3d76964fd0a5af63d548222e2badb60dafd71c4315178ba22b70574cd56aa"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2150,6 +2191,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -3942,6 +3984,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -8,8 +8,10 @@ license = "MPL-2.0"
 anyhow = "1.0"
 crossbeam = "0.8"
 flate2 = "1.0.22"
+futures = "0.3.21"
+indicatif = { version = "0.17.0-rc.9", features = ["rayon"] }
 omicron-common = { path = "../common" }
-omicron-zone-package = { version = "0.1.2" }
+omicron-zone-package = { version = "0.2.0" }
 rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -71,8 +71,10 @@ where
     if release {
         cmd.arg("--release");
     }
-    let status =
-        cmd.status().await.context(format!("Failed to run command: ({:?})", cmd))?;
+    let status = cmd
+        .status()
+        .await
+        .context(format!("Failed to run command: ({:?})", cmd))?;
     if !status.success() {
         bail!("Failed to build packages");
     }
@@ -80,22 +82,36 @@ where
     Ok(())
 }
 
-async fn do_for_all_rust_packages(config: &Config, command: &str) -> Result<()> {
+async fn do_for_all_rust_packages(
+    config: &Config,
+    command: &str,
+) -> Result<()> {
     // First, filter out all Rust packages from the configuration that should be
     // built, and partition them into "release" and "debug" categories.
-    let (release_pkgs, debug_pkgs): (Vec<_>, _) =
-        config.packages.iter().filter_map(|(name, pkg)| {
+    let (release_pkgs, debug_pkgs): (Vec<_>, _) = config
+        .packages
+        .iter()
+        .filter_map(|(name, pkg)| {
             pkg.rust.as_ref().map(|rust_pkg| (name, rust_pkg.release))
-        }).partition(|(_, release)| {
-            *release
-        });
+        })
+        .partition(|(_, release)| *release);
 
     // Execute all the release / debug packages at the same time.
     if !release_pkgs.is_empty() {
-        run_cargo_on_packages(command, release_pkgs.iter().map(|(name, _)| name), true).await?;
+        run_cargo_on_packages(
+            command,
+            release_pkgs.iter().map(|(name, _)| name),
+            true,
+        )
+        .await?;
     }
     if !debug_pkgs.is_empty() {
-        run_cargo_on_packages(command, debug_pkgs.iter().map(|(name, _)| name), false).await?;
+        run_cargo_on_packages(
+            command,
+            debug_pkgs.iter().map(|(name, _)| name),
+            false,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -153,13 +169,17 @@ in improving the cross-repository meta-build system, please contact sean@.",
             None,
             |((package_name, package), ui)| async move {
                 let total_work = package.get_total_work();
-                let progress = ui.add_package(package_name.to_string(), total_work);
+                let progress =
+                    ui.add_package(package_name.to_string(), total_work);
                 progress.set_message("bundle package".to_string());
-                package.create_with_progress(&progress, &output_directory).await?;
+                package
+                    .create_with_progress(&progress, &output_directory)
+                    .await?;
                 progress.finish();
                 Ok(())
-            }
-    ).await?;
+            },
+        )
+        .await?;
 
     Ok(())
 }
@@ -274,7 +294,9 @@ fn do_uninstall(
 
 fn in_progress_style() -> ProgressStyle {
     ProgressStyle::default_bar()
-        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
+        .template(
+            "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
+        )
         .unwrap()
         .progress_chars("#>.")
 }
@@ -307,7 +329,11 @@ impl PackageProgress {
 
 impl Progress for PackageProgress {
     fn set_message(&self, message: impl Into<std::borrow::Cow<'static, str>>) {
-        self.pb.set_message(format!("{}: {}", self.service_name, message.into()));
+        self.pb.set_message(format!(
+            "{}: {}",
+            self.service_name,
+            message.into()
+        ));
     }
 
     fn increment(&self, delta: u64) {
@@ -328,10 +354,7 @@ impl ProgressUI {
         pb.set_style(self.style.clone());
         pb.set_message(service_name.clone());
         pb.tick();
-        PackageProgress {
-            pb,
-            service_name,
-        }
+        PackageProgress { pb, service_name }
     }
 }
 

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -7,16 +7,19 @@
  */
 
 use anyhow::{anyhow, bail, Context, Result};
+use futures::stream::{self, StreamExt, TryStreamExt};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use omicron_package::{parse, SubCommand};
-use omicron_zone_package::package::Package;
+use omicron_zone_package::package::{Package, Progress};
 use rayon::prelude::*;
 use serde_derive::Deserialize;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::sync::Arc;
 use structopt::StructOpt;
+use tokio::process::Command;
 
 /// Describes the configuration for a set of packages.
 #[derive(Deserialize, Debug)]
@@ -49,50 +52,74 @@ struct Args {
     subcommand: SubCommand,
 }
 
-fn run_cargo_on_package(
+async fn run_cargo_on_packages<I, S>(
     subcmd: &str,
-    package: &str,
+    packages: I,
     release: bool,
-) -> Result<()> {
+) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
     let mut cmd = Command::new("cargo");
     // We rely on the rust-toolchain.toml file for toolchain information,
     // rather than specifying one within the packaging tool.
-    cmd.arg(subcmd).arg("-p").arg(package);
+    cmd.arg(subcmd);
+    for package in packages {
+        cmd.arg("-p").arg(package);
+    }
     if release {
         cmd.arg("--release");
     }
     let status =
-        cmd.status().context(format!("Failed to run command: ({:?})", cmd))?;
+        cmd.status().await.context(format!("Failed to run command: ({:?})", cmd))?;
     if !status.success() {
-        bail!("Failed to build package: {}", package);
+        bail!("Failed to build packages");
     }
 
     Ok(())
 }
 
-async fn do_check(config: &Config) -> Result<()> {
-    for (package_name, package) in &config.packages {
-        if let Some(rust_pkg) = &package.rust {
-            println!("Checking {}", package_name);
-            run_cargo_on_package("check", &package_name, rust_pkg.release)?;
-        }
+async fn do_for_all_rust_packages(config: &Config, command: &str) -> Result<()> {
+    // First, filter out all Rust packages from the configuration that should be
+    // built, and partition them into "release" and "debug" categories.
+    let (release_pkgs, debug_pkgs): (Vec<_>, _) =
+        config.packages.iter().filter_map(|(name, pkg)| {
+            pkg.rust.as_ref().map(|rust_pkg| (name, rust_pkg.release))
+        }).partition(|(_, release)| {
+            *release
+        });
+
+    // Execute all the release / debug packages at the same time.
+    if !release_pkgs.is_empty() {
+        run_cargo_on_packages(command, release_pkgs.iter().map(|(name, _)| name), true).await?;
+    }
+    if !debug_pkgs.is_empty() {
+        run_cargo_on_packages(command, debug_pkgs.iter().map(|(name, _)| name), false).await?;
     }
     Ok(())
+}
+
+async fn do_check(config: &Config) -> Result<()> {
+    do_for_all_rust_packages(config, "check").await
+}
+
+async fn do_build(config: &Config) -> Result<()> {
+    do_for_all_rust_packages(config, "build").await
 }
 
 async fn do_package(config: &Config, output_directory: &Path) -> Result<()> {
     create_dir_all(&output_directory)
         .map_err(|err| anyhow!("Cannot create output directory: {}", err))?;
 
-    for (package_name, package) in &config.packages {
-        if let Some(rust_pkg) = &package.rust {
-            println!("Building: {}", package_name);
-            run_cargo_on_package("build", package_name, rust_pkg.release)?;
-        }
-        package.create(&output_directory).await?;
-    }
+    let ui = ProgressUI::new();
+    let ui_refs = vec![ui.clone(); config.packages.len()];
+
+    do_build(&config).await?;
 
     for (package_name, package) in &config.external_packages {
+        let progress = ui.add_package(package_name.to_string(), 1);
+        progress.set_message("finding package".to_string());
         let path = package.get_output_path(&output_directory);
         if !path.exists() {
             bail!(
@@ -110,7 +137,29 @@ in improving the cross-repository meta-build system, please contact sean@.",
                     .to_string_lossy(),
             );
         }
+        progress.finish();
     }
+
+    stream::iter(&config.packages)
+        // It's a pain to clone a value into closures - see
+        // https://github.com/rust-lang/rfcs/issues/2407 - so in the meantime,
+        // we explicitly create the references to the UI we need for each
+        // package.
+        .zip(stream::iter(ui_refs))
+        // We convert the stream type to operate on Results, so we may invoke
+        // "try_for_each_concurrent" more easily.
+        .map(Ok::<_, anyhow::Error>)
+        .try_for_each_concurrent(
+            None,
+            |((package_name, package), ui)| async move {
+                let total_work = package.get_total_work();
+                let progress = ui.add_package(package_name.to_string(), total_work);
+                progress.set_message("bundle package".to_string());
+                package.create_with_progress(&progress, &output_directory).await?;
+                progress.finish();
+                Ok(())
+            }
+    ).await?;
 
     Ok(())
 }
@@ -221,6 +270,69 @@ fn do_uninstall(
     println!("Removing: {}", install_dir.to_string_lossy());
     remove_all_unless_already_removed(install_dir)?;
     Ok(())
+}
+
+fn in_progress_style() -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
+        .unwrap()
+        .progress_chars("#>.")
+}
+
+fn completed_progress_style() -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg:.green}")
+        .unwrap()
+        .progress_chars("#>.")
+}
+
+// Struct managing display of progress to UI.
+struct ProgressUI {
+    multi: MultiProgress,
+    style: ProgressStyle,
+}
+
+struct PackageProgress {
+    pb: ProgressBar,
+    service_name: String,
+}
+
+impl PackageProgress {
+    fn finish(&self) {
+        self.pb.set_style(completed_progress_style());
+        self.pb.finish_with_message(format!("{}: done", self.service_name));
+        self.pb.tick();
+    }
+}
+
+impl Progress for PackageProgress {
+    fn set_message(&self, message: impl Into<std::borrow::Cow<'static, str>>) {
+        self.pb.set_message(format!("{}: {}", self.service_name, message.into()));
+    }
+
+    fn increment(&self, delta: u64) {
+        self.pb.inc(delta);
+    }
+}
+
+impl ProgressUI {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            multi: MultiProgress::new(),
+            style: in_progress_style(),
+        })
+    }
+
+    fn add_package(&self, service_name: String, total: u64) -> PackageProgress {
+        let pb = self.multi.add(ProgressBar::new(total));
+        pb.set_style(self.style.clone());
+        pb.set_message(service_name.clone());
+        pb.tick();
+        PackageProgress {
+            pb,
+            service_name,
+        }
+    }
 }
 
 #[tokio::main]


### PR DESCRIPTION
- Builds all the packages we need concurrently, before starting the rest of the packaging process
- Execute the packaging process concurrently
- Makes use of https://github.com/oxidecomputer/omicron-package/pull/6 to add a progress bar for the packaging process

![package](https://user-images.githubusercontent.com/3258857/158448358-2c61e469-0a1c-4237-8320-577d77accc18.gif)
