### PR TITLE
use pool_authorized() for all lookups

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -121,7 +121,7 @@ impl DataStore {
     // the database.  Eventually, this function should only be used for doing
     // authentication in the first place (since we can't do an authz check in
     // that case).
-    pub(super) fn pool(&self) -> &bb8::Pool<ConnectionManager<DbConnection>> {
+    fn pool(&self) -> &bb8::Pool<ConnectionManager<DbConnection>> {
         self.pool.pool()
     }
 

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -227,12 +227,9 @@ async fn verify_endpoint(
     let log = log.new(o!("url" => endpoint.url));
     info!(log, "test: begin endpoint");
 
-    // Determine the expected status code for unauthenticated requests, based on
-    // the endpoint's visibility.
-    let unauthn_status = match endpoint.visibility {
-        Visibility::Public => StatusCode::UNAUTHORIZED,
-        Visibility::Protected => StatusCode::NOT_FOUND,
-    };
+    // When the user is not authenticated, failing any authz check results in a
+    // "401 Unauthorized" status code.
+    let unauthn_status = StatusCode::UNAUTHORIZED;
 
     // Determine the expected status code for authenticated, unauthorized
     // requests, based on the endpoint's visibility.


### PR DESCRIPTION
Recall that the `DataStore` has two methods for getting a database connection: `pool()` and `pool_authorized(opctx: &OpContext)`.  The latter checks whether the caller is even allowed to query the database.  All authenticated users have this permission, so it's kind of silly.  But this seemed useful as a belt-and-suspenders way to ensure that if we accidentally add some unauthenticated code path, an attacker can't use this to trivially DoS the database.  We should eventually be using `pool_authorized()` everywhere and rip out `pool()` altogether.  Right now, lookups use `pool()`, only for historical reasons.  It's time to switch these to use `pool_authorized(opctx)`.

This changes some failure modes for unauthenticated users!  Previously, if an unauthenticated user tried to fetch, say, `/organizations/foo`, they would have gotten a 404.  Same if they tried to update or delete it.  That's because we'd look up the resource, find they didn't have read access, and send a 404.  To be clear, I think that behavior remains reasonable.  But with this change, we're kicking them out before even doing the lookup.  I think that's also reasonable.  From some casual research, it seems that people often advocate for using 401 when there's _any_ authz error and no credentials were provided, so we're consistent with expectations there.  This is also what our own docs/http-status-codes.adoc says.

This is especially relevant when we get to Silos.  Once we do #850, it won't even be possible to do the lookup without credentials, so it makes sense to kick the request out quickly in that case -- and with a 401.