### PR TITLE
authz: protect VPC route endpoints

### DIFF
--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -513,6 +513,7 @@ impl ApiResourceError for ProjectChild {
 
 pub type Disk = ProjectChild;
 pub type Instance = ProjectChild;
+pub type RouterRoute = ProjectChild;
 pub type Vpc = ProjectChild;
 pub type VpcRouter = ProjectChild;
 pub type VpcSubnet = ProjectChild;

--- a/nexus/src/authz/mod.rs
+++ b/nexus/src/authz/mod.rs
@@ -169,6 +169,7 @@ pub use api_resources::FleetChild;
 pub use api_resources::Instance;
 pub use api_resources::Organization;
 pub use api_resources::Project;
+pub use api_resources::RouterRoute;
 pub use api_resources::Vpc;
 pub use api_resources::VpcRouter;
 pub use api_resources::VpcSubnet;

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2653,7 +2653,7 @@ impl DataStore {
     }
 
     /// Lookup a VpcRouter by name and return the full database record, along
-    /// with an [`authz::Vpc`] for subsequent authorization checks
+    /// with an [`authz::VpcRouter`] for subsequent authorization checks
     pub async fn vpc_router_fetch(
         &self,
         opctx: &OpContext,
@@ -2692,7 +2692,7 @@ impl DataStore {
         opctx: &OpContext,
         authz_vpc: &authz::Vpc,
         router: VpcRouter,
-    ) -> CreateResult<VpcRouter> {
+    ) -> CreateResult<(authz::VpcRouter, VpcRouter)> {
         opctx.authorize(authz::Action::CreateChild, authz_vpc).await?;
 
         use db::schema::vpc_router::dsl;
@@ -2713,7 +2713,14 @@ impl DataStore {
                     ),
                 )
             })?;
-        Ok(router)
+        Ok((
+            authz_vpc.child_generic(
+                ResourceType::VpcRouter,
+                router.id(),
+                LookupType::ById(router.id()),
+            ),
+            router,
+        ))
     }
 
     pub async fn vpc_delete_router(
@@ -2767,30 +2774,39 @@ impl DataStore {
 
     pub async fn router_list_routes(
         &self,
-        router_id: &Uuid,
+        opctx: &OpContext,
+        authz_router: &authz::VpcRouter,
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<RouterRoute> {
-        use db::schema::router_route::dsl;
+        opctx.authorize(authz::Action::ListChildren, authz_router).await?;
 
+        use db::schema::router_route::dsl;
         paginated(dsl::router_route, dsl::name, pagparams)
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::router_id.eq(*router_id))
+            .filter(dsl::router_id.eq(authz_router.id()))
             .select(RouterRoute::as_select())
-            .load_async::<db::model::RouterRoute>(self.pool())
+            .load_async::<db::model::RouterRoute>(
+                self.pool_authorized(opctx).await?,
+            )
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
     }
 
-    pub async fn router_route_fetch_by_name(
+    /// Fetches a RouterRoute from the database and returns both the database
+    /// row and an [`authz::RouterRoute`] for doing authz checks
+    ///
+    /// See [`DataStore::organization_lookup_noauthz()`] for intended use cases
+    /// and caveats.
+    // TODO-security See the note on organization_lookup_noauthz().
+    async fn route_lookup_noauthz(
         &self,
-        router_id: &Uuid,
+        authz_vpc_router: &authz::VpcRouter,
         route_name: &Name,
-    ) -> LookupResult<RouterRoute> {
+    ) -> LookupResult<(authz::RouterRoute, RouterRoute)> {
         use db::schema::router_route::dsl;
-
         dsl::router_route
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::router_id.eq(*router_id))
+            .filter(dsl::router_id.eq(authz_vpc_router.id()))
             .filter(dsl::name.eq(route_name.clone()))
             .select(RouterRoute::as_select())
             .get_result_async(self.pool())
@@ -2804,21 +2820,76 @@ impl DataStore {
                     ),
                 )
             })
