### PR TITLE
[package] Remove zones on installation

### DIFF
--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -325,8 +325,9 @@ fn do_install(
         Ok(())
     })?;
 
-    // Ensure we start from a clean slate - remove all packages.
+    // Ensure we start from a clean slate - remove all zones & packages.
     uninstall_all_packages(config);
+    uninstall_all_omicron_zones()?;
 
     // Extract and install the bootstrap service, which itself extracts and
     // installs other services.


### PR DESCRIPTION
This is already a part of the "uninstall" script, but removing it during the "install" process ensures we don't have zones leftover.

Now that the bootstrap agent and RSS are taking on a more significant role prior to bringup of the Sled Agent, it's important that we start from a clean slate, even before the sled agent has booted.