### PR TITLE
Remove Nexus dependency on Sled Agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,6 @@ dependencies = [
  "num-integer",
  "omicron-common",
  "omicron-rpaths",
- "omicron-sled-agent",
  "omicron-test-utils",
  "openapi-lint",
  "openapiv3",

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -31,6 +31,9 @@ pub const DNS_PORT: u16 = 53;
 pub const DNS_SERVER_PORT: u16 = 5353;
 pub const SLED_AGENT_PORT: u16 = 12345;
 
+/// The port propolis-server listens on inside the propolis zone.
+pub const PROPOLIS_PORT: u16 = 12400;
+
 // Anycast is a mechanism in which a single IP address is shared by multiple
 // devices, and the destination is located based on routing distance.
 //

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -69,9 +69,6 @@ features = [ "usdt-probes" ]
 [dependencies.omicron-common]
 path = "../common"
 
-[dependencies.omicron-sled-agent]
-path = "../sled-agent"
-
 [dependencies.oximeter]
 version = "0.1.0"
 path = "../oximeter/oximeter"

--- a/nexus/src/db/model/instance.rs
+++ b/nexus/src/db/model/instance.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use db_macros::Resource;
 use omicron_common::api::external;
 use omicron_common::api::internal;
-use omicron_sled_agent::common::instance::PROPOLIS_PORT;
+use omicron_common::address::PROPOLIS_PORT;
 use std::net::SocketAddr;
 use uuid::Uuid;
 

--- a/nexus/src/db/model/instance.rs
+++ b/nexus/src/db/model/instance.rs
@@ -9,9 +9,9 @@ use crate::db::schema::{disk, instance};
 use crate::external_api::params;
 use chrono::{DateTime, Utc};
 use db_macros::Resource;
+use omicron_common::address::PROPOLIS_PORT;
 use omicron_common::api::external;
 use omicron_common::api::internal;
-use omicron_common::address::PROPOLIS_PORT;
 use std::net::SocketAddr;
 use uuid::Uuid;
 

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -14,9 +14,6 @@ use omicron_common::api::external::InstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use propolis_client::api::InstanceState as PropolisInstanceState;
 
-/// The port propolis-server listens on inside the propolis zone.
-pub const PROPOLIS_PORT: u16 = 12400;
-
 /// Action to be taken on behalf of state transition.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Action {

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -5,7 +5,7 @@
 //! API for controlling a single instance.
 
 use crate::common::instance::{
-    Action as InstanceAction, InstanceStates, PROPOLIS_PORT,
+    Action as InstanceAction, InstanceStates,
 };
 use crate::illumos::running_zone::{
     InstalledZone, RunCommandError, RunningZone,
@@ -23,6 +23,7 @@ use crate::params::{
 };
 use anyhow::anyhow;
 use futures::lock::{Mutex, MutexGuard};
+use omicron_common::address::PROPOLIS_PORT;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use omicron_common::backoff;
 use propolis_client::api::DiskRequest;

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -4,9 +4,7 @@
 
 //! API for controlling a single instance.
 
-use crate::common::instance::{
-    Action as InstanceAction, InstanceStates,
-};
+use crate::common::instance::{Action as InstanceAction, InstanceStates};
 use crate::illumos::running_zone::{
     InstalledZone, RunCommandError, RunningZone,
 };


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/1156

Before, an incremental build of Sled Agent (touch `lib.rs`, then run `cargo build --timings`) looked like this:

![image](https://user-images.githubusercontent.com/3258857/171946864-8abd0724-f4b8-4f17-a058-4118c0023aaf.png)

After this PR, the rebuild looks like this:

![image](https://user-images.githubusercontent.com/3258857/171947046-69bdf78f-c7b5-43cd-9ad0-11de2e608b19.png)

(Note the scale!)

This significantly reduces incremental re-build times, by avoiding re-building Nexus when poking at the sled agent.