### PR TITLE
Tunnel sled initialization requests through sprockets sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,8 +2811,10 @@ dependencies = [
  "omicron-sled-agent",
  "serde",
  "serde_derive",
+ "sp-sim",
  "structopt",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.5",
+ "heapless",
 ]
 
 [[package]]
@@ -59,7 +60,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -224,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.6",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
@@ -425,6 +426,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +575,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "lazy_static",
  "proc-macro-hack",
  "tiny-keccak",
@@ -757,7 +783,7 @@ dependencies = [
  "futures",
  "futures-core",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "reqwest",
  "ringbuffer",
  "schemars",
@@ -930,6 +956,19 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "darling"
@@ -1232,6 +1271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
  "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -1707,6 +1760,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
@@ -1878,6 +1942,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2234,6 +2307,12 @@ checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "lalrpop"
@@ -2919,7 +2998,10 @@ dependencies = [
  "slog-term",
  "smf",
  "socket2",
+ "sp-sim",
  "spdm",
+ "sprockets-host",
+ "sprockets-proxy",
  "structopt",
  "subprocess",
  "tar",
@@ -3443,6 +3525,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3614,17 @@ dependencies = [
  "serde_derive",
  "strum_macros 0.23.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3835,13 +3948,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3871,11 +4007,29 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3926,7 +4080,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "redox_syscall",
  "thiserror",
 ]
@@ -4550,6 +4704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4874,9 +5038,41 @@ source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda66962
 dependencies = [
  "derive_more",
  "hubpack",
+ "rand 0.8.5",
  "salty",
  "serde",
  "serde-big-array 0.4.1",
+]
+
+[[package]]
+name = "sprockets-host"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
+dependencies = [
+ "anyhow",
+ "clap 3.1.18",
+ "derive_more",
+ "futures",
+ "pin-project",
+ "ring",
+ "serde",
+ "slog",
+ "sprockets-common",
+ "sprockets-session",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "sprockets-proxy"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
+dependencies = [
+ "serde",
+ "slog",
+ "sprockets-host",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -4892,6 +5088,26 @@ dependencies = [
  "serde",
  "sprockets-common",
  "tinyvec",
+]
+
+[[package]]
+name = "sprockets-session"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
+dependencies = [
+ "chacha20poly1305",
+ "derive_more",
+ "ed25519",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac 0.12.1",
+ "hubpack",
+ "rand_core 0.6.3",
+ "serde",
+ "sha3",
+ "sprockets-common",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -5860,7 +6076,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "serde",
 ]
 
@@ -5917,7 +6133,7 @@ checksum = "6a56f1fe9df13cff48de34c468a28d38ebede6af79ef5f2bef0b8f6b4a4a28ea"
 dependencies = [
  "ff",
  "group",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "serde",
  "serde-big-array 0.3.3",
@@ -5946,6 +6162,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -6202,6 +6424,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.3",
+ "zeroize",
 ]
 
 [[package]]

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -12,8 +12,10 @@ omicron-sled-agent = { path = "../sled-agent" }
 omicron-package = { path = "../package" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
+sp-sim = { path = "../sp-sim" }
 structopt = "0.3"
 thiserror = "1.0"
+toml = "0.5.9"
 
 # Disable doc builds by default for our binaries to work around issue
 # rust-lang/cargo#8373.  These docs would not be very useful anyway.

--- a/deploy/src/bin/sled-agent-overlay-files.rs
+++ b/deploy/src/bin/sled-agent-overlay-files.rs
@@ -11,7 +11,9 @@ use omicron_sled_agent::bootstrap::trust_quorum::{
     RackSecret, ShareDistribution,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use sp_sim::config::GimletConfig;
+use sp_sim::config::SpCommonConfig;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -60,8 +62,40 @@ fn overlay_secret_shares(
     Ok(())
 }
 
+// Generate a config file for a simulated SP in each deployment server folder.
+fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
+    // We will eventually need to flesh out more of this config; for now,
+    // it's sufficient to only generate an SP that emulates a RoT.
+    let mut config = GimletConfig {
+        common: SpCommonConfig {
+            multicast_addr: None,
+            bind_addrs: None,
+            serial_number: [0; 16],
+            manufacturing_root_cert_seed: [0; 32],
+            device_id_cert_seed: [0; 32],
+        },
+        components: Vec::new(),
+    };
+
+    // Our lazy device ID generation fails if we overflow a u8.
+    assert!(server_dirs.len() <= 255, "expand simulated SP ID generation");
+
+    for server_dir in server_dirs {
+        config.common.serial_number[0] += 1;
+        config.common.device_id_cert_seed[0] += 1;
+
+        let bytes = toml::ser::to_vec(&config).unwrap();
+        let path = server_dir.join("config-sp.toml");
+        std::fs::write(&path, bytes)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let args = Args::from_args_safe().map_err(|err| anyhow!(err))?;
     overlay_secret_shares(args.threshold, &args.directories)?;
+    overlay_sp_configs(&args.directories)?;
     Ok(())
 }

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -35,6 +35,9 @@ slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_deb
 slog-dtrace = "0.2"
 smf = "0.2"
 spdm = { git = "https://github.com/oxidecomputer/spdm", rev = "9742f6e" }
+sp-sim = { path = "../sp-sim" }
+sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
+sprockets-proxy = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
 socket2 = { version = "0.4", features = [ "all" ] }
 structopt = "0.3"
 tar = "0.4"

--- a/sled-agent/src/bootstrap/config.rs
+++ b/sled-agent/src/bootstrap/config.rs
@@ -8,6 +8,8 @@ use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use serde::Deserialize;
 use serde::Serialize;
+use sp_sim::config::GimletConfig;
+use std::net::SocketAddrV6;
 use uuid::Uuid;
 
 pub const BOOTSTRAP_AGENT_PORT: u16 = 12346;
@@ -20,4 +22,10 @@ pub struct Config {
     pub log: ConfigLogging,
 
     pub rss_config: Option<crate::rack_setup::config::SetupServiceConfig>,
+
+    // If present, `dropshot` should bind to a localhost address, and we'll
+    // configure a sprockets-proxy pointed to it that listens on this
+    // (non-localhost) address.
+    pub sprockets_proxy_bind_addr: Option<SocketAddrV6>,
+    pub sp_config: Option<GimletConfig>,
 }

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -8,9 +8,15 @@ use super::agent::Agent;
 use super::config::Config;
 use super::http_entrypoints::ba_api as http_api;
 use crate::config::Config as SledConfig;
+use crate::sp::SpHandle;
+use dropshot::HttpServer;
 use slog::Drain;
+use slog::Logger;
 use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::net::SocketAddrV6;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Wraps a [Agent] object, and provides helper methods for exposing it
 /// via an HTTP interface.
@@ -38,9 +44,15 @@ impl Server {
         } else {
             debug!(log, "registered DTrace probes");
         }
+
+        info!(log, "detecting (real or simulated) SP");
+        let sp = SpHandle::detect(&config.sp_config, &sled_config, &log)
+            .await
+            .map_err(|err| format!("Failed to detect local SP: {err}"))?;
+
         info!(log, "setting up bootstrap agent server");
         let bootstrap_agent = Arc::new(
-            Agent::new(log.clone(), sled_config, address)
+            Agent::new(log.clone(), sled_config, address, sp.clone())
                 .await
                 .map_err(|e| e.to_string())?,
         );
@@ -55,6 +67,20 @@ impl Server {
         )
         .map_err(|error| format!("initializing server: {}", error))?
         .start();
+
+        // Are connections to our bootstrap dropshot server being tunneled
+        // through a sprockets proxy? If so, start up our half.
+        if let Some(sprockets_proxy_bind_addr) =
+            config.sprockets_proxy_bind_addr
+        {
+            spawn_sprockets_proxy(
+                &sp,
+                &http_server,
+                sprockets_proxy_bind_addr,
+                &log,
+            )
+            .await?;
+        }
 
         let server = Server { bootstrap_agent, http_server };
 
@@ -87,4 +113,59 @@ pub fn run_openapi() -> Result<(), String> {
         .contact_email("api@oxide.computer")
         .write(&mut std::io::stdout())
         .map_err(|e| e.to_string())
+}
+
+async fn spawn_sprockets_proxy(
+    sp: &Option<SpHandle>,
+    http_server: &HttpServer<Arc<Agent>>,
+    sprockets_proxy_bind_addr: SocketAddrV6,
+    log: &Logger,
+) -> Result<(), String> {
+    // We can only start a sprockets proxy if we have an SP.
+    let sp = sp.as_ref().ok_or(
+        "Misconfiguration: cannot start a sprockets proxy without an SP",
+    )?;
+
+    // If we're running a sprockets proxy, our dropshot server should be
+    // listening on localhost.
+    let dropshot_addr = http_server.local_addr();
+    if !dropshot_addr.ip().is_loopback() {
+        return Err(concat!(
+            "Misconfiguration: bootstrap dropshot IP address should ",
+            "be loopback when using a sprockets proxy"
+        )
+        .into());
+    }
+
+    let proxy_config = sprockets_proxy::Config {
+        bind_address: SocketAddr::V6(sprockets_proxy_bind_addr),
+        target_address: dropshot_addr,
+        role: sprockets_proxy::Role::Server,
+    };
+    let proxy_log = log.new(o!("component" => "sprockets-proxy (Bootstrap)"));
+
+    // TODO-cleanup The `Duration` passed to `Proxy::new()` is the timeout
+    // for communicating with the RoT. Currently it can be set to anything
+    // at all (our simulated RoT always responds immediately). Should the
+    // value move to our config?
+    let proxy = sprockets_proxy::Proxy::new(
+        &proxy_config,
+        sp.manufacturing_public_key(),
+        sp.rot_handle(),
+        sp.rot_certs(),
+        Duration::from_secs(5),
+        proxy_log,
+    )
+    .await
+    .map_err(|err| format!("Failed to start sprockets proxy: {err}"))?;
+
+    tokio::spawn(async move {
+        // TODO-robustness `proxy.run()` only fails if `accept()`ing on our
+        // already-bound listening socket fails, which means something has
+        // gone very wrong. Do we have any recourse other than panicking?
+        // What does dropshot do if `accept()` fails?
+        proxy.run().await.expect("sprockets server proxy failed");
+    });
+
+    Ok(())
 }

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -32,6 +32,7 @@ pub mod rack_setup;
 pub mod server;
 mod services;
 mod sled_agent;
+mod sp;
 mod storage_manager;
 mod updates;
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -137,10 +137,7 @@ struct ServiceInner {
 }
 
 impl ServiceInner {
-    fn new(
-        log: Logger,
-        peer_monitor: PeerMonitorObserver,
-    ) -> Self {
+    fn new(log: Logger, peer_monitor: PeerMonitorObserver) -> Self {
         ServiceInner { log, peer_monitor: Mutex::new(peer_monitor) }
     }
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -46,6 +46,9 @@ pub enum SetupServiceError {
 
     #[error("Failed to construct an HTTP client: {0}")]
     HttpClient(reqwest::Error),
+
+    #[error("Failed to construct a sprockets proxy: {0}")]
+    SprocketsProxy(#[from] sprockets_proxy::Error),
 }
 
 // The workload / information allocated to a single sled.
@@ -134,7 +137,10 @@ struct ServiceInner {
 }
 
 impl ServiceInner {
-    fn new(log: Logger, peer_monitor: PeerMonitorObserver) -> Self {
+    fn new(
+        log: Logger,
+        peer_monitor: PeerMonitorObserver,
+    ) -> Self {
         ServiceInner { log, peer_monitor: Mutex::new(peer_monitor) }
     }
 

--- a/sled-agent/src/sp.rs
+++ b/sled-agent/src/sp.rs
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Interface to a (currently simulated) SP / RoT.
+
+use crate::config::Config as SledConfig;
+use crate::illumos::dladm::Dladm;
+use crate::illumos::dladm::FindPhysicalLinkError;
+use crate::zone::EnsureGzAddressError;
+use crate::zone::Zones;
+use slog::Logger;
+use sp_sim::config::GimletConfig;
+use sp_sim::RotRequestV1;
+use sp_sim::RotResponseV1;
+use sp_sim::SimulatedSp as SpSimSimulatedSp;
+use sprockets_host::Ed25519Certificates;
+use sprockets_host::Ed25519PublicKey;
+use sprockets_host::RotManager;
+use sprockets_host::RotManagerHandle;
+use sprockets_host::RotOpV1;
+use sprockets_host::RotResultV1;
+use sprockets_host::RotTransport;
+use std::collections::VecDeque;
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+use thiserror::Error;
+
+// These error cases are mostly simulation-specific; the list will grow once we
+// have real hardware (and may shrink if/when we remove or collapse simulated
+// cases). We mark the enum `non_exhaustive` to save some pain in the future.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SpError {
+    #[error("Simulated SP config specifies distinct IP addresses ({0}, {1})")]
+    SimulatedSpMultipleIpAddresses(Ipv6Addr, Ipv6Addr),
+    #[error("Can't access physical link, and none in config: {0}")]
+    FindPhysicalLinkError(#[from] FindPhysicalLinkError),
+    #[error("Could not ensure IP address {addr} in global zone for simulated SP: {err}")]
+    EnsureGlobalZoneAddressError { addr: Ipv6Addr, err: EnsureGzAddressError },
+    #[error("Could not start simualted SP: {0}")]
+    StartSimSpError(String),
+    #[error("Communication with RoT failed: {0}")]
+    RotCommunicationError(String),
+}
+
+#[derive(Clone)]
+pub struct SpHandle {
+    inner: Inner,
+}
+
+impl SpHandle {
+    /// Attempt to detect the presence of an SP.
+    ///
+    /// Currently the only "detection" performed is whether `sp_config` is
+    /// `Some(_)`, in which case a simulated SP is started, and a handle to it
+    /// is returned.
+    ///
+    /// A return value of `Ok(None)` means no SP is available.
+    pub async fn detect(
+        sp_config: &Option<GimletConfig>,
+        sled_config: &SledConfig,
+        log: &Logger,
+    ) -> Result<Option<Self>, SpError> {
+        let inner = if let Some(config) = sp_config.as_ref() {
+            let sim_sp = start_simulated_sp(config, sled_config, log).await?;
+            Some(Inner::SimulatedSp(sim_sp))
+        } else {
+            None
+        };
+        Ok(inner.map(|inner| Self { inner }))
+    }
+
+    pub fn manufacturing_public_key(&self) -> Ed25519PublicKey {
+        match &self.inner {
+            Inner::SimulatedSp(sim) => sim.sp.manufacturing_public_key(),
+        }
+    }
+
+    // TODO The error type here leaks that we only currently support simulated
+    // SPs and will need work once we support a real SP.
+    pub fn rot_handle(&self) -> RotManagerHandle<SimRotTransportError> {
+        match &self.inner {
+            Inner::SimulatedSp(sim) => sim.rot_handle.clone(),
+        }
+    }
+
+    pub fn rot_certs(&self) -> Ed25519Certificates {
+        match &self.inner {
+            Inner::SimulatedSp(sim) => sim.rot_certs,
+        }
+    }
+}
+
+#[derive(Clone)]
+enum Inner {
+    SimulatedSp(SimulatedSp),
+}
+
+#[derive(Clone)]
+struct SimulatedSp {
+    sp: Arc<sp_sim::Gimlet>,
+    rot_certs: Ed25519Certificates,
+    rot_handle: RotManagerHandle<SimRotTransportError>,
+}
+
+async fn start_simulated_sp(
+    sp_config: &GimletConfig,
+    sled_config: &SledConfig,
+    log: &Logger,
+) -> Result<SimulatedSp, SpError> {
+    // Is our simulated SP going to bind to addresses (acting like management
+    // network IPs)?
+    if let Some(bind_addrs) = sp_config.common.bind_addrs {
+        // Sanity check that the sim SP config only specifies one IP address; we
+        // can simulate multiple management network ports by using different TCP
+        // ports.
+        let sp_addr = bind_addrs[0].ip();
+        for addr in bind_addrs[1..].iter().copied().chain(
+            sp_config.components.iter().filter_map(|comp| comp.serial_console),
+        ) {
+            if sp_addr != addr.ip() {
+                return Err(SpError::SimulatedSpMultipleIpAddresses(
+                    *sp_addr,
+                    *addr.ip(),
+                ));
+            }
+        }
+
+        // Ensure we have the global zone IP address we need for the SP.
+        let data_link = if let Some(link) = sled_config.data_link.clone() {
+            link
+        } else {
+            Dladm::find_physical()?
+        };
+        Zones::ensure_has_global_zone_v6_address(data_link, *sp_addr, "simsp")
+            .map_err(|err| SpError::EnsureGlobalZoneAddressError {
+                addr: *sp_addr,
+                err,
+            })?;
+    }
+
+    // Start up the simulated SP.
+    info!(log, "starting simulated gimlet SP");
+    let sp_log = log.new(o!(
+        "component" => "sp-sim",
+        "server" => sled_config.id.clone().to_string(),
+    ));
+    let sp = Arc::new(
+        sp_sim::Gimlet::spawn(&sp_config, sp_log)
+            .await
+            .map_err(|e| SpError::StartSimSpError(e.to_string()))?,
+    );
+
+    // Start up the simulated RoT.
+    info!(log, "starting simulated gimlet RoT");
+    let rot_log = log.new(o!(
+        "component" => "rot-sim",
+        "server" => sled_config.id.clone().to_string(),
+    ));
+    let transport =
+        SimRotTransport { sp: Arc::clone(&sp), responses: VecDeque::new() };
+    let (rot_manager, rot_handle) = RotManager::new(32, transport, rot_log);
+
+    // Spawn a thread to communicate with the RoT. In real hardware this
+    // ultimately uses the UART.
+    thread::Builder::new()
+        .name("sim-rot".to_string())
+        .spawn(move || {
+            rot_manager.run();
+        })
+        .unwrap();
+
+    // Ask the simulated RoT for its certs. The deadline is ignored by our
+    // simulated rot transport; just pass "now".
+    let rot_certs_result = rot_handle
+        .call(RotOpV1::GetCertificates, Instant::now())
+        .await
+        .map_err(|err| SpError::RotCommunicationError(err.to_string()))?;
+    let rot_certs = match rot_certs_result {
+        RotResultV1::Certificates(certs) => certs,
+        RotResultV1::Err(err) => {
+            return Err(SpError::RotCommunicationError(format!("{err:?}")));
+        }
+        other => {
+            return Err(SpError::RotCommunicationError(format!(
+                "unexpected response to GetCertificates request: {other:?}"
+            )));
+        }
+    };
+
+    Ok(SimulatedSp { sp, rot_certs, rot_handle })
+}
+
+struct SimRotTransport {
+    sp: Arc<sp_sim::Gimlet>,
+    responses: VecDeque<RotResponseV1>,
+}
+
+#[derive(Debug, Error)]
+pub enum SimRotTransportError {
+    #[error("RoT sprockets error: {0}")]
+    RotSprocketError(sp_sim::RotSprocketError),
+    #[error("Empty recv queue (recv called more than send?)")]
+    EmptyRecvQueue,
+}
+
+impl RotTransport for SimRotTransport {
+    type Error = SimRotTransportError;
+
+    fn send(
+        &mut self,
+        req: RotRequestV1,
+        _deadline: std::time::Instant,
+    ) -> Result<(), Self::Error> {
+        let response = self
+            .sp
+            .rot_request(req)
+            .map_err(SimRotTransportError::RotSprocketError)?;
+        self.responses.push_back(response);
+        Ok(())
+    }
+
+    fn recv(
+        &mut self,
+        _deadline: std::time::Instant,
+    ) -> Result<RotResponseV1, Self::Error> {
+        self.responses.pop_front().ok_or(SimRotTransportError::EmptyRecvQueue)
+    }
+}


### PR DESCRIPTION
Changes included in this PR:

* The sled-agent binary will look for a `config-sp.toml` file (similarly to how it looks for `config-rss.toml`) that defines the configuration for a simulated SP/RoT. If found, it will tweak the bootstrap config to set up a sprockets proxy (more on this below).
* The bootstrap-agent server will attempt to "detect" an SP. Currently the only mechanism implemented here is that if the config for a simulated SP is present, it will spawn a simulated SP / RoT pair and return a handle to it.
* If we have a handle to an SP, we will start a sprockets server-side proxy that sits in front of the bootstrap-agent dropshot server.
* If we have a handle to an SP, when connecting to a bootstrap-agent dropshot server, we will spawn a (temporary) sprockets client-side proxy and connect to it instead of to the target dropshot server directly.

Without a handle to an SP (or prior to this PR), connections from bootstrap-agent-to-bootstrap-agent to init sleds were direct:

```mermaid
graph TD
    A[bootstrap-agent] -->|bootstrap network| B[bootstrap-agent dropshot server]
```

After this PR and with a handle to an SP, connections between bootstrap agents now flow through sprockets proxies on localhost:

```mermaid
graph TD
    A[bootstrap-agent] -->|loopback| B(sprockets-proxy client)
    B -->|bootstrap network| C(sprockets-proxy server)
    C -->|loopback| D[bootstrap-agent dropshot server]
```

The use of TCP over localhost has (potentially severe) security implications; they're noted in a `TODO-security` comment in `sled-agent/src/bin/sled-agent.rs` where we set up the listen address for dropshot, but I'd be happy to lift them to a github issue if that would be better.

I tried to include sufficient logging to follow the proxy connections, but it still leaves something to be desired since dropshot logs only include the connection coming from the proxy in front of it (on localhost). Here's a snippet from starting up the control plane for the first time on two VMs, `helios1` and `helios2`, between when RSS determines the plan and when the two bootstrap agents receive the sled agent requests and begin starting them:

helios1 (where RSS runs):

```
[2022-05-27T15:58:25.417243705Z]  INFO: SledAgent/RSS/1203 on helios1: Plan written to storage
[2022-05-27T15:58:25.417953006Z]  INFO: SledAgent/BootstrapAgentRssHandler/1203 on helios1: Received initialization request from RSS (target_sled=[fdb0:5254:e4:589f::1]:12346)
    request: SledAgentRequest { subnet: Ipv6Subnet { net: Ipv6Net(Ipv6Network { addr: fd00:1122:3344:101::, prefix: 64 }) } }
[2022-05-27T15:58:25.421191274Z]  INFO: SledAgent/BootstrapAgentRssHandler/1203 on helios1: Sending request to peer agent via sprockets proxy (sprockets_proxy=[::1]:55077, peer=[fdb0:5254:e4:589f::1]:12346)
[2022-05-27T15:58:25.422068466Z] DEBUG: SledAgent/BootstrapAgentRssHandler/1203 on helios1: client request (BootstrapAgentClient=http://[::1]:55077, body=Some(Body), uri=http://[::1]:55077/start_sled, method=PUT)
[2022-05-27T15:58:25.428789402Z]  INFO: SledAgent/BootstrapAgentRssHandler/1203 on helios1: Received initialization request from RSS (target_sled=[fdb0:5254:8a:8c1c::1]:12346)
    request: SledAgentRequest { subnet: Ipv6Subnet { net: Ipv6Net(Ipv6Network { addr: fd00:1122:3344:102::, prefix: 64 }) } }
[2022-05-27T15:58:25.437910465Z]  INFO: SledAgent/BootstrapAgentRssHandler/1203 on helios1: Sending request to peer agent via sprockets proxy (sprockets_proxy=[::1]:45838, peer=[fdb0:5254:8a:8c1c::1]:12346)
[2022-05-27T15:58:25.439813844Z] DEBUG: SledAgent/BootstrapAgentRssHandler/1203 on helios1: client request (BootstrapAgentClient=http://[::1]:45838, body=Some(Body), uri=http://[::1]:45838/start_sled, method=PUT)
[2022-05-27T15:58:25.441400725Z] DEBUG: SledAgent/BootstrapAgentRssHandler/1203 on helios1: accepted connection (BootstrapAgentClientSprocketsProxy=[fdb0:5254:e4:589f::1]:12346, addr=[::1]:35121)
[2022-05-27T15:58:25.442681917Z] DEBUG: SledAgent/BootstrapAgentRssHandler/1203 on helios1: accepted connection (BootstrapAgentClientSprocketsProxy=[fdb0:5254:8a:8c1c::1]:12346, addr=[::1]:54020)
[2022-05-27T15:58:25.443910963Z] DEBUG: SledAgent/sprockets-proxy (Bootstrap)/1203 on helios1: accepted connection (addr=[fdb0:5254:8a:8c1c::1]:43834)
[2022-05-27T15:58:25.444767204Z]  INFO: SledAgent/dropshot (Bootstrap)/1203 on helios1: accepted connection (local_addr=[::1]:34196, remote_addr=[::1]:54778)
[2022-05-27T15:58:25.457097147Z]  INFO: SledAgent/BootstrapAgent/1203 on helios1: Loading Sled Agent: SledAgentRequest { subnet: Ipv6Subnet { net: Ipv6Net(Ipv6Network { addr: fd00:1122:3344:102::, prefix: 64 }) } } (server=fb0f7546-4d46-40ca-9d56-cbb810684ca
7)
[2022-05-27T15:58:25.457642039Z]  INFO: SledAgent/1203 on helios1: setting up sled agent server
```

helios2:

```
[2022-05-27T15:58:25.408747892Z] DEBUG: SledAgent/sprockets-proxy (Bootstrap)/873 on helios2: accepted connection (addr=[fdb0:5254:8a:8c1c::1]:36552)
[2022-05-27T15:58:25.409870173Z]  INFO: SledAgent/dropshot (Bootstrap)/873 on helios2: accepted connection (local_addr=[::1]:62291, remote_addr=[::1]:37219)
[2022-05-27T15:58:25.432786801Z]  INFO: SledAgent/BootstrapAgent/873 on helios2: Loading Sled Agent: SledAgentRequest { subnet: Ipv6Subnet { net: Ipv6Net(Ipv6Network { addr: fd00:1122:3344:101::, prefix: 64 }) } } (server=fb0f7546-4d46-40ca-9d56-cbb810684ca7
)
[2022-05-27T15:58:25.434327107Z]  INFO: SledAgent/873 on helios2: setting up sled agent server
```

Setting up the above requires using `thing-flinger` to (among other things) distribute `config-sp.toml` files so all nodes know to simulate SP/RoTs, which are required to establish sprockets sessions. That happens in `sled-agent-overlay-files` and is included in this PR.

~~My setup is having trouble starting nexus, but I believe that to be a VM networking issue and not related to the changes in this PR, given the above logs and the lack of changes to nexus/service-related code. I'm going to continue to debug that but believe this code is ready to review even without tracking that all the way down.~~ Edit: This was fixed by #1132.