### PR TITLE
s/return/exit/ at top-level of install_opte.sh

### DIFF
--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -88,9 +88,9 @@ pkg set-publisher -p "$XDE_REPO_PATH" --search-first
 RC=0
 pkg update || RC=$?;
 if [[ "$RC" -eq 0 ]] || [[ "$RC" -eq 4 ]]; then
-    return 0
+    exit 0
 else
-    return "$RC"
+    exit "$RC"
 fi
 
 # Actually install the xde kernel module and opteadm tool


### PR DESCRIPTION
Running `tools/install_prerequisites.sh` on a fresh VM failed with

```
./tools/install_opte.sh: line 85: return: can only `return' from a function or sourced script
```

which should be fixed by this change.