### PR TITLE
missing index on vpc_firewall_rule

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -755,7 +755,7 @@ CREATE TABLE omicron.public.vpc_firewall_rule (
     priority INT4 CHECK (priority BETWEEN 0 AND 65535) NOT NULL
 );
 
-CREATE UNIQUE INDEX ON omicron.public.vpc_router (
+CREATE UNIQUE INDEX ON omicron.public.vpc_firewall_rule (
     vpc_id,
     name
 ) WHERE


### PR DESCRIPTION
#980 had me looking for tables with multiple partial indexes and I discovered that it looks like there was a copy/paste mistake in defining the indexes for `vpc_firewall_rule`.  In fact, we define the exact same index on `vpc_router` twice instead.  I looked quickly at the code paths around listing and updating firewall rules and I do believe that the index by (`vpc_id`, `name`) is correct.