### PR TITLE
Adds ability to override Oximeter's logging configuration

### DIFF
--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -137,6 +137,7 @@ pub async fn test_setup_with_config(
     // Set up an Oximeter collector server
     let collector_id = Uuid::parse_str(OXIMETER_UUID).unwrap();
     let oximeter = start_oximeter(
+        log.new(o!("component" => "oximeter")),
         server.http_server_internal.local_addr(),
         clickhouse.port(),
         collector_id,
@@ -192,6 +193,7 @@ pub async fn start_sled_agent(
 }
 
 pub async fn start_oximeter(
+    log: Logger,
     nexus_address: SocketAddr,
     db_port: u16,
     id: Uuid,
@@ -211,7 +213,7 @@ pub async fn start_oximeter(
         },
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Error },
     };
-    Oximeter::new(&config).await.map_err(|e| e.to_string())
+    Oximeter::with_logger(&config, log).await.map_err(|e| e.to_string())
 }
 
 #[derive(Debug, Clone, oximeter::Target)]

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -274,6 +274,7 @@ async fn test_oximeter_reregistration() {
 
     // Restart oximeter again, and verify that we have even more new data.
     context.oximeter = nexus_test_utils::start_oximeter(
+        context.logctx.log.new(o!("component" => "oximeter")),
         context.server.http_server_internal.local_addr(),
         context.clickhouse.port(),
         oximeter_id,


### PR DESCRIPTION
- Adds constructor for specifying a `slog::Logger` directly when making
  an `Oximeter` instance, overriding whatever's in the configuration.
- Set the logger for `Oximeter` in the tests, so everything logs to the
  same place