### PR TITLE
sled-agent-sim and docs need update for IPv6 requirement

### DIFF
--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -122,9 +122,7 @@ Nexus can also serve the web console. Instructions for generating the static ass
 +
 [source,text]
 ----
-$ cargo run --bin=sled-agent-sim -- $(uuidgen) 127.0.0.1:12345 127.0.0.1:12221
-...
-Jun 02 12:21:50.989 INFO listening, local_addr: 127.0.0.1:12345, component: dropshot
+$ cargo run --bin=sled-agent-sim -- $(uuidgen) [::1]:12345 127.0.0.1:12221
 ----
 
 . `oximeter` is similar to `nexus`, requiring a configuration file. You can use `oximeter/collector/config.toml`, and the whole thing can be run with:

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -76,7 +76,7 @@ async fn do_run() -> Result<(), CmdError> {
         storage: ConfigStorage {
             // Create 10 "virtual" U.2s, with 1 TB of storage.
             zpools: vec![ConfigZpool { size: 1 << 40 }; 10],
-            ip: args.sled_agent_addr.ip().clone().into(),
+            ip: (*args.sled_agent_addr.ip()).into(),
         },
     };
 

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -17,6 +17,7 @@ use omicron_sled_agent::sim::{
 use std::net::SocketAddr;
 use structopt::StructOpt;
 use uuid::Uuid;
+use std::net::SocketAddrV6;
 
 fn parse_sim_mode(src: &str) -> Result<SimMode, String> {
     match src {
@@ -44,7 +45,7 @@ struct Args {
     uuid: Uuid,
 
     #[structopt(name = "SA_IP:PORT", parse(try_from_str))]
-    sled_agent_addr: SocketAddr,
+    sled_agent_addr: SocketAddrV6,
 
     #[structopt(name = "NEXUS_IP:PORT", parse(try_from_str))]
     nexus_addr: SocketAddr,
@@ -67,7 +68,7 @@ async fn do_run() -> Result<(), CmdError> {
         sim_mode: args.sim_mode,
         nexus_address: args.nexus_addr,
         dropshot: ConfigDropshot {
-            bind_address: args.sled_agent_addr,
+            bind_address: args.sled_agent_addr.into(),
             request_body_max_bytes: 1024 * 1024,
             ..Default::default()
         },
@@ -75,7 +76,7 @@ async fn do_run() -> Result<(), CmdError> {
         storage: ConfigStorage {
             // Create 10 "virtual" U.2s, with 1 TB of storage.
             zpools: vec![ConfigZpool { size: 1 << 40 }; 10],
-            ip: args.sled_agent_addr.ip(),
+            ip: args.sled_agent_addr.ip().clone().into(),
         },
     };
 

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -15,9 +15,9 @@ use omicron_sled_agent::sim::{
     run_server, Config, ConfigStorage, ConfigZpool, SimMode,
 };
 use std::net::SocketAddr;
+use std::net::SocketAddrV6;
 use structopt::StructOpt;
 use uuid::Uuid;
-use std::net::SocketAddrV6;
 
 fn parse_sim_mode(src: &str) -> Result<SimMode, String> {
     match src {


### PR DESCRIPTION
If I follow the simulated instructions to run a sled agent, it starts up okay, but when we try to provision a VM to it, the request fails with a 500:

```
Apr 14 19:20:43.722 INFO request completed, error_message_external: Internal Server Error, error_message_internal: Sled IP address must be IPv6, response_code: 500, uri: /organizations/maze-war/projects/prod-online/instances, method: POST, req_id: 919a8d0d-3c7c-4c13-846d-a6d9abbb5503, remote_addr: 127.0.0.1:44584, local_addr: 127.0.0.1:12220, component: dropshot_external, name: e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c
```

I think this changed with #891.

This change updates `sled-agent-sim` to require a v6 address to listen on and updates the instructions to use the v6 loopback address instead of the v4 one.

Here's what the failure looks like if you try to use the v4 loopback:

```
$ cargo run --bin=sled-agent-sim -- $(uuidgen) 127.0.0.1:12345 127.0.0.1:12221
   Compiling omicron-sled-agent v0.1.0 (/home/dap/omicron-auth-2/sled-agent)
    Finished dev [unoptimized + debuginfo] target(s) in 12.51s
     Running `target/debug/sled-agent-sim a82717ae-105a-edb8-aa47-daebfee2a4b6 '127.0.0.1:12345' '127.0.0.1:12221'`
sled-agent-sim: parsing arguments: error: Invalid value for '<SA_IP:PORT>': invalid IP address syntax
```