### PR TITLE
MGS/sp-sim: Teach simulated SPs about their interface to the management network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dropshot",
+ "futures",
  "gateway-messages",
  "hex",
  "omicron-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,7 +4303,6 @@ dependencies = [
  "hex",
  "omicron-common",
  "serde",
- "serde_repr",
  "slog",
  "slog-dtrace",
  "structopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "hex",
  "omicron-common",
  "serde",
+ "serde_repr",
  "slog",
  "slog-dtrace",
  "structopt",

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -8,8 +8,12 @@ pub mod sp_impl;
 mod variable_packet;
 
 use bitflags::bitflags;
-use core::{fmt, str};
-use serde::{Deserialize, Serialize};
+use core::fmt;
+use core::str;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
 
 pub use hubpack::error::Error as HubpackError;
 pub use hubpack::{deserialize, serialize, SerializedSize};
@@ -39,6 +43,16 @@ pub enum RequestKind {
     IgnitionCommand { target: u8, command: IgnitionCommand },
     SpState,
     SerialConsoleWrite(SerialConsole),
+}
+
+/// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr,
+)]
+#[repr(u8)]
+pub enum SpPort {
+    One = 1,
+    Two = 2,
 }
 
 // TODO: Not all SPs are capable of crafting all these response kinds, but the

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -8,11 +8,11 @@ id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
 [known_sps]
 switches = [
     # first switch is assumed to be the local ignition controller
-    { sp = "127.0.0.1:23456", switch_port = "127.0.0.1:33456" },
+    { sp = "[::1]:33300", switch_port = "[::1]:33200" },
 ]
 sleds = [
-    { sp = "127.0.0.1:23457", switch_port = "127.0.0.1:33457" },
-    { sp = "127.0.0.1:23458", switch_port = "127.0.0.1:33458" },
+    { sp = "[::1]:33310", switch_port = "[::1]:33201" },
+    { sp = "[::1]:33320", switch_port = "[::1]:33202" },
 ]
 power_controllers = [
 ]

