### PR TITLE
[sled agent] Add default routes, using GZ addresses as gateways

### DIFF
--- a/sled-agent/src/illumos/running_zone.rs
+++ b/sled-agent/src/illumos/running_zone.rs
@@ -11,6 +11,7 @@ use crate::illumos::zone::{AddressRequest, ZONE_PREFIX};
 use crate::opte::OptePort;
 use ipnetwork::IpNetwork;
 use slog::Logger;
+use std::net::Ipv6Addr;
 use std::path::PathBuf;
 
 #[cfg(test)]
@@ -171,17 +172,17 @@ impl RunningZone {
         Ok(network)
     }
 
-    pub async fn add_route(
+    pub async fn add_default_route(
         &self,
-        destination: ipnetwork::Ipv6Network,
+        gateway: Ipv6Addr,
     ) -> Result<(), RunCommandError> {
         self.run_cmd(&[
             "/usr/sbin/route",
             "add",
             "-inet6",
-            &format!("{}/{}", destination.network(), destination.prefix()),
+            "default",
             "-inet6",
-            &destination.ip().to_string(),
+            &gateway.to_string(),
         ])?;
         Ok(())
     }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -248,6 +248,9 @@ impl ServiceManager {
                 Error::ZoneCommand { intent: "Adding Route".to_string(), err }
             })?;
 
+            // TODO: Related to
+            // https://github.com/oxidecomputer/omicron/pull/1124 , should we
+            // avoid importing this manifest?
             debug!(self.log, "importing manifest");
 
             running_zone
@@ -266,6 +269,18 @@ impl ServiceManager {
 
             let smf_name = format!("svc:/system/illumos/{}", service.name);
             let default_smf_name = format!("{}:default", smf_name);
+
+            running_zone
+                .run_cmd(&[
+                    "/usr/sbin/routeadm",
+                    "-e",
+                    "ipv6-routing",
+                    "-u",
+                ])
+                .map_err(|err| Error::ZoneCommand {
+                    intent: "enabling IPv6 routing".to_string(),
+                    err,
+                })?;
 
             match service.name.as_str() {
                 "internal-dns" => {

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -270,6 +270,10 @@ impl ServiceManager {
             let smf_name = format!("svc:/system/illumos/{}", service.name);
             let default_smf_name = format!("{}:default", smf_name);
 
+            // Ensure the IPv6 traffic can be routed to this non-global zone.
+            //
+            // This is particularly important for accessing Nexus' external
+            // interface from off-device.
             running_zone
                 .run_cmd(&[
                     "/usr/sbin/routeadm",

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -489,7 +489,7 @@ mod test {
         wait_ctx.expect().return_once(|_, _| Ok(()));
         // Import the manifest, enable the service
         let execute_ctx = crate::illumos::execute_context();
-        execute_ctx.expect().times(3).returning(|_| {
+        execute_ctx.expect().times(5).returning(|_| {
             Ok(std::process::Output {
                 status: std::process::ExitStatus::from_raw(0),
                 stdout: vec![],

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -275,6 +275,12 @@ impl ServiceManager {
             // This is particularly important for accessing Nexus' external
             // interface from off-device.
             running_zone
+                .run_cmd(&["/usr/sbin/routeadm", "-e", "ipv6-forwarding"])
+                .map_err(|err| Error::ZoneCommand {
+                    intent: "enabling IPv6 forwarding".to_string(),
+                    err,
+                })?;
+            running_zone
                 .run_cmd(&["/usr/sbin/routeadm", "-e", "ipv6-routing", "-u"])
                 .map_err(|err| Error::ZoneCommand {
                     intent: "enabling IPv6 routing".to_string(),

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -275,12 +275,7 @@ impl ServiceManager {
             // This is particularly important for accessing Nexus' external
             // interface from off-device.
             running_zone
-                .run_cmd(&[
-                    "/usr/sbin/routeadm",
-                    "-e",
-                    "ipv6-routing",
-                    "-u",
-                ])
+                .run_cmd(&["/usr/sbin/routeadm", "-e", "ipv6-routing", "-u"])
                 .map_err(|err| Error::ZoneCommand {
                     intent: "enabling IPv6 routing".to_string(),
                     err,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -275,15 +275,16 @@ impl ServiceManager {
             // This is particularly important for accessing Nexus' external
             // interface from off-device.
             running_zone
-                .run_cmd(&["/usr/sbin/routeadm", "-e", "ipv6-forwarding"])
+                .run_cmd(&[
+                    "/usr/sbin/routeadm",
+                    "-e",
+                    "ipv6-forwarding",
+                    "-e",
+                    "ipv6-routing",
+                    "-u",
+                ])
                 .map_err(|err| Error::ZoneCommand {
-                    intent: "enabling IPv6 forwarding".to_string(),
-                    err,
-                })?;
-            running_zone
-                .run_cmd(&["/usr/sbin/routeadm", "-e", "ipv6-routing", "-u"])
-                .map_err(|err| Error::ZoneCommand {
-                    intent: "enabling IPv6 routing".to_string(),
+                    intent: "enabling IPv6 forwarding & routing".to_string(),
                     err,
                 })?;
 
@@ -489,7 +490,7 @@ mod test {
         wait_ctx.expect().return_once(|_, _| Ok(()));
         // Import the manifest, enable the service
         let execute_ctx = crate::illumos::execute_context();
-        execute_ctx.expect().times(5).returning(|_| {
+        execute_ctx.expect().times(4).returning(|_| {
             Ok(std::process::Output {
                 status: std::process::ExitStatus::from_raw(0),
                 stdout: vec![],

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -15,9 +15,7 @@ use crate::params::DatasetKind;
 use futures::stream::FuturesOrdered;
 use futures::FutureExt;
 use futures::StreamExt;
-use ipnetwork::Ipv6Network;
 use nexus_client::types::{DatasetPutRequest, ZpoolPutRequest};
-use omicron_common::address::AZ_PREFIX;
 use omicron_common::api::external::{ByteCount, ByteCountRangeError};
 use omicron_common::backoff;
 use schemars::JsonSchema;
@@ -497,9 +495,10 @@ async fn ensure_running_zone(
 
             zone.ensure_address(address_request).await?;
 
-            let gz_subnet =
-                Ipv6Network::new(underlay_address, AZ_PREFIX).unwrap();
-            zone.add_route(gz_subnet).await.map_err(Error::ZoneCommand)?;
+            let gateway = underlay_address;
+            zone.add_default_route(gateway)
+                .await
+                .map_err(Error::ZoneCommand)?;
 
             dataset_info
                 .start_zone(log, &zone, dataset_info.address, do_format)


### PR DESCRIPTION
Follow-up to https://github.com/oxidecomputer/omicron/pull/1066

This ensures that L3 routing from off-device can reach the external Nexus interface.