### PR TITLE
[smf] Log to stdout, not a different log

### DIFF
--- a/smf/internal-dns/config.toml
+++ b/smf/internal-dns/config.toml
@@ -5,7 +5,7 @@ request_body_max_bytes = 1048576
 # Show log messages of this level and more severe
 level = "info"
 mode = "file"
-path = "/var/oxide/internal-dns.log"
+path = "/dev/stdout"
 if_exists = "append"
 
 [data]

--- a/smf/nexus/config.toml
+++ b/smf/nexus/config.toml
@@ -32,7 +32,7 @@ bind_address = "[fd00:1122:3344:0101::3]:12221"
 # Show log messages of this level and more severe
 level = "info"
 mode = "file"
-path = "/var/oxide/nexus.log"
+path = "/dev/stdout"
 if_exists = "append"
 
 # Configuration for interacting with the timeseries database

--- a/smf/oximeter/config.toml
+++ b/smf/oximeter/config.toml
@@ -12,7 +12,7 @@ batch_interval = 5 # In seconds
 [log]
 level = "debug"
 mode = "file"
-path = "/var/oxide/oximeter.log"
+path = "/dev/stdout"
 if_exists = "append"
 
 [dropshot]

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -27,5 +27,5 @@ zpools = [
 [log]
 level = "info"
 mode = "file"
-path = "/var/oxide/sled-agent.log"
+path = "/dev/stdout"
 if_exists = "append"


### PR DESCRIPTION
- This ensures the output still exists in the `svcs -L ...` file
- ... while also being Bunyan formatted