### PR TITLE
Remove extra params wrapper for `network_interfaces` in instance create api

### DIFF
--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -94,7 +94,7 @@ pub struct NetworkInterfaceCreate {
 #[serde(tag = "type", content = "params")]
 pub enum InstanceNetworkInterfaceAttachment {
     /// Create one or more `NetworkInterface`s for the `Instance`
-    Create(InstanceNetworkInterfaceCreate),
+    Create(Vec<NetworkInterfaceCreate>),
 
     /// Default networking setup, which creates a single interface with an
     /// auto-assigned IP address from project's "default" VPC and "default" VPC
@@ -103,11 +103,6 @@ pub enum InstanceNetworkInterfaceAttachment {
 
     /// No network interfaces at all will be created for the instance.
     None,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceNetworkInterfaceCreate {
-    pub params: Vec<NetworkInterfaceCreate>,
 }
 
 impl Default for InstanceNetworkInterfaceAttachment {

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -273,7 +273,7 @@ async fn sic_allocate_network_interface_ids(
         params::InstanceNetworkInterfaceAttachment::Create(
             ref create_params,
         ) => {
-            if create_params.params.len()
+            if create_params.len()
                 > crate::nexus::MAX_NICS_PER_INSTANCE.try_into().unwrap()
             {
                 return Err(ActionError::action_failed(
@@ -287,8 +287,8 @@ async fn sic_allocate_network_interface_ids(
                     ),
                 ));
             }
-            let mut ids = Vec::with_capacity(create_params.params.len());
-            for _ in 0..create_params.params.len() {
+            let mut ids = Vec::with_capacity(create_params.len());
+            for _ in 0..create_params.len() {
                 ids.push(Uuid::new_v4());
             }
             Ok(ids)
@@ -307,11 +307,7 @@ async fn sic_create_network_interfaces(
         params::InstanceNetworkInterfaceAttachment::Create(
             ref create_params,
         ) => {
-            sic_create_custom_network_interfaces(
-                &sagactx,
-                &create_params.params,
-            )
-            .await
+            sic_create_custom_network_interfaces(&sagactx, &create_params).await
         }
     }
 }

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -549,11 +549,10 @@ async fn test_instance_create_saga_removes_instance_database_record(
         subnet_name: default_name.clone(),
         ip: Some(requested_address),
     };
-    let interface_params = params::InstanceNetworkInterfaceAttachment::Create(
-        params::InstanceNetworkInterfaceCreate {
-            params: vec![if0_params.clone()],
-        },
-    );
+    let interface_params =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            if0_params.clone()
+        ]);
 
     // Create the parameters for the instance itself, and create it.
     let instance_params = params::InstanceCreate {
@@ -611,11 +610,10 @@ async fn test_instance_create_saga_removes_instance_database_record(
         subnet_name: default_name.clone(),
         ip: Some(requested_address),
     };
-    let interface_params = params::InstanceNetworkInterfaceAttachment::Create(
-        params::InstanceNetworkInterfaceCreate {
-            params: vec![if0_params.clone()],
-        },
-    );
+    let interface_params =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            if0_params.clone()
+        ]);
     let instance_params = params::InstanceCreate {
         network_interfaces: interface_params,
         ..instance_params.clone()
@@ -657,11 +655,10 @@ async fn test_instance_with_single_explicit_ip_address(
         subnet_name: default_name.clone(),
         ip: Some(requested_address),
     };
-    let interface_params = params::InstanceNetworkInterfaceAttachment::Create(
-        params::InstanceNetworkInterfaceCreate {
-            params: vec![if0_params.clone()],
-        },
-    );
+    let interface_params =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            if0_params.clone()
+        ]);
 
     // Create the parameters for the instance itself, and create it.
     let instance_params = params::InstanceCreate {
@@ -773,11 +770,11 @@ async fn test_instance_with_new_custom_network_interfaces(
         subnet_name: non_default_subnet_name.clone(),
         ip: None,
     };
-    let interface_params = params::InstanceNetworkInterfaceAttachment::Create(
-        params::InstanceNetworkInterfaceCreate {
-            params: vec![if0_params.clone(), if1_params.clone()],
-        },
-    );
+    let interface_params =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            if0_params.clone(),
+            if1_params.clone(),
+        ]);
 
     // Create the parameters for the instance itself, and create it.
     let instance_params = params::InstanceCreate {
@@ -1049,11 +1046,11 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         subnet_name: default_name.clone(),
         ip: Some("172.30.0.6".parse().unwrap()),
     };
-    let interface_params = params::InstanceNetworkInterfaceAttachment::Create(
-        params::InstanceNetworkInterfaceCreate {
-            params: vec![if0_params.clone(), if1_params.clone()],
-        },
-    );
+    let interface_params =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            if0_params.clone(),
+            if1_params.clone(),
+        ]);
 
     // Create the parameters for the instance itself, and create it.
     let instance_params = params::InstanceCreate {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5423,7 +5423,10 @@
             "type": "object",
             "properties": {
               "params": {
-                "$ref": "#/components/schemas/InstanceNetworkInterfaceCreate"
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NetworkInterfaceCreate"
+                }
               },
               "type": {
                 "type": "string",
@@ -5467,20 +5470,6 @@
               "type"
             ]
           }
-        ]
-      },
-      "InstanceNetworkInterfaceCreate": {
-        "type": "object",
-        "properties": {
-          "params": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NetworkInterfaceCreate"
-            }
-          }
-        },
-        "required": [
-          "params"
         ]
       },
       "InstanceResultsPage": {


### PR DESCRIPTION
I've been working through wiring up the UI to the instance create api and I ran across a relatively strange paradigm. When adding a network interface to the instance create endpoint it required a nested `params` key that made the api awkward.

Here's a rough example of what it'd look like in the post body.

```js
{
  network_interfaces: {
    type: "Create",
    params: {
      params: {
        ...NetworkInterfaceParams
      }
    }
  }
}
```

So far as I can tell the `InstanceNetworkInterfaceCreate` isn't actually necessary but I could be missing some future intent here. 