### PR TITLE
Bump expectorate so we get the pretty diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,9 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "regex",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -878,12 +880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,12 +1165,13 @@ dependencies = [
 
 [[package]]
 name = "expectorate"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804d601ea8a13ddbecf5ab4b6cf75b5d6d0539479c6fb2aea1596e352a5ee27e"
+checksum = "5d9b457178b54cf0321a39fb6643ad7b9c705cf483ad4fb6d6092054e9ce839e"
 dependencies = [
- "difference",
+ "console",
  "newline-converter",
+ "similar",
 ]
 
 [[package]]
@@ -4075,6 +4072,12 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -35,6 +35,6 @@ parse-display = "0.5.4"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 serde_urlencoded = "0.7.1"
 tokio = { version = "1.17", features = [ "test-util" ] }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -31,7 +31,7 @@ version = "1.16"
 features = [ "full" ]
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 http = "0.2.5"
 omicron-test-utils = { path = "../test-utils" }
 openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -25,7 +25,7 @@ trust-dns-proto = "0.21"
 trust-dns-server = "0.21"
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 internal-dns-client = { path = "../internal-dns-client" }
 omicron-test-utils = { path = "../test-utils" }
 openapiv3 = "1.0"

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -117,7 +117,7 @@ features = [ "serde", "v4" ]
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "async_tokio" ] }
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 nexus-test-utils-macros = { path = "test-utils-macros" }
 nexus-test-utils = { path = "test-utils" }
 omicron-test-utils = { path = "../test-utils" }

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -62,7 +62,7 @@ pub async fn spoof_login(
         return Ok(Response::builder()
             .status(StatusCode::UNAUTHORIZED)
             .header(header::SET_COOKIE, clear_session_cookie_header_value())
-            .body("".into())?); // TODO: failed login response body?
+            .body("unauthorized".into())?); // TODO: failed login response body?
     }
 
     let user_id = user_id.unwrap();

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1806,7 +1806,7 @@ async fn project_vpcs_get_vpc(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Create a VPC in a project. This will cause a failure in the OpenAPI spec test.
+/// Create a VPC in a project.
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs",

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1806,7 +1806,7 @@ async fn project_vpcs_get_vpc(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Create a VPC in a project.
+/// Create a VPC in a project. This will cause a failure in the OpenAPI spec test.
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/vpcs",

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -22,7 +22,7 @@ toml = "0.5.8"
 uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 omicron-test-utils = { path = "../../test-utils" }
 openapiv3 = "1.0"
 serde_json = "1.0.79"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -46,7 +46,7 @@ vsss-rs = { version = "2.0.0-pre0", default-features = false, features = ["std"]
 zone = "0.1"
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 http = "0.2.5"
 mockall = "0.11"
 omicron-test-utils = { path = "../test-utils" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -37,7 +37,7 @@ version = "0.7"
 features = [ "with-chrono-0_4", "with-uuid-0_8" ]
 
 [dev-dependencies]
-expectorate = "1.0.4"
+expectorate = "1.0.5"
 
 # Disable doc builds by default for our binaries to work around issue
 # rust-lang/cargo#8373.  These docs would not be very useful anyway.


### PR DESCRIPTION
https://github.com/oxidecomputer/expectorate/pull/10 adds a pretty-printed diff that only shows the lines changed instead of the whole file. https://github.com/oxidecomputer/expectorate/pull/11 adds color output. Let's do it! I will make and revert a change that causes an OpenAPI spec failure to test the output.