### PR TITLE
[sled-agent] Avoid races on service import, properties on instances, explicit refresh

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -531,8 +531,7 @@ impl Instance {
         // Insteady, we re-try adding the instance until it succeeds.
         // This implies that the service was added successfully.
         info!(
-            inner.log,
-            "Adding {} as a {} service", &instance_name, smf_service_name
+            inner.log, "Adding service"; "smf_name" => &smf_instance_name
         );
         backoff::retry_notify(
             backoff::internal_service_policy(),
@@ -559,7 +558,7 @@ impl Instance {
         )
         .await?;
 
-        info!(inner.log, "Adding service property group");
+        info!(inner.log, "Adding service property group 'config'");
         running_zone.run_cmd(&[
             crate::illumos::zone::SVCCFG,
             "-s",
@@ -569,7 +568,7 @@ impl Instance {
             "astring",
         ])?;
 
-        info!(inner.log, "Setting server address property");
+        info!(inner.log, "Setting server address property"; "address" => &server_addr);
         running_zone.run_cmd(&[
             crate::illumos::zone::SVCCFG,
             "-s",


### PR DESCRIPTION
Fixes #1115 , hopefully.

## Previously

I used the following script:

```bash
set -x
oxide org     create myorg -D "description"
oxide project create --organization myorg myproject -D "description"
set +x

set -x
for i in {0..10000}; do
  INSTANCE_NAME="myinstance${i}"
  oxide instance create --organization myorg --project myproject ${INSTANCE_NAME} -D "description" -c 2 -m 1073741824 --hostname myinstance
  oxide instance stop   --confirm --organization myorg --project myproject ${INSTANCE_NAME}
  oxide instance delete --confirm --organization myorg --project myproject ${INSTANCE_NAME}
done
set +x
```

After < 10 iterations, I'd typically see an SMF failure, either due to a missing property, or due to some issue on import.

After discussion with @bnaecker and @rmustacc , we confirmed that the Propolis Server zone automatically imports the manifest, and that it may be racing with an explicit import.

## This PR

This PR performs the following actions:

1. Rather than importing the manifest, we simply try to add a service instance in a retry loop. As seen in the log files, this typically fails for the first couple invocations (with the output `svccfg: Pattern 'svc:/system/illumos/propolis-
server' doesn't match any instances or services`), but succeeds once the built-in `configd` service has finished importing the propolis manifest.
2. It sets configuration parameters on the service *instance*, rather than the service itself.
3. It explicitly refreshes the instance before enabling it, to make sure the properties are up-to-date.

The aforementioned "create an instance, stop it, destroy it" script has been running on my machine for nearly 100 iterations without a single failure using this PR, which is a major improvement.