### PR TITLE
Make simulated SP's management network simulation optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "hubpack",
  "serde",
  "serde_repr",
+ "smoltcp",
 ]
 
 [[package]]
@@ -1941,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "hubpack"
 version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack?branch=main#d98084b85cc45fe589a49dd95403d7b41533375c"
+source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
  "hubpack_derive",
  "serde",
@@ -1950,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "hubpack_derive"
 version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack?branch=main#d98084b85cc45fe589a49dd95403d7b41533375c"
+source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gateway-messages/Cargo.toml
+++ b/gateway-messages/Cargo.toml
@@ -9,8 +9,14 @@ bitflags = "1.3.2"
 serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 serde_repr = { version = "0.1" }
 
-hubpack = { git = "https://github.com/cbiffle/hubpack", branch = "main" }
+hubpack = { git = "https://github.com/cbiffle/hubpack", rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25" }
+
+[dependencies.smoltcp]
+version = "0.8"
+default-features = false
+features = ["proto-ipv6"]
+optional = true
 
 [features]
-default = []
+default = ["smoltcp"]
 std = []

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -20,31 +20,39 @@ use crate::SpMessageKind;
 use crate::SpPort;
 use crate::SpState;
 use hubpack::SerializedSize;
-use std::net::SocketAddr;
+
+#[cfg(feature = "std")]
+use std::net::SocketAddrV6;
+
+#[cfg(not(feature = "std"))]
+pub struct SocketAddrV6 {
+    pub ip: smoltcp::wire::Ipv6Address,
+    pub port: u16,
+}
 
 pub trait SpHandler {
     fn discover(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<DiscoverResponse, ResponseError>;
 
     fn ignition_state(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
         target: u8,
     ) -> Result<IgnitionState, ResponseError>;
 
     fn bulk_ignition_state(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<BulkIgnitionState, ResponseError>;
 
     fn ignition_command(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
         target: u8,
         command: IgnitionCommand,
@@ -52,7 +60,7 @@ pub trait SpHandler {
 
     fn sp_state(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<SpState, ResponseError>;
 
@@ -61,7 +69,7 @@ pub trait SpHandler {
     // UDP chunks; can SP ensure it writes all data locally?
     fn serial_console_write(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
         packet: SerialConsole,
     ) -> Result<(), ResponseError>;
@@ -181,7 +189,7 @@ impl SpServer {
     /// the caller should send back to the requester.
     pub fn dispatch<H: SpHandler>(
         &mut self,
-        sender: SocketAddr,
+        sender: SocketAddrV6,
         port: SpPort,
         data: &[u8],
         handler: &mut H,

--- a/gateway/tests/integration_tests/setup.rs
+++ b/gateway/tests/integration_tests/setup.rs
@@ -114,7 +114,7 @@ pub async fn test_setup_with_config(
             SpType::Sled => simrack.gimlets[target_sp.slot].local_addr(sp_port),
             SpType::Power => todo!(),
         };
-        port_config.multicast_addr.set_port(sp_addr.port());
+        port_config.multicast_addr.set_port(sp_addr.unwrap().port());
     }
 
     // Start gateway server

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1.53"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3"
-gateway-messages = { path = "../gateway-messages" }
+gateway-messages = { path = "../gateway-messages", default-features = false, features = ["std"] }
 hex = "0.4.3"
 omicron-common = { path = "../common" }
 slog-dtrace = "0.2"

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -15,27 +15,33 @@ use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Common configuration for all flavors of SP
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct SpCommonConfig {
+    /// IPv6 multicast address to join.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub multicast_addr: Option<Ipv6Addr>,
+    /// UDP address of the two (fake) KSZ8463 ports
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub bind_addrs: Option<[SocketAddrV6; 2]>,
+    /// Fake serial number
+    pub serial_number: SerialNumber,
+}
+
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SidecarConfig {
-    /// IPv6 multicast address to join.
-    pub multicast_addr: Ipv6Addr,
-    /// UDP address of the two (fake) KSZ8463 ports
-    pub bind_addrs: [SocketAddrV6; 2],
-    /// Fake serial number
-    pub serial_number: SerialNumber,
+    #[serde(flatten)]
+    pub common: SpCommonConfig,
 }
 
 /// Configuration of a simulated gimlet SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GimletConfig {
-    /// IPv6 multicast address to join.
-    pub multicast_addr: Ipv6Addr,
-    /// UDP address of the two (fake) KSZ8463 ports
-    pub bind_addrs: [SocketAddrV6; 2],
-    /// Fake serial number
-    pub serial_number: SerialNumber,
+    #[serde(flatten)]
+    pub common: SpCommonConfig,
     /// Attached components
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub components: Vec<SpComponentConfig>,
 }
 
@@ -51,7 +57,7 @@ pub struct SpComponentConfig {
 
 /// Configuration of a set of simulated SPs
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct SimulatedSps {
+pub struct SimulatedSpsConfig {
     /// Simulated sidecar(s)
     pub sidecar: Vec<SidecarConfig>,
     /// Simulated gimlet(s)
@@ -62,7 +68,7 @@ pub struct SimulatedSps {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
     /// List of SPs to simulate.
-    pub simulated_sps: SimulatedSps,
+    pub simulated_sps: SimulatedSpsConfig,
     /// Server-wide logging configuration.
     pub log: ConfigLogging,
 }

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -10,7 +10,7 @@ use gateway_messages::SerialNumber;
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::Ipv6Addr;
-use std::net::SocketAddr;
+use std::net::SocketAddrV6;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -21,7 +21,7 @@ pub struct SidecarConfig {
     /// IPv6 multicast address to join.
     pub multicast_addr: Ipv6Addr,
     /// UDP address of the two (fake) KSZ8463 ports
-    pub bind_addrs: [SocketAddr; 2],
+    pub bind_addrs: [SocketAddrV6; 2],
     /// Fake serial number
     pub serial_number: SerialNumber,
 }
@@ -32,7 +32,7 @@ pub struct GimletConfig {
     /// IPv6 multicast address to join.
     pub multicast_addr: Ipv6Addr,
     /// UDP address of the two (fake) KSZ8463 ports
-    pub bind_addrs: [SocketAddr; 2],
+    pub bind_addrs: [SocketAddrV6; 2],
     /// Fake serial number
     pub serial_number: SerialNumber,
     /// Attached components
@@ -46,7 +46,7 @@ pub struct SpComponentConfig {
     pub name: String,
     /// Socket address we'll use to expose this component's serial console
     /// via TCP.
-    pub serial_console: Option<SocketAddr>,
+    pub serial_console: Option<SocketAddrV6>,
 }
 
 /// Configuration of a set of simulated SPs

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -32,8 +32,10 @@ pub enum Responsiveness {
 pub trait SimulatedSp {
     /// Hexlified serial number.
     fn serial_number(&self) -> String;
-    /// Listening UDP address of the given port of this simulated SP.
-    fn local_addr(&self, port: SpPort) -> SocketAddrV6;
+
+    /// Listening UDP address of the given port of this simulated SP, if it was
+    /// configured to listen.
+    fn local_addr(&self, port: SpPort) -> Option<SocketAddrV6>;
 
     /// Simulate the SP being unresponsive, in which it ignores all incoming
     /// messages.

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -15,7 +15,7 @@ pub use gimlet::Gimlet;
 pub use server::logger;
 pub use sidecar::Sidecar;
 pub use slog::Logger;
-use std::net::SocketAddr;
+use std::net::SocketAddrV6;
 
 pub mod ignition_id {
     pub const GIMLET: u16 = 0b0000_0000_0001_0001;
@@ -33,7 +33,8 @@ pub trait SimulatedSp {
     /// Hexlified serial number.
     fn serial_number(&self) -> String;
     /// Listening UDP address of the given port of this simulated SP.
-    fn local_addr(&self, port: SpPort) -> SocketAddr;
+    fn local_addr(&self, port: SpPort) -> SocketAddrV6;
+
     /// Simulate the SP being unresponsive, in which it ignores all incoming
     /// messages.
     async fn set_responsiveness(&self, r: Responsiveness);


### PR DESCRIPTION
Our initial integration of the simulated SP into `sled-agent` will be to exercise sprockets via a simulated RoT, which does not require opening ports to pretend to live on the management network. To avoid headaches dealing with IP addresses, networking, etc., related to simulating those management network ports, this PR makes them entirely optional; we can now start a simulated SP that only provides a fake RoT, no networking.

Given this PR is relatively mechanical and only touches test-only code, I'm not tagging anyone for review and am happy to merge once CI is green.