### PR TITLE
MGS: Replace canned SP identification with RFD250-style discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "once_cell",
  "ringbuffer",
  "serde",
+ "serde_with",
  "slog",
  "thiserror",
  "tokio",

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -10,6 +10,7 @@ http = "0.2.6"
 hyper = "0.14.17"
 ringbuffer = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.12.0"
 thiserror = "1.0.30"
 tokio-tungstenite = "0.17"
 tokio-stream = "0.1.8"

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -9,41 +9,31 @@ use crate::error::Error;
 use crate::error::SpCommunicationError;
 use crate::error::StartupError;
 use crate::management_switch::ManagementSwitch;
-use crate::management_switch::ManagementSwitchDiscovery;
 use crate::management_switch::SpSocket;
 use crate::management_switch::SwitchPort;
-use crate::recv_handler::RecvHandler;
 use crate::Elapsed;
-use crate::KnownSps;
 use crate::SpIdentifier;
+use crate::SwitchConfig;
 use crate::Timeout;
 use futures::stream::FuturesUnordered;
 use futures::Future;
 use futures::Stream;
-use gateway_messages::version;
 use gateway_messages::BulkIgnitionState;
 use gateway_messages::DiscoverResponse;
 use gateway_messages::IgnitionCommand;
 use gateway_messages::IgnitionState;
-use gateway_messages::Request;
 use gateway_messages::RequestKind;
-use gateway_messages::ResponseError;
 use gateway_messages::ResponseKind;
 use gateway_messages::SerialConsole;
-use gateway_messages::SerializedSize;
 use gateway_messages::SpComponent;
 use gateway_messages::SpState;
 use hyper::header;
 use hyper::upgrade;
 use hyper::Body;
