### PR TITLE
Fixes improves OPTE installation and improves errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "illumos-ddi-dki"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cb1767c#cb1767c80d4e9d97cb79901eed3c9d08e1fb3826"
+source = "git+https://github.com/oxidecomputer/opte?rev=b998015#b9980158540d15d44cfc5d17fc0a5d1848c5e1ae"
 dependencies = [
  "illumos-sys-hdrs",
 ]
@@ -2053,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cb1767c#cb1767c80d4e9d97cb79901eed3c9d08e1fb3826"
+source = "git+https://github.com/oxidecomputer/opte?rev=b998015#b9980158540d15d44cfc5d17fc0a5d1848c5e1ae"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cb1767c#cb1767c80d4e9d97cb79901eed3c9d08e1fb3826"
+source = "git+https://github.com/oxidecomputer/opte?rev=b998015#b9980158540d15d44cfc5d17fc0a5d1848c5e1ae"
 dependencies = [
  "anymap",
  "cfg-if 0.1.10",
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cb1767c#cb1767c80d4e9d97cb79901eed3c9d08e1fb3826"
+source = "git+https://github.com/oxidecomputer/opte?rev=b998015#b9980158540d15d44cfc5d17fc0a5d1848c5e1ae"
 dependencies = [
  "libc",
  "libnet",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -48,8 +48,8 @@ vsss-rs = { version = "2.0.0-pre2", default-features = false, features = ["std"]
 zone = "0.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "cb1767c" }
-opte = { git = "https://github.com/oxidecomputer/opte", rev = "cb1767c", features = [ "api", "std" ] }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "b998015" }
+opte = { git = "https://github.com/oxidecomputer/opte", rev = "b998015", features = [ "api", "std" ] }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/sled-agent/src/illumos/dladm.rs
+++ b/sled-agent/src/illumos/dladm.rs
@@ -170,9 +170,8 @@ impl Dladm {
         Ok(())
     }
 
-    /// Returns VNICs that may be managed by the Sled Agent of a particular
-    /// kind.
-    pub fn get_vnics(kind: VnicKind) -> Result<Vec<String>, GetVnicError> {
+    /// Returns VNICs that may be managed by the Sled Agent.
+    pub fn get_vnics() -> Result<Vec<String>, GetVnicError> {
         let mut command = std::process::Command::new(PFEXEC);
         let cmd = command.args(&[DLADM, "show-vnic", "-p", "-o", "LINK"]);
         let output = execute(cmd).map_err(|err| GetVnicError { err })?;
@@ -183,15 +182,7 @@ impl Dladm {
                 // Ensure this is a kind of VNIC that the sled agent could be
                 // responsible for.
                 match VnicKind::from_name(name) {
-                    Some(vnic_kind) => {
-                        // Ensure matches the caller-specified VnicKind
-                        if vnic_kind == kind {
-                            Some(name.to_owned())
-                        } else {
-                            None
-                        }
-                    }
-                    // Always ignore this VNIC if it's not a valid VnicKind.
+                    Some(_) => Some(name.to_owned()),
                     None => None,
                 }
             })

--- a/sled-agent/src/illumos/dladm.rs
+++ b/sled-agent/src/illumos/dladm.rs
@@ -185,12 +185,11 @@ impl Dladm {
 
     // Return true if a VNIC with the provided name may be managed by the sled
     // agent.
-    fn is_sled_agent_vnic<S: AsRef<str>>(name: S) -> bool {
-        let name = name.as_ref();
-        name.starts_with(VNIC_PREFIX) ||
-            name.starts_with(VNIC_PREFIX_OPTE) ||
-            name == "net0" ||
-            name == "net1"
+    fn is_sled_agent_vnic(name: &str) -> bool {
+        name.starts_with(VNIC_PREFIX)
+            || name.starts_with(VNIC_PREFIX_OPTE)
+            || name == "net0"
+            || name == "net1"
     }
 
     /// Remove a vnic from the sled.

--- a/sled-agent/src/illumos/running_zone.rs
+++ b/sled-agent/src/illumos/running_zone.rs
@@ -221,11 +221,14 @@ impl RunningZone {
             },
         )?;
 
+        let control_vnic = Vnic::wrap_existing(vnic_name)
+            .expect("Failed to wrap valid control VNIC");
+
         Ok(Self {
             inner: InstalledZone {
                 log: log.new(o!("zone" => zone_name.to_string())),
                 name: zone_name.to_string(),
-                control_vnic: Vnic::wrap_existing(vnic_name),
+                control_vnic,
                 // TODO(https://github.com/oxidecomputer/omicron/issues/725)
                 //
                 // Re-initialize guest_vnic state by inspecting the zone.

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -255,7 +255,7 @@ mod test {
         zones_get_ctx.expect().return_once(|| Ok(vec![]));
 
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
-        dladm_get_vnics_ctx.expect().return_once(|_| Ok(vec![]));
+        dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
 
         let im = InstanceManager::new(
             log,
@@ -337,7 +337,7 @@ mod test {
         zones_get_ctx.expect().return_once(|| Ok(vec![]));
 
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
-        dladm_get_vnics_ctx.expect().return_once(|_| Ok(vec![]));
+        dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
 
         let im = InstanceManager::new(
             log,

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -255,7 +255,7 @@ mod test {
         zones_get_ctx.expect().return_once(|| Ok(vec![]));
 
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
-        dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
+        dladm_get_vnics_ctx.expect().return_once(|_| Ok(vec![]));
 
         let im = InstanceManager::new(
             log,
@@ -337,7 +337,7 @@ mod test {
         zones_get_ctx.expect().return_once(|| Ok(vec![]));
 
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
-        dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
+        dladm_get_vnics_ctx.expect().return_once(|_| Ok(vec![]));
 
         let im = InstanceManager::new(
             log,

--- a/sled-agent/src/opte/mock_opte.rs
+++ b/sled-agent/src/opte/mock_opte.rs
@@ -183,3 +183,8 @@ pub fn initialize_xde_driver(log: &Logger) -> Result<(), Error> {
     slog::warn!(log, "`xde` driver is a fiction on non-illumos systems");
     Ok(())
 }
+
+pub fn delete_all_xde_devices(log: &Logger) -> Result<(), Error> {
+    slog::warn!(log, "`xde` driver is a fiction on non-illumos systems");
+    Ok(())
+}

--- a/sled-agent/src/opte/opte.rs
+++ b/sled-agent/src/opte/opte.rs
@@ -42,7 +42,9 @@ pub enum Error {
     #[error("Failed to get VNICs for xde underlay devices: {0}")]
     GetVnic(#[from] crate::illumos::dladm::GetVnicError),
 
-    #[error("No xde driver configuration file exists at '/kernel/drv/xde.conf'")]
+    #[error(
+        "No xde driver configuration file exists at '/kernel/drv/xde.conf'"
+    )]
     NoXdeConf,
 
     #[error(transparent)]
@@ -283,7 +285,7 @@ pub fn initialize_xde_driver(log: &Logger) -> Result<(), Error> {
             "exist on the system."
         );
         return Err(Error::Opte(opte_ioctl::Error::InvalidArgument(
-            String::from(MESSAGE)
+            String::from(MESSAGE),
         )));
     }
     for nic in &underlay_nics {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -163,19 +163,15 @@ impl SledAgent {
         // This should be accessible via:
         // $ dladm show-linkprop -c -p zone -o LINK,VALUE
         //
-        // Delete VNICs in this order:
-        //
-        // - Oxide control VNICs
-        // - Guest VNICs over xde devices
-        let vnics = Dladm::get_vnics(VnicKind::OxideControl)?
-            .into_iter()
-            .chain(Dladm::get_vnics(VnicKind::Guest)?);
-        for vnic in vnics {
+        // Note that we don't currently delete the VNICs in any particular
+        // order. That should be OK, since we're definitely deleting the guest
+        // VNICs before the xde devices, which is the main constraint.
+        for vnic in Dladm::get_vnics()? {
             warn!(
               log,
               "Deleting existing VNIC";
                 "vnic_name" => &vnic,
-                "vnic_kind" => ?VnicKind::from_name(&vnic),
+                "vnic_kind" => ?VnicKind::from_name(&vnic).unwrap(),
             );
             Dladm::delete_vnic(&vnic)?;
         }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -167,9 +167,9 @@ impl SledAgent {
         //
         // - Oxide control VNICs
         // - Guest VNICs over xde devices
-        let vnics = Dladm::get_vnics(Some(VnicKind::OxideControl))?
+        let vnics = Dladm::get_vnics(VnicKind::OxideControl)?
             .into_iter()
-            .chain(Dladm::get_vnics(Some(VnicKind::Guest))?);
+            .chain(Dladm::get_vnics(VnicKind::Guest)?);
         for vnic in vnics {
             warn!(
               log,

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -5,6 +5,7 @@
 //! Sled agent implementation
 
 use crate::config::Config;
+use crate::illumos::vnic::VnicKind;
 use crate::illumos::zfs::{
     Mountpoint, ZONE_ZFS_DATASET, ZONE_ZFS_DATASET_MOUNTPOINT,
 };
@@ -148,7 +149,7 @@ impl SledAgent {
         // to leave the running Zones intact).
         let zones = Zones::get()?;
         for z in zones {
-            warn!(log, "Deleting zone: {}", z.name());
+            warn!(log, "Deleting existing zone"; "zone_name" => z.name());
             Zones::halt_and_remove_logged(&log, z.name())?;
         }
 
@@ -162,17 +163,31 @@ impl SledAgent {
         // This should be accessible via:
         // $ dladm show-linkprop -c -p zone -o LINK,VALUE
         //
-        // Note that this currently deletes only VNICs that start with the
-        // prefix the sled-agent uses. We'll need to generate an alert or
-        // otherwise handle VNICs that we _don't_ expect.
-        let vnics = Dladm::get_vnics()?;
-        for vnic in vnics
-            .iter()
-            .filter(|vnic| vnic.starts_with(crate::illumos::dladm::VNIC_PREFIX))
-        {
-            warn!(log, "Deleting VNIC: {}", vnic);
+        // Delete VNICs in this order:
+        //
+        // - Oxide control VNICs
+        // - Guest VNICs over xde devices
+        let vnics = Dladm::get_vnics(Some(VnicKind::OxideControl))?
+            .into_iter()
+            .chain(Dladm::get_vnics(Some(VnicKind::Guest))?);
+        for vnic in vnics {
+            warn!(
+              log,
+              "Deleting existing VNIC";
+                "vnic_name" => &vnic,
+                "vnic_kind" => ?VnicKind::from_name(&vnic),
+            );
             Dladm::delete_vnic(&vnic)?;
         }
+
+        // Also delete any extant xde devices. These should also eventually be
+        // recovered / tracked, to avoid interruption of any guests that are
+        // still running. That's currently irrelevant, since we're deleting the
+        // zones anyway.
+        //
+        // This is also tracked by
+        // https://github.com/oxidecomputer/omicron/issues/725.
+        crate::opte::delete_all_xde_devices(&log)?;
 
         let storage = StorageManager::new(
             &log,

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -80,7 +80,7 @@ function ensure_helios_dev_is_non_sticky {
     if [[ "$STICKINESS" = "sticky" ]]; then
         pkg set-publisher --non-sticky helios-dev
         STICKINESS="$(helios_dev_stickiness)"
-        if [[ "$STICKINESS" = "non-sticky" ]]; then
+        if [[ "$STICKINESS" = "sticky" ]]; then
             echo "Failed to make helios-dev publisher non-sticky"
             exit 1
         fi

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -59,10 +59,58 @@ function sha_from_url {
     curl -L "$SHA_URL" 2> /dev/null | cut -d ' ' -f 1
 }
 
+# Echo the stickiness, 'sticky' or 'non-sticky' of the `helios-dev` publisher
+function helios_dev_stickiness {
+    local LINE="$(pkg publisher | grep '^helios-dev')"
+    if [[ -z "$LINE" ]]; then
+        echo "Expected a publisher named helios-dev, exiting!"
+        exit 1
+    fi
+    if [[ -z "$(echo "$LINE" | grep 'non-sticky')" ]]; then
+        echo "sticky"
+    else
+        echo "non-sticky"
+    fi
+}
+
+# Ensure that the `helios-dev` publisher is non-sticky. This does not modify the
+# publisher, if it is already non-sticky.
+function ensure_helios_dev_is_non_sticky {
+    local STICKINESS="$(helios_dev_stickiness)"
+    if [[ "$STICKINESS" = "sticky" ]]; then
+        pkg set-publisher --non-sticky helios-dev
+        STICKINESS="$(helios_dev_stickiness)"
+        if [[ "$STICKINESS" = "non-sticky" ]]; then
+            echo "Failed to make helios-dev publisher non-sticky"
+            exit 1
+        fi
+    else
+        echo "helios-dev publisher is already non-sticky"
+    fi
+}
+
+function verify_publisher_search_order {
+    local EXPECTED=("on-nightly" "helios-netdev" "helios-dev")
+    local N_EXPECTED="${#EXPECTED[*]}"
+    readarray -t ACTUAL < <(pkg publisher -H | cut -d ' ' -f 1)
+    local N_ACTUAL="${#ACTUAL[*]}"
+    if [[ $N_EXPECTED -ne $N_ACTUAL ]]; then
+        echo "Mismatched number of publishers, expected: $N_EXPECTED, found: $N_ACTUAL"
+        exit 1
+    fi
+    for ((i=0;i<N_ACTUAL;i++))
+    do
+        if [[ "${EXPECTED[i]}" != "${ACTUAL[i]}" ]]; then
+            echo "Mismatched publishers: ${EXPECTED[i]} vs ${ACTUAL[i]}"
+            exit 1
+        fi
+    done
+}
+
 # `helios-netdev` provides the xde kernel driver and the `opteadm` userland tool
 # for interacting with it.
 HELIOS_NETDEV_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/opte/repo"
-HELIOS_NETDEV_COMMIT="7f57b5d959fcd91100feb14ac83aefcee1c96a50"
+HELIOS_NETDEV_COMMIT="b9980158540d15d44cfc5d17fc0a5d1848c5e1ae"
 HELIOS_NETDEV_REPO_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p"
 HELIOS_NETDEV_REPO_SHA_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p.sha256"
 HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"
@@ -82,11 +130,13 @@ download_and_check_sha "$XDE_REPO_URL" "$(sha_from_url "$XDE_REPO_SHA_URL")"
 # Set the `helios-dev` repo as non-sticky, meaning that packages that were
 # originally provided by it may be updated by another repository, if that repo
 # provides newer versions of the packages.
-pkg set-publisher --non-sticky helios-dev
+ensure_helios_dev_is_non_sticky
 
 # Add the OPTE and xde repositories and update packages.
 pkg set-publisher -p "$HELIOS_NETDEV_REPO_PATH" --search-first
 pkg set-publisher -p "$XDE_REPO_PATH" --search-first
+
+verify_publisher_search_order
 
 # Actually update packages, handling case where no updates are needed
 RC=0

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -62,7 +62,7 @@ function sha_from_url {
 # `helios-netdev` provides the xde kernel driver and the `opteadm` userland tool
 # for interacting with it.
 HELIOS_NETDEV_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/opte/repo"
-HELIOS_NETDEV_COMMIT="cb1767c80d4e9d97cb79901eed3c9d08e1fb3826"
+HELIOS_NETDEV_COMMIT="7f57b5d959fcd91100feb14ac83aefcee1c96a50"
 HELIOS_NETDEV_REPO_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p"
 HELIOS_NETDEV_REPO_SHA_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p.sha256"
 HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"
@@ -70,7 +70,7 @@ HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"
 # The xde repo provides a full OS/Net incorporation, with updated kernel bits
 # that the `xde` kernel module and OPTE rely on.
 XDE_REPO_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/os-build/xde"
-XDE_REPO_COMMIT="485065f3b3292e2198db0629341492672b1e29f7"
+XDE_REPO_COMMIT="fc0717b76a92d1e317955ec33477133257982670"
 XDE_REPO_URL="$XDE_REPO_BASE_URL/$XDE_REPO_COMMIT/repo.p5p"
 XDE_REPO_SHA_URL="$XDE_REPO_BASE_URL/$XDE_REPO_COMMIT/repo.p5p.sha256"
 XDE_REPO_PATH="$XDE_DIR/$(basename "$XDE_REPO_URL")"
@@ -91,9 +91,8 @@ pkg set-publisher -p "$XDE_REPO_PATH" --search-first
 # Actually update packages, handling case where no updates are needed
 RC=0
 pkg update || RC=$?;
-if [[ "$RC" -eq 0 ]] || [[ "$RC" -eq 4 ]]; then
-    exit 0
-else
+if [[ "$RC" -ne 0 ]] && [[ "$RC" -ne 4 ]]; then
+    echo "Adding OPTE and/or xde package repositories failed"
     exit "$RC"
 fi
 


### PR DESCRIPTION
- Fixes mismerge in `tools/install_opte.sh` that prevented installing
  OPTE package on a system that didn't previously have it
- Improves error messages when either xde driver fails or the expected
  virtual networking devices don't exist