### PR TITLE
"unauthorized" test could print summary of requests made

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,6 +2441,7 @@ dependencies = [
  "structopt",
  "subprocess",
  "tempfile",
+ "term",
  "thiserror",
  "tokio",
  "tokio-postgres",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -123,6 +123,7 @@ omicron-test-utils = { path = "../test-utils" }
 openapiv3 = "1.0"
 regex = "1.5.5"
 subprocess = "0.2.8"
+term = "0.7"
 
 [dev-dependencies.openapi-lint]
 git = "https://github.com/oxidecomputer/openapi-lint"

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -465,8 +465,12 @@ fn record_operation(whichtest: WhichTest<'_>) {
     // think the color is pointless, but it does help the reader make sense of
     // the mess of numbers that shows up in the table for the different response
     // codes.
-    let mut t = term::stdout().unwrap();
-    t.fg(term::color::GREEN).unwrap();
+    let t = term::stdout();
+    if let Some(term) = t {
+        t.fg(term::color::GREEN).unwrap();
+    }
     write!(t, "{}", c).unwrap();
-    t.reset().unwrap();
+    if let Some(term) = t {
+        t.reset().unwrap();
+    }
 }

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -76,21 +76,17 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
 const VERIFY_HEADER: &str = r#"
 SUMMARY OF REQUESTS MADE
 
-KEY:
+KEY, USING HEADER AND EXAMPLE ROW:
 
           +----------------------------> privileged GET (expects 200)
           |                              (digit = last digit of 200-level
           |                              response)
           |
-          |   +----+----+----+----+----> HTTP methods tested (see below)
-          |   |    |    |    |    |      (digit = last digit of 400-level
-          |   |    |    |    |    |       response)
-          |   |    |    |    |    |
-          |   |    |    |    |    |  +-> privileged GET (expects same as above)
-          |   |    |    |    |    |  |   (digit = last digit of 200-level
-          |   |    |    |    |    |  |    response)
-          |  _|   _|   _|   _|   _|  |   ('-' => skipped (N/A))
-          ^ /  \ /  \ /  \ /  \ /  \ ^
+          |                          +-> privileged GET (expects same as above)
+          |                          |   (digit = last digit of 200-level
+          |                          |    response)
+          |                          |   ('-' => skipped (N/A))
+          ^                          ^
 HEADER:   G GET  PUT  POST DEL  TRCE G  URL
 EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
     ROW     ^^^^
@@ -99,6 +95,12 @@ EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
              +||----------------------< unauthenticated request
               +|----------------------< bad authentication: no such user
                +----------------------< bad authentication: invalid syntax
+
+            \__/ \__/ \__/ \__/ \__/
+            GET  PUT  etc.  The test cases are repeated for each HTTP method.
+
+            The number in each cell is the last digit of the 400-level response
+            that was expected for this test case.
 
     In this case, an unauthenthicated request to "GET /organizations" returned
     401.  All requests to "PUT /organizations" returned 405.

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -76,24 +76,29 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
 const VERIFY_HEADER: &str = r#"
 SUMMARY OF REQUESTS MADE
 
-          +----------------------------- privileged GET (expects 200)
-          |                              (digit = last digit of 200-level response)
+KEY:
+
+          +----------------------------> privileged GET (expects 200)
+          |                              (digit = last digit of 200-level
+          |                              response)
           |
-          |   +----+----+----+----+----- HTTP methods tested (see below)
-          |   |    |    |    |    |      (digit = last digit of 400-level response)
+          |   +----+----+----+----+----> HTTP methods tested (see below)
+          |   |    |    |    |    |      (digit = last digit of 400-level
+          |   |    |    |    |    |       response)
           |   |    |    |    |    |
-          |   |    |    |    |    |  +-- privileged GET (expects same as above)
-          |   |    |    |    |    |  |   (digit = last digit of 200-level response)
+          |   |    |    |    |    |  +-> privileged GET (expects same as above)
+          |   |    |    |    |    |  |   (digit = last digit of 200-level
+          |   |    |    |    |    |  |    response)
           |  _|   _|   _|   _|   _|  |   ('-' => skipped (N/A))
-          v /  \ /  \ /  \ /  \ /  \ v
+          ^ /  \ /  \ /  \ /  \ /  \ ^
 HEADER:   G GET  PUT  POST DEL  TRCE G  URL
 EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
-    ROW     ||||
-            ||||                        TEST CASES FOR EACH HTTP METHOD:
-            +|||-----------------------     authenticated, unauthorized request
-             +||-----------------------     unauthenticated request
-              +|-----------------------     bad authentication: no such user
-               +-----------------------     bad authentication: invalid syntax
+    ROW     ^^^^
+            ||||                      TEST CASES FOR EACH HTTP METHOD:
+            +|||----------------------< authenticated, unauthorized request
+             +||----------------------< unauthenticated request
+              +|----------------------< bad authentication: no such user
+               +----------------------< bad authentication: invalid syntax
 
     In this case, an unauthenthicated request to "GET /organizations" returned
     401.  All requests to "PUT /organizations" returned 405.

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -67,10 +67,39 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
 
     // Verify the hardcoded endpoints.
     info!(log, "verifying endpoints");
+    print!("{}", VERIFY_HEADER);
     for endpoint in &*VERIFY_ENDPOINTS {
         verify_endpoint(&log, client, endpoint).await;
     }
 }
