### PR TITLE
clean up "test-privileged", "test-unprivileged" users

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -15,8 +15,7 @@ session_absolute_timeout_minutes = 480
 # List of authentication schemes to support.
 #
 # This is not fleshed out yet and the only reason to change it now is for
-# working on authentication or authorization.  Neither is really implemented
-# yet.
+# working on authentication or authorization.
 [authn]
 # TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
 schemes_external = ["spoof", "session_cookie"]

--- a/nexus/src/authn/external/mod.rs
+++ b/nexus/src/authn/external/mod.rs
@@ -191,7 +191,6 @@ mod test {
             user_builtin_id: "1c91bab2-4841-669f-cc32-de80da5bbf39"
                 .parse()
                 .unwrap(),
-            silo_id: *crate::db::fixed_data::silo::SILO_ID,
         };
         let grunt1 = Box::new(GruntScheme {
             name: name1,
@@ -208,7 +207,6 @@ mod test {
             user_builtin_id: "799684af-533a-cb66-b5ac-ab55a791d5ef"
                 .parse()
                 .unwrap(),
-            silo_id: *crate::db::fixed_data::silo::SILO_ID,
         };
         let grunt2 = Box::new(GruntScheme {
             name: name2,

--- a/nexus/src/authn/external/session_cookie.rs
+++ b/nexus/src/authn/external/session_cookie.rs
@@ -107,13 +107,8 @@ where
             }
         };
 
-        // TODO-security Once we have real SiloUsers and we can have
-        // "test-privileged" and "test-unprivileged" be Silo Users, this should
-        // be changed accordingly.  Until then, the integration tests attempt to
-        // use this scheme with "test-privileged", which requires that we
-        // interpret these as BuiltinUsers.
-        let actor = Actor::UserBuiltin {
-            user_builtin_id: session.silo_user_id(),
+        let actor = Actor::SiloUser {
+            silo_user_id: session.silo_user_id(),
             silo_id: session.silo_id(),
         };
 

--- a/nexus/src/authn/external/spoof.rs
+++ b/nexus/src/authn/external/spoof.rs
@@ -63,7 +63,6 @@ lazy_static! {
     /// Actor (id) used for the special "bad credentials" error
     static ref SPOOF_RESERVED_BAD_CREDS_ACTOR: Actor = Actor::UserBuiltin {
         user_builtin_id: "22222222-2222-2222-2222-222222222222".parse().unwrap(),
-        silo_id: *crate::db::fixed_data::silo::SILO_ID,
     };
     /// Complete HTTP header value to trigger the "bad actor" error
     pub static ref SPOOF_HEADER_BAD_ACTOR: Authorization<Bearer> =
@@ -150,7 +149,7 @@ fn authn_spoof(raw_value: Option<&Authorization<Bearer>>) -> SchemeResult {
             let silo_id = *crate::db::fixed_data::silo::SILO_ID;
             let actor = match actor_kind {
                 ActorType::Builtin => {
-                    Actor::UserBuiltin { user_builtin_id: actor_id, silo_id }
+                    Actor::UserBuiltin { user_builtin_id: actor_id }
                 }
                 ActorType::Silo => {
                     Actor::SiloUser { silo_user_id: actor_id, silo_id }

--- a/nexus/src/authn/mod.rs
+++ b/nexus/src/authn/mod.rs
@@ -69,7 +69,7 @@ impl Context {
         self.actor_required().ok()
     }
 
-    /// Returns the authenticated actor if present, Unauthenticated error
+    /// Returns the authenticated actor if present or an Unauthenticated error
     /// otherwise
     pub fn actor_required(
         &self,
@@ -84,7 +84,7 @@ impl Context {
         }
     }
 
-    /// Returns the current actor's Silo if they have one, and an appropriate
+    /// Returns the current actor's Silo if they have one or an appropriate
     /// error otherwise
     ///
     /// This is intended for code paths that always expect a Silo to be present.
@@ -112,7 +112,7 @@ impl Context {
     ///
     /// * there's an authenticated user with an associated Silo (most common)
     /// * there's an authenticated built-in user who has no associated Silo
-    /// * there's no authenticated user
+    /// * there's no authenticated user (returned as an error)
     ///
     /// Built-in users have no Silo, and so they usually can't do anything that
     /// might use a Silo.  You usually want to use [`Context::silo_required()`]

--- a/nexus/src/authn/mod.rs
+++ b/nexus/src/authn/mod.rs
@@ -97,10 +97,10 @@ impl Context {
     ) -> Result<authz::Silo, omicron_common::api::external::Error> {
         self.silo_or_builtin().and_then(|maybe_silo| {
             maybe_silo.ok_or_else(|| {
-                omicron_common::api::external::Error::internal_error(&format!(
+                omicron_common::api::external::Error::internal_error(
                     "needed Silo for a built-in user, but \
-                        built-in users have no Silo"
-                ))
+                        built-in users have no Silo",
+                )
             })
         })
     }

--- a/nexus/src/authz/actor.rs
+++ b/nexus/src/authz/actor.rs
@@ -45,7 +45,7 @@ impl oso::PolarClass for AnyActor {
 #[derive(Clone, Debug)]
 pub struct AuthenticatedActor {
     actor_id: Uuid,
-    silo_id: Uuid,
+    silo_id: Option<Uuid>,
     roles: RoleSet,
 }
 
@@ -76,17 +76,19 @@ impl oso::PolarClass for AuthenticatedActor {
             .add_constant(
                 AuthenticatedActor {
                     actor_id: authn::USER_DB_INIT.id,
-                    silo_id: authn::USER_DB_INIT.silo_id,
+                    silo_id: None,
                     roles: RoleSet::new(),
                 },
                 "USER_DB_INIT",
             )
             .add_attribute_getter("silo", |a: &AuthenticatedActor| {
-                super::Silo::new(
-                    super::FLEET,
-                    a.silo_id,
-                    LookupType::ById(a.silo_id),
-                )
+                a.silo_id.map(|silo_id| {
+                    super::Silo::new(
+                        super::FLEET,
+                        silo_id,
+                        LookupType::ById(silo_id),
+                    )
+                })
             })
     }
 }

--- a/nexus/src/authz/context.rs
+++ b/nexus/src/authz/context.rs
@@ -204,7 +204,7 @@ mod test {
             crate::db::datastore::datastore_test(&logctx, &db).await;
         let authz_privileged = authz_context_for_actor(
             &logctx.log,
-            authn::Context::internal_test_user(),
+            authn::Context::privileged_test_user(),
             Arc::clone(&datastore),
         );
         authz_privileged
@@ -224,9 +224,7 @@ mod test {
         ));
         let authz_nobody = authz_context_for_actor(
             &logctx.log,
-            authn::Context::test_context_for_builtin_user(
-                authn::USER_TEST_UNPRIVILEGED.id,
-            ),
+            authn::Context::unprivileged_test_user(),
             Arc::clone(&datastore),
         );
         authz_nobody
@@ -253,7 +251,7 @@ mod test {
 
         let authz_privileged = authz_context_for_actor(
             &logctx.log,
-            authn::Context::internal_test_user(),
+            authn::Context::privileged_test_user(),
             Arc::clone(&datastore),
         );
         authz_privileged
@@ -264,9 +262,7 @@ mod test {
             );
         let authz_nobody = authz_context_for_actor(
             &logctx.log,
-            authn::Context::test_context_for_builtin_user(
-                authn::USER_TEST_UNPRIVILEGED.id,
-            ),
+            authn::Context::unprivileged_test_user(),
             Arc::clone(&datastore),
         );
         authz_nobody

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -152,7 +152,8 @@ resource Silo {
 has_relation(fleet: Fleet, "parent_fleet", silo: Silo)
 	if silo.fleet = fleet;
 has_role(actor: AuthenticatedActor, "viewer", silo: Silo)
-	# TODO-coverage We should have a test that exercises this case.
+	# TODO-security TODO-coverage We should have a test that exercises this
+	# case.
 	if silo in actor.silo;
 
 resource Organization {

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -152,9 +152,7 @@ resource Silo {
 has_relation(fleet: Fleet, "parent_fleet", silo: Silo)
 	if silo.fleet = fleet;
 has_role(actor: AuthenticatedActor, "viewer", silo: Silo)
-	#if actor.silo != nil and actor.silo.unwrap() = silo;
-	# XXX-dap
-	# TODO definitely want coverage for this
+	# TODO-coverage We should have a test that exercises this case.
 	if silo in actor.silo;
 
 resource Organization {

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -152,7 +152,10 @@ resource Silo {
 has_relation(fleet: Fleet, "parent_fleet", silo: Silo)
 	if silo.fleet = fleet;
 has_role(actor: AuthenticatedActor, "viewer", silo: Silo)
-	if actor.silo = silo;
+	#if actor.silo != nil and actor.silo.unwrap() = silo;
+	# XXX-dap
+	# TODO definitely want coverage for this
+	if silo in actor.silo;
 
 resource Organization {
 	permissions = [

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -378,13 +378,17 @@ impl OpContext {
 
     /// Returns a context suitable for automated tests where an OpContext is
     /// needed outside of a Dropshot context
+    // Ideally this would only be exposed under `#[cfg(test)]`.  However, it's
+    // used by integration tests (via `app::test_interfaces::TestInterfaces`) in
+    // order to construct OpContexts that let them observe and muck with state
+    // outside public interfaces.
     pub fn for_tests(
         log: slog::Logger,
         datastore: Arc<DataStore>,
     ) -> OpContext {
         let created_instant = Instant::now();
         let created_walltime = SystemTime::now();
-        let authn = Arc::new(authn::Context::internal_test_user());
+        let authn = Arc::new(authn::Context::privileged_test_user());
         let authz = authz::Context::new(
             Arc::clone(&authn),
             Arc::new(authz::Authz::new(&log)),

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -30,7 +30,7 @@ use crate::authz::{self, ApiResource};
 use crate::context::OpContext;
 use crate::db::fixed_data::role_assignment::BUILTIN_ROLE_ASSIGNMENTS;
 use crate::db::fixed_data::role_builtin::BUILTIN_ROLES;
-use crate::db::fixed_data::silo::{DEFAULT_SILO, SILO_ID};
+use crate::db::fixed_data::silo::DEFAULT_SILO;
 use crate::db::lookup::LookupPath;
 use crate::db::{
     self,
@@ -2388,8 +2388,6 @@ impl DataStore {
             &*authn::USER_INTERNAL_READ,
             &*authn::USER_EXTERNAL_AUTHN,
             &*authn::USER_SAGA_RECOVERY,
-            &*authn::USER_TEST_PRIVILEGED,
-            &*authn::USER_TEST_UNPRIVILEGED,
         ]
         .iter()
         .map(|u| {
@@ -2405,19 +2403,6 @@ impl DataStore {
         })
         .collect::<Vec<UserBuiltin>>();
 
-        // TODO: This should probably be removed when we can switch
-        // "test-privileged" and "test-unprivileged" to normal silo users rather
-        // than built-in users.
-        debug!(opctx.log, "creating silo_user entries for built-in users");
-        for builtin_user in &builtin_users {
-            self.silo_user_create(SiloUser::new(
-                *SILO_ID,
-                builtin_user.identity.id, /* silo user id */
-            ))
-            .await?;
-        }
-        info!(opctx.log, "created silo_user entries for built-in users");
-
         debug!(opctx.log, "attempting to create built-in users");
         let count = diesel::insert_into(dsl::user_builtin)
             .values(builtin_users)
@@ -2429,6 +2414,60 @@ impl DataStore {
                 public_error_from_diesel_pool(e, ErrorHandler::Server)
             })?;
         info!(opctx.log, "created {} built-in users", count);
+
+        Ok(())
+    }
+
+    /// Load the testing users into the database
+    pub async fn load_silo_users(
+        &self,
+        opctx: &OpContext,
+    ) -> Result<(), Error> {
+        use db::schema::silo_user::dsl;
+
+        opctx.authorize(authz::Action::Modify, &authz::DATABASE).await?;
+
+        let users =
+            [&*authn::USER_TEST_PRIVILEGED, &*authn::USER_TEST_UNPRIVILEGED];
+
+        debug!(opctx.log, "attempting to create silo users");
+        let count = diesel::insert_into(dsl::silo_user)
+            .values(users)
+            .on_conflict(dsl::id)
+            .do_nothing()
+            .execute_async(self.pool_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel_pool(e, ErrorHandler::Server)
+            })?;
+        info!(opctx.log, "created {} silo users", count);
+
+        Ok(())
+    }
+
+    /// Load role assignments for the test users into the database
+    pub async fn load_silo_user_role_assignments(
+        &self,
+        opctx: &OpContext,
+    ) -> Result<(), Error> {
+        use db::schema::role_assignment::dsl;
+        debug!(opctx.log, "attempting to create silo user role assignments");
+        let count = diesel::insert_into(dsl::role_assignment)
+            .values(&*db::fixed_data::silo_user::ROLE_ASSIGNMENTS_PRIVILEGED)
+            .on_conflict((
+                dsl::identity_type,
+                dsl::identity_id,
+                dsl::resource_type,
+                dsl::resource_id,
+                dsl::role_name,
+            ))
+            .do_nothing()
+            .execute_async(self.pool_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel_pool(e, ErrorHandler::Server)
+            })?;
+        info!(opctx.log, "created {} silo user role assignments", count);
 
         Ok(())
     }
@@ -2496,7 +2535,6 @@ impl DataStore {
 
         opctx.authorize(authz::Action::Modify, &authz::DATABASE).await?;
 
-        // The built-in "test-privileged" user gets the "fleet admin" role.
         debug!(opctx.log, "attempting to create built-in role assignments");
         let count = diesel::insert_into(dsl::role_assignment)
             .values(&*BUILTIN_ROLE_ASSIGNMENTS)
@@ -3094,6 +3132,8 @@ pub async fn datastore_test(
     datastore.load_builtin_roles(&opctx).await.unwrap();
     datastore.load_builtin_role_asgns(&opctx).await.unwrap();
     datastore.load_builtin_silos(&opctx).await.unwrap();
+    datastore.load_silo_users(&opctx).await.unwrap();
+    datastore.load_silo_user_role_assignments(&opctx).await.unwrap();
 
     // Create an OpContext with the credentials of "test-privileged" for general
     // testing.
@@ -3108,6 +3148,7 @@ mod test {
     use super::*;
     use crate::authz;
     use crate::db::explain::ExplainableAsync;
+    use crate::db::fixed_data::silo::SILO_ID;
     use crate::db::identity::Resource;
     use crate::db::lookup::LookupPath;
     use crate::db::model::{ConsoleSession, DatasetKind, Project};
@@ -3173,6 +3214,12 @@ mod test {
         let logctx = dev::test_setup_log("test_session_methods");
         let mut db = test_setup_database(&logctx.log).await;
         let (opctx, datastore) = datastore_test(&logctx, &db).await;
+        let authn_opctx = OpContext::for_background(
+            logctx.log.new(o!("component" => "TestExternalAuthn")),
+            Arc::new(authz::Authz::new(&logctx.log)),
+            authn::Context::external_authn(),
+            Arc::clone(&datastore),
+        );
 
         let token = "a_token".to_string();
         let silo_user_id = Uuid::new_v4();
@@ -3184,8 +3231,10 @@ mod test {
             silo_user_id,
         };
 
-        let _ =
-            datastore.session_create(&opctx, session.clone()).await.unwrap();
+        let _ = datastore
+            .session_create(&authn_opctx, session.clone())
+            .await
+            .unwrap();
 
         // Associate silo with user
         datastore
@@ -3209,7 +3258,8 @@ mod test {
         assert_eq!(session.silo_user_id, fetched.silo_user_id);
 
         // trying to insert the same one again fails
-        let duplicate = datastore.session_create(&opctx, session.clone()).await;
+        let duplicate =
+            datastore.session_create(&authn_opctx, session.clone()).await;
         assert!(matches!(
             duplicate,
             Err(Error::InternalError { internal_message: _ })

--- a/nexus/src/db/fixed_data/mod.rs
+++ b/nexus/src/db/fixed_data/mod.rs
@@ -33,6 +33,7 @@ use lazy_static::lazy_static;
 pub mod role_assignment;
 pub mod role_builtin;
 pub mod silo;
+pub mod silo_user;
 pub mod user_builtin;
 
 lazy_static! {

--- a/nexus/src/db/fixed_data/role_assignment.rs
+++ b/nexus/src/db/fixed_data/role_assignment.rs
@@ -13,26 +13,6 @@ use lazy_static::lazy_static;
 lazy_static! {
     pub static ref BUILTIN_ROLE_ASSIGNMENTS: Vec<RoleAssignment> =
         vec![
-            // The "test-privileged" user gets the "admin" role on the sole
-            // Fleet.  This will grant them all permissions on all resources.
-            RoleAssignment::new(
-                IdentityType::UserBuiltin,
-                user_builtin::USER_TEST_PRIVILEGED.id,
-                role_builtin::FLEET_ADMIN.resource_type,
-                *FLEET_ID,
-                role_builtin::FLEET_ADMIN.role_name,
-            ),
-
-            // The same user also needs "fleet authenticator" to be able to
-            // create test sessions.
-            RoleAssignment::new(
-                IdentityType::UserBuiltin,
-                user_builtin::USER_TEST_PRIVILEGED.id,
-                role_builtin::FLEET_AUTHENTICATOR.resource_type,
-                *FLEET_ID,
-                role_builtin::FLEET_AUTHENTICATOR.role_name,
-            ),
-
             // The "internal-api" user gets the "admin" role on the sole Fleet.
             // This will grant them (nearly) all permissions on all resources.
             // TODO-security We should scope this down (or, really, figure out a

--- a/nexus/src/db/fixed_data/silo_user.rs
+++ b/nexus/src/db/fixed_data/silo_user.rs
@@ -11,6 +11,9 @@ use lazy_static::lazy_static;
 lazy_static! {
     /// Test user that's granted all privileges, used for automated testing and
     /// local development
+    // TODO-security Once we have a way to bootstrap the initial Silo with the
+    // initial privileged user, this user should be created in the test suite,
+    // not automatically at Nexus startup.
     pub static ref USER_TEST_PRIVILEGED: db::model::SiloUser =
         db::model::SiloUser::new(
             *db::fixed_data::silo::SILO_ID,
@@ -33,6 +36,9 @@ lazy_static! {
         ];
 
     /// Test user that's granted no privileges, used for automated testing
+    // TODO-security Once we have a way to bootstrap the initial Silo with the
+    // initial privileged user, this user should be created in the test suite,
+    // not automatically at Nexus startup.
     pub static ref USER_TEST_UNPRIVILEGED: db::model::SiloUser =
         db::model::SiloUser::new(
             *db::fixed_data::silo::SILO_ID,

--- a/nexus/src/db/fixed_data/silo_user.rs
+++ b/nexus/src/db/fixed_data/silo_user.rs
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Built-in Silo Users
+
+use super::role_builtin;
+use crate::db;
+use crate::db::identity::Asset;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Test user that's granted all privileges, used for automated testing and
+    /// local development
+    pub static ref USER_TEST_PRIVILEGED: db::model::SiloUser =
+        db::model::SiloUser::new(
+            *db::fixed_data::silo::SILO_ID,
+            // "4007" looks a bit like "root".
+            "001de000-05e4-4000-8000-000000004007".parse().unwrap()
+        );
+
+    /// Role assignments needed for the privileged user
+    pub static ref ROLE_ASSIGNMENTS_PRIVILEGED:
+        Vec<db::model::RoleAssignment> = vec![
+            // The "test-privileged" user gets the "admin" role on the sole
+            // Fleet.  This will grant them all permissions on all resources.
+            db::model::RoleAssignment::new(
+                db::model::IdentityType::SiloUser,
+                USER_TEST_PRIVILEGED.id(),
+                role_builtin::FLEET_ADMIN.resource_type,
+                *db::fixed_data::FLEET_ID,
+                role_builtin::FLEET_ADMIN.role_name,
+            ),
+        ];
+
+    /// Test user that's granted no privileges, used for automated testing
+    pub static ref USER_TEST_UNPRIVILEGED: db::model::SiloUser =
+        db::model::SiloUser::new(
+            *db::fixed_data::silo::SILO_ID,
+            // 60001 is the decimal uid for "nobody" on Helios.
+            "001de000-05e4-4000-8000-000000060001".parse().unwrap()
+        );
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::assert_valid_uuid;
+    use super::USER_TEST_PRIVILEGED;
+    use super::USER_TEST_UNPRIVILEGED;
+    use crate::db::identity::Asset;
+
+    #[test]
+    fn test_silo_user_ids_are_valid() {
+        assert_valid_uuid(&USER_TEST_PRIVILEGED.id());
+        assert_valid_uuid(&USER_TEST_UNPRIVILEGED.id());
+    }
+}

--- a/nexus/src/db/fixed_data/user_builtin.rs
+++ b/nexus/src/db/fixed_data/user_builtin.rs
@@ -3,14 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //! Built-in users
 
-use crate::db::fixed_data::silo::SILO_ID;
 use lazy_static::lazy_static;
 use omicron_common::api;
 use uuid::Uuid;
 
 pub struct UserBuiltinConfig {
     pub id: Uuid,
-    pub silo_id: Uuid,
     pub name: api::external::Name,
     pub description: &'static str,
 }
@@ -18,15 +16,11 @@ pub struct UserBuiltinConfig {
 impl UserBuiltinConfig {
     fn new_static(
         id: &str,
-        silo_id: &str,
         name: &str,
         description: &'static str,
     ) -> UserBuiltinConfig {
         UserBuiltinConfig {
             id: id.parse().expect("invalid uuid for builtin user id"),
-            silo_id: silo_id
-                .parse()
-                .expect("invalid uuid for builtin user silo id"),
             name: name.parse().expect("invalid name for builtin user name"),
             description,
         }
@@ -41,7 +35,6 @@ lazy_static! {
             // "0001" is the first possible user that wouldn't be confused with
             // 0, or root.
             "001de000-05e4-4000-8000-000000000001",
-            &SILO_ID.to_string().as_str(),
             "db-init",
             "used for seeding initial database data",
         );
@@ -50,7 +43,6 @@ lazy_static! {
     pub static ref USER_INTERNAL_API: UserBuiltinConfig =
         UserBuiltinConfig::new_static(
             "001de000-05e4-4000-8000-000000000002",
-            &SILO_ID.to_string().as_str(),
             "internal-api",
             "used by Nexus when handling internal API requests",
         );
@@ -60,7 +52,6 @@ lazy_static! {
         UserBuiltinConfig::new_static(
             // "4ead" looks like "read"
             "001de000-05e4-4000-8000-000000004ead",
-            &SILO_ID.to_string().as_str(),
             "internal-read",
             "used by Nexus to read privileged control plane data",
         );
@@ -70,7 +61,6 @@ lazy_static! {
         UserBuiltinConfig::new_static(
             // "3a8a" looks a bit like "saga".
             "001de000-05e4-4000-8000-000000003a8a",
-            &SILO_ID.to_string().as_str(),
             "saga-recovery",
             "used by Nexus when recovering sagas",
         );
@@ -80,7 +70,6 @@ lazy_static! {
         UserBuiltinConfig::new_static(
             // "3a8a" looks a bit like "saga".
             "001de000-05e4-4000-8000-000000000003",
-            &SILO_ID.to_string().as_str(),
             "external-authn",
             "used by Nexus when authenticating external requests",
         );

--- a/nexus/src/db/fixed_data/user_builtin.rs
+++ b/nexus/src/db/fixed_data/user_builtin.rs
@@ -84,29 +84,6 @@ lazy_static! {
             "external-authn",
             "used by Nexus when authenticating external requests",
         );
-
-    /// Test user that's granted all privileges, used for automated testing and
-    /// local development
-    // TODO-security This eventually needs to go, maybe replaced with some kind
-    // of deployment-specific customization.
-    pub static ref USER_TEST_PRIVILEGED: UserBuiltinConfig =
-        UserBuiltinConfig::new_static(
-            // "4007" looks a bit like "root".
-            "001de000-05e4-4000-8000-000000004007",
-            &SILO_ID.to_string().as_str(),
-            "test-privileged",
-            "used for testing with all privileges",
-        );
-
-    /// Test user that's granted no privileges, used for automated testing
-    pub static ref USER_TEST_UNPRIVILEGED: UserBuiltinConfig =
-        UserBuiltinConfig::new_static(
-            // 60001 is the decimal uid for "nobody" on Helios.
-            "001de000-05e4-4000-8000-000000060001",
-            &SILO_ID.to_string().as_str(),
-            "test-unprivileged",
-            "used for testing with no privileges",
-        );
 }
 
 #[cfg(test)]
@@ -117,8 +94,6 @@ mod test {
     use super::USER_INTERNAL_API;
     use super::USER_INTERNAL_READ;
     use super::USER_SAGA_RECOVERY;
-    use super::USER_TEST_PRIVILEGED;
-    use super::USER_TEST_UNPRIVILEGED;
 
     #[test]
     fn test_builtin_user_ids_are_valid() {
@@ -127,7 +102,5 @@ mod test {
         assert_valid_uuid(&USER_EXTERNAL_AUTHN.id);
         assert_valid_uuid(&USER_INTERNAL_READ.id);
         assert_valid_uuid(&USER_SAGA_RECOVERY.id);
-        assert_valid_uuid(&USER_TEST_PRIVILEGED.id);
-        assert_valid_uuid(&USER_TEST_UNPRIVILEGED.id);
     }
 }

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -8,16 +8,19 @@
 //! external API, but in order to avoid CORS issues for now, we are serving
 //! these routes directly from the external API.
 use super::views;
-use crate::authn::external::{
-    cookies::Cookies,
-    session_cookie::{
-        clear_session_cookie_header_value, session_cookie_header_value,
-        SessionStore, SESSION_COOKIE_COOKIE_NAME,
-    },
-};
 use crate::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
 use crate::context::OpContext;
 use crate::ServerContext;
+use crate::{
+    authn::external::{
+        cookies::Cookies,
+        session_cookie::{
+            clear_session_cookie_header_value, session_cookie_header_value,
+            SessionStore, SESSION_COOKIE_COOKIE_NAME,
+        },
+    },
+    db::identity::Asset,
+};
 use dropshot::{
     endpoint, HttpError, HttpResponseOk, Path, Query, RequestContext, TypedBody,
 };
@@ -54,8 +57,8 @@ pub async fn spoof_login(
     let nexus = &apictx.nexus;
     let params = params.into_inner();
     let user_id: Option<Uuid> = match params.username.as_str() {
-        "privileged" => Some(USER_TEST_PRIVILEGED.id),
-        "unprivileged" => Some(USER_TEST_UNPRIVILEGED.id),
+        "privileged" => Some(USER_TEST_PRIVILEGED.id()),
+        "unprivileged" => Some(USER_TEST_UNPRIVILEGED.id()),
         _ => None,
     };
 

--- a/nexus/src/populate.rs
+++ b/nexus/src/populate.rs
@@ -200,12 +200,55 @@ impl Populator for PopulateBuiltinSilos {
     }
 }
 
+/// Populates the "test-privileged" and "test-unprivileged" silo users
+// TODO-security Once we have a proper bootstrapping mechanism, we should not
+// need to do this.  But right now, if you don't do this, then there will be no
+// identities that you can use to do anything else -- including create other
+// users or even set up a Silo that's connected to an identity provider.  This
+// is needed for interactive use of Nexus (e.g., demos or just working on Nexus)
+// as well as the test suite.
+#[derive(Debug)]
+struct PopulateSiloUsers;
+impl Populator for PopulateSiloUsers {
+    fn populate<'a, 'b>(
+        &self,
+        opctx: &'a OpContext,
+        datastore: &'a DataStore,
+    ) -> BoxFuture<'b, Result<(), Error>>
+    where
+        'a: 'b,
+    {
+        async { datastore.load_silo_users(opctx).await.map(|_| ()) }.boxed()
+    }
+}
+
+/// Populates the role assignments for the "test-privileged" user
+#[derive(Debug)]
+struct PopulateSiloUserRoleAssignments;
+impl Populator for PopulateSiloUserRoleAssignments {
+    fn populate<'a, 'b>(
+        &self,
+        opctx: &'a OpContext,
+        datastore: &'a DataStore,
+    ) -> BoxFuture<'b, Result<(), Error>>
+    where
+        'a: 'b,
+    {
+        async {
+            datastore.load_silo_user_role_assignments(opctx).await.map(|_| ())
+        }
+        .boxed()
+    }
+}
+
 lazy_static! {
-    static ref ALL_POPULATORS: [&'static dyn Populator; 4] = [
+    static ref ALL_POPULATORS: [&'static dyn Populator; 6] = [
         &PopulateBuiltinUsers,
         &PopulateBuiltinRoles,
         &PopulateBuiltinRoleAssignments,
         &PopulateBuiltinSilos,
+        &PopulateSiloUsers,
+        &PopulateSiloUserRoleAssignments,
     ];
 }
 

--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -439,7 +439,6 @@ impl<'a> NexusRequest<'a> {
         match mode {
             AuthnMode::UnprivilegedUser => {
                 let header_value = spoof::make_header_value(
-                    spoof::ActorType::Silo,
                     authn::USER_TEST_UNPRIVILEGED.id(),
                 );
                 self.request_builder = self.request_builder.header(
@@ -448,20 +447,15 @@ impl<'a> NexusRequest<'a> {
                 );
             }
             AuthnMode::PrivilegedUser => {
-                let header_value = spoof::make_header_value(
-                    spoof::ActorType::Silo,
-                    authn::USER_TEST_PRIVILEGED.id(),
-                );
+                let header_value =
+                    spoof::make_header_value(authn::USER_TEST_PRIVILEGED.id());
                 self.request_builder = self.request_builder.header(
                     &http::header::AUTHORIZATION,
                     header_value.0.encode(),
                 );
             }
             AuthnMode::SiloUser(silo_user_id) => {
-                let header_value = spoof::make_header_value(
-                    spoof::ActorType::Silo,
-                    silo_user_id,
-                );
+                let header_value = spoof::make_header_value(silo_user_id);
                 self.request_builder = self.request_builder.header(
                     &http::header::AUTHORIZATION,
                     header_value.0.encode(),

--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -11,6 +11,7 @@ use dropshot::test_util::ClientTestContext;
 use dropshot::ResultsPage;
 use headers::authorization::Credentials;
 use omicron_nexus::authn::external::spoof;
+use omicron_nexus::db::identity::Asset;
 use std::convert::TryInto;
 use std::fmt::Debug;
 
@@ -438,8 +439,8 @@ impl<'a> NexusRequest<'a> {
         match mode {
             AuthnMode::UnprivilegedUser => {
                 let header_value = spoof::make_header_value(
-                    spoof::ActorType::Builtin,
-                    authn::USER_TEST_UNPRIVILEGED.id,
+                    spoof::ActorType::Silo,
+                    authn::USER_TEST_UNPRIVILEGED.id(),
                 );
                 self.request_builder = self.request_builder.header(
                     &http::header::AUTHORIZATION,
@@ -448,8 +449,8 @@ impl<'a> NexusRequest<'a> {
             }
             AuthnMode::PrivilegedUser => {
                 let header_value = spoof::make_header_value(
-                    spoof::ActorType::Builtin,
-                    authn::USER_TEST_PRIVILEGED.id,
+                    spoof::ActorType::Silo,
+                    authn::USER_TEST_PRIVILEGED.id(),
                 );
                 self.request_builder = self.request_builder.header(
                     &http::header::AUTHORIZATION,

--- a/nexus/tests/integration_tests/authn_http.rs
+++ b/nexus/tests/integration_tests/authn_http.rs
@@ -61,12 +61,8 @@ async fn test_authn_spoof_allowed() {
 
     // Successful authentication
     let valid_uuid = "7f927c86-3371-4295-c34a-e3246a4b9c02";
-    let header = spoof::make_header_value(
-        spoof::ActorType::Builtin,
-        valid_uuid.parse().unwrap(),
-    )
-    .0
-    .encode();
+    let header =
+        spoof::make_header_value(valid_uuid.parse().unwrap()).0.encode();
     assert_eq!(
         whoami_request(Some(header), None, &testctx).await.unwrap(),
         WhoamiResponse {
@@ -199,7 +195,6 @@ async fn test_authn_spoof_unconfigured() {
         None,
         Some(
             spoof::make_header_value(
-                spoof::ActorType::Builtin,
                 "7f927c86-3371-4295-c34a-e3246a4b9c02".parse().unwrap(),
             )
             .0

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -19,6 +19,7 @@ use omicron_nexus::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
 use omicron_nexus::external_api::console_api::LoginParams;
 use omicron_nexus::external_api::params::OrganizationCreate;
 use omicron_nexus::external_api::views;
+use omicron_nexus::db::identity::Asset;
 
 #[nexus_test]
 async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
@@ -231,7 +232,7 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .parsed_body::<views::SessionUser>()
         .unwrap();
 
-    assert_eq!(priv_user, views::SessionUser { id: USER_TEST_PRIVILEGED.id });
+    assert_eq!(priv_user, views::SessionUser { id: USER_TEST_PRIVILEGED.id() });
 
     // make sure it returns different things for different users
     let unpriv_user = NexusRequest::object_get(testctx, "/session/me")
@@ -244,7 +245,7 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
 
     assert_eq!(
         unpriv_user,
-        views::SessionUser { id: USER_TEST_UNPRIVILEGED.id }
+        views::SessionUser { id: USER_TEST_UNPRIVILEGED.id() }
     );
 }
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -16,10 +16,10 @@ use nexus_test_utils::{
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_nexus::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
+use omicron_nexus::db::identity::Asset;
 use omicron_nexus::external_api::console_api::LoginParams;
 use omicron_nexus::external_api::params::OrganizationCreate;
 use omicron_nexus::external_api::views;
-use omicron_nexus::db::identity::Asset;
 
 #[nexus_test]
 async fn test_sessions(cptestctx: &ControlPlaneTestContext) {

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -21,26 +21,15 @@ use omicron_common::api::external::ObjectIdentity;
 use omicron_nexus::authn::USER_TEST_UNPRIVILEGED;
 use omicron_nexus::authz;
 use omicron_nexus::db::fixed_data;
+use omicron_nexus::db::identity::Asset;
 use omicron_nexus::db::identity::Resource;
 use omicron_nexus::external_api::shared;
 use omicron_nexus::external_api::views;
 
 lazy_static! {
     /// Authentication mode used for testing
-    // The role assignment APIs only support assigning roles to Silo users and
-    // eventually other externally-visible things like service accounts and
-    // groups.  They don't support assigning roles to built-in users.  So to
-    // test enforcement, we'll need to use a silo user.  We could create our
-    // own, but the facilities for doing that don't really exist.  Fortunately,
-    // there's currently a corresponding silo user for every built-in user, so
-    // we can just choose the one for the "unprivileged" user.
-    //
-    // This will all change when we have first-class facilities for creating
-    // silo users because we won't ship the "privileged" and "unprivileged"
-    // users and we won't create silo users for built-in users.  Hopefully this
-    // happens soon!
-    static ref AUTHN_TEST_USER: AuthnMode =
-        AuthnMode::SiloUser(USER_TEST_UNPRIVILEGED.id);
+    // XXX-dap remove this altogether
+    static ref AUTHN_TEST_USER: AuthnMode = AuthnMode::UnprivilegedUser;
 }
 
 /// Describes the role assignment test for a particular kind of resource
@@ -454,7 +443,7 @@ async fn run_test<T: RoleAssignmentTest>(
     let mut new_policy = initial_policy.clone();
     let role_assignment = shared::RoleAssignment {
         identity_type: shared::IdentityType::SiloUser,
-        identity_id: USER_TEST_UNPRIVILEGED.id,
+        identity_id: USER_TEST_UNPRIVILEGED.id(),
         role_name: T::ROLE,
     };
     new_policy.role_assignments.push(role_assignment.clone());

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -10,7 +10,6 @@ use futures::Future;
 use futures::FutureExt;
 use http::Method;
 use http::StatusCode;
-use lazy_static::lazy_static;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::resource_helpers::create_organization;
@@ -25,12 +24,6 @@ use omicron_nexus::db::identity::Asset;
 use omicron_nexus::db::identity::Resource;
 use omicron_nexus::external_api::shared;
 use omicron_nexus::external_api::views;
-
-lazy_static! {
-    /// Authentication mode used for testing
-    // XXX-dap remove this altogether
-    static ref AUTHN_TEST_USER: AuthnMode = AuthnMode::UnprivilegedUser;
-}
 
 /// Describes the role assignment test for a particular kind of resource
 ///
@@ -137,7 +130,7 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
                     Method::GET,
                     RESOURCE_URL,
                 )
-                .authn_as(AUTHN_TEST_USER.clone())
+                .authn_as(AuthnMode::UnprivilegedUser)
                 .execute()
                 .await
                 .unwrap();
@@ -156,7 +149,7 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
             async {
                 let _: dropshot::ResultsPage<views::Sled> =
                     NexusRequest::object_get(client, RESOURCE_URL)
-                        .authn_as(AUTHN_TEST_USER.clone())
+                        .authn_as(AuthnMode::UnprivilegedUser)
                         .execute()
                         .await
                         .unwrap()
@@ -382,7 +375,7 @@ where
             Method::GET,
             resource_url,
         )
-        .authn_as(AUTHN_TEST_USER.clone())
+        .authn_as(AuthnMode::UnprivilegedUser)
         .execute()
         .await
         .unwrap();
@@ -410,7 +403,7 @@ where
         // (This is not really a policy test so we're not going to check all
         // possible actions.)
         let resource: V = NexusRequest::object_get(client, resource_url)
-            .authn_as(AUTHN_TEST_USER.clone())
+            .authn_as(AuthnMode::UnprivilegedUser)
             .execute()
             .await
             .unwrap()
@@ -463,7 +456,7 @@ async fn run_test<T: RoleAssignmentTest>(
         &policy_url,
         &new_policy,
     )
-    .authn_as(AUTHN_TEST_USER.clone())
+    .authn_as(AuthnMode::UnprivilegedUser)
     .execute()
     .await
     .unwrap();
@@ -513,7 +506,7 @@ async fn run_test<T: RoleAssignmentTest>(
     // revoke their own access.
     let updated_policy: shared::Policy<T::RoleType> =
         NexusRequest::object_put(client, &policy_url, Some(&initial_policy))
-            .authn_as(AUTHN_TEST_USER.clone())
+            .authn_as(AuthnMode::UnprivilegedUser)
             .execute()
             .await
             .unwrap()

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -35,12 +35,6 @@ async fn test_users_builtin(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(u.identity.id, authn::USER_EXTERNAL_AUTHN.id);
     let u = users.remove(&authn::USER_SAGA_RECOVERY.name.to_string()).unwrap();
     assert_eq!(u.identity.id, authn::USER_SAGA_RECOVERY.id);
-    let u =
-        users.remove(&authn::USER_TEST_PRIVILEGED.name.to_string()).unwrap();
-    assert_eq!(u.identity.id, authn::USER_TEST_PRIVILEGED.id);
-    let u =
-        users.remove(&authn::USER_TEST_UNPRIVILEGED.name.to_string()).unwrap();
-    assert_eq!(u.identity.id, authn::USER_TEST_UNPRIVILEGED.id);
     assert!(users.is_empty(), "found unexpected built-in users");
 
     // TODO-coverage add test for fetching individual users, including invalid


### PR DESCRIPTION
This change cleans up a few things related to the built-in users:

- The test users ("test-privileged" and "test-unprivileged") are now Silo Users rather than built-in users.  (This enables the rest of the cleanup below.)
- We no longer create a Silo User for any built-in users.  (We used to create a Silo User for each built-in user).
- Built-in users no longer have a Silo associated with them.  (Recall that built-in users are identities used _by Nexus_ to limit its own privileges.  They're not principals in the usual sense and they're not supposed to be associated with any Silo in particular.)
- It's no longer possible to authenticate to the external API as a built-in user.  #1051 recently extended "spoof" to treat users as Silo Users by default, but allow specifying a built-in user.  Now you can't specify a built-in user.

There are a few more things that would be nice to do but we can't do quite yet:

- In principle, it'd be nice if we didn't create the test users (`test-privileged` and `test-unprivileged`) in Nexus, but rather in the test suite.  However, `test-privileged` is the only identity that's ever really capable of doing anything -- including creating other users.  So we need it to be created by Nexus during startup -- the test suite has no creds it could use to do this itself.  The eventual answer here is the [bootstrapping of the initial Silo and IdP integration discussed in RFD 234](https://github.com/oxidecomputer/rfd/tree/master/rfd/0234#initial-setup-special-silos).  (The test users are also used by the console spoof login, but that's not really a blocker for this.  It's really just the lack of a real bootstrapping process.)
- The default Silo is used for a lot less now.  It'd be nice to remove it, but we can't for the same reason -- we need a real bootstrapping process to get things started.