### PR TITLE
MGS: Start `gateway-sp-comms` crate with a `ManagementSwitch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-sp-comms"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "gateway-messages",
+ "omicron-test-utils",
+ "ringbuffer",
+ "serde",
+ "slog",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "expectorate",
  "futures",
  "gateway-messages",
+ "gateway-sp-comms",
  "hex",
  "http",
  "omicron-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "gateway",
     "gateway-client",
     "gateway-messages",
+    "gateway-sp-comms",
     "nexus",
     "nexus/src/db/db-macros",
     "nexus/test-utils",

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gateway-sp-comms"
+version = "0.1.0"
+edition = "2018"
+license = "MPL-2.0"
+
+[dependencies]
+futures = "0.3.21"
+ringbuffer = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.30"
+uuid = "0.8"
+
+gateway-messages = { path = "../gateway-messages", features = ["std"] }
+
+[dependencies.slog]
+version = "2.7"
+features = [ "max_level_trace", "release_max_level_debug" ]
+
+[dependencies.tokio]
+version = "1.16"
+features = [ "full" ]
+
+[dev-dependencies]
+omicron-test-utils = { path = "../test-utils" }

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use std::io;
+use std::net::SocketAddr;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StartupError {
+    #[error("error binding to UDP address {addr}: {err}")]
+    UdpBind { addr: SocketAddr, err: io::Error },
+}

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -20,5 +20,5 @@ pub use management_switch::SwitchPort;
 // TODO these will remain public for a while, but eventually will be removed
 // altogther; currently these provide a way to hard-code the rack topology,
 // which is not what we want.
-pub use management_switch::KnownSps;
 pub use management_switch::KnownSp;
+pub use management_switch::KnownSps;

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+pub mod error;
+mod management_switch;
+
+pub use management_switch::SpIdentifier;
+pub use management_switch::SpType;
+
+// TODO the following should probably not be pub once this crate is more
+// complete; for now make them pub so `gateway` can use them directly
+pub use management_switch::ManagementSwitch;
+pub use management_switch::ManagementSwitchDiscovery;
+pub use management_switch::SpSocket;
+pub use management_switch::SwitchPort;
+
+// TODO these will remain public for a while, but eventually will be removed
+// altogther; currently these provide a way to hard-code the rack topology,
+// which is not what we want.
+pub use management_switch::KnownSps;
+pub use management_switch::KnownSp;

--- a/gateway-sp-comms/src/management_switch.rs
+++ b/gateway-sp-comms/src/management_switch.rs
@@ -1,0 +1,595 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//!
+//! Long-running task responsible for tracking the topology of the SPs connected
+//! to the management network switch ports.
+//!
+//! See RFD 250 for details.
+//!
+
+use crate::error::StartupError;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpMessage;
+use serde::Deserialize;
+use serde::Serialize;
+use slog::debug;
+use slog::warn;
+use slog::Logger;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::task::JoinHandle;
+
+/// TODO For now, we don't do RFD 250-style discovery; instead, we take a
+/// hard-coded list of known SPs. Each known SP has two address: the (presumably
+/// fake) SP and the "local" address for the corresponding management switch
+/// port.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct KnownSp {
+    pub sp: SocketAddr,
+    pub switch_port: SocketAddr,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct KnownSps {
+    /// Must be nonempty. The first is interpreted as the local ignition
+    /// controller.
+    pub switches: Vec<KnownSp>,
+    /// Must be nonempty. TBD which we assume (if any) is our local SP.
+    pub sleds: Vec<KnownSp>,
+    /// May be empty.
+    pub power_controllers: Vec<KnownSp>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SpIdentifier {
+    pub typ: SpType,
+    pub slot: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SpType {
+    Switch,
+    Sled,
+    Power,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SwitchPort(usize);
+
+impl SwitchPort {
+    pub fn as_ignition_target(self) -> u8 {
+        // TODO should we use a u16 to describe ignition targets instead? rack
+        // v1 is limited to 36, unclear what ignition will look like in future
+        // products
+        assert!(
+            self.0 <= usize::from(u8::MAX),
+            "cannot exceed 255 ignition targets / switch ports"
+        );
+        self.0 as u8
+    }
+}
+
+#[derive(Debug)]
+pub struct ManagementSwitchDiscovery {
+    inner: Arc<Inner>,
+}
+
+impl ManagementSwitchDiscovery {
+    // TODO: Replace this with real RFD 250-style discovery. For now, just take
+    // a hardcoded list of (simulated) SPs and a list of addresses to bind to.
+    // For now, we assumes SPs should talk to the bound addresses in the order
+    //
+    // ```
+    // [switch 0, switch 1, ..., switch n - 1,
+    //  sled 0,   sled 1,   ..., sled n - 1,
+    //  power_controller 0, ..., power_controller n - 1]
+    // ```
+    //
+    // and any leftover bind addresses are ignored.
+    pub async fn placeholder_start(
+        known_sps: KnownSps,
+        log: Logger,
+    ) -> Result<Self, StartupError> {
+        assert!(!known_sps.switches.is_empty(), "at least one switch required");
+        assert!(!known_sps.sleds.is_empty(), "at least one sled required");
+
+        let mut ports = Vec::new();
+        for known_sps in [
+            &known_sps.switches,
+            &known_sps.sleds,
+            &known_sps.power_controllers,
+        ] {
+            for bind_addr in known_sps.iter().map(|k| k.switch_port) {
+                ports.push(UdpSocket::bind(bind_addr).await.map_err(
+                    |err| StartupError::UdpBind { addr: bind_addr, err },
+                )?);
+            }
+        }
+
+        let inner = Arc::new(Inner { log, known_sps, ports });
+
+        Ok(Self { inner })
+    }
+
+    /// Get a list of all ports on this switch.
+    // TODO 1 currently this only returns configured ports based on
+    // `placeholder_start`; eventually it should be all real management switch
+    // ports.
+    //
+    // TODO 2 should we attach the SP type to each port? For now just return a
+    // flat list.
+    pub fn all_ports(
+        &self,
+    ) -> impl ExactSizeIterator<Item = SwitchPort> + 'static {
+        (0..self.inner.ports.len()).map(SwitchPort)
+    }
+
+    /// Consume `self` and start a long-running task to receive packets on all
+    /// ports, calling `recv_callback` for each.
+    pub fn start_recv_task<F>(self, recv_callback: F) -> ManagementSwitch
+    where
+        F: Fn(SwitchPort, &'_ [u8]) + Send + 'static,
+    {
+        let recv_task = {
+            let inner = Arc::clone(&self.inner);
+            tokio::spawn(recv_task(inner, recv_callback))
+        };
+        ManagementSwitch { inner: self.inner, recv_task }
+    }
+}
+
+#[derive(Debug)]
+pub struct ManagementSwitch {
+    inner: Arc<Inner>,
+
+    // handle to the running task that calls recv on all `switch_ports` sockets;
+    // we keep this handle only to kill it when we're dropped
+    recv_task: JoinHandle<()>,
+}
+
+impl Drop for ManagementSwitch {
+    fn drop(&mut self) {
+        self.recv_task.abort();
+    }
+}
+
+impl ManagementSwitch {
+    /// Get the socket connected to the local ignition controller.
+    pub fn ignition_controller(&self) -> SpSocket {
+        // TODO for now this is guaranteed to exist based on the assertions in
+        // `placeholder_start`; once that's replaced by a non-placeholder
+        // implementation, revisit this.
+        let port = self.inner.switch_port(SpType::Switch, 0).unwrap();
+        self.inner.sp_socket(port).unwrap()
+    }
+
+    pub fn switch_port_from_ignition_target(
+        &self,
+        target: usize,
+    ) -> Option<SwitchPort> {
+        // TODO this assumes `self.inner.ports` is ordered the same as ignition
+        // targets; confirm once we replace `placeholder_start`
+        if target < self.inner.ports.len() {
+            Some(SwitchPort(target))
+        } else {
+            None
+        }
+    }
+
+    pub fn switch_port(
+        &self,
+        id: SpIdentifier,
+    ) -> Option<SwitchPort> {
+        self.inner.switch_port(id.typ, id.slot)
+    }
+
+    pub fn switch_port_to_id(&self, port: SwitchPort) -> SpIdentifier {
+        self.inner.port_to_id(port)
+    }
+
+    pub fn sp_socket(&self, port: SwitchPort) -> Option<SpSocket<'_>> {
+        self.inner.sp_socket(port)
+    }
+}
+
+/// Wrapper for a UDP socket on one of our switch ports that knows the address
+/// of the SP connected to this port.
+#[derive(Debug)]
+pub struct SpSocket<'a> {
+    socket: &'a UdpSocket,
+    addr: SocketAddr,
+    port: SwitchPort,
+}
+
+impl SpSocket<'_> {
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn port(&self) -> SwitchPort {
+        self.port
+    }
+
+    /// Wrapper around `send_to` that uses the SP address stored in `self` as
+    /// the destination address.
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send_to(buf, self.addr).await
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    log: Logger,
+    known_sps: KnownSps,
+
+    // One UDP socket per management switch port. For now, this is guaranteed to
+    // have a length equal to the sum of the lengths of the fields of
+    // `known_sps`; eventually, it will be guaranteed to be the length of the
+    // number of ports on the connected management switch.
+    ports: Vec<UdpSocket>,
+}
+
+impl Inner {
+    /// Convert a logical SP location (e.g., "sled 7") into a port on the
+    /// management switch.
+    fn switch_port(&self, sp_type: SpType, slot: usize) -> Option<SwitchPort> {
+        // map `sp_type` down to the range of port slots that cover it
+        let (base_slot, num_slots) = match sp_type {
+            SpType::Switch => (0, self.known_sps.switches.len()),
+            SpType::Sled => {
+                (self.known_sps.switches.len(), self.known_sps.sleds.len())
+            }
+            SpType::Power => (
+                self.known_sps.switches.len() + self.known_sps.sleds.len(),
+                self.known_sps.power_controllers.len(),
+            ),
+        };
+
+        if slot < num_slots {
+            Some(SwitchPort(base_slot + slot))
+        } else {
+            None
+        }
+    }
+
+    /// Convert a [`SwitchPort`] into the logical identifier of the SP connected
+    /// to that port.
+    fn port_to_id(&self, port: SwitchPort) -> SpIdentifier {
+        let mut n = port.0;
+
+        for (typ, num) in [
+            (SpType::Switch, self.known_sps.switches.len()),
+            (SpType::Sled, self.known_sps.sleds.len()),
+            (SpType::Power, self.known_sps.power_controllers.len()),
+        ] {
+            if n < num {
+                return SpIdentifier { typ, slot: n };
+            }
+            n -= num;
+        }
+
+        unreachable!("invalid port instance {:?}", port);
+    }
+
+    /// Get the local bound address for the given switch port.
+    #[cfg(test)] // for now we only use this in unit tests
+    fn local_addr(&self, port: SwitchPort) -> io::Result<SocketAddr> {
+        self.ports[port.0].local_addr()
+    }
+
+    /// Get the socket to use to communicate with an AP and the socket address
+    /// of that SP.
+    fn sp_socket(&self, port: SwitchPort) -> Option<SpSocket<'_>> {
+        // NOTE: For now, it's not possible for this method to return `None`. We
+        // control construction of `SwitchPort`s, and only hand them out for
+        // valid "ports" where we know an SP is (at least supposed to) be
+        // listening. In the future this may return `None` if there is no SP
+        // connected on this port.
+        let mut n = port.0;
+        for known_sps in [
+            &self.known_sps.switches,
+            &self.known_sps.sleds,
+            &self.known_sps.power_controllers,
+        ] {
+            if n < known_sps.len() {
+                return Some(SpSocket {
+                    socket: &self.ports[port.0],
+                    addr: known_sps[n].sp,
+                    port,
+                });
+            }
+            n -= known_sps.len();
+        }
+
+        // We only construct `SwitchPort`s with valid indices, so the only way
+        // to get here is if someone constructs two `ManagementSwitch` instances
+        // (with different port cardinalities) and then mixes up `SwitchPort`s
+        // between them (or other similarly outlandish shenanigans) - fine to
+        // panic in that case.
+        unreachable!("invalid port {:?}", port)
+    }
+}
+
+async fn recv_task<F>(inner: Arc<Inner>, mut callback: F)
+where
+    F: FnMut(SwitchPort, &'_ [u8]),
+{
+    // helper function to tag a socket's `.readable()` future with an index; we
+    // need this to make rustc happy about the types we push into
+    // `recv_all_sockets` below
+    async fn readable_with_port(
+        port: SwitchPort,
+        sock: &UdpSocket,
+    ) -> (SwitchPort, io::Result<()>) {
+        let result = sock.readable().await;
+        (port, result)
+    }
+
+    // set up collection of futures tracking readability of all switch port
+    // sockets
+    let mut recv_all_sockets = FuturesUnordered::new();
+    for (i, sock) in inner.ports.iter().enumerate() {
+        recv_all_sockets.push(readable_with_port(SwitchPort(i), sock));
+    }
+
+    let mut buf = [0; SpMessage::MAX_SIZE];
+
+    loop {
+        // `recv_all_sockets.next()` will never return `None` because we
+        // immediately push a new future into it every time we pull one out
+        // (to reregister readable interest in the corresponding socket)
+        let (port, result) = recv_all_sockets.next().await.unwrap();
+
+        // immediately push a new future requesting readability interest, as
+        // noted above
+        let sock = &inner.ports[port.0];
+        recv_all_sockets.push(readable_with_port(port, sock));
+
+        // TODO how do we handle errors here (or from `recv()` below)?
+        // currently just log them and retry, assuming any socket errors are
+        // ephemeral
+        if let Err(err) = result {
+            warn!(
+                inner.log,
+                "error checking socket readability";
+                "port" => ?port,
+                "err" => err,
+            );
+            continue;
+        }
+
+        match sock.try_recv_from(&mut buf) {
+            Ok((n, addr)) => {
+                if Some(addr) != inner.sp_socket(port).map(|s| s.addr) {
+                    // TODO what do we do here? we received a packet from an
+                    // address that doesn't match what we believe is the SP's
+                    // address. for now, log and discard
+                    warn!(
+                        inner.log,
+                        "discarding packet from unknown source";
+                        "port" => ?port,
+                        "src_addr" => addr,
+                    );
+                } else {
+                    debug!(inner.log, "received {} bytes", n; "port" => ?port);
+                    callback(port, &buf[..n]);
+                }
+            }
+            // spurious wakeup; no need to log, just continue
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => (),
+            Err(err) => {
+                warn!(
+                    inner.log,
+                    "error in recv_from";
+                    "port" => ?port,
+                    "err" => err,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future;
+    use omicron_test_utils::dev::poll;
+    use omicron_test_utils::dev::poll::CondCheckError;
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+    use std::mem;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    // collection of sockets that act like SPs for the purposes of these tests
+    struct Harness {
+        switches: Vec<UdpSocket>,
+        sleds: Vec<UdpSocket>,
+        pscs: Vec<UdpSocket>,
+    }
+
+    impl Harness {
+        async fn new() -> Self {
+            const NUM_SWITCHES: usize = 1;
+            const NUM_SLEDS: usize = 2;
+            const NUM_POWER_CONTROLLERS: usize = 1;
+
+            let mut switches = Vec::with_capacity(NUM_SWITCHES);
+            let mut sleds = Vec::with_capacity(NUM_SLEDS);
+            let mut pscs = Vec::with_capacity(NUM_POWER_CONTROLLERS);
+            for _ in 0..NUM_SWITCHES {
+                switches.push(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+            }
+            for _ in 0..NUM_SLEDS {
+                sleds.push(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+            }
+            for _ in 0..NUM_POWER_CONTROLLERS {
+                pscs.push(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+            }
+
+            Self { switches, sleds, pscs }
+        }
+
+        fn all_sockets(&self) -> impl Iterator<Item = &'_ UdpSocket> {
+            self.switches
+                .iter()
+                .chain(self.sleds.iter())
+                .chain(self.pscs.iter())
+        }
+
+        fn as_known_sps(&self) -> KnownSps {
+            KnownSps {
+                switches: self
+                    .switches
+                    .iter()
+                    .map(|sock| KnownSp {
+                        sp: sock.local_addr().unwrap(),
+                        switch_port: "127.0.0.1:0".parse().unwrap(),
+                    })
+                    .collect(),
+                sleds: self
+                    .sleds
+                    .iter()
+                    .map(|sock| KnownSp {
+                        sp: sock.local_addr().unwrap(),
+                        switch_port: "127.0.0.1:0".parse().unwrap(),
+                    })
+                    .collect(),
+                power_controllers: self
+                    .pscs
+                    .iter()
+                    .map(|sock| KnownSp {
+                        sp: sock.local_addr().unwrap(),
+                        switch_port: "127.0.0.1:0".parse().unwrap(),
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recv_task() {
+        let harness = Harness::new().await;
+
+        // create a switch, pointed at our harness's fake SPs, with a
+        // callback that accumlates received packets into a hashmap
+        let received: Arc<Mutex<HashMap<SwitchPort, Vec<Vec<u8>>>>> =
+            Arc::default();
+        let discovery = ManagementSwitchDiscovery::placeholder_start(
+            harness.as_known_sps(),
+            Logger::root(slog::Discard, slog::o!()),
+        )
+        .await
+        .unwrap();
+        let switch = discovery.start_recv_task({
+            let received = Arc::clone(&received);
+            move |port, data| {
+                let mut received = received.lock().unwrap();
+                received.entry(port).or_default().push(data.to_vec());
+            }
+        });
+
+        // Actual test - send a bunch of data to each of the ports...
+        let mut expected: HashMap<SwitchPort, Vec<Vec<u8>>> = HashMap::new();
+        for i in 0..10 {
+            for (port_num, sock) in harness.all_sockets().enumerate() {
+                let port = SwitchPort(port_num);
+                let data = format!("message {} to {:?}", i, port).into_bytes();
+
+                let addr = switch.inner.local_addr(port).unwrap();
+                sock.send_to(&data, addr).await.unwrap();
+                expected.entry(port).or_default().push(data);
+            }
+        }
+        // ... and confirm we received them all. messages should be in order per
+        // socket, but we don't check ordering of messages across sockets since
+        // that may vary
+        {
+            let received = Arc::clone(&received);
+            poll::wait_for_condition(
+                move || {
+                    let result = if expected == *received.lock().unwrap() {
+                        Ok(())
+                    } else {
+                        Err(CondCheckError::<Infallible>::NotYet)
+                    };
+                    future::ready(result)
+                },
+                &Duration::from_millis(10),
+                &Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+        }
+
+        // before dropping `switch`, confirm that the count on `received` is
+        // exactly 2: us and the receive task. after dropping `switch` it will
+        // be only us.
+        assert_eq!(Arc::strong_count(&received), 2);
+
+        // dropping `switch` should cancel its corresponding recv task, which
+        // we can confirm by checking that the ref count on `received` drops to
+        // 1 (just us). we have to poll for this since it's not necessarily
+        // immediate; recv_task is presumably running on a tokio thread
+        mem::drop(switch);
+        poll::wait_for_condition(
+            move || {
+                let result = match Arc::strong_count(&received) {
+                    1 => Ok(()),
+                    2 => Err(CondCheckError::<Infallible>::NotYet),
+                    n => panic!("bogus count {}", n),
+                };
+                future::ready(result)
+            },
+            &Duration::from_millis(10),
+            &Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sp_socket() {
+        let harness = Harness::new().await;
+
+        let discovery = ManagementSwitchDiscovery::placeholder_start(
+            harness.as_known_sps(),
+            Logger::root(slog::Discard, slog::o!()),
+        )
+        .await
+        .unwrap();
+        let switch = discovery.start_recv_task(|_port, _data| { /* ignore */ });
+
+        // confirm messages sent to the switch's sp sockets show up on our
+        // harness sockets
+        let mut buf = [0; SpMessage::MAX_SIZE];
+        for (typ, sp_sockets) in [
+            (SpType::Switch, &harness.switches),
+            (SpType::Sled, &harness.sleds),
+            (SpType::Power, &harness.pscs),
+        ] {
+            for (slot, sp_sock) in sp_sockets.iter().enumerate() {
+                let port = switch.inner.switch_port(typ, slot).unwrap();
+                let sock = switch.inner.sp_socket(port).unwrap();
+
+                let message = format!("{:?} {}", typ, slot).into_bytes();
+                sock.send(&message).await.unwrap();
+
+                let (n, addr) = sp_sock.recv_from(&mut buf).await.unwrap();
+
+                // confirm we received the expected message from the
+                // corresponding switch port
+                assert_eq!(&buf[..n], message);
+                assert_eq!(addr, switch.inner.local_addr(port).unwrap());
+            }
+        }
+    }
+}

--- a/gateway-sp-comms/src/management_switch.rs
+++ b/gateway-sp-comms/src/management_switch.rs
@@ -184,10 +184,7 @@ impl ManagementSwitch {
         }
     }
 
-    pub fn switch_port(
-        &self,
-        id: SpIdentifier,
-    ) -> Option<SwitchPort> {
+    pub fn switch_port(&self, id: SpIdentifier) -> Option<SwitchPort> {
         self.inner.switch_port(id.typ, id.slot)
     }
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -19,6 +19,7 @@ toml = "0.5.6"
 uuid = "0.8"
 
 gateway-messages = { path = "../gateway-messages", features = ["std"] }
+gateway-sp-comms = { path = "../gateway-sp-comms" }
 omicron-common = { path = "../common" }
 
 [dependencies.slog]

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -4,16 +4,18 @@
 
 # Identifier for this instance of MGS
 id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
-udp_bind_address = "127.0.0.1:22222"
 
 [known_sps]
-# TODO we repeat the ignition_controller IP as a switch; should we specify it as
-# an index into `switches` instead? Punting since this isn't how we want to map
-# our known SPs anyway.
-ignition_controller = "127.0.0.1:23456"
-switches = ["127.0.0.1:23456"]
-sleds = ["127.0.0.1:23457", "127.0.0.1:23458"]
-power_controllers = []
+switches = [
+    # first switch is assumed to be the local ignition controller
+    { sp = "127.0.0.1:23456", switch_port = "127.0.0.1:33456" },
+]
+sleds = [
+    { sp = "127.0.0.1:23457", switch_port = "127.0.0.1:33457" },
+    { sp = "127.0.0.1:23458", switch_port = "127.0.0.1:33458" },
+]
+power_controllers = [
+]
 
 [timeouts]
 ignition_controller_millis = 1_000

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -51,13 +51,8 @@ impl ServerContext {
         config: &Config,
         log: &Logger,
     ) -> Result<Arc<Self>, StartupError> {
-        let sp_comms = Arc::new(
-            SpCommunicator::new(
-                config.known_sps.clone(),
-                log,
-            )
-            .await?,
-        );
+        let sp_comms =
+            Arc::new(SpCommunicator::new(config.known_sps.clone(), log).await?);
         Ok(Arc::new(ServerContext {
             sp_comms,
             timeouts: Timeouts::from(&config.timeouts),

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -2,10 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{
-    sp_comms::{SpCommunicator, StartupError},
-    Config,
-};
+use crate::sp_comms::SpCommunicator;
+use crate::Config;
+use gateway_sp_comms::error::StartupError;
 use slog::Logger;
 use std::{sync::Arc, time::Duration};
 
@@ -54,7 +53,6 @@ impl ServerContext {
     ) -> Result<Arc<Self>, StartupError> {
         let sp_comms = Arc::new(
             SpCommunicator::new(
-                config.udp_bind_address,
                 config.known_sps.clone(),
                 log,
             )

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -9,7 +9,6 @@ pub mod http_entrypoints; // TODO pub only for testing - is this right?
 mod sp_comms;
 
 pub use config::Config;
-pub use config::KnownSps;
 pub use context::ServerContext;
 use slog::{debug, error, info, o, Logger};
 use std::sync::Arc;

--- a/gateway/src/sp_comms.rs
+++ b/gateway/src/sp_comms.rs
@@ -18,7 +18,6 @@ pub(crate) use self::serial_console_history::SerialConsoleContents;
 use self::bulk_state_get::OutstandingSpStateRequests;
 use self::serial_console_history::SerialConsoleHistory;
 
-use crate::config::KnownSps;
 use crate::http_entrypoints::SpState;
 use dropshot::HttpError;
 use gateway_messages::sp_impl::SerialConsolePacketizer;
@@ -34,6 +33,13 @@ use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 use gateway_messages::SpMessage;
 use gateway_messages::SpMessageKind;
+use gateway_sp_comms::error::StartupError;
+use gateway_sp_comms::KnownSps;
+use gateway_sp_comms::ManagementSwitch;
+use gateway_sp_comms::ManagementSwitchDiscovery;
+use gateway_sp_comms::SpIdentifier;
+use gateway_sp_comms::SpSocket;
+use gateway_sp_comms::SwitchPort;
 use slog::debug;
 use slog::error;
 use slog::info;
@@ -47,19 +53,11 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use thiserror::Error;
-use tokio::net::UdpSocket;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::oneshot::Sender;
-use tokio::task::JoinHandle;
 use tokio::time::Instant;
-
-#[derive(Debug, Error)]
-pub enum StartupError {
-    #[error("error binding to UDP address {addr}: {err}")]
-    UdpBind { addr: SocketAddr, err: io::Error },
-}
 
 // TODO This has some duplication with `gateway::error::Error`. This might be
 // right if these comms are going to move to their own crate, but at the moment
@@ -84,8 +82,12 @@ pub enum Error {
     SpError(#[from] ResponseError),
     #[error("timeout")]
     Timeout,
-    #[error("no known SP at {0}")]
-    SpDoesNotExist(SocketAddr),
+    #[error("received ignition target for an unknown port ({0})")]
+    UnknownIgnitionTargetPort(usize),
+    #[error("unknown SP destination address for {0:?}")]
+    UnknownSpAddress(SwitchPort),
+    #[error("nonexistent SP {0:?}")]
+    SpDoesNotExist(SpIdentifier),
 
     // ----
     // client errors
@@ -117,6 +119,8 @@ impl From<Error> for HttpError {
             | Error::BogusResponseType { .. }
             | Error::SpError(_)
             | Error::Timeout
+            | Error::UnknownIgnitionTargetPort(_)
+            | Error::UnknownSpAddress(_)
             | Error::SpDoesNotExist(_) => {
                 HttpError::for_internal_error(err.to_string())
             }
@@ -164,75 +168,70 @@ mod response_kind_names {
 #[derive(Debug)]
 pub struct SpCommunicator {
     log: Logger,
-    socket: Arc<UdpSocket>,
-    known_sps: KnownSps,
+    switch: ManagementSwitch,
     sp_state: Arc<AllSpState>,
     bulk_state_requests: OutstandingSpStateRequests,
     request_id: AtomicU32,
-    recv_task: JoinHandle<()>,
-}
-
-impl Drop for SpCommunicator {
-    fn drop(&mut self) {
-        // default `JoinHandle` drop behavior is to detach; we want to kill our
-        // recv task if we're dropped.
-        self.recv_task.abort();
-    }
 }
 
 impl SpCommunicator {
     pub async fn new(
-        bind_addr: SocketAddr,
         known_sps: KnownSps,
         log: &Logger,
     ) -> Result<Self, StartupError> {
-        let socket =
-            Arc::new(UdpSocket::bind(bind_addr).await.map_err(|err| {
-                StartupError::UdpBind { addr: bind_addr, err }
-            })?);
-        let log = log.new(o!(
-            "componennt" => "SpCommunicator",
-            "local_addr" => bind_addr,
-        ));
-
-        // build our fixed-keys-after-this-point map of known SP IPs
-        let sp_state = Arc::new(AllSpState::new(&known_sps));
-
-        let recv_task = RecvTask::new(
-            Arc::clone(&socket),
-            Arc::clone(&sp_state),
+        let log = log.new(o!("componennt" => "SpCommunicator"));
+        let discovery = ManagementSwitchDiscovery::placeholder_start(
+            known_sps,
             log.clone(),
-        );
-        let recv_task = tokio::spawn(recv_task.run());
-        info!(&log, "started sp-server");
+        )
+        .await?;
+
+        // build our map of switch ports to state-of-the-SP-on-that-port
+        let sp_state = Arc::new(AllSpState::new(&discovery));
+
+        let recv_handler = RecvHandler::new(Arc::clone(&sp_state), log.clone());
+        let switch = discovery
+            .start_recv_task(move |port, data| recv_handler.handle(port, data));
+
+        info!(&log, "started SP communicator");
         Ok(Self {
             log,
-            socket,
-            known_sps,
+            switch,
             sp_state,
             bulk_state_requests: OutstandingSpStateRequests::default(),
             request_id: AtomicU32::new(0),
-            recv_task,
         })
     }
 
-    pub fn placeholder_known_sps(&self) -> &KnownSps {
-        &self.known_sps
+    fn id_to_port(&self, sp: SpIdentifier) -> Result<SwitchPort, Error> {
+        self.switch.switch_port(sp).ok_or(Error::SpDoesNotExist(sp))
+    }
+
+    pub(crate) fn port_to_id(&self, port: SwitchPort) -> SpIdentifier {
+        self.switch.switch_port_to_id(port)
     }
 
     pub(crate) async fn state_get(
         &self,
-        sp: SocketAddr,
+        sp: SpIdentifier,
         timeout: Instant,
     ) -> Result<SpState, Error> {
-        tokio::time::timeout_at(timeout, self.state_get_impl(sp)).await?
+        self.state_get_by_port(self.id_to_port(sp)?, timeout).await
+    }
+
+    async fn state_get_by_port(
+        &self,
+        port: SwitchPort,
+        timeout: Instant,
+    ) -> Result<SpState, Error> {
+        tokio::time::timeout_at(timeout, self.state_get_impl(port)).await?
     }
 
     pub(crate) fn bulk_state_start(
         self: &Arc<Self>,
         timeout: Instant,
         retain_grace_period: Duration,
-        sps: impl Iterator<Item = (usize, IgnitionState, Option<SocketAddr>)>,
+        sps: impl Iterator<Item = (SwitchPort, IgnitionState)>,
     ) -> SpStateRequestId {
         self.bulk_state_requests.start(timeout, retain_grace_period, sps, self)
     }
@@ -240,17 +239,24 @@ impl SpCommunicator {
     pub(crate) async fn bulk_state_get_progress(
         &self,
         id: &SpStateRequestId,
-        last_seen_target: Option<u8>,
+        last_seen: Option<SpIdentifier>,
         timeout: Duration,
         limit: usize,
     ) -> Result<BulkStateProgress, Error> {
+        let last_seen = match last_seen {
+            Some(sp) => Some(self.id_to_port(sp)?),
+            None => None,
+        };
         self.bulk_state_requests
-            .get(id, last_seen_target, timeout, limit, &self.log)
+            .get(id, last_seen, timeout, limit, &self.log)
             .await
     }
 
-    async fn state_get_impl(&self, sp: SocketAddr) -> Result<SpState, Error> {
-        match self.request_response(sp, RequestKind::SpState).await? {
+    async fn state_get_impl(&self, port: SwitchPort) -> Result<SpState, Error> {
+        let sp =
+            self.switch.sp_socket(port).ok_or(Error::UnknownSpAddress(port))?;
+
+        match self.request_response(&sp, RequestKind::SpState).await? {
             ResponseKind::SpState(state) => Ok(SpState::Enabled {
                 serial_number: hex::encode(&state.serial_number[..]),
             }),
@@ -263,17 +269,16 @@ impl SpCommunicator {
 
     pub(crate) fn serial_console_get(
         &self,
-        sp: SocketAddr,
+        sp: SpIdentifier,
         component: &SpComponent,
     ) -> Result<Option<SerialConsoleContents>, Error> {
-        let sp =
-            self.sp_state.all_sps.get(&sp).ok_or(Error::SpDoesNotExist(sp))?;
-        Ok(sp.serial_console_from_sp.lock().unwrap().contents(component))
+        let state = self.sp_state.get(self.id_to_port(sp)?);
+        Ok(state.serial_console_from_sp.lock().unwrap().contents(component))
     }
 
     pub(crate) async fn serial_console_post(
         &self,
-        sp: SocketAddr,
+        sp: SpIdentifier,
         component: SpComponent,
         data: &[u8],
         timeout: Duration,
@@ -287,15 +292,17 @@ impl SpCommunicator {
 
     async fn serial_console_post_impl(
         &self,
-        sp: SocketAddr,
+        sp: SpIdentifier,
         component: SpComponent,
         data: &[u8],
     ) -> Result<(), Error> {
-        let sp_state = self
-            .sp_state
-            .all_sps
-            .get(&sp)
-            .ok_or_else(|| Error::SpDoesNotExist(sp))?;
+        let sp_port = self.id_to_port(sp)?;
+        let sp_state = self.sp_state.get(self.id_to_port(sp)?);
+
+        let sp_sock = self
+            .switch
+            .sp_socket(sp_port)
+            .ok_or(Error::UnknownSpAddress(sp_port))?;
 
         let mut packetizers = sp_state.serial_console_to_sp.lock().await;
         let packetizer = packetizers
@@ -304,7 +311,7 @@ impl SpCommunicator {
 
         for packet in packetizer.packetize(data) {
             let request = RequestKind::SerialConsoleWrite(packet);
-            match self.request_response(sp, request).await? {
+            match self.request_response(&sp_sock, request).await? {
                 ResponseKind::SerialConsoleWriteAck => (),
                 other => {
                     return Err(Error::from_unhandled_response_kind(
@@ -321,25 +328,33 @@ impl SpCommunicator {
     pub async fn bulk_ignition_get(
         &self,
         timeout: Duration,
-    ) -> Result<Vec<IgnitionState>, Error> {
+    ) -> Result<Vec<(SwitchPort, IgnitionState)>, Error> {
         tokio::time::timeout(timeout, self.bulk_ignition_get_impl()).await?
     }
 
     async fn bulk_ignition_get_impl(
         &self,
-    ) -> Result<Vec<IgnitionState>, Error> {
-        // XXX We currently assume we know which ignition controller is our
-        // local one, and only use it for ignition interactions.
-        let controller = self.known_sps.ignition_controller;
-
+    ) -> Result<Vec<(SwitchPort, IgnitionState)>, Error> {
+        let controller = self.switch.ignition_controller();
         let request = RequestKind::BulkIgnitionState;
 
-        match self.request_response(controller, request).await? {
-            ResponseKind::BulkIgnitionState(state) => Ok(state.targets
-                [..usize::from(state.num_targets)]
-                .iter()
-                .copied()
-                .collect()),
+        match self.request_response(&controller, request).await? {
+            ResponseKind::BulkIgnitionState(state) => {
+                let mut results = Vec::new();
+                for (i, state) in state.targets
+                    [..usize::from(state.num_targets)]
+                    .iter()
+                    .copied()
+                    .enumerate()
+                {
+                    let port = self
+                        .switch
+                        .switch_port_from_ignition_target(i)
+                        .ok_or_else(|| Error::UnknownIgnitionTargetPort(i))?;
+                    results.push((port, state));
+                }
+                Ok(results)
+            }
             other => {
                 return Err(Error::from_unhandled_response_kind(
                     &other,
@@ -353,23 +368,22 @@ impl SpCommunicator {
     // send a u8 in the UDP message, so just take that for now.
     pub async fn ignition_get(
         &self,
-        target: u8,
+        sp: SpIdentifier,
         timeout: Duration,
     ) -> Result<IgnitionState, Error> {
-        tokio::time::timeout(timeout, self.ignition_get_impl(target)).await?
+        tokio::time::timeout(timeout, self.ignition_get_impl(sp)).await?
     }
 
     async fn ignition_get_impl(
         &self,
-        target: u8,
+        sp: SpIdentifier,
     ) -> Result<IgnitionState, Error> {
-        // XXX We currently assume we know which ignition controller is our
-        // local one, and only use it for ignition interactions.
-        let controller = self.known_sps.ignition_controller;
+        let controller = self.switch.ignition_controller();
+        let port = self.id_to_port(sp)?;
+        let request =
+            RequestKind::IgnitionState { target: port.as_ignition_target() };
 
-        let request = RequestKind::IgnitionState { target };
-
-        match self.request_response(controller, request).await? {
+        match self.request_response(&controller, request).await? {
             ResponseKind::IgnitionState(state) => Ok(state),
             other => {
                 return Err(Error::from_unhandled_response_kind(
@@ -382,39 +396,41 @@ impl SpCommunicator {
 
     pub async fn ignition_power_on(
         &self,
-        target: u8,
+        sp: SpIdentifier,
         timeout: Duration,
     ) -> Result<(), Error> {
         tokio::time::timeout(
             timeout,
-            self.ignition_command(target, IgnitionCommand::PowerOn),
+            self.ignition_command(sp, IgnitionCommand::PowerOn),
         )
         .await?
     }
 
     pub async fn ignition_power_off(
         &self,
-        target: u8,
+        sp: SpIdentifier,
         timeout: Duration,
     ) -> Result<(), Error> {
         tokio::time::timeout(
             timeout,
-            self.ignition_command(target, IgnitionCommand::PowerOff),
+            self.ignition_command(sp, IgnitionCommand::PowerOff),
         )
         .await?
     }
 
     async fn ignition_command(
         &self,
-        target: u8,
+        sp: SpIdentifier,
         command: IgnitionCommand,
     ) -> Result<(), Error> {
-        // XXX We currently assume we know which ignition controller is our
-        // local one, and only use it for ignition interactions.
-        let controller = self.known_sps.ignition_controller;
-        let request = RequestKind::IgnitionCommand { target, command };
+        let controller = self.switch.ignition_controller();
+        let port = self.id_to_port(sp)?;
+        let request = RequestKind::IgnitionCommand {
+            target: port.as_ignition_target(),
+            command,
+        };
 
-        match self.request_response(controller, request).await? {
+        match self.request_response(&controller, request).await? {
             ResponseKind::IgnitionCommandAck => Ok(()),
             other => {
                 return Err(Error::from_unhandled_response_kind(
@@ -427,7 +443,7 @@ impl SpCommunicator {
 
     async fn request_response(
         &self,
-        sp: SocketAddr,
+        sp: &SpSocket<'_>,
         request: RequestKind,
     ) -> Result<ResponseKind, Error> {
         // request IDs will eventually roll over; since we enforce timeouts
@@ -436,7 +452,8 @@ impl SpCommunicator {
             self.request_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         // tell our background receiver to expect a response to this request
-        let response = self.sp_state.insert_expected_response(sp, request_id);
+        let response =
+            self.sp_state.insert_expected_response(sp.port(), request_id);
 
         // Serialize and send our request. We know `buf` is large enough for any
         // `Request`, so unwrapping here is fine.
@@ -446,11 +463,11 @@ impl SpCommunicator {
         let n = gateway_messages::serialize(&mut buf, &request).unwrap();
 
         let serialized_request = &buf[..n];
-        debug!(&self.log, "sending {:?} to SP {}", request, sp);
-        self.socket
-            .send_to(serialized_request, sp)
-            .await
-            .map_err(|err| Error::UdpSend { addr: sp, err: Arc::new(err) })?;
+        debug!(&self.log, "sending {:?} to SP {:?}", request, sp);
+        sp.send(serialized_request).await.map_err(|err| Error::UdpSend {
+            addr: sp.addr(),
+            err: Arc::new(err),
+        })?;
 
         // recv() can only fail if the sender is dropped, but we're holding it
         // in `self.outstanding_requests`; unwrap() is fine.
@@ -458,30 +475,21 @@ impl SpCommunicator {
     }
 }
 
-/// Handle for the background tokio task responsible for receiving incoming UDP
-/// messages.
+/// Handler for incoming packets received on management switch ports.
 ///
-/// TODO We currently assume that we know (before this task is spawned) the IP
-/// address of all SPs with which we want to communicate, and that those IP
-/// addresses will not change while we're running. These assumptions are wrong -
-/// hot swapping sleds will lead to both being violated.
+/// When the communicator wants to send a request on behalf of an HTTP request:
 ///
-/// This task is spawned when `SpCommunicator` is created, and runs until it is
-/// dropped. When the communicator wants to send a request on behalf of an HTTP
-/// request:
-///
-/// 1. `SpCommunicator` creates a tokio oneshot channel for this task to use to
-///    send the response.
+/// 1. `SpCommunicator` creates a tokio oneshot channel for this handler to use
+///    to send the response.
 /// 2. `SpCommunicator` inserts the sending half of that channel into
-///    `outstanding_requests`, which is keyed by both the SP IP address and the
+///    `outstanding_requests`, which is keyed by both the switch port and the
 ///    u32 ID attached to the request.
 /// 3. `SpCommunicator` sends the UDP packet containing the request to the
 ///    target SP, and waits for a response on the channel it created in 1.
 /// 4. When we receive a packet, we check:
-///    a. Did it come from an IP address in our list of SP IPs?
-///    b. Does it parse as a `Response`?
-///    c. Is there a corresponding entry in `outstanding_requests` for this IP +
-///    request ID?
+///    a. Does it parse as a `Response`?
+///    b. Is there a corresponding entry in `outstanding_requests` for this port
+///       + request ID?
 ///    If so, we send the response on the channel, which unblocks
 ///    `SpCommunicator`, who can now return the response to its caller.
 ///
@@ -492,93 +500,74 @@ impl SpCommunicator {
 /// We can also receive messages from SPs that are not responses to oustanding
 /// requests. These are handled on a case-by-case basis; e.g., serial console
 /// data is pushed into the in-memory ringbuffer corresponding to the source.
-struct RecvTask {
-    socket: Arc<UdpSocket>,
+struct RecvHandler {
     sp_state: Arc<AllSpState>,
     log: Logger,
 }
 
-impl RecvTask {
-    fn new(
-        socket: Arc<UdpSocket>,
-        sp_state: Arc<AllSpState>,
-        log: Logger,
-    ) -> Self {
-        Self { socket, sp_state, log }
+impl RecvHandler {
+    fn new(sp_state: Arc<AllSpState>, log: Logger) -> Self {
+        Self { sp_state, log }
     }
 
-    async fn run(self) {
-        let mut buf = [0; SpMessage::MAX_SIZE];
-        loop {
-            // raw recv
-            let (n, addr) = match self.socket.recv_from(&mut buf).await {
-                Ok((n, addr)) => (n, addr),
-                Err(err) => {
-                    error!(&self.log, "recv_from() failed: {}", err);
-                    continue;
-                }
-            };
-            debug!(&self.log, "received {} bytes from {}", n, addr);
+    fn handle(&self, port: SwitchPort, buf: &[u8]) {
+        debug!(&self.log, "received {} bytes from {:?}", buf.len(), port);
 
-            // parse into an `SpMessage`
-            let sp_msg =
-                match gateway_messages::deserialize::<SpMessage>(&buf[..n]) {
-                    Ok((msg, _extra)) => {
-                        // TODO should we check that `extra` is empty? if the
-                        // response is maximal size any extra data is silently
-                        // discarded anyway, so probably not?
-                        msg
-                    }
-                    Err(err) => {
-                        error!(
-                            &self.log,
-                            "discarding malformed message ({})", err
-                        );
-                        continue;
-                    }
-                };
-            debug!(&self.log, "received {:?} from {}", sp_msg, addr);
-
-            // `version` is intentionally the first 4 bytes of the packet; we
-            // could check it before trying to deserialize?
-            if sp_msg.version != version::V1 {
-                error!(
-                    &self.log,
-                    "discarding message with unsupported version {}",
-                    sp_msg.version
-                );
-                continue;
+        // parse into an `SpMessage`
+        let sp_msg = match gateway_messages::deserialize::<SpMessage>(buf) {
+            Ok((msg, _extra)) => {
+                // TODO should we check that `extra` is empty? if the
+                // response is maximal size any extra data is silently
+                // discarded anyway, so probably not?
+                msg
             }
+            Err(err) => {
+                error!(&self.log, "discarding malformed message ({})", err);
+                return;
+            }
+        };
+        debug!(&self.log, "received {:?} from {:?}", sp_msg, port);
 
-            // decide whether this is a response to an outstanding request or an
-            // unprompted message
-            match sp_msg.kind {
-                SpMessageKind::Response { request_id, result } => {
-                    self.handle_response(addr, request_id, result);
-                }
-                SpMessageKind::SerialConsole(serial_console) => {
-                    self.handle_serial_console(addr, serial_console);
-                }
+        // `version` is intentionally the first 4 bytes of the packet; we
+        // could check it before trying to deserialize?
+        if sp_msg.version != version::V1 {
+            error!(
+                &self.log,
+                "discarding message with unsupported version {}",
+                sp_msg.version
+            );
+            return;
+        }
+
+        // decide whether this is a response to an outstanding request or an
+        // unprompted message
+        match sp_msg.kind {
+            SpMessageKind::Response { request_id, result } => {
+                self.handle_response(port, request_id, result);
+            }
+            SpMessageKind::SerialConsole(serial_console) => {
+                self.handle_serial_console(port, serial_console);
             }
         }
     }
 
     fn handle_response(
         &self,
-        addr: SocketAddr,
+        port: SwitchPort,
         request_id: u32,
         result: Result<ResponseKind, ResponseError>,
     ) {
         // see if we know who to send the response to
-        let tx = match self.sp_state.remove_expected_response(addr, request_id)
+        let tx = match self.sp_state.remove_expected_response(port, request_id)
         {
             Some(tx) => tx,
             None => {
-                error!(&self.log,
-                        "discarding unexpected response {} from {} (possibly past timeout?)",
-                        request_id,
-                        addr,
-                    );
+                error!(
+                    &self.log,
+                    "discarding unexpected response {} from {:?} (possibly past timeout?)",
+                    request_id,
+                    port,
+                );
                 return;
             }
         };
@@ -600,73 +589,71 @@ impl RecvTask {
             // a garbage response somehow.
             error!(
                 &self.log,
-                "discarding unexpected response {} from {} (receiver gone)",
+                "discarding unexpected response {} from {:?} (receiver gone)",
                 request_id,
-                addr,
+                port,
             );
         }
     }
 
-    fn handle_serial_console(&self, addr: SocketAddr, packet: SerialConsole) {
+    fn handle_serial_console(&self, port: SwitchPort, packet: SerialConsole) {
         debug!(
             &self.log,
-            "received serial console data from {}: {:?}", addr, packet
+            "received serial console data from {:?}: {:?}", port, packet
         );
-        self.sp_state.push_serial_console(addr, packet, &self.log);
+        self.sp_state.push_serial_console(port, packet, &self.log);
     }
 }
 
 #[derive(Debug)]
 struct AllSpState {
-    all_sps: HashMap<SocketAddr, SingleSpState>,
+    all_sps: HashMap<SwitchPort, SingleSpState>,
 }
 
 impl AllSpState {
-    fn new(known_sps: &KnownSps) -> Self {
-        let mut all_sps = HashMap::new();
-        for sp_list in [
-            &known_sps.switches,
-            &known_sps.sleds,
-            &known_sps.power_controllers,
-        ] {
-            for &sp in sp_list {
-                all_sps.insert(sp, SingleSpState::default());
-            }
+    fn new(switch: &ManagementSwitchDiscovery) -> Self {
+        let all_ports = switch.all_ports();
+        let mut all_sps = HashMap::with_capacity(all_ports.len());
+        for port in all_ports {
+            all_sps.insert(port, SingleSpState::default());
         }
         Self { all_sps }
     }
 
+    fn get(&self, port: SwitchPort) -> &SingleSpState {
+        // we initialize `all_sps` with state for every switch port, so the only
+        // way to panic here is to construct a port that didn't exist when we
+        // were created
+        self.all_sps
+            .get(&port)
+            .expect("sp state doesn't contain an entry for a valid switch port")
+    }
+
     fn push_serial_console(
         &self,
-        sp: SocketAddr,
+        port: SwitchPort,
         packet: SerialConsole,
         log: &Logger,
     ) {
-        // caller should never try to send a request to an SP we don't know
-        // about, since it created us with all SPs it knows.
-        let state = self.all_sps.get(&sp).expect("nonexistent SP");
+        let state = self.get(port);
         state.serial_console_from_sp.lock().unwrap().push(packet, log);
     }
 
     fn insert_expected_response(
         &self,
-        sp: SocketAddr,
+        port: SwitchPort,
         request_id: u32,
     ) -> ResponseReceiver {
-        // caller should never try to send a request to an SP we don't know
-        // about, since it created us with all SPs it knows.
-        let state = self.all_sps.get(&sp).expect("nonexistent SP");
+        let state = self.get(port);
         state.outstanding_requests.insert(request_id)
     }
 
     fn remove_expected_response(
         &self,
-        sp: SocketAddr,
+        port: SwitchPort,
         request_id: u32,
     ) -> Option<Sender<Result<ResponseKind, ResponseError>>> {
-        // caller should never try to send a request to an SP we don't know
-        // about, since it created us with all SPs it knows.
-        let state = self.all_sps.get(&sp).expect("nonexistent SP");
+        let state = self.get(port);
         state.outstanding_requests.remove(request_id)
     }
 }

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -6,13 +6,10 @@
 # NOTE: The test suite always overrides this.
 id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
 
-udp_bind_address = "127.0.0.1:0"
-
 [known_sps]
 # NOTE: The test suite overrides this section based on the configured simulator.
-ignition_controller = "127.0.0.1:0"
-switches = ["127.0.0.1:0"]
-sleds = ["127.0.0.1:0", "127.0.0.1:0"]
+switches = []
+sleds = []
 power_controllers = []
 
 [timeouts]


### PR DESCRIPTION
This is a first step to extracting all of `sp_comms` from `gateway` into `gateway-sp-comms`. It removes several placeholder oddities, like the gateway only listening on one UDP socket and identifying SPs by a mix of `SocketAddr`s and ignition target indices. Most communications are now tracked by `SwitchPort`, an opaque type provided by `ManagementSwitch` indicating which port of the management switch the communication is happening on. The switch instance provides methods to convert between logical IDs (type + slot) and ports, look up the SP socket address for a corresponding port, etc; the implementations of those functions are where all the placeholder logic now lives, which should make `gateway` somewhat more realistic.

`ManagementSwitch` should present an interface that is close to what we expect based on RFD 250, at least after discovery / topology has taken place: each port on the management switch has both a local UDP socket (corresponding to the vnic for the appropriate port's vlan) and a socket address for the SP at the other end (assuming we've discovered that on startup; handling hot swap etc is down the line).

PR logistics - this builds on #746, and is currently targeted at that branch. Once it's merged I'll retarget this to main. I'm going to continue the SP comms extraction, but wanted to pause here to keep the PR in "borderline too large" territory before getting to "monstrously large".