### PR TITLE
switch to stable toolchain

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (ubuntu-20.04)"
 #: variety = "basic"
 #: target = "ubuntu-20.04"
-#: rust_toolchain = "stable-1.66.1"
+#: rust_toolchain = "1.66.1"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (ubuntu-20.04)"
 #: variety = "basic"
 #: target = "ubuntu-20.04"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "stable-1.66.1"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,7 +53,7 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
+ptime -m cargo build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
@@ -63,8 +63,7 @@ ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 # from end-to-end-tests.
 #
 banner test
-ptime -m cargo +'nightly-2022-09-27' test --locked --verbose \
-    --no-fail-fast
+ptime -m cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "stable-1.66.1"
+#: rust_toolchain = "1.66.1"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "stable-1.66.1"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,7 +53,7 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
+ptime -m cargo build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
@@ -63,8 +63,7 @@ ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 # from end-to-end-tests.
 #
 banner test
-ptime -m cargo +'nightly-2022-09-27' test --locked --verbose \
-    --no-fail-fast
+ptime -m cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/build-end-to-end-tests.sh
+++ b/.github/buildomat/jobs/build-end-to-end-tests.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build-end-to-end-tests"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "stable-1.66.1"
+#: rust_toolchain = "1.66.1"
 #: output_rules = [
 #:	"=/work/*.gz",
 #: ]

--- a/.github/buildomat/jobs/build-end-to-end-tests.sh
+++ b/.github/buildomat/jobs/build-end-to-end-tests.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build-end-to-end-tests"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-04-27"
+#: rust_toolchain = "stable-1.66.1"
 #: output_rules = [
 #:	"=/work/*.gz",
 #: ]

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -3,7 +3,7 @@
 #: name = "clippy (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "stable-1.66.1"
+#: rust_toolchain = "1.66.1"
 #: output_rules = []
 #:
 

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -3,7 +3,7 @@
 #: name = "clippy (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "stable-1.66.1"
 #: output_rules = []
 #:
 
@@ -24,4 +24,4 @@ ptime -m bash ./tools/install_builder_prerequisites.sh -y
 
 banner clippy
 # See the corresponding GitHub Actions job for more about these arguments.
-ptime -m cargo +'nightly-2022-09-27' clippy --all-targets -- --deny warnings --allow clippy::style
+ptime -m cargo clippy --all-targets -- --deny warnings --allow clippy::style

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -3,7 +3,7 @@
 #: name = "helios / package"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "stable-1.66.1"
+#: rust_toolchain = "1.66.1"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
 #:	"=/work/zones/*.tar.gz",

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -3,7 +3,7 @@
 #: name = "helios / package"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "stable-1.66.1"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
 #:	"=/work/zones/*.tar.gz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,13 +1495,13 @@ dependencies = [
 [[package]]
 name = "diesel-dtrace"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/diesel-dtrace?rev=18748d9f76c94e1f4400fbec0859b3e77a221a8d#18748d9f76c94e1f4400fbec0859b3e77a221a8d"
