### PR TITLE
disable string table compression on illumos in development

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,3 +7,11 @@
 [build]
 rustdocflags = "--document-private-items"
 
+# On illumos, use `-znocompstrtab` to reduce link time.
+#
+# Note that these flags are overridden by a user's environment variable, so
+# things critical to correctness probably don't belong here.
+[target.x86_64-unknown-illumos]
+rustflags = [
+    "-C", "link-arg=-Wl,-znocompstrtab"
+]


### PR DESCRIPTION
See #1122. This change configures Cargo to pass `-znostrcompress` when building on illumos.  This flag is [documented](https://docs.oracle.com/cd/E19683-01/817-3677/chapter2-1/index.html) with:

> String tables are compressed by the link-editor by removing duplicate entries and tail substrings. This compression can significantly reduce the size of any string tables. A compressed .dynstr table can produce a smaller text segment and hence reduce runtime paging activity. Because of these benefits, string table compression is enabled by default.
> Linking objects that contribute a very large number of symbols may increase the link-edit time due to the string table compression. To avoid this cost during development use the link-editors -z nocompstrtab option.

As I read this, the default behavior uses more link time to improve runtime performance over the long term.  This doesn't feel like a great tradeoff for development.  Using `-znocompstrtab` makes a notable improvement on my incremental rebuild time.  I'll post some numbers.  @rmustacc, I'd love a +1 from you that I'm not missing something important about the consequences of using this flag in development.

There are some caveats:

- [This is overridden by a user's `RUSTFLAGS` environment variable.](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags) That's annoying but I'm not sure where else to put this.
- From what @jmpesp mentioned in #995, this might override a user's $HOME/.cargo/config?  I haven't found this documented in Cargo.  I'm not sure what use cases this matters for besides the one James mentioned there.  I'm hopeful this won't be a problem in this case because we're only doing this on illumos and James's override is only for Linux?
