### PR TITLE
Move sled initialization requests from RSS to bootstrap-agent

### DIFF
--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -11,6 +11,7 @@ pub mod discovery;
 mod http_entrypoints;
 pub mod multicast;
 pub(crate) mod params;
+pub(crate) mod rss_handle;
 pub mod server;
 mod spdm;
 pub mod trust_quorum;

--- a/sled-agent/src/bootstrap/rss_handle.rs
+++ b/sled-agent/src/bootstrap/rss_handle.rs
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! sled-agent's handle to the Rack Setup Service it spawns
+
+use super::client as bootstrap_agent_client;
+use super::discovery::PeerMonitorObserver;
+use super::params::SledAgentRequest;
+use crate::rack_setup::config::SetupServiceConfig;
+use crate::rack_setup::service::Service;
+use futures::stream::FuturesUnordered;
+use futures::Future;
+use futures::StreamExt;
+use omicron_common::backoff::internal_service_policy;
+use omicron_common::backoff::retry_notify;
+use omicron_common::backoff::BackoffError;
+use slog::Logger;
+use std::net::SocketAddrV6;
+use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+pub(super) struct RssHandle {
+    _rss: Service,
+    task: JoinHandle<()>,
+}
+
+impl Drop for RssHandle {
+    fn drop(&mut self) {
+        // NOTE: Ideally, with async drop, we'd await completion of the our task
+        // handler.
+        //
+        // Without that option, we instead opt to simply cancel the task to
+        // ensure it does not remain alive beyond the handle itself.
+        self.task.abort();
+    }
+}
+
+impl RssHandle {
+    // Start the Rack setup service.
+    pub(super) fn start_rss(
+        log: &Logger,
+        config: SetupServiceConfig,
+        peer_monitor: PeerMonitorObserver,
+    ) -> Self {
+        let (tx, rx) = rss_sled_agent_channel();
+
+        let rss = Service::new(
+            log.new(o!("component" => "RSS")),
+            config,
+            peer_monitor,
+            tx,
+        );
+        let log = log.new(o!("component" => "BootstrapAgentRssHandler"));
+        let task = tokio::spawn(async move {
+            handle_rss_requests(&log, rx).await;
+        });
+        Self { _rss: rss, task }
+    }
+}
+
+async fn handle_rss_requests(log: &Logger, requests: RssSledAgentReceiver) {
+    requests
+        .initialize_sleds(log, |bootstrap_addr, request| async move {
+            info!(
+                log, "Received initialization request from RSS";
+                "request" => ?request,
+                "target_sled" => %bootstrap_addr,
+            );
+
+            initialize_sled_agent(log, bootstrap_addr, &request)
+                .await
+                .map_err(|err| {
+                    format!(
+                        "Failed to initialize sled agent at {}: {}",
+                        bootstrap_addr, err
+                    )
+                })?;
+
+            info!(
+                log, "Initialized sled agent";
+                "target_sled" => %bootstrap_addr,
+            );
+
+            Ok(())
+        })
+        .await;
+}
+
+#[derive(Debug, Error)]
+enum InitializeSledAgentError {
+    #[error("Failed to construct an HTTP client: {0}")]
+    HttpClient(#[from] reqwest::Error),
+
+    #[error("Error making HTTP request to Bootstrap Agent: {0}")]
+    BootstrapApi(
+        #[from]
+        bootstrap_agent_client::Error<bootstrap_agent_client::types::Error>,
+    ),
+}
+
+async fn initialize_sled_agent(
+    log: &Logger,
+    bootstrap_addr: SocketAddrV6,
+    request: &SledAgentRequest,
+) -> Result<(), InitializeSledAgentError> {
+    let dur = std::time::Duration::from_secs(60);
+
+    let client = reqwest::ClientBuilder::new()
+        .connect_timeout(dur)
+        .timeout(dur)
+        .build()?;
+
+    let url = format!("http://{}", bootstrap_addr);
+    info!(log, "Sending request to peer agent: {}", url);
+    let client = bootstrap_agent_client::Client::new_with_client(
+        &url,
+        client,
+        log.new(o!("BootstrapAgentClient" => url.clone())),
+    );
+
+    let sled_agent_initialize = || async {
+        client
+            .start_sled(&bootstrap_agent_client::types::SledAgentRequest {
+                subnet: bootstrap_agent_client::types::Ipv6Subnet {
+                    net: bootstrap_agent_client::types::Ipv6Net(
+                        request.subnet.net().to_string(),
+                    ),
+                },
+            })
+            .await
+            .map_err(BackoffError::transient)?;
+
+        Ok::<
+            (),
+            BackoffError<
+                bootstrap_agent_client::Error<
+                    bootstrap_agent_client::types::Error,
+                >,
+            >,
+        >(())
+    };
+
+    let log_failure = |error, _| {
+        warn!(log, "failed to start sled agent"; "error" => ?error);
+    };
+    retry_notify(internal_service_policy(), sled_agent_initialize, log_failure)
+        .await?;
+    info!(log, "Peer agent at {} initialized", url);
+    Ok(())
+}
+
+// RSS needs to send requests (and receive responses) to and from its local sled
+// agent over some communication channel. Currently RSS lives in-process with
+// sled-agent, so we can use tokio channels. If we move out-of-process we'll
+// need to switch to something like Unix domain sockets. We'll wrap the
+// communication in the types below to avoid using tokio channels directly and
+// leave a breadcrumb for where the work will need to be done to switch the
+// communication mechanism.
+fn rss_sled_agent_channel() -> (RssSledAgentSender, RssSledAgentReceiver) {
+    let (tx, rx) = mpsc::channel(32);
+    (RssSledAgentSender { inner: tx }, RssSledAgentReceiver { inner: rx })
+}
+
+type InnerInitRequest = (
+    Vec<(SocketAddrV6, SledAgentRequest)>,
+    oneshot::Sender<Result<(), String>>,
+);
+
+pub(crate) struct RssSledAgentSender {
+    inner: mpsc::Sender<InnerInitRequest>,
+}
+
+impl RssSledAgentSender {
+    pub(crate) async fn initialize_sleds(
+        &self,
+        requests: Vec<(SocketAddrV6, SledAgentRequest)>,
+    ) -> Result<(), String> {
+        let (tx, rx) = oneshot::channel();
+
+        // IPC will require real error handling, but we know the sled-agent task
+        // will not close the channel until we do and that it will always send a
+        // response, so unwrapping here is fine.
+        self.inner.send((requests, tx)).await.unwrap();
+        rx.await.unwrap()
+    }
+}
+
+struct RssSledAgentReceiver {
+    inner: mpsc::Receiver<InnerInitRequest>,
+}
+
+impl RssSledAgentReceiver {
+    async fn initialize_sleds<F, Fut>(mut self, log: &Logger, init_one_sled: F)
+    where
+        F: Fn(SocketAddrV6, SledAgentRequest) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let (requests, tx_response) = match self.inner.recv().await {
+            Some(requests) => requests,
+            None => {
+                warn!(
+                    log,
+                    "Failed receiving sled initialization requests from RSS",
+                );
+                return;
+            }
+        };
+
+        let mut futs = requests
+            .into_iter()
+            .map(|(addr, req)| init_one_sled(addr, req))
+            .collect::<FuturesUnordered<_>>();
+
+        // Wait for all initialization requests to complete, but stop on the
+        // first error.
+        while let Some(result) = futs.next().await {
+            if result.is_err() {
+                // IPC will require real error handling, but we know the
+                // RSS task is waiting for our response, so unwrapping here is
+                // fine (we can only panic if RSS already panicked).
+                tx_response.send(result).unwrap();
+                return;
+            }
+        }
+
+        // All init requests succeeded; inform RSS of completion.
+        tx_response.send(Ok(())).unwrap();
+    }
+}

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -5,10 +5,10 @@
 //! Rack Setup Service implementation
 
 use super::config::{SetupServiceConfig as Config, SledRequest};
