### PR TITLE
Move creation of `/var/oxide` from RSS to bootstrap-agent

### DIFF
--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -138,6 +138,22 @@ impl Agent {
             "server" => sled_config.id.to_string(),
         ));
 
+        // We expect this directory to exist - ensure that it does, before any
+        // subsequent operations which may write configs here.
+        info!(
+            log, "Ensuring config directory exists";
+            "path" => omicron_common::OMICRON_CONFIG_PATH,
+        );
+        tokio::fs::create_dir_all(omicron_common::OMICRON_CONFIG_PATH)
+            .await
+            .map_err(|err| BootstrapError::Io {
+                message: format!(
+                    "Creating config directory {}",
+                    omicron_common::OMICRON_CONFIG_PATH
+                ),
+                err,
+            })?;
+
         let data_link = if let Some(link) = sled_config.data_link.clone() {
             link
         } else {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -416,18 +416,6 @@ impl ServiceInner {
     ) -> Result<(), SetupServiceError> {
         info!(self.log, "Injecting RSS configuration: {:#?}", config);
 
-        // We expect this directory to exist - ensure that it does, before any
-        // subsequent operations which may write configs here.
-        tokio::fs::create_dir_all(omicron_common::OMICRON_CONFIG_PATH)
-            .await
-            .map_err(|err| SetupServiceError::Io {
-                message: format!(
-                    "Creating config directory {}",
-                    omicron_common::OMICRON_CONFIG_PATH
-                ),
-                err,
-            })?;
-
         // Check if a previous RSS plan has completed successfully.
         //
         // If it has, the system should be up-and-running.


### PR DESCRIPTION
In single-sled cases, our current RSS implementation would create
`/var/oxide` before issuing requests that would ultimately end up
creating files under it. However, in multisled cases, `/var/oxide` would
only be created on the sled running RSS; requests to other sleds that
tried to write files in that directory would fail.

This commit moves the creation of the directory from "early in RSS" to
"early in bootstrap-agent", ensuring it happens on all sleds.