### PR TITLE
Limits the number of network interfaces per instance

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -550,7 +550,12 @@ CREATE TABLE omicron.public.network_interface (
     /* FK into VPCSubnet table. */
     subnet_id UUID NOT NULL,
     mac STRING(17) NOT NULL, -- e.g., "ff:ff:ff:ff:ff:ff"
-    ip INET NOT NULL
+    ip INET NOT NULL,
+    /*
+     * Limited to 8 NICs per instance. This value must be kept in sync with
+     * `crate::nexus::MAX_NICS_PER_INSTANCE`.
+     */
+    slot INT2 NOT NULL CHECK (slot >= 0 AND slot < 8)
 );
 
 /* TODO-completeness

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -2319,12 +2319,13 @@ pub struct NetworkInterface {
     pub vpc_id: Uuid,
     pub subnet_id: Uuid,
     pub mac: MacAddr,
-    pub ip: ipnetwork::IpNetwork,
     // TODO-correctness: We need to split this into an optional V4 and optional V6 address, at
     // least one of which will always be specified.
     //
     // If user requests an address of either kind, give exactly that and not the other.
     // If neither is specified, auto-assign one of each?
+    pub ip: ipnetwork::IpNetwork,
+    pub slot: i16,
 }
 
 impl From<NetworkInterface> for external::NetworkInterface {

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -91,6 +91,7 @@ table! {
         subnet_id -> Uuid,
         mac -> Text,
         ip -> Inet,
+        slot -> Int2,
     }
 }
 

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -120,6 +120,8 @@ pub static BASE_ARTIFACT_DIR: &str = "/var/tmp/oxide_artifacts";
 
 pub(crate) const MAX_DISKS_PER_INSTANCE: u32 = 8;
 
+pub(crate) const MAX_NICS_PER_INSTANCE: u32 = 8;
+
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {
     /// uuid for this nexus instance.
@@ -1346,9 +1348,8 @@ impl Nexus {
                 &DataPageParams {
                     marker: None,
                     direction: dropshot::PaginationOrder::Ascending,
-                    // TODO: is there a limit to the number of NICs an instance
-                    // can have attached?
-                    limit: std::num::NonZeroU32::new(8).unwrap(),
+                    limit: std::num::NonZeroU32::new(MAX_NICS_PER_INSTANCE)
+                        .unwrap(),
                 },
             )
             .await?

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -272,6 +272,20 @@ async fn sic_allocate_network_interface_ids(
         params::InstanceNetworkInterfaceAttachment::Create(
             ref create_params,
         ) => {
+            if create_params.params.len()
+                > crate::nexus::MAX_NICS_PER_INSTANCE.try_into().unwrap()
+            {
+                return Err(ActionError::action_failed(
+                    Error::invalid_request(
+                        format!(
+                            "Instances may not have more than {}
+                            network interfaces",
+                            crate::nexus::MAX_NICS_PER_INSTANCE
+                        )
+                        .as_str(),
+                    ),
+                ));
+            }
             let mut ids = Vec::with_capacity(create_params.params.len());
             for _ in 0..create_params.params.len() {
                 ids.push(Uuid::new_v4());


### PR DESCRIPTION
- Limits interfaces to 8 inline with RFD 135
- Adds check against this limit in instance create saga
- Adds subquery to the interface creation query that checks this limit
  too. This works by assigning each NIC a slot on the device, and
  assigns the lowest available slot, up to the limit.
- Add test against the total per-instance limit