### PR TITLE
Force `zpool create` when setting up file-backed zpools

### DIFF
--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -50,7 +50,7 @@ function ensure_zpools {
         fi
         success "ZFS vdev $VDEV_PATH exists"
         if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
-            zpool create "$ZPOOL" "$VDEV_PATH"
+            zpool create -f "$ZPOOL" "$VDEV_PATH"
         fi
         success "ZFS zpool $ZPOOL exists"
     done


### PR DESCRIPTION
File-backed zpools can get into a state (e.g., after rebooting a VM)
where the zpool does not show up in `zpool list` but still exists
somewhere, causing `zpool create` (without -f) to fail with an error
like:

```
+ zpool create oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b /home/john/omicron/tools/../oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b.vdev
invalid vdev specification
use '-f' to override the following errors:
/home/john/omicron/tools/../oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b.vdev is part of potentially active pool 'oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b'
```