### PR TITLE
Group name/version into a single distribution struct

### DIFF
--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -201,8 +201,8 @@ impl super::Nexus {
                     ),
                     volume_id: volume.id(),
                     url: Some(url.clone()),
-                    distribution: params.distribution.into(),
-                    version: params.version,
+                    distribution: params.distribution.name,
+                    version: params.distribution.version,
                     digest: None, // not computed for URL type
                     block_size: db_block_size,
                     size: size.into(),

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -618,92 +618,11 @@ pub enum ImageSource {
 
 /// OS image distribution
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Distribution(String);
-
-impl From<Distribution> for String {
-    fn from(distribution: Distribution) -> String {
-        distribution.0
-    }
-}
-
-impl TryFrom<String> for Distribution {
-    type Error = String;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.len() > 63 {
-            return Err(String::from(
-                "distribution may contain at most 63 characters",
-            ));
-        }
-
-        let mut iter = value.chars();
-
-        let first = iter.next().ok_or_else(|| {
-            String::from("distribution requires at least one character")
-        })?;
-        if !first.is_ascii_lowercase() {
-            return Err(String::from(
-                "distribution must begin with an ASCII lowercase character",
-            ));
-        }
-
-        let mut last = first;
-        for c in iter {
-            last = c;
-
-            if !c.is_ascii_lowercase() && !c.is_digit(10) && c != '-' {
-                return Err(format!(
-                    "distribution contains invalid character: \"{}\" (allowed \
-                     characters are lowercase ASCII, digits, and \"-\")",
-                    c
-                ));
-            }
-        }
-
-        if last == '-' {
-            return Err(String::from("distribution cannot end with \"-\""));
-        }
-
-        Ok(Distribution(value))
-    }
-}
-
-impl FromStr for Distribution {
-    type Err = String;
-    fn from_str(value: &str) -> Result<Self, String> {
-        Distribution::try_from(String::from(value))
-    }
-}
-
-impl JsonSchema for Distribution {
-    fn schema_name() -> String {
-        "Distribution".to_string()
-    }
-
-    fn json_schema(
-        _gen: &mut schemars::gen::SchemaGenerator,
-    ) -> schemars::schema::Schema {
-        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
-            metadata: Some(Box::new(schemars::schema::Metadata {
-                title: Some("OS image distribution".to_string()),
-                description: Some(
-                    "Distribution must begin with a lower case ASCII letter, be \
-                     composed exclusively of lowercase ASCII, uppercase \
-                     ASCII, numbers, and '-', and may not end with a '-'."
-                        .to_string(),
-                ),
-                ..Default::default()
-            })),
-            instance_type: Some(schemars::schema::SingleOrVec::Single(
-                Box::new(schemars::schema::InstanceType::String),
-            )),
-            string: Some(Box::new(schemars::schema::StringValidation {
-                max_length: Some(63),
-                min_length: None,
-                pattern: Some("[a-z](|[a-zA-Z0-9-]*[a-zA-Z0-9])".to_string()),
-            })),
-            ..Default::default()
-        })
-    }
+pub struct Distribution {
+    /// The name of the distribution (e.g. "alpine" or "ubuntu")
+    pub name: Name,
+    /// The version of the distribution (e.g. "3.10" or "18.04")
+    pub version: String,
 }
 
 /// Create-time parameters for an
@@ -716,9 +635,6 @@ pub struct GlobalImageCreate {
 
     /// OS image distribution
     pub distribution: Distribution,
-
-    /// image version
-    pub version: String,
 
     /// block size in bytes
     pub block_size: BlockSize,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -254,8 +254,10 @@ lazy_static! {
                 description: String::from(""),
             },
             source: params::ImageSource::Url { url: HTTP_SERVER.url("/image.raw").to_string() },
-            distribution: params::Distribution::try_from(String::from("alpine")).unwrap(),
-            version: String::from("edge"),
+            distribution: params::Distribution {
+                name: "alpine".parse().unwrap(),
+                version: String::from("edge"),
+            }
             block_size: params::BlockSize::try_from(4096).unwrap(),
         };
 

--- a/nexus/tests/integration_tests/images.rs
+++ b/nexus/tests/integration_tests/images.rs
@@ -58,8 +58,10 @@ async fn test_global_image_create(cptestctx: &ControlPlaneTestContext) {
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -102,8 +104,10 @@ async fn test_global_image_create_url_404(cptestctx: &ControlPlaneTestContext) {
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -137,8 +141,10 @@ async fn test_global_image_create_bad_url(cptestctx: &ControlPlaneTestContext) {
             ),
         },
         source: params::ImageSource::Url { url: "not_a_url".to_string() },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -185,8 +191,10 @@ async fn test_global_image_create_bad_content_length(
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -234,8 +242,10 @@ async fn test_global_image_create_bad_image_size(
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -283,8 +293,10 @@ async fn test_make_disk_from_global_image(cptestctx: &ControlPlaneTestContext) {
         source: params::ImageSource::Url {
             url: server.url("/alpine/edge.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
@@ -351,8 +363,10 @@ async fn test_make_disk_from_global_image_too_small(
         source: params::ImageSource::Url {
             url: server.url("/alpine/edge.raw").to_string(),
         },
-        distribution: "alpine".parse().unwrap(),
-        version: "edge".into(),
+        distribution: params::Distribution {
+            name: "alpine".parse().unwrap(),
+            version: "edge".into(),
+        },
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 


### PR DESCRIPTION
From a conversation in console chat today I realized there's some ambiguity in the global image api around `distribution` and `version`. Right now those are both top level fields, but the `version` actually applies to the `distribution` (e.g. `20.04` may be the version and `ubuntu` the distribution). To make that relationship explicit I've grouped the into a single struct. 

<details>
<summary>Chat</summary>

<p align="center">
  <img src="https://user-images.githubusercontent.com/3087225/172739304-5593ae06-d6ba-43c9-8b0f-e35a158f790a.png"/>
</p>
</details>

---

I removed the mechanisms around `Distribution` mirroring the implementation of `Name`, but that's just for brevity. It can be added back as `DistributionName` or something. The other big thing to note is that I really only changed the shape of the API. The actual model still has `distribution` and `version` as top level fields given that that's closer to how they're actually stored. This can be updated too though if needed. 



