### PR TITLE
update to uuid v1.0.0 (part 1 of 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
  "toml",
  "tracing",
  "usdt",
- "uuid",
+ "uuid 0.8.2",
  "version_check",
 ]
 
@@ -793,7 +793,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "twox-hash",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ dependencies = [
  "crucible-common",
  "serde",
  "tokio-util 0.7.2",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -999,7 +999,7 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -1011,7 +1011,7 @@ dependencies = [
  "lock_api",
  "serde",
  "usdt",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1123,8 +1123,8 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dropshot"
-version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#016c8b929453a77c3dcb119a199abe9cf5c5d296"
+version = "0.7.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#53106a852b4936e3a4b5d54e9801f3dc58ba9238"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1156,14 +1156,14 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "usdt",
- "uuid",
+ "uuid 1.0.0",
  "version_check",
 ]
 
 [[package]]
 name = "dropshot_endpoint"
-version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#016c8b929453a77c3dcb119a199abe9cf5c5d296"
+version = "0.7.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#53106a852b4936e3a4b5d54e9801f3dc58ba9238"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1607,7 +1607,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "usdt",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2495,7 +2495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2522,7 +2522,7 @@ dependencies = [
  "serde_json",
  "slog",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2681,7 +2681,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2728,7 +2728,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ dependencies = [
  "toml",
  "tough",
  "usdt",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2890,7 +2890,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.2",
  "toml",
- "uuid",
+ "uuid 1.0.0",
  "vsss-rs",
  "zone",
 ]
@@ -3088,7 +3088,7 @@ dependencies = [
  "serde",
  "thiserror",
  "trybuild",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "reqwest",
  "serde",
  "slog",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3127,7 +3127,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3166,7 +3166,7 @@ dependencies = [
  "futures",
  "http",
  "oximeter",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3195,7 +3195,7 @@ dependencies = [
  "slog-dtrace",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3543,7 +3543,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3659,8 +3659,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/progenitor#1af79ebec75f0c8ad3c0c5561783e3e9db03077a"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor#0f48c29935eec11aefbc74ae2d9c99fda5e99b72"
 dependencies = [
  "anyhow",
  "getopts",
@@ -3674,8 +3674,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/progenitor#1af79ebec75f0c8ad3c0c5561783e3e9db03077a"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor#0f48c29935eec11aefbc74ae2d9c99fda5e99b72"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3687,8 +3687,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/progenitor#1af79ebec75f0c8ad3c0c5561783e3e9db03077a"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor#0f48c29935eec11aefbc74ae2d9c99fda5e99b72"
 dependencies = [
  "getopts",
  "heck 0.4.0",
@@ -3709,8 +3709,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-macro"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/progenitor#1af79ebec75f0c8ad3c0c5561783e3e9db03077a"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor#0f48c29935eec11aefbc74ae2d9c99fda5e99b72"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -3736,7 +3736,7 @@ dependencies = [
  "slog",
  "structopt",
  "thiserror",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -4096,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
@@ -4184,9 +4184,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
  "bytes",
  "chrono",
@@ -4194,14 +4194,15 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 0.8.2",
+ "uuid 1.0.0",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4334,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4586,7 +4587,7 @@ dependencies = [
  "reqwest",
  "serde",
  "slog",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -4823,7 +4824,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "steno"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/steno?branch=main#578498bbb43f9061c636b938dff98e7ece0b0efc"
+source = "git+https://github.com/oxidecomputer/steno?branch=main#703cad54fdd70815ac84dcf08a439b54077e9600"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4837,7 +4838,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -5535,7 +5536,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -5548,8 +5549,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "typify"
-version = "0.0.6-dev"
-source = "git+https://github.com/oxidecomputer/typify#90894d81e303cd56056b179f31b60401efa3462d"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcda9918fb3098219b36e3deca897c3be450dd9bfdb8e7a43e12380e0054f6c"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -5557,8 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.6-dev"
-source = "git+https://github.com/oxidecomputer/typify#90894d81e303cd56056b179f31b60401efa3462d"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8011d3c44c06af5930d7c9b0fbdc74a8ed4c4b5d35be07adc910a2679a4b9748"
 dependencies = [
  "heck 0.4.0",
  "log",
@@ -5574,8 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.0.6-dev"
-source = "git+https://github.com/oxidecomputer/typify#90894d81e303cd56056b179f31b60401efa3462d"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6804c9de8bccf2e4be79d54442b165d0134766d99529712e139460fdc3a9db66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5748,6 +5752,16 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8ea317a9dfee65d7c018a1fda89fdec63a560ef3#8ea317a9dfee65d7c018a1fda89fdec63a560ef3"
+source = "git+https://github.com/oxidecomputer/crucible?rev=57f0951793a74b31afd824bc3a0e5d89a41a540b#57f0951793a74b31afd824bc3a0e5d89a41a540b"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -759,14 +759,14 @@ dependencies = [
  "toml",
  "tracing",
  "usdt",
- "uuid 0.8.2",
+ "uuid",
  "version_check",
 ]
 
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8ea317a9dfee65d7c018a1fda89fdec63a560ef3#8ea317a9dfee65d7c018a1fda89fdec63a560ef3"
+source = "git+https://github.com/oxidecomputer/crucible?rev=57f0951793a74b31afd824bc3a0e5d89a41a540b#57f0951793a74b31afd824bc3a0e5d89a41a540b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8ea317a9dfee65d7c018a1fda89fdec63a560ef3#8ea317a9dfee65d7c018a1fda89fdec63a560ef3"
+source = "git+https://github.com/oxidecomputer/crucible?rev=57f0951793a74b31afd824bc3a0e5d89a41a540b#57f0951793a74b31afd824bc3a0e5d89a41a540b"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -793,13 +793,13 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "twox-hash",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8ea317a9dfee65d7c018a1fda89fdec63a560ef3#8ea317a9dfee65d7c018a1fda89fdec63a560ef3"
+source = "git+https://github.com/oxidecomputer/crucible?rev=57f0951793a74b31afd824bc3a0e5d89a41a540b#57f0951793a74b31afd824bc3a0e5d89a41a540b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -807,13 +807,13 @@ dependencies = [
  "crucible-common",
  "serde",
  "tokio-util 0.7.2",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "crucible-scope"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8ea317a9dfee65d7c018a1fda89fdec63a560ef3#8ea317a9dfee65d7c018a1fda89fdec63a560ef3"
+source = "git+https://github.com/oxidecomputer/crucible?rev=57f0951793a74b31afd824bc3a0e5d89a41a540b#57f0951793a74b31afd824bc3a0e5d89a41a540b"
 dependencies = [
  "anyhow",
  "futures",
@@ -999,19 +999,19 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
 name = "diesel-dtrace"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/diesel-dtrace?rev=bec89c2f2b01a79ae99b4db667bfcea5fb2fef04#bec89c2f2b01a79ae99b4db667bfcea5fb2fef04"
+source = "git+https://github.com/oxidecomputer/diesel-dtrace#ce623dd6a2d59024a9330bc37e54426c4ccf9167"
 dependencies = [
  "diesel",
  "lock_api",
  "serde",
  "usdt",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "usdt",
- "uuid 1.0.0",
+ "uuid",
  "version_check",
 ]
 
@@ -1607,7 +1607,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "usdt",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2495,7 +2495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2522,7 +2522,7 @@ dependencies = [
  "serde_json",
  "slog",
  "tokio",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2681,7 +2681,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2728,7 +2728,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ dependencies = [
  "toml",
  "tough",
  "usdt",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2890,7 +2890,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.2",
  "toml",
- "uuid 1.0.0",
+ "uuid",
  "vsss-rs",
  "zone",
 ]
@@ -3088,7 +3088,7 @@ dependencies = [
  "serde",
  "thiserror",
  "trybuild",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ dependencies = [
  "reqwest",
  "serde",
  "slog",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3127,7 +3127,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3166,7 +3166,7 @@ dependencies = [
  "futures",
  "http",
  "oximeter",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3195,7 +3195,7 @@ dependencies = [
  "slog-dtrace",
  "thiserror",
  "tokio",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3543,7 +3543,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=845c9cffc482739d417761aa1c668895f24b776d#845c9cffc482739d417761aa1c668895f24b776d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b75a0a60d8928632c158e6d433b586d55774c59a#b75a0a60d8928632c158e6d433b586d55774c59a"
 dependencies = [
  "crucible",
  "reqwest",
@@ -3736,7 +3736,7 @@ dependencies = [
  "slog",
  "structopt",
  "thiserror",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -4194,8 +4194,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid 0.8.2",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4587,7 +4586,7 @@ dependencies = [
  "reqwest",
  "serde",
  "slog",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4838,7 +4837,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5746,16 +5745,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
 
 [[package]]
 name = "uuid"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ macaddr = { version = "1.0.1", features = [ "serde_std" ] }
 rand = "0.8.4"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 ring = "0.16"
-schemars = { version = "0.8", features = [ "chrono", "uuid" ] }
+schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -29,8 +29,8 @@ steno = { git = "https://github.com/oxidecomputer/steno", branch = "main" }
 structopt = "0.3"
 thiserror = "1.0"
 tokio = { version = "1.18", features = [ "full" ] }
-tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-0_8" ] }
-uuid = { version = "0.8", features = [ "serde", "v4" ] }
+tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }
+uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
 parse-display = "0.5.4"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 

--- a/gateway-client/Cargo.toml
+++ b/gateway-client/Cargo.toml
@@ -26,5 +26,5 @@ version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.uuid]
-version = "0.8"
+version = "1.0.0"
 features = [ "serde", "v4" ]

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "1.0.31"
 tokio-tungstenite = "0.17"
 tokio-stream = "0.1.8"
 usdt = "0.3.1"
-uuid = "0.8"
+uuid = "1.0.0"
 
 gateway-messages = { path = "../gateway-messages", features = ["std"] }
 omicron-common = { path = "../common" }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -18,7 +18,7 @@ slog-dtrace = "0.2"
 structopt = "0.3"
 thiserror = "1.0.31"
 toml = "0.5.9"
-uuid = "0.8"
+uuid = "1.0.0"
 
 gateway-messages = { path = "../gateway-messages", features = ["std"] }
 gateway-sp-comms = { path = "../gateway-sp-comms" }

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "3.1", features = [ "derive" ] }
 internal-dns-client = { path = "../internal-dns-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 pretty-hex = "0.3.0"
-schemars = "0.8"
+schemars = "0.8.10"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sled = "0.34"

--- a/nexus-client/Cargo.toml
+++ b/nexus-client/Cargo.toml
@@ -25,5 +25,5 @@ version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.uuid]
-version = "0.8"
+version = "1.0.0"
 features = [ "serde", "v4" ]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -89,8 +89,8 @@ version = "0.1.0"
 path = "../oximeter/producer"
 
 [dependencies.schemars]
-version = "0.8"
-features = [ "chrono", "uuid" ]
+version = "0.8.10"
+features = [ "chrono", "uuid1" ]
 
 [dependencies.serde]
 version = "1.0"
@@ -110,10 +110,10 @@ features = [ "full" ]
 
 [dependencies.tokio-postgres]
 version = "0.7"
-features = [ "with-chrono-0_4", "with-serde_json-1", "with-uuid-0_8" ]
+features = [ "with-chrono-0_4", "with-serde_json-1", "with-uuid-1" ]
 
 [dependencies.uuid]
-version = "0.8"
+version = "1.0.0"
 features = [ "serde", "v4" ]
 
 [dev-dependencies]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -15,8 +15,9 @@ authz-macros = { path = "src/authz/authz-macros" }
 base64 = "0.13.0"
 bb8 = "0.8.0"
 cookie = "0.16"
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "8ea317a9dfee65d7c018a1fda89fdec63a560ef3" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b" }
 diesel = { version = "2.0.0-rc.0", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
+diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace" }
 fatfs = "0.3.5"
 futures = "0.3.21"
 headers = "0.3.7"
@@ -59,10 +60,6 @@ path = "../api_identity"
 [dependencies.chrono]
 version = "0.4"
 features = [ "serde" ]
-
-[dependencies.diesel-dtrace]
-git = "https://github.com/oxidecomputer/diesel-dtrace"
-rev = "bec89c2f2b01a79ae99b4db667bfcea5fb2fef04"
 
 [dependencies.dropshot]
 git = "https://github.com/oxidecomputer/dropshot"

--- a/nexus/src/db/fixed_data/mod.rs
+++ b/nexus/src/db/fixed_data/mod.rs
@@ -51,7 +51,7 @@ fn assert_valid_uuid(id: &uuid::Uuid) {
     };
 
     match id.get_variant() {
-        Some(uuid::Variant::RFC4122) => (),
+        uuid::Variant::RFC4122 => (),
         _ => panic!("unexpected variant in uuid: {:?}", id),
     };
 }

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -24,7 +24,7 @@ parse-display = "0.5.4"
 serde = { version = "1.0",  features = [ "derive" ] }
 serde_json = "1.0"
 slog = { version = "2.7",  features = [ "max_level_trace", "release_max_level_debug" ] }
-uuid = { version = "0.8", features = [ "serde", "v4" ] }
+uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
 
 [build-dependencies]
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6136,6 +6136,7 @@
           },
           "disks": {
             "description": "The disks to be created or attached for this instance.",
+            "default": [],
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/InstanceDiskAttachment"
@@ -6155,6 +6156,9 @@
           },
           "network_interfaces": {
             "description": "The network interfaces to be created for this instance.",
+            "default": {
+              "type": "default"
+            },
             "allOf": [
               {
                 "$ref": "#/components/schemas/InstanceNetworkInterfaceAttachment"
@@ -6163,6 +6167,7 @@
           },
           "user_data": {
             "description": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data.",
+            "default": "",
             "type": "string"
           }
         },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -969,6 +969,7 @@
             }
           },
           "gz_addresses": {
+            "default": [],
             "type": "array",
             "items": {
               "type": "string",

--- a/oximeter-client/Cargo.toml
+++ b/oximeter-client/Cargo.toml
@@ -24,5 +24,5 @@ version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.uuid]
-version = "0.8"
+version = "1.0.0"
 features = [ "serde", "v4" ]

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -19,7 +19,7 @@ structopt = "0.3"
 thiserror = "1.0.31"
 tokio = "1.18"
 toml = "0.5.9"
-uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
+uuid = { version = "1.0.0", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -14,7 +14,7 @@ dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main",
 oximeter = { path = "../oximeter" }
 regex = "1.5.5"
 reqwest = { version = "0.11.8", features = [ "json" ] }
-schemars = { version = "0.8.8", features = [ "uuid", "bytes", "chrono" ] }
+schemars = { version = "0.8.10", features = [ "uuid1", "bytes", "chrono" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1.0.79"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
@@ -23,7 +23,7 @@ slog-term = "2.9"
 structopt = "0.3"
 thiserror = "1.0.31"
 tokio = { version = "1.18", features = [ "rt-multi-thread", "macros" ] }
-uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
+uuid = { version = "1.0.0", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
 itertools = "0.10.1"

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -10,7 +10,7 @@ dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main",
 futures = "0.3.21"
 oximeter = { path = "../oximeter" }
 http = { version = "0.2.7", optional = true }
-uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
+uuid = { version = "1.0.0", features = [ "v4", "serde" ] }
 
 [features]
 default = ["http-instruments"]

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -10,10 +10,10 @@ bytes = { version = "1.0.1", features = [ "serde" ] }
 chrono = { version = "0.4.19", features = [ "serde" ] }
 num-traits = "0.2.15"
 oximeter-macro-impl = { path = "../oximeter-macro-impl" }
-schemars = { version = "0.8.8", features = [ "uuid", "bytes", "chrono" ] }
+schemars = { version = "0.8.10", features = [ "uuid1", "bytes", "chrono" ] }
 serde = { version = "1", features = [ "derive" ] }
 thiserror = "1.0.31"
-uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
+uuid = { version = "1.0.0", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
 trybuild = "1.0.61"

--- a/oximeter/producer/Cargo.toml
+++ b/oximeter/producer/Cargo.toml
@@ -12,10 +12,10 @@ nexus-client = { path = "../../nexus-client" }
 omicron-common = { path = "../../common" }
 oximeter = { path = "../oximeter" }
 reqwest = { version = "0.11.8", features = [ "json" ] }
-schemars = { version = "0.8.8", features = [ "uuid", "bytes", "chrono" ] }
+schemars = { version = "0.8.10", features = [ "uuid1", "bytes", "chrono" ] }
 serde = { version = "1", features = [ "derive" ] }
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 slog-dtrace = "0.2"
 tokio = "1.18"
 thiserror = "1.0.31"
-uuid = { version = "0.8.2", features = [ "v4", "serde" ] }
+uuid = { version = "1.0.0", features = [ "v4", "serde" ] }

--- a/sled-agent-client/Cargo.toml
+++ b/sled-agent-client/Cargo.toml
@@ -25,5 +25,5 @@ version = "2.5"
 features = [ "max_level_trace", "release_max_level_debug" ]
 
 [dependencies.uuid]
-version = "0.8"
+version = "1.0.0"
 features = [ "serde", "v4" ]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -27,7 +27,7 @@ progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "845c9cffc482739d417761aa1c668895f24b776d" }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls", "stream"] }
-schemars = { version = "0.8", features = [ "chrono", "uuid" ] }
+schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sled-agent-client = { path = "../sled-agent-client" }
@@ -43,7 +43,7 @@ thiserror = "1.0"
 tokio = { version = "1.18", features = [ "full" ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = "0.5.9"
-uuid = { version = "0.8", features = [ "serde", "v4" ] }
+uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
 vsss-rs = { version = "2.0.0-pre2", default-features = false, features = ["std"] }
 zone = "0.1"
 

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "1.1"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 # Only used by the simulated sled agent.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "8ea317a9dfee65d7c018a1fda89fdec63a560ef3" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.21"
 ipnetwork = "0.18"
@@ -24,7 +24,7 @@ omicron-common = { path = "../common" }
 p256 = "0.9.0"
 percent-encoding = "2.1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "845c9cffc482739d417761aa1c668895f24b776d" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b75a0a60d8928632c158e6d433b586d55774c59a" }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -34,7 +34,7 @@ features = [ "full" ]
 
 [dependencies.tokio-postgres]
 version = "0.7"
-features = [ "with-chrono-0_4", "with-uuid-0_8" ]
+features = [ "with-chrono-0_4", "with-uuid-1" ]
 
 [dev-dependencies]
 expectorate = "1.0.5"


### PR DESCRIPTION
The `uuid` crate has been updated to version 1.0.0 which is great and terrible. Omicron has several dependencies that all need to use the same version of `uuid`; some make that easier than others.

- `schemars` added a `uuid1` feature flag (for which `uuid` will be an alias at some point) https://github.com/GREsau/schemars/pull/142
- `tokio-postgres` requires us to move from the `with-uuid-0_8` feature to `with-uuid-1`
- `diesel` expanded their dependency range for `uuid` so we don't need to do anything (i.e. `version = ">=0.7.0, <2.0.0"`) and note that this is what `schemars` should have done https://github.com/diesel-rs/diesel/pull/3137

In addition we had to update several leaf crates we control:
- progenitor https://github.com/oxidecomputer/progenitor/pull/61
- typify (although it only uses `uuid` as a dev-dependency) https://github.com/oxidecomputer/typify/pull/54
- steno https://github.com/oxidecomputer/steno/pull/28 (thanks @davepacheco!)
- diesel-dtrace https://github.com/oxidecomputer/diesel-dtrace/pull/5 (which looks a lot like `diesel` above)

The real pain is the intertwining of `omicron` with `crucible` and `propolis`. My proposal is the following:

1. [ ] Merge this PR which includes git revs for the `propolis` and `crucible` PRs
2. [ ] Update https://github.com/oxidecomputer/crucible/pull/334 to refer to the rev in (1) and merge
3. [ ] Update https://github.com/oxidecomputer/propolis/pull/130 to refer to the revs in (1) and (2) and merge
4. [ ] Merge another PR in `omicron` that refers to the revs in (2) and (3)