### PR TITLE
buildomat: allow dependabot/renovate jobs without manual approval

### DIFF
--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -8,3 +8,13 @@ enable = true
 # Require approval for pull requests made by users outside our organisation.
 #
 org_only = true
+
+#
+# We accept pull requests from several automated services that are outside the
+# organisation.  Allow jobs from those sources to proceed without manual
+# approval:
+#
+allow_users = [
+	"dependabot[bot]",
+	"renovate[bot]",
+]


### PR DESCRIPTION
As requested in oxidecomputer/buildomat#5 I have added support for pre-authorisation for specific users, which I am, here, using to allow Dependabot and Renovate PRs to run buildomat jobs without manual authorisation from an organisation member.