### PR TITLE
Read-only instance serial console API endpoint in Nexus.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util 0.7.3",
  "toml",
  "uuid",

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -107,7 +107,9 @@ pub enum UpdateArtifactKind {
 /// Sent to a sled agent to request the contents of an Instance's serial console.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct InstanceSerialConsoleRequest {
-    /// Character index in the serial buffer (since instance boot) from which to read.
+    /// Character index in the serial buffer from which to read.
+    /// - If positive, this is the number of bytes output since instance start.
+    /// - If negative, this indexes backwards from the end of the most recently buffered data.
     pub byte_offset: Option<isize>,
     /// Maximum number of bytes of buffered serial console contents (after byte_offset) to return.
     pub max_bytes: Option<usize>,
@@ -116,6 +118,10 @@ pub struct InstanceSerialConsoleRequest {
 /// Contents of an Instance's serial console buffer.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceSerialConsoleData {
-    pub data: Vec<u8>, // might not be UTF-8.
+    /// The bytes starting from the requested offset up to either the end of the buffer or the
+    /// request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.
+    pub data: Vec<u8>,
+    /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
+    /// of the last byte returned in `data`.
     pub last_byte_offset: usize,
 }

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -103,31 +103,3 @@ pub struct UpdateArtifact {
 pub enum UpdateArtifactKind {
     Zone,
 }
-
-/// Forwarded to a sled agent to request the contents of an Instance's serial console.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct InstanceSerialConsoleRequest {
-    /// Character index in the serial buffer from which to read, counting the bytes output since
-    /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
-    /// provided, `most_recent` must *not* be provided.
-    pub from_start: Option<u64>,
-    /// Character index in the serial buffer from which to read, counting *backward* from the most
-    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
-    /// exclusivity)
-    pub most_recent: Option<u64>,
-    /// Maximum number of bytes of buffered serial console contents to return. If the requested
-    /// range runs to the end of the available buffer, the data returned will be shorter than
-    /// `max_bytes`.
-    pub max_bytes: Option<u64>,
-}
-
-/// Contents of an Instance's serial console buffer.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceSerialConsoleData {
-    /// The bytes starting from the requested offset up to either the end of the buffer or the
-    /// request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.
-    pub data: Vec<u8>,
-    /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
-    /// of the last byte returned in `data`.
-    pub last_byte_offset: u64,
-}

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -104,15 +104,21 @@ pub enum UpdateArtifactKind {
     Zone,
 }
 
-/// Sent to a sled agent to request the contents of an Instance's serial console.
+/// Forwarded to a sled agent to request the contents of an Instance's serial console.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct InstanceSerialConsoleRequest {
-    /// Character index in the serial buffer from which to read.
-    /// - If positive, this is the number of bytes output since instance start.
-    /// - If negative, this indexes backwards from the end of the most recently buffered data.
-    pub byte_offset: Option<isize>,
-    /// Maximum number of bytes of buffered serial console contents (after byte_offset) to return.
-    pub max_bytes: Option<usize>,
+    /// Character index in the serial buffer from which to read, counting the bytes output since
+    /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
+    /// provided, `most_recent` must *not* be provided.
+    pub from_start: Option<u32>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
+    /// exclusivity)
+    pub most_recent: Option<u32>,
+    /// Maximum number of bytes of buffered serial console contents to return. If the requested
+    /// range runs to the end of the available buffer, the data returned will be shorter than
+    /// `max_bytes`.
+    pub max_bytes: Option<u32>,
 }
 
 /// Contents of an Instance's serial console buffer.
@@ -123,5 +129,5 @@ pub struct InstanceSerialConsoleData {
     pub data: Vec<u8>,
     /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
     /// of the last byte returned in `data`.
-    pub last_byte_offset: usize,
+    pub last_byte_offset: u32,
 }

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -103,3 +103,19 @@ pub struct UpdateArtifact {
 pub enum UpdateArtifactKind {
     Zone,
 }
+
+/// Sent to a sled agent to request the contents of an Instance's serial console.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleRequest {
+    /// Character index in the serial buffer (since instance boot) from which to read.
+    pub byte_offset: Option<isize>,
+    /// Maximum number of bytes of buffered serial console contents (after byte_offset) to return.
+    pub max_bytes: Option<usize>,
+}
+
+/// Contents of an Instance's serial console buffer.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceSerialConsoleData {
+    pub data: Vec<u8>, // might not be UTF-8.
+    pub last_byte_offset: usize,
+}

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -110,15 +110,15 @@ pub struct InstanceSerialConsoleRequest {
     /// Character index in the serial buffer from which to read, counting the bytes output since
     /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
     /// provided, `most_recent` must *not* be provided.
-    pub from_start: Option<u32>,
+    pub from_start: Option<u64>,
     /// Character index in the serial buffer from which to read, counting *backward* from the most
     /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
     /// exclusivity)
-    pub most_recent: Option<u32>,
+    pub most_recent: Option<u64>,
     /// Maximum number of bytes of buffered serial console contents to return. If the requested
     /// range runs to the end of the available buffer, the data returned will be shorter than
     /// `max_bytes`.
-    pub max_bytes: Option<u32>,
+    pub max_bytes: Option<u64>,
 }
 
 /// Contents of an Instance's serial console buffer.
@@ -129,5 +129,5 @@ pub struct InstanceSerialConsoleData {
     pub data: Vec<u8>,
     /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
     /// of the last byte returned in `data`.
-    pub last_byte_offset: u32,
+    pub last_byte_offset: u64,
 }

--- a/gateway/tests/integration_tests/commands.rs
+++ b/gateway/tests/integration_tests/commands.rs
@@ -24,7 +24,7 @@ fn test_gateway_openapi_sled() {
         .arg("--openapi")
         .arg("examples/config.toml");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_SUCCESS);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
     assert_contents("tests/output/cmd-gateway-openapi-stderr", &stderr_text);
 
     let spec: OpenAPI = serde_json::from_str(&stdout_text)