+
+const VERIFY_HEADER: &str = r#"
+SUMMARY OF REQUESTS MADE
+
+          +----------------------------- privileged GET (expects 200)
+          |                              (digit = last digit of 200-level response)
+          |
+          |   +----+----+----+----+----- HTTP methods tested (see below)
+          |   |    |    |    |    |      (digit = last digit of 400-level response)
+          |   |    |    |    |    |
+          |   |    |    |    |    |  +-- privileged GET (expects same as above)
+          |   |    |    |    |    |  |   (digit = last digit of 200-level response)
+          |  _|   _|   _|   _|   _|  |   ('-' => skipped (N/A))
+          v /  \ /  \ /  \ /  \ /  \ v
+HEADER:   G GET  PUT  POST DEL  TRCE G  URL
+EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
+    ROW     ||||
+            ||||                        TEST CASES FOR EACH HTTP METHOD:
+            +|||-----------------------     authenticated, unauthorized request
+             +||-----------------------     unauthenticated request
+              +|-----------------------     bad authentication: no such user
+               +-----------------------     bad authentication: invalid syntax
+
+    In this case, an unauthenthicated request to "GET /organizations" returned
+    401.  All requests to "PUT /organizations" returned 405.
+
+G GET  PUT  POST DEL  TRCE G  URL
+"#;
 
 //
 // SETUP PHASE
