### PR TITLE
SSH public keys

### DIFF
--- a/common/src/api/external/error.rs
+++ b/common/src/api/external/error.rs
@@ -93,6 +93,12 @@ impl From<&Name> for LookupType {
     }
 }
 
+impl From<Uuid> for LookupType {
+    fn from(uuid: Uuid) -> Self {
+        LookupType::ById(uuid)
+    }
+}
+
 impl Error {
     /// Returns whether the error is likely transient and could reasonably be
     /// retried

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -516,6 +516,7 @@ pub enum ResourceType {
     Fleet,
     Silo,
     SiloUser,
+    SshKey,
     ConsoleSession,
     Organization,
     Project,

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -217,6 +217,33 @@ CREATE TABLE omicron.public.silo_user (
 );
 
 /*
+ * Users' public SSH keys, per RFD 44
+ */
+CREATE TABLE omicron.public.ssh_key (
+    id UUID PRIMARY KEY,
+    name STRING(63) NOT NULL,
+    description STRING(512) NOT NULL,
+    time_created TIMESTAMPTZ NOT NULL,
+    time_modified TIMESTAMPTZ NOT NULL,
+    time_deleted TIMESTAMPTZ,
+
+    /* FK into silo_user table */
+    silo_user_id UUID NOT NULL,
+
+    /*
+     * A 4096 bit RSA key without comment encodes to 726 ASCII characters.
+     * A (256 bit) Ed25519 key w/o comment encodes to 82 ASCII characters.
+     */
+    public_key STRING(1023) NOT NULL
+);
+
+CREATE UNIQUE INDEX ON omicron.public.ssh_key (
+    silo_user_id,
+    name
+) WHERE
+    time_deleted IS NULL;
+
+/*
  * Organizations
  */
 

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -335,14 +335,6 @@ authz_resource! {
 }
 
 authz_resource! {
-    name = "SiloUser",
-    parent = "Fleet",
-    primary_key = Uuid,
-    roles_allowed = false,
-    polar_snippet = FleetChild,
-}
-
-authz_resource! {
     name = "RoleBuiltin",
     parent = "Fleet",
     primary_key = (String, String),
@@ -371,6 +363,22 @@ authz_resource! {
     parent = "Fleet",
     primary_key = Uuid,
     roles_allowed = true,
+    polar_snippet = Custom,
+}
+
+authz_resource! {
+    name = "SiloUser",
+    parent = "Silo",
+    primary_key = Uuid,
+    roles_allowed = false,
+    polar_snippet = Custom,
+}
+
+authz_resource! {
+    name = "SshKey",
+    parent = "SiloUser",
+    primary_key = Uuid,
+    roles_allowed = false,
     polar_snippet = Custom,
 }
 

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -260,19 +260,12 @@ resource SiloUser {
 	    "read",
 	    "create_child",
 	];
-	roles = [ "admin", "collaborator", "viewer" ];
-
-	"list_children" if "viewer";
-	"read" if "viewer";
-	"viewer" if "collaborator";
-	"create_child" if "collaborator";
-	"collaborator" if "admin";
-	"modify" if "admin";
-
 	relations = { parent_silo: Silo };
-	"admin" if "admin" on "parent_silo";
-	"collaborator" if "collaborator" on "parent_silo";
-	"viewer" if "viewer" on "parent_silo";
+
+	"list_children" if "viewer" on "parent_silo";
+	"read" if "viewer" on "parent_silo";
+	"modify" if "admin" on "parent_silo";
+	"create_child" if "admin" on "parent_silo";
 }
 has_relation(silo: Silo, "parent_silo", user: SiloUser)
 	if user.silo = silo;

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -230,8 +230,29 @@ has_relation(fleet: Fleet, "parent_fleet", collection: ConsoleSessionList)
 # read silo users and modify their sessions.  This is necessary for login to
 # work.
 has_permission(actor: AuthenticatedActor, "read", user: SiloUser)
-	if has_role(actor, "external-authenticator", user.fleet);
+	if has_role(actor, "external-authenticator", user.silo.fleet);
 has_permission(actor: AuthenticatedActor, "read", session: ConsoleSession)
 	if has_role(actor, "external-authenticator", session.fleet);
 has_permission(actor: AuthenticatedActor, "modify", session: ConsoleSession)
 	if has_role(actor, "external-authenticator", session.fleet);
+
+resource SiloUser {
+	permissions = [ "read", "modify", "create_child" ];
+        relations = { parent_silo: Silo };
+
+        "read" if "read" on "parent_silo";
+        "modify" if "modify" on "parent_silo";
+        "create_child" if "create_child" on "parent_silo";
+}
+has_relation(silo: Silo, "parent_silo", user: SiloUser)
+	if user.silo = silo;
+
+resource SshKey {
+	permissions = [ "read", "modify" ];
+	relations = { silo_user: SiloUser };
+
+	"read" if "read" on "silo_user";
+	"modify" if "modify" on "silo_user";
+}
+has_relation(user: SiloUser, "silo_user", ssh_key: SshKey)
+	if ssh_key.silo_user = user;

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -237,12 +237,25 @@ has_permission(actor: AuthenticatedActor, "modify", session: ConsoleSession)
 	if has_role(actor, "external-authenticator", session.fleet);
 
 resource SiloUser {
-	permissions = [ "read", "modify", "create_child" ];
-        relations = { parent_silo: Silo };
+	permissions = [
+	    "list_children",
+	    "modify",
+	    "read",
+	    "create_child",
+	];
+	roles = [ "admin", "collaborator", "viewer" ];
 
-        "read" if "read" on "parent_silo";
-        "modify" if "modify" on "parent_silo";
-        "create_child" if "create_child" on "parent_silo";
+	"list_children" if "viewer";
+	"read" if "viewer";
+	"viewer" if "collaborator";
+	"create_child" if "collaborator";
+	"collaborator" if "admin";
+	"modify" if "admin";
+
+	relations = { parent_silo: Silo };
+	"admin" if "admin" on "parent_silo";
+	"collaborator" if "collaborator" on "parent_silo";
+	"viewer" if "viewer" on "parent_silo";
 }
 has_relation(silo: Silo, "parent_silo", user: SiloUser)
 	if user.silo = silo;

--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -65,6 +65,7 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<Oso, anyhow::Error> {
         ConsoleSession::init(),
         Rack::init(),
         RoleBuiltin::init(),
+        SshKey::init(),
         Silo::init(),
         SiloUser::init(),
         Sled::init(),

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2864,10 +2864,7 @@ mod test {
 
         // Associate silo with user
         let silo_user = datastore
-            .silo_user_create(SiloUser::new(
-                *SILO_ID,
-                silo_user_id,
-            ))
+            .silo_user_create(SiloUser::new(*SILO_ID, silo_user_id))
             .await
             .unwrap();
 

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2685,11 +2685,11 @@ impl DataStore {
     pub async fn ssh_keys_list(
         &self,
         silo_user_id: Uuid,
-        page_params: &DataPageParams<'_, Uuid>,
+        page_params: &DataPageParams<'_, Name>,
     ) -> ListResultVec<SshKey> {
         use db::schema::ssh_key::dsl;
 
-        paginated(dsl::ssh_key, dsl::id, page_params)
+        paginated(dsl::ssh_key, dsl::name, page_params)
             .filter(dsl::silo_user_id.eq(silo_user_id))
             .filter(dsl::time_deleted.is_null())
             .select(SshKey::as_select())

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2779,6 +2779,8 @@ impl DataStore {
         authz_user: &authz::SiloUser,
         page_params: &DataPageParams<'_, Name>,
     ) -> ListResultVec<SshKey> {
+        opctx.authorize(authz::Action::ListChildren, authz_user).await?;
+
         use db::schema::ssh_key::dsl;
         paginated(dsl::ssh_key, dsl::name, page_params)
             .filter(dsl::silo_user_id.eq(authz_user.id()))

--- a/nexus/src/db/db-macros/src/lookup.rs
+++ b/nexus/src/db/db-macros/src/lookup.rs
@@ -340,7 +340,7 @@ fn generate_misc_helpers(config: &Config) -> TokenStream {
                 if let Err(_) = &maybe_silo {
                     error!(
                         log,
-                        "unexpected successful lookup of siloed resource\
+                        "unexpected successful lookup of siloed resource \
                         {:?} with no silo in OpContext",
                         #resource_name_str,
                     );

--- a/nexus/src/db/db-macros/src/lookup.rs
+++ b/nexus/src/db/db-macros/src/lookup.rs
@@ -352,8 +352,8 @@ fn generate_misc_helpers(config: &Config) -> TokenStream {
                     use crate::authz::ApiResourceError;
                     error!(
                         log,
-                        "unexpected successful lookup of siloed resource\
-                        {:?} in a different Silo from current actor (resource\
+                        "unexpected successful lookup of siloed resource \
+                        {:?} in a different Silo from current actor (resource \
                         Silo {}, actor Silo {})",
                         #resource_name_str,
                         resource_silo_id,

--- a/nexus/src/db/lookup.rs
+++ b/nexus/src/db/lookup.rs
@@ -325,31 +325,6 @@ impl<'a> LookupPath<'a> {
         Sled { key: SledKey::PrimaryKey(Root { lookup_root: self }, id) }
     }
 
-    /// Select a resource of type SshKey, identified by its id
-    pub fn ssh_key_id(self, id: Uuid) -> SshKey<'a> {
-        SshKey { key: SshKeyKey::PrimaryKey(Root { lookup_root: self }, id) }
-    }
-
-    /// Select a resource of type SshKey, identified by its name
-    pub fn ssh_key_name<'b, 'c>(self, name: &'b Name) -> SshKey<'c>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        let key = match self.opctx.authn.actor_required() {
-            Ok(actor) => {
-                let root = Root { lookup_root: self };
-                let silo_user_key = SiloUserKey::PrimaryKey(root, actor.id);
-                SshKeyKey::Name(SiloUser { key: silo_user_key }, name)
-            }
-            Err(error) => {
-                let root = Root { lookup_root: self };
-                SshKeyKey::Error(root, error)
-            }
-        };
-        SshKey { key }
-    }
-
     /// Select a resource of type UpdateAvailableArtifact, identified by its
     /// `(name, version, kind)` tuple
     pub fn update_available_artifact_tuple(

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -11,7 +11,7 @@ use crate::db::schema::{
     console_session, dataset, disk, image, instance, metric_producer,
     network_interface, organization, oximeter, project, rack, region,
     role_assignment_builtin, role_builtin, router_route, silo, silo_user, sled,
-    snapshot, update_available_artifact, user_builtin, volume, vpc,
+    snapshot, ssh_key, update_available_artifact, user_builtin, volume, vpc,
     vpc_firewall_rule, vpc_router, vpc_subnet, zpool,
 };
 use crate::defaults;
@@ -993,6 +993,32 @@ impl SiloUser {
             identity: SiloUserIdentity::new(user_id),
             silo_id,
             time_deleted: None,
+        }
+    }
+}
+
+/// Describes a user's public SSH key within the database.
+#[derive(Clone, Debug, Insertable, Queryable, Resource, Selectable)]
+#[table_name = "ssh_key"]
+pub struct SshKey {
+    #[diesel(embed)]
+    identity: SshKeyIdentity,
+
+    pub silo_user_id: Uuid,
+    pub public_key: String,
+}
+
+impl SshKey {
+    pub fn new(silo_user_id: Uuid, params: params::SshKeyCreate) -> Self {
+        Self::new_with_id(Uuid::new_v4(), silo_user_id, params)
+    }
+
+
+    pub fn new_with_id(id: Uuid, silo_user_id: Uuid, params: params::SshKeyCreate) -> Self {
+        Self {
+            identity: SshKeyIdentity::new(id, params.identity),
+            silo_user_id,
+            public_key: params.public_key,
         }
     }
 }

--- a/nexus/src/db/model.rs
+++ b/nexus/src/db/model.rs
@@ -1013,8 +1013,11 @@ impl SshKey {
         Self::new_with_id(Uuid::new_v4(), silo_user_id, params)
     }
 
-
-    pub fn new_with_id(id: Uuid, silo_user_id: Uuid, params: params::SshKeyCreate) -> Self {
+    pub fn new_with_id(
+        id: Uuid,
+        silo_user_id: Uuid,
+        params: params::SshKeyCreate,
+    ) -> Self {
         Self {
             identity: SshKeyIdentity::new(id, params.identity),
             silo_user_id,

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -138,6 +138,19 @@ table! {
 }
 
 table! {
+    ssh_key (id) {
+        id -> Uuid,
+        name -> Text,
+        description -> Text,
+        time_created -> Timestamptz,
+        time_modified -> Timestamptz,
+        time_deleted -> Nullable<Timestamptz>,
+        silo_user_id -> Uuid,
+        public_key -> Text,
+    }
+}
+
+table! {
     organization (id) {
         id -> Uuid,
         silo_id -> Uuid,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -11,8 +11,8 @@ use crate::ServerContext;
 use super::{
     console_api, params,
     views::{
-        Image, Organization, Project, Rack, Role, Silo, Sled, Snapshot, User,
-        Vpc, VpcRouter, VpcSubnet,
+        Image, Organization, Project, Rack, Role, Silo, Sled, Snapshot, SshKey,
+        User, Vpc, VpcRouter, VpcSubnet,
     },
 };
 use crate::context::OpContext;
@@ -173,6 +173,11 @@ pub fn external_api() -> NexusApiDescription {
 
         api.register(roles_get)?;
         api.register(roles_get_role)?;
+
+        api.register(sshkeys_get)?;
+        api.register(sshkeys_get_key)?;
+        api.register(sshkeys_post)?;
+        api.register(sshkeys_delete_key)?;
 
         api.register(console_api::spoof_login)?;
         api.register(console_api::spoof_login_form)?;
@@ -2849,6 +2854,114 @@ async fn roles_get_role(
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let role = nexus.role_builtin_fetch(&opctx, &role_name).await?;
         Ok(HttpResponseOk(role.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+// Per-user SSH public keys
+
+/// List the current user's SSH public keys
+#[endpoint {
+    method = GET,
+    path = "/session/me/sshkeys",
+    tags = ["sshkeys"],
+}]
+async fn sshkeys_get(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    query_params: Query<PaginatedById>,
+) -> Result<HttpResponseOk<ResultsPage<SshKey>>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let query = query_params.into_inner();
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let &actor = opctx.authn.actor_required()?;
+        let silo_user_id = actor.id;
+        let ssh_keys = nexus
+            .ssh_keys_list(
+                &opctx,
+                silo_user_id,
+                &data_page_params_for(&rqctx, &query)?
+            )
+            .await?
+            .into_iter()
+            .map(SshKey::from)
+            .collect::<Vec<SshKey>>();
+        Ok(HttpResponseOk(ScanById::results_page(&query, ssh_keys)?))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Create a new SSH public key for the current user
+#[endpoint {
+    method = POST,
+    path = "/session/me/sshkeys",
+    tags = ["sshkeys"],
+}]
+async fn sshkeys_post(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    new_key: TypedBody<params::SshKeyCreate>,
+) -> Result<HttpResponseOk<SshKey>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let &actor = opctx.authn.actor_required()?;
+        let silo_user_id = actor.id;
+        let ssh_key = nexus
+            .ssh_key_create(&opctx, silo_user_id, new_key.into_inner())
+            .await?;
+        Ok(HttpResponseOk(ssh_key.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Path parameters for SSH key requests by name
+#[derive(Deserialize, JsonSchema)]
+struct SshKeyPathParams {
+    ssh_key_name: Name,
+}
+
+/// Get (by name) an SSH public key belonging to the current user
+#[endpoint {
+    method = GET,
+    path = "/session/me/sshkeys/{ssh_key_name}",
+    tags = ["sshkeys"],
+}]
+async fn sshkeys_get_key(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path_params: Path<SshKeyPathParams>,
+) -> Result<HttpResponseOk<SshKey>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+    let ssh_key_name = &path.ssh_key_name;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let ssh_key = nexus.ssh_key_fetch(&opctx, ssh_key_name).await?;
+        Ok(HttpResponseOk(ssh_key.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Delete (by name) an SSH public key belonging to the current user
+#[endpoint {
+    method = DELETE,
+    path = "/session/me/sshkeys/{ssh_key_name}",
+    tags = ["sshkeys"],
+}]
+async fn sshkeys_delete_key(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path_params: Path<SshKeyPathParams>,
+) -> Result<HttpResponseDeleted, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+    let ssh_key_name = &path.ssh_key_name;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        nexus.ssh_key_delete(&opctx, ssh_key_name).await?;
+        Ok(HttpResponseDeleted())
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2881,7 +2881,7 @@ async fn sshkeys_get(
             .ssh_keys_list(
                 &opctx,
                 silo_user_id,
-                &data_page_params_for(&rqctx, &query)?
+                &data_page_params_for(&rqctx, &query)?,
             )
             .await?
             .into_iter()

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2877,11 +2877,10 @@ async fn sshkeys_get(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
         let page_params =
             data_page_params_for(&rqctx, &query)?.map_name(Name::ref_cast);
         let ssh_keys = nexus
-            .ssh_keys_list(&opctx, &authz_user, &page_params)
+            .ssh_keys_list(&opctx, actor.id, &page_params)
             .await?
             .into_iter()
             .map(SshKey::from)
@@ -2906,9 +2905,8 @@ async fn sshkeys_post(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
         let ssh_key = nexus
-            .ssh_key_create(&opctx, &authz_user, new_key.into_inner())
+            .ssh_key_create(&opctx, actor.id, new_key.into_inner())
             .await?;
         Ok(HttpResponseCreated(ssh_key.into()))
     };
@@ -2938,9 +2936,8 @@ async fn sshkeys_get_key(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
         let ssh_key =
-            nexus.ssh_key_fetch(&opctx, &authz_user, ssh_key_name).await?;
+            nexus.ssh_key_fetch(&opctx, actor.id, ssh_key_name).await?;
         Ok(HttpResponseOk(ssh_key.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2963,8 +2960,7 @@ async fn sshkeys_delete_key(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
-        nexus.ssh_key_delete(&opctx, &authz_user, ssh_key_name).await?;
+        nexus.ssh_key_delete(&opctx, actor.id, ssh_key_name).await?;
         Ok(HttpResponseDeleted())
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2876,11 +2876,11 @@ async fn sshkeys_get(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let silo_user_id = actor.id;
+        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
         let page_params =
             data_page_params_for(&rqctx, &query)?.map_name(Name::ref_cast);
         let ssh_keys = nexus
-            .ssh_keys_list(&opctx, silo_user_id, &page_params)
+            .ssh_keys_list(&opctx, &authz_user, &page_params)
             .await?
             .into_iter()
             .map(SshKey::from)
@@ -2905,9 +2905,9 @@ async fn sshkeys_post(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
-        let silo_user_id = actor.id;
+        let (authz_user, _) = nexus.silo_user_fetch(&opctx, actor.id).await?;
         let ssh_key = nexus
-            .ssh_key_create(&opctx, silo_user_id, new_key.into_inner())
+            .ssh_key_create(&opctx, &authz_user, new_key.into_inner())
             .await?;
         Ok(HttpResponseCreated(ssh_key.into()))
     };

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -439,11 +439,14 @@ pub struct UserBuiltinCreate {
 // and so have an implicit silo user ID which must be passed seperately
 // to the creation routine. Note that this disagrees with RFD 44.
 
+/// Create-time parameters for an [`SshKey`](crate::external_api::views::SshKey)
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SshKeyCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    pub public_key: String, // e.g., "ssh-ed25519 AAAAC3NzaC..."
+
+    /// SSH public key, e.g., `"ssh-ed25519 AAAAC3NzaC..."`
+    pub public_key: String,
 }
 
 #[cfg(test)]

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -433,6 +433,19 @@ pub struct UserBuiltinCreate {
     pub identity: IdentityMetadataCreateParams,
 }
 
+// SSH PUBLIC KEYS
+//
+// The SSH key mangement endpoints are currently under `/session/me`,
+// and so have an implicit silo user ID which must be passed seperately
+// to the creation routine. Note that this disagrees with RFD 44.
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SshKeyCreate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataCreateParams,
+    pub public_key: String, // e.g., "ssh-ed25519 AAAAC3NzaC..."
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/nexus/src/external_api/tag-config.json
+++ b/nexus/src/external_api/tag-config.json
@@ -104,6 +104,12 @@
         "url": "http://oxide.computer/docs/#xxx"
       }
     },
+    "sshkeys": {
+      "description": "Public SSH keys for an individual user",
+      "external_docs": {
+        "url": "http://oxide.computer/docs/#xxx"
+      }
+    },
     "subnets": {
       "description": "This tag should be moved into a generic network tag",
       "external_docs": {

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -289,9 +289,11 @@ impl From<model::RoleBuiltin> for Role {
 pub struct SshKey {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
+
     /// The user to whom this key belongs
     pub silo_user_id: Uuid,
-    /// The SSH public key
+
+    /// SSH public key, e.g., `"ssh-ed25519 AAAAC3NzaC..."`
     pub public_key: String,
 }
 

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -281,3 +281,26 @@ impl From<model::RoleBuiltin> for Role {
         }
     }
 }
+
+// SSH KEYS
+
+/// Client view of a [`SshKey`]
+#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SshKey {
+    #[serde(flatten)]
+    pub identity: IdentityMetadata,
+    /// The user to whom this key belongs
+    pub silo_user_id: Uuid,
+    /// The SSH public key
+    pub public_key: String,
+}
+
+impl From<model::SshKey> for SshKey {
+    fn from(ssh_key: model::SshKey) -> Self {
+        Self {
+            identity: ssh_key.identity(),
+            silo_user_id: ssh_key.silo_user_id,
+            public_key: ssh_key.public_key,
+        }
+    }
+}

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -3870,7 +3870,10 @@ impl Nexus {
             .lookup_for(authz::Action::CreateChild)
             .await?;
         assert_eq!(authz_user.id(), silo_user_id);
-        Ok(self.db_datastore.ssh_key_create(opctx, &authz_user, ssh_key).await?)
+        Ok(self
+            .db_datastore
+            .ssh_key_create(opctx, &authz_user, ssh_key)
+            .await?)
     }
 
     pub async fn ssh_key_delete(

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -3836,7 +3836,6 @@ impl Nexus {
         authz_user: &authz::SiloUser,
         page_params: &DataPageParams<'_, Name>,
     ) -> ListResultVec<SshKey> {
-        opctx.authorize(authz::Action::ListChildren, authz_user).await?;
         self.db_datastore.ssh_keys_list(opctx, authz_user, page_params).await
     }
 

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -3676,7 +3676,7 @@ impl Nexus {
         &self,
         _opctx: &OpContext,
         silo_user_id: Uuid,
-        page_params: &DataPageParams<'_, Uuid>,
+        page_params: &DataPageParams<'_, Name>,
     ) -> ListResultVec<SshKey> {
         self.db_datastore.ssh_keys_list(silo_user_id, page_params).await
     }

--- a/nexus/src/nexus.rs
+++ b/nexus/src/nexus.rs
@@ -3684,9 +3684,11 @@ impl Nexus {
     pub async fn ssh_key_fetch(
         &self,
         opctx: &OpContext,
+        authz_user: &authz::SiloUser,
         ssh_key_name: &Name,
     ) -> LookupResult<SshKey> {
         let (.., ssh_key) = LookupPath::new(opctx, &self.datastore())
+            .silo_user_id(authz_user.id())
             .ssh_key_name(ssh_key_name)
             .fetch()
             .await?;
@@ -3707,10 +3709,12 @@ impl Nexus {
     pub async fn ssh_key_delete(
         &self,
         opctx: &OpContext,
+        authz_user: &authz::SiloUser,
         ssh_key_name: &Name,
     ) -> DeleteResult {
         let (.., authz_ssh_key, ssh_key) =
             LookupPath::new(opctx, &self.datastore())
+                .silo_user_id(authz_user.id())
                 .ssh_key_name(ssh_key_name)
                 .fetch()
                 .await?;

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -242,6 +242,21 @@ lazy_static! {
             },
             disk: DEMO_DISK_NAME.clone(),
         };
+
+    // SSH public keys
+    pub static ref SSH_KEYS_URL: String =
+        "/session/me/sshkeys".to_string();
+    pub static ref DEMO_SSH_KEY_NAME: Name = "demo-ssh-key".parse().unwrap();
+    pub static ref DEMO_SSH_KEY_URL: String =
+        format!("{}/{}", *SSH_KEYS_URL, *DEMO_SSH_KEY_NAME);
+    pub static ref DEMO_SSH_KEY_CREATE: params::SshKeyCreate =
+        params::SshKeyCreate {
+            identity: IdentityMetadataCreateParams {
+                name: DEMO_SSH_KEY_NAME.clone(),
+                description: String::from("my SSH public key"),
+            },
+            public_key: "ssh-test AAAAAAAAA".to_string(),
+        };
 }
 
 /// Describes an API endpoint to be verified by the "unauthorized" test
@@ -788,6 +803,25 @@ lazy_static! {
             url: &*URL_USERS_DB_INIT,
             visibility: Visibility::Protected,
             allowed_methods: vec![AllowedMethod::Get],
+        },
+
+        VerifyEndpoint {
+            url: &*SSH_KEYS_URL,
+            visibility: Visibility::Protected,
+            allowed_methods: vec![
+                AllowedMethod::Get,
+                AllowedMethod::Post(
+                    serde_json::to_value(&*DEMO_SSH_KEY_CREATE).unwrap()
+                ),
+            ],
+        },
+        VerifyEndpoint {
+            url: &*DEMO_SSH_KEY_URL,
+            visibility: Visibility::Protected,
+            allowed_methods: vec![
+                AllowedMethod::Get,
+                AllowedMethod::Delete,
+            ],
         },
 
         /* Hardware */

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -243,21 +243,6 @@ lazy_static! {
             },
             disk: DEMO_DISK_NAME.clone(),
         };
-
-    // SSH public keys
-    pub static ref SSH_KEYS_URL: String =
-        "/session/me/sshkeys".to_string();
-    pub static ref DEMO_SSH_KEY_NAME: Name = "demo-ssh-key".parse().unwrap();
-    pub static ref DEMO_SSH_KEY_URL: String =
-        format!("{}/{}", *SSH_KEYS_URL, *DEMO_SSH_KEY_NAME);
-    pub static ref DEMO_SSH_KEY_CREATE: params::SshKeyCreate =
-        params::SshKeyCreate {
-            identity: IdentityMetadataCreateParams {
-                name: DEMO_SSH_KEY_NAME.clone(),
-                description: String::from("my SSH public key"),
-            },
-            public_key: "ssh-test AAAAAAAAA".to_string(),
-        };
 }
 
 /// Describes an API endpoint to be verified by the "unauthorized" test

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -806,25 +806,6 @@ lazy_static! {
             allowed_methods: vec![AllowedMethod::Get],
         },
 
-        VerifyEndpoint {
-            url: &*SSH_KEYS_URL,
-            visibility: Visibility::Protected,
-            allowed_methods: vec![
-                AllowedMethod::Get,
-                AllowedMethod::Post(
-                    serde_json::to_value(&*DEMO_SSH_KEY_CREATE).unwrap()
-                ),
-            ],
-        },
-        VerifyEndpoint {
-            url: &*DEMO_SSH_KEY_URL,
-            visibility: Visibility::Protected,
-            allowed_methods: vec![
-                AllowedMethod::Get,
-                AllowedMethod::Delete,
-            ],
-        },
-
         /* Hardware */
 
         VerifyEndpoint {

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -16,6 +16,7 @@ mod projects;
 mod roles_builtin;
 mod router_routes;
 mod silos;
+mod ssh_keys;
 mod subnet_allocation;
 mod timeseries;
 mod unauthorized;

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -66,7 +66,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(silos.len(), 1);
     assert_eq!(silos[0].identity.name, "discoverable");
 
-    // Create a new user in the discoverable silo, then create a console session
+    // Create a new user in the discoverable silo
     let new_silo_user = nexus
         .silo_user_create(
             silos[0].identity.id, /* silo id */
@@ -75,9 +75,10 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         .await
         .unwrap();
 
+    // TODO-coverage, TODO-security: Add test for Silo-local session
+    // when we can use users in another Silo.
+
     let authn_opctx = nexus.opctx_external_authn();
-    let session =
-        nexus.session_create(authn_opctx, new_silo_user.id()).await.unwrap();
 
     // Create organization with built-in user auth
     // Note: this currently goes to the built-in silo!
@@ -134,12 +135,6 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     // Verify silo user was also deleted
     nexus
         .silo_user_fetch(authn_opctx, new_silo_user.id())
-        .await
-        .expect_err("unexpected success");
-
-    // Verify new user's console session isn't valid anymore.
-    nexus
-        .session_fetch(authn_opctx, session.token.clone())
         .await
         .expect_err("unexpected success");
 }

--- a/nexus/tests/integration_tests/ssh_keys.rs
+++ b/nexus/tests/integration_tests/ssh_keys.rs
@@ -1,0 +1,122 @@
+//! Sanity-tests for public SSH keys
+
+use http::{method::Method, StatusCode};
+
+use nexus_test_utils::http_testing::{AuthnMode, NexusRequest};
+use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::ControlPlaneTestContext;
+use nexus_test_utils_macros::nexus_test;
+
+use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_nexus::external_api::params::SshKeyCreate;
+use omicron_nexus::external_api::views::SshKey;
+
+#[nexus_test]
+async fn test_ssh_keys(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+
+    // Ensure we start with an empty list of SSH keys.
+    let keys = objects_list_page_authz::<SshKey>(client, "/session/me/sshkeys")
+        .await
+        .items;
+    assert_eq!(keys.len(), 0);
+
+    // Ensure GET fails on non-existent keys.
+    NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        "/session/me/sshkeys/nonexistent",
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make GET request");
+
+    // Ensure we can POST new keys.
+    let new_keys = vec![
+        ("key1", "an SSH public key", "ssh-test AAAAAAAA"),
+        ("key2", "another SSH public key", "ssh-test BBBBBBBB"),
+        ("key3", "yet another public key", "ssh-test CCCCCCCC"),
+    ];
+    for (name, description, public_key) in &new_keys {
+        let new_key: SshKey = NexusRequest::objects_post(
+            client,
+            "/session/me/sshkeys",
+            &SshKeyCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: name.parse().unwrap(),
+                    description: description.to_string(),
+                },
+                public_key: public_key.to_string(),
+            },
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make POST request")
+        .parsed_body()
+        .unwrap();
+        assert_eq!(new_key.identity.name.as_str(), *name);
+        assert_eq!(new_key.identity.description, *description);
+        assert_eq!(new_key.public_key, *public_key);
+    }
+
+    // Ensure we can GET one of the keys we just posted.
+    let key1: SshKey = NexusRequest::object_get(
+        client,
+        &format!("/session/me/sshkeys/{}", new_keys[0].0),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make GET request")
+    .parsed_body()
+    .unwrap();
+    assert_eq!(key1.identity.name.as_str(), new_keys[0].0);
+    assert_eq!(key1.identity.description, new_keys[0].1);
+    assert_eq!(key1.public_key, new_keys[0].2);
+
+    // Ensure we can GET the list of keys we just posted.
+    // TODO-coverage: pagination
+    let keys: Vec<SshKey> = NexusRequest::iter_collection_authn(
+        client,
+        "/session/me/sshkeys",
+        "sort_by=name-ascending",
+        Some(new_keys.len()),
+    )
+    .await
+    .expect("failed to list keys")
+    .all_items;
+    assert_eq!(keys.len(), new_keys.len());
+    for (key, (name, description, public_key)) in
+        keys.iter().zip(new_keys.iter())
+    {
+        assert_eq!(key.identity.name.as_str(), *name);
+        assert_eq!(key.identity.description, *description);
+        assert_eq!(key.public_key, *public_key);
+    }
+
+    // Ensure we can DELETE a key.
+    let deleted_key_name = new_keys[0].0;
+    NexusRequest::object_delete(
+        client,
+        &format!("/session/me/sshkeys/{}", deleted_key_name),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to DELETE key");
+
+    // Ensure that we can't GET the key we just deleted.
+    NexusRequest::expect_failure(
+        client,
+        StatusCode::NOT_FOUND,
+        Method::GET,
+        &format!("/session/me/sshkeys/{}", deleted_key_name),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make GET request");
+}

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -193,11 +193,6 @@ lazy_static! {
             url: "/images",
             body: serde_json::to_value(&*DEMO_IMAGE_CREATE).unwrap(),
         },
-        // Create an SSH public key
-        SetupReq {
-            url: &*SSH_KEYS_URL,
-            body: serde_json::to_value(&*DEMO_SSH_KEY_CREATE).unwrap(),
-        },
     ];
 }
 

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -522,11 +522,14 @@ fn record_operation(whichtest: WhichTest<'_>) {
         // Note that this likely still writes the color-changing control
         // characters to the real stdout, even without "--nocapture".  That
         // sucks, but at least you don't see them.
-        term.fg(term::color::GREEN).unwrap();
-        term.flush().unwrap();
+        //
+        // We also don't unwrap() the results of printing control codes
+        // in case the terminal doesn't support them.
+        let _ = term.fg(term::color::GREEN);
+        let _ = term.flush();
         print!("{}", c);
-        term.reset().unwrap();
-        term.flush().unwrap();
+        let _ = term.reset();
+        let _ = term.flush();
     } else {
         print!("{}", c);
     }

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -169,6 +169,11 @@ lazy_static! {
             url: &*DEMO_PROJECT_URL_INSTANCES,
             body: serde_json::to_value(&*DEMO_INSTANCE_CREATE).unwrap(),
         },
+        // Create an SSH public key
+        SetupReq {
+            url: &*SSH_KEYS_URL,
+            body: serde_json::to_value(&*DEMO_SSH_KEY_CREATE).unwrap(),
+        },
     ];
 }
 

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -118,6 +118,13 @@ project_snapshots_get                    /organizations/{organization_name}/proj
 project_snapshots_get_snapshot           /organizations/{organization_name}/projects/{project_name}/snapshots/{snapshot_name}
 project_snapshots_post                   /organizations/{organization_name}/projects/{project_name}/snapshots
 
+API operations found with tag "sshkeys"
+OPERATION ID                             URL PATH
+sshkeys_delete_key                       /session/me/sshkeys/{ssh_key_name}
+sshkeys_get                              /session/me/sshkeys
+sshkeys_get_key                          /session/me/sshkeys/{ssh_key_name}
+sshkeys_post                             /session/me/sshkeys
+
 API operations found with tag "subnets"
 OPERATION ID                             URL PATH
 subnet_network_interfaces_get            /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/network-interfaces

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,4 +1,8 @@
 API endpoints with no coverage in authz tests:
+sshkeys_delete_key                       (delete "/session/me/sshkeys/{ssh_key_name}")
 session_me                               (get    "/session/me")
+sshkeys_get                              (get    "/session/me/sshkeys")
+sshkeys_get_key                          (get    "/session/me/sshkeys/{ssh_key_name}")
 spoof_login                              (post   "/login")
 logout                                   (post   "/logout")
+sshkeys_post                             (post   "/session/me/sshkeys")

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7028,7 +7028,7 @@
             ]
           },
           "public_key": {
-            "description": "The SSH public key",
+            "description": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`",
             "type": "string"
           },
           "silo_user_id": {
@@ -7058,7 +7058,7 @@
         ]
       },
       "SshKeyCreate": {
-        "description": "Create-time identity-related parameters",
+        "description": "Create-time parameters for an [`SshKey`](crate::external_api::views::SshKey)",
         "type": "object",
         "properties": {
           "description": {
@@ -7068,6 +7068,7 @@
             "$ref": "#/components/schemas/Name"
           },
           "public_key": {
+            "description": "SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`",
             "type": "string"
           }
         },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4400,6 +4400,168 @@
         }
       }
     },
+    "/session/me/sshkeys": {
+      "get": {
+        "tags": [
+          "sshkeys"
+        ],
+        "summary": "List the current user's SSH public keys",
+        "operationId": "sshkeys_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retreive the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SshKeyResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "tags": [
+          "sshkeys"
+        ],
+        "summary": "Create a new SSH public key for the current user",
+        "operationId": "sshkeys_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SshKeyCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SshKey"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/session/me/sshkeys/{ssh_key_name}": {
+      "get": {
+        "tags": [
+          "sshkeys"
+        ],
+        "summary": "Get (by name) an SSH public key belonging to the current user",
+        "operationId": "sshkeys_get_key",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ssh_key_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SshKey"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "sshkeys"
+        ],
+        "summary": "Delete (by name) an SSH public key belonging to the current user",
+        "operationId": "sshkeys_delete_key",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ssh_key_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/silos": {
       "get": {
         "tags": [
@@ -6844,6 +7006,98 @@
           "items"
         ]
       },
+      "SshKey": {
+        "description": "Client view of a [`SshKey`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "public_key": {
+            "description": "The SSH public key",
+            "type": "string"
+          },
+          "silo_user_id": {
+            "description": "The user to whom this key belongs",
+            "type": "string",
+            "format": "uuid"
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "public_key",
+          "silo_user_id",
+          "time_created",
+          "time_modified"
+        ]
+      },
+      "SshKeyCreate": {
+        "description": "Create-time identity-related parameters",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "public_key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "public_key"
+        ]
+      },
+      "SshKeyResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SshKey"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
       "TimeseriesName": {
         "title": "The name of a timeseries",
         "description": "Names are constructed by concatenating the target and metric names with ':'. Target and metric names must be lowercase alphanumeric characters with '_' separating words.",
@@ -7974,6 +8228,13 @@
     {
       "name": "snapshots",
       "description": "Snapshots of Virtual Disks at a particular point in time.",
+      "externalDocs": {
+        "url": "http://oxide.computer/docs/#xxx"
+      }
+    },
+    {
+      "name": "sshkeys",
+      "description": "Public SSH keys for an individual user",
       "externalDocs": {
         "url": "http://oxide.computer/docs/#xxx"
       }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4434,7 +4434,7 @@
             "in": "query",
             "name": "sort_by",
             "schema": {
-              "$ref": "#/components/schemas/IdSortMode"
+              "$ref": "#/components/schemas/NameSortMode"
             },
             "style": "form"
           }
@@ -4476,8 +4476,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation",
+          "201": {
+            "description": "successful creation",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Add SSH public keys as a new resource type under `SiloUser`.

The HTTP endpoint paths differ from those specified by RFD 44: the base path is `/session/me/sshkeys`, and specific keys are accessed by name rather than ID. The latter could be addressed as a follow-up by making the `unauthorized` test runner record IDs of created objects so they can be subsequently deleted.

Outstanding issues:
- [x] Some tests failing authz, probably because of improper Polar rules for `SiloUser`
- [x] Need more integration tests
- [ ] Sync with RFD 44
