### PR TITLE
Bring back docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,42 @@
+#
+# GitHub Actions configuration to automatically build and publish a Docker image
+# for Omicron.  See README for details.
+#
+name: docker-image
+on: push
+jobs:
+  docker-image:
+    runs-on: ubuntu-18.04
+    steps:
+      # actions/checkout@v2
+      - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract branch name
+        shell: bash
+        run: BRANCH="${GITHUB_HEAD_REF//\//-}"; echo "::set-output name=branch::${BRANCH:-main}"
+        id: extract_branch
+      - name: Build and push
+        # This pushes a docker image to github's container registry.
+        # It is not a public image by default.
+        # The docs are here: https://github.com/docker/build-push-action
+        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        with:
+          push: ${{ ! startsWith(github.ref, 'refs/heads/dependabot') }}
+          file: ./Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/omicron:${{ steps.extract_branch.outputs.branch }},ghcr.io/${{ github.repository_owner }}/omicron:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract branch name
         shell: bash
-        run: BRANCH="${GITHUB_HEAD_REF//\//-}"; echo "::set-output name=branch::${BRANCH:-main}"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME//\//-})"
         id: extract_branch
       - name: Build and push
         # This pushes a docker image to github's container registry.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN apt-get update && apt-get install -y \
 	libpq5 \
 	libssl1.1 \
 	libsqlite3-0 \
+	xmlsec1 \
+	libxmlsec1-dev \
+	libxmlsec1-openssl \
+	pkg-config \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,16 @@ WORKDIR /usr/src/omicron
 COPY . .
 
 WORKDIR /usr/src/omicron
-RUN tools/install_prerequisites.sh -y
+RUN apt-get update && apt-get install -y \
+	libpq-dev \
+	pkg-config \
+	xmlsec1 \
+	libxmlsec1-dev \
+	libxmlsec1-openssl \
+	libclang-dev \
+	libsqlite3-dev \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 RUN cargo build --release
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ WORKDIR /usr/src/omicron
 COPY . .
 
 WORKDIR /usr/src/omicron
+
+# sudo and path thing are only needed to get prereqs script to run
 ENV PATH=/usr/src/omicron/out/cockroachdb/bin:/usr/src/omicron/out/clickhouse:${PATH} 
 RUN apt-get update && apt-get install -y sudo --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN tools/install_prerequisites.sh -y
+
 RUN cargo build --release
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,9 @@ WORKDIR /usr/src/omicron
 COPY . .
 
 WORKDIR /usr/src/omicron
-RUN apt-get update && apt-get install -y \
-	libpq-dev \
-	pkg-config \
-	xmlsec1 \
-	libxmlsec1-dev \
-	libxmlsec1-openssl \
-	libclang-dev \
-	libsqlite3-dev \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+ENV PATH=/usr/src/omicron/out/cockroachdb/bin:/usr/src/omicron/out/clickhouse:${PATH} 
+RUN apt-get update && apt-get install -y sudo --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN tools/install_prerequisites.sh -y
 RUN cargo build --release
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# 
+# Dockerfile: build a Docker image for Omicron.  This is used by the console for
+# prototyping and development.  This will not be used for deployment to a real 
+# rack.
+# 
+# ------------------------------------------------------------------------------
+# Cargo Build Stage
+# ------------------------------------------------------------------------------
+
+FROM rust:latest as cargo-build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /usr/src/omicron
+
+COPY . .
+
+WORKDIR /usr/src/omicron
+RUN cargo build --release
+
+# ------------------------------------------------------------------------------
+# Final Stage
+# ------------------------------------------------------------------------------
+
+FROM debian:sid-slim
+
+RUN apt-get update && apt-get install -y \
+	ca-certificates \
+	libpq5 \
+	libssl1.1 \
+	libsqlite3-0 \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+COPY --from=cargo-build /usr/src/omicron/target/release/nexus /usr/bin/nexus
+COPY --from=cargo-build /usr/src/omicron/target/release/omicron-dev /usr/bin/omicron-dev
+COPY --from=cargo-build /usr/src/omicron/target/release/omicron-package /usr/bin/omicron-package
+COPY --from=cargo-build /usr/src/omicron/target/release/sled-agent-sim /usr/bin/sled-agent-sim
+
+CMD ["sled-agent-sim"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /usr/src/omicron
 COPY . .
 
 WORKDIR /usr/src/omicron
+RUN tools/install_prerequisites.sh -y
 RUN cargo build --release
 
 # ------------------------------------------------------------------------------
@@ -29,10 +30,6 @@ RUN apt-get update && apt-get install -y \
 	libpq5 \
 	libssl1.1 \
 	libsqlite3-0 \
-	xmlsec1 \
-	libxmlsec1-dev \
-	libxmlsec1-openssl \
-	pkg-config \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/README.adoc
+++ b/README.adoc
@@ -49,6 +49,10 @@ This mode of operation will be used in production.
 
 See: xref:docs/how-to-run.adoc[].
 
+== Docker image
+
+This repo includes a Dockerfile that builds an image containing the Nexus and sled agent.  There's a GitHub Actions workflow that builds and publishes the Docker image.  This is used by the https://github.com/oxidecomputer/console/[console] project for prototyping, demoing, and testing.  This is **not** the way Omicron will be deployed on production systems, but it's a useful vehicle for working with it.
+
 == Configuration reference
 
 `nexus` requires a TOML configuration file.  There's an example in

--- a/README.adoc
+++ b/README.adoc
@@ -51,7 +51,7 @@ See: xref:docs/how-to-run.adoc[].
 
 == Docker image
 
-This repo includes a Dockerfile that builds an image containing the Nexus and sled agent.  There's a GitHub Actions workflow that builds and publishes the Docker image.  This is used by the https://github.com/oxidecomputer/console/[console] project for prototyping, demoing, and testing.  This is **not** the way Omicron will be deployed on production systems, but it's a useful vehicle for working with it.
+This repo includes a Dockerfile that builds an image containing the Nexus and sled agent.  There's a GitHub Actions workflow that builds and publishes the Docker image.  This is used by [cli](https://github.com/oxidecomputer/cli) for testing. This is **not** the way Omicron will be deployed on production systems, but it's a useful vehicle for working with it.
 
 == Configuration reference
 

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -80,11 +80,11 @@ if [[ "${HOST_OS}" == "Linux" ]]; then
     'libclang-dev'
     'libsqlite3-dev'
   )
