### PR TITLE
[sled agent] Allow the setting of a custom physical link, on which VNICs are allocated

### DIFF
--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -5,6 +5,7 @@
 //! Interfaces for working with sled agent configuration
 
 use crate::common::vlan::VlanID;
+use crate::illumos::dladm::PhysicalLink;
 use crate::illumos::zpool::ZpoolName;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -30,6 +31,11 @@ pub struct Config {
     pub vlan: Option<VlanID>,
     /// Optional list of zpools to be used as "discovered disks".
     pub zpools: Option<Vec<ZpoolName>>,
+
+    /// The data link on which to allocate VNICs.
+    ///
+    /// If unsupplied, we default to the first physical device.
+    pub data_link: Option<PhysicalLink>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/sled-agent/src/illumos/dladm.rs
+++ b/sled-agent/src/illumos/dladm.rs
@@ -7,6 +7,7 @@
 use crate::common::vlan::VlanID;
 use crate::illumos::{execute, ExecutionError, PFEXEC};
 use omicron_common::api::external::MacAddr;
+use serde::{Deserialize, Serialize};
 
 pub const VNIC_PREFIX: &str = "ox";
 pub const VNIC_PREFIX_CONTROL: &str = "oxControl";
@@ -26,7 +27,7 @@ pub enum Error {
 }
 
 /// The name of a physical datalink.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PhysicalLink(pub String);
 
 /// Wraps commands for interacting with data links.

--- a/sled-agent/src/illumos/running_zone.rs
+++ b/sled-agent/src/illumos/running_zone.rs
@@ -12,10 +12,10 @@ use ipnetwork::IpNetwork;
 use slog::Logger;
 use std::path::PathBuf;
 
-#[cfg(not(test))]
-use crate::illumos::{dladm::Dladm, zone::Zones};
 #[cfg(test)]
-use crate::illumos::{dladm::MockDladm as Dladm, zone::MockZones as Zones};
+use crate::illumos::zone::MockZones as Zones;
+#[cfg(not(test))]
+use crate::illumos::zone::Zones;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -195,8 +195,7 @@ impl InstalledZone {
         devices: &[zone::Device],
         vnics: Vec<Vnic>,
     ) -> Result<InstalledZone, Error> {
-        let physical_dl = Dladm::find_physical()?;
-        let control_vnic = vnic_allocator.new_control(&physical_dl, None)?;
+        let control_vnic = vnic_allocator.new_control(None)?;
 
         // The zone name is based on:
         // - A unique Oxide prefix ("oxz_")

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -9,7 +9,7 @@ use slog::Logger;
 use std::net::IpAddr;
 
 use crate::illumos::addrobj::AddrObject;
-use crate::illumos::dladm::{Dladm, VNIC_PREFIX_CONTROL};
+use crate::illumos::dladm::{Dladm, PhysicalLink, VNIC_PREFIX_CONTROL};
 use crate::illumos::zfs::ZONE_ZFS_DATASET_MOUNTPOINT;
 use crate::illumos::{execute, PFEXEC};
 
@@ -404,6 +404,38 @@ impl Zones {
         Ok(())
     }
 
+    // TODO(https://github.com/oxidecomputer/omicron/issues/821): We
+    // should remove this function when Sled Agents are provided IPv6 addresses
+    // from RSS.
+    pub fn ensure_has_global_zone_v6_address(
+        physical_link: Option<PhysicalLink>,
+    ) -> Result<(), Error> {
+        // Ensure that addrconf has been set up in the Global
+        // Zone.
+
+        let link = if let Some(link) = physical_link {
+            link
+        } else {
+            Dladm::find_physical()?
+        };
+        let gz_link_local_addrobj = AddrObject::new(&link.0, "linklocal")?;
+        Self::ensure_has_link_local_v6_address(None, &gz_link_local_addrobj)?;
+
+        // Ensure that a static IPv6 address has been allocated
+        // to the Global Zone. Without this, we don't have a way
+        // to route to IP addresses that we want to create in
+        // the non-GZ.
+        Self::ensure_address(
+            None,
+            &gz_link_local_addrobj.on_same_interface("v6route")?,
+            AddressRequest::new_static(
+                "fd00:1234::".parse().unwrap(),
+                Some(16),
+            ),
+        )?;
+        Ok(())
+    }
+
     // Creates an IP address within a Zone.
     #[allow(clippy::needless_lifetimes)]
     fn create_address<'a>(
@@ -421,31 +453,6 @@ impl Zones {
                 AddressRequest::Dhcp => {}
                 AddressRequest::Static(addr) => {
                     if addr.is_ipv6() {
-                        // Ensure that addrconf has been set up in the Global
-                        // Zone.
-                        let gz_link_local_addrobj = AddrObject::new(
-                            &Dladm::find_physical()?.0,
-                            "linklocal",
-                        )?;
-                        Self::ensure_has_link_local_v6_address(
-                            None,
-                            &gz_link_local_addrobj,
-                        )?;
-
-                        // Ensure that a static IPv6 address has been allocated
-                        // to the Global Zone. Without this, we don't have a way
-                        // to route to IP addresses that we want to create in
-                        // the non-GZ.
-                        Self::ensure_address(
-                            None,
-                            &gz_link_local_addrobj
-                                .on_same_interface("v6route")?,
-                            AddressRequest::new_static(
-                                "fd00:1234::".parse().unwrap(),
-                                Some(16),
-                            ),
-                        )?;
-
                         // Finally, actually ensure that the v6 address we want
                         // exists within the zone.
                         Self::ensure_has_link_local_v6_address(

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -130,8 +130,13 @@ impl SledAgent {
             Dladm::delete_vnic(&vnic)?;
         }
 
-        let storage =
-            StorageManager::new(&log, *id, nexus_client.clone()).await?;
+        let storage = StorageManager::new(
+            &log,
+            *id,
+            nexus_client.clone(),
+            config.data_link.clone(),
+        )
+        .await?;
         if let Some(pools) = &config.zpools {
             for pool in pools {
                 info!(
@@ -142,9 +147,14 @@ impl SledAgent {
                 storage.upsert_zpool(pool).await?;
             }
         }
-        let instances =
-            InstanceManager::new(log.clone(), vlan, nexus_client.clone())?;
-        let services = ServiceManager::new(log.clone()).await?;
+        let instances = InstanceManager::new(
+            log.clone(),
+            vlan,
+            nexus_client.clone(),
+            config.data_link.clone(),
+        )?;
+        let services =
+            ServiceManager::new(log.clone(), config.data_link.clone()).await?;
 
         Ok(SledAgent { storage, instances, nexus_client, services })
     }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -102,6 +102,13 @@ impl SledAgent {
             true,
         )?;
 
+        // Ensure the global zone has a functioning IPv6 address.
+        //
+        // TODO(https://github.com/oxidecomputer/omicron/issues/821): This
+        // should be removed once the Sled Agent is initialized with a
+        // RSS-provided IP address. In the meantime, we just pick one.
+        Zones::ensure_has_global_zone_v6_address(config.data_link.clone())?;
+
         // Identify all existing zones which should be managed by the Sled
         // Agent.
         //

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -4,6 +4,7 @@
 
 //! Management of sled-local storage.
 
+use crate::illumos::dladm::PhysicalLink;
 use crate::illumos::running_zone::{
     Error as RunningZoneError, InstalledZone, RunningZone,
 };
@@ -812,6 +813,7 @@ impl StorageManager {
         log: &Logger,
         sled_id: Uuid,
         nexus_client: Arc<NexusClient>,
+        physical_link: Option<PhysicalLink>,
     ) -> Result<Self, Error> {
         let log = log.new(o!("component" => "sled agent storage manager"));
         let pools = Arc::new(Mutex::new(HashMap::new()));
@@ -824,7 +826,7 @@ impl StorageManager {
             pools: pools.clone(),
             new_pools_rx,
             new_filesystems_rx,
-            vnic_allocator: VnicAllocator::new("Storage"),
+            vnic_allocator: VnicAllocator::new("Storage", physical_link)?,
         };
         Ok(StorageManager {
             pools,

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -15,6 +15,11 @@ zpools = [
   "oxp_f4b4dc87-ab46-49fb-a4b4-d361ae214c03",
 ]
 
+# An optional data link on which VNICs should be created.
+# If empty, this will be equivalent to the first result from:
+# $ dladm show-phys -p -o LINK
+# data_link = "igb0"
+
 # Address of the Sled Agent itself
 #
 # With the usage of non-global zones, we no longer can use localhost addresses,


### PR DESCRIPTION
## Previous Behavior

`Dladm::find_physical()` would run `dladm show-phys -p -o LINK`, grab the first outputted link, and use that as a  "base link" on which to allocate all other VNICs. For users with multiple physical datalinks, this behavior could be potentially undesirable.

## New Behavior

Allow callers to customize which datalink they'd prefer to use for VNIC allocations by plumbing it up to the Sled Agent config files. Additionally, refactors some of the related VNIC allocation code to make this more feasible.