### PR TITLE
Miscellaneous thing-flinger changes

### DIFF
--- a/package/src/bin/deployment-example.toml
+++ b/package/src/bin/deployment-example.toml
@@ -3,23 +3,20 @@
 #
 # It is ingested by the `thing-flinger` tool.
 
-# This must be an absolute path
-local_source = "/Users/ajs/oxide/omicron"
+# This must be an absolute path. It refers to the path to Omicron on the
+# machine where thing-flinger is being executed.
+omicron_path = "/local/path/to/omicron"
 
 [builder]
 # `server` must refer to one of the `servers` in the servers table
-server = "atrium"
-
-# This must be an absolute path
-omicron_path = "/home/andrew/oxide/omicron"
-
-# Git branch, sha, etc...
-git_treeish = "thing-flinger2"
+server = "foo"
+# This must be an absolute path. It refers to the path to Omicron on the
+# builder server.
+omicron_path = "/remote/path/to/omicron"
 
 [deployment]
-servers = ["sock", "buskin"]
+servers = ["foo", "bar"]
 rack_secret_threshold = 2
-
 # Location where files to install will be placed before running
 # `omicron-package install`
 #
@@ -27,20 +24,10 @@ rack_secret_threshold = 2
 # We specifically allow for $HOME in validating the absolute path
 staging_dir = "$HOME/omicron_staging"
 
-[servers.tarz]
-username = "ajs"
-addr = "tarz.local"
+[servers.foo]
+username = "me"
+addr = "foo"
 
-[servers.atrium]
-username = "andrew"
-addr = "atrium.eng.oxide.computer"
-
-[servers.sock]
-username = "andrew"
-addr = "sock.eng.oxide.computer"
-
-[servers.buskin]
-username = "andrew"
-addr = "buskin.eng.oxide.computer"
-
-
+[servers.bar]
+username = "me"
+addr = "bar"

--- a/package/src/bin/thing-flinger.rs
+++ b/package/src/bin/thing-flinger.rs
@@ -21,7 +21,6 @@ use thiserror::Error;
 struct Builder {
     pub server: String,
     pub omicron_path: PathBuf,
-    pub git_treeish: String,
 }
 
 // A server on which an omicron package is deployed
