### PR TITLE
Adds basic per-sled sequential IP address allocation

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -64,8 +64,11 @@ CREATE TABLE omicron.public.sled (
     time_deleted TIMESTAMPTZ,
     rcgen INT NOT NULL,
 
+    /* The IP address and bound port of the sled agent server. */
     ip INET NOT NULL,
     port INT4 NOT NULL,
+
+    /* The last address allocated to an Oxide service on this sled. */
     last_used_address INET NOT NULL
 );
 

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -65,7 +65,8 @@ CREATE TABLE omicron.public.sled (
     rcgen INT NOT NULL,
 
     ip INET NOT NULL,
-    port INT4 NOT NULL
+    port INT4 NOT NULL,
+    last_used_address INET NOT NULL
 );
 
 /*

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -641,6 +641,8 @@ pub struct Sled {
 // `./smf/sled-agent/config-rss.toml`. This avoids conflicts with those
 // addresses, but should be removed when they are entirely under the
 // control of Nexus or RSS.
+//
+// See https://github.com/oxidecomputer/omicron/issues/732 for tracking issue.
 pub(crate) const STATIC_IPV6_ADDRESS_OFFSET: u16 = 20;
 impl Sled {
     // TODO-cleanup: We should be using IPv6 only for Oxide services, including

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -71,8 +71,8 @@ table! {
         state_generation -> Int8,
         active_server_id -> Uuid,
         active_propolis_id -> Uuid,
-        target_propolis_id -> Nullable<Uuid>,
         active_propolis_ip -> Nullable<Inet>,
+        target_propolis_id -> Nullable<Uuid>,
         migration_id -> Nullable<Uuid>,
         ncpus -> Int8,
         memory -> Int8,
@@ -222,6 +222,7 @@ table! {
 
         ip -> Inet,
         port -> Int4,
+        last_used_address -> Inet,
     }
 }
 

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -17,7 +17,7 @@ use oximeter_collector::Oximeter;
 use oximeter_producer::Server as ProducerServer;
 use slog::o;
 use slog::Logger;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
 use uuid::Uuid;
@@ -176,7 +176,7 @@ pub async fn start_sled_agent(
         sim_mode: sim::SimMode::Explicit,
         nexus_address,
         dropshot: ConfigDropshot {
-            bind_address: SocketAddr::new("127.0.0.1".parse().unwrap(), 0),
+            bind_address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0),
             request_body_max_bytes: 1024 * 1024,
             ..Default::default()
         },
@@ -184,7 +184,7 @@ pub async fn start_sled_agent(
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug },
         storage: sim::ConfigStorage {
             zpools: vec![],
-            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            ip: IpAddr::from(Ipv6Addr::LOCALHOST),
         },
     };
 
@@ -197,7 +197,7 @@ pub async fn start_oximeter(
     id: Uuid,
 ) -> Result<Oximeter, String> {
     let db = oximeter_collector::DbConfig {
-        address: SocketAddr::new("::1".parse().unwrap(), db_port),
+        address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), db_port),
         batch_size: 10,
         batch_interval: 1,
     };
@@ -206,7 +206,7 @@ pub async fn start_oximeter(
         nexus_address,
         db,
         dropshot: ConfigDropshot {
-            bind_address: SocketAddr::new("::1".parse().unwrap(), 0),
+            bind_address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0),
             ..Default::default()
         },
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Error },
@@ -254,7 +254,7 @@ pub async fn start_producer_server(
     //
     // This listens on any available port, and the server internally updates this to the actual
     // bound port of the Dropshot HTTP server.
-    let producer_address = SocketAddr::new("::1".parse().unwrap(), 0);
+    let producer_address = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0);
     let server_info = ProducerEndpoint {
         id,
         address: producer_address,

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -75,6 +75,9 @@ pub enum Error {
 
 /// Describes the type of addresses which may be requested from a zone.
 #[derive(Copy, Clone, Debug)]
+// TODO-cleanup: Remove, along with moving to IPv6 addressing everywhere.
+// See https://github.com/oxidecomputer/omicron/issues/889.
+#[allow(dead_code)]
 pub enum AddressRequest {
     Dhcp,
     Static(IpNetwork),

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -25,6 +25,7 @@ use omicron_common::backoff;
 use propolis_client::api::DiskRequest;
 use propolis_client::Client as PropolisClient;
 use slog::Logger;
+use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -180,6 +181,9 @@ struct InstanceInner {
 
     // The ID of the Propolis server (and zone) running this instance
     propolis_id: Uuid,
+
+    // The IP address of the Propolis server running this instance
+    propolis_ip: IpAddr,
 
     // NIC-related properties
     vnic_allocator: VnicAllocator,
@@ -422,6 +426,7 @@ impl Instance {
                 vcpus: initial.runtime.ncpus.0 as u8,
             },
             propolis_id: initial.runtime.propolis_uuid,
+            propolis_ip: initial.runtime.propolis_addr.unwrap().ip(),
             vnic_allocator,
             requested_nics: initial.nics,
             requested_disks: initial.disks,
@@ -480,12 +485,12 @@ impl Instance {
         .await?;
 
         let running_zone = RunningZone::boot(installed_zone).await?;
-        let network = running_zone.ensure_address(AddressRequest::Dhcp).await?;
+        let addr_request = AddressRequest::new_static(inner.propolis_ip, None);
+        let network = running_zone.ensure_address(addr_request).await?;
         info!(inner.log, "Created address {} for zone: {}", network, zname);
 
         // Run Propolis in the Zone.
-        let server_addr = SocketAddr::new(network.ip(), PROPOLIS_PORT);
-
+        let server_addr = SocketAddr::new(inner.propolis_ip, PROPOLIS_PORT);
         running_zone.run_cmd(&[
             crate::illumos::zone::SVCCFG,
             "import",
@@ -678,7 +683,7 @@ mod test {
                 sled_uuid: Uuid::new_v4(),
                 propolis_uuid: test_propolis_uuid(),
                 dst_propolis_uuid: None,
-                propolis_addr: None,
+                propolis_addr: Some("[fd00:1de::74]:12400".parse().unwrap()),
                 migration_uuid: None,
                 ncpus: InstanceCpuCount(2),
                 memory: ByteCount::from_mebibytes_u32(512),


### PR DESCRIPTION
- Adds the `last_used_address` column to the `omicron.sled` table, which
  tracks the last IP address within the sled's prefix allocated to a
  service running on the sled
- Adds method for selecting the next IP address from the `sled` table,
  with a few basic tests for it
- Uses a static address when launching guest instances, providing it to
  the propolis server managing them.