### PR TITLE
Add missing sqlite3 dep for sled-agent-sim docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
 	ca-certificates \
 	libpq5 \
 	libssl1.1 \
+	libsqlite3-0 \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Not entirely sure how this worked before but upon trying to actually run `sled-agent-sim` in the docker container it failed to find libsqlite3:

```console
$ docker container logs sled-agent
sled-agent-sim: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory
sled-agent-sim: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory
sled-agent-sim: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory
sled-agent-sim: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory
[...repeated...]
```

I ran into this as because of failing CI on my PR in the cli repo: https://github.com/oxidecomputer/cli/pull/127

Adding the `libsqlite3-0` package seems to be enough to get things working. Tried the image generated from this commit and it seems to work: https://github.com/oxidecomputer/cli/pull/127/commits/b72b9fddb1b89041255668a079b7ffc06b851090