--- a/internal-dns/tests/openapi_test.rs
+++ b/internal-dns/tests/openapi_test.rs
@@ -15,8 +15,8 @@ const CMD_API_GEN: &str = env!("CARGO_BIN_EXE_apigen");
 #[test]
 fn test_internal_dns_openapi() {
     let exec = Exec::cmd(path_to_executable(CMD_API_GEN));
-    let (exit_status, stdout, _) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_SUCCESS);
+    let (exit_status, stdout, stderr) = run_command(exec);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr);
 
     let spec: OpenAPI =
         serde_json::from_str(&stdout).expect("stdout was not valid OpenAPI");

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -894,8 +894,8 @@ impl super::Nexus {
         organization_name: &Name,
         project_name: &Name,
         instance_name: &Name,
-        params: &nexus::InstanceSerialConsoleRequest,
-    ) -> Result<nexus::InstanceSerialConsoleData, Error> {
+        params: &params::InstanceSerialConsoleRequest,
+    ) -> Result<params::InstanceSerialConsoleData, Error> {
         let db_instance = self
             .instance_fetch(
                 opctx,
@@ -917,7 +917,7 @@ impl super::Nexus {
             .await?;
         let sa_data: sled_agent_client::types::InstanceSerialConsoleData =
             data.into_inner();
-        Ok(nexus::InstanceSerialConsoleData {
+        Ok(params::InstanceSerialConsoleData {
             data: sa_data.data,
             last_byte_offset: sa_data.last_byte_offset,
         })

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -916,7 +916,7 @@ impl super::Nexus {
             )
             .await?;
         let sa_data: sled_agent_client::types::InstanceSerialConsoleData =
-            data.into_inner().into();
+            data.into_inner();
         Ok(nexus::InstanceSerialConsoleData {
             data: sa_data.data,
             last_byte_offset: sa_data.last_byte_offset,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -909,15 +909,17 @@ impl super::Nexus {
         let data = sa
             .instance_serial_get(
                 &db_instance.identity().id,
-                params.byte_offset.map(|x| x as i32),
-                params.max_bytes.map(|x| x as u32),
+                // these parameters are all the same type; OpenAPI puts them in alphabetical order.
+                params.from_start,
+                params.max_bytes,
+                params.most_recent,
             )
             .await?;
         let sa_data: sled_agent_client::types::InstanceSerialConsoleData =
             data.into_inner().into();
         Ok(nexus::InstanceSerialConsoleData {
             data: sa_data.data,
-            last_byte_offset: sa_data.last_byte_offset as usize,
+            last_byte_offset: sa_data.last_byte_offset,
         })
     }
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -58,6 +58,9 @@ use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::Saga;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRules;
+use omicron_common::api::internal::nexus::{
+    InstanceSerialConsoleData, InstanceSerialConsoleRequest,
+};
 use omicron_common::{
     api::external::http_pagination::data_page_params_for, bail_unless,
 };
@@ -116,6 +119,7 @@ pub fn external_api() -> NexusApiDescription {
         api.register(project_instances_instance_reboot)?;
         api.register(project_instances_instance_start)?;
         api.register(project_instances_instance_stop)?;
+        api.register(project_instances_instance_serial_get)?;
 
         // Globally-scoped Images API
         api.register(images_get)?;
@@ -1416,6 +1420,39 @@ async fn project_instances_instance_stop(
             )
             .await?;
         Ok(HttpResponseAccepted(instance.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Get contents of an instance's serial console.
+#[endpoint {
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial",
+    tags = ["instances"],
+}]
+async fn project_instances_instance_serial_get(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path_params: Path<InstancePathParam>,
+    query_params: Query<InstanceSerialConsoleRequest>,
+) -> Result<HttpResponseOk<InstanceSerialConsoleData>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+    let organization_name = &path.organization_name;
+    let project_name = &path.project_name;
+    let instance_name = &path.instance_name;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let data = nexus
+            .instance_serial_console_data(
+                &opctx,
+                &organization_name,
+                &project_name,
+                &instance_name,
+                &query_params.into_inner(),
+            )
+            .await?;
+        Ok(HttpResponseOk(data.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -58,9 +58,6 @@ use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::Saga;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRules;
-use omicron_common::api::internal::nexus::{
-    InstanceSerialConsoleData, InstanceSerialConsoleRequest,
-};
 use omicron_common::{
     api::external::http_pagination::data_page_params_for, bail_unless,
 };
@@ -1433,8 +1430,8 @@ async fn project_instances_instance_stop(
 async fn project_instances_instance_serial_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
-    query_params: Query<InstanceSerialConsoleRequest>,
-) -> Result<HttpResponseOk<InstanceSerialConsoleData>, HttpError> {
+    query_params: Query<params::InstanceSerialConsoleRequest>,
+) -> Result<HttpResponseOk<params::InstanceSerialConsoleData>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1452,7 +1452,7 @@ async fn project_instances_instance_serial_get(
                 &query_params.into_inner(),
             )
             .await?;
-        Ok(HttpResponseOk(data.into()))
+        Ok(HttpResponseOk(data))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -442,6 +442,34 @@ pub struct InstanceMigrate {
     pub dst_sled_id: Uuid,
 }
 
+/// Forwarded to a sled agent to request the contents of an Instance's serial console.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleRequest {
+    /// Character index in the serial buffer from which to read, counting the bytes output since
+    /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
+    /// provided, `most_recent` must *not* be provided.
+    pub from_start: Option<u64>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
+    /// exclusivity)
+    pub most_recent: Option<u64>,
+    /// Maximum number of bytes of buffered serial console contents to return. If the requested
+    /// range runs to the end of the available buffer, the data returned will be shorter than
+    /// `max_bytes`.
+    pub max_bytes: Option<u64>,
+}
+
+/// Contents of an Instance's serial console buffer.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceSerialConsoleData {
+    /// The bytes starting from the requested offset up to either the end of the buffer or the
+    /// request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.
+    pub data: Vec<u8>,
+    /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
+    /// of the last byte returned in `data`.
+    pub last_byte_offset: u64,
+}
+
 // VPCS
 
 /// Create-time parameters for a [`Vpc`](crate::external_api::views::Vpc)

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -45,7 +45,7 @@ fn write_config(config: &str) -> PathBuf {
 fn test_nexus_no_args() {
     let exec = Exec::cmd(path_to_nexus());
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents("tests/output/cmd-nexus-noargs-stdout", &stdout_text);
     assert_contents("tests/output/cmd-nexus-noargs-stderr", &stderr_text);
 }
@@ -54,7 +54,7 @@ fn test_nexus_no_args() {
 fn test_nexus_bad_config() {
     let exec = Exec::cmd(path_to_nexus()).arg("nonexistent");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_FAILURE);
+    assert_exit_code(exit_status, EXIT_FAILURE, &stderr_text);
     assert_contents("tests/output/cmd-nexus-badconfig-stdout", &stdout_text);
     assert_eq!(
         stderr_text,
@@ -68,7 +68,7 @@ fn test_nexus_invalid_config() {
     let exec = Exec::cmd(path_to_nexus()).arg(&config_path);
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
     fs::remove_file(&config_path).expect("failed to remove temporary file");
-    assert_exit_code(exit_status, EXIT_FAILURE);
+    assert_exit_code(exit_status, EXIT_FAILURE, &stderr_text);
     assert_contents(
         "tests/output/cmd-nexus-invalidconfig-stdout",
         &stdout_text,
@@ -97,7 +97,7 @@ fn run_command_with_arg(arg: &str) -> (String, String) {
     let exec = Exec::cmd(path_to_nexus()).arg(&config_path).arg(arg);
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
     fs::remove_file(&config_path).expect("failed to remove temporary file");
-    assert_exit_code(exit_status, EXIT_SUCCESS);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
 
     (stdout_text, stderr_text)
 }

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -195,6 +195,8 @@ lazy_static! {
         format!("{}/detach", *DEMO_INSTANCE_DISKS_URL);
     pub static ref DEMO_INSTANCE_NICS_URL: String =
         format!("{}/network-interfaces", *DEMO_INSTANCE_URL);
+    pub static ref DEMO_INSTANCE_SERIAL_URL: String =
+        format!("{}/serial", *DEMO_INSTANCE_URL);
     pub static ref DEMO_INSTANCE_CREATE: params::InstanceCreate =
         params::InstanceCreate {
             identity: IdentityMetadataCreateParams {
@@ -864,6 +866,13 @@ lazy_static! {
                         dst_sled_id: uuid::Uuid::new_v4(),
                     }
                 ).unwrap()),
+            ],
+        },
+        VerifyEndpoint {
+            url: &*DEMO_INSTANCE_SERIAL_URL,
+            visibility: Visibility::Protected,
+            allowed_methods: vec![
+                AllowedMethod::GetNonexistent // has required query parameters
             ],
         },
 

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -2257,7 +2257,8 @@ async fn test_instance_serial(cptestctx: &ControlPlaneTestContext) {
     let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Make sure we get a 404 if we try to access the serial console before creation.
-    let instance_serial_url = format!("{}/kris-picks/serial", url_instances);
+    let instance_serial_url =
+        format!("{}/kris-picks/serial?from_start=0", url_instances);
     let error: HttpErrorResponseBody = NexusRequest::expect_failure(
         client,
         StatusCode::NOT_FOUND,

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -39,7 +39,6 @@ use nexus_test_utils::resource_helpers::{
 };
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
-use omicron_common::api::internal::nexus::InstanceSerialConsoleData;
 
 static ORGANIZATION_NAME: &str = "test-org";
 static PROJECT_NAME: &str = "springfield-squidport";
@@ -2289,7 +2288,7 @@ async fn test_instance_serial(cptestctx: &ControlPlaneTestContext) {
             > instance.runtime.time_run_state_updated
     );
 
-    let serial_data: InstanceSerialConsoleData =
+    let serial_data: params::InstanceSerialConsoleData =
         NexusRequest::object_get(client, &instance_serial_url)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -44,6 +44,7 @@ project_instances_delete_instance        /organizations/{organization_name}/proj
 project_instances_get                    /organizations/{organization_name}/projects/{project_name}/instances
 project_instances_get_instance           /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}
 project_instances_instance_reboot        /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot
+project_instances_instance_serial_get    /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial
 project_instances_instance_start         /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start
 project_instances_instance_stop          /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop
 project_instances_migrate_instance       /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2469,6 +2469,85 @@
         }
       }
     },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial": {
+      "get": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Get contents of an instance's serial console.",
+        "operationId": "project_instances_instance_serial_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "byte_offset",
+            "description": "Character index in the serial buffer (since instance boot) from which to read.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "int"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "max_bytes",
+            "description": "Maximum number of bytes of buffered serial console contents (after byte_offset) to return.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSerialConsoleData"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start": {
       "post": {
         "tags": [
@@ -6866,6 +6945,29 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "InstanceSerialConsoleData": {
+        "description": "Contents of an Instance's serial console buffer.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          },
+          "last_byte_offset": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data",
+          "last_byte_offset"
         ]
       },
       "InstanceState": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2511,7 +2511,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -2523,7 +2523,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -2535,7 +2535,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -6976,7 +6976,7 @@
           "last_byte_offset": {
             "description": "The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request) of the last byte returned in `data`.",
             "type": "integer",
-            "format": "uint32",
+            "format": "uint64",
             "minimum": 0
           }
         },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2506,23 +2506,36 @@
           },
           {
             "in": "query",
-            "name": "byte_offset",
-            "description": "Character index in the serial buffer (since instance boot) from which to read.",
+            "name": "from_start",
+            "description": "Character index in the serial buffer from which to read, counting the bytes output since instance start. If this is not provided, `most_recent` must be provided, and if this *is* provided, `most_recent` must *not* be provided.",
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "int"
+              "format": "uint32",
+              "minimum": 0
             },
             "style": "form"
           },
           {
             "in": "query",
             "name": "max_bytes",
-            "description": "Maximum number of bytes of buffered serial console contents (after byte_offset) to return.",
+            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`.",
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "most_recent",
+            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance. (See note on `from_start` about mutual exclusivity)",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
               "minimum": 0
             },
             "style": "form"
@@ -6952,6 +6965,7 @@
         "type": "object",
         "properties": {
           "data": {
+            "description": "The bytes starting from the requested offset up to either the end of the buffer or the request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.",
             "type": "array",
             "items": {
               "type": "integer",
@@ -6960,8 +6974,9 @@
             }
           },
           "last_byte_offset": {
+            "description": "The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request) of the last byte returned in `data`.",
             "type": "integer",
-            "format": "uint",
+            "format": "uint32",
             "minimum": 0
           }
         },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -147,7 +147,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -159,7 +159,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -171,7 +171,7 @@
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint32",
+              "format": "uint64",
               "minimum": 0
             },
             "style": "form"
@@ -930,7 +930,7 @@
           "last_byte_offset": {
             "description": "The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request) of the last byte returned in `data`.",
             "type": "integer",
-            "format": "uint32",
+            "format": "uint64",
             "minimum": 0
           }
         },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -142,23 +142,36 @@
           },
           {
             "in": "query",
-            "name": "byte_offset",
-            "description": "Character index in the serial buffer (since instance boot) from which to read.",
+            "name": "from_start",
+            "description": "Character index in the serial buffer from which to read, counting the bytes output since instance start. If this is not provided, `most_recent` must be provided, and if this *is* provided, `most_recent` must *not* be provided.",
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "int"
+              "format": "uint32",
+              "minimum": 0
             },
             "style": "form"
           },
           {
             "in": "query",
             "name": "max_bytes",
-            "description": "Maximum number of bytes of buffered serial console contents (after byte_offset) to return.",
+            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`.",
             "schema": {
               "nullable": true,
               "type": "integer",
-              "format": "uint",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "most_recent",
+            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance. (See note on `from_start` about mutual exclusivity)",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
               "minimum": 0
             },
             "style": "form"
@@ -906,6 +919,7 @@
         "type": "object",
         "properties": {
           "data": {
+            "description": "The bytes starting from the requested offset up to either the end of the buffer or the request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.",
             "type": "array",
             "items": {
               "type": "integer",
@@ -914,8 +928,9 @@
             }
           },
           "last_byte_offset": {
+            "description": "The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request) of the last byte returned in `data`.",
             "type": "integer",
-            "format": "uint",
+            "format": "uint32",
             "minimum": 0
           }
         },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -126,6 +126,64 @@
         }
       }
     },
+    "/instances/{instance_id}/serial": {
+      "get": {
+        "operationId": "instance_serial_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "byte_offset",
+            "description": "Character index in the serial buffer (since instance boot) from which to read.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "int"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "max_bytes",
+            "description": "Maximum number of bytes of buffered serial console contents (after byte_offset) to return.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSerialConsoleData"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/services": {
       "put": {
         "operationId": "services_put",
@@ -841,6 +899,29 @@
         },
         "required": [
           "run_state"
+        ]
+      },
+      "InstanceSerialConsoleData": {
+        "description": "Contents of an Instance's serial console buffer.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          },
+          "last_byte_offset": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data",
+          "last_byte_offset"
         ]
       },
       "InstanceState": {

--- a/oximeter/collector/tests/test_commands.rs
+++ b/oximeter/collector/tests/test_commands.rs
@@ -34,7 +34,7 @@ fn write_config(config: &str) -> PathBuf {
 fn test_oximeter_no_args() {
     let exec = Exec::cmd(path_to_oximeter());
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents("tests/output/cmd-oximeter-noargs-stdout", &stdout_text);
     assert_contents("tests/output/cmd-oximeter-noargs-stderr", &stderr_text);
 }
@@ -53,7 +53,7 @@ fn test_oximeter_openapi() {
     let exec = Exec::cmd(path_to_oximeter()).arg(&config_path).arg("--openapi");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
     fs::remove_file(&config_path).expect("failed to remove temporary file");
-    assert_exit_code(exit_status, EXIT_SUCCESS);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
     assert_contents("tests/output/cmd-oximeter-openapi-stderr", &stderr_text);
 
     let spec: OpenAPI = serde_json::from_str(&stdout_text)

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -43,6 +43,7 @@ tar = "0.4"
 tempfile = "3.3"
 thiserror = "1.0"
 tokio = { version = "1.18", features = [ "full" ] }
+tokio-tungstenite = "0.17.1"
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = "0.5.9"
 uuid = { version = "1.1.0", features = [ "serde", "v4" ] }

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -5,7 +5,8 @@
 //! HTTP entrypoint functions for the sled agent's exposed API
 
 use crate::params::{
-    DatasetEnsureBody, DiskEnsureBody, InstanceEnsureBody, ServiceEnsureBody,
+    DatasetEnsureBody, DiskEnsureBody, InstanceEnsureBody,
+    InstanceSerialConsoleData, InstanceSerialConsoleRequest, ServiceEnsureBody,
 };
 use crate::serial::ByteOffset;
 use dropshot::{
@@ -13,11 +14,9 @@ use dropshot::{
     HttpResponseUpdatedNoContent, Path, Query, RequestContext, TypedBody,
 };
 use omicron_common::api::external::Error;
+use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use omicron_common::api::internal::nexus::UpdateArtifact;
-use omicron_common::api::internal::nexus::{
-    DiskRuntimeState, InstanceSerialConsoleData, InstanceSerialConsoleRequest,
-};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::sync::Arc;

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -742,7 +742,7 @@ impl Instance {
                 ttybuf.contents(byte_offset, max_bytes).await?;
             Ok(InstanceSerialConsoleData {
                 data,
-                last_byte_offset: last_byte_offset as u32,
+                last_byte_offset: last_byte_offset as u64,
             })
         } else {
             Err(crate::serial::Error::Existential.into())

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -18,14 +18,13 @@ use crate::opte::OptePortAllocator;
 use crate::params::NetworkInterface;
 use crate::params::{
     InstanceHardware, InstanceMigrateParams, InstanceRuntimeStateRequested,
+    InstanceSerialConsoleData,
 };
 use crate::serial::{ByteOffset, SerialConsoleBuffer};
 use anyhow::anyhow;
 use futures::lock::{Mutex, MutexGuard};
 use omicron_common::address::PROPOLIS_PORT;
-use omicron_common::api::internal::nexus::{
-    InstanceRuntimeState, InstanceSerialConsoleData,
-};
+use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use omicron_common::backoff;
 use propolis_client::api::DiskRequest;
 use propolis_client::Client as PropolisClient;

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -643,7 +643,7 @@ impl Instance {
         // Create the propolis zone and resources
         let setup = self.setup_propolis_locked(&mut inner).await?;
 
-        let ws_uri = setup.client.ws_uri_instance_serial_console();
+        let ws_uri = setup.client.instance_serial_console_ws_uri();
 
         // Ensure the instance exists in the Propolis Server before we start
         // using it.

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -10,11 +10,10 @@ use crate::nexus::NexusClient;
 use crate::opte::OptePortAllocator;
 use crate::params::{
     InstanceHardware, InstanceMigrateParams, InstanceRuntimeStateRequested,
+    InstanceSerialConsoleData,
 };
 use crate::serial::ByteOffset;
-use omicron_common::api::internal::nexus::{
-    InstanceRuntimeState, InstanceSerialConsoleData,
-};
+use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use slog::Logger;
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -11,6 +11,7 @@ use crate::opte::OptePortAllocator;
 use crate::params::{
     InstanceHardware, InstanceMigrateParams, InstanceRuntimeStateRequested,
 };
+use crate::serial::ByteOffset;
 use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, InstanceSerialConsoleData,
 };
@@ -171,7 +172,7 @@ impl InstanceManager {
     pub async fn instance_serial_console_buffer_data(
         &self,
         instance_id: Uuid,
-        byte_offset: Option<isize>,
+        byte_offset: ByteOffset,
         max_bytes: Option<usize>,
     ) -> Result<InstanceSerialConsoleData, Error> {
         let instance = {

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -29,6 +29,7 @@ mod nexus;
 mod opte;
 mod params;
 pub mod rack_setup;
+mod serial;
 pub mod server;
 mod services;
 mod sled_agent;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -158,6 +158,34 @@ pub struct InstanceRuntimeStateRequested {
     pub migration_params: Option<InstanceRuntimeStateMigrateParams>,
 }
 
+/// Request the contents of an Instance's serial console.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleRequest {
+    /// Character index in the serial buffer from which to read, counting the bytes output since
+    /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
+    /// provided, `most_recent` must *not* be provided.
+    pub from_start: Option<u64>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
+    /// exclusivity)
+    pub most_recent: Option<u64>,
+    /// Maximum number of bytes of buffered serial console contents to return. If the requested
+    /// range runs to the end of the available buffer, the data returned will be shorter than
+    /// `max_bytes`.
+    pub max_bytes: Option<u64>,
+}
+
+/// Contents of an Instance's serial console buffer.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceSerialConsoleData {
+    /// The bytes starting from the requested offset up to either the end of the buffer or the
+    /// request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.
+    pub data: Vec<u8>,
+    /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
+    /// of the last byte returned in `data`.
+    pub last_byte_offset: u64,
+}
+
 /// The type of a dataset, and an auxiliary information necessary
 /// to successfully launch a zone managing the associated data.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Connects to propolis-server's websocket endpoint for an instance's serial console, and
 //! maintains a buffer of an instance's serial console data, holding both the first mebibyte and the
 //! most recent mebibyte of console output.
@@ -29,7 +33,15 @@ const DEFAULT_MAX_LENGTH: isize = 16 * 1024;
 struct BufferData {
     beginning: Vec<u8>,
     rolling: VecDeque<u8>,
-    total_bytes: isize,
+    total_bytes: usize,
+}
+
+#[derive(Copy, Clone)]
+pub enum ByteOffset {
+    /// The byte index since instance start.
+    FromStart(usize),
+    /// The byte index *backwards* from the most recently buffered data.
+    MostRecent(usize),
 }
 
 impl BufferData {
@@ -51,52 +63,56 @@ impl BufferData {
             self.beginning.extend(drain);
         }
         self.rolling.extend(msg);
-        self.total_bytes += read_size as isize;
+        self.total_bytes += read_size;
     }
 
-    /// Get an iterator of serial console bytes from the live buffer.
-    /// `since`:
-    /// - if positive, is the byte index since instance start.
-    /// - if negative, is the byte index backwards from the most recently buffered data.
-    /// - if none, yields the most recent `DEFAULT_MAX_LENGTH` of data.
+    /// Returns a tuple containing:
+    /// - an iterator of serial console bytes from the live buffer.
+    /// - the absolute byte index since instance start at which the iterator *begins*.
     fn contents_iter(
         &self,
-        byte_offset: Option<isize>,
+        byte_offset: ByteOffset,
     ) -> Result<(Box<dyn Iterator<Item = u8> + '_>, usize), Error> {
-        let start = byte_offset.unwrap_or(-DEFAULT_MAX_LENGTH);
-        let (from_start, from_end) = self.offsets_from_start_and_end(start);
-        let iter: Box<dyn Iterator<Item = u8> + '_> = if from_end
-            > self.rolling.len()
-        {
-            if from_start < self.beginning.len() {
-                // is it still possible to stitch together `beginning` and `rolling`?
-                if self.total_bytes as usize
-                    == self.rolling.len() + self.beginning.len()
-                {
-                    Box::new(
-                        self.beginning
-                            .iter()
-                            .skip(from_start)
-                            .chain(self.rolling.iter())
-                            .copied(),
-                    )
-                } else {
-                    Box::new(self.beginning.iter().copied().skip(from_start))
-                }
-            } else {
-                return Err(Error::ExpiredRange(from_start));
-            }
-        } else {
-            // apologies to Takenobu Mitsuyoshi
+        let (from_start, from_end) =
+            self.offsets_from_start_and_end(byte_offset);
+
+        // determine whether we should pull from beginning or rolling (or if we're straddling both)
+        if self.total_bytes == self.rolling.len() + self.beginning.len() {
+            // still contiguous
+            Ok((
+                Box::new(
+                    self.beginning
+                        .iter()
+                        .chain(self.rolling.iter())
+                        .skip(from_start)
+                        .copied(),
+                ),
+                from_start,
+            ))
+        } else if from_start < self.beginning.len() {
+            // requesting from beginning buffer
+            Ok((
+                Box::new(self.beginning.iter().copied().skip(from_start)),
+                from_start,
+            ))
+        } else if from_end < self.rolling.len() {
+            // (apologies to Takenobu Mitsuyoshi)
             let rolling_start = self.rolling.len() - from_end as usize;
-            Box::new(self.rolling.iter().copied().skip(rolling_start))
-        };
-        Ok((iter, from_start))
+            Ok((
+                Box::new(self.rolling.iter().copied().skip(rolling_start)),
+                from_start,
+            ))
+        } else {
+            Err(Error::ExpiredRange(from_start))
+        }
     }
 
+    /// Returns a tuple containing:
+    /// - a `Vec` of the requested range of serial console bytes from the live buffer.
+    /// - the absolute byte index since instance start at which the `Vec<u8>` *ends*.
     fn contents_vec(
         &self,
-        byte_offset: Option<isize>,
+        byte_offset: ByteOffset,
         max_bytes: Option<usize>,
     ) -> Result<(Vec<u8>, usize), Error> {
         let (iter, from_start) = self.contents_iter(byte_offset)?;
@@ -107,29 +123,42 @@ impl BufferData {
         Ok((data, end_offset))
     }
 
-    fn offsets_from_start_and_end(&self, start: isize) -> (usize, usize) {
-        if start >= 0 {
-            if self.total_bytes > start {
-                (start as usize, (self.total_bytes - start) as usize)
-            } else {
-                (self.total_bytes as usize, 0)
+    fn offsets_from_start_and_end(
+        &self,
+        byte_offset: ByteOffset,
+    ) -> (usize, usize) {
+        match byte_offset {
+            ByteOffset::FromStart(offset) => {
+                if self.total_bytes > offset {
+                    (offset, self.total_bytes - offset)
+                } else {
+                    // if asking for a byte offset we haven't reached yet, just start from the end.
+                    (self.total_bytes, 0)
+                }
             }
-        } else {
-            if self.total_bytes > -start {
-                ((self.total_bytes + start) as usize, -start as usize)
-            } else {
-                (0, self.total_bytes as usize)
+            ByteOffset::MostRecent(offset) => {
+                if self.total_bytes > offset {
+                    (self.total_bytes - offset, offset)
+                } else {
+                    // if asking for the most recent N > total_bytes, just start from the beginning.
+                    (0, self.total_bytes)
+                }
             }
         }
     }
 }
 
+/// An abstraction for buffering the contents of the websocket stream representing a Propolis
+/// instance's serial console output, intended for retrieval by the web console or other monitoring
+/// or troubleshooting tools.
 pub(crate) struct SerialConsoleBuffer {
     task: JoinHandle<()>,
     data: Arc<RwLock<BufferData>>,
 }
 
 impl SerialConsoleBuffer {
+    /// Create a SerialConsoleBuffer and spawn a thread to receive data from the given websocket to
+    /// populate the buffer.
     pub(crate) fn new(ws_uri: String, log: Logger) -> Self {
         let data = Arc::new(RwLock::new(BufferData::new(TTY_BUFFER_SIZE)));
         let data_inner = data.clone();
@@ -174,9 +203,18 @@ impl SerialConsoleBuffer {
                                 }
                             );
                         }
-                        Some(Ok(msg)) => {
-                            data_inner.write().await.consume(msg.into_data());
+                        Some(Ok(Message::Text(text))) => {
+                            data_inner.write().await.consume(text.into_bytes());
                         }
+                        Some(Ok(Message::Binary(data))) => {
+                            data_inner.write().await.consume(data);
+                        }
+                        // Frame won't exist at this level, and ping reply is handled by tungstenite
+                        Some(Ok(
+                            Message::Frame(_)
+                            | Message::Ping(_)
+                            | Message::Pong(_),
+                        )) => {}
                     }
                 },
                 Err(e) => {
@@ -188,9 +226,15 @@ impl SerialConsoleBuffer {
         SerialConsoleBuffer { task, data }
     }
 
+    /// Get a tuple containing:
+    /// - a `Vec<u8>` of serial console bytes from the live buffer.
+    /// - the absolute byte index since instance start at which the returned `Vec<u8>` *ends*.
+    /// given a `byte_offset` indicating the index from which the returned `Vec<u8>` should start,
+    /// and a `max_bytes` parameter, specifying a maximum length for the returned `Vec<u8>`, which
+    /// will be `DEFAULT_MAX_LENGTH` if left unspecified.
     pub(crate) async fn contents(
         &self,
-        byte_offset: Option<isize>,
+        byte_offset: ByteOffset,
         max_bytes: Option<usize>,
     ) -> Result<(Vec<u8>, usize), Error> {
         self.data.read().await.contents_vec(byte_offset, max_bytes)
@@ -206,14 +250,15 @@ impl Drop for SerialConsoleBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ByteOffset::*;
 
     // for more legible assertions
     fn sugar(
         buf: &BufferData,
-        byte_offset: isize,
+        byte_offset: ByteOffset,
         max_bytes: usize,
     ) -> (String, usize) {
-        buf.contents_vec(Some(byte_offset), Some(max_bytes))
+        buf.contents_vec(byte_offset, Some(max_bytes))
             .map(|x| (String::from_utf8(x.0).expect("invalid utf-8"), x.1))
             .expect("serial range query failed")
     }
@@ -222,41 +267,44 @@ mod tests {
     fn test_continuous_buffer_range_abstraction() {
         let mut buf = BufferData::new(16);
 
-        assert_eq!(buf.contents_vec(None, None).unwrap(), (vec![], 0));
-        assert_eq!(sugar(&buf, 0, 0), (String::new(), 0));
-        assert_eq!(sugar(&buf, 0, 11), (String::new(), 0));
-        assert_eq!(sugar(&buf, 11, 0), (String::new(), 0));
-        assert_eq!(sugar(&buf, 11, 11), (String::new(), 0));
+        assert_eq!(buf.contents_vec(FromStart(0), None).unwrap(), (vec![], 0));
+        assert_eq!(sugar(&buf, FromStart(0), 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(0), 11), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(11), 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(11), 11), (String::new(), 0));
 
         let line = "This is an example of text.";
         let line_bytes = line.as_bytes().to_vec();
 
         buf.consume(Vec::from(&line_bytes[..9]));
-        assert_eq!(sugar(&buf, 8, 5), ("a".to_string(), 9));
+        assert_eq!(sugar(&buf, FromStart(8), 5), ("a".to_string(), 9));
         buf.consume(Vec::from(&line_bytes[9..]));
 
         assert_eq!(
-            buf.contents_vec(None, None).unwrap(),
+            buf.contents_vec(FromStart(0), None).unwrap(),
             (line_bytes, line.len())
         );
         assert_eq!(
-            sugar(&buf, 0, line.len() + 10),
+            sugar(&buf, FromStart(0), line.len() + 10),
             (line.to_string(), line.len())
         );
-        assert_eq!(sugar(&buf, 8, 5), ("an ex".to_string(), 13));
-        assert_eq!(sugar(&buf, 100, 10), (String::new(), line.len()));
-        assert_eq!(sugar(&buf, -10, 4), ("e of".to_string(), 21));
+        assert_eq!(sugar(&buf, FromStart(8), 5), ("an ex".to_string(), 13));
         assert_eq!(
-            sugar(&buf, -10, 400),
+            sugar(&buf, FromStart(100), 10),
+            (String::new(), line.len())
+        );
+        assert_eq!(sugar(&buf, MostRecent(10), 4), ("e of".to_string(), 21));
+        assert_eq!(
+            sugar(&buf, MostRecent(10), 400),
             ("e of text.".to_string(), line.len())
         );
-        assert_eq!(sugar(&buf, -100, 4), ("This".to_string(), 4));
+        assert_eq!(sugar(&buf, MostRecent(100), 4), ("This".to_string(), 4));
 
         buf.consume("\nNo thing beside remains.".as_bytes().to_vec());
-        assert_eq!(sugar(&buf, -10, 4), ("e re".to_string(), 46));
-        assert_eq!(sugar(&buf, 8, 8), ("an examp".to_string(), 16));
-        assert_eq!(sugar(&buf, 8, 12), ("an examp".to_string(), 16));
+        assert_eq!(sugar(&buf, MostRecent(10), 4), ("e re".to_string(), 46));
+        assert_eq!(sugar(&buf, FromStart(8), 8), ("an examp".to_string(), 16));
+        assert_eq!(sugar(&buf, FromStart(8), 12), ("an examp".to_string(), 16));
 
-        assert!(buf.contents_vec(Some(16), None).is_err());
+        assert!(buf.contents_vec(FromStart(16), None).is_err());
     }
 }

--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -1,0 +1,262 @@
+//! Connects to propolis-server's websocket endpoint for an instance's serial console, and
+//! maintains a buffer of an instance's serial console data, holding both the first mebibyte and the
+//! most recent mebibyte of console output.
+
+use futures::StreamExt;
+use omicron_common::backoff::{retry, BackoffError, ExponentialBackoff};
+use slog::Logger;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::Message;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("I/O failure in serial console socket: {0}")]
+    SocketIo(#[from] tokio_tungstenite::tungstenite::Error),
+
+    #[error("Requested byte offset is no longer cached: {0}")]
+    ExpiredRange(usize),
+
+    #[error("No rolling buffer was allocated for this instance.")]
+    Existential,
+}
+
+const TTY_BUFFER_SIZE: usize = 1024 * 1024;
+const DEFAULT_MAX_LENGTH: isize = 16 * 1024;
+
+struct BufferData {
+    beginning: Vec<u8>,
+    rolling: VecDeque<u8>,
+    total_bytes: isize,
+}
+
+impl BufferData {
+    fn new(buffer_size: usize) -> Self {
+        BufferData {
+            beginning: Vec::with_capacity(buffer_size),
+            rolling: VecDeque::with_capacity(buffer_size),
+            total_bytes: 0,
+        }
+    }
+
+    fn consume(&mut self, msg: Vec<u8>) {
+        let headroom = self.rolling.capacity() - self.rolling.len();
+        let read_size = msg.len();
+        if read_size > headroom {
+            let to_capture = self.beginning.capacity() - self.beginning.len();
+            let drain =
+                self.rolling.drain(0..(read_size - headroom)).take(to_capture);
+            self.beginning.extend(drain);
+        }
+        self.rolling.extend(msg);
+        self.total_bytes += read_size as isize;
+    }
+
+    /// Get an iterator of serial console bytes from the live buffer.
+    /// `since`:
+    /// - if positive, is the byte index since instance start.
+    /// - if negative, is the byte index backwards from the most recently buffered data.
+    /// - if none, yields the most recent `DEFAULT_MAX_LENGTH` of data.
+    fn contents_iter(
+        &self,
+        byte_offset: Option<isize>,
+    ) -> Result<(Box<dyn Iterator<Item = u8> + '_>, usize), Error> {
+        let start = byte_offset.unwrap_or(-DEFAULT_MAX_LENGTH);
+        let (from_start, from_end) = self.offsets_from_start_and_end(start);
+        let iter: Box<dyn Iterator<Item = u8> + '_> = if from_end
+            > self.rolling.len()
+        {
+            if from_start < self.beginning.len() {
+                // is it still possible to stitch together `beginning` and `rolling`?
+                if self.total_bytes as usize
+                    == self.rolling.len() + self.beginning.len()
+                {
+                    Box::new(
+                        self.beginning
+                            .iter()
+                            .skip(from_start)
+                            .chain(self.rolling.iter())
+                            .copied(),
+                    )
+                } else {
+                    Box::new(self.beginning.iter().copied().skip(from_start))
+                }
+            } else {
+                return Err(Error::ExpiredRange(from_start));
+            }
+        } else {
+            // apologies to Takenobu Mitsuyoshi
+            let rolling_start = self.rolling.len() - from_end as usize;
+            Box::new(self.rolling.iter().copied().skip(rolling_start))
+        };
+        Ok((iter, from_start))
+    }
+
+    fn contents_vec(
+        &self,
+        byte_offset: Option<isize>,
+        max_bytes: Option<usize>,
+    ) -> Result<(Vec<u8>, usize), Error> {
+        let (iter, from_start) = self.contents_iter(byte_offset)?;
+        let data: Vec<u8> = iter
+            .take(max_bytes.unwrap_or(DEFAULT_MAX_LENGTH as usize))
+            .collect();
+        let end_offset = from_start + data.len();
+        Ok((data, end_offset))
+    }
+
+    fn offsets_from_start_and_end(&self, start: isize) -> (usize, usize) {
+        if start >= 0 {
+            if self.total_bytes > start {
+                (start as usize, (self.total_bytes - start) as usize)
+            } else {
+                (self.total_bytes as usize, 0)
+            }
+        } else {
+            if self.total_bytes > -start {
+                ((self.total_bytes + start) as usize, -start as usize)
+            } else {
+                (0, self.total_bytes as usize)
+            }
+        }
+    }
+}
+
+pub(crate) struct SerialConsoleBuffer {
+    task: JoinHandle<()>,
+    data: Arc<RwLock<BufferData>>,
+}
+
+impl SerialConsoleBuffer {
+    pub(crate) fn new(ws_uri: String, log: Logger) -> Self {
+        let data = Arc::new(RwLock::new(BufferData::new(TTY_BUFFER_SIZE)));
+        let data_inner = data.clone();
+        let task = tokio::task::spawn(async move {
+            let connect_future =
+                retry(ExponentialBackoff::default(), || async {
+                    match tokio_tungstenite::connect_async(&ws_uri).await {
+                        Ok(x) => Ok(x),
+                        Err(err) => {
+                            warn!(
+                                log,
+                                "TTY connection to {}: {:?}", &ws_uri, err
+                            );
+                            Err(BackoffError::Transient {
+                                err,
+                                retry_after: None,
+                            })
+                        }
+                    }
+                });
+            match connect_future.await {
+                Ok((mut websocket, _)) => loop {
+                    match websocket.next().await {
+                        None => {
+                            warn!(log, "Nothing read from {}", &ws_uri);
+                        }
+                        Some(Err(e)) => {
+                            error!(
+                                log,
+                                "Reading TTY from {}: {:?}", &ws_uri, e
+                            );
+                        }
+                        Some(Ok(Message::Close(details))) => {
+                            info!(
+                                log,
+                                "Closing TTY connection to {}{}",
+                                ws_uri,
+                                if let Some(cf) = details {
+                                    format!(": {}", cf)
+                                } else {
+                                    String::new()
+                                }
+                            );
+                        }
+                        Some(Ok(msg)) => {
+                            data_inner.write().await.consume(msg.into_data());
+                        }
+                    }
+                },
+                Err(e) => {
+                    error!(log, "Failed to open propolis serial console websocket: {:?}", e);
+                }
+            }
+        });
+
+        SerialConsoleBuffer { task, data }
+    }
+
+    pub(crate) async fn contents(
+        &self,
+        byte_offset: Option<isize>,
+        max_bytes: Option<usize>,
+    ) -> Result<(Vec<u8>, usize), Error> {
+        self.data.read().await.contents_vec(byte_offset, max_bytes)
+    }
+}
+
+impl Drop for SerialConsoleBuffer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // for more legible assertions
+    fn sugar(
+        buf: &BufferData,
+        byte_offset: isize,
+        max_bytes: usize,
+    ) -> (String, usize) {
+        buf.contents_vec(Some(byte_offset), Some(max_bytes))
+            .map(|x| (String::from_utf8(x.0).expect("invalid utf-8"), x.1))
+            .expect("serial range query failed")
+    }
+
+    #[test]
+    fn test_continuous_buffer_range_abstraction() {
+        let mut buf = BufferData::new(16);
+
+        assert_eq!(buf.contents_vec(None, None).unwrap(), (vec![], 0));
+        assert_eq!(sugar(&buf, 0, 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, 0, 11), (String::new(), 0));
+        assert_eq!(sugar(&buf, 11, 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, 11, 11), (String::new(), 0));
+
+        let line = "This is an example of text.";
+        let line_bytes = line.as_bytes().to_vec();
+
+        buf.consume(Vec::from(&line_bytes[..9]));
+        assert_eq!(sugar(&buf, 8, 5), ("a".to_string(), 9));
+        buf.consume(Vec::from(&line_bytes[9..]));
+
+        assert_eq!(
+            buf.contents_vec(None, None).unwrap(),
+            (line_bytes, line.len())
+        );
+        assert_eq!(
+            sugar(&buf, 0, line.len() + 10),
+            (line.to_string(), line.len())
+        );
+        assert_eq!(sugar(&buf, 8, 5), ("an ex".to_string(), 13));
+        assert_eq!(sugar(&buf, 100, 10), (String::new(), line.len()));
+        assert_eq!(sugar(&buf, -10, 4), ("e of".to_string(), 21));
+        assert_eq!(
+            sugar(&buf, -10, 400),
+            ("e of text.".to_string(), line.len())
+        );
+        assert_eq!(sugar(&buf, -100, 4), ("This".to_string(), 4));
+
+        buf.consume("\nNo thing beside remains.".as_bytes().to_vec());
+        assert_eq!(sugar(&buf, -10, 4), ("e re".to_string(), 46));
+        assert_eq!(sugar(&buf, 8, 8), ("an examp".to_string(), 16));
+        assert_eq!(sugar(&buf, 8, 12), ("an examp".to_string(), 16));
+
+        assert!(buf.contents_vec(Some(16), None).is_err());
+    }
+}

--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -157,7 +157,7 @@ pub(crate) struct SerialConsoleBuffer {
 }
 
 impl SerialConsoleBuffer {
-    /// Create a SerialConsoleBuffer and spawn a thread to receive data from the given websocket to
+    /// Create a SerialConsoleBuffer and spawn a task to receive data from the given websocket to
     /// populate the buffer.
     pub(crate) fn new(ws_uri: String, log: Logger) -> Self {
         let data = Arc::new(RwLock::new(BufferData::new(TTY_BUFFER_SIZE)));

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -301,6 +301,11 @@ impl<S: Simulatable + 'static> SimCollection<S> {
         }
         rv
     }
+
+    pub async fn sim_contains(self: &Arc<Self>, id: &Uuid) -> bool {
+        let objects = self.objects.lock().await;
+        objects.contains_key(id)
+    }
 }
 
 #[cfg(test)]

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -4,20 +4,22 @@
 
 //! HTTP entrypoint functions for the sled agent's exposed API
 
-use crate::params::{DiskEnsureBody, InstanceEnsureBody};
+use crate::params::{
+    DiskEnsureBody, InstanceEnsureBody, InstanceSerialConsoleData,
+    InstanceSerialConsoleRequest,
+};
 use crate::serial::ByteOffset;
+use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Path;
+use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
-use dropshot::{endpoint, Query};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
-use omicron_common::api::internal::nexus::InstanceSerialConsoleData;
-use omicron_common::api::internal::nexus::InstanceSerialConsoleRequest;
 use omicron_common::api::internal::nexus::UpdateArtifact;
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -215,7 +215,7 @@ impl SledAgent {
         let end = (start + max_bytes.unwrap_or(16 * 1024)).min(buf.len());
         let data = buf[start..end].as_bytes().to_vec();
 
-        let last_byte_offset = (start + data.len()) as u32;
+        let last_byte_offset = (start + data.len()) as u64;
 
         Ok(InstanceSerialConsoleData { data, last_byte_offset })
     }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -7,14 +7,13 @@
 use crate::nexus::NexusClient;
 use crate::params::{
     DiskStateRequested, InstanceHardware, InstanceRuntimeStateRequested,
+    InstanceSerialConsoleData,
 };
 use crate::serial::ByteOffset;
 use futures::lock::Mutex;
 use omicron_common::api::external::Error;
+use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
-use omicron_common::api::internal::nexus::{
-    DiskRuntimeState, InstanceSerialConsoleData,
-};
 use slog::Logger;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -18,6 +18,7 @@ use crate::params::{
 };
 use crate::services::ServiceManager;
 use crate::storage_manager::StorageManager;
+use omicron_common::api::internal::nexus::InstanceSerialConsoleData;
 use omicron_common::api::{
     internal::nexus::DiskRuntimeState, internal::nexus::InstanceRuntimeState,
     internal::nexus::UpdateArtifact,
@@ -322,5 +323,21 @@ impl SledAgent {
         crate::updates::download_artifact(artifact, self.nexus_client.as_ref())
             .await?;
         Ok(())
+    }
+
+    pub async fn instance_serial_console_data(
+        &self,
+        instance_id: Uuid,
+        byte_offset: Option<isize>,
+        max_bytes: Option<usize>,
+    ) -> Result<InstanceSerialConsoleData, Error> {
+        self.instances
+            .instance_serial_console_buffer_data(
+                instance_id,
+                byte_offset,
+                max_bytes,
+            )
+            .await
+            .map_err(Error::from)
     }
 }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -14,11 +14,11 @@ use crate::instance_manager::InstanceManager;
 use crate::nexus::NexusClient;
 use crate::params::{
     DatasetKind, DiskStateRequested, InstanceHardware, InstanceMigrateParams,
-    InstanceRuntimeStateRequested, ServiceEnsureBody,
+    InstanceRuntimeStateRequested, InstanceSerialConsoleData,
+    ServiceEnsureBody,
 };
 use crate::services::ServiceManager;
 use crate::storage_manager::StorageManager;
-use omicron_common::api::internal::nexus::InstanceSerialConsoleData;
 use omicron_common::api::{
     internal::nexus::DiskRuntimeState, internal::nexus::InstanceRuntimeState,
     internal::nexus::UpdateArtifact,

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -34,6 +34,7 @@ use crate::illumos::{dladm::Dladm, zfs::Zfs, zone::Zones};
 use crate::illumos::{
     dladm::MockDladm as Dladm, zfs::MockZfs as Zfs, zone::MockZones as Zones,
 };
+use crate::serial::ByteOffset;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -328,7 +329,7 @@ impl SledAgent {
     pub async fn instance_serial_console_data(
         &self,
         instance_id: Uuid,
-        byte_offset: Option<isize>,
+        byte_offset: ByteOffset,
         max_bytes: Option<usize>,
     ) -> Result<InstanceSerialConsoleData, Error> {
         self.instances

--- a/sled-agent/tests/integration_tests/commands.rs
+++ b/sled-agent/tests/integration_tests/commands.rs
@@ -29,7 +29,7 @@ fn path_to_sled_agent_sim() -> PathBuf {
 fn test_sled_agent_sim_no_args() {
     let exec = Exec::cmd(path_to_sled_agent_sim());
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents(
         "tests/output/cmd-sled-agent-sim-noargs-stdout",
         &stdout_text,
@@ -50,7 +50,7 @@ fn path_to_sled_agent() -> PathBuf {
 fn test_sled_agent_no_args() {
     let exec = Exec::cmd(path_to_sled_agent());
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents("tests/output/cmd-sled-agent-noargs-stdout", &stdout_text);
     assert_contents("tests/output/cmd-sled-agent-noargs-stderr", &stderr_text);
 }
@@ -59,7 +59,7 @@ fn test_sled_agent_no_args() {
 fn test_sled_agent_openapi_sled() {
     let exec = Exec::cmd(path_to_sled_agent()).arg("openapi");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_SUCCESS);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
     assert_contents(
         "tests/output/cmd-sled-agent-openapi-sled-stderr",
         &stderr_text,

--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -37,13 +37,13 @@ pub fn path_to_executable(cmd_name: &str) -> PathBuf {
 }
 
 #[track_caller]
-pub fn assert_exit_code(exit_status: ExitStatus, code: u32) {
+pub fn assert_exit_code(exit_status: ExitStatus, code: u32, stderr_text: &str) {
     if let ExitStatus::Exited(exit_code) = exit_status {
         assert_eq!(exit_code, code as u32);
     } else {
         panic!(
-            "expected normal process exit with code {}, got {:?}",
-            code, exit_status
+            "expected normal process exit with code {}, got {:?}\n\nprocess stderr:{}",
+            code, exit_status, stderr_text
         );
     }
 }

--- a/test-utils/tests/test_omicron_dev.rs
+++ b/test-utils/tests/test_omicron_dev.rs
@@ -295,7 +295,7 @@ async fn test_db_killed() {
 fn test_omicron_dev_no_args() {
     let exec = Exec::cmd(path_to_omicron_dev());
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents("tests/output/cmd-omicron-dev-noargs-stdout", &stdout_text);
     assert_contents("tests/output/cmd-omicron-dev-noargs-stderr", &stderr_text);
 }
@@ -304,7 +304,7 @@ fn test_omicron_dev_no_args() {
 fn test_omicron_dev_bad_cmd() {
     let exec = Exec::cmd(path_to_omicron_dev()).arg("bogus-command");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents(
         "tests/output/cmd-omicron-dev-bad-cmd-stdout",
         &stdout_text,
@@ -319,7 +319,7 @@ fn test_omicron_dev_bad_cmd() {
 fn test_omicron_dev_db_populate_no_args() {
     let exec = Exec::cmd(path_to_omicron_dev()).arg("db-populate");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents(
         "tests/output/cmd-omicron-dev-db-populate-noargs-stdout",
         &stdout_text,
@@ -334,7 +334,7 @@ fn test_omicron_dev_db_populate_no_args() {
 fn test_omicron_dev_db_wipe_no_args() {
     let exec = Exec::cmd(path_to_omicron_dev()).arg("db-wipe");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
-    assert_exit_code(exit_status, EXIT_USAGE);
+    assert_exit_code(exit_status, EXIT_USAGE, &stderr_text);
     assert_contents(
         "tests/output/cmd-omicron-dev-db-wipe-noargs-stdout",
         &stdout_text,


### PR DESCRIPTION
This first-pass implementation is simply a GET with parameters for
byte offset since boot and length, with the intent of providing something
simple for the web frontend to use. It's implemented by cacheing both the
first MiB and most recent MiB of serial console output in the sled-agent,
though this detail is not important in itself (i.e. it could just as well
have the meat of the implementation moved to propolis-server.)

NB: Requires https://github.com/oxidecomputer/propolis/pull/131 (so won't pass checks without it)