### PR TITLE
Require each NIC on an instance to be in a unique subnet

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -711,13 +711,14 @@ CREATE UNIQUE INDEX ON omicron.public.network_interface (
 
 /*
  * Index used to verify that an Instance's networking is contained
- * within a single VPC.
+ * within a single VPC, and that all interfaces are in unique VPC
+ * Subnets.
  */
 CREATE UNIQUE INDEX ON omicron.public.network_interface (
     instance_id,
     name
 )
-STORING (vpc_id)
+STORING (vpc_id, subnet_id)
 WHERE
     time_deleted IS NULL;
 

--- a/nexus/src/db/queries/network_interface.rs
+++ b/nexus/src/db/queries/network_interface.rs
@@ -47,6 +47,8 @@ pub enum InsertError {
     NoSlotsAvailable,
     /// There are no MAC addresses available
     NoMacAddrressesAvailable,
+    /// Multiple NICs must be in different VPC Subnets
+    NonUniqueVpcSubnets,
     /// Any other error
     External(external::Error),
 }
@@ -119,6 +121,11 @@ impl InsertError {
                     "No available MAC addresses for interface",
                 )
             }
+            InsertError::NonUniqueVpcSubnets => {
+                external::Error::invalid_request(
+                    "Each interface for an instance must be in a distinct VPC Subnet"
+                )
+            }
             InsertError::External(e) => e,
         }
     }
