### PR TITLE
Fixes conflation of Instance ID and Propolis server ID

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -244,7 +244,7 @@ impl InstanceInner {
             .as_ref()
             .expect("Propolis client should be initialized before usage")
             .client
-            .instance_state_put(*self.propolis_id(), request)
+            .instance_state_put(*self.id(), request)
             .await?;
         Ok(())
     }
@@ -579,9 +579,9 @@ impl Instance {
         //
         // They aren't modified after being initialized, so it's fine to grab
         // a copy.
-        let (propolis_id, client) = {
+        let (instance_id, client) = {
             let inner = self.inner.lock().await;
-            let id = *inner.propolis_id();
+            let id = *inner.id();
             let client = inner.running_state.as_ref().unwrap().client.clone();
             (id, client)
         };
@@ -591,7 +591,7 @@ impl Instance {
             // State monitoring always returns the most recent state/gen pair
             // known to Propolis.
             let response =
-                client.instance_state_monitor(propolis_id, gen).await?;
+                client.instance_state_monitor(instance_id, gen).await?;
             let reaction =
                 self.inner.lock().await.observe_state(response.state).await?;
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -169,8 +169,6 @@ struct PropolisSetup {
 }
 
 struct InstanceInner {
-    id: Uuid,
-
     log: Logger,
 
     // Properties visible to Propolis
@@ -194,7 +192,7 @@ struct InstanceInner {
 
 impl InstanceInner {
     fn id(&self) -> &Uuid {
-        &self.id
+        &self.properties.id
     }
 
     /// UUID of the underlying propolis-server process
@@ -403,7 +401,6 @@ impl Instance {
         info!(log, "Instance::new w/initial HW: {:?}", initial);
         let instance = InstanceInner {
             log: log.new(o!("instance id" => id.to_string())),
-            id,
             // NOTE: Mostly lies.
             properties: propolis_client::api::InstanceProperties {
                 id,

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -176,6 +176,9 @@ struct InstanceInner {
     // Properties visible to Propolis
     properties: propolis_client::api::InstanceProperties,
 
+    // The ID of the Propolis server (and zone) running this instance
+    propolis_id: Uuid,
+
     // NIC-related properties
     vnic_allocator: VnicAllocator,
     requested_nics: Vec<NetworkInterface>,
@@ -196,7 +199,7 @@ impl InstanceInner {
 
     /// UUID of the underlying propolis-server process
     fn propolis_id(&self) -> &Uuid {
-        &self.properties.id
+        &self.propolis_id
     }
 
     async fn observe_state(
@@ -403,7 +406,7 @@ impl Instance {
             id,
             // NOTE: Mostly lies.
             properties: propolis_client::api::InstanceProperties {
-                id: initial.runtime.propolis_uuid,
+                id,
                 name: initial.runtime.hostname.clone(),
                 description: "Test description".to_string(),
                 image_id: Uuid::nil(),
@@ -414,6 +417,7 @@ impl Instance {
                 // InstanceCpuCount here, to avoid any casting...
                 vcpus: initial.runtime.ncpus.0 as u8,
             },
+            propolis_id: initial.runtime.propolis_uuid,
             vnic_allocator,
             requested_nics: initial.nics,
             vlan,


### PR DESCRIPTION
It appears that during work to support live migration, the UUID for an
Instance and the Propolis server hosting that instance were conflated.
This stores the Propolis ID as a separate field of the `InstanceInner`
object for clarity.