### PR TITLE
Add API endpoint for updating network interfaces

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -814,14 +814,19 @@ CREATE UNIQUE INDEX ON omicron.public.network_interface (
  * Index used to verify that an Instance's networking is contained
  * within a single VPC, and that all interfaces are in unique VPC
  * Subnets.
+ *
+ * This is also used to quickly find the primary interface for an
+ * instance, since we store the `is_primary` column. Such queries are
+ * mostly used when setting a new primary interface for an instance.
  */
 CREATE UNIQUE INDEX ON omicron.public.network_interface (
     instance_id,
     name
 )
-STORING (vpc_id, subnet_id)
+STORING (vpc_id, subnet_id, is_primary)
 WHERE
     time_deleted IS NULL;
+
 
 CREATE TYPE omicron.public.vpc_router_kind AS ENUM (
     'system',

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -39,6 +39,8 @@ use crate::db::fixed_data::silo::DEFAULT_SILO;
 use crate::db::lookup::LookupPath;
 use crate::db::model::DatabaseString;
 use crate::db::model::IncompleteVpc;
+use crate::db::model::NetworkInterfaceUpdate;
+use crate::db::model::Vpc;
 use crate::db::queries::network_interface;
 use crate::db::queries::vpc::InsertVpcQuery;
 use crate::db::queries::vpc_subnet::FilterConflictingVpcSubnetRangesQuery;
@@ -56,7 +58,7 @@ use crate::db::{
         OrganizationUpdate, OximeterInfo, ProducerEndpoint, Project,
         ProjectUpdate, Rack, Region, RoleAssignment, RoleBuiltin, RouterRoute,
         RouterRouteUpdate, Service, Silo, SiloUser, Sled, SshKey,
-        UpdateAvailableArtifact, UserBuiltin, Volume, Vpc, VpcFirewallRule,
+        UpdateAvailableArtifact, UserBuiltin, Volume, VpcFirewallRule,
         VpcRouter, VpcRouterUpdate, VpcSubnet, VpcSubnetUpdate, VpcUpdate,
         Zpool,
     },
@@ -1942,6 +1944,148 @@ impl DataStore {
             .load_async::<NetworkInterface>(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
+    }
+
+    /// Update a network interface associated with a given instance.
+    pub async fn instance_update_network_interface(
+        &self,
+        opctx: &OpContext,
+        authz_instance: &authz::Instance,
+        authz_interface: &authz::NetworkInterface,
+        updates: NetworkInterfaceUpdate,
+    ) -> UpdateResult<NetworkInterface> {
+        use crate::db::schema::network_interface::dsl;
+
+        // This database operation is surprisingly subtle, and I don't believe
+        // it's possible to express in a single query.
+        //
+        // First, we need to check whether the instance is stopped. We do that
+        // in other cases with a CTE designed to fail if that's not true, but
+        // we're forced into a transaction by other considerations below.
+        //
+        // More importantly, setting a new primary interface is a pretty complex
+        // operation, and depends on the identity of the target. There are four
+        // cases, the truth table for (make_primary, target_is_primary)
+        //  - (false, _) => In this case, we only need to update a single row,
+        //  and we can apply the updates requested, minus the make_primary
+        //  value, unconditionally. This is pretty straightforward.
+        //
+        //  - (true, true) => This is also pretty simple, since we can just
+        //  apply the updates directly.
+        //
+        //  - (true, false) => This one is complicated. We need to apply all
+        //  updates to the target row, and then set the `is_primary` column of
+        //  the old primary to false. This isn't a single query.
+        //
+        //  The issue is that for the latter two cases, we don't know which
+        //  we're taking until we make a query to the database. We need to
+        //  figure out if the target is the primary first, and then apply one or
+        //  two updates accordingly.
+        //
+        //  This is all pretty complicated, with a number of branches and
+        //  additional consistency checks, such as the fact that the instance
+        //  has to be stopped. For now, we'll just bite the bullet and run this
+        //  all in a transaction.
+
+        // Build up some of the queries first, outside the transaction.
+        //
+        // This selects the existing primary interface.
+        let instance_id = authz_instance.id();
+        let interface_id = authz_interface.id();
+        let find_primary_query = dsl::network_interface
+            .filter(dsl::instance_id.eq(instance_id))
+            .filter(dsl::is_primary.eq(true))
+            .filter(dsl::time_deleted.is_null())
+            .select(NetworkInterface::as_select());
+
+        // This returns the state of the associated instance.
+        let stopped_instance_query = db::schema::instance::dsl::instance
+            .filter(db::schema::instance::dsl::id.eq(instance_id))
+            .filter(db::schema::instance::dsl::time_deleted.is_null())
+            .select(Instance::as_select());
+        let stopped =
+            db::model::InstanceState::new(external::InstanceState::Stopped);
+
+        // This is the actual query to update the target interface.
+        let make_primary = matches!(updates.make_primary, Some(true));
+        let update_target_query = diesel::update(dsl::network_interface)
+            .filter(dsl::id.eq(interface_id))
+            .filter(dsl::time_deleted.is_null())
+            .set(updates)
+            .returning(NetworkInterface::as_returning());
+
+        // Errors returned from the below transactions.
+        #[derive(Debug)]
+        enum NetworkInterfaceUpdateError {
+            InstanceNotStopped,
+            FailedToUnsetPrimary(diesel::result::Error),
+        }
+        type TxnError = TransactionError<NetworkInterfaceUpdateError>;
+
+        let pool = self.pool_authorized(opctx).await?;
+        if make_primary {
+            pool.transaction(move |conn| {
+                let instance_state = stopped_instance_query
+                    .get_result(conn)?
+                    .runtime_state
+                    .state;
+                if instance_state != stopped {
+                    return Err(TxnError::CustomError(
+                        NetworkInterfaceUpdateError::InstanceNotStopped,
+                    ));
+                }
+
+                // First, get the primary interface
+                let primary_interface = find_primary_query.get_result(conn)?;
+
+                // If the target and primary are different, we need to toggle
+                // the primary into a secondary.
+                if primary_interface.identity.id != interface_id {
+                    if let Err(e) = diesel::update(dsl::network_interface)
+                        .filter(dsl::id.eq(primary_interface.identity.id))
+                        .filter(dsl::time_deleted.is_null())
+                        .set(dsl::is_primary.eq(false))
+                        .execute(conn)
+                    {
+                        return Err(TxnError::CustomError(
+                            NetworkInterfaceUpdateError::FailedToUnsetPrimary(
+                                e,
+                            ),
+                        ));
+                    }
+                }
+
+                // In any case, update the actual target
+                Ok(update_target_query.get_result(conn)?)
+            })
+        } else {
+            // In this case, we can just directly apply the updates. By
+            // construction, `updates.make_primary` is `None`, so nothing will
+            // be done there. The other columns always need to be updated, and
+            // we're only hitting a single row. Note that we still need to
+            // verify the instance is stopped.
+            pool.transaction(move |conn| {
+                let instance_state = stopped_instance_query
+                    .get_result(conn)?
+                    .runtime_state
+                    .state;
+                if instance_state != stopped {
+                    return Err(TxnError::CustomError(
+                        NetworkInterfaceUpdateError::InstanceNotStopped,
+                    ));
+                }
+                Ok(update_target_query.get_result(conn)?)
+            })
+        }
+        .await
+        .map_err(|e| match e {
+            TxnError::CustomError(
+                NetworkInterfaceUpdateError::InstanceNotStopped,
+            ) => Error::invalid_request(
+                "Instance must be stopped to update its network interfaces",
+            ),
+            _ => Error::internal_error(&format!("Transaction error: {:?}", e)),
+        })
     }
 
     // Create a record for a new Oximeter instance

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -1999,7 +1999,7 @@ impl DataStore {
             .select(NetworkInterface::as_select());
 
         // This returns the state of the associated instance.
-        let stopped_instance_query = db::schema::instance::dsl::instance
+        let instance_query = db::schema::instance::dsl::instance
             .filter(db::schema::instance::dsl::id.eq(instance_id))
             .filter(db::schema::instance::dsl::time_deleted.is_null())
             .select(Instance::as_select());
@@ -2025,10 +2025,8 @@ impl DataStore {
         let pool = self.pool_authorized(opctx).await?;
         if make_primary {
             pool.transaction(move |conn| {
-                let instance_state = stopped_instance_query
-                    .get_result(conn)?
-                    .runtime_state
-                    .state;
+                let instance_state =
+                    instance_query.get_result(conn)?.runtime_state.state;
                 if instance_state != stopped {
                     return Err(TxnError::CustomError(
                         NetworkInterfaceUpdateError::InstanceNotStopped,
@@ -2065,10 +2063,8 @@ impl DataStore {
             // we're only hitting a single row. Note that we still need to
             // verify the instance is stopped.
             pool.transaction(move |conn| {
-                let instance_state = stopped_instance_query
-                    .get_result(conn)?
-                    .runtime_state
-                    .state;
+                let instance_state =
+                    instance_query.get_result(conn)?.runtime_state.state;
                 if instance_state != stopped {
                     return Err(TxnError::CustomError(
                         NetworkInterfaceUpdateError::InstanceNotStopped,

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -284,6 +284,33 @@ pub struct NetworkInterfaceCreate {
     pub ip: Option<IpAddr>,
 }
 
+/// Parameters for updating a
+/// [`NetworkInterface`](omicron_common::api::external::NetworkInterface).
+///
+/// Note that modifying IP addresses for an interface is not yet supported, a
+/// new interface must be created instead.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct NetworkInterfaceUpdate {
+    #[serde(flatten)]
+    pub identity: IdentityMetadataUpdateParams,
+
+    /// Make a secondary interface the instance's primary interface.
+    ///
+    /// If applied to a secondary interface, that interface will become the
+    /// primary on the next reboot of the instance. Note that this may have
+    /// implications for routing between instances, as the new primary interface
+    /// will be on a distinct subnet from the previous primary interface.
+    ///
+    /// Note that this can only be used to select a new primary interface for an
+    /// instance. Requests to change the primary interface into a secondary will
+    /// return an error.
+    // TODO-completeness TODO-docs: When we get there, this should note that a
+    // change in the primary interface will result in changes to the DNS records
+    // for the instance, though not the name.
+    #[serde(default)]
+    pub make_primary: bool,
+}
+
 // INSTANCES
 
 pub const MIN_MEMORY_SIZE_BYTES: u32 = 1 << 30; // 1 GiB

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -225,6 +225,15 @@ lazy_static! {
             subnet_name: DEMO_VPC_SUBNET_NAME.clone(),
             ip: None,
         };
+    pub static ref DEMO_INSTANCE_NIC_PUT: params::NetworkInterfaceUpdate = {
+        params::NetworkInterfaceUpdate {
+            identity: IdentityMetadataUpdateParams {
+                name: None,
+                description: Some(String::from("an updated description")),
+            },
+            make_primary: false,
+        }
+    };
 }
 
 // Separate lazy_static! blocks to avoid hitting some recursion limit when compiling
@@ -875,6 +884,9 @@ lazy_static! {
             allowed_methods: vec![
                 AllowedMethod::Get,
                 AllowedMethod::Delete,
+                AllowedMethod::Put(
+                    serde_json::to_value(&*DEMO_INSTANCE_NIC_PUT).unwrap()
+                ),
             ],
         },
 

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -39,6 +39,7 @@ instance_network_interfaces_delete_interface /organizations/{organization_name}/
 instance_network_interfaces_get          /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces
 instance_network_interfaces_get_interface /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces/{interface_name}
 instance_network_interfaces_post         /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces
+instance_network_interfaces_put_interface /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces/{interface_name}
 project_instances_delete_instance        /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}
 project_instances_get                    /organizations/{organization_name}/projects/{project_name}/instances
 project_instances_get_instance           /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2282,6 +2282,79 @@
           }
         }
       },
+      "put": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Update information about an instance's network interface",
+        "operationId": "instance_network_interfaces_put_interface",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "interface_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NetworkInterfaceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkInterface"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "delete": {
         "tags": [
           "instances"
@@ -7010,6 +7083,29 @@
         "required": [
           "items"
         ]
+      },
+      "NetworkInterfaceUpdate": {
+        "description": "Parameters for updating a [`NetworkInterface`](omicron_common::api::external::NetworkInterface).\n\nNote that modifying IP addresses for an interface is not yet supported, a new interface must be created instead.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "make_primary": {
+            "description": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error.",
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
       },
       "Organization": {
         "description": "Client view of an [`Organization`]",


### PR DESCRIPTION
- Adds the HTTP endpoint to PUT updates to an instance's network
  interfaces
- Adds transaction-based method for applying these updates. The
  transaction is mainly necessary to correctly make a new primary
  interface, specifically marking the old primary as now secondary. It
  also helps with a potential race when checking if the instance being
  operated on is stopped. The interactive transaction is unfortunate,
  but appears required, since the entire operation of setting a new
  primary cannot be expressed as a single query.
- Adds tests, especially verifying making a new primary interface
- Adds PUT endpoint to auth tests