### PR TITLE
Update thing-flinger for modern Omicron

### DIFF
--- a/deploy/src/bin/deployment-example.toml
+++ b/deploy/src/bin/deployment-example.toml
@@ -24,6 +24,8 @@ rss_server = "foo"
 # This must be an absolute path
 # We specifically allow for $HOME in validating the absolute path
 staging_dir = "$HOME/omicron_staging"
+# which servers to deploy to deploy
+servers = ["foo", "bar"]
 
 [servers.foo]
 username = "me"

--- a/deploy/src/bin/deployment-example.toml
+++ b/deploy/src/bin/deployment-example.toml
@@ -24,7 +24,7 @@ rss_server = "foo"
 # This must be an absolute path
 # We specifically allow for $HOME in validating the absolute path
 staging_dir = "$HOME/omicron_staging"
-# which servers to deploy to deploy
+# which servers to deploy
 servers = ["foo", "bar"]
 
 [servers.foo]

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -382,13 +382,11 @@ fn do_install_prereqs(config: &Config) -> Result<()> {
     );
 
     let server_names = std::iter::once(&config.builder.server).chain(
-        config.deployment.servers.iter().filter_map(|s| {
-            if *s != config.builder.server {
-                Some(s)
-            } else {
-                None
-            }
-        }),
+        config
+            .deployment
+            .servers
+            .iter()
+            .filter(|s| **s != config.builder.server),
     );
 
     // Install functions to run in parallel on each server

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -45,6 +45,9 @@ struct Config {
     deployment: Deployment,
 
     #[serde(default)]
+    rss_config_path: Option<PathBuf>,
+
+    #[serde(default)]
     debug: bool,
 }
 
