### PR TITLE
many tests do not clean up after themselves

### DIFF
--- a/gateway/tests/integration_tests/serial_console.rs
+++ b/gateway/tests/integration_tests/serial_console.rs
@@ -101,12 +101,13 @@ async fn serial_console_communication() {
             Message::Binary(msg_from_sp)
         );
     }
+
+    testctx.teardown().await;
 }
 
 #[tokio::test]
 async fn serial_console_detach() {
-    let testctx =
-        setup::test_setup("serial_console_communication", SpPort::One).await;
+    let testctx = setup::test_setup("serial_console_detach", SpPort::One).await;
     let client = &testctx.client;
     let simrack = &testctx.simrack;
 
@@ -185,4 +186,6 @@ async fn serial_console_detach() {
         ws.next().await.unwrap().unwrap(),
         Message::Binary(b"world".to_vec())
     );
+
+    testctx.teardown().await;
 }

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -3158,6 +3158,7 @@ mod test {
         assert_eq!(0, disk1_datasets.intersection(&disk2_datasets).count());
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -3224,6 +3225,7 @@ mod test {
         }
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     #[tokio::test]
@@ -3272,6 +3274,7 @@ mod test {
         assert!(matches!(err, Error::ServiceUnavailable { .. }));
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     // TODO: This test should be updated when the correct handling
@@ -3318,6 +3321,7 @@ mod test {
         datastore.region_allocate(&opctx, volume1_id, &params).await.unwrap();
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     // Validate that queries which should be executable without a full table
@@ -3376,6 +3380,7 @@ mod test {
         );
 
         let _ = db.cleanup().await;
+        logctx.cleanup_successful();
     }
 
     // Test sled-specific IPv6 address allocation

--- a/nexus/src/db/explain.rs
+++ b/nexus/src/db/explain.rs
@@ -190,6 +190,7 @@ mod test {
             )
             .await
             .unwrap();
+        logctx.cleanup_successful();
     }
 
     // Tests the ".explain_async()" method in an asynchronous context.
@@ -211,6 +212,7 @@ mod test {
             .unwrap();
 
         assert_contents("tests/output/test-explain-output", &explanation);
+        logctx.cleanup_successful();
     }
 
     // Tests that ".explain()" can tell us when we're doing full table scans.
@@ -236,5 +238,6 @@ mod test {
             "Expected [{}] to contain 'FULL SCAN'",
             explanation
         );
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/src/db/lookup.rs
+++ b/nexus/src/db/lookup.rs
@@ -617,5 +617,6 @@ mod test {
         } if *o == org_id && **p == project_name));
 
         db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -99,6 +99,7 @@ async fn test_update_end_to_end() {
 
     server.close().await.expect("failed to shut down dropshot server");
     cptestctx.teardown().await;
+    logctx.cleanup_successful();
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=


### PR DESCRIPTION
In the tradition of #499 and #543, this change fixes most of the tests that currently leave detritus in $TMPDIR.  I looked into this while looking at #988.  Like I said in #543, we could really use a macro like @teisenbe did in #502 but for things that only use a LogContext.  I'm not taking that on right now.

This does not fix the internal_dns tests because that's a bunch more work.  I filed #990 for that.

I may separately look at having CI fail if a successful run leaves anything in $TMPDIR.