### PR TITLE
fix some issues with the "updates" test

### DIFF
--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -40,7 +40,7 @@ use tough::key_source::KeySource;
 use tough::schema::{KeyHolder, RoleKeys, RoleType, Root};
 use tough::sign::Sign;
 
-const UPDATE_IMAGE_PATH: &'static str = "/var/tmp/zones/cockroachdb";
+const UPDATE_IMAGE_PATH: &'static str = "/var/tmp/zones/omicron-test-component";
 
 #[tokio::test]
 async fn test_update_end_to_end() {
@@ -225,21 +225,21 @@ fn generate_targets() -> (TempDir, Vec<&'static str>) {
     let dir = TempDir::new().unwrap();
 
     // The update artifact. This will someday be a tarball of some variety.
-    std::fs::write(dir.path().join("cockroachdb-1"), TARGET_CONTENTS).unwrap();
+    std::fs::write(dir.path().join("omicron-test-component-1"), TARGET_CONTENTS).unwrap();
 
     // artifacts.json, which describes all available artifacts.
     let artifacts = ArtifactsDocument {
         artifacts: vec![UpdateArtifact {
-            name: "cockroachdb".into(),
+            name: "omicron-test-component".into(),
             version: 1,
             kind: Some(UpdateArtifactKind::Zone),
-            target: "cockroachdb-1".into(),
+            target: "omicron-test-component".into(),
         }],
     };
     let f = File::create(dir.path().join("artifacts.json")).unwrap();
     serde_json::to_writer_pretty(f, &artifacts).unwrap();
 
-    (dir, vec!["cockroachdb-1", "artifacts.json"])
+    (dir, vec!["omicron-test-component-1", "artifacts.json"])
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -46,7 +46,7 @@ const UPDATE_IMAGE_PATH: &'static str = "/var/tmp/zones/cockroachdb";
 async fn test_update_end_to_end() {
     let mut config = load_test_config();
 
-    // If the output file already exists, record the mtime.
+    // remove any existing output file from a previous run
     match tokio::fs::remove_file(UPDATE_IMAGE_PATH).await {
         Ok(_) => (),
         Err(e) if matches!(e.kind(), std::io::ErrorKind::NotFound) => (),

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -40,9 +40,6 @@ use tough::key_source::KeySource;
 use tough::schema::{KeyHolder, RoleKeys, RoleType, Root};
 use tough::sign::Sign;
 
-// If you're getting a double-panic here, run the test with
-// `cargo test -- --nocapture test_update_end_to_end` to get output.
-// `dropshot::HttpServer`'s `Drop` implementation panics.
 #[tokio::test]
 async fn test_update_end_to_end() {
     let mut config = load_test_config();
@@ -62,7 +59,6 @@ async fn test_update_end_to_end() {
             .unwrap()
             .start();
     let local_addr = server.local_addr();
-    tokio::spawn(async move { server.await });
 
     // stand up the test environment
     config.updates = Some(UpdatesConfig {
@@ -92,6 +88,7 @@ async fn test_update_end_to_end() {
         TARGET_CONTENTS
     );
 
+    server.close().await.expect("failed to shut down dropshot server");
     cptestctx.teardown().await;
 }
 


### PR DESCRIPTION
The "updates" integration test was essential for catching a very subtle issue with #905!  That said, while debugging the problem, I ran into a few issues with it.  I'm writing these up in gory detail because they were very confusing and I'm sure I'm going to run into stuff like this again and I hope these notes will be helpful.

# Panics on success (test passes anyway)

On "main", the test panics, then passes anyway.  You wouldn't normally notice:

```
$ cargo test -p omicron-nexus -- test_update_end_to_end
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth/nexus/test-utils)
    Finished test [unoptimized + debuginfo] target(s) in 1m 20s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
test integration_tests::updates::test_update_end_to_end ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 3.80s

   Doc-tests omicron-nexus

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.02s
```

unless you run it with `--nocapture`.  I'll use RUST_BACKTRACE too:

```
$ RUST_BACKTRACE=1 cargo test -p omicron-nexus -- --nocapture test_update_end_to_end
    Finished test [unoptimized + debuginfo] target(s) in 0.38s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15255.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15255.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15255.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15255.1.log"
thread 'integration_tests::updates::test_update_end_to_end' panicked at 'failed to send close signal: ()', /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/0590171/dropshot/src/server.rs:594:24
stack backtrace:
   0: rust_begin_unwind
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panicking.rs:107:14
   2: core::result::unwrap_failed
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/result.rs:1613:5
   3: core::result::Result<T,E>::expect
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/result.rs:1255:23
   4: <dropshot::server::HttpServer<C> as core::ops::drop::Drop>::drop
             at /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/0590171/dropshot/src/server.rs:594:13
   5: core::ptr::drop_in_place<dropshot::server::HttpServer<test_all::integration_tests::updates::FileServerContext>>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
   6: core::ptr::drop_in_place<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:65:31
   7: core::ptr::drop_in_place<core::future::from_generator::GenFuture<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
   8: core::ptr::drop_in_place<tokio::runtime::task::core::Stage<core::future::from_generator::GenFuture<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>>>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
   9: tokio::runtime::task::core::CoreStage<T>::set_stage::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:214:35
  10: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/loom/std/unsafe_cell.rs:14:9
  11: tokio::runtime::task::core::CoreStage<T>::set_stage
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:214:9
  12: tokio::runtime::task::core::CoreStage<T>::drop_future_or_output
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:180:13
  13: tokio::runtime::task::harness::cancel_task::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:438:9
  14: core::ops::function::FnOnce::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  15: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panic/unwind_safe.rs:271:9
  16: std::panicking::try::do_call
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:406:40
  17: __rust_try
  18: std::panicking::try
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:370:19
  19: std::panic::catch_unwind
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panic.rs:133:14
  20: tokio::runtime::task::harness::cancel_task
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:437:15
  21: tokio::runtime::task::harness::Harness<T,S>::shutdown
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:147:9
  22: tokio::runtime::task::raw::shutdown
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/raw.rs:164:5
  23: tokio::runtime::task::raw::RawTask::shutdown
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/raw.rs:109:18
  24: tokio::runtime::task::Task<S>::shutdown
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/mod.rs:338:9
  25: tokio::runtime::task::list::OwnedTasks<S>::close_and_shutdown_all
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/list.rs:151:13
  26: <tokio::runtime::basic_scheduler::BasicScheduler as core::ops::drop::Drop>::drop::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:227:13
  27: tokio::runtime::basic_scheduler::CoreGuard::enter::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:57
  28: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/macros/scoped_tls.rs:61:9
  29: tokio::runtime::basic_scheduler::CoreGuard::enter
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:27
  30: <tokio::runtime::basic_scheduler::BasicScheduler as core::ops::drop::Drop>::drop
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:223:9
  31: core::ptr::drop_in_place<tokio::runtime::basic_scheduler::BasicScheduler>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  32: core::ptr::drop_in_place<tokio::runtime::Kind>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  33: core::ptr::drop_in_place<tokio::runtime::Runtime>
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  34: test_all::integration_tests::updates::test_update_end_to_end
             at ./tests/integration_tests/updates.rs:46:1
  35: test_all::integration_tests::updates::test_update_end_to_end::{{closure}}
             at ./tests/integration_tests/updates.rs:47:7
  36: core::ops::function::FnOnce::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  37: core::ops::function::FnOnce::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test integration_tests::updates::test_update_end_to_end ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 3.83s

   Doc-tests omicron-nexus

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.02s

$ 
```

What's going on here?

For reference, it's helpful to see the body of the test function after macro expansion.  I've elided some irrelevant stuff with `...`:

```
$ cargo expand -p omicron-nexus --test=test_all integration_tests::updates::test_update_end_to_end
...
#[cfg(test)]
#[rustc_test_marker]
pub const test_update_end_to_end: test::TestDescAndFn = test::TestDescAndFn {
   ...
};
fn test_update_end_to_end() {
    let body = async {

    ...

        let server = HttpServerStarter::new(&dropshot_config, api, context, &logctx.log)
            .unwrap()
            .start();
        let local_addr = server.local_addr();
        tokio::spawn(async move { server.await });
...

        ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(
            &["boom"],
            &match () {
                _args => [],
            },
        ));
        cptestctx.teardown().await;
    };
    #[allow(clippy::expect_used)]
    tokio::runtime::Builder::new_current_thread()
        .enable_all()
        .build()
        .expect("Failed building the Runtime")
        .block_on(body);
}
```

I think what's going on here is:

- The test scaffolding starts a tokio ["current thread" executor](https://docs.rs/tokio/latest/tokio/runtime/index.html#current-thread-scheduler), which runs all tasks on the current thread.
- The test starts a Dropshot server and creates a tokio task to `await` it.  This moves `server` to the other task.
- The test runs normally (to the end of the function).
- [When the builder is dropped at the end of the function, it cancels (drops) existing tasks](https://docs.rs/tokio/latest/tokio/runtime/index.html#lifetime-of-spawned-threads).  ("Once Runtime is dropped, all runtime threads are forcibly shutdown. Any tasks that have not yet completed will be dropped.").  That includes:
    - whatever tasks were spawned by Dropshot and Hyper to actually run the server
    - the task started by the test suite to _wait_ on the Dropshot server
- When that latter task gets dropped, [Dropshot's `Drop` impl attempts to send a message to the task that's actually running the server to initiate a graceful shutdown](https://github.com/oxidecomputer/dropshot/blob/dafe330b4f2b2efb9c32b4a740dff78229852ed6/dropshot/src/server.rs#L585-L597).
- That fails because the other side of the channel has _already_ been dropped -- because the executor is shutting down and already dropped that task (see above).  Dropshot panics in this case because it's not clear why this should ever happen aside from a bug.  But the panic happens from the task that now owns `server`, which is _not_ the task running the test itself.

Why does the test pass anyway?  [This behavior is trivially reproducible in the Rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=00c8fb6655ebe5522e0d2329ba9d763c).  This [modified example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=de748aa4f02902f4166d01b629f7a00f) shows that the behavior remains even if the panic in the other task happens while the test is still running.  I gather it's just that the implementation doesn't treat a panic in a separate task as fatal to the test.  (That's begging the question, though.  Why not?  I don't know.)

Before getting to the fix, I want to describe a variant involving a double panic mentioned in the comments.

# Double-panics on failure

If the test panics (as with a typical test assertion failure), it double panics, making it much harder to debug.  With this change to "main":

```
$ git diff main
diff --git a/nexus/tests/integration_tests/updates.rs b/nexus/tests/integration_tests/updates.rs
index ce7243de..83925ebe 100644
--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -92,6 +92,7 @@ async fn test_update_end_to_end() {
         TARGET_CONTENTS
     );
 
+    panic!("boom");
     cptestctx.teardown().await;
 }
 
```

Here's what it looks like:

```
$ cargo test -p omicron-nexus -- test_update_end_to_end
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth/nexus/test-utils)
warning: unreachable statement
  --> nexus/tests/integration_tests/updates.rs:96:5
   |
95 |     panic!("boom");
   |     -------------- any code following this expression is unreachable
96 |     cptestctx.teardown().await;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
   |
   = note: `#[warn(unreachable_code)]` on by default

warning: `omicron-nexus` (test "test_all") generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 1m 20s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
thread panicked while panicking. aborting.
error: test failed, to rerun pass '-p omicron-nexus --test test_all'

Caused by:
  process didn't exit successfully: `/home/dap/omicron-auth/target/debug/deps/test_all-9208224595adfa34 test_update_end_to_end` (signal: 4, SIGILL: illegal instruction)
```

Ouch.  It doesn't even say what test failed.  Here's what happens when we ask for a backtrace and get the actual output:

```
$ RUST_BACKTRACE=1 cargo test -p omicron-nexus -- --nocapture test_update_end_to_end
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth/nexus/test-utils)
warning: unreachable statement
  --> nexus/tests/integration_tests/updates.rs:96:5
   |
95 |     panic!("boom");
   |     -------------- any code following this expression is unreachable
96 |     cptestctx.teardown().await;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
   |
   = note: `#[warn(unreachable_code)]` on by default

warning: `omicron-nexus` (test "test_all") generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 1m 18s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.13697.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.13697.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.13697.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.13697.1.log"
thread 'integration_tests::updates::test_update_end_to_end' panicked at 'boom', nexus/tests/integration_tests/updates.rs:95:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panicking.rs:107:14
   2: test_all::integration_tests::updates::test_update_end_to_end::{{closure}}
             at ./tests/integration_tests/updates.rs:95:5
   3: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/future/mod.rs:80:19
   4: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/future/future.rs:119:9
   5: tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:498:48
   6: tokio::coop::with_budget::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/coop.rs:102:9
   7: std::thread::local::LocalKey<T>::try_with
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/thread/local.rs:399:16
   8: std::thread::local::LocalKey<T>::with
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/thread/local.rs:375:9
   9: tokio::coop::with_budget
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/coop.rs:95:5
  10: tokio::coop::budget
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/coop.rs:72:5
  11: tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:498:25
  12: tokio::runtime::basic_scheduler::Context::enter
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:356:19
  13: tokio::runtime::basic_scheduler::CoreGuard::block_on::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:497:36
  14: tokio::runtime::basic_scheduler::CoreGuard::enter::{{closure}}
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:57
  15: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/macros/scoped_tls.rs:61:9
  16: tokio::runtime::basic_scheduler::CoreGuard::enter
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:27
  17: tokio::runtime::basic_scheduler::CoreGuard::block_on
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:488:9
  18: tokio::runtime::basic_scheduler::BasicScheduler::block_on
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:168:24
  19: tokio::runtime::Runtime::block_on
             at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/mod.rs:475:46
  20: test_all::integration_tests::updates::test_update_end_to_end
             at ./tests/integration_tests/updates.rs:96:5
  21: test_all::integration_tests::updates::test_update_end_to_end::{{closure}}
             at ./tests/integration_tests/updates.rs:47:7
  22: core::ops::function::FnOnce::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  23: core::ops::function::FnOnce::call_once
             at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
WARN: dropped CockroachInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)
WARN: temporary directory leaked: /dangerzone/omicron_tmp/.tmpzuX0do
WARN: dropped ClickHouseInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)
thread 'integration_tests::updates::test_update_end_to_end' panicked at 'failed to send close signal: ()', /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/0590171/dropshot/src/server.rs:594:24
stack backtrace:
   0:          0xa3e537b - std::backtrace_rs::backtrace::libunwind::trace::heebc96669e4382be
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:          0xa3e537b - std::backtrace_rs::backtrace::trace_unsynchronized::h5d73f6e75302ca84
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:          0xa3e537b - std::sys_common::backtrace::_print_fmt::h09da1f53ae9317ce
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:67:5
   3:          0xa3e537b - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h9ca253331edf28dd
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:46:22
   4:          0xa43e20b - core::fmt::write::h3133d3e4e2a3272b
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/fmt/mod.rs:1149:17
   5:          0xa3d6d92 - std::io::Write::write_fmt::hfbb014b2a23b3e83
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/io/mod.rs:1697:15
   6:          0xa3e8275 - std::sys_common::backtrace::_print::h2b43d267c7a6e08a
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:49:5
   7:          0xa3e8275 - std::sys_common::backtrace::print::hc0b7d040bbd96b9f
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:36:9
   8:          0xa3e8275 - std::panicking::default_hook::{{closure}}::hc197ecca5e684f4b
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:211:50
   9:          0xa3e7e79 - std::panicking::default_hook::h496f2fd4ca6ce28b
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:228:9
  10:          0xa3e8b02 - std::panicking::rust_panic_with_hook::ha2256829f1a33664
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:606:17
  11:          0xa3e85d0 - std::panicking::begin_panic_handler::{{closure}}::hd3bb20a8518404e1
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:502:13
  12:          0xa3e5827 - std::sys_common::backtrace::__rust_end_short_backtrace::h812bac1ab7a405e9
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:139:18
  13:          0xa3e853a - rust_begin_unwind
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:498:5
  14:          0xa43ae2f - core::panicking::panic_fmt::hcd9ac1c7dd82a853
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panicking.rs:107:14
  15:          0xa43b105 - core::result::unwrap_failed::h3e533ccb86ea64e0
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/result.rs:1613:5
  16:          0xa21f0c4 - core::result::Result<T,E>::expect::h312cdf23ac91a6db
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/result.rs:1255:23
  17:          0x61991ac - <dropshot::server::HttpServer<C> as core::ops::drop::Drop>::drop::haa95a90333ec5f55
                               at /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/0590171/dropshot/src/server.rs:594:13
  18:          0x614ae55 - core::ptr::drop_in_place<dropshot::server::HttpServer<test_all::integration_tests::updates::FileServerContext>>::h914c517c54813c52
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  19:          0x6155d93 - core::ptr::drop_in_place<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>::he93cc48fac783bf1
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:65:31
  20:          0x6168fc1 - core::ptr::drop_in_place<core::future::from_generator::GenFuture<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>>::hdd84a8eba2d6bc5a
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  21:          0x617241d - core::ptr::drop_in_place<tokio::runtime::task::core::Stage<core::future::from_generator::GenFuture<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>>>::h43d14e22baf02b13
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  22:          0x5a2a849 - tokio::runtime::task::core::CoreStage<T>::set_stage::{{closure}}::h602e78aa3de4a1c8
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:214:35
  23:          0x5b5db00 - tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut::haece786443f6f8b7
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/loom/std/unsafe_cell.rs:14:9
  24:          0x5a298da - tokio::runtime::task::core::CoreStage<T>::set_stage::hea6dbe25fda8aa74
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:214:9
  25:          0x5a20466 - tokio::runtime::task::core::CoreStage<T>::drop_future_or_output::ha4d7031e003f24d1
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/core.rs:180:13
  26:          0x60c45c7 - tokio::runtime::task::harness::cancel_task::{{closure}}::h905f64794eb498aa
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:438:9
  27:          0x61400b5 - core::ops::function::FnOnce::call_once::hb05a133990e5218c
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  28:          0x5982041 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::hdb8e3820adf17ebf
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panic/unwind_safe.rs:271:9
  29:          0x61cdcda - std::panicking::try::do_call::hdfafc09688b94f56
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:406:40
  30:          0x61e0e8d - __rust_try
  31:          0x61b8bc2 - std::panicking::try::h88b9d71bd560c923
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:370:19
  32:          0x61ff671 - std::panic::catch_unwind::h0646cfce229f2c64
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panic.rs:133:14
  33:          0x60c0a48 - tokio::runtime::task::harness::cancel_task::h5798ac5f020ccc4a
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:437:15
  34:          0x612a6d9 - tokio::runtime::task::harness::Harness<T,S>::shutdown::hf28232ca864581bd
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/harness.rs:147:9
  35:          0x5d96032 - tokio::runtime::task::raw::shutdown::hce5c9480a2b969fb
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/raw.rs:164:5
  36:          0xa13080f - tokio::runtime::task::raw::RawTask::shutdown::he2f06266c79bc749
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/raw.rs:109:18
  37:          0xa1a35d2 - tokio::runtime::task::Task<S>::shutdown::haa70d79bc3637edf
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/mod.rs:338:9
  38:          0xa1e92b1 - tokio::runtime::task::list::OwnedTasks<S>::close_and_shutdown_all::he53a4ed189b4c087
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/task/list.rs:151:13
  39:          0xa134078 - <tokio::runtime::basic_scheduler::BasicScheduler as core::ops::drop::Drop>::drop::{{closure}}::h9128b1a36f61117c
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:227:13
  40:          0xa135e25 - tokio::runtime::basic_scheduler::CoreGuard::enter::{{closure}}::h70e310dcd5125875
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:57
  41:          0xa15a156 - tokio::macros::scoped_tls::ScopedKey<T>::set::hb75b7452ddf11448
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/macros/scoped_tls.rs:61:9
  42:          0xa135c5e - tokio::runtime::basic_scheduler::CoreGuard::enter::h45a09b5ecf55843d
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:555:27
  43:          0xa133fb1 - <tokio::runtime::basic_scheduler::BasicScheduler as core::ops::drop::Drop>::drop::h2c005ae6710b31de
                               at /home/dap/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/runtime/basic_scheduler.rs:223:9
  44:          0xa191325 - core::ptr::drop_in_place<tokio::runtime::basic_scheduler::BasicScheduler>::h85e460a4b508c290
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  45:          0xa18e6c3 - core::ptr::drop_in_place<tokio::runtime::Kind>::he1fd2de6ea0becc4
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  46:          0xa18e810 - core::ptr::drop_in_place<tokio::runtime::Runtime>::h46c8ab56e0f39453
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ptr/mod.rs:188:1
  47:          0x59a15c9 - test_all::integration_tests::updates::test_update_end_to_end::h770a4cd6f15266d9
                               at /home/dap/omicron-auth/nexus/tests/integration_tests/updates.rs:46:1
  48:          0x59979c1 - test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::h6fe557ddef1b47cf
                               at /home/dap/omicron-auth/nexus/tests/integration_tests/updates.rs:47:7
  49:          0x61447a1 - core::ops::function::FnOnce::call_once::hf6d970c9cdcfc3e0
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  50:          0x62bb8f6 - core::ops::function::FnOnce::call_once::heb9accac4ad831fe
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  51:          0x62bb8f6 - test::__rust_begin_short_backtrace::hab4876760c14af57
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/test/src/lib.rs:585:5
  52:          0x62ba63f - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h21046a3e6b13460c
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/alloc/src/boxed.rs:1694:9
  53:          0x62ba63f - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h5ec3b803a84b24b1
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panic/unwind_safe.rs:271:9
  54:          0x62ba63f - std::panicking::try::do_call::hf44abd26312ce7fc
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:406:40
  55:          0x62ba63f - std::panicking::try::hfaaa94d546608550
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:370:19
  56:          0x62ba63f - std::panic::catch_unwind::h5d32b502acf88c78
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panic.rs:133:14
  57:          0x62ba63f - test::run_test_in_process::he34b1ed92d971883
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/test/src/lib.rs:608:18
  58:          0x62ba63f - test::run_test::run_test_inner::{{closure}}::h3f8ec888ffa63041
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/test/src/lib.rs:500:39
  59:          0x628305a - test::run_test::run_test_inner::{{closure}}::h22baa4f491b28a40
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/test/src/lib.rs:527:37
  60:          0x628305a - std::sys_common::backtrace::__rust_begin_short_backtrace::hec69a9c8c727aadd
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys_common/backtrace.rs:123:18
  61:          0x6288df5 - std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}::h2d727788d1ab0913
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/thread/mod.rs:484:17
  62:          0x6288df5 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h301b102fa2cac8da
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/panic/unwind_safe.rs:271:9
  63:          0x6288df5 - std::panicking::try::do_call::h39490327ae1bef27
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:406:40
  64:          0x6288df5 - std::panicking::try::h99bbe111fc66c668
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panicking.rs:370:19
  65:          0x6288df5 - std::panic::catch_unwind::h043ccb6ea07d643f
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/panic.rs:133:14
  66:          0x6288df5 - std::thread::Builder::spawn_unchecked::{{closure}}::h4112a010f088b4d2
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/thread/mod.rs:483:30
  67:          0x6288df5 - core::ops::function::FnOnce::call_once{{vtable.shim}}::hd9aaba9ffbfac6d4
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/core/src/ops/function.rs:227:5
  68:          0xa3f2137 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hdb136fda048b636b
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/alloc/src/boxed.rs:1694:9
  69:          0xa3f2137 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h59748a461ff2e1ed
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/alloc/src/boxed.rs:1694:9
  70:          0xa3f2137 - std::sys::unix::thread::Thread::new::thread_start::h35db9a2ae668ff29
                               at /rustc/65c55bf931a55e6b1e5ed14ad8623814a7386424/library/std/src/sys/unix/thread.rs:106:17
  71: 0xfffffc7fee680e4c - _thrp_setup
  72: 0xfffffc7fee681160 - <unknown>
thread panicked while panicking. aborting.
error: test failed, to rerun pass '-p omicron-nexus --test test_all'

Caused by:
  process didn't exit successfully: `/home/dap/omicron-auth/target/debug/deps/test_all-9208224595adfa34 --nocapture test_update_end_to_end` (signal: 4, SIGILL: illegal instruction)

```

and here's the stack trace according to mdb:


```
> ::stack
std::panicking::rust_panic_with_hook::ha2256829f1a33664+0xfe()
std::panicking::panic_count::is_zero_slow_path::h4c65ddecada676c5()
std::sys_common::backtrace::_print_fmt::{{closure}}::{{closure}}::h7185e3bdc6e697f0+0x1f7()
std::panicking::panic_count::increase::haa6a5f88bec61f49+0x5a()
<core::panic::panic_info::PanicInfo as core::fmt::Display>::fmt::h3e235dbc330ccfac+0x10f()
core::panicking::assert_failed_inner::hc75dd7c383df0d88+0x55()
core::result::Result<T,E>::expect::h127cf387a84dfb07+0x34()
<dropshot::server::HttpServer<C> as core::ops::drop::Drop>::drop::h51f15e58e6e8efa5+0x2c()
core::ptr::drop_in_place<core::option::Option<hyper::client::conn::SendRequest<hyper::body::body::Body>>>::h62f5893cc1ecc45f+0x35()
core::ptr::drop_in_place<test_all::integration_tests::updates::test_update_end_to_end::{{closure}}::{{closure}}>::h17a2d1194acda951+0x13()
core::ptr::drop_in_place<core::future::from_generator::GenFuture<dropshot::server::InnerHttpsServerStarter<oximeter::types::ProducerRegistry>::start::{{closure}}>>::h58d767e46820a95d+0x11()
core::ptr::drop_in_place<tokio::runtime::task::core::Stage<core::future::from_generator::GenFuture<dropshot::server::InnerHttpsServerStarter<oximeter::types::ProducerRegistry>::start::{{closure}}>>>::hd8d4fe7de2f20cdd+0x4d()
tokio::runtime::task::core::CoreStage<T>::set_stage::{{closure}}::hdc6a77fa10bc08aa+0x89()
tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut::hdbc090706a1c5ae1+0x20()
0x5be08aa()
tokio::runtime::task::core::CoreStage<T>::store_output::hfea8f174c3ee2454+0x56()
tokio::runtime::task::harness::cancel_task::{{closure}}::hdc4a706d10387c5d+0x17()
core::ops::function::FnOnce::call_once::h6b2b18dea44ef6d7+0x15()
<core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<>>::call_once::h57bef6dcc64d5c70+0x11()
std::panicking::try::do_call::h030fb5f90cc9bb3a+0x2a()
std::panicking::try::do_catch::hffe5dbf4d56550ef+0x6d()
std::panicking::try::hbd0f4c64d0a52d35+2()
std::panic::catch_unwind::h04d860ba9d292526+1()
tokio::runtime::task::harness::cancel_task::h921564cb413dee3e+0xd8()
tokio::runtime::task::harness::Harness<T,S>::shutdown::h0272d3930e90ff98+0x19()
tokio::runtime::task::raw::shutdown::hbe7e5cc257bd0416+0x12()
tokio::runtime::task::raw::RawTask::new::he7b189f438174842+0x9f()
tokio::runtime::task::Task<S>::from_raw::h4c4a2eece691b472+0x12()
tokio::runtime::task::list::OwnedTasks<S>::close_and_shutdown_all::h029d8d0dee492f04+0x121()
tokio::runtime::basic_scheduler::BasicScheduler::set_context_guard::hee5c139ff35ffc03+0x78()
tokio::runtime::basic_scheduler::CoreGuard::enter::h45a09b5ecf55843d+0x125()
tokio::macros::scoped_tls::ScopedKey<T>::set::h313ec9e342ec7d91+0x26()
<tokio::runtime::basic_scheduler::Shared as tokio::util::wake::Wake>::wake::h95f3f7ecf40af8a4+0xe()
tokio::runtime::basic_scheduler::BasicScheduler::take_core::h336e459f5b3a81ae+0x161()
core::ptr::drop_in_place<[tokio::runtime::blocking::pool::Task]>::h6f08cfcdbe56c661+0x25()
core::ptr::drop_in_place<std::fs::ReadDir>::h87e89019e8aee7a1+0x13()
core::ptr::drop_in_place<std::process::Child>::h4b789c64b2e929d8+0x70()
test_all::integration_tests::updates::test_update_end_to_end::hf514cc420ab0dd8e+0x109()
<ring::rand::SystemRandom as ring::rand::sealed::SecureRandom>::fill_impl::h58d06619bcac1f9c+0x11()
core::ops::function::FnOnce::call_once::h9a54af3f503f0e92+0x11()
test::run_test::run_test_inner::{{closure}}::h3f8ec888ffa63041+0x1556()
test::run_test::run_test_inner::{{closure}}::h3f8ec888ffa63041+0x29f()
std::sys_common::backtrace::__rust_begin_short_backtrace::hec69a9c8c727aadd+0x8a()
core::ops::function::FnOnce::call_once{{vtable.shim}}::hd9aaba9ffbfac6d4+0x25()
std::sys::unix::thread::Thread::new::h2b516c3e6849846f+0x67()
libc.so.1`_thrp_setup+0x6c(fffffc7fecc80240)
libc.so.1`_lwp_start()

```

I think this is a similar sequence to the single-panic case.  Instead of the test running to normal completion, it panics.  But that doesn't actually change what happens: the executor runtime gets dropped, the Dropshot/Hyper task running the server gets dropped, the task _we_ spun up to wait on the server gets dropped, it tries to send a graceful shutdown message, that fails because the other side has already been dropped, so we panic in Dropshot.  The difference is that all this is happening _during_ another panic, so it's a double-panic and the program exits immediately.

The fix for both issues is pretty simple: there's no need to move `server` to a separate task or `await` on it at all.  (I can see how you'd think it _would_ be necessary: [the dropshot docs incorrectly say so](oxidecomputer/dropshot#323)!  (I just filed that issue.)  I'm also adding a call to `close()` for the success case.  (I don't think this is strictly necessary, but it causes the test to wait for a normal graceful shutdown.)  With these two changes: on failure, we no longer get the double-panic; and on success, we don't get any panic.  I believe the reason is that in both cases `server` is now dropped before the executor runtime, so the task running the server will still be around when we send the graceful shutdown message.

Here's the fix, plus my induced panic (delta relative to "main"):

```
@@ -62,7 +59,6 @@ async fn test_update_end_to_end() {
             .unwrap()
             .start();
     let local_addr = server.local_addr();
-    tokio::spawn(async move { server.await });
 
     // stand up the test environment
     config.updates = Some(UpdatesConfig {
@@ -92,6 +88,8 @@ async fn test_update_end_to_end() {
         TARGET_CONTENTS
     );
 
+    panic!("boom");
+    server.close().await.expect("failed to shut down dropshot server");
     cptestctx.teardown().await;
 }
```

and now it does what you'd expect:

```
$ cargo test -p omicron-nexus -- test_update_end_to_end
warning: unreachable statement
  --> nexus/tests/integration_tests/updates.rs:92:5
   |
91 |     panic!("boom");
   |     -------------- any code following this expression is unreachable
92 |     server.close().await.expect("failed to shut down dropshot server");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
   |
   = note: `#[warn(unreachable_code)]` on by default

warning: `omicron-nexus` (test "test_all") generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 0.37s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
test integration_tests::updates::test_update_end_to_end ... FAILED

failures:

---- integration_tests::updates::test_update_end_to_end stdout ----
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.14598.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.14598.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.14598.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.14598.1.log"
thread 'integration_tests::updates::test_update_end_to_end' panicked at 'boom', nexus/tests/integration_tests/updates.rs:91:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
WARN: dropped CockroachInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)
WARN: temporary directory leaked: /dangerzone/omicron_tmp/.tmpiRi6wD
WARN: dropped ClickHouseInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)


failures:
    integration_tests::updates::test_update_end_to_end

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 61 filtered out; finished in 1.36s

error: test failed, to rerun pass '-p omicron-nexus --test test_all'
```

Note it crisply says which test panicked and gives the panic message.

And if we drop the induced panic, so that the diff is now:

```
@@ -62,7 +59,6 @@ async fn test_update_end_to_end() {
             .unwrap()
             .start();
     let local_addr = server.local_addr();
-    tokio::spawn(async move { server.await });
 
     // stand up the test environment
     config.updates = Some(UpdatesConfig {
@@ -92,6 +88,7 @@ async fn test_update_end_to_end() {
         TARGET_CONTENTS
     );
 
+    server.close().await.expect("failed to shut down dropshot server");
     cptestctx.teardown().await;
 }
 
```

We get a normal test pass with no panic:

```
$ cargo test -p omicron-nexus -- --nocapture test_update_end_to_end
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth/nexus/test-utils)
    Finished test [unoptimized + debuginfo] target(s) in 1m 21s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15308.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15308.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15308.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15308.1.log"
test integration_tests::updates::test_update_end_to_end ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 3.82s

   Doc-tests omicron-nexus

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.02s

```

Hooray!

# False negative (test succeeds even though the behavior is broken)

The test checks the contents of `/var/tmp/zones/cockroachdb` to verify that the updates system successfully downloaded it from made-up TUF repo.  But it doesn't ever remove this file, and it doesn't check the mtime.  So if the test ever succeeded, then it's liable to produce a false negative in the future because the file is still there with the correct contents. That is, it will pass even if the behavior is completely wrong.

With the above fixes in place, I commented out the API call in the test that triggers all the work:

```
@@ -73,14 +73,14 @@ async fn test_update_end_to_end() {
     // - download and verify the repo
     // - return 204 Non Content
     // - tells sled agent to do the thing
-    NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, "/updates/refresh")
-            .expect_status(Some(StatusCode::NO_CONTENT)),
-    )
-    .authn_as(AuthnMode::PrivilegedUser)
-    .execute()
-    .await
-    .unwrap();
+    //NexusRequest::new(
+    //    RequestBuilder::new(client, Method::POST, "/updates/refresh")
+    //        .expect_status(Some(StatusCode::NO_CONTENT)),
+    //)
+    //.authn_as(AuthnMode::PrivilegedUser)
+    //.execute()
+    //.await
+    //.unwrap();
 
     // check sled agent did the thing
     assert_eq!(
```

The test still succeeds on my system:

```
$ cargo test -p omicron-nexus -- --nocapture test_update_end_to_end
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-auth/nexus)
   Compiling nexus-test-utils v0.1.0 (/home/dap/omicron-auth/nexus/test-utils)
warning: unused import: `RequestBuilder`
  --> nexus/tests/integration_tests/updates.rs:18:63
   |
18 | use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
   |                                                               ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `client`
  --> nexus/tests/integration_tests/updates.rs:70:9
   |
70 |     let client = &cptestctx.external_client;
   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_client`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: `omicron-nexus` (test "test_all") generated 2 warnings
    Finished test [unoptimized + debuginfo] target(s) in 1m 17s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15388.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15388.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15388.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15388.1.log"
test integration_tests::updates::test_update_end_to_end ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 3.55s

   Doc-tests omicron-nexus

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.02s

$ 
```

If I remove /var/tmp/zones/cockroachdb, it does fail:

```
$ rm -f /var/tmp/zones/cockroachdb 
$ cargo test -p omicron-nexus -- --nocapture test_update_end_to_end
warning: unused import: `RequestBuilder`
  --> nexus/tests/integration_tests/updates.rs:18:63
   |
18 | use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
   |                                                               ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `client`
  --> nexus/tests/integration_tests/updates.rs:70:9
   |
70 |     let client = &cptestctx.external_client;
   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_client`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: `omicron-nexus` (test "test_all") generated 2 warnings
    Finished test [unoptimized + debuginfo] target(s) in 0.38s
     Running unittests (target/debug/deps/omicron_nexus-2c668f699e2ff71c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/nexus-303e55b6e6353b0a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_all.rs (target/debug/deps/test_all-9208224595adfa34)

running 1 test
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15413.0.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15413.0.log"
log file: "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15413.1.log"
note: configured to log to "/dangerzone/omicron_tmp/test_all-9208224595adfa34-test_update_end_to_end.15413.1.log"
thread 'integration_tests::updates::test_update_end_to_end' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', nexus/tests/integration_tests/updates.rs:87:53
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
WARN: dropped CockroachInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)
WARN: temporary directory leaked: /dangerzone/omicron_tmp/.tmpB5dbDc
WARN: dropped ClickHouseInstance without cleaning it up first (there may still be a child process running and a temporary directory leaked)
test integration_tests::updates::test_update_end_to_end ... FAILED

failures:

failures:
    integration_tests::updates::test_update_end_to_end

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 61 filtered out; finished in 1.14s

error: test failed, to rerun pass '-p omicron-nexus --test test_all'
```

I think the cleanest solution is to have the test remove the output file before it starts (ignoring any ENOENT error, for the first time through).  That initially made me a little nervous because this path is potentially in use by a running Nexus.  And I prototyped a change that would look at the mtime of the file before running the test and make sure it changed during the test.  But as I understand it, a running Nexus would be clobbered by this test anyway because the test replaces the contents of this file with a non-usable image.  So it seems clearer and cleaner to just remove the file ourselves before doing anything else.

# Other possible improvements?

Is there any reason the test uses "cockroachdb" as the artifact name?  It would seem clearer (and would avoid interfering with a real Nexus) if it used some dummy name.

It'd also be neat if the test configured Nexus to store these update artifacts in a temporary directory created by the test itself instead of /var/tmp.  Generally, the tests try to be self-contained and avoid using global state so that they can be run in parallel without stomping on each other.  Plus, this will also avoid interfering with a real Nexus that's got that file there.

---

Issues aside, this test crisply caught a very nasty bug in #905 where I'd broken the authz check for update images, causing what should have been a successful fetch to return a 404 instead.  That was very helpful!