### PR TITLE
disallow full table scans

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -216,6 +216,13 @@ CREATE TABLE omicron.public.silo_user (
     time_deleted TIMESTAMPTZ
 );
 
+/* This index lets us quickly find users for a given silo. */
+CREATE INDEX ON omicron.public.silo_user (
+    silo_id,
+    id
+) WHERE
+    time_deleted IS NULL;
+
 /*
  * Users' public SSH keys, per RFD 44
  */
@@ -920,6 +927,11 @@ CREATE TABLE omicron.public.update_available_artifact (
     PRIMARY KEY (name, version, kind)
 );
 
+/* This index is used to quickly find outdated artifacts. */
+CREATE INDEX ON omicron.public.update_available_artifact (
+    targets_role_version
+);
+
 /*******************************************************************/
 
 /*
@@ -1065,7 +1077,6 @@ CREATE TABLE omicron.public.db_metadata (
 INSERT INTO omicron.public.db_metadata (
     name,
     value
-) VALUES (
-    'schema_version',
-    '1.0.0'
-);
+) VALUES
+    ( 'schema_version', '1.0.0' ),
+    ( 'schema_time_created', CAST(NOW() AS STRING) );

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2503,6 +2503,8 @@ impl DataStore {
             .await
             .map(|_rows_deleted| ())
             .map_err(|e| {
+                // TODO-correctness TODO-availability This should be using
+                // public_error_from_diesel_pool()
                 Error::internal_error(&format!(
                     "error deleting outdated available artifacts: {:?}",
                     e
@@ -2676,6 +2678,7 @@ impl DataStore {
         // TODO-scalability This needs to happen in batches
         let updated_rows = diesel::update(silo_user::dsl::silo_user)
             .filter(silo_user::dsl::silo_id.eq(id))
+            .filter(silo_user::dsl::time_deleted.is_null())
             .set(silo_user::dsl::time_deleted.eq(now))
             .execute_async(self.pool_authorized(opctx).await?)
             .await
@@ -2838,6 +2841,27 @@ impl DataStore {
                 )
             })?;
         Ok(())
+    }
+
+    // Test interfaces
+
+    #[cfg(test)]
+    async fn test_try_table_scan(&self, opctx: &OpContext) -> Error {
+        use db::schema::project::dsl;
+        let conn = self.pool_authorized(opctx).await;
+        if let Err(error) = conn {
+            return error;
+        }
+        let result = dsl::project
+            .select(diesel::dsl::count_star())
+            .first_async::<i64>(conn.unwrap())
+            .await;
+        match result {
+            Ok(_) => Error::internal_error("table scan unexpectedly succeeded"),
+            Err(error) => {
+                public_error_from_diesel_pool(error, ErrorHandler::Server)
+            }
+        }
     }
 }
 
@@ -3514,6 +3538,32 @@ mod test {
 
         // Delete the key we just created.
         datastore.ssh_key_delete(&opctx, &authz_ssh_key).await.unwrap();
+
+        // Clean up.
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_table_scan() {
+        let logctx = dev::test_setup_log("test_table_scan");
+        let mut db = test_setup_database(&logctx.log).await;
+        let (opctx, datastore) = datastore_test(&logctx, &db).await;
+
+        let error = datastore.test_try_table_scan(&opctx).await;
+        println!("error from attempted table scan: {:#}", error);
+        match error {
+            Error::InternalError { internal_message } => {
+                assert!(internal_message.contains(
+                    "contains a full table/index scan which is \
+                    explicitly disallowed"
+                ));
+            }
+            error => panic!(
+                "expected internal error with specific message, found {:?}",
+                error
+            ),
+        }
 
         // Clean up.
         db.cleanup().await.unwrap();

--- a/nexus/src/db/pagination.rs
+++ b/nexus/src/db/pagination.rs
@@ -200,16 +200,21 @@ mod test {
     async fn populate_users(pool: &db::Pool, values: &Vec<(i64, i64)>) {
         use schema::test_users::dsl;
 
+        // The indexes here work around the check that prevents full table
+        // scans.
         pool.pool()
             .get()
             .await
             .unwrap()
             .batch_execute_async(
                 "CREATE TABLE test_users (
-                id UUID PRIMARY KEY,
-                age INT NOT NULL,
-                height INT NOT NULL
-            )",
+                    id UUID PRIMARY KEY,
+                    age INT NOT NULL,
+                    height INT NOT NULL
+                );
+
+                CREATE INDEX ON test_users (age, height);
+                CREATE INDEX ON test_users (height, age);",
             )
             .await
             .unwrap();

--- a/nexus/src/db/pool.rs
+++ b/nexus/src/db/pool.rs
@@ -69,6 +69,10 @@ impl CustomizeConnection<Connection<DbConnection>, ConnectionError>
         &self,
         conn: &mut Connection<DbConnection>,
     ) -> Result<(), ConnectionError> {
-        conn.batch_execute_async("set disallow_full_table_scans = on;").await
+        conn.batch_execute_async(
+            "set disallow_full_table_scans = on;\
+            set large_full_scan_rows = 0;",
+        )
+        .await
     }
 }

--- a/nexus/src/db/pool.rs
+++ b/nexus/src/db/pool.rs
@@ -25,7 +25,12 @@
 // TODO-design Need TLS support (the types below hardcode NoTls).
 
 use super::Config as DbConfig;
+use async_bb8_diesel::AsyncSimpleConnection;
+use async_bb8_diesel::Connection;
+use async_bb8_diesel::ConnectionError;
 use async_bb8_diesel::ConnectionManager;
+use async_trait::async_trait;
+use bb8::CustomizeConnection;
 use diesel::PgConnection;
 use diesel_dtrace::DTraceConnection;
 
@@ -42,12 +47,28 @@ impl Pool {
     pub fn new(db_config: &DbConfig) -> Self {
         let manager =
             ConnectionManager::<DbConnection>::new(&db_config.url.url());
-        let pool = bb8::Builder::new().build_unchecked(manager);
+        let pool = bb8::Builder::new()
+            .connection_customizer(Box::new(DisallowFullTableScans {}))
+            .build_unchecked(manager);
         Pool { pool }
     }
 
     /// Returns a reference to the underlying pool.
     pub fn pool(&self) -> &bb8::Pool<ConnectionManager<DbConnection>> {
         &self.pool
+    }
+}
+
+#[derive(Debug)]
+struct DisallowFullTableScans {}
+#[async_trait]
+impl CustomizeConnection<Connection<DbConnection>, ConnectionError>
+    for DisallowFullTableScans
+{
+    async fn on_acquire(
+        &self,
+        conn: &mut Connection<DbConnection>,
+    ) -> Result<(), ConnectionError> {
+        conn.batch_execute_async("set disallow_full_table_scans = on;").await
     }
 }


### PR DESCRIPTION
tl;dr: RFD 192 talks at length about why we want to avoid table scans.  Ideally, we'd like to know at build-time if we write queries that will necessitate table scans, but this is very hard.  One easy thing we _can_ do is enable CockroachDB's `disallow_full_table_scans` option, which causes it to fail queries that would necessitate a table scan.  If the test suite passes, and we believe we have good test suite coverage for Nexus, then this gives us decent confidence that we haven't done something grossly wrong in this area.  See #254 for more discussion on this problem and different approaches for solving it.

---

In #254, [I tried](https://github.com/oxidecomputer/omicron/issues/254#issuecomment-926243830) using this option before and found way too many false positives to be useful.  In [v21.2.2](https://www.cockroachlabs.com/docs/releases/v21.2#v21-2-2) (which we've now updated past), CockroachDB has made this update:

> The optimizer has been updated so that if [disallow_full_table_scans](https://www.cockroachlabs.com/docs/v21.2/set-vars) is true, it will never plan a full table scan with an estimated row count greater than large_full_scan_rows. If no alternative plan is possible, an error will be returned, just as it was before. However, cases where an alternative plan is possible will no longer produce an error, since the alternative plan will be chosen. As a result, users should see fewer errors due to disallow_full_table_scans.

Now that we've updated past that, I thought I'd resurrect that experiment to see if we can automatically fail queries that would attempt a table scan before they do so.  It worked much better this time!

There were three test failures:

- The db pagination tests create their own table and _do_ full scans against it.  That's okay.  I just added indexes to appease the new check.
- The silo delete code path soft-deletes all silo users for that silo, but there's no corresponding index on silo_user.  Additionally, the query here was missing a `time_deleted IS NULL` filter.
- The updates code path soft-deletes outdated artifacts but was missing an index to do this.

In other words, it caught 2-3 real bugs!  The error messages were pretty good, too:

>[2022-04-29T22:05:56.730516441Z]  INFO: 2bdbae9a-3002-48fa-8b91-6285bfb28947/dropshot_external/17282 on ivanova: request completed (req_id=4d175a9c-dfe7-4f99-a0bd-df6c08054f8c, uri=/silos/discoverable, method=DELETE, remote_addr=127.0.0.1:38953, local_addr=127.0.0.1:39314, error_message_external="Internal Server Error", response_code=500)
>    error_message_internal: database error (kind = Unknown): query `UPDATE "silo_user" SET "time_deleted" = $1 WHERE ("silo_user"."silo_id" = $2)` contains a full table/index scan which is explicitly disallowed
>    HINT: try overriding the `disallow_full_table_scans` or increasing the `large_full_scan_rows` cluster/session settings

>[2022-04-29T22:06:00.51476957Z]  INFO: 3ac214f0-033f-4e29-b2f5-4ddbd8f662aa/dropshot_external/17282 on ivanova: request completed (req_id=8ec3a7ec-30ef-40cc-9cea-89134027b3d9, uri=/updates/refresh, method=POST, remote_addr=127.0.0.1:60077, local_addr=127.0.0.1:35522, error_message_external="Internal Server Error", response_code=500)
>    error_message_internal: error deleting outdated available artifacts: Connection(Query(DatabaseError(Unknown, "query `DELETE FROM \"update_available_artifact\" WHERE (\"update_available_artifact\".\"targets_role_version\" < $1)` contains a full table/index scan which is explicitly disallowed")))

(That's all part of the "internal_message" of the 500 error that gets logged with the request.)

So I think this is a good change.

There are two risks here:

- We find false positives and it gets in the way of future development.  I'm optimistic that won't be a problem just because of how few false positives we had after never having used this before.
- We find some code path that's not tested by the test suite that we would rather have function in production even if it meant a table scan.  We can't know ahead of time what those code paths are -- if we did, we'd cover them in the test suite.  It'd be nice to have an escape hatch somehow, but that'd be risky too.  And without a way to tweak configuration at runtime, it doesn't seem useful to do that right now.