### PR TITLE
ResourceType::ConsoleSessionList is not needed

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -517,7 +517,6 @@ pub enum ResourceType {
     Silo,
     SiloUser,
     ConsoleSession,
-    ConsoleSessionList,
     Organization,
     Project,
     Dataset,


### PR DESCRIPTION
This was an oversight.