### PR TITLE
Rename `ProjectRoles` and friends to `ProjectRole` etc

### DIFF
--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -23,7 +23,7 @@ impl super::Nexus {
     pub async fn fleet_fetch_policy(
         &self,
         opctx: &OpContext,
-    ) -> LookupResult<shared::Policy<authz::FleetRoles>> {
+    ) -> LookupResult<shared::Policy<authz::FleetRole>> {
         let role_assignments = self
             .db_datastore
             .role_assignment_fetch_visible(opctx, &authz::FLEET)
@@ -38,8 +38,8 @@ impl super::Nexus {
     pub async fn fleet_update_policy(
         &self,
         opctx: &OpContext,
-        policy: &shared::Policy<authz::FleetRoles>,
-    ) -> UpdateResult<shared::Policy<authz::FleetRoles>> {
+        policy: &shared::Policy<authz::FleetRole>,
+    ) -> UpdateResult<shared::Policy<authz::FleetRole>> {
         let role_assignments = self
             .db_datastore
             .role_assignment_replace_visible(

--- a/nexus/src/app/organization.rs
+++ b/nexus/src/app/organization.rs
@@ -97,7 +97,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         organization_name: &Name,
-    ) -> LookupResult<shared::Policy<authz::OrganizationRoles>> {
+    ) -> LookupResult<shared::Policy<authz::OrganizationRole>> {
         let (.., authz_org) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
             .lookup_for(authz::Action::ReadPolicy)
@@ -117,8 +117,8 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         organization_name: &Name,
-        policy: &shared::Policy<authz::OrganizationRoles>,
-    ) -> UpdateResult<shared::Policy<authz::OrganizationRoles>> {
+        policy: &shared::Policy<authz::OrganizationRole>,
+    ) -> UpdateResult<shared::Policy<authz::OrganizationRole>> {
         let (.., authz_org) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
             .lookup_for(authz::Action::ModifyPolicy)

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -156,7 +156,7 @@ impl super::Nexus {
         opctx: &OpContext,
         organization_name: &Name,
         project_name: &Name,
-    ) -> LookupResult<shared::Policy<authz::ProjectRoles>> {
+    ) -> LookupResult<shared::Policy<authz::ProjectRole>> {
         let (.., authz_project) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
             .project_name(project_name)
@@ -178,8 +178,8 @@ impl super::Nexus {
         opctx: &OpContext,
         organization_name: &Name,
         project_name: &Name,
-        policy: &shared::Policy<authz::ProjectRoles>,
-    ) -> UpdateResult<shared::Policy<authz::ProjectRoles>> {
+        policy: &shared::Policy<authz::ProjectRole>,
+    ) -> UpdateResult<shared::Policy<authz::ProjectRole>> {
         let (.., authz_project) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
             .project_name(project_name)

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -82,7 +82,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         silo_name: &Name,
-    ) -> LookupResult<shared::Policy<authz::SiloRoles>> {
+    ) -> LookupResult<shared::Policy<authz::SiloRole>> {
         let (.., authz_silo) = LookupPath::new(opctx, &self.db_datastore)
             .silo_name(silo_name)
             .lookup_for(authz::Action::ReadPolicy)
@@ -102,8 +102,8 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         silo_name: &Name,
-        policy: &shared::Policy<authz::SiloRoles>,
-    ) -> UpdateResult<shared::Policy<authz::SiloRoles>> {
+        policy: &shared::Policy<authz::SiloRole>,
+    ) -> UpdateResult<shared::Policy<authz::SiloRole>> {
         let (.., authz_silo) = LookupPath::new(opctx, &self.db_datastore)
             .silo_name(silo_name)
             .lookup_for(authz::Action::ModifyPolicy)

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -202,7 +202,7 @@ impl ApiResourceWithRoles for Fleet {
 }
 
 impl ApiResourceWithRolesType for Fleet {
-    type AllowedRoles = FleetRoles;
+    type AllowedRoles = FleetRole;
 }
 
 #[derive(
@@ -210,7 +210,7 @@ impl ApiResourceWithRolesType for Fleet {
 )]
 #[cfg_attr(test, derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
-pub enum FleetRoles {
+pub enum FleetRole {
     Admin,
     Collaborator,
     Viewer,
@@ -218,22 +218,22 @@ pub enum FleetRoles {
     // they do not show up in this enum.
 }
 
-impl db::model::DatabaseString for FleetRoles {
+impl db::model::DatabaseString for FleetRole {
     type Error = anyhow::Error;
 
     fn to_database_string(&self) -> &str {
         match self {
-            FleetRoles::Admin => "admin",
-            FleetRoles::Collaborator => "collaborator",
-            FleetRoles::Viewer => "viewer",
+            FleetRole::Admin => "admin",
+            FleetRole::Collaborator => "collaborator",
+            FleetRole::Viewer => "viewer",
         }
     }
 
     fn from_database_string(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "admin" => Ok(FleetRoles::Admin),
-            "collaborator" => Ok(FleetRoles::Collaborator),
-            "viewer" => Ok(FleetRoles::Viewer),
+            "admin" => Ok(FleetRole::Admin),
+            "collaborator" => Ok(FleetRole::Collaborator),
+            "viewer" => Ok(FleetRole::Viewer),
             _ => Err(anyhow!("unsupported Fleet role from database: {:?}", s)),
         }
     }
@@ -370,7 +370,7 @@ authz_resource! {
 }
 
 impl ApiResourceWithRolesType for Organization {
-    type AllowedRoles = OrganizationRoles;
+    type AllowedRoles = OrganizationRole;
 }
 
 #[derive(
@@ -388,28 +388,28 @@ impl ApiResourceWithRolesType for Organization {
 #[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
-pub enum OrganizationRoles {
+pub enum OrganizationRole {
     Admin,
     Collaborator,
     Viewer,
 }
 
-impl db::model::DatabaseString for OrganizationRoles {
+impl db::model::DatabaseString for OrganizationRole {
     type Error = anyhow::Error;
 
     fn to_database_string(&self) -> &str {
         match self {
-            OrganizationRoles::Admin => "admin",
-            OrganizationRoles::Collaborator => "collaborator",
-            OrganizationRoles::Viewer => "viewer",
+            OrganizationRole::Admin => "admin",
+            OrganizationRole::Collaborator => "collaborator",
+            OrganizationRole::Viewer => "viewer",
         }
     }
 
     fn from_database_string(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "admin" => Ok(OrganizationRoles::Admin),
-            "collaborator" => Ok(OrganizationRoles::Collaborator),
-            "viewer" => Ok(OrganizationRoles::Viewer),
+            "admin" => Ok(OrganizationRole::Admin),
+            "collaborator" => Ok(OrganizationRole::Collaborator),
+            "viewer" => Ok(OrganizationRole::Viewer),
             _ => Err(anyhow!(
                 "unsupported Organization role from database: {:?}",
                 s
@@ -427,7 +427,7 @@ authz_resource! {
 }
 
 impl ApiResourceWithRolesType for Project {
-    type AllowedRoles = ProjectRoles;
+    type AllowedRoles = ProjectRole;
 }
 
 #[derive(
@@ -445,28 +445,28 @@ impl ApiResourceWithRolesType for Project {
 #[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
-pub enum ProjectRoles {
+pub enum ProjectRole {
     Admin,
     Collaborator,
     Viewer,
 }
 
-impl db::model::DatabaseString for ProjectRoles {
+impl db::model::DatabaseString for ProjectRole {
     type Error = anyhow::Error;
 
     fn to_database_string(&self) -> &str {
         match self {
-            ProjectRoles::Admin => "admin",
-            ProjectRoles::Collaborator => "collaborator",
-            ProjectRoles::Viewer => "viewer",
+            ProjectRole::Admin => "admin",
+            ProjectRole::Collaborator => "collaborator",
+            ProjectRole::Viewer => "viewer",
         }
     }
 
     fn from_database_string(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "admin" => Ok(ProjectRoles::Admin),
-            "collaborator" => Ok(ProjectRoles::Collaborator),
-            "viewer" => Ok(ProjectRoles::Viewer),
+            "admin" => Ok(ProjectRole::Admin),
+            "collaborator" => Ok(ProjectRole::Collaborator),
+            "viewer" => Ok(ProjectRole::Viewer),
             _ => {
                 Err(anyhow!("unsupported Project role from database: {:?}", s))
             }
@@ -573,7 +573,7 @@ authz_resource! {
 }
 
 impl ApiResourceWithRolesType for Silo {
-    type AllowedRoles = SiloRoles;
+    type AllowedRoles = SiloRole;
 }
 
 #[derive(
@@ -591,28 +591,28 @@ impl ApiResourceWithRolesType for Silo {
 #[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
-pub enum SiloRoles {
+pub enum SiloRole {
     Admin,
     Collaborator,
     Viewer,
 }
 
-impl db::model::DatabaseString for SiloRoles {
+impl db::model::DatabaseString for SiloRole {
     type Error = anyhow::Error;
 
     fn to_database_string(&self) -> &str {
         match self {
-            SiloRoles::Admin => "admin",
-            SiloRoles::Collaborator => "collaborator",
-            SiloRoles::Viewer => "viewer",
+            SiloRole::Admin => "admin",
+            SiloRole::Collaborator => "collaborator",
+            SiloRole::Viewer => "viewer",
         }
     }
 
     fn from_database_string(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "admin" => Ok(SiloRoles::Admin),
-            "collaborator" => Ok(SiloRoles::Collaborator),
-            "viewer" => Ok(SiloRoles::Viewer),
+            "admin" => Ok(SiloRole::Admin),
+            "collaborator" => Ok(SiloRole::Collaborator),
+            "viewer" => Ok(SiloRole::Viewer),
             _ => Err(anyhow!("unsupported Silo role from database: {:?}", s)),
         }
     }
@@ -676,24 +676,24 @@ authz_resource! {
 
 #[cfg(test)]
 mod test {
-    use super::FleetRoles;
-    use super::OrganizationRoles;
-    use super::ProjectRoles;
-    use super::SiloRoles;
+    use super::FleetRole;
+    use super::OrganizationRole;
+    use super::ProjectRole;
+    use super::SiloRole;
     use crate::db::model::test_database_string_impl;
 
     #[test]
     fn test_roles_database_strings() {
-        test_database_string_impl::<FleetRoles, _>(
+        test_database_string_impl::<FleetRole, _>(
             "tests/output/authz-roles-fleet.txt",
         );
-        test_database_string_impl::<SiloRoles, _>(
+        test_database_string_impl::<SiloRole, _>(
             "tests/output/authz-roles-silo.txt",
         );
-        test_database_string_impl::<OrganizationRoles, _>(
+        test_database_string_impl::<OrganizationRole, _>(
             "tests/output/authz-roles-organization.txt",
         );
-        test_database_string_impl::<ProjectRoles, _>(
+        test_database_string_impl::<ProjectRole, _>(
             "tests/output/authz-roles-project.txt",
         );
     }

--- a/nexus/src/db/fixed_data/role_builtin.rs
+++ b/nexus/src/db/fixed_data/role_builtin.rs
@@ -104,12 +104,12 @@ mod test {
         // resource must have a corresponding entry in BUILTIN_ROLES above.
         // The reverse is not necessarily true because we have some internal
         // roles that are not exposed to end users.
-        check_public_roles::<authz::FleetRoles>(ResourceType::Fleet);
-        check_public_roles::<authz::SiloRoles>(ResourceType::Silo);
-        check_public_roles::<authz::OrganizationRoles>(
+        check_public_roles::<authz::FleetRole>(ResourceType::Fleet);
+        check_public_roles::<authz::SiloRole>(ResourceType::Silo);
+        check_public_roles::<authz::OrganizationRole>(
             ResourceType::Organization,
         );
-        check_public_roles::<authz::ProjectRoles>(ResourceType::Project);
+        check_public_roles::<authz::ProjectRole>(ResourceType::Project);
     }
 
     fn check_public_roles<T>(resource_type: ResourceType)

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -264,7 +264,7 @@ pub fn external_api() -> NexusApiDescription {
 }]
 async fn policy_get(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-) -> Result<HttpResponseOk<shared::Policy<authz::FleetRoles>>, HttpError> {
+) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
 
@@ -284,8 +284,8 @@ async fn policy_get(
 }]
 async fn policy_put(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    new_policy: TypedBody<shared::Policy<authz::FleetRoles>>,
-) -> Result<HttpResponseOk<shared::Policy<authz::FleetRoles>>, HttpError> {
+    new_policy: TypedBody<shared::Policy<authz::FleetRole>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let new_policy = new_policy.into_inner();
@@ -421,7 +421,7 @@ async fn silos_delete_silo(
 async fn silos_get_silo_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SiloPathParam>,
-) -> Result<HttpResponseOk<shared::Policy<authz::SiloRoles>>, HttpError> {
+) -> Result<HttpResponseOk<shared::Policy<authz::SiloRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
@@ -444,8 +444,8 @@ async fn silos_get_silo_policy(
 async fn silos_put_silo_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SiloPathParam>,
-    new_policy: TypedBody<shared::Policy<authz::SiloRoles>>,
-) -> Result<HttpResponseOk<shared::Policy<authz::SiloRoles>>, HttpError> {
+    new_policy: TypedBody<shared::Policy<authz::SiloRole>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::SiloRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
@@ -725,7 +725,7 @@ async fn organizations_put_organization(
 async fn organization_get_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<OrganizationPathParam>,
-) -> Result<HttpResponseOk<shared::Policy<authz::OrganizationRoles>>, HttpError>
+) -> Result<HttpResponseOk<shared::Policy<authz::OrganizationRole>>, HttpError>
 {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -750,8 +750,8 @@ async fn organization_get_policy(
 async fn organization_put_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<OrganizationPathParam>,
-    new_policy: TypedBody<shared::Policy<authz::OrganizationRoles>>,
-) -> Result<HttpResponseOk<shared::Policy<authz::OrganizationRoles>>, HttpError>
+    new_policy: TypedBody<shared::Policy<authz::OrganizationRole>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::OrganizationRole>>, HttpError>
 {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -957,7 +957,7 @@ async fn organization_projects_put_project(
 async fn organization_projects_get_project_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
-) -> Result<HttpResponseOk<shared::Policy<authz::ProjectRoles>>, HttpError> {
+) -> Result<HttpResponseOk<shared::Policy<authz::ProjectRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
@@ -983,8 +983,8 @@ async fn organization_projects_get_project_policy(
 async fn organization_projects_put_project_policy(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<ProjectPathParam>,
-    new_policy: TypedBody<shared::Policy<authz::ProjectRoles>>,
-) -> Result<HttpResponseOk<shared::Policy<authz::ProjectRoles>>, HttpError> {
+    new_policy: TypedBody<shared::Policy<authz::ProjectRole>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::ProjectRole>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -439,7 +439,7 @@ lazy_static! {
                 AllowedMethod::Get,
                 AllowedMethod::Put(
                     serde_json::to_value(
-                        &shared::Policy::<authz::FleetRoles> {
+                        &shared::Policy::<authz::FleetRole> {
                             role_assignments: vec![]
                         }
                     ).unwrap()
@@ -473,7 +473,7 @@ lazy_static! {
                 AllowedMethod::Get,
                 AllowedMethod::Put(
                     serde_json::to_value(
-                        &shared::Policy::<authz::SiloRoles> {
+                        &shared::Policy::<authz::SiloRole> {
                             role_assignments: vec![]
                         }
                     ).unwrap()
@@ -517,7 +517,7 @@ lazy_static! {
                 AllowedMethod::Get,
                 AllowedMethod::Put(
                     serde_json::to_value(
-                        &shared::Policy::<authz::OrganizationRoles> {
+                        &shared::Policy::<authz::OrganizationRole> {
                             role_assignments: vec![]
                         }
                     ).unwrap()
@@ -568,7 +568,7 @@ lazy_static! {
                 AllowedMethod::Get,
                 AllowedMethod::Put(
                     serde_json::to_value(
-                        &shared::Policy::<authz::ProjectRoles> {
+                        &shared::Policy::<authz::ProjectRole> {
                             role_assignments: vec![]
                         }
                     ).unwrap()

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -104,8 +104,8 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
 
     struct FleetRoleAssignmentTest;
     impl RoleAssignmentTest for FleetRoleAssignmentTest {
-        type RoleType = authz::FleetRoles;
-        const ROLE: Self::RoleType = authz::FleetRoles::Admin;
+        type RoleType = authz::FleetRole;
+        const ROLE: Self::RoleType = authz::FleetRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
             String::from("/policy")
@@ -169,8 +169,8 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
 async fn test_role_assignments_silo(cptestctx: &ControlPlaneTestContext) {
     struct SiloRoleAssignmentTest;
     impl RoleAssignmentTest for SiloRoleAssignmentTest {
-        type RoleType = authz::SiloRoles;
-        const ROLE: Self::RoleType = authz::SiloRoles::Admin;
+        type RoleType = authz::SiloRole;
+        const ROLE: Self::RoleType = authz::SiloRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
             format!(
@@ -238,8 +238,8 @@ async fn test_role_assignments_organization(
     };
 
     impl RoleAssignmentTest for OrganizationRoleAssignmentTest {
-        type RoleType = authz::OrganizationRoles;
-        const ROLE: Self::RoleType = authz::OrganizationRoles::Admin;
+        type RoleType = authz::OrganizationRole;
+        const ROLE: Self::RoleType = authz::OrganizationRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = false;
         fn policy_url(&self) -> String {
             format!("{}/policy", self.org_url)
@@ -300,8 +300,8 @@ async fn test_role_assignments_project(cptestctx: &ControlPlaneTestContext) {
         policy_url: format!("{}/policy", project_url),
     };
     impl RoleAssignmentTest for ProjectRoleAssignmentTest {
-        type RoleType = authz::ProjectRoles;
-        const ROLE: Self::RoleType = authz::ProjectRoles::Admin;
+        type RoleType = authz::ProjectRole;
+        const ROLE: Self::RoleType = authz::ProjectRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = false;
         fn policy_url(&self) -> String {
             self.policy_url.clone()

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -21,7 +21,7 @@ use nexus_test_utils::resource_helpers::{
 
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
-use omicron_nexus::authz::SiloRoles;
+use omicron_nexus::authz::SiloRole;
 
 use httptest::{matchers::*, responders::*, Expectation, Server};
 
@@ -88,7 +88,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     grant_iam(
         client,
         "/silos/discoverable",
-        SiloRoles::Admin,
+        SiloRole::Admin,
         new_silo_user_id,
         AuthnMode::PrivilegedUser,
     )

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -736,7 +736,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationRolesPolicy"
+                  "$ref": "#/components/schemas/OrganizationRolePolicy"
                 }
               }
             }
@@ -771,7 +771,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/OrganizationRolesPolicy"
+                "$ref": "#/components/schemas/OrganizationRolePolicy"
               }
             }
           },
@@ -783,7 +783,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationRolesPolicy"
+                  "$ref": "#/components/schemas/OrganizationRolePolicy"
                 }
               }
             }
@@ -2708,7 +2708,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectRolesPolicy"
+                  "$ref": "#/components/schemas/ProjectRolePolicy"
                 }
               }
             }
@@ -2753,7 +2753,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ProjectRolesPolicy"
+                "$ref": "#/components/schemas/ProjectRolePolicy"
               }
             }
           },
@@ -2765,7 +2765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectRolesPolicy"
+                  "$ref": "#/components/schemas/ProjectRolePolicy"
                 }
               }
             }
@@ -4632,7 +4632,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FleetRolesPolicy"
+                  "$ref": "#/components/schemas/FleetRolePolicy"
                 }
               }
             }
@@ -4655,7 +4655,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FleetRolesPolicy"
+                "$ref": "#/components/schemas/FleetRolePolicy"
               }
             }
           },
@@ -4667,7 +4667,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FleetRolesPolicy"
+                  "$ref": "#/components/schemas/FleetRolePolicy"
                 }
               }
             }
@@ -5318,7 +5318,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiloRolesPolicy"
+                  "$ref": "#/components/schemas/SiloRolePolicy"
                 }
               }
             }
@@ -5353,7 +5353,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SiloRolesPolicy"
+                "$ref": "#/components/schemas/SiloRolePolicy"
               }
             }
           },
@@ -5365,7 +5365,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiloRolesPolicy"
+                  "$ref": "#/components/schemas/SiloRolePolicy"
                 }
               }
             }
@@ -6164,7 +6164,7 @@
           "bool"
         ]
       },
-      "FleetRoles": {
+      "FleetRole": {
         "type": "string",
         "enum": [
           "admin",
@@ -6172,7 +6172,7 @@
           "viewer"
         ]
       },
-      "FleetRolesPolicy": {
+      "FleetRolePolicy": {
         "description": "Client view of a [`Policy`], which describes how this resource may be accessed\n\nNote that the Policy only describes access granted explicitly for this resource.  The policies of parent resources can also cause a user to have access to this resource.",
         "type": "object",
         "properties": {
@@ -6180,7 +6180,7 @@
             "description": "Roles directly assigned on this resource",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FleetRolesRoleAssignment"
+              "$ref": "#/components/schemas/FleetRoleRoleAssignment"
             }
           }
         },
@@ -6188,7 +6188,7 @@
           "role_assignments"
         ]
       },
-      "FleetRolesRoleAssignment": {
+      "FleetRoleRoleAssignment": {
         "description": "Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)\n\nThe resource is not part of this structure.  Rather, [`RoleAssignment`]s are put into a [`Policy`] and that Policy is applied to a particular resource.",
         "type": "object",
         "properties": {
@@ -6200,7 +6200,7 @@
             "$ref": "#/components/schemas/IdentityType"
           },
           "role_name": {
-            "$ref": "#/components/schemas/FleetRoles"
+            "$ref": "#/components/schemas/FleetRole"
           }
         },
         "required": [
@@ -7311,7 +7311,7 @@
           "items"
         ]
       },
-      "OrganizationRoles": {
+      "OrganizationRole": {
         "type": "string",
         "enum": [
           "admin",
@@ -7319,7 +7319,7 @@
           "viewer"
         ]
       },
-      "OrganizationRolesPolicy": {
+      "OrganizationRolePolicy": {
         "description": "Client view of a [`Policy`], which describes how this resource may be accessed\n\nNote that the Policy only describes access granted explicitly for this resource.  The policies of parent resources can also cause a user to have access to this resource.",
         "type": "object",
         "properties": {
@@ -7327,7 +7327,7 @@
             "description": "Roles directly assigned on this resource",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/OrganizationRolesRoleAssignment"
+              "$ref": "#/components/schemas/OrganizationRoleRoleAssignment"
             }
           }
         },
@@ -7335,7 +7335,7 @@
           "role_assignments"
         ]
       },
-      "OrganizationRolesRoleAssignment": {
+      "OrganizationRoleRoleAssignment": {
         "description": "Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)\n\nThe resource is not part of this structure.  Rather, [`RoleAssignment`]s are put into a [`Policy`] and that Policy is applied to a particular resource.",
         "type": "object",
         "properties": {
@@ -7347,7 +7347,7 @@
             "$ref": "#/components/schemas/IdentityType"
           },
           "role_name": {
-            "$ref": "#/components/schemas/OrganizationRoles"
+            "$ref": "#/components/schemas/OrganizationRole"
           }
         },
         "required": [
@@ -7456,7 +7456,7 @@
           "items"
         ]
       },
-      "ProjectRoles": {
+      "ProjectRole": {
         "type": "string",
         "enum": [
           "admin",
@@ -7464,7 +7464,7 @@
           "viewer"
         ]
       },
-      "ProjectRolesPolicy": {
+      "ProjectRolePolicy": {
         "description": "Client view of a [`Policy`], which describes how this resource may be accessed\n\nNote that the Policy only describes access granted explicitly for this resource.  The policies of parent resources can also cause a user to have access to this resource.",
         "type": "object",
         "properties": {
@@ -7472,7 +7472,7 @@
             "description": "Roles directly assigned on this resource",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ProjectRolesRoleAssignment"
+              "$ref": "#/components/schemas/ProjectRoleRoleAssignment"
             }
           }
         },
@@ -7480,7 +7480,7 @@
           "role_assignments"
         ]
       },
-      "ProjectRolesRoleAssignment": {
+      "ProjectRoleRoleAssignment": {
         "description": "Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)\n\nThe resource is not part of this structure.  Rather, [`RoleAssignment`]s are put into a [`Policy`] and that Policy is applied to a particular resource.",
         "type": "object",
         "properties": {
@@ -7492,7 +7492,7 @@
             "$ref": "#/components/schemas/IdentityType"
           },
           "role_name": {
-            "$ref": "#/components/schemas/ProjectRoles"
+            "$ref": "#/components/schemas/ProjectRole"
           }
         },
         "required": [
@@ -8360,7 +8360,7 @@
           "items"
         ]
       },
-      "SiloRoles": {
+      "SiloRole": {
         "type": "string",
         "enum": [
           "admin",
@@ -8368,7 +8368,7 @@
           "viewer"
         ]
       },
-      "SiloRolesPolicy": {
+      "SiloRolePolicy": {
         "description": "Client view of a [`Policy`], which describes how this resource may be accessed\n\nNote that the Policy only describes access granted explicitly for this resource.  The policies of parent resources can also cause a user to have access to this resource.",
         "type": "object",
         "properties": {
@@ -8376,7 +8376,7 @@
             "description": "Roles directly assigned on this resource",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SiloRolesRoleAssignment"
+              "$ref": "#/components/schemas/SiloRoleRoleAssignment"
             }
           }
         },
@@ -8384,7 +8384,7 @@
           "role_assignments"
         ]
       },
-      "SiloRolesRoleAssignment": {
+      "SiloRoleRoleAssignment": {
         "description": "Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)\n\nThe resource is not part of this structure.  Rather, [`RoleAssignment`]s are put into a [`Policy`] and that Policy is applied to a particular resource.",
         "type": "object",
         "properties": {
@@ -8396,7 +8396,7 @@
             "$ref": "#/components/schemas/IdentityType"
           },
           "role_name": {
-            "$ref": "#/components/schemas/SiloRoles"
+            "$ref": "#/components/schemas/SiloRole"
           }
         },
         "required": [


### PR DESCRIPTION
Our enums are generally not plural. An instance of the type is a role, not a roles.