@@ -148,8 +155,7 @@ fn decode_database_error(
 
     // Error message generated when we attempt to insert an interface in a
     // different VPC from the interface(s) already associated with the instance
-    const MULTIPLE_VPC_ERROR_MESSAGE: &str =
-        r#"could not parse "" as type uuid: uuid: incorrect UUID length: "#;
+    const MULTIPLE_VPC_ERROR_MESSAGE: &str = r#"could not parse "vpc_id" as type uuid: uuid: incorrect UUID length: vpc_id"#;
 
     // Error message generated when we attempt to insert NULL in the `ip`
     // column, which only happens when we run out of IPs in the subnet.
@@ -192,6 +198,12 @@ fn decode_database_error(
     const MAC_EXHAUSTION_ERROR_MESSAGE: &str =
         r#"null value in column "mac" violates not-null constraint"#;
 
+    // Error message received when attempting to add an interface in a VPC
+    // Subnet, where that instance already has an interface in that VPC Subnet.
+    // This enforces the constraint that all interfaces are in distinct VPC
+    // Subnets.
+    const NON_UNIQUE_VPC_SUBNET_ERROR_MESSAGE: &str = r#"could not parse "subnet_id" as type uuid: uuid: incorrect UUID length: subnet_id"#;
+
     match err {
         // If the address allocation subquery fails, we'll attempt to insert
         // NULL for the `ip` column. This checks that the non-NULL constraint on
@@ -227,6 +239,16 @@ fn decode_database_error(
             Error::DatabaseError(DatabaseErrorKind::NotNullViolation, ref info),
         )) if info.message() == MAC_EXHAUSTION_ERROR_MESSAGE => {
             InsertError::NoMacAddrressesAvailable
+        }
+
+        // This catches the error intentionally introduced by the
+        // `push_ensure_unique_vpc_subnet_expression` subquery, which generates
+        // a UUID parsing error if an instance has another interface in the VPC
+        // Subnet of the one we're trying to insert.
+        PoolError::Connection(ConnectionError::Query(
+            Error::DatabaseError(DatabaseErrorKind::Unknown, ref info),
+        )) if info.message() == NON_UNIQUE_VPC_SUBNET_ERROR_MESSAGE => {
+            InsertError::NonUniqueVpcSubnets
         }
 
         // This path looks specifically at constraint names.
@@ -461,13 +483,13 @@ delegate_query_fragment_impl!(NextGuestMacAddress);
 /// structure of the query is:
 ///
 /// ```text
-/// CAST(IF(<instance is in one VPC>, '<vpc_id>', '') AS UUID)
+/// CAST(IF(<instance is in one VPC>, '<vpc_id>', 'vpc_id') AS UUID)
 /// ```
 ///
-/// This selects either the actual VPC UUID (as a string) or the empty string,
-/// if any existing VPC IDs for this instance are the same. If true, we cast the
-/// VPC ID string back to a UUID. If false, we try to cast the empty string,
-/// which fails in a detectable way.
+/// This selects either the actual VPC UUID (as a string) or the literal string
+/// "vpc_id" if any existing VPC IDs for this instance are the same. If true, we
+/// cast the VPC ID string back to a UUID. If false, we try to cast the string
+/// `"vpc_id"` which fails in a detectable way.
 ///
 /// Details
 /// -------
@@ -488,16 +510,17 @@ delegate_query_fragment_impl!(NextGuestMacAddress);
 ///          <vpc_id>
 ///      ) = <vpc_id>,
 ///      '<vpc_id>', -- UUID as a string
-///      ''
+///      'vpc_id' -- The literal string "vpc_id"
 /// ) AS UUID)
 /// ```
 ///
 /// This uses a partial index on the `network_interface` table to look up the
 /// first record with the provided `instance_id`, if any. It then compares that
 /// stored `vpc_id` to the one provided to this query. If those IDs match, then
-/// the ID is returned. If they do _not_ match, the `IF` statement returns an
-/// empty string, which it tries to cast as a UUID. That fails, in a detectable
-/// way, so that we can check this case as distinct from other errors.
+/// the ID is returned. If they do _not_ match, the `IF` statement returns the
+/// string "vpc_id", which it tries to cast as a UUID. That fails, in a
+/// detectable way, so that we can check this case as distinct from other
+/// errors.
 ///
 /// Note that the `COALESCE` expression is there to handle the case where there
 /// _is_ no record with the given `instance_id`. In that case, the `vpc_id`
@@ -529,16 +552,15 @@ fn push_ensure_unique_vpc_expression<'a>(
     // This query relies on the fact that it generates a parsing error in the
     // case where there is an interface attached to a VPC that's _different_
     // from the VPC of the candidate interface. This is so that we can
-    // distinguish this error case from the one where there is no IP address
-    // available.
+    // distinguish this error case from all the others.
     //
     // To do that, we generate a query like:
     //
     // ```
-    // CAST(IF(<instance VPC is the same>, '<vpc_id>', '') AS UUID)
+    // CAST(IF(<instance VPC is the same>, '<vpc_id>', 'vpc_id') AS UUID)
     // ```
     //
-    // That empty-string cannot be cast to a UUID, so we get a parsing error,
+    // The string "vpc_id" cannot be cast to a UUID, so we get a parsing error,
     // but only if the condition _succeeds_. It's not evaluated otherwise.
     //
     // However, if we push this parameter as a UUID explicitly, the database
@@ -547,7 +569,172 @@ fn push_ensure_unique_vpc_expression<'a>(
     // evaluated too early. So we ensure both are strings here, and then ask the
     // DB to cast them after that condition is evaluated.
     out.push_bind_param::<sql_types::Text, String>(vpc_id_str)?;
-    out.push_sql(", '') AS UUID)");
+    out.push_sql(", 'vpc_id') AS UUID)");
+    Ok(())
+}
+
+/// Push a subquery that checks that all NICs for an instance are in distinct
+/// VPC Subnets.
+///
+/// This generates a subquery like:
+///
+/// ```sql
+/// CAST(IF(
+///     EXISTS(
+///        SELECT subnet_id
+///        FROM network_interface
+///        WHERE
+///            instance_id = <instance_id> AND
+///            time_deleted IS NULL AND
+///            subnet_id = <subnet_id> AND
+///            id != <interface_id>
+///     ),
+///     'subnet_id', -- the literal string "subnet_id",
+///     '<subnet_id>', -- <subnet_id> as a string,
+///     ) AS UUID
+/// )
+/// ```
+///
+/// That is, if the subnet ID provided in the query already exists for an
+/// interface on the target instance, we return the literal string
+/// `'subnet_id'`, which will fail casting to a UUID.
+///
+/// The interface ID check
+/// ----------------------
+///
+/// You'll notice what appears to be an unecessary check on the actual `id`
+/// column, `id != <interface_id>`, in the where clause of the above. This is
+/// unfortunately part of a tradeoff for two situations:
+///
+/// - Re-inserting a network interface as part of retrying a saga action
+/// - The instance's VPC Subnet validation
+///
+/// During a saga replay, we try to insert a NIC with the _exact_ same data,
+/// including the same primary key, as an existing record. This fails,
+/// obviously, but we detect and handle that case specially, since it's only
+/// possible in that one situation.
+///
+/// However, when we do that, we still run the select statement here, even
+/// though this ultimately appears on the "unevaluated" side of a `COALESCE`
+/// statement. I.e.,:
+///
+/// ```sql
+/// SELECT COALESCE(
+///     (subquery run to detect the saga replay),
+///     (subquery run to insert a new NIC)
+/// )
+/// ```
+///
+/// The documentation of the `COALESCE` function clearly indicates that the
+/// second expression will not run if the first evaluates to non-NULL.
+/// Empirically, that's not true. This doesn't appear to be due to `CAST`, since
+/// other queries without that show the same behavior.
+///
+/// This additional, redundant check is to handle the first case, saga replay.
+/// We check that the VPC Subnet for any interfaces _not equal to this one_ are
+/// different. This allows us to do the check on new interfaces, but not fail in
+/// the saga-replay case.
+fn push_ensure_unique_vpc_subnet_expression<'a>(
+    mut out: AstPass<'_, 'a, Pg>,
+    interface_id: &'a Uuid,
+    subnet_id: &'a Uuid,
+    subnet_id_str: &'a String,
+    instance_id: &'a Uuid,
+) -> diesel::QueryResult<()> {
+    out.push_sql("CAST(IF(EXISTS(SELECT ");
+    out.push_identifier(dsl::subnet_id::NAME)?;
+    out.push_sql(" FROM ");
+    NETWORK_INTERFACE_FROM_CLAUSE.walk_ast(out.reborrow())?;
+    out.push_sql(" WHERE ");
+    out.push_identifier(dsl::instance_id::NAME)?;
+    out.push_sql(" = ");
+    out.push_bind_param::<sql_types::Uuid, Uuid>(instance_id)?;
+    out.push_sql(" AND ");
+    out.push_identifier(dsl::time_deleted::NAME)?;
+    out.push_sql(" IS NULL AND ");
+    out.push_identifier(dsl::subnet_id::NAME)?;
+    out.push_sql(" = ");
+    out.push_bind_param::<sql_types::Uuid, Uuid>(subnet_id)?;
+    out.push_sql(" AND ");
+    out.push_identifier(dsl::id::NAME)?;
+    out.push_sql(" != ");
+    out.push_bind_param::<sql_types::Uuid, Uuid>(interface_id)?;
+    out.push_sql("), 'subnet_id', ");
+    out.push_bind_param::<sql_types::Text, String>(subnet_id_str)?;
+    out.push_sql(") AS UUID)");
+    Ok(())
+}
+
+/// Push the main instance-validate common-table expression.
+///
+/// This generates a CTE that looks like:
+///
+/// ```sql
+/// WITH validated_instance(vpc_id, subnet_id, slot, is_primary) AS
+///     (
+///         <ensure valid VPC>,
+///         <ensure valid VPC Subnet>,
+///         <compute next slot>,
+///         <compute is_primary>
+///     )
+/// ```
+#[allow(clippy::too_many_arguments)]
+fn push_instance_validation_cte<'a>(
+    mut out: AstPass<'_, 'a, Pg>,
+    interface_id: &'a Uuid,
+    vpc_id: &'a Uuid,
+    vpc_id_str: &'a String,
+    subnet_id: &'a Uuid,
+    subnet_id_str: &'a String,
+    instance_id: &'a Uuid,
+    next_slot_subquery: &'a NextNicSlot,
+    is_primary_subquery: &'a IsPrimaryNic,
+) -> diesel::QueryResult<()> {
+    out.push_sql("WITH validated_instance(");
+    out.push_identifier(dsl::vpc_id::NAME)?;
+    out.push_sql(", ");
+    out.push_identifier(dsl::subnet_id::NAME)?;
+    out.push_sql(", ");
+    out.push_identifier(dsl::slot::NAME)?;
+    out.push_sql(", ");
+    out.push_identifier(dsl::is_primary::NAME)?;
+    out.push_sql(") AS (SELECT ");
+    push_ensure_unique_vpc_expression(
+        out.reborrow(),
+        vpc_id,
+        vpc_id_str,
+        instance_id,
+    )?;
+    out.push_sql(" AS ");
+    out.push_identifier(dsl::vpc_id::NAME)?;
+    out.push_sql(", ");
+    push_ensure_unique_vpc_subnet_expression(
+        out.reborrow(),
+        interface_id,
+        subnet_id,
+        subnet_id_str,
+        instance_id,
+    )?;
+    out.push_sql(" AS ");
+    out.push_identifier(dsl::subnet_id::NAME)?;
+
+    // Push the suqbuery used to select and validate the slot number for the
+    // interface, including validating that there are available slots on the
+    // instance.
+    out.push_sql(", (");
+    next_slot_subquery.walk_ast(out.reborrow())?;
+    out.push_sql(") AS ");
+    out.push_identifier(dsl::slot::NAME)?;
+
+    // Push the subquery used to detect whether this interface is the primary.
+    // That's true iff there are zero interfaces for this instance at the time
+    // this interface is inserted.
+    out.push_sql(", (");
+    is_primary_subquery.walk_ast(out.reborrow())?;
+    out.push_sql(") AS ");
+    out.push_identifier(dsl::is_primary::NAME)?;
+
+    out.push_sql(") ");
     Ok(())
 }
 
