### PR TITLE
Serialize entire `SledAgentRequest` instead of just subnet

### DIFF
--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -93,8 +93,9 @@ pub(crate) struct Agent {
     sled_config: SledConfig,
 }
 
-fn get_subnet_path() -> PathBuf {
-    Path::new(omicron_common::OMICRON_CONFIG_PATH).join("subnet.toml")
+fn get_sled_agent_request_path() -> PathBuf {
+    Path::new(omicron_common::OMICRON_CONFIG_PATH)
+        .join("sled-agent-request.toml")
 }
 
 fn mac_to_socket_addr(mac: MacAddr) -> SocketAddrV6 {
@@ -147,11 +148,11 @@ impl Agent {
             sled_config,
         };
 
-        let subnet_path = get_subnet_path();
-        if subnet_path.exists() {
+        let request_path = get_sled_agent_request_path();
+        if request_path.exists() {
             info!(agent.log, "Sled already configured, loading sled agent");
             let sled_request: SledAgentRequest = toml::from_str(
-                &tokio::fs::read_to_string(&subnet_path).await?,
+                &tokio::fs::read_to_string(&request_path).await?,
             )?;
             agent.request_agent(sled_request).await?;
         }
@@ -207,13 +208,13 @@ impl Agent {
         maybe_agent.replace(server);
         info!(&self.log, "Sled Agent loaded; recording configuration");
 
-        // Record the subnet, so the sled agent can be automatically
+        // Record this request so the sled agent can be automatically
         // initialized on the next boot.
         tokio::fs::write(
-            get_subnet_path(),
+            get_sled_agent_request_path(),
             &toml::to_string(
-                &toml::Value::try_from(&request.subnet)
-                    .expect("Cannot serialize IP"),
+                &toml::Value::try_from(&request)
+                    .expect("Cannot serialize request"),
             )
             .expect("Cannot convert toml to string"),
         )


### PR DESCRIPTION
This pairs with the [deserialize call in `Agent::new()`](https://github.com/oxidecomputer/omicron/blob/cb6453f24f1ec87d73a61bf4e057ca2f23612c11/sled-agent/src/bootstrap/agent.rs#L153-L155) which expects to deserialize the full struct.

---

I had a (somewhat) functional sled-agent running, and when restarting the `sled-agent` service, it failed to restart with this error:

```
sled-agent: expected an equals, found eof at line 1 column 24
```

#967 improves this error message significantly (including adding the filename - `/var/oxide/subnet.toml` in this case), and this change fixes the underlying cause.