### PR TITLE
[sled-agent] Generalize search for addrconf

### DIFF
--- a/sled-agent/src/illumos/addrobj.rs
+++ b/sled-agent/src/illumos/addrobj.rs
@@ -44,6 +44,10 @@ impl AddrObject {
         }
         Ok(Self { interface: interface.to_string(), name: name.to_string() })
     }
+
+    pub fn interface(&self) -> &str {
+        &self.interface
+    }
 }
 
 impl ToString for AddrObject {

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -309,8 +309,9 @@ impl Zones {
         let prefix =
             if let Some(zone) = zone { vec![ZLOGIN, zone] } else { vec![] };
 
+        let interface = format!("{}/", addrobj.interface());
         let show_addr_args =
-            &[IPADM, "show-addr", "-p", "-o", "TYPE", &addrobj.to_string()];
+            &[IPADM, "show-addr", "-p", "-o", "TYPE", &interface];
 
         let args = prefix.iter().chain(show_addr_args);
         let cmd = command.args(args);


### PR DESCRIPTION
Running on Atrium, I ran the sled agent and saw the following output:

```
ipadm: Could not create address: Addrconf already in progress
```

Running `ipadm`, I could see the following line:

```
igb0/v6           addrconf ok           fe80::1ac0:4dff:fe81:7e7c/10
```

The Sled Agent, on boot, tries to assert that an IPv6 addrconf address exists. If one doesn't exist, it makes one named `linklocal` - in this case, it was trying to create `igb0/linklocal` - but totally ignoring that a (differently-named) addrconf already exists.

This PR updates the behavior of the sled agent: Rather than searching for *exactly* `igb0/linklocal`, the sled agent will instead search for `igb0/", and skip creating a new addrconf if one with *any* name exists already.