### PR TITLE
sp-sim: Add a simulated RoT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "sprockets-common"
 version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/sprockets.git?rev=8be06230bc887f1fffddb079b9ad72adc8eceecb#8be06230bc887f1fffddb079b9ad72adc8eceecb"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
 dependencies = [
  "derive_more",
  "hubpack",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "sprockets-rot"
 version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/sprockets.git?rev=8be06230bc887f1fffddb079b9ad72adc8eceecb#8be06230bc887f1fffddb079b9ad72adc8eceecb"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
 dependencies = [
  "corncobs",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +586,11 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "corncobs"
+version = "0.1.1"
+source = "git+https://github.com/cbiffle/corncobs?tag=v0.1.1#06a276928075fd5638802d46ed2d3d0c31d2d0c3"
 
 [[package]]
 name = "cortex-m"
@@ -984,6 +995,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
+]
+
+[[package]]
 name = "diesel"
 version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1222,15 @@ dependencies = [
  "der",
  "elliptic-curve",
  "hmac 0.11.0",
+ "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
+dependencies = [
  "signature",
 ]
 
@@ -1843,6 +1876,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -4158,6 +4194,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "salty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cdd38ed8bfe51e53ee991aae0791b94349d0a05cfdecd283835a8a965d4c37"
+dependencies = [
+ "ed25519",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,6 +4357,15 @@ name = "serde-big-array"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
 dependencies = [
  "serde",
 ]
@@ -4770,6 +4826,7 @@ dependencies = [
  "serde",
  "slog",
  "slog-dtrace",
+ "sprockets-rot",
  "structopt",
  "thiserror",
  "tokio",
@@ -4809,6 +4866,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
  "der",
+]
+
+[[package]]
+name = "sprockets-common"
+version = "0.1.0"
+source = "git+ssh://git@github.com/oxidecomputer/sprockets.git?rev=8be06230bc887f1fffddb079b9ad72adc8eceecb#8be06230bc887f1fffddb079b9ad72adc8eceecb"
+dependencies = [
+ "derive_more",
+ "hubpack",
+ "salty",
+ "serde",
+ "serde-big-array 0.4.1",
+]
+
+[[package]]
+name = "sprockets-rot"
+version = "0.1.0"
+source = "git+ssh://git@github.com/oxidecomputer/sprockets.git?rev=8be06230bc887f1fffddb079b9ad72adc8eceecb#8be06230bc887f1fffddb079b9ad72adc8eceecb"
+dependencies = [
+ "corncobs",
+ "derive_more",
+ "hubpack",
+ "rand 0.8.5",
+ "salty",
+ "serde",
+ "sprockets-common",
+ "tinyvec",
 ]
 
 [[package]]
@@ -5837,7 +5921,7 @@ dependencies = [
  "rand_chacha",
  "rand_core 0.6.3",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.3.3",
  "serde_cbor",
  "sha2 0.10.2",
  "zeroize",

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -28,8 +28,8 @@ async fn discovery_both_locations() {
     // both instances should report the same serial number for switch 0 and
     // switch 1, and it should match the expected values from the config
     for (switch, expected_serial) in [
-        (0, "00010001000100010001000100010001"),
-        (1, "01000100010001000100010001000100"),
+        (0, "00000000000000000000000000000001"),
+        (1, "00000000000000000000000000000002"),
     ] {
         for client in [client0, client1] {
             let url =

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -12,15 +12,25 @@ multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
+
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
 
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
+
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
+
 [[simulated_sps.gimlet.components]]
 name = "sp3"
 serial_console = "[::1]:0"
@@ -29,6 +39,10 @@ serial_console = "[::1]:0"
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
+
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000003"
+
 [[simulated_sps.gimlet.components]]
 name = "sp3"
 serial_console = "[::1]:0"

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -10,24 +10,21 @@
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
-
+serial_number = "00000000000000000000000000000001"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
 
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
-
+serial_number = "00000000000000000000000000000002"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
 
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
-
+serial_number = "00000000000000000000000000000003"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 
@@ -38,8 +35,7 @@ serial_console = "[::1]:0"
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
-
+serial_number = "00000000000000000000000000000004"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000003"
 

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -13,7 +13,7 @@ gateway-messages = { path = "../gateway-messages", default-features = false, fea
 hex = { version = "0.4.3", features = ["serde"] }
 omicron-common = { path = "../common" }
 slog-dtrace = "0.2"
-sprockets-rot = { git = "ssh://git@github.com/oxidecomputer/sprockets.git", rev = "8be06230bc887f1fffddb079b9ad72adc8eceecb" }
+sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
 structopt = "0.3"
 thiserror = "1.0"
 toml = "0.5.9"

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -10,9 +10,10 @@ async-trait = "0.1.53"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3"
 gateway-messages = { path = "../gateway-messages", default-features = false, features = ["std"] }
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 omicron-common = { path = "../common" }
 slog-dtrace = "0.2"
+sprockets-rot = { git = "ssh://git@github.com/oxidecomputer/sprockets.git", rev = "8be06230bc887f1fffddb079b9ad72adc8eceecb" }
 structopt = "0.3"
 thiserror = "1.0"
 toml = "0.5.9"

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -5,8 +5,7 @@
 [[simulated_sps.sidecar]]
 multicast_addr = "ff15:0:1de::0"
 bind_addrs = ["[::]:33300", "[::]:33301"]
-serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
-
+serial_number = "00000000000000000000000000000001"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
 
@@ -14,7 +13,7 @@ device_id_cert_seed = "01de00000000000000000000000000000000000000000000000000000
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::1"
 bind_addrs = ["[::]:33310", "[::]:33311"]
-serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+serial_number = "00000000000000000000000000000002"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
 
@@ -25,7 +24,7 @@ serial_console = "[::1]:33312"
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::2"
 bind_addrs = ["[::]:33320", "[::]:33321"]
-serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
+serial_number = "00000000000000000000000000000003"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -7,10 +7,17 @@ multicast_addr = "ff15:0:1de::0"
 bind_addrs = ["[::]:33300", "[::]:33301"]
 serial_number = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
+
+
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::1"
 bind_addrs = ["[::]:33310", "[::]:33311"]
 serial_number = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
+
 [[simulated_sps.gimlet.components]]
 name = "sp3"
 serial_console = "[::1]:33312"
@@ -19,6 +26,9 @@ serial_console = "[::1]:33312"
 multicast_addr = "ff15:0:1de::2"
 bind_addrs = ["[::]:33320", "[::]:33321"]
 serial_number = [4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7]
+manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
+device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
+
 [[simulated_sps.gimlet.components]]
 name = "sp3"
 serial_console = "[::1]:33322"

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -26,6 +26,12 @@ pub struct SpCommonConfig {
     pub bind_addrs: Option<[SocketAddrV6; 2]>,
     /// Fake serial number
     pub serial_number: SerialNumber,
+    /// 32-byte seed to create a manufacturing root certificate.
+    #[serde(with = "hex")]
+    pub manufacturing_root_cert_seed: [u8; 32],
+    /// 32-byte seed to create a Device ID certificate.
+    #[serde(with = "hex")]
+    pub device_id_cert_seed: [u8; 32],
 }
 
 /// Configuration of a simulated sidecar SP
@@ -117,5 +123,16 @@ impl std::cmp::PartialEq<std::io::Error> for LoadError {
         } else {
             false
         }
+    }
+}
+
+impl GimletConfig {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, LoadError> {
+        let path = path.as_ref();
+        let contents = std::fs::read_to_string(&path)
+            .map_err(|err| LoadError::Io { path: path.into(), err })?;
+        let config = toml::from_str(&contents)
+            .map_err(|err| LoadError::Parse { path: path.into(), err })?;
+        Ok(config)
     }
 }

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -25,6 +25,7 @@ pub struct SpCommonConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bind_addrs: Option<[SocketAddrV6; 2]>,
     /// Fake serial number
+    #[serde(with = "hex")]
     pub serial_number: SerialNumber,
     /// 32-byte seed to create a manufacturing root certificate.
     #[serde(with = "hex")]

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 mod gimlet;
+mod rot;
 mod server;
 mod sidecar;
 
@@ -15,6 +16,10 @@ pub use gimlet::Gimlet;
 pub use server::logger;
 pub use sidecar::Sidecar;
 pub use slog::Logger;
+pub use sprockets_rot::common::msgs::RotRequestV1;
+pub use sprockets_rot::common::msgs::RotResponseV1;
+use sprockets_rot::common::Ed25519PublicKey;
+pub use sprockets_rot::RotSprocketError;
 use std::net::SocketAddrV6;
 
 pub mod ignition_id {
@@ -33,6 +38,9 @@ pub trait SimulatedSp {
     /// Hexlified serial number.
     fn serial_number(&self) -> String;
 
+    /// Public key for the manufacturing cert used to sign this SP's RoT certs.
+    fn manufacturing_public_key(&self) -> Ed25519PublicKey;
+
     /// Listening UDP address of the given port of this simulated SP, if it was
     /// configured to listen.
     fn local_addr(&self, port: SpPort) -> Option<SocketAddrV6>;
@@ -40,6 +48,12 @@ pub trait SimulatedSp {
     /// Simulate the SP being unresponsive, in which it ignores all incoming
     /// messages.
     async fn set_responsiveness(&self, r: Responsiveness);
+
+    /// Send a request to the (simulated) RoT.
+    fn rot_request(
+        &self,
+        request: RotRequestV1,
+    ) -> Result<RotResponseV1, RotSprocketError>;
 }
 
 pub struct SimRack {

--- a/sp-sim/src/rot.rs
+++ b/sp-sim/src/rot.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Simualting a Root of Trust
+
+use crate::config::SpCommonConfig;
+use sprockets_rot::common::certificates::SerialNumber;
+use sprockets_rot::common::Ed25519PublicKey;
+use sprockets_rot::salty;
+use sprockets_rot::RotConfig;
+use sprockets_rot::RotSprocket;
+
+pub(crate) trait RotSprocketExt {
+    // Returns the (derived-from-config) manufacturing public key and the
+    // `RotSprocket`.
+    fn bootstrap_from_config(
+        config: &SpCommonConfig,
+    ) -> (Ed25519PublicKey, Self);
+}
+
+impl RotSprocketExt for RotSprocket {
+    fn bootstrap_from_config(
+        config: &SpCommonConfig,
+    ) -> (Ed25519PublicKey, Self) {
+        let manufacturing_keypair =
+            salty::Keypair::from(&config.manufacturing_root_cert_seed);
+        let device_id_keypair =
+            salty::Keypair::from(&config.device_id_cert_seed);
+        let serial_number = SerialNumber(config.serial_number);
+        let config = RotConfig::bootstrap_for_testing(
+            &manufacturing_keypair,
+            device_id_keypair,
+            serial_number,
+        );
+        let manufacturing_public_key =
+            Ed25519PublicKey(manufacturing_keypair.public.to_bytes());
+        (manufacturing_public_key, Self::new(config))
+    }
+}


### PR DESCRIPTION
This PR expands the simulated SP config to include 32-byte seeds for the manufacturing root cert and device ID cert, which we use via `RotSprocket::bootstrap_for_testing()` to add an RoT to the simulated SPs. We also expand the `SimualtedSp` trait to add methods to fetch the manufacturing root public key (derived from the seed in the config file) and issue a request to the simulated RoT.

This only changes `sp-sim` and is precursor work to adding sprockets-secured connections to sled-agent.