### PR TITLE
A few fixes to scripts to simulate a Gimlet on commodity machines

### DIFF
--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -79,20 +79,6 @@ function ensure_simulated_chelsios {
     done
 }
 
-# Return the IP address for the provided addrobj name, or the empty string if it
-# does not exist.
-#
-# Arguments:
-#   $1: The name of the addrobj
-function get_ip_addr_if_exists {
-    ADDR="$(ipadm show-addr -p -o ADDR "$1")"
-    if [[ "$?" -eq 0 ]]; then
-        echo "$ADDR"
-    else
-        echo ""
-    fi
-}
-
 function ensure_run_as_root {
     if [[ "$(id -u)" -ne 0 ]]; then
         echo "This script must be run as root"

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -27,20 +27,6 @@ function success {
     echo -e "\e[1;36m$1\e[0m"
 }
 
-function try_uninstall_xde {
-    RC=0
-    if ! [[ -z "$(modinfo | grep xde)" ]]; then
-        rem_drv xde
-        RC=$?
-    fi
-
-    if [[ $RC -eq 0 ]]; then
-        success "XDE kernel module uninstalled"
-    else
-        warn "Failed to uninstall XDE kernel module"
-    fi
-}
-
 function try_remove_address {
     local ADDRESS="$1"
     RC=0
@@ -71,9 +57,8 @@ function try_remove_vnic {
 
 function try_remove_vnics {
     try_remove_address "lo0/underlay"
-    VNIC_LINKS=("vioif0" "vioif1")
+    VNIC_LINKS=("net0" "net1")
     for LINK in "${VNIC_LINKS[@]}"; do
-        try_remove_address "$LINK/v6"
         try_remove_vnic "$LINK"
     done
 }
@@ -94,5 +79,5 @@ function try_destroy_zpools {
     done
 }
 
-try_uninstall_xde && try_remove_vnics
+try_remove_vnics
 try_destroy_zpools

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -19,7 +19,8 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."
 OMICRON_TOP="$PWD"
 OUT_DIR="$OMICRON_TOP/out"
-mkdir -p "$OUT_DIR"
+XDE_DIR="$OUT_DIR/xde"
+mkdir -p "$XDE_DIR"
 
 # Compute the SHA256 of the path in $1, returning just the sum
 function file_sha {
@@ -30,7 +31,7 @@ function file_sha {
 function download_and_check_sha {
     local URL="$1"
     local FILENAME="$(basename "$URL")"
-    local OUT_PATH="$OUT_DIR/$FILENAME"
+    local OUT_PATH="$XDE_DIR/$FILENAME"
     local SHA="$2"
 
     # Check if the file already exists, with the expected SHA
@@ -52,36 +53,44 @@ function sha_from_url {
     curl -L "$SHA_URL" 2> /dev/null | cut -d ' ' -f 1
 }
 
-OPTE_P5P_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0MRWX9Y0X46HBEJBW245DJY/PM097Agvf89uKmVRZ890z6saoeLp6RCcVsbYRa5PDv9DnLDT/01G0MRX6GMBV34CNANABXZXX25/01G0MSFZZWPFEQBW7JRS7ST99G/opte-0.1.58.p5p"
-OPTE_P5P_SHA_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0MRWX9Y0X46HBEJBW245DJY/PM097Agvf89uKmVRZ890z6saoeLp6RCcVsbYRa5PDv9DnLDT/01G0MRX6GMBV34CNANABXZXX25/01G0MSG01CGP6TH9THNY39G88Z/opte-0.1.58.p5p.sha256"
-OPTE_P5P_REPO_PATH="$OUT_DIR/$(basename "$OPTE_P5P_URL")"
-XDE_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0DM53XR4E008D6ET5T8DXP6/wBWo0Jsg1AG19toIyAY23xAWhzmuNKmAsF6tL18ypZODNuHK/01G0DM5DMQHF5B89VGHZ05Z4E0/01G0DMHNYQ1NS7DBX8VG3JPAP0/xde"
-XDE_SHA_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0DM53XR4E008D6ET5T8DXP6/wBWo0Jsg1AG19toIyAY23xAWhzmuNKmAsF6tL18ypZODNuHK/01G0DM5DMQHF5B89VGHZ05Z4E0/01G0DMHP47353961S3ETXBSD2T/xde.sha256"
+# Add a pkg repo by path. This will also run `pkg update`, handling the case
+# gracefully where there are no updates required
+function add_pkg_repo_and_update {
+    local REPO_PATH="$1"
+    pkg set-publisher -p "$REPO_PATH" --search-first
+    RC=0
+    pkg update || RC=$?;
+    if [[ "$RC" -eq 0 ]] || [[ "$RC" -eq 4 ]]; then
+        return 0
+    else
+        return "$RC"
+    fi
+}
 
-download_and_check_sha "$OPTE_P5P_URL" "$(sha_from_url "$OPTE_P5P_SHA_URL")"
-XDE_SHA="$(sha_from_url "$XDE_SHA_URL")"
-download_and_check_sha "$XDE_URL" "$XDE_SHA"
+# The `helios-netdev` provides the XDE kernel driver and the `opteadm` userland
+# tool for interacting with it.
+HELIOS_NETDEV_REPO_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G11AT7E4XV9J1J54GE2YDJT6/CB4WF4BVgnbvf5NI573z9osAV2LNIKogPtWJ5sfW2cNxUYQO/01G11ATFVTWAC2HSNV148PQ4ER/01G11B5MPQRBX3Q5EF45YDAW6Q/opte-0.1.60.p5p"
+HELIOS_NETDEV_REPO_SHA_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G11AT7E4XV9J1J54GE2YDJT6/CB4WF4BVgnbvf5NI573z9osAV2LNIKogPtWJ5sfW2cNxUYQO/01G11ATFVTWAC2HSNV148PQ4ER/01G11B5MR60H4N13NJKGWEEA69/opte-0.1.60.p5p.sha256"
+HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"
 
-# Move the XDE driver into it the expected location to allow operating on it
-# with `add_drv` and `rem_drv`
-DRIVER_DIR="/kernel/drv/amd64"
-XDE_FILENAME="$(basename "$XDE_URL")"
-XDE_PATH="$DRIVER_DIR/$XDE_FILENAME"
-if ! [[ -f "$XDE_PATH" ]] || [[ "$XDE_SHA" != "$(file_sha "$XDE_PATH")" ]]; then
-    echo "Replacing XDE driver"
-    mv -f "$OUT_DIR/$XDE_FILENAME" "$XDE_PATH"
-else
-    echo "XDE driver already exists with correct SHA"
-fi
+# The XDE repo provides a full OS/Net incorporation, with updated kernel bits
+# that the `xde` kernel module and OPTE rely on.
+XDE_REPO_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0ZKH44GQF88GB0GQBG9TQGW/7eOYj8L8E4MLrtvdTgGMyMu5qjYTRheV250bEvh2OkBrggX4/01G0ZKHBQ33K40S5ABZMRNWS5P/01G0ZYDDRXQ3Y4E5SG9QX8N9FK/repo.p5p"
+XDE_REPO_SHA_URL="https://buildomat.eng.oxide.computer/wg/0/artefact/01G0ZKH44GQF88GB0GQBG9TQGW/7eOYj8L8E4MLrtvdTgGMyMu5qjYTRheV250bEvh2OkBrggX4/01G0ZKHBQ33K40S5ABZMRNWS5P/01G0ZYDJDMJAYHFV9Z6XVE30X5/repo.p5p.sha256"
+XDE_REPO_PATH="$XDE_DIR/$(basename "$XDE_REPO_URL")"
 
-# Add the OPTE P5P package repository (at the top of the search order) and
-# update the OS packages. This may require a reboot.
-pkg set-publisher -p "$OPTE_P5P_REPO_PATH" --search-first
+# Download and verify the package repositorieies
+download_and_check_sha "$HELIOS_NETDEV_REPO_URL" "$(sha_from_url "$HELIOS_NETDEV_REPO_SHA_URL")"
+download_and_check_sha "$XDE_REPO_URL" "$(sha_from_url "$XDE_REPO_SHA_URL")"
+
+# Set the `helios-dev` repo as non-sticky, meaning that packages that were
+# originally provided by it may be updated by another repository, if that repo
+# provides newer versions of the packages.
 pkg set-publisher --non-sticky helios-dev
-RC=0
-pkg update || RC=$?;
-if [[ "$RC" -eq 0 ]] || [[ "$RC" -eq 4 ]]; then
-    exit 0
-else
-    exit "$RC"
-fi
+
+# Add the OPTE and XDE repositories and update packages.
+add_pkg_repo_and_update "$HELIOS_NETDEV_REPO_PATH"
+add_pkg_repo_and_update "$XDE_REPO_PATH"
+
+# Actually install the xde kernel module and opteadm tool
+pkg install driver/network/opte


### PR DESCRIPTION
- Renames VNICs from `vioifN` to `netN` to avoid collision when running
  the script inside a VM
- Remove the loopback address from the virtual hardware scripts
- Better handling of existing names
- Remove manual handling of xde kernel driver, delegating to the xde ONU
  consolidation for that
- Cleans up the `omicron-package uninstall` command to avoid removing
  the files installed by the `helios-netdev` publisher for OPTE. This is
  mostly for the `opteadm` tool.