### PR TITLE
Adds concept of a primary network interface

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1811,6 +1811,9 @@ pub struct NetworkInterface {
     pub ip: IpAddr,
     // TODO-correctness: We need to split this into an optional V4 and optional
     // V6 address, at least one of which must be specified.
+    /// True if this interface is the primary for the instance to which it's
+    /// attached.
+    pub primary: bool,
 }
 
 #[derive(

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -674,7 +674,14 @@ CREATE TABLE omicron.public.network_interface (
      * Limited to 8 NICs per instance. This value must be kept in sync with
      * `crate::nexus::MAX_NICS_PER_INSTANCE`.
      */
-    slot INT2 NOT NULL CHECK (slot >= 0 AND slot < 8)
+    slot INT2 NOT NULL CHECK (slot >= 0 AND slot < 8),
+
+    /* True if this interface is the primary interface for the instance.
+     *
+     * The primary interface appears in DNS and its address is used for external
+     * connectivity for the instance.
+     */
+    is_primary BOOL NOT NULL
 );
 
 /* TODO-completeness

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -13,8 +13,7 @@ use crate::db;
 use crate::db::identity::Resource;
 use crate::db::lookup::LookupPath;
 use crate::db::model::Name;
-use crate::db::queries::network_interface::DeleteNetworkInterfaceError;
-use crate::db::queries::network_interface::InsertNetworkInterfaceError;
+use crate::db::queries::network_interface;
 use crate::external_api::params;
 use omicron_common::api::external;
 use omicron_common::api::external::CreateResult;
@@ -682,7 +681,7 @@ impl super::Nexus {
                 interface,
             )
             .await
-            .map_err(InsertNetworkInterfaceError::into_external)?;
+            .map_err(network_interface::InsertError::into_external)?;
         Ok(interface)
     }
 
@@ -767,7 +766,7 @@ impl super::Nexus {
                 &authz_interface,
             )
             .await
-            .map_err(DeleteNetworkInterfaceError::into_external)
+            .map_err(network_interface::DeleteError::into_external)
     }
 
     /// Invoked by a sled agent to publish an updated runtime state for an

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -9,7 +9,8 @@ use crate::app::{MAX_DISKS_PER_INSTANCE, MAX_NICS_PER_INSTANCE};
 use crate::context::OpContext;
 use crate::db::identity::Resource;
 use crate::db::lookup::LookupPath;
-use crate::db::queries::network_interface::NetworkInterfaceError;
+use crate::db::queries::network_interface::InsertNetworkInterfaceError;
+use crate::defaults::DEFAULT_PRIMARY_NIC_NAME;
 use crate::external_api::params;
 use crate::saga_interface::SagaContext;
 use crate::{authn, authz, db};
@@ -242,7 +243,7 @@ async fn sic_create_network_interfaces(
     match sagactx.saga_params().create_params.network_interfaces {
         params::InstanceNetworkInterfaceAttachment::None => Ok(()),
         params::InstanceNetworkInterfaceAttachment::Default => {
-            sic_create_default_network_interface(&sagactx).await
+            sic_create_default_primary_network_interface(&sagactx).await
         }
         params::InstanceNetworkInterfaceAttachment::Create(
             ref create_params,
@@ -347,7 +348,7 @@ async fn sic_create_custom_network_interfaces(
             // crashed. The saga recovery machinery will replay just this node,
             // without first unwinding it, so any previously-inserted interfaces
             // will still exist. This is expected.
-            Err(NetworkInterfaceError::DuplicatePrimaryKey(_)) => {
+            Err(InsertNetworkInterfaceError::DuplicatePrimaryKey(_)) => {
                 // TODO-observability: We should bump a counter here.
                 let log = osagactx.log();
                 warn!(
@@ -369,8 +370,9 @@ async fn sic_create_custom_network_interfaces(
     Ok(())
 }
 
-/// Create the default network interface for an instance during the create saga
-async fn sic_create_default_network_interface(
+/// Create a default primary network interface for an instance during the create
+/// saga.
+async fn sic_create_default_primary_network_interface(
     sagactx: &ActionContext<SagaInstanceCreate>,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
@@ -379,13 +381,23 @@ async fn sic_create_default_network_interface(
     let opctx =
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
+
+    // The literal name "default" is currently used for the VPC and VPC Subnet,
+    // when not specified in the client request.
+    // TODO-completeness: We'd like to select these from Project-level defaults.
+    // See https://github.com/oxidecomputer/omicron/issues/1015.
     let default_name = Name::try_from("default".to_string()).unwrap();
     let internal_default_name = db::model::Name::from(default_name.clone());
+
+    // The name of the default primary interface.
+    let iface_name =
+        Name::try_from(DEFAULT_PRIMARY_NIC_NAME.to_string()).unwrap();
+
     let interface_params = params::NetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
-            name: default_name.clone(),
+            name: iface_name.clone(),
             description: format!(
-                "default interface for {}",
+                "default primary interface for {}",
                 saga_params.create_params.identity.name,
             ),
         },
@@ -427,7 +439,7 @@ async fn sic_create_default_network_interface(
             interface,
         )
         .await
-        .map_err(NetworkInterfaceError::into_external)
+        .map_err(InsertNetworkInterfaceError::into_external)
         .map_err(ActionError::action_failed)?;
     Ok(())
 }

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -40,8 +40,10 @@ use crate::db::lookup::LookupPath;
 use crate::db::model::DatabaseString;
 use crate::db::model::IncompleteVpc;
 use crate::db::model::Vpc;
+use crate::db::queries::network_interface::DeleteNetworkInterfaceError;
+use crate::db::queries::network_interface::DeleteNetworkInterfaceQuery;
+use crate::db::queries::network_interface::InsertNetworkInterfaceError;
 use crate::db::queries::network_interface::InsertNetworkInterfaceQuery;
-use crate::db::queries::network_interface::NetworkInterfaceError;
 use crate::db::queries::vpc::InsertVpcQuery;
 use crate::db::queries::vpc_subnet::FilterConflictingVpcSubnetRangesQuery;
 use crate::db::queries::vpc_subnet::SubnetError;
@@ -1575,15 +1577,15 @@ impl DataStore {
         authz_subnet: &authz::VpcSubnet,
         authz_instance: &authz::Instance,
         interface: IncompleteNetworkInterface,
-    ) -> Result<NetworkInterface, NetworkInterfaceError> {
+    ) -> Result<NetworkInterface, InsertNetworkInterfaceError> {
         opctx
             .authorize(authz::Action::CreateChild, authz_instance)
             .await
-            .map_err(NetworkInterfaceError::External)?;
+            .map_err(InsertNetworkInterfaceError::External)?;
         opctx
             .authorize(authz::Action::CreateChild, authz_subnet)
             .await
-            .map_err(NetworkInterfaceError::External)?;
+            .map_err(InsertNetworkInterfaceError::External)?;
         self.instance_create_network_interface_raw(&opctx, interface).await
     }
 
@@ -1591,7 +1593,7 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         interface: IncompleteNetworkInterface,
-    ) -> Result<NetworkInterface, NetworkInterfaceError> {
+    ) -> Result<NetworkInterface, InsertNetworkInterfaceError> {
         use db::schema::network_interface::dsl;
         let query = InsertNetworkInterfaceQuery::new(interface.clone());
         diesel::insert_into(dsl::network_interface)
@@ -1600,10 +1602,10 @@ impl DataStore {
             .get_result_async(
                 self.pool_authorized(opctx)
                     .await
-                    .map_err(NetworkInterfaceError::External)?,
+                    .map_err(InsertNetworkInterfaceError::External)?,
             )
             .await
-            .map_err(|e| NetworkInterfaceError::from_pool(e, &interface))
+            .map_err(|e| InsertNetworkInterfaceError::from_pool(e, &interface))
     }
 
     /// Delete all network interfaces attached to the given instance.
@@ -1634,28 +1636,32 @@ impl DataStore {
     }
 
     /// Delete a `NetworkInterface` attached to a provided instance.
+    ///
+    /// Note that the primary interface for an instance cannot be deleted if
+    /// there are any secondary interfaces.
     pub async fn instance_delete_network_interface(
         &self,
         opctx: &OpContext,
+        authz_instance: &authz::Instance,
         authz_interface: &authz::NetworkInterface,
-    ) -> DeleteResult {
-        opctx.authorize(authz::Action::Delete, authz_interface).await?;
-
-        use db::schema::network_interface::dsl;
-        let now = Utc::now();
-        let interface_id = authz_interface.id();
-        diesel::update(dsl::network_interface)
-            .filter(dsl::id.eq(interface_id))
-            .filter(dsl::time_deleted.is_null())
-            .set((dsl::time_deleted.eq(now),))
-            .execute_async(self.pool_authorized(opctx).await?)
+    ) -> Result<(), DeleteNetworkInterfaceError> {
+        opctx
+            .authorize(authz::Action::Delete, authz_interface)
             .await
-            .map_err(|e| {
-                public_error_from_diesel_pool(
-                    e,
-                    ErrorHandler::NotFoundByResource(authz_interface),
-                )
-            })?;
+            .map_err(DeleteNetworkInterfaceError::External)?;
+        let query = DeleteNetworkInterfaceQuery::new(
+            authz_instance.id(),
+            authz_interface.id(),
+        );
+        query
+            .clone()
+            .execute_async(
+                self.pool_authorized(opctx)
+                    .await
+                    .map_err(DeleteNetworkInterfaceError::External)?,
+            )
+            .await
+            .map_err(|e| DeleteNetworkInterfaceError::from_pool(e, &query))?;
         Ok(())
     }
 

--- a/nexus/src/db/model/network_interface.rs
+++ b/nexus/src/db/model/network_interface.rs
@@ -26,6 +26,8 @@ pub struct NetworkInterface {
     // If neither is specified, auto-assign one of each?
     pub ip: ipnetwork::IpNetwork,
     pub slot: i16,
+    #[diesel(column_name = is_primary)]
+    pub primary: bool,
 }
 
 impl From<NetworkInterface> for external::NetworkInterface {
@@ -37,6 +39,7 @@ impl From<NetworkInterface> for external::NetworkInterface {
             subnet_id: iface.subnet_id,
             ip: iface.ip.ip(),
             mac: *iface.mac,
+            primary: iface.primary,
         }
     }
 }

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -130,6 +130,7 @@ table! {
         mac -> Int8,
         ip -> Inet,
         slot -> Int2,
+        is_primary -> Bool,
     }
 }
 

--- a/nexus/src/defaults.rs
+++ b/nexus/src/defaults.rs
@@ -21,6 +21,10 @@ pub const MIN_VPC_IPV4_SUBNET_PREFIX: u8 = 8;
 /// The number of reserved addresses at the beginning of a subnet range.
 pub const NUM_INITIAL_RESERVED_IP_ADDRESSES: usize = 5;
 
+/// The name provided for a default primary network interface for a guest
+/// instance.
+pub const DEFAULT_PRIMARY_NIC_NAME: &str = "net0";
+
 lazy_static! {
     /// The default IPv4 subnet range assigned to the default VPC Subnet, when
     /// the VPC is created, if one is not provided in the request. See

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1759,6 +1759,11 @@ pub struct NetworkInterfacePathParam {
 }
 
 /// Detach a network interface from an instance.
+///
+/// Note that the primary interface for an instance cannot be deleted if there
+/// are any secondary interfaces. A new primary interface must be designated
+/// first. The primary interface can be deleted if there are no secondary
+/// interfaces.
 #[endpoint {
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces/{interface_name}",

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1764,6 +1764,8 @@ pub struct NetworkInterfacePathParam {
 /// are any secondary interfaces. A new primary interface must be designated
 /// first. The primary interface can be deleted if there are no secondary
 /// interfaces.
+// TODO-completeness: Add API for modifying an interface, including setting as
+// new primary. See https://github.com/oxidecomputer/omicron/issues/1153.
 #[endpoint {
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces/{interface_name}",

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -93,12 +93,15 @@ pub struct NetworkInterfaceCreate {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", content = "params", rename_all = "snake_case")]
 pub enum InstanceNetworkInterfaceAttachment {
-    /// Create one or more `NetworkInterface`s for the `Instance`
+    /// Create one or more `NetworkInterface`s for the `Instance`.
+    ///
+    /// If more than one interface is provided, then the first will be
+    /// designated the primary interface for the instance.
     Create(Vec<NetworkInterfaceCreate>),
 
-    /// Default networking setup, which creates a single interface with an
-    /// auto-assigned IP address from project's "default" VPC and "default" VPC
-    /// Subnet.
+    /// The default networking configuration for an instance is to create a
+    /// single primary interface with an automatically-assigned IP address. The
+    /// IP will be pulled from the Project's default VPC / VPC Subnet.
     Default,
 
     /// No network interfaces at all will be created for the instance.

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -211,7 +211,8 @@ lazy_static! {
         };
 
     // The instance needs a network interface, too.
-    pub static ref DEMO_INSTANCE_NIC_NAME: Name = "default".parse().unwrap();
+    pub static ref DEMO_INSTANCE_NIC_NAME: Name =
+        omicron_nexus::defaults::DEFAULT_PRIMARY_NIC_NAME.parse().unwrap();
     pub static ref DEMO_INSTANCE_NIC_URL: String =
         format!("{}/{}", *DEMO_INSTANCE_NICS_URL, *DEMO_INSTANCE_NIC_NAME);
     pub static ref DEMO_INSTANCE_NIC_CREATE: params::NetworkInterfaceCreate =

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -182,7 +182,10 @@ async fn test_instances_create_reboot_halt(
             .items;
     assert_eq!(network_interfaces.len(), 1);
     assert_eq!(network_interfaces[0].instance_id, instance.identity.id);
-    assert_eq!(network_interfaces[0].identity.name, "default");
+    assert_eq!(
+        network_interfaces[0].identity.name,
+        omicron_nexus::defaults::DEFAULT_PRIMARY_NIC_NAME
+    );
 
     // Now, simulate completion of instance boot and check the state reported.
     instance_simulate(nexus, &instance.identity.id).await;
@@ -915,18 +918,27 @@ async fn test_instance_create_delete_network_interface(
         "Expected no network interfaces for instance"
     );
 
-    // Parameters for the interface to create/attach
-    let if_params = params::NetworkInterfaceCreate {
-        identity: IdentityMetadataCreateParams {
-            name: "if0".parse().unwrap(),
-            description: String::from("a new nic"),
+    // Parameters for the interfaces to create/attach
+    let if_params = vec![
+        params::NetworkInterfaceCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "if0".parse().unwrap(),
+                description: String::from("a new nic"),
+            },
+            vpc_name: "default".parse().unwrap(),
+            subnet_name: "default".parse().unwrap(),
+            ip: Some("172.30.0.10".parse().unwrap()),
         },
-        vpc_name: "default".parse().unwrap(),
-        subnet_name: "default".parse().unwrap(),
-        ip: Some("172.30.0.10".parse().unwrap()),
-    };
-    let url_interface =
-        format!("{}/{}", url_interfaces, if_params.identity.name.as_str());
+        params::NetworkInterfaceCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "if1".parse().unwrap(),
+                description: String::from("a new nic"),
+            },
+            vpc_name: "default".parse().unwrap(),
+            subnet_name: "default".parse().unwrap(),
+            ip: Some("172.30.0.11".parse().unwrap()),
+        },
+    ];
 
     // We should not be able to create an interface while the instance is running.
     //
@@ -937,7 +949,7 @@ async fn test_instance_create_delete_network_interface(
         http::Method::POST,
         url_interfaces.as_str(),
     )
-    .body(Some(&if_params))
+    .body(Some(&if_params[0]))
     .expect_status(Some(http::StatusCode::BAD_REQUEST));
     let err = NexusRequest::new(builder)
         .authn_as(AuthnMode::PrivilegedUser)
@@ -957,33 +969,83 @@ async fn test_instance_create_delete_network_interface(
         instance_post(client, url_instance.as_str(), InstanceOp::Stop).await;
     instance_simulate(nexus, &instance.identity.id).await;
 
-    // Verify we can now make the request again
-    let response =
-        NexusRequest::objects_post(client, url_interfaces.as_str(), &if_params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .expect("Failed to create network interface on stopped instance");
-    let iface = response.parsed_body::<NetworkInterface>().unwrap();
-    assert_eq!(iface.identity.name, if_params.identity.name);
-    assert_eq!(iface.ip, if_params.ip.unwrap());
+    // Verify we can now make the requests again
+    let mut interfaces = Vec::with_capacity(2);
+    for (i, params) in if_params.iter().enumerate() {
+        let response = NexusRequest::objects_post(
+            client,
+            url_interfaces.as_str(),
+            &params,
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("Failed to create network interface on stopped instance");
+        let iface = response.parsed_body::<NetworkInterface>().unwrap();
+        assert_eq!(iface.identity.name, params.identity.name);
+        assert_eq!(iface.ip, params.ip.unwrap());
+        assert_eq!(
+            iface.primary,
+            i == 0,
+            "Only the first interface should be primary"
+        );
+        interfaces.push(iface);
+    }
 
-    // Restart the instance, verify the interface is still correct.
+    // Restart the instance, verify the interfaces are still correct.
     let instance =
         instance_post(client, url_instance.as_str(), InstanceOp::Start).await;
     instance_simulate(nexus, &instance.identity.id).await;
 
-    let iface0 = NexusRequest::object_get(client, url_interface.as_str())
+    for iface in interfaces.iter() {
+        let url_interface =
+            format!("{}/{}", url_interfaces, iface.identity.name.as_str());
+        let iface0 = NexusRequest::object_get(client, url_interface.as_str())
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .expect("Failed to get interface")
+            .parsed_body::<NetworkInterface>()
+            .expect("Failed to parse network interface from body");
+        assert_eq!(iface.identity.id, iface0.identity.id);
+        assert_eq!(iface.ip, iface0.ip);
+        assert_eq!(iface.primary, iface0.primary);
+    }
+
+    // Verify we cannot delete either interface while the instance is running
+    for iface in interfaces.iter() {
+        let url_interface =
+            format!("{}/{}", url_interfaces, iface.identity.name.as_str());
+        let err = NexusRequest::expect_failure(
+            client,
+            http::StatusCode::BAD_REQUEST,
+            http::Method::DELETE,
+            url_interface.as_str(),
+        )
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
-        .expect("Failed to get interface")
-        .parsed_body::<NetworkInterface>()
-        .expect("Failed to parse network interface from body");
-    assert_eq!(iface.identity.id, iface0.identity.id);
-    assert_eq!(iface.ip, iface0.ip);
+        .expect(
+            "Should not be able to delete network interface on running instance",
+        )
+        .parsed_body::<HttpErrorResponseBody>()
+        .expect("Failed to parse error response body");
+        assert_eq!(
+            err.message,
+            "Instance must be stopped to detach a network interface",
+            "Expected an InvalidRequest response when detaching an interface from a running instance"
+        );
+    }
 
-    // Verify we cannot delete the interface while the instance is running
+    // Stop the instance and verify we can delete the interface
+    let instance =
+        instance_post(client, url_instance.as_str(), InstanceOp::Stop).await;
+    instance_simulate(nexus, &instance.identity.id).await;
+
+    // We should not be able to delete the primary interface, while the
+    // secondary still exists
+    let url_interface =
+        format!("{}/{}", url_interfaces, interfaces[0].identity.name.as_str());
     let err = NexusRequest::expect_failure(
         client,
         http::StatusCode::BAD_REQUEST,
@@ -994,25 +1056,40 @@ async fn test_instance_create_delete_network_interface(
     .execute()
     .await
     .expect(
-        "Should not be able to delete network interface on running instance",
+        "Should not be able to delete the primary network interface \
+        while secondary interfaces still exist",
     )
     .parsed_body::<HttpErrorResponseBody>()
     .expect("Failed to parse error response body");
     assert_eq!(
         err.message,
-        "Instance must be stopped to detach a network interface",
-        "Expected an InvalidRequest response when detaching an interface from a running instance"
+        "The primary interface for an instance \
+        may not be deleted while secondary interfaces \
+        are still attached",
+        "Expected an InvalidRequest response when detaching \
+        the primary interface from an instance with at least one \
+        secondary interface",
     );
 
-    // Stop the instance and verify we can delete the interface
-    let instance =
-        instance_post(client, url_instance.as_str(), InstanceOp::Stop).await;
-    instance_simulate(nexus, &instance.identity.id).await;
+    // Verify that we can delete the secondary.
+    let url_interface =
+        format!("{}/{}", url_interfaces, interfaces[1].identity.name.as_str());
     NexusRequest::object_delete(client, url_interface.as_str())
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
-        .expect("Failed to delete interface from stopped instance");
+        .expect("Failed to delete secondary interface from stopped instance");
+
+    // Now verify that we can delete the primary
+    let url_interface =
+        format!("{}/{}", url_interfaces, interfaces[0].identity.name.as_str());
+    NexusRequest::object_delete(client, url_interface.as_str())
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect(
+            "Failed to delete sole primary interface from stopped instance",
+        );
 }
 
 /// This test specifically creates two NICs, the second of which will fail the

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2209,6 +2209,7 @@
           "instances"
         ],
         "summary": "Detach a network interface from an instance.",
+        "description": "Note that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
         "operationId": "instance_network_interfaces_delete_interface",
         "parameters": [
           {
@@ -6266,7 +6267,7 @@
         "description": "Describes an attachment of a `NetworkInterface` to an `Instance`, at the time the instance is created.",
         "oneOf": [
           {
-            "description": "Create one or more `NetworkInterface`s for the `Instance`",
+            "description": "Create one or more `NetworkInterface`s for the `Instance`.\n\nIf more than one interface is provided, then the first will be designated the primary interface for the instance.",
             "type": "object",
             "properties": {
               "params": {
@@ -6288,7 +6289,7 @@
             ]
           },
           {
-            "description": "Default networking setup, which creates a single interface with an auto-assigned IP address from project's \"default\" VPC and \"default\" VPC Subnet.",
+            "description": "The default networking configuration for an instance is to create a single primary interface with an automatically-assigned IP address. The IP will be pulled from the Project's default VPC / VPC Subnet.",
             "type": "object",
             "properties": {
               "type": {
@@ -6467,6 +6468,10 @@
               }
             ]
           },
+          "primary": {
+            "description": "True if this interface is the primary for the instance to which it's attached.",
+            "type": "boolean"
+          },
           "subnet_id": {
             "description": "The subnet to which the interface belongs.",
             "type": "string",
@@ -6495,6 +6500,7 @@
           "ip",
           "mac",
           "name",
+          "primary",
           "subnet_id",
           "time_created",
           "time_modified",


### PR DESCRIPTION
- Adds the `is_primary` column to the `network_interface` table, and a
  corresponding field `primary` in the database model and external
  `NetworkInterface` objects. Primary interfaces are used for NAT and
  appear in DNS records.
- Updates the `InsertNetworkInterfaceQuery` to automatically decide if
  this interface should be considered the primary. It considers the new
  NIC primary iff there are zero existing NICs for the instance it's to
  be attached to. That means that the first NIC added to an instance,
  either during a provision or later, is the primary. Future work could
  allow changing which NIC is the primary.
- Adds a new query for deleting a network interface from an instance,
  with improved validation. This now checks that the instance is stopped
  inside the query, fixing a TOCTOU bug. It also verifies that the
  instance either has exactly 1 interface (which must be the primary) or
  that the instance has 2 or more (we're deleting a secondary). This
  means that the primary interface cannot be deleted until all secondary
  interfaces are deleted. The reason for this restriction is that
  instances _must_ have a primary interface, and it's not clear how to
  pick a new primary from the remaining secondaries if we allow deletion
  of the primary. We force the client to make the choice.
- Adds a special error type for handling the above validation failures.
- Adds tests for this deletion behavior to the instance integration
  tests