### PR TITLE
Import maghemite mg-ddm service

### DIFF
--- a/deploy/src/bin/thing-flinger.rs
+++ b/deploy/src/bin/thing-flinger.rs
@@ -480,19 +480,16 @@ fn overlay_sled_agent(
 
     // TODO do we need any escaping here? this will definitely break if any dir
     // names have spaces
-    let dirs = sled_agent_dirs
-        .iter()
-        .map(|dir| format!(" --directories {}", dir.display()))
-        .collect::<String>();
+    let dirs = sled_agent_dirs.iter().map(|dir| format!(" {}", dir.display()));
 
     let cmd = format!(
         "sh -c 'for dir in {}; do mkdir -p $dir; done' && \
             cd {} && \
             cargo run {} --bin sled-agent-overlay-files -- {}",
-        dirs,
+        dirs.clone().collect::<String>(),
         config.builder.omicron_path.to_string_lossy(),
         config.release_arg(),
-        dirs
+        dirs.map(|dir| format!(" --directories {}", dir)).collect::<String>(),
     );
     ssh_exec(builder, &cmd, false)
 }

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -102,3 +102,14 @@ commit = "d2b8184d11d5d5f56424fe0bee13ca03d576604e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
 sha256 = "b192fbaaee850e63adaf9f7fe5ff2054a9de338d70198b1d1670285057a047be"
+
+[external_package.maghemite]
+service_name = "mg-ddm"
+zone = false
+[external_package.maghemite.source]
+type = "prebuilt"
+repo = "maghemite"
+commit = "2be097ddd1d3fd8e7f56bc0a4bfd696253b11454"
+# The SHA256 digest is automatically posted to:
+# https://buildomat.eng.oxide.computer/public/file/oxidecomputer/maghemite/image/<commit>/mg-ddm.sha256.txt
+sha256 = "94218915ec6fed75dcc81d736bd5e9ef62c9eb651a67a943b297d94d6b390941"

--- a/sled-agent/src/bootstrap/maghemite.rs
+++ b/sled-agent/src/bootstrap/maghemite.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Starting the mg-ddm service.
+
+use crate::illumos::addrobj::AddrObject;
+use slog::Logger;
+use thiserror::Error;
+
+const SERVICE_FMRI: &str = "svc:/system/illumos/mg-ddm";
+const MANIFEST_PATH: &str = "/opt/oxide/mg-ddm/pkg/ddm/manifest.xml";
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error configuring service: {0}")]
+    Config(#[from] smf::ConfigError),
+
+    #[error("Error administering service: {0}")]
+    Adm(#[from] smf::AdmError),
+
+    #[error("Error starting service: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+
+pub async fn enable_mg_ddm_service(
+    log: Logger,
+    interface: AddrObject,
+) -> Result<(), Error> {
+    tokio::task::spawn_blocking(|| {
+        enable_mg_ddm_service_blocking(log, interface)
+    })
+    .await?
+}
+
+fn enable_mg_ddm_service_blocking(
+    log: Logger,
+    interface: AddrObject,
+) -> Result<(), Error> {
+    info!(log, "Importing mg-ddm service"; "path" => MANIFEST_PATH);
+    smf::Config::import().run(MANIFEST_PATH)?;
+
+    // TODO-cleanup mg-ddm supports multiple interfaces, but `smf` currently
+    // doesn't expose an equivalent of `svccfg addpropvalue`. If we need
+    // multiple interfaces we'll need to extend smf.
+    let interface = interface.to_string();
+    info!(log, "Setting mg-ddm interface"; "interface" => interface.as_str());
+    smf::Config::set_property(SERVICE_FMRI).run(smf::Property::new(
+        smf::PropertyName::new("config", "interfaces").unwrap(),
+        smf::PropertyValue::Astring(interface),
+    ))?;
+
+    info!(log, "Enabling mg-ddm service");
+    smf::Adm::new()
+        .enable()
+        .temporary()
+        .run(smf::AdmSelection::ByPattern(&[SERVICE_FMRI]))?;
+
+    Ok(())
+}

--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -8,6 +8,7 @@ pub mod agent;
 pub mod client;
 pub mod config;
 pub mod discovery;
+mod maghemite;
 pub mod multicast;
 pub(crate) mod params;
 pub(crate) mod rss_handle;


### PR DESCRIPTION
This is PR 1 of 3 to get to the point of advertising bootstrap addresses via maghemite instead of UDP multicast. It adds the `mg-ddm` global zone service as an external package (from the private maghemite repo). I tweaked `omicron-package` to untar all global zone packages (previously `sled-agent` was the only global zone service), and have bootstrap-agent starting the service early in its life.

There are a few TODOs in this; I'm happy to address them on the PR or open issues to follow up later. The most critical is the one about using `"linklocal"` when constructing an `AddrObject`; if that assumption is wrong it might break even single-sled deployments.