--- a/gateway/tests/integration_tests/setup.rs
+++ b/gateway/tests/integration_tests/setup.rs
@@ -69,16 +69,16 @@ pub async fn test_setup_with_config(
         .sidecars
         .iter()
         .map(|simsp| KnownSp {
-            sp: simsp.local_addr(),
-            switch_port: "127.0.0.1:0".parse().unwrap(),
+            sp: simsp.local_addr(0),
+            switch_port: "[::1]:0".parse().unwrap(),
         })
         .collect::<Vec<_>>();
     let gimlets = simrack
         .gimlets
         .iter()
         .map(|simsp| KnownSp {
-            sp: simsp.local_addr(),
-            switch_port: "127.0.0.1:0".parse().unwrap(),
+            sp: simsp.local_addr(0),
+            switch_port: "[::1]:0".parse().unwrap(),
         })
         .collect::<Vec<_>>();
     server_config.known_sps = KnownSps {

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -8,22 +8,22 @@
 # concurrently.
 #
 [[simulated_sps.sidecar]]
-bind_address = "127.0.0.1:0"
+bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 [[simulated_sps.gimlet]]
-bind_address = "127.0.0.1:0"
+bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 [[simulated_sps.gimlet.components]]
 name = "sp3"
-serial_console = "127.0.0.1:0"
+serial_console = "[::1]:0"
 
 [[simulated_sps.gimlet]]
-bind_address = "127.0.0.1:0"
+bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
 [[simulated_sps.gimlet.components]]
 name = "sp3"
-serial_console = "127.0.0.1:0"
+serial_console = "[::1]:0"
 
 #
 # NOTE: for the test suite, the [log] section is ignored; sp-sim logs are rolled

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -8,10 +8,12 @@
 # concurrently.
 #
 [[simulated_sps.sidecar]]
+multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 [[simulated_sps.gimlet]]
+multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 [[simulated_sps.gimlet.components]]
@@ -19,6 +21,7 @@ name = "sp3"
 serial_console = "[::1]:0"
 
 [[simulated_sps.gimlet]]
+multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
 [[simulated_sps.gimlet.components]]

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -12,7 +12,6 @@ futures = "0.3"
 gateway-messages = { path = "../gateway-messages" }
 hex = "0.4.3"
 omicron-common = { path = "../common" }
-serde_repr = "0.1"
 slog-dtrace = "0.2"
 structopt = "0.3"
 thiserror = "1.0"

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3"
 gateway-messages = { path = "../gateway-messages" }
 hex = "0.4.3"
 omicron-common = { path = "../common" }
+serde_repr = "0.1"
 slog-dtrace = "0.2"
 structopt = "0.3"
 thiserror = "1.0"

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 anyhow = "1.0"
 async-trait = "0.1.53"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
+futures = "0.3"
 gateway-messages = { path = "../gateway-messages" }
 hex = "0.4.3"
 omicron-common = { path = "../common" }

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -3,10 +3,12 @@
 #
 
 [[simulated_sps.sidecar]]
+multicast_addr = "ff15:0:1de::0"
 bind_addrs = ["[::1]:33300", "[::1]:33301"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 [[simulated_sps.gimlet]]
+multicast_addr = "ff15:0:1de::1"
 bind_addrs = ["[::1]:33310", "[::1]:33311"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 [[simulated_sps.gimlet.components]]
@@ -14,6 +16,7 @@ name = "sp3"
 serial_console = "[::1]:33312"
 
 [[simulated_sps.gimlet]]
+multicast_addr = "ff15:0:1de::2"
 bind_addrs = ["[::1]:33320", "[::1]:33321"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
 [[simulated_sps.gimlet.components]]

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -3,22 +3,22 @@
 #
 
 [[simulated_sps.sidecar]]
-bind_address = "127.0.0.1:23456"
+bind_addrs = ["[::1]:33300", "[::1]:33301"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 [[simulated_sps.gimlet]]
-bind_address = "127.0.0.1:23457"
+bind_addrs = ["[::1]:33310", "[::1]:33311"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 [[simulated_sps.gimlet.components]]
 name = "sp3"
-serial_console = "127.0.0.1:33457"
+serial_console = "[::1]:33312"
 
 [[simulated_sps.gimlet]]
-bind_address = "127.0.0.1:23458"
+bind_addrs = ["[::1]:33320", "[::1]:33321"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
 [[simulated_sps.gimlet.components]]
 name = "sp3"
-serial_console = "127.0.0.1:33458"
+serial_console = "[::1]:33322"
 
 [log]
 # Show log messages of this level and more severe

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -9,7 +9,7 @@ use dropshot::ConfigLogging;
 use gateway_messages::SerialNumber;
 use serde::{Deserialize, Serialize};
 use std::{
-    net::SocketAddr,
+    net::{Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -17,6 +17,8 @@ use thiserror::Error;
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SidecarConfig {
+    /// IPv6 multicast address to join.
+    pub multicast_addr: Ipv6Addr,
     /// UDP address of the two (fake) KSZ8463 ports
     pub bind_addrs: [SocketAddr; 2],
     /// Fake serial number
@@ -26,6 +28,8 @@ pub struct SidecarConfig {
 /// Configuration of a simulated gimlet SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GimletConfig {
+    /// IPv6 multicast address to join.
+    pub multicast_addr: Ipv6Addr,
     /// UDP address of the two (fake) KSZ8463 ports
     pub bind_addrs: [SocketAddr; 2],
     /// Fake serial number

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -7,12 +7,23 @@
 
 use dropshot::ConfigLogging;
 use gateway_messages::SerialNumber;
-use serde::{Deserialize, Serialize};
-use std::{
-    net::{Ipv6Addr, SocketAddr},
-    path::{Path, PathBuf},
-};
+use serde::Deserialize;
+use serde::Serialize;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
+use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::path::PathBuf;
 use thiserror::Error;
+
+/// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum SpPort {
+    One = 1,
+    Two = 2,
+}
 
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -64,12 +75,6 @@ pub struct Config {
     pub simulated_sps: SimulatedSps,
     /// Server-wide logging configuration.
     pub log: ConfigLogging,
-    // Type of SP to simulate.
-    // pub sp_type: SpType,
-    // Components to simulate.
-    // pub components: SpComponents,
-    // UDP listen address.
-    // pub bind_address: SocketAddr,
 }
 
 impl Config {

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -9,21 +9,11 @@ use dropshot::ConfigLogging;
 use gateway_messages::SerialNumber;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_repr::Deserialize_repr;
-use serde_repr::Serialize_repr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
-
-/// Identifier for one of of an SP's KSZ8463 management-network-facing ports.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
-#[repr(u8)]
-pub enum SpPort {
-    One = 1,
-    Two = 2,
-}
 
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -17,8 +17,8 @@ use thiserror::Error;
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SidecarConfig {
-    /// UDP address
-    pub bind_address: SocketAddr,
+    /// UDP address of the two (fake) KSZ8463 ports
+    pub bind_addrs: [SocketAddr; 2],
     /// Fake serial number
     pub serial_number: SerialNumber,
 }
@@ -26,8 +26,8 @@ pub struct SidecarConfig {
 /// Configuration of a simulated gimlet SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GimletConfig {
-    /// UDP address
-    pub bind_address: SocketAddr,
+    /// UDP address of the two (fake) KSZ8463 ports
+    pub bind_addrs: [SocketAddr; 2],
     /// Fake serial number
     pub serial_number: SerialNumber,
     /// Attached components

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -69,8 +69,8 @@ impl Gimlet {
         // bind to our two local "KSZ" ports
         assert_eq!(gimlet.bind_addrs.len(), 2); // gimlet SP always has 2 ports
         let servers = future::try_join(
-            UdpServer::new(gimlet.bind_addrs[0]),
-            UdpServer::new(gimlet.bind_addrs[1]),
+            UdpServer::new(gimlet.bind_addrs[0], gimlet.multicast_addr, &log),
+            UdpServer::new(gimlet.bind_addrs[1], gimlet.multicast_addr, &log),
         )
         .await?;
         let servers = [servers.0, servers.1];

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -7,6 +7,7 @@ use crate::server::UdpServer;
 use crate::{Responsiveness, SimulatedSp};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use futures::future;
 use gateway_messages::sp_impl::{SerialConsolePacketizer, SpHandler, SpServer};
 use gateway_messages::{
     version, ResponseError, SerialConsole, SerialNumber, SerializedSize,
@@ -24,7 +25,7 @@ use tokio::sync::oneshot;
 use tokio::task::{self, JoinHandle};
 
 pub struct Gimlet {
-    local_addr: SocketAddr,
+    local_addrs: [SocketAddr; 2],
     serial_number: SerialNumber,
     serial_console_addrs: HashMap<String, SocketAddr>,
     commands:
@@ -47,8 +48,8 @@ impl SimulatedSp for Gimlet {
         hex::encode(self.serial_number)
     }
 
-    fn local_addr(&self) -> SocketAddr {
-        self.local_addr
+    fn local_addr(&self, port: usize) -> SocketAddr {
+        self.local_addrs[port]
     }
 
     async fn set_responsiveness(&self, r: Responsiveness) {
@@ -65,23 +66,29 @@ impl Gimlet {
     pub async fn spawn(gimlet: &GimletConfig, log: Logger) -> Result<Self> {
         info!(log, "setting up simualted gimlet");
 
-        let server = UdpServer::new(gimlet.bind_address).await?;
-        let sock = Arc::clone(server.socket());
-        let local_addr = sock
-            .local_addr()
-            .with_context(|| "could not get local address of bound socket")?;
+        // bind to our two local "KSZ" ports
+        assert_eq!(gimlet.bind_addrs.len(), 2); // gimlet SP always has 2 ports
+        let servers = future::try_join(
+            UdpServer::new(gimlet.bind_addrs[0]),
+            UdpServer::new(gimlet.bind_addrs[1]),
+        )
+        .await?;
+        let servers = [servers.0, servers.1];
+        let local_addrs = [servers[0].local_addr(), servers[1].local_addr()];
 
         let mut incoming_console_tx = HashMap::new();
         let mut inner_tasks = Vec::new();
 
-        // We want to be able to start without knowing the gateway's socket
-        // address, but we're spawning both the primary UDP task (which receives
-        // messages from the gateway) and a helper TCP task (which emulates a
-        // serial console and sends messages to the gateway unprompted). We'll
-        // share a locked `Option<SocketAddr>` between the tasks, and have the
-        // UDP task populate it. If the TCP task receives data but doesn't know
-        // the gateways address, it will just discard it.
-        let gateway_address: Arc<Mutex<Option<SocketAddr>>> = Arc::default();
+        // We want to be able to start without knowing the gateways' socket
+        // addresses, but we're spawning both the primary UDP task (which
+        // receives messages from the gateway) and a helper TCP task (which
+        // emulates a serial console and sends messages to the gateway
+        // unprompted). We'll share a locked `Option<SocketAddr>` between the
+        // tasks, and have the UDP task populate it. If the TCP task receives
+        // data but doesn't know either of the gateways addresses, it will just
+        // discard it.
+        let gateway_addresses: Arc<Mutex<[Option<SocketAddr>; 2]>> =
+            Arc::default();
 
         let mut serial_console_addrs = HashMap::new();
 
@@ -108,8 +115,11 @@ impl Gimlet {
                     component,
                     listener,
                     rx,
-                    Arc::clone(&sock),
-                    Arc::clone(&gateway_address),
+                    [
+                        Arc::clone(servers[0].socket()),
+                        Arc::clone(servers[1].socket()),
+                    ],
+                    Arc::clone(&gateway_addresses),
                     log.new(slog::o!("serial-console" => name.to_string())),
                 );
                 inner_tasks.push(task::spawn(async move {
@@ -120,8 +130,8 @@ impl Gimlet {
 
         let (commands, commands_rx) = mpsc::unbounded_channel();
         let inner = UdpTask::new(
-            server,
-            gateway_address,
+            servers,
+            gateway_addresses,
             gimlet.serial_number,
             incoming_console_tx,
             commands_rx,
@@ -131,7 +141,7 @@ impl Gimlet {
             .push(task::spawn(async move { inner.run().await.unwrap() }));
 
         Ok(Self {
-            local_addr,
+            local_addrs,
             serial_number: gimlet.serial_number,
             serial_console_addrs,
             commands,
@@ -147,8 +157,8 @@ impl Gimlet {
 struct SerialConsoleTcpTask {
     listener: TcpListener,
     incoming_serial_console: UnboundedReceiver<SerialConsole>,
-    sock: Arc<UdpSocket>,
-    gateway_address: Arc<Mutex<Option<SocketAddr>>>,
+    socks: [Arc<UdpSocket>; 2],
+    gateway_addresses: Arc<Mutex<[Option<SocketAddr>; 2]>>,
     console_packetizer: SerialConsolePacketizer,
     log: Logger,
 }
@@ -158,42 +168,61 @@ impl SerialConsoleTcpTask {
         component: SpComponent,
         listener: TcpListener,
         incoming_serial_console: UnboundedReceiver<SerialConsole>,
-        sock: Arc<UdpSocket>,
-        gateway_address: Arc<Mutex<Option<SocketAddr>>>,
+        socks: [Arc<UdpSocket>; 2],
+        gateway_addresses: Arc<Mutex<[Option<SocketAddr>; 2]>>,
         log: Logger,
     ) -> Self {
         Self {
             listener,
             incoming_serial_console,
-            sock,
-            gateway_address,
+            socks,
+            gateway_addresses,
             console_packetizer: SerialConsolePacketizer::new(component),
             log,
         }
     }
 
     async fn send_serial_console(&mut self, mut data: &[u8]) -> Result<()> {
-        let gateway_address = self.gateway_address.lock().unwrap().ok_or_else(|| anyhow!("serial console task does not know gateway's UDP address (yet?)"))?;
-
-        // if we're told to send something starting with "SKIP ", emulate a
-        // dropped packet spanning 10 bytes before sending the rest of the data.
-        if let Some(remaining) = data.strip_prefix(b"SKIP ") {
-            self.console_packetizer.danger_emulate_dropped_packets(10);
-            data = remaining;
-        }
-
-        let mut out = [0; SpMessage::MAX_SIZE];
-        for packet in self.console_packetizer.packetize(data) {
-            let message = SpMessage {
-                version: version::V1,
-                kind: SpMessageKind::SerialConsole(packet),
+        let gateway_addrs = *self.gateway_addresses.lock().unwrap();
+        for (i, (sock, &gateway_addr)) in
+            self.socks.iter().zip(&gateway_addrs).enumerate()
+        {
+            let gateway_addr = match gateway_addr {
+                Some(addr) => addr,
+                None => {
+                    info!(
+                        self.log,
+                        concat!(
+                            "MGS address on port {} not known - ",
+                            "not sending it serial console data",
+                        ),
+                        i,
+                    );
+                    continue;
+                }
             };
 
-            // We know `out` is big enough for any `SpMessage`, so no need to
-            // bubble up an error here.
-            let n =
-                gateway_messages::serialize(&mut out[..], &message).unwrap();
-            self.sock.send_to(&out[..n], gateway_address).await?;
+            // if we're told to send something starting with "SKIP ", emulate a
+            // dropped packet spanning 10 bytes before sending the rest of the
+            // data.
+            if let Some(remaining) = data.strip_prefix(b"SKIP ") {
+                self.console_packetizer.danger_emulate_dropped_packets(10);
+                data = remaining;
+            }
+
+            let mut out = [0; SpMessage::MAX_SIZE];
+            for packet in self.console_packetizer.packetize(data) {
+                let message = SpMessage {
+                    version: version::V1,
+                    kind: SpMessageKind::SerialConsole(packet),
+                };
+
+                // We know `out` is big enough for any `SpMessage`, so no need
+                // to bubble up an error here.
+                let n = gateway_messages::serialize(&mut out[..], &message)
+                    .unwrap();
+                sock.send_to(&out[..n], gateway_addr).await?;
+            }
         }
 
         Ok(())
@@ -287,8 +316,9 @@ enum CommandResponse {
 }
 
 struct UdpTask {
-    udp: UdpServer,
-    gateway_address: Arc<Mutex<Option<SocketAddr>>>,
+    udp0: UdpServer,
+    udp1: UdpServer,
+    gateway_addresses: Arc<Mutex<[Option<SocketAddr>; 2]>>,
     handler: Handler,
     commands:
         mpsc::UnboundedReceiver<(Command, oneshot::Sender<CommandResponse>)>,
@@ -296,8 +326,8 @@ struct UdpTask {
 
 impl UdpTask {
     fn new(
-        server: UdpServer,
-        gateway_address: Arc<Mutex<Option<SocketAddr>>>,
+        servers: [UdpServer; 2],
+        gateway_addresses: Arc<Mutex<[Option<SocketAddr>; 2]>>,
         serial_number: SerialNumber,
         incoming_serial_console: HashMap<
             SpComponent,
@@ -309,9 +339,11 @@ impl UdpTask {
         )>,
         log: Logger,
     ) -> Self {
+        let [udp0, udp1] = servers;
         Self {
-            udp: server,
-            gateway_address,
+            udp0,
+            udp1,
+            gateway_addresses,
             handler: Handler { log, serial_number, incoming_serial_console },
             commands,
         }
@@ -322,26 +354,30 @@ impl UdpTask {
         let mut responsiveness = Responsiveness::Responsive;
         loop {
             select! {
-                recv = self.udp.recv_from() => {
-                    if responsiveness != Responsiveness::Responsive {
-                        continue;
+                recv0 = self.udp0.recv_from() => {
+                    if let Some((resp, addr)) = handle_request(
+                        &self.gateway_addresses,
+                        &mut self.handler,
+                        recv0,
+                        &mut server,
+                        responsiveness,
+                        0,
+                    ).await? {
+                        self.udp0.send_to(resp, addr).await?;
                     }
+                }
 
-                    let (data, addr) = recv?;
-                    *self.gateway_address.lock().unwrap() = Some(addr);
-
-                    let resp = match server.dispatch(data, &mut self.handler) {
-                        Ok(resp) => resp,
-                        Err(err) => {
-                            error!(
-                                self.handler.log,
-                                "dispatching message failed: {:?}", err,
-                            );
-                            continue;
-                        }
-                    };
-
-                    self.udp.send_to(resp, addr).await?;
+                recv1 = self.udp1.recv_from() => {
+                    if let Some((resp, addr)) = handle_request(
+                        &self.gateway_addresses,
+                        &mut self.handler,
+                        recv1,
+                        &mut server,
+                        responsiveness,
+                        1,
+                    ).await? {
+                        self.udp1.send_to(resp, addr).await?;
+                    }
                 }
 
                 command = self.commands.recv() => {
@@ -362,6 +398,34 @@ impl UdpTask {
             }
         }
     }
+}
+
+async fn handle_request<'a>(
+    gateway_addresses: &Mutex<[Option<SocketAddr>; 2]>,
+    handler: &mut Handler,
+    recv: Result<(&[u8], SocketAddr)>,
+    server: &'a mut SpServer,
+    responsiveness: Responsiveness,
+    port_num: usize,
+) -> Result<Option<(&'a [u8], SocketAddr)>> {
+    match responsiveness {
+        Responsiveness::Responsive => (), // proceed
+        Responsiveness::Unresponsive => {
+            // pretend to be unresponsive - drop this packet
+            return Ok(None);
+        }
+    }
+
+    let (data, addr) =
+        recv.with_context(|| format!("recv on port {}", port_num))?;
+
+    gateway_addresses.lock().unwrap()[port_num] = Some(addr);
+
+    let resp = server
+        .dispatch(data, handler)
+        .map_err(|err| anyhow!("dispatching message failed: {:?}", err))?;
+
+    Ok(Some((resp, addr)))
 }
 
 struct Handler {

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -31,8 +31,8 @@ pub enum Responsiveness {
 pub trait SimulatedSp {
     /// Hexlified serial number.
     fn serial_number(&self) -> String;
-    /// Listening UDP address of the simulated SP.
-    fn local_addr(&self) -> SocketAddr;
+    /// Listening UDP address of the given port of this simulated SP.
+    fn local_addr(&self, port: usize) -> SocketAddr;
     /// Simulate the SP being unresponsive, in which it ignores all incoming
     /// messages.
     async fn set_responsiveness(&self, r: Responsiveness);

--- a/sp-sim/src/server.rs
+++ b/sp-sim/src/server.rs
@@ -3,13 +3,22 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::config::Config;
-use anyhow::{bail, Context, Result};
-use gateway_messages::{Request, SerializedSize};
-use slog::{debug, error, Logger};
-use std::{
-    net::{Ipv6Addr, SocketAddr},
-    sync::Arc,
-};
+use crate::Responsiveness;
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use gateway_messages::sp_impl::SpHandler;
+use gateway_messages::sp_impl::SpServer;
+use gateway_messages::Request;
+use gateway_messages::SerializedSize;
+use gateway_messages::SpPort;
+use slog::debug;
+use slog::error;
+use slog::Logger;
+use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::UdpSocket;
 
 /// Thin wrapper pairing a [`UdpSocket`] with a buffer sized for [`Request`]s.
@@ -90,4 +99,29 @@ pub fn logger(config: &Config) -> Result<Logger> {
         debug!(log, "registered DTrace probes");
     }
     Ok(log)
+}
+
+pub(crate) async fn handle_request<'a, H: SpHandler>(
+    handler: &mut H,
+    recv: Result<(&[u8], SocketAddr)>,
+    server: &'a mut SpServer,
+    responsiveness: Responsiveness,
+    port_num: SpPort,
+) -> Result<Option<(&'a [u8], SocketAddr)>> {
+    match responsiveness {
+        Responsiveness::Responsive => (), // proceed
+        Responsiveness::Unresponsive => {
+            // pretend to be unresponsive - drop this packet
+            return Ok(None);
+        }
+    }
+
+    let (data, addr) =
+        recv.with_context(|| format!("recv on {:?}", port_num))?;
+
+    let resp = server
+        .dispatch(addr, port_num, data, handler)
+        .map_err(|err| anyhow!("dispatching message failed: {:?}", err))?;
+
+    Ok(Some((resp, addr)))
 }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 
 use crate::config::Config;
 use crate::config::SidecarConfig;
+use crate::config::SpPort;
 use crate::ignition_id;
 use crate::server::UdpServer;
 use crate::Responsiveness;
@@ -181,7 +182,7 @@ impl Inner {
                         recv0,
                         &mut server,
                         responsiveness,
-                        0,
+                        SpPort::One,
                     ).await? {
                         self.udp0.send_to(resp, addr).await?;
                     }
@@ -193,7 +194,7 @@ impl Inner {
                         recv1,
                         &mut server,
                         responsiveness,
-                        1,
+                        SpPort::Two,
                     ).await? {
                         self.udp1.send_to(resp, addr).await?;
                     }
@@ -229,7 +230,7 @@ async fn handle_request<'a>(
     recv: Result<(&[u8], SocketAddr)>,
     server: &'a mut SpServer,
     responsiveness: Responsiveness,
-    port_num: usize,
+    port_num: SpPort,
 ) -> Result<Option<(&'a [u8], SocketAddr)>> {
     match responsiveness {
         Responsiveness::Responsive => (), // proceed
@@ -240,7 +241,7 @@ async fn handle_request<'a>(
     }
 
     let (data, addr) =
-        recv.with_context(|| format!("recv on port {}", port_num))?;
+        recv.with_context(|| format!("recv on {:?}", port_num))?;
 
     let resp = server
         .dispatch(data, handler)


### PR DESCRIPTION
This PR is the first of three that builds toward a preliminary implementation of [RFD 250](https://rfd.shared.oxide.computer/rfd/0250)-style SP and location discovery.

Changes in this PR:
* Each simulated SP now listens on two UDP ports instead of one (corresponding to the two ports of each real SP behind the KSZ switch).
* Each simulated SP is given an IPv6 multicast group, and the sockets on both UDP ports join that group.

There are two quirks present related to the multicast group:

1. With real hardware, all SPs will use the same multicast address - the setup of the management network switch provides isolation. For local dev/test we have no such isolation, so we can give each simulated SP a _different_ multicast address, which means a sender will only receive responses from a single SP. This affects the "real" config but in a way that should be easy to change later.
2. The code that actually joins the multicast group guards it with an "if address is actually a multicast address" - not all our CI runners allow joining IPv6 multicast groups, so for those runners we can fake it with loopback addresses. This is only in the simulator.