### PR TITLE
[package] Remove sled-agent config during install/uninstall

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -44,3 +44,12 @@ macro_rules! generate_logging_api {
         );
     };
 }
+
+/// Location on internal storage where sled-specific information is stored.
+///
+/// This is mostly private to the `omicron-sled-agent` crate, but exists in
+/// common so it may be cleared by the installation tools.
+///
+/// NOTE: Be careful when modifying this path - the installation tools will
+/// **remove the entire directory** to re-install/uninstall the system.
+pub const OMICRON_CONFIG_PATH: &'static str = "/var/tmp/oxide";

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -392,6 +392,10 @@ fn uninstall_all_packages(config: &Config) {
             let _ = smf::Config::delete().force().run(&package.service_name);
         }
     }
+
+    // Once all packages have been removed, also remove any locally-stored
+    // configuration.
+    std::fs::remove_dir_all(omicron_common::OMICRON_CONFIG_PATH).unwrap();
 }
 
 fn remove_all_unless_already_removed<P: AsRef<Path>>(path: P) -> Result<()> {

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -39,6 +39,3 @@ mod mocks;
 
 #[macro_use]
 extern crate slog;
-
-/// Location on internal storage where sled-specific information is stored.
-pub(crate) const OMICRON_CONFIG_PATH: &'static str = "/var/tmp/oxide";

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -83,8 +83,9 @@ impl ServiceInner {
         //
         // We do this by storing the configuration at "rss_config_path"
         // after successfully performing initialization.
-        let rss_config_path = std::path::Path::new(crate::OMICRON_CONFIG_PATH)
-            .join("config-rss.toml");
+        let rss_config_path =
+            std::path::Path::new(omicron_common::OMICRON_CONFIG_PATH)
+                .join("config-rss.toml");
         if rss_config_path.exists() {
             info!(
                 self.log,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -45,7 +45,7 @@ impl From<Error> for omicron_common::api::external::Error {
 }
 
 fn services_config_path() -> PathBuf {
-    Path::new(crate::OMICRON_CONFIG_PATH).join("services.toml")
+    Path::new(omicron_common::OMICRON_CONFIG_PATH).join("services.toml")
 }
 
 /// Manages miscellaneous Sled-local services.

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -135,7 +135,7 @@ impl Pool {
         &self,
         dataset_id: Uuid,
     ) -> Result<PathBuf, Error> {
-        let path = std::path::Path::new(crate::OMICRON_CONFIG_PATH)
+        let path = std::path::Path::new(omicron_common::OMICRON_CONFIG_PATH)
             .join(self.id.to_string());
         create_dir_all(&path).await?;
         let mut path = path.join(dataset_id.to_string());


### PR DESCRIPTION
## Background

The sled agent makes use of a directory on local storage to store a variety of configuration info, including:

- What services am I managing? What services should I start on reboot? How should I boot them?
- What storage am I managing? Which datasets are managed by Cockroach, Clickhouse, Crucible? How should they be initialized?

This info is pretty handy, and is almost entirely self-managed by the sled itself. *However*, Omicron is still under
development, so this format isn't really stable, because our configs aren't stable.

In the face of changing configs, we currently throw errors:

- https://github.com/oxidecomputer/omicron/blob/65e0804195e8d365b56418d691bfb00de6ed79b7/sled-agent/src/rack_setup/service.rs#L110-L122
- https://github.com/oxidecomputer/omicron/blob/65e0804195e8d365b56418d691bfb00de6ed79b7/sled-agent/src/services.rs#L222-L227

This can detect failures, but basically requires developers to manually remove these config directories.

## What does this PR do

It removes the configuration directory - effectively wiping the Sled - on install/uninstall.
Given that the install process is intended to be a "wipe, restart the world" process - as opposed the upgrade flow - this
seemed like a reasonable way to improve the developer experience.