### PR TITLE
Remove support for modifying IP subnets of a VPC Subnet

### DIFF
--- a/nexus/src/db/model/vpc_subnet.rs
+++ b/nexus/src/db/model/vpc_subnet.rs
@@ -81,8 +81,6 @@ pub struct VpcSubnetUpdate {
     pub name: Option<Name>,
     pub description: Option<String>,
     pub time_modified: DateTime<Utc>,
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
 }
 
 impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
@@ -91,8 +89,6 @@ impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
             name: params.identity.name.map(Name),
             description: params.identity.description,
             time_modified: Utc::now(),
-            ipv4_block: params.ipv4_block.map(Ipv4Net),
-            ipv6_block: params.ipv6_block.map(Ipv6Net),
         }
     }
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -251,11 +251,6 @@ pub struct VpcSubnetCreate {
 pub struct VpcSubnetUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
-    // TODO-correctness: These need to be removed. Changing these is effectively
-    // creating a new resource, so we should require explicit
-    // deletion/recreation by the client.
-    pub ipv4_block: Option<Ipv4Net>,
-    pub ipv6_block: Option<Ipv6Net>,
 }
 
 // VPC ROUTERS

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -19,7 +19,7 @@ mod cidata;
 pub mod config; // Public for testing
 pub mod context; // Public for documentation examples
 pub mod db; // Public for documentation examples
-mod defaults;
+pub mod defaults; // Public for testing
 pub mod external_api; // Public for testing
 pub mod internal_api; // Public for testing
 pub mod nexus; // Public for documentation examples

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -147,28 +147,12 @@ pub async fn create_instance(
     project_name: &str,
     instance_name: &str,
 ) -> Instance {
-    let url = format!(
-        "/organizations/{}/projects/{}/instances",
-        organization_name, project_name
-    );
-    object_create(
+    create_instance_with_nics(
         client,
-        &url,
-        &params::InstanceCreate {
-            identity: IdentityMetadataCreateParams {
-                name: instance_name.parse().unwrap(),
-                description: format!("instance {:?}", instance_name),
-            },
-            ncpus: InstanceCpuCount(4),
-            memory: ByteCount::from_mebibytes_u32(256),
-            hostname: String::from("the_host"),
-            user_data:
-                b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
-                    .to_vec(),
-            network_interfaces:
-                params::InstanceNetworkInterfaceAttachment::Default,
-            disks: vec![],
-        },
+        organization_name,
+        project_name,
+        instance_name,
+        &params::InstanceNetworkInterfaceAttachment::Default,
     )
     .await
 }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -173,6 +173,38 @@ pub async fn create_instance(
     .await
 }
 
+pub async fn create_instance_with_nics(
+    client: &ClientTestContext,
+    organization_name: &str,
+    project_name: &str,
+    instance_name: &str,
+    nics: &params::InstanceNetworkInterfaceAttachment,
+) -> Instance {
+    let url = format!(
+        "/organizations/{}/projects/{}/instances",
+        organization_name, project_name
+    );
+    object_create(
+        client,
+        &url,
+        &params::InstanceCreate {
+            identity: IdentityMetadataCreateParams {
+                name: instance_name.parse().unwrap(),
+                description: format!("instance {:?}", instance_name),
+            },
+            ncpus: InstanceCpuCount(4),
+            memory: ByteCount::from_mebibytes_u32(256),
+            hostname: String::from("the_host"),
+            user_data:
+                b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
+                    .to_vec(),
+            network_interfaces: nics.clone(),
+            disks: vec![],
+        },
+    )
+    .await
+}
+
 pub async fn create_vpc(
     client: &ClientTestContext,
     organization_name: &str,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -533,8 +533,6 @@ lazy_static! {
                             name: None,
                             description: Some("different".to_string())
                         },
-                        ipv4_block: None,
-                        ipv6_block: None,
                     }).unwrap()
                 ),
                 AllowedMethod::Delete,

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -10,14 +10,13 @@ use http::StatusCode;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
-use nexus_test_utils::resource_helpers::create_instance;
+use nexus_test_utils::resource_helpers::create_instance_with_nics;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use omicron_common::api::external::{
-    ByteCount, IdentityMetadataCreateParams, IdentityMetadataUpdateParams,
-    InstanceCpuCount, Ipv4Net, NetworkInterface,
+    ByteCount, IdentityMetadataCreateParams, InstanceCpuCount, Ipv4Net,
+    NetworkInterface,
 };
 use omicron_nexus::external_api::params;
-use std::net::IpAddr;
 
 use dropshot::test_util::ClientTestContext;
 use dropshot::HttpErrorResponseBody;
@@ -30,7 +29,20 @@ async fn create_instance_expect_failure(
     client: &ClientTestContext,
     url_instances: &String,
     name: &str,
+    subnet_name: &str,
 ) -> HttpErrorResponseBody {
+    let network_interfaces =
+        params::InstanceNetworkInterfaceAttachment::Create(vec![
+            params::NetworkInterfaceCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: name.parse().unwrap(),
+                    description: String::from("description"),
+                },
+                vpc_name: "default".parse().unwrap(),
+                subnet_name: subnet_name.parse().unwrap(),
+                ip: None,
+            },
+        ]);
     let new_instance = params::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: name.parse().unwrap(),
