### PR TITLE
fix strsize pragmas in D scripts

### DIFF
--- a/tools/dtrace/slowest-queries.d
+++ b/tools/dtrace/slowest-queries.d
@@ -1,6 +1,6 @@
 #!/usr/sbin/dtrace -qs
 
-#pragma strsize=4k
+#pragma D option strsize=4k
 
 /* Print out the slowest 5 queries every 10 seconds. */
 

--- a/tools/dtrace/trace-db-queries.d
+++ b/tools/dtrace/trace-db-queries.d
@@ -1,6 +1,6 @@
 #!/usr/sbin/dtrace -qs
 
-#pragma strsize=16k
+#pragma D option strsize=16k
 
 /* Trace all queries to the control plane database with their latency */
 


### PR DESCRIPTION
The format of the `strsize` pragmas isn't quite right in these D scripts.  It's not obvious because unrecognized pragmas are completely ignored.  We found this because we discovered while debugging #980 that DTrace didn't seem to honor the strsize that was set in the script.