### PR TITLE
Remove Omicron zones during package uninstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "hex",
  "indicatif",
  "omicron-common",
+ "omicron-sled-agent",
  "omicron-zone-package",
  "rayon",
  "reqwest",

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 indicatif = { version = "0.16.2", features = ["rayon"] }
 omicron-common = { path = "../common" }
+omicron-sled-agent = { path = "../sled-agent" }
 omicron-zone-package = { version = "0.2.0" }
 rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/sled-agent/src/illumos/running_zone.rs
+++ b/sled-agent/src/illumos/running_zone.rs
@@ -161,7 +161,7 @@ impl RunningZone {
 
 impl Drop for RunningZone {
     fn drop(&mut self) {
-        match Zones::halt_and_remove(&self.inner.log, self.name()) {
+        match Zones::halt_and_remove_logged(&self.inner.log, self.name()) {
             Ok(()) => {
                 info!(self.inner.log, "Stopped and uninstalled zone")
             }

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -572,7 +572,7 @@ impl Instance {
 
         let zname = propolis_zone_name(inner.propolis_id());
         warn!(inner.log, "Halting and removing zone: {}", zname);
-        Zones::halt_and_remove(&inner.log, &zname).unwrap();
+        Zones::halt_and_remove_logged(&inner.log, &zname).unwrap();
 
         inner.running_state.as_mut().unwrap().ticket.terminate();
 

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -34,6 +34,8 @@ mod sled_agent;
 mod storage_manager;
 mod updates;
 
+pub use illumos::zone;
+
 #[cfg(test)]
 mod mocks;
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -329,7 +329,7 @@ mod test {
     // This will shut down all allocated zones, and delete their
     // associated VNICs.
     fn drop_service_manager(mgr: ServiceManager) {
-        let halt_ctx = MockZones::halt_and_remove_context();
+        let halt_ctx = MockZones::halt_and_remove_logged_context();
         halt_ctx.expect().returning(|_, name| {
             assert_eq!(name, EXPECTED_ZONE_NAME);
             Ok(())

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -123,7 +123,7 @@ impl SledAgent {
         let zones = Zones::get()?;
         for z in zones {
             warn!(log, "Deleting zone: {}", z.name());
-            Zones::halt_and_remove(&log, z.name())?;
+            Zones::halt_and_remove_logged(&log, z.name())?;
         }
 
         // Identify all VNICs which should be managed by the Sled Agent.


### PR DESCRIPTION
- Makes `Zones::halt_and_remove` public, along with its containing
  module. A bit of refactoring to allow calling it without a
  `slog::Logger`.
- Adds call to remove any omicron zones during `omicron-package
  uninstall`