@@ -563,19 +750,28 @@ fn push_ensure_unique_vpc_expression<'a>(
 /// SELECT <id> AS id, <name> AS name, <description> AS description,
 ///        <time_created> AS time_created, <time_modified> AS time_modified,
 ///        NULL AS time_deleted, <instance_id> AS instance_id, <vpc_id> AS vpc_id,
-///        <subnet_id> AS subnet_id, <mac> AS mac, <maybe IP allocation
-///        subquery>
+///        <subnet_id> AS subnet_id, <mac> AS mac, <maybe IP allocation subquery>,
+///        <slot> AS slot, <is_primary> AS is_primary
 /// ```
 ///
 /// Instance validation
 /// -------------------
 ///
-/// This query generates a CTE that checks that the requested instance is not
-/// already associated with another VPC (since an instance's networking cannot
-/// span multiple VPCs). This query is designed to fail in a particular way if
-/// that invariant is violated, so that we can detect and report that case to
-/// the user. See [`push_ensure_unique_vpc_expression`] for details of that
-/// subquery, including how it fails.
+/// This common-table expression checks that the provided instance meets a few
+/// basic criteria, and computes some values for inserting in the new record if
+/// those checks pass. In particular this checks that:
+///
+/// 1. The instance is not already associated with another VPC, since an
+///    instance's network cannot span multiple VPCs.
+/// 2. This interface is in a distinct subnet from any other interfaces already
+///    attached to the instance.
+///
+/// It also computes:
+///
+/// 1. The slot index for this instance, verifying that the slot number is
+///    valid.
+/// 2. Whether this is the primary index for the instance. That's true iff this
+///    is the first interface inserted for the instance.
 ///
 /// IP allocation subquery
 /// ----------------------
