### PR TITLE
[console] Rename `LoginParams` to `SpoofLoginBody` for client gen reasons

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -37,7 +37,7 @@ use std::{collections::HashSet, ffi::OsString, path::PathBuf, sync::Arc};
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct LoginParams {
+pub struct SpoofLoginBody {
     pub username: String,
 }
 
@@ -53,7 +53,7 @@ pub struct LoginParams {
 }]
 pub async fn spoof_login(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: TypedBody<LoginParams>,
+    params: TypedBody<SpoofLoginBody>,
 ) -> Result<Response<Body>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -17,7 +17,7 @@ use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_nexus::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
 use omicron_nexus::db::identity::Asset;
-use omicron_nexus::external_api::console_api::LoginParams;
+use omicron_nexus::external_api::console_api::SpoofLoginBody;
 use omicron_nexus::external_api::params::OrganizationCreate;
 use omicron_nexus::external_api::views;
 
@@ -282,7 +282,7 @@ fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {
 
 async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let login = RequestBuilder::new(&testctx, Method::POST, "/login")
-        .body(Some(&LoginParams { username: "privileged".to_string() }))
+        .body(Some(&SpoofLoginBody { username: "privileged".to_string() }))
         .expect_status(Some(StatusCode::OK))
         .execute()
         .await

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -386,7 +386,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/LoginParams"
+                "$ref": "#/components/schemas/SpoofLoginBody"
               }
             }
           },
@@ -6856,17 +6856,6 @@
         "minLength": 1,
         "maxLength": 11
       },
-      "LoginParams": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "username"
-        ]
-      },
       "MacAddr": {
         "example": "ff:ff:ff:ff:ff:ff",
         "title": "A MAC address",
@@ -8356,6 +8345,17 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "SpoofLoginBody": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
         ]
       },
       "SshKey": {


### PR DESCRIPTION
As of #1139 there's now something else oxide.ts wants to call `LoginParams` and there's no reason this needs to be called that.