### PR TITLE
Move network interface authz to the data store

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -515,3 +515,4 @@ pub type Disk = ProjectChild;
 pub type Instance = ProjectChild;
 pub type Vpc = ProjectChild;
 pub type VpcSubnet = ProjectChild;
+pub type NetworkInterface = ProjectChild;

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -167,6 +167,7 @@ pub use api_resources::Disk;
 pub use api_resources::Fleet;
 pub use api_resources::FleetChild;
 pub use api_resources::Instance;
+pub use api_resources::NetworkInterface;
 pub use api_resources::Organization;
 pub use api_resources::Project;
 pub use api_resources::Vpc;

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -1686,7 +1686,7 @@ impl DataStore {
         interface: IncompleteNetworkInterface,
     ) -> Result<NetworkInterface, NetworkInterfaceError> {
         opctx
-            .authorize(authz::Action::Modify, authz_instance)
+            .authorize(authz::Action::CreateChild, authz_instance)
             .await
             .map_err(NetworkInterfaceError::External)?;
         opctx
@@ -1807,8 +1807,6 @@ impl DataStore {
         authz_instance: &authz::Instance,
         interface_name: &Name,
     ) -> DeleteResult {
-        opctx.authorize(authz::Action::Modify, authz_instance).await?;
-
         let (authz_interface, _) = self
             .network_interface_fetch(opctx, &authz_instance, interface_name)
             .await?;


### PR DESCRIPTION
- Adds a module-private function for actually inserting the database
  record, after performing authz checks. This is used in the
  publicly-available method and in tests.
- Adds authz objects to the
  `DataStore::instance_create_network_interface` method and does authz
  checks inside them.
- Reorders the instance-creation saga. This moves the instance DB record
  creation before the NIC creation, since the latter can only be
  attached to an existing instance record. This also allows uniform
  authz checks inside the `DataStore` method, which wouldn't be possible
  if the instance record were not yet in the database. Note that this
  also requires a small change to the data the instance-record-creation
  saga node serializes. It previously contained the NICs, but these are
  no longer available at that time. Instead, the NICs are deserialized
  from the saga node that creates them and used to instantiate the
  instance runtime object only inside the `sic_instance_ensure` saga
  node.
- Moves authz check for listing NICs for an instance into `DataStore`
  method
- Moves authz check for fetching a single NIC for an instance into the
  `DataStore` method
- Adds the `network_interface_fetch` method, for returning an authz
  interface and the database record, after checking read access. This
  uses a `*_noauthz` method as well, both of which are analogous to the
  other similarly-named methods. Note there's no lookup by ID or path at
  this point, since they're not really needed yet.
- Moves the check for deleting an interface into the `DataStore` method.
- Changes how deletion of a previously-deleted NIC works. We used to
  return a success, but we now return a not-found error, in line with
  the rest of the API.