@@ -625,22 +821,23 @@ fn push_interface_allocation_subquery<'a>(
     mut out: AstPass<'_, 'a, Pg>,
     query: &'a InsertQuery,
 ) -> diesel::QueryResult<()> {
-    // Push the CTE that ensures that any other interface with the same
-    // instance_id also has the same vpc_id. See
-    // `push_ensure_unique_vpc_expression` for more details. This ultimately
-    // fails the query if the requested instance is already associated with
-    // a different VPC.
-    out.push_sql("WITH vpc(");
-    out.push_identifier(dsl::vpc_id::NAME)?;
-    out.push_sql(") AS ");
-    out.push_sql("(SELECT ");
-    push_ensure_unique_vpc_expression(
+    // Push subqueries that validate the provided instance. This generates a CTE
+    // with the name `validated_instance` and columns:
+    //  - `vpc_id`
+    //  - `subnet_id`
+    //  - `slot`
+    //  - `is_primary`
+    push_instance_validation_cte(
         out.reborrow(),
+        &query.interface.identity.id,
         &query.interface.vpc_id,
         &query.vpc_id_str,
+        &query.interface.subnet.identity.id,
+        &query.subnet_id_str,
         &query.interface.instance_id,
+        &query.next_slot_subquery,
+        &query.is_primary_subquery,
     )?;
-    out.push_sql(") ");
 
     // Push the columns, values and names, that are named directly. These
     // are known regardless of whether we're allocating an IP address. These
@@ -685,16 +882,20 @@ fn push_interface_allocation_subquery<'a>(
     out.push_identifier(dsl::instance_id::NAME)?;
     out.push_sql(", ");
 
-    // Tiny subquery to select the `vpc_id` from the preceding CTE.
-    out.push_sql("(SELECT vpc_id FROM vpc) AS ");
-    out.push_identifier(dsl::vpc_id::NAME)?;
-    out.push_sql(", ");
+    // Helper function to push a suqbuery selecting something from the CTE.
+    fn select_from_cte(
+        mut out: AstPass<Pg>,
+        column: &'static str,
+    ) -> diesel::QueryResult<()> {
+        out.push_sql("(SELECT ");
+        out.push_identifier(column)?;
+        out.push_sql(" FROM validated_instance) AS ");
+        out.push_identifier(column)
+    }
 
-    out.push_bind_param::<sql_types::Uuid, Uuid>(
-        &query.interface.subnet.identity.id,
-    )?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::subnet_id::NAME)?;
+    select_from_cte(out.reborrow(), dsl::vpc_id::NAME)?;
+    out.push_sql(", ");
+    select_from_cte(out.reborrow(), dsl::subnet_id::NAME)?;
     out.push_sql(", ");
 
     // Push the subquery for selecting the a MAC address.
@@ -716,22 +917,13 @@ fn push_interface_allocation_subquery<'a>(
     }
     out.push_sql(" AS ");
     out.push_identifier(dsl::ip::NAME)?;
