### PR TITLE
Detangle sled-agent + bootstrap-agent logs

### DIFF
--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -26,7 +26,7 @@ impl Server {
         sled_config: SledConfig,
     ) -> Result<Self, String> {
         let (drain, registration) = slog_dtrace::with_drain(
-            config.log.to_logger("bootstrap-agent").map_err(|message| {
+            config.log.to_logger("SledAgent").map_err(|message| {
                 format!("initializing logger: {}", message)
             })?,
         );
@@ -39,13 +39,8 @@ impl Server {
             debug!(log, "registered DTrace probes");
         }
         info!(log, "setting up bootstrap agent server");
-
-        let ba_log = log.new(o!(
-            "component" => "BootstrapAgent",
-            "server" => config.id.clone().to_string()
-        ));
         let bootstrap_agent = Arc::new(
-            Agent::new(ba_log, sled_config, address)
+            Agent::new(log.clone(), sled_config, address)
                 .await
                 .map_err(|e| e.to_string())?,
         );

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -46,7 +46,7 @@ impl Server {
         );
 
         let ba = Arc::clone(&bootstrap_agent);
-        let dropshot_log = log.new(o!("component" => "dropshot"));
+        let dropshot_log = log.new(o!("component" => "dropshot (Bootstrap)"));
         let http_server = dropshot::HttpServerStarter::new(
             &config.dropshot,
             http_api(),

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -59,7 +59,7 @@ impl InstanceManager {
     ) -> InstanceManager {
         InstanceManager {
             inner: Arc::new(InstanceManagerInternal {
-                log,
+                log: log.new(o!("component" => "InstanceManager")),
                 nexus_client,
                 instances: Mutex::new(BTreeMap::new()),
                 vnic_allocator: VnicAllocator::new("Instance", physical_link),

--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -47,18 +47,15 @@ impl Server {
             client_log,
         ));
 
-        let sa_log = log.new(o!(
-            "sled_id" => config.id.clone().to_string()
-        ));
         let sled_agent =
-            SledAgent::new(&config, sa_log, nexus_client.clone(), addr)
+            SledAgent::new(&config, log.clone(), nexus_client.clone(), addr)
                 .await
                 .map_err(|e| e.to_string())?;
 
         let mut dropshot_config = dropshot::ConfigDropshot::default();
         dropshot_config.request_body_max_bytes = 1024 * 1024;
         dropshot_config.bind_address = SocketAddr::V6(addr);
-        let dropshot_log = log.new(o!("component" => "dropshot"));
+        let dropshot_log = log.new(o!("component" => "dropshot (SledAgent)"));
         let http_server = dropshot::HttpServerStarter::new(
             &dropshot_config,
             http_api(),

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -97,7 +97,7 @@ impl ServiceManager {
     ) -> Result<Self, Error> {
         debug!(log, "Creating new ServiceManager");
         let mgr = Self {
-            log,
+            log: log.new(o!("component" => "ServiceManager")),
             config_path,
             zones: Mutex::new(vec![]),
             vnic_allocator: VnicAllocator::new(

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -891,7 +891,7 @@ impl StorageManager {
         nexus_client: Arc<NexusClient>,
         physical_link: PhysicalLink,
     ) -> Self {
-        let log = log.new(o!("component" => "sled agent storage manager"));
+        let log = log.new(o!("component" => "StorageManager"));
         let pools = Arc::new(Mutex::new(HashMap::new()));
         let (new_pools_tx, new_pools_rx) = mpsc::channel(10);
         let (new_filesystems_tx, new_filesystems_rx) = mpsc::channel(10);


### PR DESCRIPTION
This PR does a couple things:

1. It creates a *single* logger within the Bootstrap Agent / Sled Agent process, rather than creating two loggers pointing to the same file.
2. It restructures which loggers have the value "component" / "name" set. Apparently, [`slog::Logger::new`](https://docs.rs/slog/latest/slog/struct.Logger.html#method.new) **appends** kv pairs, rather than replacing any of them, so the bunyan-formatted logs would be confused seeing (for example) a log line with multiple KV pairs using "component" as a key. To cope with this, the logs are restructured so the "top-level" log name is always `SledAgent`, and the "component" log is set only once. (This behavior can be quickly observed by running: `cat /var/oxide/sled-agent.log | grep -n -o "\"component\"" | sort -n | uniq -c`, which outputs the number of times `component` appears as a key, and the associated line in the log).