-use crate::bootstrap::{
-    client as bootstrap_agent_client, config::BOOTSTRAP_AGENT_PORT,
-    discovery::PeerMonitorObserver, params::SledAgentRequest,
-};
+use crate::bootstrap::config::BOOTSTRAP_AGENT_PORT;
+use crate::bootstrap::discovery::PeerMonitorObserver;
+use crate::bootstrap::params::SledAgentRequest;
+use crate::bootstrap::rss_handle::RssSledAgentSender;
 use crate::params::ServiceRequest;
 use omicron_common::address::{get_sled_address, ReservedRackSubnet};
 use omicron_common::backoff::{
@@ -32,11 +32,8 @@ pub enum SetupServiceError {
         err: std::io::Error,
     },
 
-    #[error("Error making HTTP request to Bootstrap Agent: {0}")]
-    BootstrapApi(
-        #[from]
-        bootstrap_agent_client::Error<bootstrap_agent_client::types::Error>,
-    ),
+    #[error("Error initializing sled via sled-agent: {0}")]
+    SledInitialization(String),
 
     #[error("Error making HTTP request to Sled Agent: {0}")]
     SledApi(#[from] sled_agent_client::Error<sled_agent_client::types::Error>),
@@ -71,14 +68,20 @@ impl Service {
     /// - `config`: The config file, which is used to setup the rack.
     /// - `peer_monitor`: The mechanism by which the setup service discovers
     ///   bootstrap agents on nearby sleds.
-    pub fn new(
+    /// - `sled_agent_requests`: Communication channel by which we can send
+    ///    commands to local sled-agent (e.g., to initialize other sleds).
+    pub(crate) fn new(
         log: Logger,
         config: Config,
         peer_monitor: PeerMonitorObserver,
+        sled_agent_requests: RssSledAgentSender,
     ) -> Self {
         let handle = tokio::task::spawn(async move {
             let svc = ServiceInner::new(log.clone(), peer_monitor);
-            if let Err(e) = svc.inject_rack_setup_requests(&config).await {
+            if let Err(e) = svc
+                .inject_rack_setup_requests(&config, &sled_agent_requests)
+                .await
+            {
                 warn!(log, "RSS injection failed: {}", e);
                 Err(e)
             } else {
@@ -132,62 +135,6 @@ struct ServiceInner {
 impl ServiceInner {
     fn new(log: Logger, peer_monitor: PeerMonitorObserver) -> Self {
         ServiceInner { log, peer_monitor: Mutex::new(peer_monitor) }
-    }
-
-    async fn initialize_sled_agent(
-        &self,
-        bootstrap_addr: SocketAddrV6,
-        request: &SledAgentRequest,
-    ) -> Result<(), SetupServiceError> {
-        let dur = std::time::Duration::from_secs(60);
-
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .map_err(SetupServiceError::HttpClient)?;
-
-        let url = format!("http://{}", bootstrap_addr);
-        info!(self.log, "Sending request to peer agent: {}", url);
-        let client = bootstrap_agent_client::Client::new_with_client(
-            &url,
-            client,
-            self.log.new(o!("BootstrapAgentClient" => url.clone())),
-        );
-
-        let sled_agent_initialize = || async {
-            client
-                .start_sled(&bootstrap_agent_client::types::SledAgentRequest {
-                    subnet: bootstrap_agent_client::types::Ipv6Subnet {
-                        net: bootstrap_agent_client::types::Ipv6Net(
-                            request.subnet.net().to_string(),
-                        ),
-                    },
-                })
-                .await
-                .map_err(BackoffError::transient)?;
-
-            Ok::<
-                (),
-                BackoffError<
-                    bootstrap_agent_client::Error<
-                        bootstrap_agent_client::types::Error,
-                    >,
-                >,
-            >(())
-        };
-
-        let log_failure = |error, _| {
-            warn!(self.log, "failed to start sled agent"; "error" => ?error);
-        };
-        retry_notify(
-            internal_service_policy(),
-            sled_agent_initialize,
-            log_failure,
-        )
-        .await?;
-        info!(self.log, "Peer agent at {} initialized", url);
-        Ok(())
     }
 
     async fn initialize_datasets(
@@ -464,6 +411,7 @@ impl ServiceInner {
     async fn inject_rack_setup_requests(
         &self,
         config: &Config,
+        sled_agent_requests: &RssSledAgentSender,
     ) -> Result<(), SetupServiceError> {
         info!(self.log, "Injecting RSS configuration: {:#?}", config);
 
@@ -522,32 +470,20 @@ impl ServiceInner {
             self.create_plan(config, addrs).await?
         };
 
-        // Issue the dataset initialization requests to all sleds.
-        futures::future::join_all(plan.iter().map(
-            |(bootstrap_addr, allocation)| async move {
-                info!(
-                    self.log,
-                    "Sending request: {:#?}", allocation.initialization_request
-                );
-
-                // First, connect to the Bootstrap Agent and tell it to
-                // initialize the Sled Agent with the specified subnet.
-                self.initialize_sled_agent(
-                    *bootstrap_addr,
-                    &allocation.initialization_request,
-                )
-                .await?;
-                info!(
-                    self.log,
-                    "Initialized sled agent on sled with bootstrap address: {}",
-                    bootstrap_addr
-                );
-                Ok(())
-            },
-        ))
-        .await
-        .into_iter()
-        .collect::<Result<_, SetupServiceError>>()?;
+        // Forward the sled initialization requests to our sled-agent.
+        sled_agent_requests
+            .initialize_sleds(
+                plan.iter()
+                    .map(|(bootstrap_addr, allocation)| {
+                        (
+                            *bootstrap_addr,
+                            allocation.initialization_request.clone(),
+                        )
+                    })
+                    .collect(),
+            )
+            .await
+            .map_err(SetupServiceError::SledInitialization)?;
 
         // Set up internal DNS services.
         futures::future::join_all(


### PR DESCRIPTION
Previously RSS connected directly to the bootstrap-agent server on all remote sleds to send initialization requests. This PR changes that path; RSS now sends requests to its local bootstrap-agent (currently via an in-memory channel, but potentially through something like a Unix domain socket), and the bootstrap-agent then connects its peer bootstrap-agents' dropshot servers to actually send the requests to all sleds.

This is done in preparation for wrapping the bootstrap-agent-to-bootstrap-agent communications in sprockets per RFD 238.