### PR TITLE
Update thing-flinger to track changes to omicron

### DIFF
--- a/deploy/README.adoc
+++ b/deploy/README.adoc
@@ -54,7 +54,11 @@ thing-flinger, pointing out room for improvement.
 
 `thing-flinger` defines three types of nodes:
 
- * Client - Where a user typically edits their code and runs thing-flinger. This can run any OS.
+ * Client - Where a user typically edits their code and runs thing-flinger. In
+   theory this can run any OS, but currently it needs to be a Helios system.
+   omicron downloads prebuilt dependencies (clickhouse, cockroachDB) for the
+   current system, and we will sync those binaries from the client to the
+   builder (and ultimately to the deployment servers).
  * Builder - A Helios box where Omicron is built and packaged
  * Deployed Server - Helios machines where Omicron will be installed and run
 
@@ -83,42 +87,55 @@ all the dependencies for Omicron installed. Following the *prerequisites* in the
 https://github.com/oxidecomputer/omicron/#build-and-run[Build and run] section of the main Omicron
 README is probably a good idea.
 
+==== Update `config-rss.toml`
+
+Currently rack setup is driven by a configuration file that lives at
+`smf/sled-agent/config-rss.toml` in the root of this repository. The committed
+configuration of that file contains a single `[[requests]]` entry (with many
+services inside it), which means it will start services on only one sled. To
+start services (e.g., nexus) on multiple sleds, add additional entries to that
+configuration file before proceeding.
+
 === Command Based Workflow
-
-==== Build thing-flinger on client
-`thing-flinger` is part of the `omicron-package` crate.
-
-`cargo build -p omicron-package`
 
 ==== sync
 Copy your source code to the builder. Note that this copies over your `.git` subdirectory on purpose so
 that a branch can be configured for building with the `git_treeish` field in the toml `builder`
 table.
 
-`./target/debug/thing-flinger -c <CONFIG.toml> sync`
+`cargo run --bin thing-flinger -- -c <CONFIG> sync`
 
-==== build-minimal
-Build necessary parts of omicron on the builder, required for future use by thing-flinger.
+==== check (optional)
+Run `cargo check` on the builder against the copy of `omicron` that was sync'd
+to it in the previous step.
 
-`./target/debug/thing-flinger -c <CONFIG> build-minimal`
+`cargo run --bin thing-flinger -- -c <CONFIG> build check`
 
-==== package 
+==== package
 Build and package omicron using `omicron-package` on the builder.
 
-`./target/debug/thing-flinger -c <CONFIG> package`
+`cargo run --bin thing-flinger -- -c <CONFIG> build package`
 
 ==== overlay
 Create files that are unique to each deployment server.
 
-`./target/debug/thing-flinger -c <CONFIG> overlay`
+`cargo run --bin thing-flinger -- -c <CONFIG> overlay`
 
-==== install 
+==== install
 Install omicron to all machines, in parallel. This consists of copying the packaged omicron tarballs
 along with overlay files, and omicron-package and its manifest to a `staging` directory on each
 deployment server, and then running omicron-package, installing overlay files, and restarting
 services.
 
-`./target/debug/thing-flinger -c <CONFIG> install`
+`cargo run --bin thing-flinger -- -c <CONFIG> deploy install`
+
+==== uninstall
+Uninstall omicron from all machines.
+
+`cargo run --bin thing-flinger -- -c <CONFIG> deploy uninstall`
+
+Note: This does not fully undo everything done by the `install` step above;
+noteably overlay files are not removed.
 
 === Current Limitations
 
@@ -140,3 +157,59 @@ effort to use securely. This particular implementation wraps the openssh ssh cli
 `std::process::Command`, rather than using the `ssh2` crate, because ssh2, as a wrapper around
 `libssh`, does not support agent-forwarding.
 