@@ -40,7 +39,7 @@ struct Deployment {
 
 #[derive(Debug, Deserialize)]
 struct Config {
-    pub local_source: PathBuf,
+    pub omicron_path: PathBuf,
     pub builder: Builder,
     pub servers: BTreeMap<String, Server>,
     pub deployment: Deployment,
@@ -74,8 +73,8 @@ enum SubCommand {
     ///
     /// Package always builds everything, but it can be set in release mode, and
     /// we expect the existing tools to run from 'target/debug'. Additionally,
-    // you can't run `Package` until you have actually built `omicron-package`,
-    // which `BuildMinimal` does.
+    /// you can't run `Package` until you have actually built `omicron-package`,
+    /// which `BuildMinimal` does.
     BuildMinimal,
 
     /// Use all subcommands from omicron-package
@@ -153,7 +152,7 @@ fn do_sync(config: &Config) -> Result<()> {
     // For rsync to copy from the source appropriately we must guarantee a
     // trailing slash.
     let src =
-        format!("{}/", config.local_source.canonicalize()?.to_string_lossy());
+        format!("{}/", config.omicron_path.canonicalize()?.to_string_lossy());
     let dst = format!(
         "{}@{}:{}",
         server.username,
@@ -176,6 +175,8 @@ fn do_sync(config: &Config) -> Result<()> {
         .arg("clickhouse/")
         .arg("--exclude")
         .arg("*.swp")
+        .arg("--exclude")
+        .arg(".git/")
         .arg("--out-format")
         .arg("File changed: %o %t %f")
         .arg(&src)
@@ -195,9 +196,8 @@ fn do_sync(config: &Config) -> Result<()> {
 fn do_build_minimal(config: &Config) -> Result<()> {
     let server = &config.servers[&config.builder.server];
     let cmd = format!(
-        "cd {} && git checkout {} && cargo build -p {} -p {}",
+        "cd {} && cargo build -p {} -p {}",
         config.builder.omicron_path.to_string_lossy(),
-        config.builder.git_treeish,
         "omicron-package",
         "omicron-sled-agent"
     );
@@ -219,9 +219,8 @@ fn do_package(config: &Config, artifact_dir: PathBuf) -> Result<()> {
     // See https://github.com/oxidecomputer/omicron/blob/8757ec542ea4ffbadd6f26094ed4ba357715d70d/rpaths/src/lib.rs
     write!(
         &mut cmd,
-        "bash -lc 'cd {} && git checkout {} && {} package --out {}'",
+        "bash -lc 'cd {} && {} package --out {}'",
         config.builder.omicron_path.to_string_lossy(),
-        config.builder.git_treeish,
         cmd_path,
         &artifact_dir,
     )?;
@@ -236,9 +235,8 @@ fn do_check(config: &Config) -> Result<()> {
 
     write!(
         &mut cmd,
-        "bash -lc 'cd {} && git checkout {} && {} check'",
+        "bash -lc 'cd {} && {} check'",
         config.builder.omicron_path.to_string_lossy(),
-        config.builder.git_treeish,
         cmd_path,
     )?;
 
@@ -324,8 +322,8 @@ fn do_overlay(config: &Config) -> Result<()> {
     // TODO: This needs to match the artifact_dir in `package`
     root_path.push("out/overlay");
     let server_dirs = dir_per_deploy_server(config, &root_path);
-    let server = &config.servers[&config.builder.server];
-    overlay_sled_agent(&server, config, &server_dirs)
+    let builder = &config.servers[&config.builder.server];
+    overlay_sled_agent(&builder, config, &server_dirs)
 }
 
 fn overlay_sled_agent(
@@ -344,12 +342,11 @@ fn overlay_sled_agent(
 
     // Create directories on builder
     let dirs = dir_string(&sled_agent_dirs);
-    let cmd = format!("sh -c 'for dir in {}; do mkdir -p $dir; done'", dirs);
-
     let cmd = format!(
-        "{} && cd {} && ./target/debug/sled-agent-overlay-files \
-            --threshold {} --directories {}",
-        cmd,
+        "sh -c 'for dir in {}; do mkdir -p $dir; done' && \
+            cd {} && \
+            cargo run --bin sled-agent-overlay-files -- --threshold {} --directories {}",
+        dirs,
         config.builder.omicron_path.to_string_lossy(),
         config.deployment.rack_secret_threshold,
         dirs
@@ -506,6 +503,12 @@ fn dir_string(dirs: &[PathBuf]) -> String {
     dirs.iter().map(|dir| dir.to_string_lossy().to_string() + " ").collect()
 }
 
+// For each server to be deployed, append the server name to `root`.
+//
+// Example (for servers "foo", "bar", "baz"):
+//
+//  dir_per_deploy_server(&config, "/my/path") ->
+//  vec!["/my/path/foo", "/my/path/bar", "/my/path/baz"]
 fn dir_per_deploy_server(config: &Config, root: &Path) -> Vec<PathBuf> {
     config
         .deployment
@@ -570,7 +573,7 @@ fn validate_absolute_path(
 }
 
 fn validate(config: &Config) -> Result<(), FlingError> {
-    validate_absolute_path(&config.local_source, "local_source")?;
+    validate_absolute_path(&config.omicron_path, "omicron_path")?;
     validate_absolute_path(
         &config.builder.omicron_path,
         "builder.omicron_path",

--- a/sled-agent/src/bin/sled-agent-overlay-files.rs
+++ b/sled-agent/src/bin/sled-agent-overlay-files.rs
@@ -21,7 +21,7 @@ use structopt::StructOpt;
     about = "Generate server unique files for deployment"
 )]
 struct Args {
-    //// The rack secret threshold
+    /// The rack secret threshold
     #[structopt(short, long)]
     threshold: usize,
 


### PR DESCRIPTION
- Update the "deployment example" to be slightly more generic
- Remove git checkouts
- Rename "local_source" to "omicron_path", to make it clear that it is intended to be akin to the remote "omicron_path"
- Avoid syncing ".git"
- Fix some docs

Addresses a portion of https://github.com/oxidecomputer/omicron/issues/828