### PR TITLE
[internal-dns] Add support for multiple records behind a single name

### DIFF
--- a/internal-dns/src/bin/dnsadm.rs
+++ b/internal-dns/src/bin/dnsadm.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
             client
                 .dns_records_set(&vec![DnsKv {
                     key: DnsRecordKey { name: cmd.name },
-                    record: DnsRecord::Aaaa(cmd.addr),
+                    records: vec![DnsRecord::Aaaa(cmd.addr)],
                 }])
                 .await?;
         }
@@ -89,12 +89,12 @@ async fn main() -> Result<()> {
             client
                 .dns_records_set(&vec![DnsKv {
                     key: DnsRecordKey { name: cmd.name },
-                    record: DnsRecord::Srv(Srv {
+                    records: vec![DnsRecord::Srv(Srv {
                         prio: cmd.prio,
                         weight: cmd.weight,
                         port: cmd.port,
                         target: cmd.target,
-                    }),
+                    })],
                 }])
                 .await?;
         }

--- a/internal-dns/src/dns_data.rs
+++ b/internal-dns/src/dns_data.rs
@@ -61,7 +61,7 @@ pub struct DnsResponse<T> {
 #[serde(rename = "DnsKv")]
 pub struct DnsKV {
     key: DnsRecordKey,
-    record: DnsRecord,
+    records: Vec<DnsRecord>,
 }
 
 // XXX some refactors to help
@@ -202,21 +202,21 @@ impl Server {
                     return;
                 }
             };
-            let record: DnsRecord = match serde_json::from_slice(bits.as_ref())
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    error!(self.log, "deserialize record: {}", e);
-                    match response.tx.send(Vec::new()) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            error!(self.log, "response tx: {:?}", e);
+            let records: Vec<DnsRecord> =
+                match serde_json::from_slice(bits.as_ref()) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!(self.log, "deserialize record: {}", e);
+                        match response.tx.send(Vec::new()) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                error!(self.log, "response tx: {:?}", e);
+                            }
                         }
+                        return;
                     }
-                    return;
-                }
-            };
-            match response.tx.send(vec![DnsKV { key, record }]) {
+                };
+            match response.tx.send(vec![DnsKV { key, records }]) {
                 Ok(_) => {}
                 Err(e) => {
                     error!(self.log, "response tx: {:?}", e);
@@ -228,7 +228,7 @@ impl Server {
             loop {
                 match iter.next() {
                     Some(Ok((k, v))) => {
-                        let record: DnsRecord =
+                        let records: Vec<DnsRecord> =
                             match serde_json::from_slice(v.as_ref()) {
                                 Ok(r) => r,
                                 Err(e) => {
@@ -266,7 +266,7 @@ impl Server {
                         };
                         result.push(DnsKV {
                             key: DnsRecordKey { name: key },
-                            record,
+                            records,
                         });
                     }
                     Some(Err(e)) => {
@@ -291,7 +291,7 @@ impl Server {
         response: DnsResponse<()>,
     ) {
         for kv in records {
-            let bits = match serde_json::to_string(&kv.record) {
+            let bits = match serde_json::to_string(&kv.records) {
                 Ok(bits) => bits,
                 Err(e) => {
                     error!(self.log, "serialize record: {}", e);

--- a/internal-dns/src/dns_server.rs
+++ b/internal-dns/src/dns_server.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use crate::dns_data::DnsRecord;
 use pretty_hex::*;
 use serde::Deserialize;
-use slog::{error, info, Logger};
+use slog::{error, Logger};
 use tokio::net::UdpSocket;
 use trust_dns_client::rr::LowerName;
 use trust_dns_proto::op::header::Header;
@@ -139,7 +139,6 @@ async fn handle_req<'a, 'b, 'c>(
         nack(&log, &mr, &socket, &header, &src).await;
         return;
     }
-    info!(log, "Records found for {}: {:?}", key, records);
 
     let mut response_records: Vec<Record> = vec![];
     for record in &records {

--- a/internal-dns/tests/basic_test.rs
+++ b/internal-dns/tests/basic_test.rs
@@ -34,7 +34,7 @@ pub async fn aaaa_crud() -> Result<(), anyhow::Error> {
     client
         .dns_records_set(&vec![DnsKv {
             key: name.clone(),
-            record: aaaa.clone(),
+            records: vec![aaaa.clone()],
         }])
         .await?;
 
@@ -42,7 +42,9 @@ pub async fn aaaa_crud() -> Result<(), anyhow::Error> {
     let records = client.dns_records_get().await?;
     assert_eq!(1, records.len());
     assert_eq!(records[0].key.name, name.name);
-    match records[0].record {
+
+    assert_eq!(1, records[0].records.len());
+    match records[0].records[0] {
         DnsRecord::Aaaa(ra) => {
             assert_eq!(ra, addr);
         }
@@ -78,7 +80,7 @@ pub async fn srv_crud() -> Result<(), anyhow::Error> {
     client
         .dns_records_set(&vec![DnsKv {
             key: name.clone(),
-            record: rec.clone(),
+            records: vec![rec.clone()],
         }])
         .await?;
 
@@ -86,7 +88,9 @@ pub async fn srv_crud() -> Result<(), anyhow::Error> {
     let records = client.dns_records_get().await?;
     assert_eq!(1, records.len());
     assert_eq!(records[0].key.name, name.name);
-    match records[0].record {
+
+    assert_eq!(1, records[0].records.len());
+    match records[0].records[0] {
         DnsRecord::Srv(ref rs) => {
             assert_eq!(rs.prio, srv.prio);
             assert_eq!(rs.weight, srv.weight);

--- a/openapi/internal-dns.json
+++ b/openapi/internal-dns.json
@@ -135,13 +135,16 @@
           "key": {
             "$ref": "#/components/schemas/DnsRecordKey"
           },
-          "record": {
-            "$ref": "#/components/schemas/DnsRecord"
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DnsRecord"
+            }
           }
         },
         "required": [
           "key",
-          "record"
+          "records"
         ]
       },
       "DnsRecord": {


### PR DESCRIPTION
This feature is necessary to implement the specification of RFD 248, which recommends
using multiple SRV records for a service with multiple backends.