@@ -40,7 +52,7 @@ async fn create_instance_expect_failure(
         memory: ByteCount::from_mebibytes_u32(256),
         hostname: name.to_string(),
         user_data: vec![],
-        network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
+        network_interfaces,
         disks: vec![],
     };
 
@@ -72,22 +84,24 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
         organization_name, project_name
     );
 
-    // Modify the default VPC to have a very small subnet so we don't need to
-    // issue many requests
-    let url_subnet = format!(
-        "/organizations/{}/projects/{}/vpcs/default/subnets/default",
+    // Create a new, small VPC Subnet, so we don't need to issue many requests
+    // to test address exhaustion.
+    let url_subnets = format!(
+        "/organizations/{}/projects/{}/vpcs/default/subnets",
         organization_name, project_name
     );
-    let subnet = "192.168.42.0/29".parse().unwrap();
-    let subnet_update = params::VpcSubnetUpdate {
-        identity: IdentityMetadataUpdateParams {
-            name: Some("default".parse().unwrap()),
-            description: None,
+    let subnet_name = "small";
+    let subnet = "192.168.42.0/26".parse().unwrap();
+    let subnet_create = params::VpcSubnetCreate {
+        identity: IdentityMetadataCreateParams {
+            name: subnet_name.parse().unwrap(),
+            description: String::from("a small subnet"),
         },
-        ipv4_block: Some(Ipv4Net(subnet)),
+        // Use the minimum subnet size
+        ipv4_block: Ipv4Net(subnet),
         ipv6_block: None,
     };
-    NexusRequest::object_put(client, &url_subnet, Some(&subnet_update))
+    NexusRequest::objects_post(client, &url_subnets, &Some(&subnet_create))
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -95,30 +109,66 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
 
     // The valid addresses for allocation in `subnet` are 192.168.42.5 and
     // 192.168.42.6. The rest are reserved as described in RFD21.
-    create_instance(client, organization_name, project_name, "i1").await;
-    create_instance(client, organization_name, project_name, "i2").await;
+    let nic = params::InstanceNetworkInterfaceAttachment::Create(vec![
+        params::NetworkInterfaceCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "eth0".parse().unwrap(),
+                description: String::from("some iface"),
+            },
+            vpc_name: "default".parse().unwrap(),
+            subnet_name: "small".parse().unwrap(),
+            ip: None,
+        },
+    ]);
+
+    // Create a shit-ton of instances, up to the size of the IP subnet.
+    //
+    // The first 5 addresses in an IP subnet are reserved, as is the broadcast
+    // address.
+    let n_initial_reserved_addresses = 5;
+    let n_final_reserved_addresses = 1;
+    let n_reserved_addresses =
+        n_initial_reserved_addresses + n_final_reserved_addresses;
+    let subnet_size = subnet.size() - n_reserved_addresses;
+    for i in 0..subnet_size {
+        create_instance_with_nics(
+            client,
+            organization_name,
+            project_name,
+            &format!("i{}", i),
+            &nic,
+        )
+        .await;
+    }
 
     // This should fail from address exhaustion
-    let error =
-        create_instance_expect_failure(client, &url_instances, "i3").await;
+    let error = create_instance_expect_failure(
+        client,
+        &url_instances,
+        "new-inst",
+        subnet_name,
+    )
+    .await;
     assert_eq!(error.message, "No available IP addresses for interface");
 
     // Verify the subnet lists the two addresses as in use
-    let url_ips = format!("{}/network-interfaces", url_subnet);
+    let url_ips = format!("{}/{}/network-interfaces", url_subnets, subnet_name);
     let mut network_interfaces =
         objects_list_page_authz::<NetworkInterface>(client, &url_ips)
             .await
             .items;
-    assert_eq!(network_interfaces.len(), 2);
+    assert_eq!(network_interfaces.len(), subnet_size as usize);
 
     // Sort by IP address to simplify the checks
     network_interfaces.sort_by(|a, b| a.ip.cmp(&b.ip));
-    assert_eq!(
-        network_interfaces[0].ip,
-        "192.168.42.5".parse::<IpAddr>().unwrap()
-    );
-    assert_eq!(
-        network_interfaces[1].ip,
-        "192.168.42.6".parse::<IpAddr>().unwrap()
-    );
+    for (iface, addr) in network_interfaces
+        .iter()
+        .zip(subnet.iter().skip(n_initial_reserved_addresses as usize))
+    {
+        assert_eq!(
+            iface.ip,
+            addr,
+            "Nexus should provide auto-assigned IP addresses in order within an IP subnet"
+        );
+    }
 }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8396,22 +8396,6 @@
             "nullable": true,
             "type": "string"
           },
-          "ipv4_block": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Ipv4Net"
-              }
-            ]
-          },
-          "ipv6_block": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Ipv6Net"
-              }
-            ]
-          },
           "name": {
             "nullable": true,
             "allOf": [


### PR DESCRIPTION
Previously, the `VpcSubnetUpdate` type allowed users to specify a new
IPv4 or IPv6 subnetwork for the VPC Subnet. That is now only supported
by creating a new subnet.