-use omicron_common::backoff;
-use omicron_common::backoff::Backoff;
-use slog::debug;
 use slog::info;
 use slog::o;
 use slog::Logger;
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering;
+use tokio::time::Instant;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_tungstenite::tungstenite::handshake;
@@ -66,28 +56,30 @@ where
 
 #[derive(Debug)]
 pub struct Communicator {
-    log: Logger,
     switch: ManagementSwitch,
-    request_id: AtomicU32,
-    recv_handler: Arc<RecvHandler>,
 }
 
 impl Communicator {
     pub async fn new(
-        known_sps: KnownSps,
+        config: SwitchConfig,
+        discovery_deadline: Instant,
         log: &Logger,
     ) -> Result<Self, StartupError> {
         let log = log.new(o!("component" => "SpCommunicator"));
-        let discovery = ManagementSwitchDiscovery::placeholder_start(
-            known_sps,
-            log.clone(),
-        )
-        .await?;
-
-        let (switch, recv_handler) = RecvHandler::new(discovery, log.clone());
+        let switch =
+            ManagementSwitch::new(config, discovery_deadline, log.clone())
+                .await?;
 
         info!(&log, "started SP communicator");
-        Ok(Self { log, switch, request_id: AtomicU32::new(0), recv_handler })
+        Ok(Self { switch })
+    }
+
+    /// Get the name of our location.
+    ///
+    /// This matches one of the names specified as a possible location in the
+    /// configuration we were given.
+    pub fn location_name(&self) -> &str {
+        &self.switch.location_name()
     }
 
     // convert an identifier to a port number; this is fallible because
@@ -103,13 +95,36 @@ impl Communicator {
         self.switch.switch_port_to_id(port)
     }
 
+    /// Returns true if we've discovered the IP address of our local ignition
+    /// controller.
+    ///
+    /// This method exists to be polled during test setup (to wait for discovery
+    /// to happen); it should not be called outside tests.
+    pub fn local_ignition_controller_address_known(&self) -> bool {
+        self.switch.ignition_controller().is_some()
+    }
+
+    /// Returns true if we've discovered the IP address of the specified SP.
+    ///
+    /// This method exists to be polled during test setup (to wait for discovery
+    /// to happen); it should not be called outside tests. In particular, it
+    /// panics instead of running an error if `sp` describes an SP that isn't
+    /// known to this communicator.
+    pub fn address_known(&self, sp: SpIdentifier) -> bool {
+        let port = self.switch.switch_port(sp).unwrap();
+        self.switch.sp_socket(port).is_some()
+    }
+
     /// Ask the local ignition controller for the ignition state of a given SP.
     pub async fn get_ignition_state(
         &self,
         sp: SpIdentifier,
         timeout: Timeout,
     ) -> Result<IgnitionState, Error> {
-        let controller = self.switch.ignition_controller();
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(Error::LocalIgnitionControllerAddressUnknown)?;
         let port = self.id_to_port(sp)?;
         let request =
             RequestKind::IgnitionState { target: port.as_ignition_target() };
@@ -129,7 +144,10 @@ impl Communicator {
         &self,
         timeout: Timeout,
     ) -> Result<Vec<(SpIdentifier, IgnitionState)>, Error> {
-        let controller = self.switch.ignition_controller();
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(Error::LocalIgnitionControllerAddressUnknown)?;
         let request = RequestKind::BulkIgnitionState;
 
         let bulk_state = self
@@ -170,7 +188,10 @@ impl Communicator {
         command: IgnitionCommand,
         timeout: Timeout,
     ) -> Result<(), Error> {
-        let controller = self.switch.ignition_controller();
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(Error::LocalIgnitionControllerAddressUnknown)?;
         let target = self.id_to_port(target_sp)?.as_ignition_target();
         let request = RequestKind::IgnitionCommand { target, command };
 
@@ -196,6 +217,11 @@ impl Communicator {
     // via UDP. SPs will continuously broadcast any serial console data, even if
     // there is no attached client. Maybe this is fine, since the serial console
     // shouldn't be noisy without a corresponding client driving it?
+    //
+    // TODO Because this method doesn't contact the target SP, it succeeds even
+    // if we don't know the IP address of that SP (yet, or possibly ever)! The
+    // connection will start working if we later discover the address, but this
+    // is probably not the behavior we want.
     pub async fn serial_console_attach(
         self: &Arc<Self>,
         request: &mut http::Request<Body>,
@@ -250,7 +276,7 @@ impl Communicator {
             .map(|key| handshake::derive_accept_key(key))
             .ok_or(Error::BadWebsocketConnection("missing websocket key"))?;
 
-        self.recv_handler.serial_console_attach(
+        self.switch.serial_console_attach(
             Arc::clone(self),
             port,
             component,
@@ -281,7 +307,7 @@ impl Communicator {
         component: &SpComponent,
     ) -> Result<(), Error> {
         let port = self.id_to_port(sp)?;
-        self.recv_handler.serial_console_detach(port, component)
+        self.switch.serial_console_detach(port, component)
     }
 
     /// Send `packet` to the given SP component's serial console.
@@ -398,102 +424,17 @@ impl Communicator {
             .collect::<FuturesUnordered<_>>()
     }
 
-    pub(crate) async fn request_response<F, T>(
+    async fn request_response<F, T>(
         &self,
         sp: &SpSocket<'_>,
-        mut kind: RequestKind,
-        mut map_response_kind: F,
+        kind: RequestKind,
+        map_response_kind: F,
         timeout: Option<Timeout>,
     ) -> Result<T, Error>
     where
         F: FnMut(ResponseKind) -> Result<T, BadResponseType>,
     {
-        // helper to wrap a future in a timeout if we have one
-        async fn maybe_with_timeout<F, U>(
-            timeout: Option<Timeout>,
-            fut: F,
-        ) -> Result<U, Elapsed>
-        where
-            F: Future<Output = U>,
-        {
-            match timeout {
-                Some(t) => t.timeout_at(fut).await,
-                None => Ok(fut.await),
-            }
-        }
-
-        // We'll use exponential backoff if and only if the SP responds with
-        // "busy"; any other error will cause the loop below to terminate.
-        let mut backoff = backoff::internal_service_policy();
-
-        loop {
-            // It would be nicer to use `backoff::retry()` instead of manually
-            // stepping the backoff policy, but the dance we do with `kind` to
-            // avoid cloning it is hard to map into `retry()` in a way that
-            // satisfies the borrow checker. ("The dance we do with `kind` to
-            // avoid cloning it" being that we move it into `request` below, and
-            // on a busy response from the SP we move it back out into the
-            // `kind` local var.)
-            let duration = backoff
-                .next_backoff()
-                .expect("internal backoff policy gave up");
-            maybe_with_timeout(timeout, tokio::time::sleep(duration))
-                .await
-                .map_err(|err| Error::Timeout {
-                    timeout: err.duration(),
-                    sp: self.port_to_id(sp.port()),
-                })?;
-
-            // request IDs will eventually roll over; since we enforce timeouts
-            // this should be a non-issue in practice. does this need testing?
-            let request_id = self.request_id.fetch_add(1, Ordering::Relaxed);
-
-            // update our recv_handler to expect a response for this request ID
-            let response_fut =
-                self.recv_handler.register_request_id(sp.port(), request_id);
-
-            // Serialize and send our request. We know `buf` is large enough for
-            // any `Request`, so unwrapping here is fine.
-            let request = Request { version: version::V1, request_id, kind };
-            let mut buf = [0; Request::MAX_SIZE];
-            let n = gateway_messages::serialize(&mut buf, &request).unwrap();
-            let serialized_request = &buf[..n];
-
-            // Actual communication, guarded by `timeout` if it's not `None`.
-            let result = maybe_with_timeout(timeout, async {
-                debug!(&self.log, "sending {:?} to SP {:?}", request, sp);
-                sp.send(serialized_request).await.map_err(|err| {
-                    SpCommunicationError::UdpSend { addr: sp.addr(), err }
-                })?;
-
-                Ok::<ResponseKind, SpCommunicationError>(response_fut.await?)
-            })
-            .await
-            .map_err(|err| Error::Timeout {
-                timeout: err.duration(),
-                sp: self.port_to_id(sp.port()),
-            })?;
-
-            match result {
-                Ok(response_kind) => {
-                    return map_response_kind(response_kind)
-                        .map_err(SpCommunicationError::from)
-                        .map_err(Error::from)
-                }
-                Err(SpCommunicationError::SpError(ResponseError::Busy)) => {
-                    debug!(
-                        &self.log,
-                        "SP busy; sleeping before retrying send";
-                        "sp" => ?sp,
-                    );
-
-                    // move `kind` back into local var; required to satisfy
-                    // borrow check of this loop
-                    kind = request.kind;
-                }
-                Err(err) => return Err(err.into()),
-            }
-        }
+        self.switch.request_response(sp, kind, map_response_kind, timeout).await
     }
 }
 

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -33,9 +33,9 @@ use hyper::Body;
 use slog::info;
 use slog::o;
 use slog::Logger;
-use tokio::time::Instant;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::time::Instant;
 use tokio_tungstenite::tungstenite::handshake;
 
 /// Helper trait that allows us to return an `impl FuturesUnordered<_>` where

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -35,8 +35,10 @@ pub enum Error {
         .0.slot,
     )]
     SpAddressUnknown(SpIdentifier),
-    #[error("timeout ({timeout:?}) elapsed communicating with {sp:?}")]
-    Timeout { timeout: Duration, sp: SpIdentifier },
+    #[error(
+        "timeout ({timeout:?}) elapsed communicating with {sp:?} on port {port}"
+    )]
+    Timeout { timeout: Duration, port: usize, sp: Option<SpIdentifier> },
     #[error("error communicating with SP: {0}")]
     SpCommunicationFailed(#[from] SpCommunicationError),
     #[error("serial console is already attached")]

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -24,13 +24,11 @@ pub mod error;
 
 pub use communicator::Communicator;
 pub use communicator::FuturesUnorderedImpl;
+pub use management_switch::LocationConfig;
+pub use management_switch::LocationDeterminationConfig;
 pub use management_switch::SpIdentifier;
 pub use management_switch::SpType;
+pub use management_switch::SwitchConfig;
+pub use management_switch::SwitchPortConfig;
 pub use timeout::Elapsed;
 pub use timeout::Timeout;
-
-// TODO these will remain public for a while, but eventually will be removed
-// altogther; currently these provide a way to hard-code the rack topology,
-// which is not what we want.
-pub use management_switch::KnownSp;
-pub use management_switch::KnownSps;

--- a/gateway-sp-comms/src/recv_handler/mod.rs
+++ b/gateway-sp-comms/src/recv_handler/mod.rs
@@ -5,12 +5,11 @@
 // Copyright 2022 Oxide Computer Company
 
 use crate::error::Error;
-use crate::management_switch::ManagementSwitch;
-use crate::management_switch::ManagementSwitchDiscovery;
 use crate::management_switch::SwitchPort;
 use crate::Communicator;
 use crate::Timeout;
 use futures::future::Fuse;
+use futures::Future;
 use futures::FutureExt;
 use futures::SinkExt;
 use futures::StreamExt;
@@ -29,12 +28,16 @@ use slog::debug;
 use slog::error;
 use slog::info;
 use slog::trace;
+use slog::warn;
 use slog::Logger;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::convert::TryInto;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -75,6 +78,7 @@ use self::request_response_map::ResponseIngestResult;
 ///    corresponding to the future returned in step 1, fulfilling it.
 #[derive(Debug)]
 pub(crate) struct RecvHandler {
+    request_id: AtomicU32,
     sp_state: HashMap<SwitchPort, SingleSpState>,
     log: Logger,
 }
@@ -83,34 +87,25 @@ impl RecvHandler {
     /// Create a new `RecvHandler` that is aware of all ports described by
     /// `switch`.
     pub(crate) fn new(
-        switch_discovery: ManagementSwitchDiscovery,
+        ports: impl ExactSizeIterator<Item = SwitchPort>,
         log: Logger,
-    ) -> (ManagementSwitch, Arc<Self>) {
+    ) -> Arc<Self> {
         // prime `sp_state` with all known ports of the switch
-        let all_ports = switch_discovery.all_ports();
-        let mut sp_state = HashMap::with_capacity(all_ports.len());
-        for port in all_ports {
+        let mut sp_state = HashMap::with_capacity(ports.len());
+        for port in ports {
             sp_state.insert(port, SingleSpState::default());
         }
 
-        // configure a `ManagementSwitch` that notifies us of every incoming
-        // packet
-        let handler = Arc::new(Self { sp_state, log });
-        let switch = {
-            let handler = Arc::clone(&handler);
-            switch_discovery.start_recv_task(move |port, buf| {
-                handler.handle_incoming_packet(port, buf)
-            })
-        };
-
-        (switch, handler)
+        // TODO: Should we init our request_id randomly instead of always
+        // starting at 0?
+        Arc::new(Self { request_id: AtomicU32::new(0), sp_state, log })
     }
 
-    // SwitchPort instances can only be created by `ManagementSwitch`, so we
-    // should never be able to instantiate a port that we don't have in
-    // `self.sp_state` (which we initialize with all ports declared by the
-    // switch we were given).
     fn sp_state(&self, port: SwitchPort) -> &SingleSpState {
+        // SwitchPort instances can only be created by `ManagementSwitch`, so we
+        // should never be able to instantiate a port that we don't have in
+        // `self.sp_state` (which we initialize with all ports declared by the
+        // switch we were given).
         self.sp_state.get(&port).expect("invalid switch port")
     }
 
@@ -210,20 +205,37 @@ impl RecvHandler {
         Ok(())
     }
 
-    /// Returns a future that will complete when we receive a response on the
-    /// given `port` with the corresponding `request_id`.
+    /// Returns a new request ID and a future that will complete when we receive
+    /// a response on the given `port` with that request ID.
     ///
     /// Panics if `port` is not one of the ports defined by the `switch` given
     /// to this `RecvHandler` when it was constructed.
-    pub(crate) async fn register_request_id(
+    pub(crate) fn register_request_id(
         &self,
         port: SwitchPort,
-        request_id: u32,
-    ) -> Result<ResponseKind, ResponseError> {
-        self.sp_state(port).requests.wait_for_response(request_id).await
+    ) -> (u32, impl Future<Output = Result<ResponseKind, ResponseError>> + '_)
+    {
+        let request_id = self.request_id.fetch_add(1, Ordering::Relaxed);
+        (request_id, self.sp_state(port).requests.wait_for_response(request_id))
     }
 
-    fn handle_incoming_packet(&self, port: SwitchPort, buf: &[u8]) {
+    /// Returns the address of the SP connected to `port`, if we know it.
+    pub(crate) fn remote_addr(&self, port: SwitchPort) -> Option<SocketAddr> {
+        *self.sp_state(port).addr.lock().unwrap()
+    }
+
+    // Only available for tests: set the remote address of a given port.
+    #[cfg(test)]
+    pub(crate) fn set_remote_addr(&self, port: SwitchPort, addr: SocketAddr) {
+        *self.sp_state(port).addr.lock().unwrap() = Some(addr);
+    }
+
+    pub(crate) fn handle_incoming_packet(
+        &self,
+        port: SwitchPort,
+        addr: SocketAddr,
+        buf: &[u8],
+    ) {
         trace!(&self.log, "received {} bytes from {:?}", buf.len(), port);
 
         // the first four bytes of packets we expect is always a version number;
@@ -268,6 +280,35 @@ impl RecvHandler {
             }
         };
         debug!(&self.log, "received {:?} from {:?}", sp_msg, port);
+
+        // update our knowledge of the sender's address
+        let state = self.sp_state(port);
+        match state.addr.lock().unwrap().replace(addr) {
+            None => {
+                // expected but rare: our first packet on this port
+                debug!(
+                    &self.log, "discovered remote address for port";
+                    "port" => ?port,
+                    "addr" => %addr,
+                );
+            }
+            Some(old) if old == addr => {
+                // expected; we got another packet from the expected address
+            }
+            Some(old) => {
+                // unexpected; the remote address changed
+                // TODO-security - What should we do here? Could the sled have
+                // been physically replaced and we're now hearing from a new SP?
+                // This question/TODO may go away on its own if we add an
+                // authenticated channel?
+                warn!(
+                    &self.log, "updated remote address for port";
+                    "port" => ?port,
+                    "old_addr" => %old,
+                    "new_addr" => %addr,
+                );
+            }
+        }
 
         // decide whether this is a response to an outstanding request or an
         // unprompted message
@@ -341,6 +382,7 @@ impl RecvHandler {
 
 #[derive(Debug, Default)]
 struct SingleSpState {
+    addr: Mutex<Option<SocketAddr>>,
     requests: RequestResponseMap<u32, Result<ResponseKind, ResponseError>>,
     serial_console_tasks: Mutex<HashMap<SpComponent, SerialConsoleTaskHandle>>,
 }

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -5,19 +5,69 @@
 # Identifier for this instance of MGS
 id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
 
-[known_sps]
-switches = [
-    # first switch is assumed to be the local ignition controller
-    { sp = "[::1]:33300", switch_port = "[::1]:33200" },
-]
-sleds = [
-    { sp = "[::1]:33310", switch_port = "[::1]:33201" },
-    { sp = "[::1]:33320", switch_port = "[::1]:33202" },
-]
-power_controllers = [
-]
+[switch]
+# which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
+# our contact to the ignition controller)
+local_ignition_controller_port = 0
+
+[switch.location]
+# possible locations where MGS could be running; these names appear in logs and
+# are used in the remainder of the `[switch.*]` configuration to define port
+# mappings
+names = ["switch0", "switch1"]
+
+# `[[switch.location.determination]]` is a list of switch ports we should
+# contact in order to determine our location; each port defines a subset of
+# `[switch.location.names]` which are the possible location(s) of this MGS
+# instance if the message was received on the given SP port. When MGS starts, it
+# will send a discovery message on each port listed in this section, collect the
+# responses, and determine its location via the intersection of the names listed
+# below (for all ports which returned a successful response). This process can
+# fail if too few SPs respond (leaving us with 2 or more possible locations) or
+# if there is a miscabling that results in an unsolvable system (e.g.,
+# determination 0 reports "switch0" and determination 1 reports "switch1").
+[[switch.location.determination]]
+switch_port = 1
+sp_port_1 = ["switch0"]
+sp_port_2 = ["switch1"]
+
+[[switch.location.determination]]
+switch_port = 2
+sp_port_1 = ["switch0"]
+sp_port_2 = ["switch1"]
+
+# `[[switch.port.*]]` defines the local data link address (in RFD 250 terms, the
+# interface configured to use VLAN tag  assigned to the given port) and the
+# logical ID of the remote SP ("sled 7", "switch 1", etc.), which must have an
+# entry for each member of `[switch.location]` above.
+#
+# TODO This section has some concessions to local testing: ultimately we will
+# use a single multicast address, target port, and source port, but for now all
+# three are configured on a per-port basis, which allows a single system to
+# simulate a full set of ports and SPs.
+[switch.port.0]
+data_link_addr = "[::]:33200"
+multicast_addr = "[ff15:0:1de::0]:33300"
+[switch.port.0.location]
+switch0 = ["switch", 0]
+switch1 = ["switch", 1]
+
+[switch.port.1]
+data_link_addr = "[::]:33201"
+multicast_addr = "[ff15:0:1de::1]:33310"
+[switch.port.1.location]
+switch0 = ["sled", 0]
+switch1 = ["sled", 0]
+
+[switch.port.2]
+data_link_addr = "[::]:33202"
+multicast_addr = "[ff15:0:1de::2]:33320"
+[switch.port.2.location]
+switch0 = ["sled", 1]
+switch1 = ["sled", 1]
 
 [timeouts]
+discovery_millis = 1_000
 ignition_controller_millis = 1_000
 sp_request_millis = 1_000
 bulk_request_default_millis = 5_000

--- a/gateway/src/bin/gateway.rs
+++ b/gateway/src/bin/gateway.rs
@@ -41,6 +41,6 @@ async fn do_run() -> Result<(), CmdError> {
     if args.openapi {
         run_openapi().map_err(CmdError::Failure)
     } else {
-        run_server(&config).await.map_err(CmdError::Failure)
+        run_server(config).await.map_err(CmdError::Failure)
     }
 }

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -6,7 +6,7 @@
 //! configuration
 
 use dropshot::{ConfigDropshot, ConfigLogging};
-use gateway_sp_comms::KnownSps;
+use gateway_sp_comms::SwitchConfig;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::path::PathBuf;
@@ -14,6 +14,9 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Timeouts {
+    /// Timeout for running the discovery process to determine logical mappings
+    /// of switches/sleds.
+    pub discovery_millis: u64,
     /// Timeout for messages to our local ignition controller SP.
     pub ignition_controller_millis: u64,
     /// Timeout for requests sent to arbitrary SPs.
@@ -46,8 +49,8 @@ pub struct Config {
     pub timeouts: Timeouts,
     /// Dropshot configuration for API server
     pub dropshot: ConfigDropshot,
-    /// Placeholder description of all known SPs in the system.
-    pub known_sps: KnownSps,
+    /// Configuration of the management switch.
+    pub switch: SwitchConfig,
     /// Server-wide logging configuration.
     pub log: ConfigLogging,
 }

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{bulk_state_get::BulkSpStateRequests, Config};
-use gateway_sp_comms::error::StartupError;
+use crate::bulk_state_get::BulkSpStateRequests;
 use gateway_sp_comms::Communicator;
+use gateway_sp_comms::{error::StartupError, SwitchConfig};
 use slog::Logger;
 use std::{sync::Arc, time::Duration};
+use tokio::time::Instant;
 
 /// Shared state used by API request handlers
 pub struct ServerContext {
@@ -49,15 +50,19 @@ impl From<&'_ crate::config::Timeouts> for Timeouts {
 
 impl ServerContext {
     pub async fn new(
-        config: &Config,
+        switch_config: SwitchConfig,
+        timeouts: crate::config::Timeouts,
         log: &Logger,
     ) -> Result<Arc<Self>, StartupError> {
-        let comms =
-            Arc::new(Communicator::new(config.known_sps.clone(), log).await?);
+        let discovery_deadline =
+            Instant::now() + Duration::from_millis(timeouts.discovery_millis);
+        let comms = Arc::new(
+            Communicator::new(switch_config, discovery_deadline, log).await?,
+        );
         Ok(Arc::new(ServerContext {
             sp_comms: Arc::clone(&comms),
             bulk_sp_state_requests: BulkSpStateRequests::new(comms, log),
-            timeouts: Timeouts::from(&config.timeouts),
+            timeouts: Timeouts::from(&timeouts),
         }))
     }
 }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Server {
 impl Server {
     /// Start a gateway server.
     pub async fn start(
-        config: &Config,
+        config: Config,
         _rack_id: Uuid,
         log: &Logger,
     ) -> Result<Server, String> {
@@ -52,8 +52,9 @@ impl Server {
             }
         }
 
-        let apictx =
-            ServerContext::new(config, &log).await.map_err(|error| {
+        let apictx = ServerContext::new(config.switch, config.timeouts, &log)
+            .await
+            .map_err(|error| {
                 format!("initializing server context: {}", error)
             })?;
 
@@ -90,7 +91,7 @@ impl Server {
 }
 
 /// Run an instance of the [Server].
-pub async fn run_server(config: &Config) -> Result<(), String> {
+pub async fn run_server(config: Config) -> Result<(), String> {
     use slog::Drain;
     let (drain, registration) = slog_dtrace::with_drain(
         config

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -6,13 +6,76 @@
 # NOTE: The test suite always overrides this.
 id = "8afcb12d-f625-4df9-bdf2-f495c3bbd323"
 
-[known_sps]
-# NOTE: The test suite overrides this section based on the configured simulator.
-switches = []
-sleds = []
-power_controllers = []
+[switch]
+# which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
+# our contact to the ignition controller)
+local_ignition_controller_port = 0
+
+[switch.location]
+# possible locations where MGS could be running; these names appear in logs and
+# are used in the remainder of the `[switch.*]` configuration to define port
+# mappings
+names = ["switch0", "switch1"]
+
+# `[[switch.location.determination]]` is a list of switch ports we should
+# contact in order to determine our location; each port defines a subset of
+# `[switch.location.names]` which are the possible location(s) of this MGS
+# instance if the message was received on the given SP port. When MGS starts, it
+# will send a discovery message on each port listed in this section, collect the
+# responses, and determine its location via the intersection of the names listed
+# below (for all ports which returned a successful response). This process can
+# fail if too few SPs respond (leaving us with 2 or more possible locations) or
+# if there is a miscabling that results in an unsolvable system (e.g.,
+# determination 0 reports "switch0" and determination 1 reports "switch1").
+[[switch.location.determination]]
+switch_port = 1
+sp_port_1 = ["switch0"]
+sp_port_2 = ["switch1"]
+
+[[switch.location.determination]]
+switch_port = 2
+sp_port_1 = ["switch0"]
+sp_port_2 = ["switch1"]
+
+# `[[switch.port.*]]` defines the local data link address (in RFD 250 terms, the
+# interface configured to use VLAN tag  assigned to the given port) and the
+# logical ID of the remote SP ("sled 7", "switch 1", etc.), which must have an
+# entry for each member of `[switch.location]` above.
+#
+# TODO This section has some concessions to local testing: ultimately we will
+# use a single multicast address, target port, and source port, but for now all
+# three are configured on a per-port basis, which allows a single system to
+# simulate a full set of ports and SPs.
+[switch.port.0]
+data_link_addr = "[::1]:0"
+multicast_addr = "[::1]:0"
+[switch.port.0.location]
+switch0 = ["switch", 0]
+switch1 = ["switch", 1]
+
+[switch.port.1]
+data_link_addr = "[::1]:0"
+multicast_addr = "[::1]:0"
+[switch.port.1.location]
+switch0 = ["switch", 1]
+switch1 = ["switch", 0]
+
+[switch.port.2]
+data_link_addr = "[::1]:0"
+multicast_addr = "[::1]:0"
+[switch.port.2.location]
+switch0 = ["sled", 0]
+switch1 = ["sled", 0]
+
+[switch.port.3]
+data_link_addr = "[::1]:0"
+multicast_addr = "[::1]:0"
+[switch.port.3.location]
+switch0 = ["sled", 1]
+switch1 = ["sled", 1]
 
 [timeouts]
+discovery_millis = 10_000
 ignition_controller_millis = 10_000
 sp_request_millis = 10_000
 bulk_request_default_millis = 10_000

--- a/gateway/tests/integration_tests/bulk_state_get.rs
+++ b/gateway/tests/integration_tests/bulk_state_get.rs
@@ -10,6 +10,7 @@ use super::SpStateExt;
 use dropshot::test_util;
 use dropshot::Method;
 use dropshot::ResultsPage;
+use gateway_messages::SpPort;
 use http::StatusCode;
 use omicron_gateway::http_entrypoints::SpIdentifier;
 use omicron_gateway::http_entrypoints::SpIgnition;
@@ -34,7 +35,8 @@ macro_rules! assert_eq_unordered {
 
 #[tokio::test]
 async fn bulk_sp_get_all_online() {
-    let testctx = setup::test_setup("bulk_sp_get_all_online").await;
+    let testctx =
+        setup::test_setup("bulk_sp_get_all_online", SpPort::One).await;
     let client = &testctx.client;
 
     // simulator just started; all SPs are online
@@ -58,7 +60,8 @@ async fn bulk_sp_get_all_online() {
 
 #[tokio::test]
 async fn bulk_sp_get_one_sp_powered_off() {
-    let testctx = setup::test_setup("bulk_sp_get_all_online").await;
+    let testctx =
+        setup::test_setup("bulk_sp_get_all_online", SpPort::One).await;
     let client = &testctx.client;
 
     // simulator just started; all SPs are online
@@ -119,7 +122,8 @@ async fn bulk_sp_get_one_sp_powered_off() {
 
 #[tokio::test]
 async fn bulk_sp_get_one_sp_unresponsive() {
-    let testctx = setup::test_setup("bulk_sp_get_all_online").await;
+    let testctx =
+        setup::test_setup("bulk_sp_get_all_online", SpPort::One).await;
     let client = &testctx.client;
 
     // simulator just started; all SPs are online

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use super::setup;
+use dropshot::test_util;
+use gateway_messages::SpPort;
+use omicron_gateway::http_entrypoints::SpInfo;
+use omicron_gateway::http_entrypoints::SpState;
+
+#[tokio::test]
+async fn discovery_both_locations() {
+    let testctx0 =
+        setup::test_setup("discovery_both_locations_0", SpPort::One).await;
+    let testctx1 =
+        setup::test_setup("discovery_both_locations_1", SpPort::Two).await;
+
+    let client0 = &testctx0.client;
+    let client1 = &testctx1.client;
+
+    // the two instances should've discovered that they were switch0 and
+    // switch1, respectively
+    assert_eq!(testctx0.server.apictx.sp_comms.location_name(), "switch0");
+    assert_eq!(testctx1.server.apictx.sp_comms.location_name(), "switch1");
+
+    // both instances should report the same serial number for switch 0 and
+    // switch 1, and it should match the expected values from the config
+    for (switch, expected_serial) in [
+        (0, "00010001000100010001000100010001"),
+        (1, "01000100010001000100010001000100"),
+    ] {
+        for client in [client0, client1] {
+            let url =
+                format!("{}", client0.url(&format!("/sp/switch/{}", switch)));
+
+            let resp: SpInfo = test_util::object_get(client, &url).await;
+            match resp.details {
+                SpState::Enabled { serial_number } => {
+                    assert_eq!(serial_number, expected_serial)
+                }
+                other => panic!("unexpected state {:?}", other),
+            }
+        }
+    }
+
+    testctx0.teardown().await;
+    testctx1.teardown().await;
+}

--- a/gateway/tests/integration_tests/mod.rs
+++ b/gateway/tests/integration_tests/mod.rs
@@ -16,6 +16,7 @@ use sp_sim::SimulatedSp;
 
 mod bulk_state_get;
 mod commands;
+mod location_discovery;
 mod serial_console;
 mod setup;
 

--- a/gateway/tests/integration_tests/serial_console.rs
+++ b/gateway/tests/integration_tests/serial_console.rs
@@ -9,6 +9,7 @@ use super::setup;
 use super::SpStateExt;
 use dropshot::Method;
 use futures::prelude::*;
+use gateway_messages::SpPort;
 use http::uri::Scheme;
 use http::StatusCode;
 use http::Uri;
@@ -59,7 +60,8 @@ async fn sim_sp_serial_console(
 
 #[tokio::test]
 async fn serial_console_communication() {
-    let testctx = setup::test_setup("serial_console_communication").await;
+    let testctx =
+        setup::test_setup("serial_console_communication", SpPort::One).await;
     let client = &testctx.client;
     let simrack = &testctx.simrack;
 
@@ -103,7 +105,8 @@ async fn serial_console_communication() {
 
 #[tokio::test]
 async fn serial_console_detach() {
-    let testctx = setup::test_setup("serial_console_communication").await;
+    let testctx =
+        setup::test_setup("serial_console_communication", SpPort::One).await;
     let client = &testctx.client;
     let simrack = &testctx.simrack;
 

--- a/gateway/tests/integration_tests/setup.rs
+++ b/gateway/tests/integration_tests/setup.rs
@@ -6,12 +6,18 @@
 
 use dropshot::test_util::ClientTestContext;
 use dropshot::test_util::LogContext;
-use gateway_sp_comms::KnownSp;
-use gateway_sp_comms::KnownSps;
+use gateway_messages::SpPort;
+use gateway_sp_comms::SpType;
+use omicron_test_utils::dev::poll;
+use omicron_test_utils::dev::poll::CondCheckError;
 use slog::o;
 use sp_sim::SimRack;
 use sp_sim::SimulatedSp;
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::future;
 use std::path::Path;
+use std::time::Duration;
 use uuid::Uuid;
 
 // TODO this exact value is copy/pasted from `nexus/test-utils` - should we
@@ -45,15 +51,44 @@ pub fn load_test_config() -> (omicron_gateway::Config, sp_sim::Config) {
     (server_config, sp_sim_config)
 }
 
-pub async fn test_setup(test_name: &str) -> GatewayTestContext {
-    let (mut server_config, mut sp_sim_config) = load_test_config();
-    test_setup_with_config(test_name, &mut server_config, &mut sp_sim_config)
-        .await
+pub async fn test_setup(
+    test_name: &str,
+    sp_port: SpPort,
+) -> GatewayTestContext {
+    let (server_config, mut sp_sim_config) = load_test_config();
+    test_setup_with_config(
+        test_name,
+        sp_port,
+        server_config,
+        &mut sp_sim_config,
+    )
+    .await
+}
+
+fn expected_location(
+    config: &omicron_gateway::Config,
+    sp_port: SpPort,
+) -> String {
+    let config = &config.switch.location;
+    let mut locations = config.names.iter().cloned().collect::<HashSet<_>>();
+
+    for determination in &config.determination {
+        let refined = match sp_port {
+            SpPort::One => &determination.sp_port_1,
+            SpPort::Two => &determination.sp_port_2,
+        };
+
+        locations.retain(|name| refined.contains(name));
+    }
+
+    assert_eq!(locations.len(), 1);
+    locations.into_iter().next().unwrap()
 }
 
 pub async fn test_setup_with_config(
     test_name: &str,
-    server_config: &mut omicron_gateway::Config,
+    sp_port: SpPort,
+    mut server_config: omicron_gateway::Config,
     sp_sim_config: &mut sp_sim::Config,
 ) -> GatewayTestContext {
     // Use log settings from the server config and ignore log settings in
@@ -64,35 +99,65 @@ pub async fn test_setup_with_config(
     // Start fake rack of simulated SPs
     let simrack = SimRack::start(sp_sim_config, log).await.unwrap();
 
-    // Update gateway config to match the simulated rack.
-    let sidecars = simrack
-        .sidecars
-        .iter()
-        .map(|simsp| KnownSp {
-            sp: simsp.local_addr(0),
-            switch_port: "[::1]:0".parse().unwrap(),
-        })
-        .collect::<Vec<_>>();
-    let gimlets = simrack
-        .gimlets
-        .iter()
-        .map(|simsp| KnownSp {
-            sp: simsp.local_addr(0),
-            switch_port: "[::1]:0".parse().unwrap(),
-        })
-        .collect::<Vec<_>>();
-    server_config.known_sps = KnownSps {
-        switches: sidecars,
-        sleds: gimlets,
-        power_controllers: vec![], // TODO
-    };
+    let expected_location = expected_location(&server_config, sp_port);
+
+    // Update multicast addrs of `server_config` to point to the SP ports that
+    // will identify us as the expected location
+    for port_config in server_config.switch.port.values_mut() {
+        // we need to know whether this port points to a switch or sled; for now
+        // assume that matches whether we end up as `switch0` or `switch1`
+        let target_sp = port_config.location.get(&expected_location).unwrap();
+        let sp_addr = match target_sp.typ {
+            SpType::Switch => {
+                simrack.sidecars[target_sp.slot].local_addr(sp_port)
+            }
+            SpType::Sled => simrack.gimlets[target_sp.slot].local_addr(sp_port),
+            SpType::Power => todo!(),
+        };
+        port_config.multicast_addr.set_port(sp_addr.port());
+    }
 
     // Start gateway server
     let rack_id = Uuid::parse_str(RACK_UUID).unwrap();
 
-    let server = omicron_gateway::Server::start(server_config, rack_id, log)
-        .await
-        .unwrap();
+    let server =
+        omicron_gateway::Server::start(server_config.clone(), rack_id, log)
+            .await
+            .unwrap();
+
+    // Make sure it discovered the location we expect
+    assert_eq!(server.apictx.sp_comms.location_name(), expected_location);
+
+    // Build a list of all SPs defined in our config
+    let mut all_sp_ids = Vec::new();
+    for port_config in server_config.switch.port.values() {
+        all_sp_ids.push(
+            port_config
+                .location
+                .get(server.apictx.sp_comms.location_name())
+                .copied()
+                .unwrap(),
+        );
+    }
+
+    // Wait until the server has figured out the socket address of all those SPs
+    poll::wait_for_condition::<(), Infallible, _, _>(
+        || {
+            let comms = &server.apictx.sp_comms;
+            let result = if comms.local_ignition_controller_address_known()
+                && all_sp_ids.iter().all(|&id| comms.address_known(id))
+            {
+                Ok(())
+            } else {
+                Err(CondCheckError::NotYet)
+            };
+            future::ready(result)
+        },
+        &Duration::from_millis(100),
+        &Duration::from_secs(1),
+    )
+    .await
+    .unwrap();
 
     let client = ClientTestContext::new(
         server.http_server.local_addr(),

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -12,6 +12,11 @@ multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
+[[simulated_sps.sidecar]]
+multicast_addr = "::1"
+bind_addrs = ["[::1]:0", "[::1]:0"]
+serial_number = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -4,12 +4,12 @@
 
 [[simulated_sps.sidecar]]
 multicast_addr = "ff15:0:1de::0"
-bind_addrs = ["[::1]:33300", "[::1]:33301"]
+bind_addrs = ["[::]:33300", "[::]:33301"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::1"
-bind_addrs = ["[::1]:33310", "[::1]:33311"]
+bind_addrs = ["[::]:33310", "[::]:33311"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 [[simulated_sps.gimlet.components]]
 name = "sp3"
@@ -17,7 +17,7 @@ serial_console = "[::1]:33312"
 
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::2"
-bind_addrs = ["[::1]:33320", "[::1]:33321"]
+bind_addrs = ["[::]:33320", "[::]:33321"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
 [[simulated_sps.gimlet.components]]
 name = "sp3"

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -56,8 +56,12 @@ impl SimulatedSp for Gimlet {
         hex::encode(self.serial_number)
     }
 
-    fn local_addr(&self, port: usize) -> SocketAddr {
-        self.local_addrs[port]
+    fn local_addr(&self, port: SpPort) -> SocketAddr {
+        let i = match port {
+            SpPort::One => 0,
+            SpPort::Two => 1,
+        };
+        self.local_addrs[i]
     }
 
     async fn set_responsiveness(&self, r: Responsiveness) {

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -10,6 +10,7 @@ mod sidecar;
 pub use anyhow::Result;
 use async_trait::async_trait;
 pub use config::Config;
+use gateway_messages::SpPort;
 pub use gimlet::Gimlet;
 pub use server::logger;
 pub use sidecar::Sidecar;
@@ -32,7 +33,7 @@ pub trait SimulatedSp {
     /// Hexlified serial number.
     fn serial_number(&self) -> String;
     /// Listening UDP address of the given port of this simulated SP.
-    fn local_addr(&self, port: usize) -> SocketAddr;
+    fn local_addr(&self, port: SpPort) -> SocketAddr;
     /// Simulate the SP being unresponsive, in which it ignores all incoming
     /// messages.
     async fn set_responsiveness(&self, r: Responsiveness);

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -56,8 +56,12 @@ impl SimulatedSp for Sidecar {
         hex::encode(self.serial_number)
     }
 
-    fn local_addr(&self, port: usize) -> SocketAddr {
-        self.local_addrs[port]
+    fn local_addr(&self, port: SpPort) -> SocketAddr {
+        let i = match port {
+            SpPort::One => 0,
+            SpPort::Two => 1,
+        };
+        self.local_addrs[i]
     }
 
     async fn set_responsiveness(&self, r: Responsiveness) {


### PR DESCRIPTION
This PR builds on #933 and is the third of three providing a preliminary implementation of [RFD 250](https://rfd.shared.oxide.computer/rfd/0250)-style SP and location discovery.

This PR removes the placeholder `KnownSps` and related types. MGS now runs the discovery process introduced in #933 on startup and uses those results to identify mappings. The `gateway/tests/integration_tests/location_discovery.rs` integration test shows starting two instances of MGS: one infers itself to be sidecar-a and the other sidecar-b, and critically they both agree on which SPs correspond to "switch 0" and "switch 1".