### PR TITLE
stop spraying numbers to stdout during test runs

### DIFF
--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -482,8 +482,20 @@ fn record_operation(whichtest: WhichTest<'_>) {
     // codes.
     let t = term::stdout();
     if let Some(mut term) = t {
+        // We just want to write one green character to stdout.  But we also
+        // want it to be captured by the test runner like people usually expect
+        // when they haven't passed "--nocapture".  The test runner only
+        // captures output from the `print!` family of macros, not all writes to
+        // stdout.  So we write the formatting control character, flush that (to
+        // make sure it gets emitted before our character), use print for our
+        // character, reset the terminal, then flush that.
+        //
+        // Note that this likely still writes the color-changing control
+        // characters to the real stdout, even without "--nocapture".  That
+        // sucks, but at least you don't see them.
         term.fg(term::color::GREEN).unwrap();
-        write!(term, "{}", c).unwrap();
+        term.flush().unwrap();
+        print!("{}", c);
         term.reset().unwrap();
         term.flush().unwrap();
     } else {


### PR DESCRIPTION
After #832, a regular `cargo test` includes junk emitted by the "unauthorized" test.  Here's what it looks like:

```
$ cargo test -p omicron-nexus --test=test_all integration_tests::unauthorized
...
    Finished test [unoptimized + debuginfo] target(s) in 2m 40s
     Running tests/test_all.rs (target/debug/deps/test_all-e908bfecb6111b9f)

running 2 tests
test integration_tests::unauthorized_coverage::test_unauthorized_coverage ... ok
03111555531115555555500411141115555411155550041115555411155555555004111411155554111555500411155554111555555550041114111555541115555004111411155555555555500411155554111555555550041114111555541115555004111555555555555555500411155554111555555550041114111555541115555004111555541115555555500411141115555411155550041115555411155555555004111555555554111555500411155555555555555550-55555555411155555555--55555555411155555555-041115555411155555555-041115555555541115555-041115555411155555555-041115555555541115555-04111555541115555555500411155555555411155550-55555555411155555555--55555555411155555555--55555555411155555555--55555555411155555555-04111555541115555555500411155555555411155550031115555555555555555004111555555555555555500311155555555555555550041115555555555555555003111555555555555555500411155555555555555550031115555555555555555004111555555555555555500311155555555555555550-31115555555555555555-0311155555555555555550-55555555311155555555-031115555311155555555-041115555555541115555-test integration_tests::unauthorized::test_unauthorized ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 58 filtered out; finished in 12.47s

```

After a lot of digging, I found that under normal conditions (i.e., without --nocapture), the built-in test runner apparently only redirects output from the print/eprint family.  It does _not_ redirect all of stdout -- and in particular it does not redirect writes made with `write!`.  As a result, we were spraying these characters to stdout even when `--nocapture` wasn't specified.

After this change:

```
$ cargo test -p omicron-nexus --test=test_all integration_tests::unauthorized
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth-2/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth-2/nexus/test-utils)
    Finished test [unoptimized + debuginfo] target(s) in 1m 01s
     Running tests/test_all.rs (target/debug/deps/test_all-e908bfecb6111b9f)

running 2 tests
test integration_tests::unauthorized_coverage::test_unauthorized_coverage ... ok
test integration_tests::unauthorized::test_unauthorized ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 58 filtered out; finished in 12.64s

```

But you still get the output with `--nocapture`:

```
$ cargo test -p omicron-nexus --test=test_all -- --nocapture integration_tests::unauthorized::test_unauthorized
    Finished test [unoptimized + debuginfo] target(s) in 0.38s
     Running tests/test_all.rs (target/debug/deps/test_all-e908bfecb6111b9f)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-e908bfecb6111b9f-test_unauthorized.11897.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-e908bfecb6111b9f-test_unauthorized.11897.0.log"

SUMMARY OF REQUESTS MADE

KEY, USING HEADER AND EXAMPLE ROW:

          +----------------------------> privileged GET (expects 200 or 500)
          |                              (digit = last digit of status code)
          |
          |                          +-> privileged GET (expects same as above)
          |                          |   (digit = last digit of status code)
          |                          |   ('-' => skipped (N/A))
          ^                          ^
HEADER:   G GET  PUT  POST DEL  TRCE G  URL
EXAMPLE:  0 3111 5555 3111 5555 5555 0  /organizations
    ROW     ^^^^
            ||||                      TEST CASES FOR EACH HTTP METHOD:
            +|||----------------------< authenticated, unauthorized request
             +||----------------------< unauthenticated request
              +|----------------------< bad authentication: no such user
               +----------------------< bad authentication: invalid syntax

            \__/ \__/ \__/ \__/ \__/
            GET  PUT  etc.  The test cases are repeated for each HTTP method.

            The number in each cell is the last digit of the 400-level response
            that was expected for this test case.

    In this case, an unauthenthicated request to "GET /organizations" returned
    401.  All requests to "PUT /organizations" returned 405.

G GET  PUT  POST DEL  TRCE G  URL
0 3111 5555 3111 5555 5555 0  /organizations
0 4111 4111 5555 4111 5555 0  /organizations/demo-org
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects
0 4111 4111 5555 4111 5555 0  /organizations/demo-org/projects/demo-project
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs
0 4111 4111 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc
0 4111 4111 5555 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/firewall/rules
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/subnets
0 4111 4111 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/subnets/demo-vpc-subnet
0 4111 5555 5555 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/subnets/demo-vpc-subnet/network-interfaces
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers
0 4111 4111 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router/routes
0 4111 4111 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/vpcs/demo-vpc/routers/demo-vpc-router/routes/demo-router-route
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/disks
0 4111 5555 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/disks/demo-disk
0 4111 5555 5555 5555 5555 0  /organizations/demo-org/projects/demo-project/instances/demo-instance/disks
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/disks/attach
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/disks/detach
0 4111 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/images
0 4111 5555 5555 4111 5555 -  /organizations/demo-org/projects/demo-project/images/demo-image
0 4111 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/snapshots
0 4111 5555 5555 4111 5555 -  /organizations/demo-org/projects/demo-project/snapshots/demo-snapshot
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/instances
0 4111 5555 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/instances/demo-instance
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/start
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/stop
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/reboot
- 5555 5555 4111 5555 5555 -  /organizations/demo-org/projects/demo-project/instances/demo-instance/migrate
0 4111 5555 4111 5555 5555 0  /organizations/demo-org/projects/demo-project/instances/demo-instance/network-interfaces
0 4111 5555 5555 4111 5555 0  /organizations/demo-org/projects/demo-project/instances/demo-instance/network-interfaces/default
0 3111 5555 5555 5555 5555 0  /roles
0 4111 5555 5555 5555 5555 0  /roles/fleet.admin
0 3111 5555 5555 5555 5555 0  /users
0 4111 5555 5555 5555 5555 0  /users/db-init
0 3111 5555 5555 5555 5555 0  /hardware/racks
0 4111 5555 5555 5555 5555 0  /hardware/racks/c19a698f-c6f9-4a17-ae30-20d711b8f7dc
0 3111 5555 5555 5555 5555 0  /hardware/sleds
0 4111 5555 5555 5555 5555 0  /hardware/sleds/b6d65341-167c-41df-9b5c-41cded99c229
0 3111 5555 5555 5555 5555 0  /sagas
- 3111 5555 5555 5555 5555 -  /sagas/48a1b8c8-fc1c-6fea-9de9-fdeb8dda7823
0 3111 5555 5555 5555 5555 0  /timeseries/schema
- 5555 5555 3111 5555 5555 -  /updates/refresh
0 3111 5555 3111 5555 5555 -  /images
0 4111 5555 5555 4111 5555 -  /images/demo-image
test integration_tests::unauthorized::test_unauthorized ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 12.41s


```
