### PR TITLE
Build flake debugging: free up additional disk space

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,3 +6,8 @@
 #
 [build]
 rustdocflags = "--document-private-items"
+
+[target.x86_64-unknown-linux-gnu]
+# Attempt to get more verbose output from the linker in the event that linking
+# fails.
+rustflags = ["-C", "link-args=-Wl,-V"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,8 +104,26 @@ jobs:
       if: ${{ github.ref != 'refs/heads/main' }}
     - name: Report cargo version
       run: cargo --version
-    - name: Report disk space
-      run: df -h .
+    - name: Remove unnecessary software
+      run: |
+        echo "Disk space:"
+        df -h
+
+        if [ -d "/usr/share/dotnet" ]; then
+          echo "Removing dotnet"
+          sudo rm -rf /usr/share/dotnet
+        fi
+        if [ -d "/usr/local/lib/android" ]; then
+          echo "Removing android"
+          sudo rm -rf /usr/local/lib/android
+        fi
+        if [ -d "/opt/ghc" ]; then
+          echo "Removing haskell"
+          sudo rm -rf /opt/ghc
+        fi
+
+        echo "Disk space:"
+        df -h
     - name: Configure GitHub cache for CockroachDB binaries
       id: cache-cockroachdb
       # actions/cache@v2.1.4


### PR DESCRIPTION
There's some evidence #868 may be caused by the ubuntu-18.04 runner not having quite enough disk space to complete the build+test. This PR adds two things to attempt to help debug and/or resolve it:

1. Enable more verbose linker output (only under linux, which is the only OS experiencing these failures)
2. Remove a few large software packages installed by default in the github runner that we don't need

The latter step takes a couple minutes, which is far from ideal, but it increases the free disk space from ~27G to ~43G, so if disk space is the cause and we were on the fence, this should buy a fair bit of breathing room. The specific directories I'm removing came from https://github.com/easimon/maximize-build-space; that repo is an action that we could use directly, but I suspect we don't want that. It's trying to maximize the available disk space, including by using LVM to span `/` and `/mnt`, which it notes may have a performance impact.