### PR TITLE
Don't fail install_opte.sh if driver/network/opte is already installed.

### DIFF
--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -151,4 +151,9 @@ if [[ "$RC" -ne 0 ]] && [[ "$RC" -ne 4 ]]; then
 fi
 
 # Actually install the xde kernel module and opteadm tool
-pkg install driver/network/opte
+RC=0
+pkg install driver/network/opte || RC=$?;
+if [[ "$RC" -ne 0 ]] && [[ "$RC" -ne 4 ]]; then
+    echo "Installing opte failed"
+    exit "$RC"
+fi


### PR DESCRIPTION
`install_opte.sh` will fail if any subcommands return a non-zero exit code. `pkg install` seems to return exit code 4 if the package is already installed so let's not bail on that here.