### PR TITLE
don't override rustflags

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,7 +7,3 @@
 [build]
 rustdocflags = "--document-private-items"
 
-[target.x86_64-unknown-linux-gnu]
-# Attempt to get more verbose output from the linker in the event that linking
-# fails.
-rustflags = ["-C", "link-args=-Wl,-V"]


### PR DESCRIPTION
if linking fails and someone wants more information, they can set
rustflags on their machine - don't override rustflags for everyone,
they're unfortunately not additive.