### PR TITLE
Add tunable parameters for Nexus config

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -84,6 +84,9 @@ pub struct Nexus {
     /// Contents of the trusted root role for the TUF repository.
     updates_config: Option<config::UpdatesConfig>,
 
+    /// The tunable parameters from a configuration file
+    tunables: config::Tunables,
+
     /// Operational context used for Instance allocation
     opctx_alloc: OpContext,
 
@@ -151,6 +154,7 @@ impl Nexus {
             populate_status,
             timeseries_client,
             updates_config: config.updates.clone(),
+            tunables: config.tunables.clone(),
             opctx_alloc: OpContext::for_background(
                 log.new(o!("component" => "InstanceAllocator")),
                 Arc::clone(&authz),
@@ -189,6 +193,11 @@ impl Nexus {
 
         *nexus.recovery_task.lock().unwrap() = Some(recovery_task);
         nexus
+    }
+
+    /// Return the tunable configuration parameters, e.g. for use in tests.
+    pub fn tunables(&self) -> &config::Tunables {
+        &self.tunables
     }
 
     pub async fn wait_for_populate(&self) -> Result<(), anyhow::Error> {

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -49,7 +49,8 @@ impl super::Nexus {
             ));
         }
         if params.ipv4_block.prefix() < defaults::MIN_VPC_IPV4_SUBNET_PREFIX
-            || params.ipv4_block.prefix() > defaults::MAX_VPC_IPV4_SUBNET_PREFIX
+            || params.ipv4_block.prefix()
+                > self.tunables.max_vpc_ipv4_subnet_prefix
         {
             return Err(external::Error::invalid_request(&format!(
                 concat!(
@@ -57,7 +58,7 @@ impl super::Nexus {
                     "length between {} and {}, inclusive"
                 ),
                 defaults::MIN_VPC_IPV4_SUBNET_PREFIX,
-                defaults::MAX_VPC_IPV4_SUBNET_PREFIX
+                self.tunables.max_vpc_ipv4_subnet_prefix,
             )));
         }
 

--- a/nexus/src/defaults.rs
+++ b/nexus/src/defaults.rs
@@ -18,11 +18,6 @@ use std::net::Ipv6Addr;
 /// NOTE: This is the minimum _prefix_, which sets the maximum subnet size.
 pub const MIN_VPC_IPV4_SUBNET_PREFIX: u8 = 8;
 
-/// Maximum prefix size supported in IPv4 VPC Subnets.
-///
-/// NOTE: This is the maximum _prefix_, which sets the minimum subnet size.
-pub const MAX_VPC_IPV4_SUBNET_PREFIX: u8 = 26;
-
 /// The number of reserved addresses at the beginning of a subnet range.
 pub const NUM_INITIAL_RESERVED_IP_ADDRESSES: usize = 5;
 

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -54,3 +54,8 @@ path = "UNUSED"
 # is listening.
 [timeseries_db]
 address = "[::1]:0"
+
+# Tunable parameters used during tests
+[tunables]
+# Allow small subnets, so we can test IP address exhaustion easily / quickly
+max_vpc_ipv4_subnet_prefix = 29


### PR DESCRIPTION
- Add the `[tunables]` section to the nexus config
- Includes a key `max_vpc_ipv4_subnet_prefix`. This takes the place of
  the compile-time constant
  `omicron_nexus::defaults::MAX_VPC_IPV4_SUBNET_PREFIX`. The proximal
  reason for this is to allow a small subnet when testing, to keep the
  subnet allocation integration test short.