### PR TITLE
[omicron-package] Don't bail if the omicron config path already doesn't exist while trying to clean up.

### DIFF
--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -395,7 +395,8 @@ fn uninstall_all_packages(config: &Config) {
 
     // Once all packages have been removed, also remove any locally-stored
     // configuration.
-    std::fs::remove_dir_all(omicron_common::OMICRON_CONFIG_PATH).unwrap();
+    remove_all_unless_already_removed(omicron_common::OMICRON_CONFIG_PATH)
+        .unwrap();
 }
 
 fn remove_all_unless_already_removed<P: AsRef<Path>>(path: P) -> Result<()> {


### PR DESCRIPTION
Small tweak to #888 so that we don't trip on an innocuous failure during uninstall. I ran into this while trying to run `omicron-package uninstall` (presumably after having run it previously).