+    out.push_sql(", ");
 
-    // Push the suqbuery used to select and validate the slot number for the
-    // interface, including validating that there are available slots on the
-    // instance.
-    out.push_sql(", (");
-    query.next_slot_subquery.walk_ast(out.reborrow())?;
-    out.push_sql(") AS ");
-    out.push_identifier(dsl::slot::NAME)?;
+    select_from_cte(out.reborrow(), dsl::slot::NAME)?;
+    out.push_sql(", ");
+    select_from_cte(out.reborrow(), dsl::is_primary::NAME)?;
 
-    // Push the subquery used to detect whether this interface is the primary.
-    // That's true iff there are zero interfaces for this instance at the time
-    // this interface is inserted.
-    out.push_sql(", (");
-    query.is_primary_subquery.walk_ast(out.reborrow())?;
-    out.push_sql(") AS ");
-    out.push_identifier(dsl::is_primary::NAME)
+    Ok(())
 }
 
 /// Type used to insert conditionally insert a network interface.
@@ -814,6 +1006,7 @@ pub struct InsertQuery {
     // type. By storing these values in the struct, they'll live at least as
     // long as the entire call to [`QueryFragment<Pg>::walk_ast`].
     vpc_id_str: String,
+    subnet_id_str: String,
     ip_sql: Option<IpNetwork>,
     next_mac_subquery: NextGuestMacAddress,
     next_ipv4_address_subquery: NextGuestIpv4Address,
@@ -824,6 +1017,7 @@ pub struct InsertQuery {
 impl InsertQuery {
     pub fn new(interface: IncompleteNetworkInterface) -> Self {
         let vpc_id_str = interface.vpc_id.to_string();
+        let subnet_id_str = interface.subnet.identity.id.to_string();
         let ip_sql = interface.ip.map(|ip| ip.into());
         let next_mac_subquery = NextGuestMacAddress::new(interface.vpc_id);
         let next_ipv4_address_subquery = NextGuestIpv4Address::new(
@@ -837,6 +1031,7 @@ impl InsertQuery {
             interface,
             now: Utc::now(),
             vpc_id_str,
+            subnet_id_str,
             ip_sql,
             next_mac_subquery,
             next_ipv4_address_subquery,
@@ -1330,6 +1525,7 @@ mod tests {
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_common::api::external::Ipv4Net;
     use omicron_common::api::external::Ipv6Net;
+    use omicron_common::api::external::Name;
     use omicron_test_utils::dev;
     use std::convert::TryInto;
     use std::net::IpAddr;
@@ -1352,8 +1548,12 @@ mod tests {
         // 16 addresses, less the 6 that are reserved.
         let ipv4_block = Ipv4Net("172.30.0.0/28".parse().unwrap());
         let ipv6_block = Ipv6Net("fd12:3456:7890::/64".parse().unwrap());
+        let other_ipv4_block = Ipv4Net("172.31.0.0/28".parse().unwrap());
+        let other_ipv6_block = Ipv6Net("fd12:3456:7891::/64".parse().unwrap());
         let subnet_name = "subnet-a".to_string().try_into().unwrap();
         let other_subnet_name = "subnet-b".to_string().try_into().unwrap();
+        let other_valid_subnet_name =
+            "subnet-c".to_string().try_into().unwrap();
         let description = "some description".to_string();
         let vpc_id = "d402369d-c9ec-c5ad-9138-9fbee732d53e".parse().unwrap();
         let other_vpc_id =
@@ -1361,6 +1561,8 @@ mod tests {
         let subnet_id = "093ad2db-769b-e3c2-bc1c-b46e84ce5532".parse().unwrap();
         let other_subnet_id =
             "695debcc-e197-447d-ffb2-976150a7b7cf".parse().unwrap();
+        let other_valid_subnet_id =
+            "e9274bde-1ef6-40b8-8e9d-ca67942a1d3a".parse().unwrap();
         let subnet = VpcSubnet::new(
             subnet_id,
             vpc_id,
@@ -1380,6 +1582,16 @@ mod tests {
             },
             ipv4_block,
             ipv6_block,
+        );
+        let other_valid_subnet = VpcSubnet::new(
+            other_valid_subnet_id,
+            vpc_id,
+            IdentityMetadataCreateParams {
+                name: other_valid_subnet_name,
+                description: description.to_string(),
+            },
+            other_ipv4_block,
+            other_ipv6_block,
         );
 
         // Insert a network interface with a known valid IP address, attached to
@@ -1410,13 +1622,14 @@ mod tests {
             "The requested IP address should be available when no interfaces exist in the table"
         );
 
-        // Insert an interface on the same instance, but with an
-        // automatically-assigned IP address. It should have the next address.
+        // Insert an interface on a new instance, but with an
+        // automatically-assigned IP address. This specifically tests that we
+        // sequentially allocate IP addresses within a single VPC Subnet.
         let expected_address =
             "172.30.0.6".parse::<std::net::IpAddr>().unwrap();
         let interface = IncompleteNetworkInterface::new(
             Uuid::new_v4(),
-            instance_id,
+            Uuid::new_v4(),
             vpc_id,
             subnet.clone(),
             IdentityMetadataCreateParams {
@@ -1437,10 +1650,11 @@ mod tests {
             "Failed to automatically assign the next available IP address"
         );
 
-        // Inserting an interface with the same IP should fail.
+        // Inserting an interface with the same IP should fail, even if all
+        // other parameters are valid.
         let interface = IncompleteNetworkInterface::new(
             Uuid::new_v4(),
-            instance_id,
+            Uuid::new_v4(),
             vpc_id,
             subnet.clone(),
             IdentityMetadataCreateParams {
@@ -1464,9 +1678,9 @@ mod tests {
             Uuid::new_v4(),
             instance_id,
             vpc_id,
-            subnet.clone(),
+            other_valid_subnet.clone(),
             IdentityMetadataCreateParams {
-                name: "interface-b".parse().unwrap(),
+                name: "interface-a".parse().unwrap(),
                 description: String::from("description"),
             },
             None,
@@ -1481,6 +1695,27 @@ mod tests {
                 Err(InsertError::External(Error::ObjectAlreadyExists { .. })),
             ),
             "Requesting an interface with the same name on the same instance should fail"
+        );
+
+        // Inserting an interface in the same VPC Subnet should fail.
+        let interface = IncompleteNetworkInterface::new(
+            Uuid::new_v4(),
+            instance_id,
+            vpc_id,
+            subnet.clone(),
+            IdentityMetadataCreateParams {
+                name: "interface-b".parse().unwrap(),
+                description: String::from("description"),
+            },
+            None,
+        )
+        .unwrap();
+        let result = db_datastore
+            .instance_create_network_interface_raw(&opctx, interface)
+            .await;
+        assert!(
+            matches!(result, Err(InsertError::NonUniqueVpcSubnets)),
+            "Each interface for an instance must be in distinct VPC Subnets"
         );
 
         // Inserting an interface that is attached to the same instance, but in a different VPC,
@@ -1537,7 +1772,7 @@ mod tests {
         }
         let interface = IncompleteNetworkInterface::new(
             Uuid::new_v4(),
-            instance_id,
+            Uuid::new_v4(),
             vpc_id,
             subnet.clone(),
             IdentityMetadataCreateParams {
@@ -1582,6 +1817,30 @@ mod tests {
                 ),
             );
         }
+
+        // We also should be able to insert multiple interfaces on the same
+        // instance, as long as the VPC is the same and the VPC Subnets are
+        // _different_.
+        let interface = IncompleteNetworkInterface::new(
+            Uuid::new_v4(),
+            instance_id,
+            vpc_id,
+            other_subnet.clone(),
+            IdentityMetadataCreateParams {
+                name: "interface-f".parse().unwrap(), // Same name
+                description: String::from("description"),
+            },
+            None,
+        )
+        .unwrap();
+        let result = db_datastore
+            .instance_create_network_interface_raw(&opctx, interface)
+            .await;
+        assert!(
+            result.is_ok(),
+            "Should be able to allocate multiple interfaces on the same \
+            instance, as long as they're in different VPC Subnets",
+        );
 
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
@@ -1672,7 +1931,8 @@ mod tests {
         } else {
             panic!(
                 "Expected a InsertError::DuplicatePrimaryKey \
-                error when inserting the exact same interface"
+                error when inserting the exact same interface, found: {:?}",
+                result,
             );
         }
 
@@ -1697,23 +1957,27 @@ mod tests {
         let opctx = OpContext::for_tests(log.new(o!()), db_datastore.clone());
         let ipv4_block = Ipv4Net("172.30.0.0/26".parse().unwrap());
         let ipv6_block = Ipv6Net("fd12:3456:7890::/64".parse().unwrap());
-        let subnet_name = "subnet-a".to_string().try_into().unwrap();
+        let subnet_name = Name::try_from("subnet-a".to_string()).unwrap();
         let description = "some description".to_string();
         let vpc_id = "d402369d-c9ec-c5ad-9138-9fbee732d53e".parse().unwrap();
-        let subnet_id = "093ad2db-769b-e3c2-bc1c-b46e84ce5532".parse().unwrap();
-        let subnet = VpcSubnet::new(
-            subnet_id,
-            vpc_id,
-            IdentityMetadataCreateParams {
-                name: subnet_name,
-                description: description.to_string(),
-            },
-            ipv4_block,
-            ipv6_block,
-        );
         let instance_id =
             "90d8542f-52dc-cacb-fa2b-ea0940d6bcb7".parse().unwrap();
         for slot in 0..MAX_NICS_PER_INSTANCE {
+            // Each NIC must be in a different VPC Subnet.
+            //
+            // Note that this subnet is completely fictitious and nonsensical.
+            // It doesn't actually exist in the database, since that would
+            // violate the name-uniqueness and IP subnet-overlap checks.
+            let subnet = VpcSubnet::new(
+                Uuid::new_v4(),
+                vpc_id,
+                IdentityMetadataCreateParams {
+                    name: subnet_name.clone(),
+                    description: description.to_string(),
+                },
+                ipv4_block,
+                ipv6_block,
+            );
             let interface = IncompleteNetworkInterface::new(
                 Uuid::new_v4(),
                 instance_id,
@@ -1750,6 +2014,16 @@ mod tests {
         }
 
         // The next one should fail
+        let subnet = VpcSubnet::new(
+            Uuid::new_v4(),
+            vpc_id,
+            IdentityMetadataCreateParams {
+                name: subnet_name,
+                description: description.to_string(),
+            },
+            ipv4_block,
+            ipv6_block,
+        );
         let interface = IncompleteNetworkInterface::new(
             Uuid::new_v4(),
             instance_id,


### PR DESCRIPTION
- Adds additional query logic the `network_interface::InsertQuery` that
  fails the query if the VPC Subnet for a new interface is the same as
  that for an existing interface on the instance.
- Updates tests to conform to and verify new unique VPC Subnet behavior