### PR TITLE
[config] Make the Omicron configuration more durable

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -52,4 +52,4 @@ macro_rules! generate_logging_api {
 ///
 /// NOTE: Be careful when modifying this path - the installation tools will
 /// **remove the entire directory** to re-install/uninstall the system.
-pub const OMICRON_CONFIG_PATH: &'static str = "/var/tmp/oxide";
+pub const OMICRON_CONFIG_PATH: &'static str = "/var/oxide";


### PR DESCRIPTION
Update the path from `/var/tmp/oxide` to `/var/oxide`. The install / uninstall tools are automatically handling cleaning out this directory, so it's safe to use a longer-lived directory.