### PR TITLE
Packaging Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "regex",
  "terminal_size",
- "unicode-width",
  "winapi",
 ]
 
@@ -1514,14 +1512,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0-rc.9"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e540eeecee89ed4391cbbe2c86a9df6c061fc93f7710e2af69cbfccdc6564eae"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
+ "lazy_static",
  "number_prefix",
  "rayon",
- "unicode-width",
+ "regex",
 ]
 
 [[package]]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -75,7 +75,7 @@ repo = "crucible"
 commit = "aec731421ddbb6f5ec733185b82493bcf62c8011"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-sha256 = "fc7ee178a3320b53e2975fa38cbde4bbb9b68c71ddcc5aeff61bdce519b2f4d7"
+sha256 = "c024e5ea6715f43e416e83bbc0327ec166e22886a81dcd9fe5adff36cc327dcc"
 
 # Refer to
 #   https://github.com/oxidecomputer/propolis/blob/master/package/README.md
@@ -87,4 +87,4 @@ zone = true
 type = "prebuilt"
 repo = "propolis"
 commit = "e984409a425df97338efa2c53ba3e40c73668638"
-sha256 = "0c7bd314614f9413493558d7592d67156089887ab9736149934518c12ebd125f"
+sha256 = "206ef42e90d157e3314f4745ddb4422b3c93a16881749824037853e6f39f3762"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -10,7 +10,7 @@ crossbeam = "0.8"
 flate2 = "1.0.22"
 futures = "0.3.21"
 hex = "0.4.3"
-indicatif = { version = "0.17.0-rc.9", features = ["rayon"] }
+indicatif = { version = "0.16.2", features = ["rayon"] }
 omicron-common = { path = "../common" }
 omicron-zone-package = { version = "0.2.0" }
 rayon = "1.5"

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -285,7 +285,9 @@ async fn do_package(config: &Config, output_directory: &Path) -> Result<()> {
             },
         );
 
-    tokio::try_join!(external_pkg_stream, internal_pkg_stream,)?;
+    tokio::task::spawn_blocking(move || ui.multi.join());
+    tokio::try_join!(external_pkg_stream, internal_pkg_stream)?;
+
     Ok(())
 }
 
@@ -412,14 +414,12 @@ fn in_progress_style() -> ProgressStyle {
         .template(
             "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
         )
-        .unwrap()
         .progress_chars("#>.")
 }
 
 fn completed_progress_style() -> ProgressStyle {
     ProgressStyle::default_bar()
         .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg:.green}")
-        .unwrap()
         .progress_chars("#>.")
 }
 


### PR DESCRIPTION
- Updates SHA256 digests, which were out of sync (... and correctly reporting "digest mismatch", which is good, I suppose)
- Reverts to an older version of indicatif to avoid hitting https://github.com/console-rs/indicatif/issues/405 , which has not been fixed yet