+            .map(|r| {
+                (
+                    authz_vpc_router.child_generic(
+                        ResourceType::RouterRoute,
+                        r.id(),
+                        LookupType::ByName(route_name.to_string()),
+                    ),
+                    r,
+                )
+            })
+    }
+
+    /// Lookup a RouterRoute by name and return the full database record, along
+    /// with an [`authz::RouterRoute`] for subsequent authorization checks
+    pub async fn route_fetch(
+        &self,
+        opctx: &OpContext,
+        authz_vpc_router: &authz::VpcRouter,
+        name: &Name,
+    ) -> LookupResult<(authz::RouterRoute, RouterRoute)> {
+        let (authz_route, db_route) =
+            self.route_lookup_noauthz(authz_vpc_router, name).await?;
+        opctx.authorize(authz::Action::Read, &authz_route).await?;
+        Ok((authz_route, db_route))
+    }
+
+    /// Look up the id for a RouterRoute based on its name
+    ///
+    /// Returns an [`authz::RouterRoute`] (which makes the id available).
+    ///
+    /// Like the other "lookup_by_path()" functions, this function does no authz
+    /// checks.
+    pub async fn route_lookup_by_path(
+        &self,
+        organization_name: &Name,
+        project_name: &Name,
+        vpc_name: &Name,
+        router_name: &Name,
+        route_name: &Name,
+    ) -> LookupResult<authz::RouterRoute> {
+        let authz_vpc_router = self
+            .vpc_router_lookup_by_path(
+                organization_name,
+                project_name,
+                vpc_name,
+                router_name,
+            )
+            .await?;
+        self.vpc_router_lookup_noauthz(&authz_vpc_router, route_name)
+            .await
+            .map(|(v, _)| v)
     }
 
     pub async fn router_create_route(
         &self,
+        opctx: &OpContext,
+        authz_router: &authz::VpcRouter,
         route: RouterRoute,
     ) -> CreateResult<RouterRoute> {
+        assert_eq!(authz_router.id(), route.router_id);
+        opctx.authorize(authz::Action::CreateChild, authz_router).await?;
+
         use db::schema::router_route::dsl;
         let router_id = route.router_id;
-        let name = route.name().clone();
 
         VpcRouter::insert_resource(
             router_id,
             diesel::insert_into(dsl::router_route).values(route),
         )
-        .insert_and_get_result_async(self.pool())
+        .insert_and_get_result_async(self.pool_authorized(opctx).await?)
         .await
         .map_err(|e| match e {
             AsyncInsertError::CollectionNotFound => Error::ObjectNotFound {
@@ -2828,33 +2899,31 @@ impl DataStore {
             AsyncInsertError::DatabaseError(e) => {
                 public_error_from_diesel_pool(
                     e,
-                    ErrorHandler::Conflict(
-                        ResourceType::RouterRoute,
-                        name.as_str(),
-                    ),
+                    ErrorHandler::NotFoundByResource(authz_router),
                 )
             }
         })
     }
 
-    pub async fn router_delete_route(&self, route_id: &Uuid) -> DeleteResult {
-        use db::schema::router_route::dsl;
+    pub async fn router_delete_route(
+        &self,
+        opctx: &OpContext,
+        authz_route: &authz::RouterRoute,
+    ) -> DeleteResult {
+        opctx.authorize(authz::Action::Delete, authz_route).await?;
 
+        use db::schema::router_route::dsl;
         let now = Utc::now();
         diesel::update(dsl::router_route)
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::id.eq(*route_id))
+            .filter(dsl::id.eq(authz_route.id()))
             .set(dsl::time_deleted.eq(now))
-            .returning(RouterRoute::as_returning())
-            .get_result_async(self.pool())
+            .execute_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| {
                 public_error_from_diesel_pool(
                     e,
-                    ErrorHandler::NotFoundByLookup(
-                        ResourceType::RouterRoute,
-                        LookupType::ById(*route_id),
-                    ),
+                    ErrorHandler::NotFoundByResource(authz_route),
                 )
             })?;
         Ok(())
@@ -2862,27 +2931,26 @@ impl DataStore {
 
     pub async fn router_update_route(
         &self,
-        route_id: &Uuid,
+        opctx: &OpContext,
+        authz_route: &authz::RouterRoute,
         route_update: RouterRouteUpdate,
-    ) -> Result<(), Error> {
-        use db::schema::router_route::dsl;
+    ) -> UpdateResult<RouterRoute> {
+        opctx.authorize(authz::Action::Modify, authz_route).await?;
 
+        use db::schema::router_route::dsl;
         diesel::update(dsl::router_route)
             .filter(dsl::time_deleted.is_null())
-            .filter(dsl::id.eq(*route_id))
+            .filter(dsl::id.eq(authz_route.id()))
             .set(route_update)
-            .execute_async(self.pool())
+            .returning(RouterRoute::as_returning())
+            .get_result_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| {
                 public_error_from_diesel_pool(
                     e,
-                    ErrorHandler::NotFoundByLookup(
-                        ResourceType::RouterRoute,
-                        LookupType::ById(*route_id),
-                    ),
+                    ErrorHandler::NotFoundByResource(authz_route),
                 )
-            })?;
-        Ok(())
+            })
     }
 
     // TODO-correctness: fix session method errors. the map_errs turn all errors

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2884,6 +2884,7 @@ impl DataStore {
 
         use db::schema::router_route::dsl;
         let router_id = route.router_id;
+        let name = route.name().clone();
 
         VpcRouter::insert_resource(
             router_id,
@@ -2899,7 +2900,10 @@ impl DataStore {
             AsyncInsertError::DatabaseError(e) => {
                 public_error_from_diesel_pool(
                     e,
-                    ErrorHandler::NotFoundByResource(authz_router),
+                    ErrorHandler::Conflict(
+                        ResourceType::RouterRoute,
+                        name.as_str(),
+                    ),
                 )
             }
         })

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1950,8 +1950,10 @@ async fn routers_routes_get(
     let query = query_params.into_inner();
     let path = path_params.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let routes = nexus
             .router_list_routes(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
@@ -1992,8 +1994,10 @@ async fn routers_routes_get_route(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let route = nexus
-            .router_lookup_route(
+            .route_fetch(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
@@ -2021,8 +2025,10 @@ async fn routers_routes_post(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         let route = nexus
             .router_create_route(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
@@ -2050,8 +2056,10 @@ async fn routers_routes_delete_route(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
         nexus
             .router_delete_route(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
@@ -2074,13 +2082,15 @@ async fn routers_routes_put_route(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<RouterRoutePathParam>,
     router_params: TypedBody<RouterRouteUpdateParams>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+) -> Result<HttpResponseOk<RouterRoute>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let handler = async {
-        nexus
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let router_route = nexus
             .router_update_route(
+                &opctx,
                 &path.organization_name,
                 &path.project_name,
                 &path.vpc_name,
@@ -2089,7 +2099,7 @@ async fn routers_routes_put_route(
                 &router_params.into_inner(),
             )
             .await?;
-        Ok(HttpResponseUpdatedNoContent())
+        Ok(HttpResponseOk(router_route.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -2368,6 +2368,7 @@ impl Nexus {
             .1)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn router_create_route(
         &self,
         opctx: &OpContext,
@@ -2434,6 +2435,7 @@ impl Nexus {
         self.db_datastore.router_delete_route(opctx, &authz_route).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn router_update_route(
         &self,
         opctx: &OpContext,

--- a/nexus/tests/integration_tests/router_routes.rs
+++ b/nexus/tests/integration_tests/router_routes.rs
@@ -2,21 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
-
-use dropshot::test_util::{
-    object_delete, object_get, objects_list_page, objects_post,
-};
 use dropshot::Method;
 use http::StatusCode;
+use nexus_test_utils::http_testing::AuthnMode;
+use nexus_test_utils::http_testing::NexusRequest;
+use nexus_test_utils::identity_eq;
+use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::{
-    IdentityMetadataCreateParams, IdentityMetadataUpdateParams, Name,
+    IdentityMetadataCreateParams, IdentityMetadataUpdateParams,
     RouteDestination, RouteTarget, RouterRoute, RouterRouteCreateParams,
     RouterRouteKind, RouterRouteUpdateParams,
 };
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use nexus_test_utils::resource_helpers::{
     create_organization, create_project, create_router, create_vpc,
@@ -52,7 +52,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     create_vpc(&client, organization_name, project_name, vpc_name).await;
 
     // Get the system router's routes
-    let system_router_routes = objects_list_page::<RouterRoute>(
+    let system_router_routes = objects_list_page_authz::<RouterRoute>(
         client,
         get_routes_url("system").as_str(),
     )
@@ -67,13 +67,18 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(default_route.kind, RouterRouteKind::Default);
 
     // It errors if you try to delete the default route
-    let error = client
-        .make_request_error(
-            Method::DELETE,
-            get_route_url("system", "default").as_str(),
-            StatusCode::METHOD_NOT_ALLOWED,
-        )
-        .await;
+    let error: dropshot::HttpErrorResponseBody = NexusRequest::expect_failure(
+        client,
+        StatusCode::METHOD_NOT_ALLOWED,
+        Method::DELETE,
+        get_route_url("system", "default").as_str(),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
     assert_eq!(error.message, "DELETE not allowed on system routes");
 
     // Create a custom router
@@ -87,7 +92,7 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     .await;
 
     // Get routes list for custom router
-    let routes = objects_list_page::<RouterRoute>(
+    let routes = objects_list_page_authz::<RouterRoute>(
         client,
         get_routes_url(router_name).as_str(),
     )
@@ -100,10 +105,10 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     let route_url = get_route_url(router_name, route_name);
 
     // Create a new custom route
-    objects_post::<RouterRouteCreateParams, RouterRoute>(
+    let route_created: RouterRoute = NexusRequest::objects_post(
         client,
         get_routes_url(router_name).as_str(),
-        RouterRouteCreateParams {
+        &RouterRouteCreateParams {
             identity: IdentityMetadataCreateParams {
                 name: route_name.parse().unwrap(),
                 description: "It's a route, what else can I say?".to_string(),
@@ -112,11 +117,24 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
             destination: RouteDestination::Subnet("loopback".parse().unwrap()),
         },
     )
-    .await;
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+    assert_eq!(route_created.identity.name.to_string(), route_name);
 
     // Get the route and verify its state
-    let route = object_get::<RouterRoute>(client, route_url.as_str()).await;
-    assert_eq!(route.identity.name, route_name.parse::<Name>().unwrap());
+    let route: RouterRoute =
+        NexusRequest::object_get(client, route_url.as_str())
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .unwrap()
+            .parsed_body()
+            .unwrap();
+    identity_eq(&route_created.identity, &route.identity);
     assert_eq!(route.kind, RouterRouteKind::Custom);
     assert_eq!(
         route.target,
@@ -128,42 +146,53 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
     );
 
     // Ensure a route can be updated
-    client
-        .make_request(
-            Method::PUT,
-            route_url.as_str(),
-            Some(RouterRouteUpdateParams {
-                identity: IdentityMetadataUpdateParams {
-                    name: Some(route_name.parse().unwrap()),
-                    description: None,
-                },
-                target: RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(
-                    192, 168, 1, 1,
-                ))),
-                destination: RouteDestination::Subnet(
-                    "loopback".parse().unwrap(),
-                ),
-            }),
-            StatusCode::NO_CONTENT,
-        )
-        .await
-        .unwrap();
-    let route = object_get::<RouterRoute>(client, route_url.as_str()).await;
-
+    NexusRequest::object_put(
+        client,
+        route_url.as_str(),
+        Some(&RouterRouteUpdateParams {
+            identity: IdentityMetadataUpdateParams {
+                name: Some(route_name.parse().unwrap()),
+                description: None,
+            },
+            target: RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(
+                192, 168, 1, 1,
+            ))),
+            destination: RouteDestination::Subnet("loopback".parse().unwrap()),
+        }),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
+    let route: RouterRoute =
+        NexusRequest::object_get(client, route_url.as_str())
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .unwrap()
+            .parsed_body()
+            .unwrap();
     assert_eq!(route.identity.name, route_name);
     assert_eq!(
         route.target,
         RouteTarget::Ip(IpAddr::from(Ipv4Addr::new(192, 168, 1, 1,)))
     );
 
-    object_delete(client, route_url.as_str()).await;
+    NexusRequest::object_delete(client, route_url.as_str())
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .unwrap();
 
     // Requesting the deleted route 404s
-    client
-        .make_request_error(
-            Method::GET,
-            get_route_url(router_name, route_name).as_str(),
-            StatusCode::NOT_FOUND,
-        )
-        .await;
+    NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        get_route_url(router_name, route_name).as_str(),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
 }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -3238,8 +3238,15 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "resource updated"
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterRoute"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"


### PR DESCRIPTION
Same old story, different routes.

Like the other network-related routes so far, I'm also changing PUT to return 200 to match the rest of the API.