+== Notes on Using VMs as Deployed Servers on a Linux Host
+
+TODO: This section should be fleshed out more and potentially lifted to its own
+document; for now this is a collection of rough notes.
+
+It's possible to use a Linux libvirt host running multiple helios VMs as the
+builder/deployment server targets, but it requires some additional setup beyond
+what [`helios-engvm`](https://github.com/oxidecomputer/helios-engvm).
+
+To enable communication between the VMs over their IPv6 bootstrap networks:
+
+1. Enable IPv6 and DHCP on the virtual network libvirt uses for the VMs; e.g.,
+
+```xml
+  <ip family="ipv6" address="fdb0:5254::1" prefix="96">
+    <dhcp>
+      <range start="fdb0:5254::100" end="fdb0:5254::1ff"/>
+    </dhcp>
+  </ip>
+```
+
+After booting the VMs with this enabled, they should be able to ping each other
+over their acquired IPv6 addresses, but connecting to each other over the
+`bootstrap6` interface that sled-agent creates will fail.
+
+2. Explicitly add routes in the Linux host for the `bootstrap6` addresses,
+specifying the virtual interface libvirt created that is used by the VMs.
+
+```
+bash% sudo ip -6 route add fdb0:5254:13:7331::1/64 dev virbr1
+bash% sudo ip -6 route add fdb0:5254:f0:acfd::1/64 dev virbr1
+```
+
+3. Once the sled-agents advance sufficiently to set up `sled6` interfaces,
+routes need to be added for them both in the Linux host and in the Helios VMs.
+Assuming two sleds with these interfaces:
+
+```
+# VM 1
+vioif0/sled6      static   ok           fd00:1122:3344:1::1/64
+# VM 2
+vioif0/sled6      static   ok           fd00:1122:3344:2::1/64
+```
+
+The Linux host needs to be told to route that subnet to the appropriate virtual
+interface:
+
+```
+bash% ip -6 route add fd00:1122:3344::1/48 dev virbr1
+```
+
+and each Helios VM needs to be told to route that subnet to the host gateway:
+
+```
+vm% pfexec route add -inet6 fd00:1122:3344::/48 $IPV6_HOST_GATEWAY_ADDR
+```

--- a/deploy/README.adoc
+++ b/deploy/README.adoc
@@ -166,9 +166,17 @@ effort to use securely. This particular implementation wraps the openssh ssh cli
 TODO: This section should be fleshed out more and potentially lifted to its own
 document; for now this is a collection of rough notes.
 
+---
+
 It's possible to use a Linux libvirt host running multiple helios VMs as the
 builder/deployment server targets, but it requires some additional setup beyond
 what [`helios-engvm`](https://github.com/oxidecomputer/helios-engvm).
+
+`thing-flinger` does not have any support for running the
+`tools/create_virtual_hardware.sh` script; this will need to be done by hand on
+each VM.
+
+---
 
 To enable communication between the VMs over their IPv6 bootstrap networks:
 

--- a/deploy/README.adoc
+++ b/deploy/README.adoc
@@ -95,9 +95,7 @@ configuration file before proceeding.
 === Command Based Workflow
 
 ==== sync
-Copy your source code to the builder. Note that this copies over your `.git` subdirectory on purpose so
-that a branch can be configured for building with the `git_treeish` field in the toml `builder`
-table.
+Copy your source code to the builder.
 
 `cargo run --bin thing-flinger -- -c <CONFIG> sync`
 
@@ -138,9 +136,6 @@ Uninstall omicron from all machines.
 
 `cargo run --bin thing-flinger -- -c <CONFIG> deploy uninstall`
 
-Note: This does not fully undo everything done by the `install` step above;
-noteably overlay files are not removed.
-
 === Current Limitations
 
 `thing-flinger` is an early prototype. It has served so far to demonstrate that unique files,
@@ -170,7 +165,7 @@ document; for now this is a collection of rough notes.
 
 It's possible to use a Linux libvirt host running multiple helios VMs as the
 builder/deployment server targets, but it requires some additional setup beyond
-what [`helios-engvm`](https://github.com/oxidecomputer/helios-engvm).
+[`helios-engvm`](https://github.com/oxidecomputer/helios-engvm).
 
 `thing-flinger` does not have any support for running the
 `tools/create_virtual_hardware.sh` script; this will need to be done by hand on

--- a/deploy/README.adoc
+++ b/deploy/README.adoc
@@ -54,11 +54,7 @@ thing-flinger, pointing out room for improvement.
 
 `thing-flinger` defines three types of nodes:
 
- * Client - Where a user typically edits their code and runs thing-flinger. In
-   theory this can run any OS, but currently it needs to be a Helios system.
-   omicron downloads prebuilt dependencies (clickhouse, cockroachDB) for the
-   current system, and we will sync those binaries from the client to the
-   builder (and ultimately to the deployment servers).
+ * Client - Where a user typically edits their code and runs thing-flinger. This can run any OS.
  * Builder - A Helios box where Omicron is built and packaged
  * Deployed Server - Helios machines where Omicron will be installed and run
 
@@ -104,6 +100,14 @@ that a branch can be configured for building with the `git_treeish` field in the
 table.
 
 `cargo run --bin thing-flinger -- -c <CONFIG> sync`
+
+==== Install Prerequisites
+Install necessary build and runtime dependencies (including downloading prebuilt
+binaries like Clickhouse and CockroachDB) on the builder and all deployment
+targets. This step only needs to be performed once, absent any changes to the
+dependencies, but is idempotent so may be run multiple times.
+
+`cargo run --bin thing-flinger -- -c <CONFIG> install-prereqs`
 
 ==== check (optional)
 Run `cargo check` on the builder against the copy of `omicron` that was sync'd

--- a/deploy/src/bin/deployment-example.toml
+++ b/deploy/src/bin/deployment-example.toml
@@ -15,7 +15,9 @@ server = "foo"
 omicron_path = "/remote/path/to/omicron"
 
 [deployment]
-servers = ["foo", "bar"]
+# which server is responsible for running the rack setup service; must
+# refer to one of the `servers` in the servers table
+rss_server = "foo"
 rack_secret_threshold = 2
 # Location where files to install will be placed before running
 # `omicron-package install`

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -470,8 +470,8 @@ fn overlay_sled_agent(
     config: &Config,
     sled_agent_dirs: &[PathBuf],
 ) -> Result<()> {
-    // Send SSH command to create directories on builder and generate share
-    // secrets.
+    // Send SSH command to create directories on builder and generate secret
+    // shares.
 
     // TODO do we need any escaping here? this will definitely break if any dir
     // names have spaces

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -460,16 +460,25 @@ fn single_server_install(
 ) -> Result<()> {
     let server = &config.servers[server_name];
 
-    println!("COPYING packages from builder -> deploy server");
+    println!(
+        "COPYING packages from builder ({}) -> deploy server ({})",
+        builder.addr, server_name
+    );
     copy_package_artifacts_to_staging(config, pkg_dir, builder, server)?;
 
-    println!("COPYING deploy tool from builder -> deploy server");
+    println!(
+        "COPYING deploy tool from builder ({}) -> deploy server ({})",
+        builder.addr, server_name
+    );
     copy_omicron_package_binary_to_staging(config, builder, server)?;
 
-    println!("COPYING manifest from builder -> deploy server");
+    println!(
+        "COPYING manifest from builder ({}) -> deploy server ({})",
+        builder.addr, server_name
+    );
     copy_package_manifest_to_staging(config, builder, server)?;
 
-    println!("INSTALLING packages on deploy server");
+    println!("INSTALLING packages on deploy server ({})", server_name);
     run_omicron_package_install_from_staging(
         config,
         server,
@@ -477,7 +486,10 @@ fn single_server_install(
         &install_dir,
     )?;
 
-    println!("COPYING overlay files from builder -> deploy server");
+    println!(
+        "COPYING overlay files from builder ({}) -> deploy server ({})",
+        builder.addr, server_name
+    );
     copy_overlay_files_to_staging(
         config,
         pkg_dir,
@@ -486,10 +498,10 @@ fn single_server_install(
         server_name,
     )?;
 
-    println!("INSTALLING overlay files into the install directory of the deploy server");
+    println!("INSTALLING overlay files into the install directory of the deploy server ({})", server_name);
     install_overlay_files_from_staging(config, server, &install_dir)?;
 
-    println!("RESTARTING services on the deploy server");
+    println!("RESTARTING services on the deploy server ({})", server_name);
     restart_services(server)
 }
 

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -23,15 +23,10 @@ pub fn parse<P: AsRef<Path>, C: DeserializeOwned>(
 ) -> Result<C, ParseError> {
     let path = path.as_ref();
     let contents = std::fs::read_to_string(path).map_err(|err| {
-        ParseError::Io {
-            message: format!("failed reading {path:?}"),
-            err,
-        }
+        ParseError::Io { message: format!("failed reading {path:?}"), err }
     })?;
-    let cfg = toml::from_str::<C>(&contents).map_err(|err| ParseError::Toml {
-        path: path.to_path_buf(),
-        err,
-    })?;
+    let cfg = toml::from_str::<C>(&contents)
+        .map_err(|err| ParseError::Toml { path: path.to_path_buf(), err })?;
     Ok(cfg)
 }
 

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -12,17 +12,26 @@ use thiserror::Error;
 /// Errors which may be returned when parsing the server configuration.
 #[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("Cannot parse toml: {0}")]
-    Toml(#[from] toml::de::Error),
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
+    #[error("Error deserializing toml from {path}: {err}")]
+    Toml { path: PathBuf, err: toml::de::Error },
+    #[error("IO error: {message}: {err}")]
+    Io { message: String, err: std::io::Error },
 }
 
 pub fn parse<P: AsRef<Path>, C: DeserializeOwned>(
     path: P,
 ) -> Result<C, ParseError> {
-    let contents = std::fs::read_to_string(path.as_ref())?;
-    let cfg = toml::from_str::<C>(&contents)?;
+    let path = path.as_ref();
+    let contents = std::fs::read_to_string(path).map_err(|err| {
+        ParseError::Io {
+            message: format!("failed reading {path:?}"),
+            err,
+        }
+    })?;
+    let cfg = toml::from_str::<C>(&contents).map_err(|err| ParseError::Toml {
+        path: path.to_path_buf(),
+        err,
+    })?;
     Ok(cfg)
 }
 

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -23,10 +23,12 @@ trap on_exit ERR
 #
 # -y  Assume "yes" intead of showing confirmation prompts.
 ASSUME_YES="false"
-while getopts y flag
+SKIP_PATH_CHECK="false"
+while getopts yp flag
 do
   case "${flag}" in
-    y) ASSUME_YES="true" ;
+    y) ASSUME_YES="true" ;;
+    p) SKIP_PATH_CHECK="true" ;;
   esac
 done
 
@@ -166,7 +168,12 @@ function show_hint
   esac
 }
 
-# Check all paths before returning an error.
+# Check all paths before returning an error, unless we were told not too.
+if [[ "$SKIP_PATH_CHECK" == "true" ]]; then
+  echo "All prerequisites installed successfully"
+  exit 0
+fi
+
 ANY_PATH_ERROR="false"
 for command in "${expected_in_path[@]}"; do
   rc=0

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -19,13 +19,28 @@ function on_exit
 
 trap on_exit ERR
 
-# Offers a confirmation prompt.
+# Parse command line options:
+#
+# -y  Assume "yes" intead of showing confirmation prompts.
+ASSUME_YES="false"
+while getopts y flag
+do
+  case "${flag}" in
+    y) ASSUME_YES="true" ;
+  esac
+done
+
+# Offers a confirmation prompt, unless we were passed `-y`.
 #
 # Args:
 #  $1: Text to be displayed
 function confirm
 {
-  read -r -p "$1 (y/n): " response
+  if [[ "${ASSUME_YES}" == "true" ]]; then
+    response=y
+  else
+    read -r -p "$1 (y/n): " response
+  fi
   case $response in
     [yY])
       true


### PR DESCRIPTION
This PR is the output of attempting to follow the instructions in [deploy/README.adoc](https://github.com/oxidecomputer/omicron/blob/d2bf956eb3d8c74e634668062ed96ae26ac9e566/deploy/README.adoc) to use thing-flinger to set up a 2-sled omicron deployment on helios VMs on my Linux workstation. The changes are limited to `deploy/` with two exceptions:

1. Adding context to errors in `omicron-package` (in the spirit of #967)
2. Adding two command-line switches to `install_prerequisites.sh` to make it more friendly in a scripted context (`-y` to skip confirm prompts and `-p` to skip the check of `$PATH` at the end)

Even with these changes, deploying multisled via thing-flinger isn't completely working, for at least two reasons:

1. If using VMs, one must manually run `create_virtual_hardware.sh` on each of the deployment target VMs. This might be worth adding to thing-flinger if testing on multiple VMs becomes more common?
2. There are still some sled-specific configuration settings under `smf/` that thing-flinger broadcasts to all sled-agents. The most immediate one is that RSS is responsible for distributing IP addresses assigned to service-specific zones, but the configuration of the service itself (including what IP address to bind to) is separate.

An example of the second point for nexus:

https://github.com/oxidecomputer/omicron/blob/main/smf/sled-agent/config-rss.toml#L43-L48 lists addresses RSS hands out for a nexus instance

https://github.com/oxidecomputer/omicron/blob/main/smf/nexus/config.toml#L23-L29 are the same addresses repeated in the nexus config

If one adds a second nexus service to RSS's config with a different pair of addresses, there's not currently a way to (automatically) distribute a tweaked nexus `config.toml` containing those different addresses. @smklein and I chatted briefly about this, and I think it's covered under #822 - if RSS is responsible for handing out addresses, they ultimately shouldn't be hardcoded into nexus's config at all.