### PR TITLE
MGS: Improve error messages when we timeout waiting for an SP

### DIFF
--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -8,6 +8,7 @@ use crate::SpIdentifier;
 use gateway_messages::ResponseError;
 use std::io;
 use std::net::SocketAddr;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -26,8 +27,8 @@ pub enum Error {
         .0.slot,
     )]
     SpAddressUnknown(SpIdentifier),
-    #[error("timeout elapsed")]
-    Timeout,
+    #[error("timeout ({timeout:?}) elapsed communicating with {sp:?}")]
+    Timeout { timeout: Duration, sp: SpIdentifier },
     #[error("error communicating with SP: {0}")]
     SpCommunicationFailed(#[from] SpCommunicationError),
     #[error("serial console is already attached")]
@@ -53,10 +54,4 @@ pub enum SpCommunicationError {
 pub struct BadResponseType {
     pub expected: &'static str,
     pub got: &'static str,
-}
-
-impl From<tokio::time::error::Elapsed> for Error {
-    fn from(_: tokio::time::error::Elapsed) -> Self {
-        Self::Timeout
-    }
 }

--- a/gateway-sp-comms/src/lib.rs
+++ b/gateway-sp-comms/src/lib.rs
@@ -16,6 +16,7 @@
 mod communicator;
 mod management_switch;
 mod recv_handler;
+mod timeout;
 
 pub use usdt::register_probes;
 
@@ -25,6 +26,8 @@ pub use communicator::Communicator;
 pub use communicator::FuturesUnorderedImpl;
 pub use management_switch::SpIdentifier;
 pub use management_switch::SpType;
+pub use timeout::Elapsed;
+pub use timeout::Timeout;
 
 // TODO these will remain public for a while, but eventually will be removed
 // altogther; currently these provide a way to hard-code the rack topology,

--- a/gateway-sp-comms/src/recv_handler/mod.rs
+++ b/gateway-sp-comms/src/recv_handler/mod.rs
@@ -9,6 +9,7 @@ use crate::management_switch::ManagementSwitch;
 use crate::management_switch::ManagementSwitchDiscovery;
 use crate::management_switch::SwitchPort;
 use crate::Communicator;
+use crate::Timeout;
 use futures::future::Fuse;
 use futures::FutureExt;
 use futures::SinkExt;
@@ -414,7 +415,7 @@ impl SerialConsoleTask {
                     .serial_console_send_packet(
                         self.port,
                         packet,
-                        tokio::time::Instant::now() + self.sp_ack_timeout,
+                        Timeout::from_now(self.sp_ack_timeout),
                     )
                     .map_ok(move |()| packet_data_len)
                     .fuse();

--- a/gateway-sp-comms/src/timeout.rs
+++ b/gateway-sp-comms/src/timeout.rs
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use futures::Future;
+use futures::TryFutureExt;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// Error type returned from [`Timeout::timeout_at()`].
+#[derive(Debug, Clone, Copy)]
+pub struct Elapsed(pub Timeout);
+
+impl Elapsed {
+    /// Get the duration of the timeout that elapsed.
+    pub fn duration(&self) -> Duration {
+        self.0.duration()
+    }
+}
+
+/// Representation of a timeout as both its starting time and its duration.
+#[derive(Debug, Clone, Copy)]
+pub struct Timeout {
+    start: Instant,
+    duration: Duration,
+}
+
+impl Timeout {
+    /// Create a new `Timeout` with the given duration starting from
+    /// [`Instant::now()`].
+    pub fn from_now(duration: Duration) -> Self {
+        Self { start: Instant::now(), duration }
+    }
+
+    /// Get the [`Instant`] when this timeout expires.
+    pub fn end(&self) -> Instant {
+        self.start + self.duration
+    }
+
+    /// Get the duration of this timeout.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Wrap a future with this timeout.
+    pub fn timeout_at<T>(
+        self,
+        future: T,
+    ) -> impl Future<Output = Result<T::Output, Elapsed>>
+    where
+        T: Future,
+    {
+        tokio::time::timeout_at(self.end(), future)
+            .map_err(move |_| Elapsed(self))
+    }
+}

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -56,7 +56,7 @@ where
             err.to_string(),
         ),
         SpCommsError::SpAddressUnknown(_)
-        | SpCommsError::Timeout
+        | SpCommsError::Timeout { .. }
         | SpCommsError::SpCommunicationFailed(_) => {
             HttpError::for_internal_error(err.to_string())
         }

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -28,11 +28,11 @@ use dropshot::TypedBody;
 use dropshot::WhichPage;
 use gateway_messages::IgnitionCommand;
 use gateway_sp_comms::error::Error as SpCommsError;
+use gateway_sp_comms::Timeout as SpTimeout;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::Instant;
 
 #[derive(
     Debug,
@@ -268,7 +268,7 @@ async fn sp_list(
                 .unwrap_or(apictx.timeouts.bulk_request_default)
                 // TODO do we also want a floor for the timeout?
                 .min(apictx.timeouts.bulk_request_max);
-            let timeout = Instant::now() + timeout;
+            let timeout = SpTimeout::from_now(timeout);
 
             let request_id = apictx
                 .bulk_sp_state_requests
@@ -290,7 +290,7 @@ async fn sp_list(
         .get(
             &request_id,
             last_seen_target.map(Into::into),
-            Instant::now() + apictx.timeouts.bulk_request_page,
+            SpTimeout::from_now(apictx.timeouts.bulk_request_page),
             page_limit,
         )
         .await?;
@@ -316,7 +316,7 @@ async fn sp_list(
                     // TODO Treating "communication failed" and "we don't know
                     // the IP address" as "unresponsive" may not be right. Do we
                     // need more refined errors?
-                    SpCommsError::Timeout
+                    SpCommsError::Timeout { .. }
                     | SpCommsError::SpCommunicationFailed(_)
                     | SpCommsError::SpAddressUnknown(_) => {
                         SpState::Unresponsive
@@ -369,12 +369,13 @@ async fn sp_get(
     // putting it here, the time it takes us to query ignition counts against
     // the client's timeout; that seems right but puts us in a bind if their
     // timeout expires while we're still waiting for ignition.
-    let timeout = Instant::now()
-        + query
+    let timeout = SpTimeout::from_now(
+        query
             .into_inner()
             .timeout_millis
             .map(|n| Duration::from_millis(u64::from(n)))
-            .unwrap_or(apictx.timeouts.sp_request);
+            .unwrap_or(apictx.timeouts.sp_request),
+    );
 
     // ping the ignition controller first; if it says the SP is off or otherwise
     // unavailable, we're done.
@@ -387,7 +388,7 @@ async fn sp_get(
         // ignition indicates the SP is on; ask it for its state
         match comms.get_state(sp.into(), timeout).await {
             Ok(state) => SpState::from(state),
-            Err(SpCommsError::Timeout) => SpState::Unresponsive,
+            Err(SpCommsError::Timeout { .. }) => SpState::Unresponsive,
             Err(other) => return Err(http_err_from_comms_err(other)),
         }
     } else {
@@ -569,9 +570,9 @@ async fn ignition_list(
     let sp_comms = &apictx.sp_comms;
 
     let all_state = sp_comms
-        .get_ignition_state_all(
-            Instant::now() + apictx.timeouts.ignition_controller,
-        )
+        .get_ignition_state_all(SpTimeout::from_now(
+            apictx.timeouts.ignition_controller,
+        ))
         .await
         .map_err(http_err_from_comms_err)?;
 
@@ -602,7 +603,7 @@ async fn ignition_get(
         .sp_comms
         .get_ignition_state(
             sp.into(),
-            Instant::now() + apictx.timeouts.ignition_controller,
+            SpTimeout::from_now(apictx.timeouts.ignition_controller),
         )
         .await
         .map_err(http_err_from_comms_err)?;
@@ -628,7 +629,7 @@ async fn ignition_power_on(
         .send_ignition_command(
             sp.into(),
             IgnitionCommand::PowerOn,
-            Instant::now() + apictx.timeouts.ignition_controller,
+            SpTimeout::from_now(apictx.timeouts.ignition_controller),
         )
         .await
         .map_err(http_err_from_comms_err)?;
@@ -653,7 +654,7 @@ async fn ignition_power_off(
         .send_ignition_command(
             sp.into(),
             IgnitionCommand::PowerOff,
-            Instant::now() + apictx.timeouts.ignition_controller,
+            SpTimeout::from_now(apictx.timeouts.ignition_controller),
         )
         .await
         .map_err(http_err_from_comms_err)?;

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -13,12 +13,12 @@ sleds = []
 power_controllers = []
 
 [timeouts]
-ignition_controller_millis = 500
-sp_request_millis = 500
-bulk_request_default_millis = 1_000
-bulk_request_max_millis = 2_000
-bulk_request_page_millis = 500
-bulk_request_retain_grace_period_millis = 2_000
+ignition_controller_millis = 10_000
+sp_request_millis = 10_000
+bulk_request_default_millis = 20_000
+bulk_request_max_millis = 40_000
+bulk_request_page_millis = 10_000
+bulk_request_retain_grace_period_millis = 10_000
 
 #
 # NOTE: for the test suite, the port MUST be 0 (in order to bind to any


### PR DESCRIPTION
This should address #951:

1. Timeout log messages now include both the timeout duration and the SP we timed out waiting for; what was previously

```
error_message_internal="timeout elapsed"
```

is now something like

```
"error_message_internal":"timeout (500ms) elapsed communicating with SpIdentifier { typ: Switch, slot: 0 }"
```

2. Increase the timeouts for communication with simulated SPs during integration tests.

I don't love the latter of those at all - "flaky test with a timeout? increase the timeout" feels awful. But I'm not sure what a reasonable alternative is in this case. Since MGS is communicating with SPs over UDP, it has to have timeouts waiting for responses from those SPs, and the integration tests therefore inherently have those timeouts. This PR feels like it bumps them up to "surely we'll never hit these even in CI runners" territory, but if there are better alternatives I'd be happy to pursue them.