### PR TITLE
prevent accidentally destroying shared machines

### DIFF
--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -17,6 +17,12 @@ set -x
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 OMICRON_TOP="$SOURCE_DIR/.."
 
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
 # Select the physical link over which to simulate the Chelsio links
 if [[ $# -ge 1 ]]; then
     PHYSICAL_LINK="$1"

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -14,6 +14,12 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."
 OMICRON_TOP="$PWD"
 
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
 if [[ "$(id -u)" -ne 0 ]]; then
     echo "This must be run as root"
     exit 1

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -6,6 +6,12 @@ set -e
 set -u
 set -x
 
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
 if [[ "$(uname)" != "SunOS" ]]; then
     echo "This script is intended for Helios only"
 fi

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -2,6 +2,12 @@
 
 set -eu
 
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+  echo "This system has the marker file $MARKER, aborting." >&2
+  exit 1
+fi
+
 # Set the CWD to Omicron's source.
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."


### PR DESCRIPTION
Some of the scripts in tools/ are increasingly destructive, and can
be deleterious when executed on a shared build machine where the
user has appropriate privileges.  To avoid issues, we will look for
a marker file that should prevent us from doing anything (especially
as root) to mutate the machine.  To mark a build machine as
off-limits:

    # mkdir -p /etc/opt/oxide
    # touch /etc/opt/oxide/NO_INSTALL