### PR TITLE
Rename `disk` field to `name` in `DiskIdentifier` and `InstanceDiskAttach`

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1140,7 +1140,7 @@ async fn instance_disks_attach(
                 &organization_name,
                 &project_name,
                 &instance_name,
-                &disk_to_attach.into_inner().disk.into(),
+                &disk_to_attach.into_inner().name.into(),
             )
             .await?;
         Ok(HttpResponseAccepted(disk.into()))
@@ -1172,7 +1172,7 @@ async fn instance_disks_detach(
                 &organization_name,
                 &project_name,
                 &instance_name,
-                &disk_to_detach.into_inner().disk.into(),
+                &disk_to_detach.into_inner().name.into(),
             )
             .await?;
         Ok(HttpResponseAccepted(disk.into()))

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -125,7 +125,7 @@ pub enum InstanceDiskAttachment {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceDiskAttach {
     /// A disk name to attach
-    pub disk: Name,
+    pub name: Name,
 }
 
 /// Create-time parameters for an [`Instance`](omicron_common::api::external::Instance)
@@ -265,7 +265,7 @@ impl DiskCreate {
 /// attached or detached to an instance
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiskIdentifier {
-    pub disk: Name,
+    pub name: Name,
 }
 
 /// Parameters for the

--- a/nexus/src/sagas.rs
+++ b/nexus/src/sagas.rs
@@ -619,7 +619,7 @@ async fn ensure_instance_disk_attach_state(
         }
         params::InstanceDiskAttachment::Attach(instance_disk_attach) => {
             let disk_name: db::model::Name =
-                instance_disk_attach.disk.clone().into();
+                instance_disk_attach.name.clone().into();
 
             if attached {
                 osagactx

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -359,7 +359,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &url_instance2_attach_disk)
             .body(Some(&params::DiskIdentifier {
-                disk: disk.identity.name.clone(),
+                name: disk.identity.name.clone(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -391,7 +391,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &url_instance2_attach_disk)
             .body(Some(&params::DiskIdentifier {
-                disk: disk.identity.name.clone(),
+                name: disk.identity.name.clone(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -413,7 +413,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &url_instance_attach_disk)
             .body(Some(&params::DiskIdentifier {
-                disk: disk.identity.name.clone(),
+                name: disk.identity.name.clone(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -471,7 +471,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &url_instance_attach_disk)
             .body(Some(&params::DiskIdentifier {
-                disk: disk.identity.name.clone(),
+                name: disk.identity.name.clone(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -709,7 +709,7 @@ async fn disk_post(
 ) -> Disk {
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, url)
-            .body(Some(&params::DiskIdentifier { disk: disk_name }))
+            .body(Some(&params::DiskIdentifier { name: disk_name }))
             .expect_status(Some(StatusCode::ACCEPTED)),
     )
     .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -595,7 +595,7 @@ lazy_static! {
             allowed_methods: vec![
                 AllowedMethod::Post(
                     serde_json::to_value(params::DiskIdentifier {
-                        disk: DEMO_DISK_NAME.clone()
+                        name: DEMO_DISK_NAME.clone()
                     }).unwrap()
                 )
             ],
@@ -606,7 +606,7 @@ lazy_static! {
             allowed_methods: vec![
                 AllowedMethod::Post(
                     serde_json::to_value(params::DiskIdentifier {
-                        disk: DEMO_DISK_NAME.clone()
+                        name: DEMO_DISK_NAME.clone()
                     }).unwrap()
                 )
             ],

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1137,7 +1137,7 @@ async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         disks: vec![params::InstanceDiskAttachment::Attach(
             params::InstanceDiskAttach {
-                disk: Name::try_from(String::from("probablydata")).unwrap(),
+                name: Name::try_from(String::from("probablydata")).unwrap(),
             },
         )],
     };
@@ -1234,7 +1234,7 @@ async fn test_attach_eight_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        disk: Name::try_from(
+                        name: Name::try_from(
                             format!("probablydata{}", i).to_string(),
                         )
                         .unwrap(),
@@ -1339,7 +1339,7 @@ async fn test_cannot_attach_nine_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        disk: Name::try_from(
+                        name: Name::try_from(
                             format!("probablydata{}", i).to_string(),
                         )
                         .unwrap(),
@@ -1465,7 +1465,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        disk: Name::try_from(
+                        name: Name::try_from(
                             format!("probablydata{}", i).to_string(),
                         )
                         .unwrap(),

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4867,12 +4867,12 @@
         "description": "Parameters for the [`Disk`](omicron_common::api::external::Disk) to be attached or detached to an instance",
         "type": "object",
         "properties": {
-          "disk": {
+          "name": {
             "$ref": "#/components/schemas/Name"
           }
         },
         "required": [
-          "disk"
+          "name"
         ]
       },
       "DiskResultsPage": {
@@ -5380,7 +5380,7 @@
             "description": "During instance creation, attach this disk",
             "type": "object",
             "properties": {
-              "disk": {
+              "name": {
                 "description": "A disk name to attach",
                 "allOf": [
                   {
@@ -5396,7 +5396,7 @@
               }
             },
             "required": [
-              "disk",
+              "name",
               "type"
             ]
           }


### PR DESCRIPTION
For consistency.