### PR TITLE
internal-dns: NXDOMAIN/SERVFAIL where appropriate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "toml",
+ "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",
  "trust-dns-server",

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.18", features = [ "full" ] }
 toml = "0.5"
 trust-dns-proto = "0.21"
 trust-dns-server = "0.21"
+trust-dns-client = "0.21"
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/internal-dns/src/bin/apigen.rs
+++ b/internal-dns/src/bin/apigen.rs
@@ -7,7 +7,7 @@ use internal_dns::dropshot_server::api;
 use std::fs::File;
 use std::io;
 
-fn usage(args: &Vec<String>) -> String {
+fn usage(args: &[String]) -> String {
     format!("{} [output path]", args[0])
 }
 

--- a/internal-dns/src/bin/dns-server.rs
+++ b/internal-dns/src/bin/dns-server.rs
@@ -27,6 +27,9 @@ struct Args {
 
     #[clap(long)]
     dns_address: SocketAddrV6,
+
+    #[clap(long)]
+    dns_zone: String,
 }
 
 #[tokio::main]
@@ -34,6 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let args = Args::parse();
     let config_file = &args.config_file;
     let dns_address = &args.dns_address;
+    let zone = &args.dns_zone;
     let config_file_contents = std::fs::read_to_string(config_file)
         .with_context(|| format!("read config file {:?}", config_file))?;
     let mut config: internal_dns::Config =
@@ -55,6 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
         let log = log.clone();
         let dns_config = internal_dns::dns_server::Config {
             bind_address: dns_address.to_string(),
+            zone: zone.to_string(),
         };
         tokio::spawn(async move {
             internal_dns::dns_server::run(log, db, dns_config).await

--- a/internal-dns/src/dns_server.rs
+++ b/internal-dns/src/dns_server.rs
@@ -129,6 +129,7 @@ async fn handle_req<'a, 'b, 'c>(
             Ok(r) => r,
             Err(e) => {
                 error!(log, "deserialize record: {}", e);
+                nack(&log, &mr, &socket, &header, &src).await;
                 return;
             }
         };

--- a/smf/internal-dns/manifest.xml
+++ b/smf/internal-dns/manifest.xml
@@ -13,13 +13,14 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/internal-dns/bin/dns-server --config-file /var/svc/manifest/site/internal-dns/config.toml --server-address %{config/server_address} --dns-address %{config/dns_address} &amp;'
+      exec='ctrun -l child -o noorphan,regent /opt/oxide/internal-dns/bin/dns-server --config-file /var/svc/manifest/site/internal-dns/config.toml --server-address %{config/server_address} --dns-address %{config/dns_address} --dns-zone %{config/dns_zone} &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 
   <property_group name='config' type='application'>
     <propval name='server_address' type='astring' value='unknown' />
     <propval name='dns_address' type='astring' value='unknown' />
+    <propval name='dns_zone' type='astring' value='oxide.internal' />
   </property_group>
 
   <property_group name='startd' type='framework'>


### PR DESCRIPTION
Currently when the internal DNS server encounters an error, or has no
records to serve, it will just return a DNS response with no resource
records. This causes issues for resolvers that expect:

- A SERVFAIL for records the DNS server cannot resolve.
- An NXDOMAIN for records the DNS server asserts do not exist.

This patch updates the internal DNS server to conform to those
expectations.

This required adding a zone configuration option to the internal DNS
server that identifies what domain it's presiding over. Any records that
do not fall within that domain will result in a SERVFAIL, causing
resolvers to look for other DNS servers for answers. This particular
failure mode falls under the SERVFAIL DNS Error Code 7 [1] "No Reachable
Authority" as the internal DNS server does not take responsibility for
recursive resolution.

[1] https://tools.ietf.org/id/draft-ietf-dnsop-extended-error-05.html#rfc.section.4.2.7