### PR TITLE
Add OPTE uninstallation script

### DIFF
--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -142,18 +142,36 @@ ensure_helios_dev_is_non_sticky
 add_publisher "$HELIOS_NETDEV_REPO_PATH"
 add_publisher "$XDE_REPO_PATH"
 
-# Actually update packages, handling case where no updates are needed
+# Actually install the xde kernel module and opteadm tool
 RC=0
-pkg update || RC=$?;
+pkg install -v pkg://helios-netdev/driver/network/opte || RC=$?
 if [[ "$RC" -ne 0 ]] && [[ "$RC" -ne 4 ]]; then
-    echo "Adding OPTE and/or xde package repositories failed"
+    echo "Installing xde kernel driver and opteadm tool failed"
     exit "$RC"
 fi
 
-# Actually install the xde kernel module and opteadm tool
+# Check the user's path
 RC=0
-pkg install driver/network/opte || RC=$?;
-if [[ "$RC" -ne 0 ]] && [[ "$RC" -ne 4 ]]; then
-    echo "Installing opte failed"
+which opteadm > /dev/null || RC=$?
+if [[ "$RC" -ne 0 ]]; then
+    echo "The \`opteadm\` administration tool is not on your path."
+    echo "You may add \"/opt/oxide/opte/bin\" to your path to access it."
+fi
+
+# Install the kernel bits required for the xde kernel driver to operate
+# correctly
+RC=0
+pkg install -v pkg://on-nightly/consolidation/osnet/osnet-incorporation* || RC=$?
+if [[ "$RC" -eq 0 ]]; then
+    echo "The xde kernel driver, opteadm tool, and xde-related kernel bits"
+    echo "have successfully been installed. A reboot may be required to activate"
+    echo "the new boot environment, if the kernel has been changed (upgrade"
+    echo "or downgrade)"
+    exit 0
+elif [[ "$RC" -eq 4 ]]; then
+    echo "The kernel appears to be up-to-date for use with opte"
+    exit 0
+else
+    echo "Installing kernel bits for xde failed"
     exit "$RC"
 fi

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -93,7 +93,6 @@ function uninstall_xde_and_opte {
 }
 
 function ensure_not_already_on_helios {
-    local CONSOLIDATION="$1"
     RC=0
     pkg list "$STOCK_CONSOLIDATION"* || RC=$?
     if [[ $RC -eq 0 ]]; then

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -71,7 +71,7 @@ function to_stock_helios {
 function ensure_helios_publisher_exists {
     pkg publisher "$HELIOS_PUBLISHER" > /dev/null || \
         echo "No \"$HELIOS_PUBLISHER\" publisher exists on this system!"
-    CONSOLIDATION="$(pkg list --no-refresh -H -af "$STOCK_CONSOLIDATION"@latest || echo "")"
+    local CONSOLIDATION="$(pkg list --no-refresh -H -af "$STOCK_CONSOLIDATION"@latest || echo "")"
     if [[ -z "$CONSOLIDATION" ]]; then
         echo "No osnet-incorporation package exists on this system,"
         echo "so we cannot determine the exact package to install"
@@ -85,7 +85,7 @@ function ensure_helios_publisher_exists {
 
 # Actually uninstall the opteadm tool and xde driver
 function uninstall_xde_and_opte {
-    RC=0
+    local RC=0
     pkg uninstall -v --ignore-missing pkg://helios-netdev/driver/network/opte || RC=$?
     if [[ $RC -ne 0 ]] && [[ $RC -ne 4 ]]; then
         exit $RC
@@ -93,7 +93,7 @@ function uninstall_xde_and_opte {
 }
 
 function ensure_not_already_on_helios {
-    RC=0
+    local RC=0
     pkg list "$STOCK_CONSOLIDATION"* || RC=$?
     if [[ $RC -eq 0 ]]; then
         echo "This system appears to already be running stock Helios"
@@ -102,7 +102,7 @@ function ensure_not_already_on_helios {
 }
 
 CONSOLIDATION="$(ensure_helios_publisher_exists)"
-ensure_not_already_on_helios "$CONSOLIDATION"
+ensure_not_already_on_helios
 uninstall_xde_and_opte
 for PUBLISHER in "${PUBLISHERS[@]}"; do
     remove_publisher "$PUBLISHER"

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Small tool to _uninstall_ OPTE and the xde kernel driver and ONU bits.
+#
+# This should bring the system back to the stock Helios bits.
+
+set -e
+set -u
+set -x
+
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
+if [[ "$(uname)" != "SunOS" ]]; then
+    echo "This script is intended for Helios only"
+    exit 1
+fi
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "This must be run as root"
+    exit 1
+fi
+
+# Remove these publishers if they exist
+PUBLISHERS=("on-nightly" "helios-netdev")
+
+# The stock Helios publisher and incorporation base information to revert to
+HELIOS_PUBLISHER="helios-dev"
+STOCK_CONSOLIDATION="pkg://$HELIOS_PUBLISHER/consolidation/osnet/osnet-incorporation"
+
+# Remove a publisher in $1, assuming it matches a few basic assumptions
+function remove_publisher {
+    local PUBLISHER="$1"
+    local LINE="$(pkg publisher | grep "$PUBLISHER" | tr -s ' ')"
+    if [[ -z "$LINE" ]]; then
+        echo "Publisher \"$PUBLISHER\" does not exist, ignoring"
+        return 0
+    fi
+    local ORIGIN="$(echo "$LINE" | cut -d ' ' -f 5)"
+    if [[ -z "$ORIGIN" ]]; then
+        echo "Cannot determine origin URI for publisher \"$PUBLISHER\""
+        exit 1
+    fi
+    if [[ "${ORIGIN:0:7}" != "file://" ]]; then
+        echo "Expected a file origin URI for publisher \"$PUBLISHER\""
+        exit 1
+    fi
+
+    # Unset the publisher, but do not do anything with the file.
+    echo "Unsetting publisher \"$PUBLISHER\""
+    pkg unset-publisher "$PUBLISHER"
+}
+
+# Install stock incorporation from helios-dev, pushing the publisher to the top
+function to_stock_helios {
+    local CONSOLIDATION="$1"
+    echo "Installing stock Helios kernel and networking bits"
+    echo "provided by the consolidation package:"
+    echo "\"$CONSOLIDATION\""
+    echo "Note that this may entail an upgrade, depending on"
+    echo "how your Helios system is configured."
+    pkg set-publisher --sticky --search-first "$HELIOS_PUBLISHER"
+    pkg install --no-refresh -v "$CONSOLIDATION"
+}
+
+# If helios-dev exists, echo the full osnet-incorporation package we'll be
+# installing to. If it does _not_ exist, fail.
+function ensure_helios_publisher_exists {
+    pkg publisher "$HELIOS_PUBLISHER" > /dev/null || \
+        echo "No \"$HELIOS_PUBLISHER\" publisher exists on this system!"
+    CONSOLIDATION="$(pkg list --no-refresh -H -af "$STOCK_CONSOLIDATION"@latest || echo "")"
+    if [[ -z "$CONSOLIDATION" ]]; then
+        echo "No osnet-incorporation package exists on this system,"
+        echo "so we cannot determine the exact package to install"
+        echo "to revert to stock Helios. You may need to update your"
+        echo "helios-dev publisher to refresh that publishers list of"
+        echo "available packages, with \"pkg refresh helios-dev\""
+        exit 1
+    fi
+    echo "$CONSOLIDATION" | tr -s ' ' | cut -d ' ' -f 1,3 | tr ' ' '@'
+}
+
+# Actually uninstall the opteadm tool and xde driver
+function uninstall_xde_and_opte {
+    RC=0
+    pkg uninstall -v --ignore-missing pkg://helios-netdev/driver/network/opte || RC=$?
+    if [[ $RC -ne 0 ]] && [[ $RC -ne 4 ]]; then
+        exit $RC
+    fi
+}
+
+function ensure_not_already_on_helios {
+    local CONSOLIDATION="$1"
+    RC=0
+    pkg list "$STOCK_CONSOLIDATION"* || RC=$?
+    if [[ $RC -eq 0 ]]; then
+        echo "This system appears to already be running stock Helios"
+        exit 1
+    fi
+}
+
+CONSOLIDATION="$(ensure_helios_publisher_exists)"
+ensure_not_already_on_helios "$CONSOLIDATION"
+uninstall_xde_and_opte
+for PUBLISHER in "${PUBLISHERS[@]}"; do
+    remove_publisher "$PUBLISHER"
+done
+to_stock_helios "$CONSOLIDATION"


### PR DESCRIPTION
Adds ./tools/uninstall_opte.sh. This can be used to revert a system
which is on an xde-compatible kernel back to stock Helios bits. This
also updates the install_opte.sh script a bit to install exactly the
osnet-incorporation consolidation package that we expect to need in
order to be compatible with xde and OPTE.

Using this, we should be able to switch back and forth between an
xde-compatible and stock Helios kernel with minimal fuss.