### PR TITLE
Thing-flinger: Allow deployment to single node

### DIFF
--- a/deploy/src/bin/sled-agent-overlay-files.rs
+++ b/deploy/src/bin/sled-agent-overlay-files.rs
@@ -37,6 +37,13 @@ fn overlay_secret_shares(
     server_dirs: &[PathBuf],
 ) -> Result<()> {
     let total_shares = server_dirs.len();
+    if total_shares < 2 {
+        println!(
+            "Skipping secret share distribution: only one server \
+             available."
+        );
+        return Ok(());
+    }
     let secret = RackSecret::new();
     let (shares, verifier) = secret
         .split(threshold, total_shares)


### PR DESCRIPTION
`sled-agent-overlay-files` generates secret shares for rack unlock in a
multinode cluster. However, rack secrets and their resulting shares can only be
created for clusters with 2 or more nodes. As we want to be able to use
thing-flinger to deploy to a single node system, we skip generation of the
secret if there is only one deployment server. This works because the sled-agent
bootstrap code runs in single node mode if no share is found.

Without this change, the user would get a `vsss_rs::Error::SharingMinThreshold`
error when running `thing-flinger overlay`.