### PR TITLE
Script to populate alpine image

### DIFF
--- a/tools/populate/populate-alpine.sh
+++ b/tools/populate/populate-alpine.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Simple script to install the alpine image included with propolis.
+
+if ! oxide api images > /dev/null; then
+        echo "Problem detected running the oxide CLI"
+    echo "Please install, set path, or setup authorization"
+    exit 1
+fi
+
+oxide api /images --method POST --input - <<EOF
+{
+  "name": "alpine",
+  "description": "boot from propolis zone blob!",
+  "block_size": 512,
+  "distribution": {
+    "name": "alpine",
+    "version": "propolis-blob"
+  },
+  "source": {
+    "type": "you_can_boot_anything_as_long_as_its_alpine"
+  }
+}
+EOF
+if [[ $? -ne 0 ]]; then
+        echo "There was a problem installing the alpine image"
+    echo "Please check Nexus logs for possible clues"
+    echo "pfexec zlogin oxz_nexus \"tail \\\$(svcs -L nexus)\""
+    exit 1
+fi


### PR DESCRIPTION
A simple script to add alpine to list of images provided by the rack.
I made a little effort to fail with some grace for common problems.

When there is an error with the `oxide` command"
```
$ ./tools/populate/populate-alpine.sh 
./tools/populate/populate-alpine.sh: line 4: oxide: command not found
Problem detected running the oxide CLI
Please install, set path, or setup authorization
```
When the CLI is not authorized:
```
$ ./tools/populate/populate-alpine.sh 
No hosts found. Try logging in with `oxide auth login`.
Problem detected running the oxide CLI
Please install, set path, or setup authorization
```

When things work:
```
$ ./tools/populate/populate-alpine.sh
{
  "block_size": 512,
  "description": "boot from propolis zone blob!",
  "digest": null,
  "distribution": "alpine",
  "id": "f327252a-4c86-4868-a2cb-f7d0dcf97447",
  "name": "alpine",
  "size": 104857600,
  "time_created": "2022-06-23T22:24:33.788250Z",
  "time_modified": "2022-06-23T22:24:33.788250Z",
  "url": null,
  "version": "propolis-blob"
}
```

When the image creation fails:
```
$ ./tools/populate/populate-alpine.sh
400 Bad Request Bad Request
There was a problem installing the alpine image
Please check Nexus logs for possible clues
pfexec zlogin oxz_nexus "tail \$(svcs -L nexus)"
```