-  sudo apt-get update
+  apt-get update
   if [[ "${ASSUME_YES}" == "true" ]]; then
-    sudo apt-get install -y ${packages[@]}
+    apt-get install -y ${packages[@]}
   else
-      confirm "Install (or update) [${packages[*]}]?" && sudo apt-get install ${packages[@]}
+      confirm "Install (or update) [${packages[*]}]?" && apt-get install ${packages[@]}
   fi
 elif [[ "${HOST_OS}" == "SunOS" ]]; then
   packages=(

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -80,11 +80,11 @@ if [[ "${HOST_OS}" == "Linux" ]]; then
     'libclang-dev'
     'libsqlite3-dev'
   )
-  apt-get update
+  sudo apt-get update
   if [[ "${ASSUME_YES}" == "true" ]]; then
-    apt-get install -y ${packages[@]}
+    sudo apt-get install -y ${packages[@]}
   else
-      confirm "Install (or update) [${packages[*]}]?" && apt-get install ${packages[@]}
+      confirm "Install (or update) [${packages[*]}]?" && sudo apt-get install ${packages[@]}
   fi
 elif [[ "${HOST_OS}" == "SunOS" ]]; then
   packages=(


### PR DESCRIPTION
Turns out the CLI needs it for testing, plus @karencfv will also be using it for testing Terraform.

---

Here's the diff between this branch and the commit _before_ the one where I deleted the Dockerfile: https://github.com/oxidecomputer/omicron/compare/a09934dc49cf7fa0fb6ce6989f250cb0a10b4b92...undelete-docker. The only difference from the original versions of these files (the Dockerfile and the GH workflow file) is that I added a `apt-get install` line before `cargo build`.

The natural thing would be to run `tools/install_prerequesites.sh` there instead, but I couldn't get that to work for a couple of reasons. First, it doesn't like the `sudo` commands — `sudo` is not available by default. Getting rid of the sudos made it get farther ([CI run](https://github.com/oxidecomputer/omicron/runs/6903754712?check_suite_focus=true)) but then it failed on something else:

```
#12 20.15 ERROR: cockroach seems installed, but was not found in PATH. Please add it.
#12 20.15 cockroach should have been installed to '/usr/src/omicron/out/cockroachdb/bin'
#12 20.15 ERROR: clickhouse seems installed, but was not found in PATH. Please add it.
#12 20.15 clickhouse should have been installed to '/usr/src/omicron/out/clickhouse'
```

Not sure what to do about that.

In any case, to prove it _can_ work, I have instead taken `install_prerequisites.sh` back out of the Dockerfile and instead manually copied in the packages it installs into an explicit `apt-get install` in the Dockerfile. That works, though it is of course brittle because it doesn't automatically bring in packages as they're added to the prereqs script. There are also probably more packages being installed than we actually need.