### PR TITLE
[cleanup][nexus] Store ports in DB as u16s

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -66,7 +66,7 @@ CREATE TABLE omicron.public.sled (
 
     /* The IP address and bound port of the sled agent server. */
     ip INET NOT NULL,
-    port INT4 NOT NULL,
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
 
     /* The last address allocated to an Oxide service on this sled. */
     last_used_address INET NOT NULL
@@ -114,7 +114,7 @@ CREATE TABLE omicron.public.Dataset (
 
     /* Contact information for the dataset */
     ip INET NOT NULL,
-    port INT4 NOT NULL,
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
 
     kind omicron.public.dataset_kind NOT NULL,
 
@@ -550,7 +550,7 @@ CREATE TABLE omicron.public.oximeter (
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
     ip INET NOT NULL,
-    port INT4 NOT NULL
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL
 );
 
 /*
@@ -561,7 +561,7 @@ CREATE TABLE omicron.public.metric_producer (
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
     ip INET NOT NULL,
-    port INT4 NOT NULL,
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
     interval FLOAT NOT NULL,
     /* TODO: Is this length appropriate? */
     base_route STRING(512) NOT NULL,

--- a/nexus/src/db/model/dataset.rs
+++ b/nexus/src/db/model/dataset.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{DatasetKind, Generation, Region};
+use super::{DatasetKind, Generation, Region, SqlU16};
 use crate::db::collection_insert::DatastoreCollection;
 use crate::db::schema::{dataset, region};
 use chrono::{DateTime, Utc};
@@ -36,7 +36,7 @@ pub struct Dataset {
     pub pool_id: Uuid,
 
     ip: ipnetwork::IpNetwork,
-    port: i32,
+    port: SqlU16,
 
     kind: DatasetKind,
     pub size_used: Option<i64>,

--- a/nexus/src/db/model/dataset.rs
+++ b/nexus/src/db/model/dataset.rs
@@ -66,8 +66,7 @@ impl Dataset {
     }
 
     pub fn address(&self) -> SocketAddr {
-        // TODO: avoid this unwrap
-        self.address_with_port(u16::try_from(self.port).unwrap())
+        self.address_with_port(self.port.into())
     }
 
     pub fn address_with_port(&self, port: u16) -> SocketAddr {

--- a/nexus/src/db/model/oximeter_info.rs
+++ b/nexus/src/db/model/oximeter_info.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::SqlU16;
 use crate::db::schema::oximeter;
 use crate::internal_api;
 use chrono::{DateTime, Utc};
@@ -19,8 +20,7 @@ pub struct OximeterInfo {
     pub time_modified: DateTime<Utc>,
     /// The address on which this oximeter instance listens for requests
     pub ip: ipnetwork::IpNetwork,
-    // TODO: Make use of SqlU16
-    pub port: i32,
+    pub port: SqlU16,
 }
 
 impl OximeterInfo {

--- a/nexus/src/db/model/producer_endpoint.rs
+++ b/nexus/src/db/model/producer_endpoint.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::SqlU16;
 use crate::db::identity::Asset;
 use crate::db::schema::metric_producer;
 use db_macros::Asset;
@@ -17,8 +18,7 @@ pub struct ProducerEndpoint {
     identity: ProducerEndpointIdentity,
 
     pub ip: ipnetwork::IpNetwork,
-    // TODO: Make use of SqlU16
-    pub port: i32,
+    pub port: SqlU16,
     pub interval: f64,
     pub base_route: String,
     pub oximeter_id: Uuid,

--- a/nexus/src/db/model/sled.rs
+++ b/nexus/src/db/model/sled.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::Generation;
+use super::{Generation, SqlU16};
 use crate::db::collection_insert::DatastoreCollection;
 use crate::db::ipv6;
 use crate::db::schema::{sled, zpool};
@@ -24,8 +24,7 @@ pub struct Sled {
 
     // ServiceAddress (Sled Agent).
     pub ip: ipv6::Ipv6Addr,
-    // TODO: Make use of SqlU16
-    pub port: i32,
+    pub port: SqlU16,
 
     /// The last IP address provided to an Oxide service on this sled
     pub last_used_address: ipv6::Ipv6Addr,

--- a/nexus/src/db/model/sled.rs
+++ b/nexus/src/db/model/sled.rs
@@ -8,7 +8,6 @@ use crate::db::ipv6;
 use crate::db::schema::{sled, zpool};
 use chrono::{DateTime, Utc};
 use db_macros::Asset;
-use std::convert::TryFrom;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
@@ -60,8 +59,7 @@ impl Sled {
     }
 
     pub fn address(&self) -> SocketAddrV6 {
-        // TODO: avoid this unwrap
-        self.address_with_port(u16::try_from(self.port).unwrap())
+        self.address_with_port(self.port.into())
     }
 
     pub fn address_with_port(&self, port: u16) -> SocketAddrV6 {

--- a/nexus/src/db/model/u16.rs
+++ b/nexus/src/db/model/u16.rs
@@ -7,12 +7,25 @@ use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
 use diesel::serialize::{self, ToSql};
 use diesel::sql_types;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// Representation of a [`u16`] in the database.
 /// We need this because the database does not support unsigned types.
 /// This handles converting from the database's INT4 to the actual u16.
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, FromSqlRow)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    AsExpression,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    FromSqlRow,
+    Serialize,
+    Deserialize,
+)]
 #[diesel(sql_type = sql_types::Int4)]
 #[repr(transparent)]
 pub struct SqlU16(pub u16);

--- a/nexus/src/db/model/vpc_firewall_rule.rs
+++ b/nexus/src/db/model/vpc_firewall_rule.rs
@@ -160,7 +160,10 @@ impl ToSql<sql_types::Int4, Pg> for VpcFirewallRulePriority {
         &'a self,
         out: &mut serialize::Output<'a, '_, Pg>,
     ) -> serialize::Result {
-        SqlU16(self.0 .0).to_sql(&mut out.reborrow())
+        <SqlU16 as ToSql<sql_types::Int4, Pg>>::to_sql(
+            &SqlU16(self.0 .0),
+            &mut out.reborrow(),
+        )
     }
 }
 


### PR DESCRIPTION
This stores ports as `u16`s instead of `u32`s, when possible.

This avoids unnecessary `unwraps` within `nexus/model`, and keeps the internal details of storage as a deserialization issue.