### PR TITLE
detach disks on instance delete

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -1024,6 +1024,7 @@ impl DataStore {
                     ErrorHandler::NotFoundByResource(authz_instance),
                 )
             })?;
+
         match result.status {
             UpdateStatus::Updated => Ok(()),
             UpdateStatus::NotUpdatedButExists => {


### PR DESCRIPTION
lookup all disks attached to an instance during instance delete, and
detach them before the instance is been deleted.

fixes https://github.com/oxidecomputer/omicron/issues/1031