### PR TITLE
Allow the console to be served over HTTP, using session cookies

### DIFF
--- a/nexus/src/authn/external/session_cookie.rs
+++ b/nexus/src/authn/external/session_cookie.rs
@@ -55,6 +55,8 @@ pub const SESSION_COOKIE_SCHEME_NAME: authn::SchemeName =
 
 /// Generate session cookie header
 pub fn session_cookie_header_value(token: &str, max_age: Duration) -> String {
+    // TODO(https://github.com/oxidecomputer/omicron/issues/249): We should
+    // insert "Secure;" back into this string.
     format!(
         "{}={}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
         SESSION_COOKIE_COOKIE_NAME,

--- a/nexus/src/authn/external/session_cookie.rs
+++ b/nexus/src/authn/external/session_cookie.rs
@@ -56,7 +56,7 @@ pub const SESSION_COOKIE_SCHEME_NAME: authn::SchemeName =
 /// Generate session cookie header
 pub fn session_cookie_header_value(token: &str, max_age: Duration) -> String {
     format!(
-        "{}={}; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age={}",
+        "{}={}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
         SESSION_COOKIE_COOKIE_NAME,
         token,
         max_age.num_seconds()
@@ -380,17 +380,17 @@ mod test {
     fn test_session_cookie_value() {
         assert_eq!(
             session_cookie_header_value("abc", Duration::seconds(5)),
-            "session=abc; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=5"
+            "session=abc; Path=/; HttpOnly; SameSite=Lax; Max-Age=5"
         );
 
         assert_eq!(
             session_cookie_header_value("abc", Duration::seconds(-5)),
-            "session=abc; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=-5"
+            "session=abc; Path=/; HttpOnly; SameSite=Lax; Max-Age=-5"
         );
 
         assert_eq!(
             session_cookie_header_value("", Duration::zero()),
-            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0"
+            "session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
         );
     }
 }

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -29,7 +29,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
         .expect_status(Some(StatusCode::NO_CONTENT))
         .expect_response_header(
             header::SET_COOKIE,
-            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
+            "session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
         )
         .execute()
         .await
@@ -84,7 +84,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
         // logout also clears the cookie client-side
         .expect_response_header(
             header::SET_COOKIE,
-            "session=; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=0",
+            "session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
         )
         .execute()
         .await
@@ -291,7 +291,7 @@ async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let (session_token, rest) = session_cookie.split_once("; ").unwrap();
 
     assert!(session_token.starts_with("session="));
-    assert_eq!(rest, "Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=3600");
+    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=3600");
 
     session_token.to_string()
 }

--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -14,7 +14,7 @@ session_absolute_timeout_minutes = 480
 
 [authn]
 # TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
-schemes_external = ["spoof"]
+schemes_external = ["spoof", "session_cookie"]
 
 [database]
 # URL for connecting to the database


### PR DESCRIPTION
- We have been serving Nexus' external API over HTTP, not HTTPS. This is a known deficiency, tracked by https://github.com/oxidecomputer/omicron/issues/249.
- Session cookies, which are used when authenticating to the console, use the [Secure](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies) attribute to ensure that they're exclusively sent over HTTPS.
- @david-crespo has theorized that "this worked anyway" because the console had been typically accessed over localhost, and an exception was granted.

Until HTTPS integration is adopted across the stack more universally, allow the console to be served in the interim. This change is necessary to access Nexus-from-within-a-Zone, as it is no longer accessible over localhost.

This change should be undone once https://github.com/oxidecomputer/omicron/issues/249 has progressed.