### PR TITLE
[thing-flinger] Simplify packaging commands

### DIFF
--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -578,7 +578,8 @@ fn ssh_exec(
         .arg(&server.addr)
         .arg(&remote_cmd);
     cmd.env("SSH_AUTH_SOCK", auth_sock);
-    let exit_status = cmd.status()
+    let exit_status = cmd
+        .status()
         .context(format!("Failed to run {} on {}", remote_cmd, server.addr))?;
     if !exit_status.success() {
         anyhow::bail!("Command failed: {}", exit_status);

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -84,8 +84,7 @@ enum SubCommand {
     /// commands on the build host.
     BuildMinimal,
 
-    /// Use all subcommands from omicron-package
-    #[structopt(flatten)]
+    /// Runs a packaging command on the "builder" server.
     Package(PackageSubCommand),
 
     /// Create an overlay directory tree for each deployment server
@@ -216,7 +215,7 @@ fn do_build_minimal(config: &Config) -> Result<()> {
 }
 
 fn do_package(config: &Config, artifact_dir: PathBuf) -> Result<()> {
-    let server = &config.servers[&config.builder.server];
+    let builder = &config.servers[&config.builder.server];
     let artifact_dir = artifact_dir
         .to_str()
         .ok_or_else(|| FlingError::BadString("artifact_dir".to_string()))?;
@@ -235,7 +234,7 @@ fn do_package(config: &Config, artifact_dir: PathBuf) -> Result<()> {
         &artifact_dir,
     );
 
-    ssh_exec(&server, &cmd, false)
+    ssh_exec(&builder, &cmd, false)
 }
 
 fn do_check(config: &Config) -> Result<()> {

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -504,10 +504,16 @@ async fn main() -> Result<()> {
             do_package(&config, &artifact_dir).await?;
         }
         SubCommand::Build(BuildCommand::Check) => do_check(&config).await?,
-        SubCommand::Deploy(DeployCommand::Install { artifact_dir, install_dir }) => {
+        SubCommand::Deploy(DeployCommand::Install {
+            artifact_dir,
+            install_dir,
+        }) => {
             do_install(&config, &artifact_dir, &install_dir)?;
         }
-        SubCommand::Deploy(DeployCommand::Uninstall { artifact_dir, install_dir }) => {
+        SubCommand::Deploy(DeployCommand::Uninstall {
+            artifact_dir,
+            install_dir,
+        }) => {
             do_uninstall(&config, &artifact_dir, &install_dir)?;
         }
     }

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -7,7 +7,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use omicron_package::{parse, SubCommand};
+use omicron_package::{parse, BuildCommand, DeployCommand};
 use omicron_zone_package::package::{Package, Progress};
 use rayon::prelude::*;
 use ring::digest::{Context as DigestContext, Digest, SHA256};
@@ -24,7 +24,7 @@ use tokio::process::Command;
 /// Describes the origin of an externally-built package.
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "lowercase")]
-pub enum ExternalPackageSource {
+enum ExternalPackageSource {
     /// Downloads the package from the following URL:
     ///
     /// <https://buildomat.eng.oxide.computer/public/file/oxidecomputer/REPO/image/COMMIT/PACKAGE>
@@ -36,24 +36,33 @@ pub enum ExternalPackageSource {
 
 /// Describes a package which originates from outside this repo.
 #[derive(Deserialize, Debug)]
-pub struct ExternalPackage {
+struct ExternalPackage {
     #[serde(flatten)]
-    pub package: Package,
+    package: Package,
 
-    pub source: ExternalPackageSource,
+    source: ExternalPackageSource,
 }
 
 /// Describes the configuration for a set of packages.
 #[derive(Deserialize, Debug)]
-pub struct Config {
+struct Config {
     /// Packages to be built and installed.
     #[serde(default, rename = "package")]
-    pub packages: BTreeMap<String, Package>,
+    packages: BTreeMap<String, Package>,
 
     /// Packages to be installed, but which have been created outside this
     /// repository.
     #[serde(default, rename = "external_package")]
-    pub external_packages: BTreeMap<String, ExternalPackage>,
+    external_packages: BTreeMap<String, ExternalPackage>,
+}
+
+/// All packaging subcommands.
+#[derive(Debug, StructOpt)]
+enum SubCommand {
+    #[structopt(flatten)]
+    Build(BuildCommand),
+    #[structopt(flatten)]
+    Deploy(DeployCommand),
 }
 
 #[derive(Debug, StructOpt)]
@@ -491,14 +500,14 @@ async fn main() -> Result<()> {
     }
 
     match &args.subcommand {
-        SubCommand::Package { artifact_dir } => {
+        SubCommand::Build(BuildCommand::Package { artifact_dir }) => {
             do_package(&config, &artifact_dir).await?;
         }
-        SubCommand::Check => do_check(&config).await?,
-        SubCommand::Install { artifact_dir, install_dir } => {
+        SubCommand::Build(BuildCommand::Check) => do_check(&config).await?,
+        SubCommand::Deploy(DeployCommand::Install { artifact_dir, install_dir }) => {
             do_install(&config, &artifact_dir, &install_dir)?;
         }
-        SubCommand::Uninstall { artifact_dir, install_dir } => {
+        SubCommand::Deploy(DeployCommand::Uninstall { artifact_dir, install_dir }) => {
             do_uninstall(&config, &artifact_dir, &install_dir)?;
         }
     }

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -23,8 +23,9 @@ pub fn parse<P: AsRef<Path>, C: DeserializeOwned>(
     Ok(cfg)
 }
 
+/// Commands which should execute on a host building packages.
 #[derive(Debug, StructOpt)]
-pub enum SubCommand {
+pub enum BuildCommand {
     /// Builds the packages specified in a manifest, and places them into a target
     /// directory.
     Package {
@@ -36,6 +37,11 @@ pub enum SubCommand {
     },
     /// Checks the packages specified in a manifest, without building.
     Check,
+}
+
+/// Commands which should execute on a host installing packages.
+#[derive(Debug, StructOpt)]
+pub enum DeployCommand {
     /// Installs the packages to a target machine.
     Install {
         /// The directory from which artifacts will be pulled.


### PR DESCRIPTION
## Old behavior

Although thing-flinger distinguishes between "build" and "deployment" servers in the config file, the CLI commands don't make it clear "what commands run things where". For example: `package` only ran on the builder, but `install` would cause the builder to transfer files to the deploy servers. Additionally, by exposing a command called "build-minimal", the caller *must* have a clear picture of "what source is on each machine, what version is it, and what packages should be installed when". This is a pretty high cognitive burden - personally, I wrote the underlying packaging tools, but still had to verify this experimentally!

```
cargo run --bin thing-flinger -- --config myconfig.toml build-minimal
cargo run --bin thing-flinger -- --config myconfig.toml package
cargo run --bin thing-flinger -- --config myconfig.toml check
cargo run --bin thing-flinger -- --config myconfig.toml install
cargo run --bin thing-flinger -- --config myconfig.toml uninstall
```

## New behavior

This PR introduces a handful of simplifications:

1. "Build minimal" has been removed. For commands which need the tools to exist on the deployment servers, this command is called, but as an implementation detail. Additionally, invoking binaries on the builder machine via `cargo` incurs a rebuild if necessary anyway.
2. The "package" commands have been split into two categories: "build" and "deploy". "build" commands are sent to the builder server, "deploy" commands transfer state to the deployment servers and execute operations there.

New invocations:

```
cargo run --bin thing-flinger -- --config myconfig.toml build package
cargo run --bin thing-flinger -- --config myconfig.toml build check
cargo run --bin thing-flinger -- --config myconfig.toml deploy install
cargo run --bin thing-flinger -- --config myconfig.toml deploy uninstall
```