@@ -216,6 +245,7 @@ async fn verify_endpoint(
         .any(|allowed| matches!(allowed, AllowedMethod::Get));
     let resource_before: Option<serde_json::Value> = if get_allowed {
         info!(log, "test: privileged GET");
+        record_operation(WhichTest::PrivilegedGet(Some(&http::StatusCode::OK)));
         Some(
             NexusRequest::object_get(client, endpoint.url)
                 .authn_as(AuthnMode::PrivilegedUser)
@@ -227,8 +257,11 @@ async fn verify_endpoint(
         )
     } else {
         warn!(log, "test: skipping privileged GET (method not allowed)");
+        record_operation(WhichTest::PrivilegedGet(None));
         None
     };
+
+    print!(" ");
 
     // For each of the HTTP methods we use in the API as well as TRACE, we'll
     // make several requests to this URL and verify the results.
@@ -258,6 +291,7 @@ async fn verify_endpoint(
         .await
         .unwrap();
         verify_response(&response);
+        record_operation(WhichTest::Unprivileged(&expected_status));
 
         // Next, make an unauthenticated request.
         info!(log, "test: unauthenticated"; "method" => ?method);
@@ -273,6 +307,7 @@ async fn verify_endpoint(
                 .await
                 .unwrap();
         verify_response(&response);
+        record_operation(WhichTest::Unauthenticated(&expected_status));
 
         // Now try a few requests with bogus credentials.  We should get the
         // same error as if we were unauthenticated.  This is sort of duplicated
@@ -304,6 +339,7 @@ async fn verify_endpoint(
                 .await
                 .unwrap();
         verify_response(&response);
+        record_operation(WhichTest::UnknownUser(&expected_status));
 
         // Now try a syntactically invalid authn header.
         info!(log, "test: bogus creds: bad cred syntax"; "method" => ?method);
@@ -320,6 +356,9 @@ async fn verify_endpoint(
                 .await
                 .unwrap();
         verify_response(&response);
+        record_operation(WhichTest::InvalidHeader(&expected_status));
+
+        print!(" ");
     }
 
     // If we fetched the resource earlier, fetch it again and check the state.
@@ -348,7 +387,14 @@ async fn verify_endpoint(
             resource_before, resource_after,
             "resource changed after making a bunch of failed requests"
         );
+        record_operation(WhichTest::PrivilegedGetCheck(Some(
+            &http::StatusCode::OK,
+        )));
+    } else {
+        record_operation(WhichTest::PrivilegedGetCheck(None));
     }
+
+    println!("  {}", endpoint.url);
 }
 
 /// Verifies the body of an HTTP response for status codes 401, 403, 404, or 405
@@ -378,4 +424,42 @@ fn verify_response(response: &TestResponse) {
         }
         _ => unimplemented!(),
     }
+}
+
+/// Describes the tests run by [`verify_endpoint()`].
+enum WhichTest<'a> {
+    PrivilegedGet(Option<&'a http::StatusCode>),
+    Unprivileged(&'a http::StatusCode),
+    Unauthenticated(&'a http::StatusCode),
+    UnknownUser(&'a http::StatusCode),
+    InvalidHeader(&'a http::StatusCode),
+    PrivilegedGetCheck(Option<&'a http::StatusCode>),
+}
+
+/// Prints one cell of the giant summary table describing the successful result
+/// of one HTTP request.
+fn record_operation(whichtest: WhichTest<'_>) {
+    // Extract the status code for the test.
+    let status_code = match whichtest {
+        WhichTest::PrivilegedGet(s) | WhichTest::PrivilegedGetCheck(s) => s,
+        WhichTest::Unprivileged(s) => Some(s),
+        WhichTest::Unauthenticated(s) => Some(s),
+        WhichTest::UnknownUser(s) => Some(s),
+        WhichTest::InvalidHeader(s) => Some(s),
+    };
+
+    // We'll print out the third digit of the HTTP status code.
+    let c = match status_code {
+        Some(s) => s.as_str().chars().nth(2).unwrap(),
+        None => '-',
+    };
+
+    // We only get here for successful results, so they're all green.  You might
+    // think the color is pointless, but it does help the reader make sense of
+    // the mess of numbers that shows up in the table for the different response
+    // codes.
+    let mut t = term::stdout().unwrap();
+    t.fg(term::color::GREEN).unwrap();
+    write!(t, "{}", c).unwrap();
+    t.reset().unwrap();
 }

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -466,11 +466,12 @@ fn record_operation(whichtest: WhichTest<'_>) {
     // the mess of numbers that shows up in the table for the different response
     // codes.
     let t = term::stdout();
-    if let Some(term) = t {
-        t.fg(term::color::GREEN).unwrap();
-    }
-    write!(t, "{}", c).unwrap();
-    if let Some(term) = t {
-        t.reset().unwrap();
+    if let Some(mut term) = t {
+        term.fg(term::color::GREEN).unwrap();
+        write!(term, "{}", c).unwrap();
+        term.reset().unwrap();
+        term.flush().unwrap();
+    } else {
+        print!("{}", c);
     }
 }

--- a/nexus/tests/integration_tests/unauthorized_coverage.rs
+++ b/nexus/tests/integration_tests/unauthorized_coverage.rs
@@ -73,8 +73,6 @@ fn test_unauthorized_coverage() {
         })
         .collect();
 
-    println!("spec operations: {:?}", spec_operations);
-
     // Go through each of the authz test cases and match each one against an
     // OpenAPI operation.
     let mut unexpected_endpoints = String::from(


### PR DESCRIPTION
This change causes the "unauthorized" integration test to print a summary table of all the requests it made.  It's a pretty dense visual representation: it technically includes the URL path, HTTP method, and status code.  Here's a text version:

```
$ cargo test -p omicron-nexus --test=test_all -- --nocapture integration_tests::unauthorized::test_unauthorized
    Finished test [unoptimized + debuginfo] target(s) in 0.76s
     Running tests/test_all.rs (target/debug/deps/test_all-41f3abf497b5cf9f)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-41f3abf497b5cf9f-test_unauthorized.9505.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-41f3abf497b5cf9f-test_unauthorized.9505.0.log"

SUMMARY OF REQUESTS MADE

          +----------------------------- privileged GET (expects 200)
          |                              (digit = last digit of 200-level response)
          |
          |   +----+----+----+----+----- HTTP methods tested (see below)
          |   |    |    |    |    |      (digit = last digit of 400-level response)
          |   |    |    |    |    |
          |   |    |    |    |    |  +-- privileged GET (expects same as above)
          |   |    |    |    |    |  |   (digit = last digit of 200-level response)
          |  _|   _|   _|   _|   _|  |   ('-' => skipped (N/A))
          v /  \ /  \ /  \ /  \ /  \ v
HEADER:   G GET  PUT  POST DEL  TRCE G  URL
EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
    ROW     ||||
            ||||                        TEST CASES FOR EACH HTTP METHOD:
            +|||-----------------------     authenticated, unauthorized request
             +||-----------------------     unauthenticated request
              +|-----------------------     bad authentication: no such user
               +-----------------------     bad authentication: invalid syntax

    In this case, an unauthenthicated request to "GET /organizations" returned
    401.  All requests to "PUT /organizations" returned 405.

G GET  PUT  POST DEL  TRCE G  URL
0 3111 5555 3111 5555 5555 0  /organizations
0 4411 4411 5555 4411 5555 0  /organizations/demo-org
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects
0 4411 4411 5555 4411 5555 0  /organizations/demo-org/projects/demo-project
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs
0 4411 4411 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc
0 4411 4411 5555 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/firewall/rules
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/subnets
0 4411 4411 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/subnets/demo-vpc-subnet
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers
0 4411 4411 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router/routes
0 4411 4411 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router/routes/demo-router-route
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/disks
0 4411 5555 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/disks/demo-disk
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/disks/attach
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/disks/detach
0 4411 5555 4411 5555 5555 0  /organizations/demo-org/projects/demo-project/instances
0 4411 5555 5555 4411 5555 0  /organizations/demo-org/projects/demo-project/instances/demo-instance
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/start
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/stop
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/reboot
- 5555 5555 4411 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/migrate
0 3111 5555 5555 5555 5555 0  /roles
0 4411 5555 5555 5555 5555 0  /roles/fleet.admin
0 3111 5555 5555 5555 5555 0  /users
0 4411 5555 5555 5555 5555 0  /users/db-init
0 3111 5555 5555 5555 5555 0  /hardware/racks
0 4411 5555 5555 5555 5555 0  /hardware/racks/c19a698f-c6f9-4a17-ae30-20d711b8f7dc
0 3111 5555 5555 5555 5555 0  /hardware/sleds
0 4411 5555 5555 5555 5555 0  /hardware/sleds/b6d65341-167c-41df-9b5c-41cded99c229
0 3111 5555 5555 5555 5555 0  /sagas
- 3111 5555 5555 5555 5555 -  /sagas/48a1b8c8-fc1c-6fea-9de9-fdeb8dda7823
0 3111 5555 5555 5555 5555 0  /timeseries/schema
- 5555 5555 3111 5555 5555 -  /updates/refresh
test integration_tests::unauthorized::test_unauthorized ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 9.72s
```

It prints the numbers in green:

![Screen Shot 2022-03-29 at 2 52 00 PM](https://user-images.githubusercontent.com/532688/160713329-31f87130-0df3-4580-adaf-44e4ae3272e4.png)

Note that it never prints anything other than green -- if something produces an unexpected result, the test still panics.  Still, it seemed useful to have the color here to emphasize that it's what's expected, since it's hard to compute what the right status code should be for each cell in the table.

Spoiler: the catalyst is to be able to demo authz, during which I would explain the various requests made by the test.