### PR TITLE
[nexus] Populate rack during initialization

### DIFF
--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -24,11 +24,15 @@ use tokio::io::AsyncWriteExt;
 static BASE_ARTIFACT_DIR: &str = "/var/tmp/oxide_artifacts";
 
 impl super::Nexus {
-    fn tuf_base_url(&self) -> Option<String> {
-        self.updates_config.as_ref().map(|c| {
-            let rack = self.as_rack();
+    async fn tuf_base_url(
+        &self,
+        opctx: &OpContext,
+    ) -> Result<Option<String>, Error> {
+        let rack = self.rack_lookup(opctx, &self.rack_id).await?;
+
+        Ok(self.updates_config.as_ref().map(|c| {
             rack.tuf_base_url.unwrap_or_else(|| c.default_base_url.clone())
-        })
+        }))
     }
 
     pub async fn updates_refresh_metadata(
@@ -42,10 +46,11 @@ impl super::Nexus {
                 message: "updates system not configured".into(),
             }
         })?;
-        let base_url =
-            self.tuf_base_url().ok_or_else(|| Error::InvalidRequest {
+        let base_url = self.tuf_base_url(opctx).await?.ok_or_else(|| {
+            Error::InvalidRequest {
                 message: "updates system not configured".into(),
-            })?;
+            }
+        })?;
         let trusted_root = tokio::fs::read(&updates_config.trusted_root)
             .await
             .map_err(|e| Error::InternalError {
@@ -129,8 +134,10 @@ impl super::Nexus {
         artifact: UpdateArtifact,
     ) -> Result<Vec<u8>, Error> {
         let mut base_url =
-            self.tuf_base_url().ok_or_else(|| Error::InvalidRequest {
-                message: "updates system not configured".into(),
+            self.tuf_base_url(opctx).await?.ok_or_else(|| {
+                Error::InvalidRequest {
+                    message: "updates system not configured".into(),
+                }
             })?;
         if !base_url.ends_with('/') {
             base_url.push('/');

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2940,11 +2940,13 @@ async fn hardware_racks_get(
     let query = query_params.into_inner();
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        let rack_stream = nexus
+        let racks = nexus
             .racks_list(&opctx, &data_page_params_for(&rqctx, &query)?)
-            .await?;
-        let view_list = to_list::<db::model::Rack, Rack>(rack_stream).await;
-        Ok(HttpResponseOk(ScanById::results_page(&query, view_list)?))
+            .await?
+            .into_iter()
+            .map(|r| r.into())
+            .collect();
+        Ok(HttpResponseOk(ScanById::results_page(&query, racks)?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/populate.rs
+++ b/nexus/src/populate.rs
@@ -43,13 +43,14 @@
 //! each populator behaves as expected in the above ways.
 
 use crate::context::OpContext;
-use crate::db::DataStore;
+use crate::db::{self, DataStore};
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use lazy_static::lazy_static;
 use omicron_common::api::external::Error;
 use omicron_common::backoff;
 use std::sync::Arc;
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub enum PopulateStatus {
@@ -58,14 +59,26 @@ pub enum PopulateStatus {
     Failed(String),
 }
 
+/// Auxiliary data necessary to populate the database.
+pub struct PopulateArgs {
+    rack_id: Uuid,
+}
+
+impl PopulateArgs {
+    pub fn new(rack_id: Uuid) -> Self {
+        Self { rack_id }
+    }
+}
+
 pub fn populate_start(
     opctx: OpContext,
     datastore: Arc<DataStore>,
+    args: PopulateArgs,
 ) -> tokio::sync::watch::Receiver<PopulateStatus> {
     let (tx, rx) = tokio::sync::watch::channel(PopulateStatus::NotDone);
 
     tokio::spawn(async move {
-        let result = populate(&opctx, &datastore).await;
+        let result = populate(&opctx, &datastore, &args).await;
         if let Err(error) = tx.send(match result {
             Ok(()) => PopulateStatus::Done,
             Err(message) => PopulateStatus::Failed(message),
@@ -80,17 +93,19 @@ pub fn populate_start(
 async fn populate(
     opctx: &OpContext,
     datastore: &DataStore,
+    args: &PopulateArgs,
 ) -> Result<(), String> {
     for p in *ALL_POPULATORS {
         let db_result = backoff::retry_notify(
             backoff::internal_service_policy(),
             || async {
-                p.populate(opctx, datastore).await.map_err(|error| match &error
-                {
-                    Error::ServiceUnavailable { .. } => {
-                        backoff::BackoffError::transient(error)
+                p.populate(opctx, datastore, args).await.map_err(|error| {
+                    match &error {
+                        Error::ServiceUnavailable { .. } => {
+                            backoff::BackoffError::transient(error)
+                        }
+                        _ => backoff::BackoffError::Permanent(error),
                     }
-                    _ => backoff::BackoffError::Permanent(error),
                 })
             },
             |error, delay| {
@@ -130,6 +145,7 @@ trait Populator: std::fmt::Debug + Send + Sync {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b;
@@ -143,6 +159,7 @@ impl Populator for PopulateBuiltinUsers {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -159,6 +176,7 @@ impl Populator for PopulateBuiltinRoles {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -175,6 +193,7 @@ impl Populator for PopulateBuiltinRoleAssignments {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -192,6 +211,7 @@ impl Populator for PopulateBuiltinSilos {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -214,6 +234,7 @@ impl Populator for PopulateSiloUsers {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -230,6 +251,7 @@ impl Populator for PopulateSiloUserRoleAssignments {
         &self,
         opctx: &'a OpContext,
         datastore: &'a DataStore,
+        _args: &'a PopulateArgs,
     ) -> BoxFuture<'b, Result<(), Error>>
     where
         'a: 'b,
@@ -241,19 +263,43 @@ impl Populator for PopulateSiloUserRoleAssignments {
     }
 }
 
+#[derive(Debug)]
+struct PopulateRack;
+impl Populator for PopulateRack {
+    fn populate<'a, 'b>(
+        &self,
+        opctx: &'a OpContext,
+        datastore: &'a DataStore,
+        args: &'a PopulateArgs,
+    ) -> BoxFuture<'b, Result<(), Error>>
+    where
+        'a: 'b,
+    {
+        async {
+            datastore
+                .rack_insert(opctx, &db::model::Rack::new(args.rack_id))
+                .await?;
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
 lazy_static! {
-    static ref ALL_POPULATORS: [&'static dyn Populator; 6] = [
+    static ref ALL_POPULATORS: [&'static dyn Populator; 7] = [
         &PopulateBuiltinUsers,
         &PopulateBuiltinRoles,
         &PopulateBuiltinRoleAssignments,
         &PopulateBuiltinSilos,
         &PopulateSiloUsers,
         &PopulateSiloUserRoleAssignments,
+        &PopulateRack,
     ];
 }
 
 #[cfg(test)]
 mod test {
+    use super::PopulateArgs;
     use super::Populator;
     use super::ALL_POPULATORS;
     use crate::authn;
@@ -265,6 +311,7 @@ mod test {
     use omicron_common::api::external::Error;
     use omicron_test_utils::dev;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_populators() {
@@ -287,16 +334,18 @@ mod test {
         );
         let log = &logctx.log;
 
+        let args = PopulateArgs::new(Uuid::new_v4());
+
         // Running each populator once under normal conditions should work.
         info!(&log, "populator {:?}, run 1", p);
-        p.populate(&opctx, &datastore)
+        p.populate(&opctx, &datastore, &args)
             .await
             .with_context(|| format!("populator {:?} (try 1)", p))
             .unwrap();
 
         // It should also work fine to run it again.
         info!(&log, "populator {:?}, run 2 (idempotency check)", p);
-        p.populate(&opctx, &datastore)
+        p.populate(&opctx, &datastore, &args)
             .await
             .with_context(|| {
                 format!(
@@ -331,7 +380,7 @@ mod test {
         );
 
         info!(&log, "populator {:?}, with database offline", p);
-        match p.populate(&opctx, &datastore).await {
+        match p.populate(&opctx, &datastore, &args).await {
             Err(Error::ServiceUnavailable { .. }) => (),
             Ok(_) => panic!(
                 "populator {:?}: unexpectedly succeeded with no database",


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/omicron/pull/1216

- Populates Rack row in DB during initialization
- Modifies Rack-based lookups to avoid relying on in-memory cache