+source = "git+https://github.com/oxidecomputer/diesel-dtrace?rev=309bd361d886a237fbdd5d74992bdbd783f98bff#309bd361d886a237fbdd5d74992bdbd783f98bff"
 dependencies = [
  "diesel",
- "lock_api",
  "serde",
  "usdt",
  "uuid",
+ "version_check",
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=482bae9bfa704282e981008abae9328344150d36#482bae9bfa704282e981008abae9328344150d36"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=7725d20c750c7cd2a39cf15b1e95e250c3681487#7725d20c750c7cd2a39cf15b1e95e250c3681487"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=482bae9bfa704282e981008abae9328344150d36#482bae9bfa704282e981008abae9328344150d36"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=7725d20c750c7cd2a39cf15b1e95e250c3681487#7725d20c750c7cd2a39cf15b1e95e250c3681487"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2212,6 +2212,7 @@ dependencies = [
  "tokio",
  "usdt",
  "uuid",
+ "version_check",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=7725d20c750c7cd2a39cf15b1e95e250c3681487#7725d20c750c7cd2a39cf15b1e95e250c3681487"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=e35df234f9db57b1b7fc0a8ca279fb2774ff1046#e35df234f9db57b1b7fc0a8ca279fb2774ff1046"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=7725d20c750c7cd2a39cf15b1e95e250c3681487#7725d20c750c7cd2a39cf15b1e95e250c3681487"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=e35df234f9db57b1b7fc0a8ca279fb2774ff1046#e35df234f9db57b1b7fc0a8ca279fb2774ff1046"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ name = "omicron-nexus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-bb8-diesel",
  "async-trait",
  "authz-macros",
@@ -3933,6 +3934,7 @@ name = "omicron-sled-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "base64 0.21.0",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "7725d20c750c7cd2a39cf15b1e95e250c3681487" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "7725d20c750c7cd2a39cf15b1e95e250c3681487" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "e35df234f9db57b1b7fc0a8ca279fb2774ff1046" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "e35df234f9db57b1b7fc0a8ca279fb2774ff1046" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,15 +123,15 @@ db-macros = { path = "nexus/db-macros" }
 debug-ignore = "1.0.5"
 derive_more = "0.99.17"
 diesel = { version = "2.0.3" }
-diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
+diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "309bd361d886a237fbdd5d74992bdbd783f98bff" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 expectorate = "1.0.6"
 fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "482bae9bfa704282e981008abae9328344150d36" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "482bae9bfa704282e981008abae9328344150d36" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "7725d20c750c7cd2a39cf15b1e95e250c3681487" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "7725d20c750c7cd2a39cf15b1e95e250c3681487" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2299,7 +2299,7 @@ mod test {
         assert_eq!(2793, tb3.to_whole_gibibytes());
         assert_eq!(2, tb3.to_whole_tebibytes());
 
-        let three_tebibytes = (3u64 * 1024 * 1024 * 1024 * 1024) as u64;
+        let three_tebibytes = 3u64 * 1024 * 1024 * 1024 * 1024;
         let tib3 = ByteCount::try_from(three_tebibytes).unwrap();
         assert_eq!(three_tebibytes, tib3.to_bytes());
         assert_eq!(3 * 1024 * 1024 * 1024, tib3.to_whole_kibibytes());

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -788,7 +788,7 @@ async fn sp_component_active_slot_set(
     let component = component_from_str(&component)?;
     let slot = body.into_inner().slot;
 
-    sp.set_component_active_slot(component, slot)
+    sp.set_component_active_slot(component, slot, false)
         .await
         .map_err(SpCommsError::from)?;
 

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -85,6 +85,7 @@ oximeter-instruments = { workspace = true, features = ["http-instruments"] }
 oximeter-producer.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 criterion.workspace = true
 expectorate.workspace = true
 hyper-rustls.workspace = true

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -579,7 +579,8 @@ impl super::Nexus {
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, num::NonZeroU32};
+    use assert_matches::assert_matches;
+    use std::num::NonZeroU32;
 
     use crate::context::OpContext;
     use crate::db::model::UpdateStatus;

--- a/nexus/src/db/datastore/mod.rs
+++ b/nexus/src/db/datastore/mod.rs
@@ -269,6 +269,7 @@ mod test {
     };
     use crate::db::queries::vpc_subnet::FilterConflictingVpcSubnetRangesQuery;
     use crate::external_api::params;
+    use assert_matches::assert_matches;
     use chrono::{Duration, Utc};
     use nexus_test_utils::db::test_setup_database;
     use omicron_common::api::external::{
@@ -276,7 +277,6 @@ mod test {
     };
     use omicron_test_utils::dev;
     use ref_cast::RefCast;
-    use std::assert_matches::assert_matches;
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
     use std::sync::Arc;

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -11,8 +11,6 @@
 #![allow(clippy::unnecessary_wraps)]
 // Clippy's style lints are useful, but not worth running automatically.
 #![allow(clippy::style)]
-// assert_matches! is pretty useful for tests so just enable it conditionally.
-#![cfg_attr(test, feature(assert_matches))]
 
 pub mod app; // Public for documentation examples
 pub mod authn; // Public only for testing

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -169,13 +169,13 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
         objects_list_page_authz::<NetworkInterface>(client, &url_ips)
             .await
             .items;
-    assert_eq!(network_interfaces.len(), subnet_size as usize);
+    assert_eq!(network_interfaces.len(), subnet_size);
 
     // Sort by IP address to simplify the checks
     network_interfaces.sort_by(|a, b| a.ip.cmp(&b.ip));
     for (iface, addr) in network_interfaces
         .iter()
-        .zip(subnet.iter().skip(NUM_INITIAL_RESERVED_IP_ADDRESSES as usize))
+        .zip(subnet.iter().skip(NUM_INITIAL_RESERVED_IP_ADDRESSES))
     {
         assert_eq!(
             iface.ip,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,14 +1,5 @@
-#
-# We use nightly for the "asm" unstable Rust feature, used within Propolis for
-# dtrace probes.
-#
-# We specify a specific, known-good nightly to avoid regular breakage.
-# Once all unstable features that we use are stabilized, we should switch back
-# to "stable".
-#
-
 [toolchain]
 # NOTE: This toolchain is also specified within .github/buildomat/jobs/{build-and-test,package}.sh.
 # If you update it here, update that file too.
-channel = "nightly-2022-09-27"
+channel = "stable"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # NOTE: This toolchain is also specified within .github/buildomat/jobs/{build-and-test,package}.sh.
 # If you update it here, update that file too.
-channel = "stable"
+channel = "1.66.1"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,11 @@
 [toolchain]
-# NOTE: This toolchain is also specified within .github/buildomat/jobs/{build-and-test,package}.sh.
-# If you update it here, update that file too.
+# NOTE: This toolchain is also specified in various jobs in
+# .github/buildomat/jobs/.  If you update it here, update those files too.
+#
+# We choose a specific toolchain (rather than "stable") for repeatability.  The
+# intent is to keep this up-to-date with recently-released stable Rust.
+#
+# Right now, we skip 1.67 due to rust-lang/cargo#11629.  There are workarounds
+# for that but it's simpler to just skip this release.
 channel = "1.66.1"
 profile = "default"

--- a/sled-agent-client/src/lib.rs
+++ b/sled-agent-client/src/lib.rs
@@ -210,7 +210,7 @@ impl From<omicron_common::api::external::Vni> for types::Vni {
 
 impl From<types::Vni> for omicron_common::api::external::Vni {
     fn from(s: types::Vni) -> Self {
-        Self::try_from(s.0 as u32).unwrap()
+        Self::try_from(s.0).unwrap()
     }
 }
 

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -64,6 +64,7 @@ libefi-illumos = { git = "https://github.com/oxidecomputer/libefi-illumos", bran
 opte-ioctl.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 expectorate.workspace = true
 http.workspace = true
 mockall.workspace = true

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -357,13 +357,13 @@ mod test {
         InstanceRuntimeStateMigrateParams, InstanceRuntimeStateRequested,
         InstanceStateRequested as Requested,
     };
+    use assert_matches::assert_matches;
     use chrono::Utc;
     use omicron_common::api::external::{
         ByteCount, Error, Generation, InstanceCpuCount, InstanceState as State,
     };
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
     use propolis_client::api::InstanceState as Observed;
-    use std::assert_matches::assert_matches;
     use uuid::Uuid;
 
     fn make_instance() -> InstanceStates {
@@ -589,7 +589,7 @@ mod test {
                 // state we failed on.
                 (state, instance.request_transition(&migrating_req())),
                 (_, Err(Error::InvalidRequest { message }))
-                    if message.contains("cannot migrate instance"),
+                    if message.contains("cannot migrate instance")
             );
         }
     }
@@ -611,7 +611,7 @@ mod test {
         verify_state(&instance, State::Running, None);
 
         let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None),);
+        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
         verify_state(&instance, State::Migrating, Some(Requested::Running));
         assert_eq!(
             migrating_req.migration_params.map(|m| m.migration_id),
@@ -640,11 +640,11 @@ mod test {
         verify_state(&instance, State::Running, None);
 
         let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None),);
+        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
         verify_state(&instance, State::Migrating, Some(Requested::Running));
 
         // A subsequent request for the same migration is a no-op
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None),);
+        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
         verify_state(&instance, State::Migrating, Some(Requested::Running));
     }
 
@@ -667,7 +667,7 @@ mod test {
         assert_matches!(
             instance.request_transition(&runtime_state(Requested::Migrating)),
             Err(Error::InvalidRequest { message })
-                if message.contains("expected migration IDs to transition"),
+                if message.contains("expected migration IDs to transition")
         );
     }
 
@@ -688,7 +688,7 @@ mod test {
         verify_state(&instance, State::Running, None);
 
         let mut migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None),);
+        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
         verify_state(&instance, State::Migrating, Some(Requested::Running));
 
         // We keep the Migration ID the same but pass a different
@@ -698,7 +698,7 @@ mod test {
         assert_matches!(
             instance.request_transition(&migrating_req),
             Err(Error::InvalidRequest { message })
-                if message.contains("already perfoming given migration to different propolis"),
+                if message.contains("already perfoming given migration to different propolis")
         );
     }
 
@@ -720,7 +720,7 @@ mod test {
 
         assert_matches!(
             instance.request_transition(&migrating_req()),
-            Ok(None),
+            Ok(None)
         );
         verify_state(&instance, State::Migrating, Some(Requested::Running));
 
@@ -728,7 +728,7 @@ mod test {
             // NOTE: different migration parameters given in subsequent request
             instance.request_transition(&migrating_req()),
             Err(Error::InvalidRequest { message })
-                if message.contains("migration already in progress"),
+                if message.contains("migration already in progress")
         );
     }
 
@@ -749,7 +749,7 @@ mod test {
         verify_state(&instance, State::Running, None);
 
         let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None),);
+        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
         verify_state(&instance, State::Migrating, Some(Requested::Running));
 
         // This shouldn't happen during the normal course of operation
@@ -764,7 +764,7 @@ mod test {
         assert_matches!(
             instance.request_transition(&migrating_req),
             Err(Error::InternalError { internal_message })
-                if internal_message.contains("migrating but no dst propolis id present"),
+                if internal_message.contains("migrating but no dst propolis id present")
         );
 
         // Instance is still marked as 'Migrating' but we'll
@@ -776,7 +776,7 @@ mod test {
         assert_matches!(
             instance.request_transition(&migrating_req),
             Err(Error::InternalError { internal_message })
-                if internal_message.contains("migrating but no migration id present"),
+                if internal_message.contains("migrating but no migration id present")
         );
     }
 }

--- a/sled-agent/src/illumos/zpool.rs
+++ b/sled-agent/src/illumos/zpool.rs
@@ -209,7 +209,7 @@ impl Zpool {
 
 /// A wrapper around a zpool name.
 ///
-/// This expects that the format will be: oxp_<UUID> - we parse
+/// This expects that the format will be: `oxp_<UUID>` - we parse
 /// the prefix when reading the structure, and validate that the UUID
 /// can be utilized.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -9,8 +9,6 @@
 #![allow(rustdoc::private_intra_doc_links)]
 // Clippy's style lints are useful, but not worth running automatically.
 #![allow(clippy::style)]
-// assert_matches! is pretty useful for tests so just enable it conditionally.
-#![cfg_attr(test, feature(assert_matches))]
 
 // Module for executing the simulated sled agent.
 pub mod sim;

--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -100,7 +100,7 @@ impl BufferData {
             ))
         } else if from_end < self.rolling.len() {
             // (apologies to Takenobu Mitsuyoshi)
-            let rolling_start = self.rolling.len() - from_end as usize;
+            let rolling_start = self.rolling.len() - from_end;
             Ok((
                 Box::new(self.rolling.iter().copied().skip(rolling_start)),
                 from_start,

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1044,6 +1044,7 @@ impl SpHandler for Handler {
         port: SpPort,
         component: SpComponent,
         slot: u16,
+        persist: bool,
     ) -> Result<(), SpError> {
         warn!(
             &self.log, "asked to set component active slot (not supported for sim components)";
@@ -1051,6 +1052,7 @@ impl SpHandler for Handler {
             "port" => ?port,
             "component" => ?component,
             "slot" => slot,
+            "persist" => persist,
         );
         Err(SpError::RequestUnsupportedForComponent)
     }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -836,6 +836,7 @@ impl SpHandler for Handler {
         port: SpPort,
         component: SpComponent,
         slot: u16,
+        persist: bool,
     ) -> Result<(), SpError> {
         warn!(
             &self.log, "asked to set component active slot (not supported for sim components)";
@@ -843,6 +844,7 @@ impl SpHandler for Handler {
             "port" => ?port,
             "component" => ?component,
             "slot" => slot,
+            "persist" => persist,
         );
         Err(SpError::RequestUnsupportedForComponent)
     }

--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -39,7 +39,7 @@ pub fn path_to_executable(cmd_name: &str) -> PathBuf {
 #[track_caller]
 pub fn assert_exit_code(exit_status: ExitStatus, code: u32, stderr_text: &str) {
     if let ExitStatus::Exited(exit_code) = exit_status {
-        assert_eq!(exit_code, code as u32);
+        assert_eq!(exit_code, code);
     } else {
         panic!(
             "expected normal process exit with code {}, got {:?}\n\nprocess stderr:{}",

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -88,7 +88,7 @@ impl ArtifactGetter for WicketdArtifactStore {
                             );
                         })
                         .ok()?;
-            let mut bytes = BytesMut::with_capacity(size as usize);
+            let mut bytes = BytesMut::with_capacity(size);
             bytes.put_bytes(0, size);
             return Some(Body::from(bytes.freeze()));
         }


### PR DESCRIPTION
This does not build yet.  Known blockers:

- [x] diesel-dtrace needs to drop use of `#![feature(asm)]`
- [x] slog-dtrace needs to drop use of `#![feature(asm)]`
- [x] use of async_closure (@smklein says he's removing it)

Other changes in this PR:

- We had some drift in the way our dropshot deps were declared which results in two copies in Cargo.lock.  This prevents the use of `cargo update -p dropshot --precise`.  I suspect that's why we haven't seen dependabot updates to dropshot in a couple of weeks.  (note: I'm doing this in #917 as well)