### PR TITLE
[sled-agent] Add tests for service management, fix prefix-matching bug

### DIFF
--- a/sled-agent/src/illumos/dladm.rs
+++ b/sled-agent/src/illumos/dladm.rs
@@ -27,7 +27,7 @@ pub enum Error {
 }
 
 /// The name of a physical datalink.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct PhysicalLink(pub String);
 
 /// Wraps commands for interacting with data links.

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -44,13 +44,16 @@ impl From<Error> for omicron_common::api::external::Error {
     }
 }
 
-fn services_config_path() -> PathBuf {
+/// The default path to service configuration, if one is not
+/// explicitly provided.
+pub fn default_services_config_path() -> PathBuf {
     Path::new(crate::OMICRON_CONFIG_PATH).join("services.toml")
 }
 
 /// Manages miscellaneous Sled-local services.
 pub struct ServiceManager {
     log: Logger,
+    config_path: Option<PathBuf>,
     zones: Mutex<Vec<RunningZone>>,
     vnic_allocator: VnicAllocator,
 }
@@ -58,17 +61,28 @@ pub struct ServiceManager {
 impl ServiceManager {
     /// Creates a service manager, which returns once all requested services
     /// have been started.
+    ///
+    /// Args:
+    /// - `log`: The logger
+    /// - `physical_link`: An optional physical link on which to allocate
+    /// datalinks. By default, the first physical link is used.
+    /// - `config_path`: An optional path to a configuration file to store
+    /// the record of services. By default, [`default_services_config_path`]
+    /// is used.
     pub async fn new(
         log: Logger,
         physical_link: Option<PhysicalLink>,
+        config_path: Option<PathBuf>,
     ) -> Result<Self, Error> {
+        debug!(log, "Creating new ServiceManager");
         let mgr = Self {
             log,
+            config_path,
             zones: Mutex::new(vec![]),
             vnic_allocator: VnicAllocator::new("Service", physical_link)?,
         };
 
-        let config_path = services_config_path();
+        let config_path = mgr.services_config_path();
         if config_path.exists() {
             info!(
                 &mgr.log,
@@ -76,7 +90,7 @@ impl ServiceManager {
                 config_path.to_string_lossy()
             );
             let cfg: ServiceEnsureBody = toml::from_str(
-                &tokio::fs::read_to_string(&services_config_path()).await?,
+                &tokio::fs::read_to_string(&config_path).await?,
             )?;
             let mut existing_zones = mgr.zones.lock().await;
             mgr.initialize_services_locked(&mut existing_zones, &cfg.services)
@@ -92,6 +106,16 @@ impl ServiceManager {
         Ok(mgr)
     }
 
+    // Returns either the path to the explicitly provided config path, or
+    // chooses the default one.
+    fn services_config_path(&self) -> PathBuf {
+        if let Some(path) = &self.config_path {
+            path.clone()
+        } else {
+            default_services_config_path()
+        }
+    }
+
     // Populates `existing_zones` according to the requests in `services`.
     async fn initialize_services_locked(
         &self,
@@ -105,7 +129,9 @@ impl ServiceManager {
         for service in services {
             // Before we bother allocating anything for this request, check if
             // this service has already been created.
-            if existing_zones.iter().any(|z| z.name() == service.name) {
+            let expected_zone_name =
+                InstalledZone::get_zone_name(&service.name, None);
+            if existing_zones.iter().any(|z| z.name() == expected_zone_name) {
                 info!(self.log, "Service {} already exists", service.name);
                 continue;
             } else {
@@ -140,6 +166,8 @@ impl ServiceManager {
                 );
             }
 
+            debug!(self.log, "importing manifest");
+
             running_zone.run_cmd(&[
                 crate::illumos::zone::SVCCFG,
                 "import",
@@ -148,6 +176,8 @@ impl ServiceManager {
                     service.name
                 ),
             ])?;
+
+            debug!(self.log, "enabling service");
 
             running_zone.run_cmd(&[
                 crate::illumos::zone::SVCADM,
@@ -170,10 +200,10 @@ impl ServiceManager {
         request: ServiceEnsureBody,
     ) -> Result<(), Error> {
         let mut existing_zones = self.zones.lock().await;
-        let config_path = services_config_path();
+        let config_path = self.services_config_path();
         if config_path.exists() {
             let cfg: ServiceEnsureBody = toml::from_str(
-                &tokio::fs::read_to_string(&services_config_path()).await?,
+                &tokio::fs::read_to_string(&config_path).await?,
             )?;
             let known_services = cfg.services;
 
@@ -203,12 +233,227 @@ impl ServiceManager {
 
         let serialized_services = toml::Value::try_from(&request)
             .expect("Cannot serialize service list");
-        tokio::fs::write(
-            &services_config_path(),
-            toml::to_string(&serialized_services)?,
-        )
-        .await?;
+        tokio::fs::write(&config_path, toml::to_string(&serialized_services)?)
+            .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::illumos::{
+        dladm::MockDladm, dladm::PhysicalLink, svc, zone::MockZones,
+    };
+    use std::os::unix::process::ExitStatusExt;
+
+    const SVC_NAME: &str = "my_svc";
+    const EXPECTED_ZONE_NAME: &str = "oxz_my_svc";
+    const EXPECTED_LINK_NAME: &str = "my_link";
+
+    // Returns the expectations for a new service to be created.
+    fn expect_new_service() -> Vec<Box<dyn std::any::Any>> {
+        // Create a VNIC
+        let create_vnic_ctx = MockDladm::create_vnic_context();
+        create_vnic_ctx.expect().return_once(|physical_link, _, _, _| {
+            assert_eq!(
+                physical_link,
+                &PhysicalLink(EXPECTED_LINK_NAME.to_string())
+            );
+            Ok(())
+        });
+        // Install the Omicron Zone
+        let install_ctx = MockZones::install_omicron_zone_context();
+        install_ctx.expect().return_once(|_, name, _, _, _, _| {
+            assert_eq!(name, EXPECTED_ZONE_NAME);
+            Ok(())
+        });
+        // Boot the zone
+        let boot_ctx = MockZones::boot_context();
+        boot_ctx.expect().return_once(|name| {
+            assert_eq!(name, EXPECTED_ZONE_NAME);
+            Ok(())
+        });
+        // Wait for the networking service.
+        let wait_ctx = svc::wait_for_service_context();
+        wait_ctx.expect().return_once(|_, _| Ok(()));
+        // Import the manifest, enable the service
+        let execute_ctx = crate::illumos::execute_context();
+        execute_ctx.expect().times(2).returning(|_| {
+            Ok(std::process::Output {
+                status: std::process::ExitStatus::from_raw(0),
+                stdout: vec![],
+                stderr: vec![],
+            })
+        });
+
+        vec![
+            Box::new(create_vnic_ctx),
+            Box::new(install_ctx),
+            Box::new(boot_ctx),
+            Box::new(wait_ctx),
+            Box::new(execute_ctx),
+        ]
+    }
+
+    // Prepare to call "ensure" for a new service, then actually call "ensure".
+    async fn ensure_new_service(mgr: &ServiceManager) {
+        let _expectations = expect_new_service();
+
+        mgr.ensure(ServiceEnsureBody {
+            services: vec![ServiceRequest {
+                name: SVC_NAME.to_string(),
+                addresses: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+    }
+
+    // Prepare to call "ensure" for a service which already exists. We should
+    // return the service without actually installing a new zone.
+    async fn ensure_existing_service(mgr: &ServiceManager) {
+        mgr.ensure(ServiceEnsureBody {
+            services: vec![ServiceRequest {
+                name: SVC_NAME.to_string(),
+                addresses: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+    }
+
+    // Prepare to drop the service manager.
+    //
+    // This will shut down all allocated zones, and delete their
+    // associated VNICs.
+    fn drop_service_manager(mgr: ServiceManager) {
+        let halt_ctx = MockZones::halt_and_remove_context();
+        halt_ctx.expect().returning(|_, name| {
+            assert_eq!(name, EXPECTED_ZONE_NAME);
+            Ok(())
+        });
+        let delete_vnic_ctx = MockDladm::delete_vnic_context();
+        delete_vnic_ctx.expect().returning(|_| Ok(()));
+
+        // Explicitly drop the servie manager
+        drop(mgr);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_ensure_service() {
+        let logctx =
+            omicron_test_utils::dev::test_setup_log("test_ensure_service");
+        let log = logctx.log.clone();
+
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let config = config_dir.path().join("services.toml");
+        let mgr = ServiceManager::new(
+            log,
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config),
+        )
+        .await
+        .unwrap();
+
+        ensure_new_service(&mgr).await;
+        drop_service_manager(mgr);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_ensure_service_which_already_exists() {
+        let logctx = omicron_test_utils::dev::test_setup_log(
+            "test_ensure_service_which_already_exists",
+        );
+        let log = logctx.log.clone();
+
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let config = config_dir.path().join("services.toml");
+        let mgr = ServiceManager::new(
+            log,
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config),
+        )
+        .await
+        .unwrap();
+
+        ensure_new_service(&mgr).await;
+        ensure_existing_service(&mgr).await;
+        drop_service_manager(mgr);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_services_are_recreated_on_reboot() {
+        let logctx = omicron_test_utils::dev::test_setup_log(
+            "test_services_are_recreated_on_reboot",
+        );
+
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let config = config_dir.path().join("services.toml");
+
+        // First, spin up a ServiceManager, create a new service, and tear it
+        // down.
+        let mgr = ServiceManager::new(
+            logctx.log.clone(),
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config.clone()),
+        )
+        .await
+        .unwrap();
+        ensure_new_service(&mgr).await;
+        drop_service_manager(mgr);
+
+        // Before we re-create the service manager - notably, using the same
+        // config file! - expect that a service gets initialized.
+        let _expectations = expect_new_service();
+        let mgr = ServiceManager::new(
+            logctx.log.clone(),
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config.clone()),
+        )
+        .await
+        .unwrap();
+        drop_service_manager(mgr);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_services_do_not_persist_without_config() {
+        let logctx = omicron_test_utils::dev::test_setup_log(
+            "test_services_do_not_persist_without_config",
+        );
+
+        let config_dir = tempfile::TempDir::new().unwrap();
+        let config = config_dir.path().join("services.toml");
+
+        // First, spin up a ServiceManager, create a new service, and tear it
+        // down.
+        let mgr = ServiceManager::new(
+            logctx.log.clone(),
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config.clone()),
+        )
+        .await
+        .unwrap();
+        ensure_new_service(&mgr).await;
+        drop_service_manager(mgr);
+
+        // Next, delete the config. This means the service we just created will
+        // not be remembered on the next initialization.
+        std::fs::remove_file(&config).unwrap();
+
+        // Observe that the old service is not re-initialized.
+        let mgr = ServiceManager::new(
+            logctx.log.clone(),
+            Some(PhysicalLink(EXPECTED_LINK_NAME.to_string())),
+            Some(config.clone()),
+        )
+        .await
+        .unwrap();
+        drop_service_manager(mgr);
     }
 }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -360,6 +360,8 @@ mod test {
 
         ensure_new_service(&mgr).await;
         drop_service_manager(mgr);
+
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -383,6 +385,8 @@ mod test {
         ensure_new_service(&mgr).await;
         ensure_existing_service(&mgr).await;
         drop_service_manager(mgr);
+
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -418,6 +422,8 @@ mod test {
         .await
         .unwrap();
         drop_service_manager(mgr);
+
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -455,5 +461,7 @@ mod test {
         .await
         .unwrap();
         drop_service_manager(mgr);
+
+        logctx.cleanup_successful();
     }
 }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -161,7 +161,8 @@ impl SledAgent {
             config.data_link.clone(),
         )?;
         let services =
-            ServiceManager::new(log.clone(), config.data_link.clone()).await?;
+            ServiceManager::new(log.clone(), config.data_link.clone(), None)
+                .await?;
 
         Ok(SledAgent { storage, instances, nexus_client, services })
     }


### PR DESCRIPTION
## Background

@leftwo helped identify an issue where the ServiceManager attempts to create a service which already exists because it failed to identify that one was already running, based on the name. This resulted in a "DLPI link error", as the zone management logic tried to re-allocate an in-use IP address.

## What this patch does

- Refactors `ServiceManager` to be slightly easier to test
- Fixes the prefix matching issue (it now checks for the existence of "oxz_my_svc" for a service named "my_svc", which is what the zone is actually named).
- Adds a regression test for this issue, as well as tests for a handful of other basic behaviors.