### PR TITLE
normalize dropshot dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
  "crucible-common",
  "crucible-protocol",
  "crucible-scope",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "futures",
  "futures-core",
  "rand 0.8.5",
@@ -971,45 +971,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "dropshot_endpoint 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
- "futures",
- "hostname",
- "http",
- "hyper",
- "indexmap",
- "openapiv3",
- "paste",
- "percent-encoding",
- "proc-macro2",
- "rustls",
- "rustls-pemfile",
- "schemars",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "slog",
- "slog-async",
- "slog-bunyan",
- "slog-json",
- "slog-term",
- "tokio",
- "tokio-rustls",
- "toml",
- "usdt",
- "uuid",
-]
-
-[[package]]
-name = "dropshot"
-version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot#0590171143964e32d913113df85174771d4699d9"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "chrono",
- "dropshot_endpoint 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot)",
+ "dropshot_endpoint",
  "futures",
  "hostname",
  "http",
@@ -1041,18 +1003,6 @@ dependencies = [
 name = "dropshot_endpoint"
 version = "0.6.1-dev"
 source = "git+https://github.com/oxidecomputer/dropshot?branch=main#0590171143964e32d913113df85174771d4699d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream",
- "syn",
-]
-
-[[package]]
-name = "dropshot_endpoint"
-version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot#0590171143964e32d913113df85174771d4699d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1851,7 +1801,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 3.1.8",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot)",
+ "dropshot",
  "expectorate",
  "internal-dns-client",
  "omicron-test-utils",
@@ -2222,7 +2172,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "headers",
  "http",
  "hyper",
@@ -2337,7 +2287,7 @@ dependencies = [
  "api_identity",
  "backoff",
  "chrono",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "futures",
  "http",
@@ -2384,7 +2334,7 @@ name = "omicron-gateway"
 version = "0.1.0"
 dependencies = [
  "clap 3.1.8",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "futures",
  "gateway-messages",
@@ -2428,7 +2378,7 @@ dependencies = [
  "db-macros",
  "diesel",
  "diesel-dtrace",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "futures",
  "headers",
@@ -2524,7 +2474,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "crucible-agent-client",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "futures",
  "http",
@@ -2571,7 +2521,7 @@ name = "omicron-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "futures",
  "libc",
@@ -2752,7 +2702,7 @@ dependencies = [
 name = "oximeter-collector"
 version = "0.1.0"
 dependencies = [
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "expectorate",
  "nexus-client",
  "omicron-common",
@@ -2782,7 +2732,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "itertools",
  "omicron-test-utils",
  "oximeter",
@@ -2806,7 +2756,7 @@ name = "oximeter-instruments"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "futures",
  "http",
  "oximeter",
@@ -2828,7 +2778,7 @@ name = "oximeter-producer"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "nexus-client",
  "omicron-common",
  "oximeter",
@@ -4276,7 +4226,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dropshot 0.6.1-dev (git+https://github.com/oxidecomputer/dropshot?branch=main)",
+ "dropshot",
  "gateway-messages",
  "hex",
  "omicron-common",

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "3.1", features = [ "derive" ] }
-dropshot = { git = "https://github.com/oxidecomputer/dropshot" }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 pretty-hex = "0.2.1"
 schemars = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 async-trait = "0.1.53"
 bytes = { version = "1.0.1", features = [ "serde" ] }
 chrono = { version = "0.4.19", features = [ "serde" ] }
-dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 oximeter = { path = "../oximeter" }
 regex = "1.5.5"
 reqwest = { version = "0.11.8", features = [ "json" ] }


### PR DESCRIPTION
Some recent packages used slightly different dropshot dependencies.  The internal-dns one was a particular problem because it didn't have the branch name in it.  This results in two entries for dropshot in Cargo.lock, and causes `cargo update -p` to not work for updating Dropshot.  I suspect this is why we haven't been getting dependabot updates for Dropshot.

```
$ cargo update -p dropshot --precise dafe330b4f2b2efb9c32b4a740dff78229852ed6
error: There are multiple `dropshot` packages in your project, and the specification `dropshot` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  https://github.com/oxidecomputer/dropshot#0.6.1-dev
  https://github.com/oxidecomputer/dropshot#0.6.1-dev

$ cargo update -p https://github.com/oxidecomputer/dropshot#0.6.1-dev --precise dafe330b4f2b2efb9c32b4a740dff78229852ed6
error: There are multiple `dropshot` packages in your project, and the specification `https://github.com/oxidecomputer/dropshot#0.6.1-dev` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  https://github.com/oxidecomputer/dropshot#0.6.1-dev
  https://github.com/oxidecomputer/dropshot#0.6.1-dev
```

After this lands, I will poke Dependabot to see if that fixed it.