@@ -672,7 +675,11 @@ fn overlay_rss_config(
 ) -> Result<()> {
     // Sync `config-rss.toml` to the directory for the RSS server on the
     // builder.
-    let src = config.omicron_path.join("smf/sled-agent/config-rss.toml");
+    let src = if let Some(src) = &config.rss_config_path {
+        src.clone()
+    } else {
+        config.omicron_path.join("smf/sled-agent/config-rss.toml")
+    };
     let dst = format!(
         "{}@{}:{}",
         builder.username,

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -989,7 +989,6 @@ fn main() -> Result<()> {
         SubCommand::Deploy(DeployCommand::Install {
             artifact_dir,
             install_dir,
-            ..
         }) => {
             do_build_minimal(&config)?;
             do_install(&config, &artifact_dir, &install_dir);

--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -919,7 +919,7 @@ fn ssh_exec(
         .arg(&remote_cmd);
 
     // If the builder is the same as the client, this will likely not be set,
-    // as the keys will reside on the builder. j
+    // as the keys will reside on the builder.
     if let Some(auth_sock) = std::env::var_os("SSH_AUTH_SOCK") {
         cmd.env("SSH_AUTH_SOCK", auth_sock);
     }

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -299,7 +299,7 @@ async fn do_package(config: &Config, output_directory: &Path) -> Result<()> {
     Ok(())
 }
 
-fn do_install(
+fn do_unpack(
     config: &Config,
     artifact_dir: &Path,
     install_dir: &Path,
@@ -369,6 +369,14 @@ fn do_install(
         archive.unpack(&service_path)?;
     }
 
+    Ok(())
+}
+
+fn do_activate(
+    config: &Config,
+    install_dir: &Path,
+    log: &Logger,
+) -> Result<()> {
     // Install the bootstrap service, which itself extracts and
     // installs other services.
     if let Some(package) = config.packages.get("omicron-sled-agent") {
@@ -381,10 +389,21 @@ fn do_install(
             "Installing boostrap service from {}",
             manifest_path.to_string_lossy()
         );
+
         smf::Config::import().run(&manifest_path)?;
     }
 
     Ok(())
+}
+
+fn do_install(
+    config: &Config,
+    artifact_dir: &Path,
+    install_dir: &Path,
+    log: &Logger,
+) -> Result<()> {
+    do_unpack(config, artifact_dir, install_dir, log)?;
+    do_activate(config, install_dir, log)
 }
 
 fn uninstall_all_omicron_zones() -> Result<()> {
@@ -593,6 +612,15 @@ async fn main() -> Result<()> {
             install_dir,
         }) => {
             do_uninstall(&config, &artifact_dir, &install_dir, &log).await?;
+        }
+        SubCommand::Deploy(DeployCommand::Unpack {
+            artifact_dir,
+            install_dir,
+        }) => {
+            do_unpack(&config, &artifact_dir, &install_dir, &log)?;
+        }
+        SubCommand::Deploy(DeployCommand::Activate { install_dir }) => {
+            do_activate(&config, &install_dir, &log)?;
         }
     }
 

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -46,7 +46,9 @@ pub enum BuildCommand {
 /// Commands which should execute on a host installing packages.
 #[derive(Debug, Subcommand)]
 pub enum DeployCommand {
-    /// Installs the packages to a target machine.
+    /// Installs the packages to a target machine and starts the sled-agent
+    ///
+    /// This is a combination of `Unpack` and `Activate`
     Install {
         /// The directory from which artifacts will be pulled.
         ///
@@ -69,6 +71,28 @@ pub enum DeployCommand {
         artifact_dir: PathBuf,
 
         /// The directory to which artifacts were installed.
+        ///
+        /// Defaults to "/opt/oxide".
+        #[clap(long = "out", default_value = "/opt/oxide", action)]
+        install_dir: PathBuf,
+    },
+    // Unpacks the package files on the target machine
+    Unpack {
+        /// The directory from which artifacts will be pulled.
+        ///
+        /// Should match the format from the Package subcommand.
+        #[clap(long = "in", default_value = "out", action)]
+        artifact_dir: PathBuf,
+
+        /// The directory to which artifacts will be installed.
+        ///
+        /// Defaults to "/opt/oxide".
+        #[clap(long = "out", default_value = "/opt/oxide", action)]
+        install_dir: PathBuf,
+    },
+    // Installs the sled-agent illumos service and starts it
+    Activate {
+        /// The directory to which artifacts will be installed.
         ///
         /// Defaults to "/opt/oxide".
         #[clap(long = "out", default_value = "/opt/oxide", action)]

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -28,6 +28,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 pub enum TrustQuorumMembership {
@@ -212,7 +213,13 @@ impl Inner {
     async fn wait_for_sled_initialization(
         &self,
     ) -> Result<Arc<Option<ShareDistribution>>, String> {
+        // Channel on which we receive the trust quorum share after quorum has
+        // been established.
         let (tx_share, mut rx_share) = mpsc::channel(1);
+
+        // Shared trust quorum share allowing us to return the share while we're
+        // still establishing quorum.
+        let initial_share = Arc::new(Mutex::new(None));
 
         loop {
             // Wait for either a new client or a response on our channel sent by
@@ -237,9 +244,15 @@ impl Inner {
             let sp = self.sp.clone();
             let ba = Arc::clone(&self.bootstrap_agent);
             let tx_share = tx_share.clone();
+            let initial_share = Arc::clone(&initial_share);
             tokio::spawn(async move {
                 match serve_request_before_quorum_initialization(
-                    stream, sp, &ba, tx_share, &log,
+                    stream,
+                    sp,
+                    &ba,
+                    tx_share,
+                    &initial_share,
+                    &log,
                 )
                 .await
                 {
@@ -256,6 +269,7 @@ async fn serve_request_before_quorum_initialization(
     sp: Option<SpHandle>,
     bootstrap_agent: &Agent,
     tx_share: mpsc::Sender<Option<ShareDistribution>>,
+    initial_share: &Mutex<Option<ShareDistribution>>,
     log: &Logger,
 ) -> Result<(), String> {
     // Establish sprockets session (if we have an SP).
@@ -263,7 +277,16 @@ async fn serve_request_before_quorum_initialization(
         stream,
         &sp,
         SprocketsRole::Server,
-        None, // We don't have our trust quorum members yet
+        // If we've already received a sled agent request, any future
+        // connections to us are only allowed for members of our trust quorum.
+        // If we haven't yet received a sled agent request, we don't know our
+        // trust quorum members, and have to blindly accept any valid sprockets
+        // connection.
+        initial_share
+            .lock()
+            .await
+            .as_ref()
+            .map(|dist| dist.member_device_id_certs.as_slice()),
         log,
     )
     .await
@@ -273,6 +296,15 @@ async fn serve_request_before_quorum_initialization(
         Request::SledAgentRequest(request, trust_quorum_share) => {
             let trust_quorum_share =
                 trust_quorum_share.map(ShareDistribution::from);
+
+            // Save the trust quorum share _before_ calling request_agent, so
+            // that we can return it in the `Request::ShareRequest` branch below
+            //
+            // TODO should we check that if `initial_share` is already
+            // `Some(_)`, the value is the same? If it's not, we got two
+            // different shares from RSS...
+            *initial_share.lock().await = trust_quorum_share.clone();
+
             match bootstrap_agent
                 .request_agent(&*request, &trust_quorum_share)
                 .await
@@ -293,10 +325,13 @@ async fn serve_request_before_quorum_initialization(
                 }
             }
         }
-        Request::ShareRequest => {
-            warn!(log, "Share requested before we have one");
-            Err("Share request failed: share unavailable".to_string())
-        }
+        Request::ShareRequest => match initial_share.lock().await.clone() {
+            Some(dist) => Ok(Response::ShareResponse(dist.share.clone())),
+            None => {
+                warn!(log, "Share requested before we have one");
+                Err("Share request failed: share unavailable".to_string())
+            }
+        },
     };
 
     write_response(&mut stream, response).await

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -326,7 +326,7 @@ async fn serve_request_before_quorum_initialization(
             }
         }
         Request::ShareRequest => match initial_share.lock().await.clone() {
-            Some(dist) => Ok(Response::ShareResponse(dist.share.clone())),
+            Some(dist) => Ok(Response::ShareResponse(dist.share)),
             None => {
                 warn!(log, "Share requested before we have one");
                 Err("Share request failed: share unavailable".to_string())


### PR DESCRIPTION
Omicron has undergone many enhancements in the last few months including, but no limited to, some things that affect Falcon:
 * RSS existing and generating a rack distribution plan and secret
 * Automated network setup and routing via Maghemite
 * External TLS certificate support

Some support for these features in falcon was already included in prior commits. This commit includes support during the `install-prereqs` command via the following functions:
```rust
    install_rustup_on_deployment_servers(config);
    create_virtual_hardware_on_deployment_servers(config);
    create_external_tls_cert_on_builder(config)?;
```
It also allows a location on the client to be provided for the `config-rss.toml` so that different configs can be used when deploying to different topologies. This is especially useful with falcon.

Besides installing all the necessary pre-requisites to support the new Omicron features, thing-flinger itself has been improved by parallelizing all installs and deploys, and delaying the startup of sled-agent until after the overlay files are in place. Prior restarts triggered https://github.com/oxidecomputer/omicron/issues/1592 which are now no longer an issue. In order to allow this, two new deploy commands were added to `omicron-package`: `DeployCommand::Unpack` and `DeployCommand::Activate` which separate the unpacking of package files from the installation of SMF manifests and starting of services. 

While running thing-flinger deployments, I noticed that trust-quorum was no longer working and secrets were not being shared. With some help from @jgallagher that has since been rectified.

With all these changes, thing-flinger is now capable of deploying into arbitrary falcon topologies, with the first one being exemplified in https://github.com/oxidecomputer/falcon-omicron which provides a two node setup. I have run this locally on my helios box and am working to get it running on buildomat.
