### PR TITLE
pagination should not require `ObjectIdentity`

### DIFF
--- a/common/src/api/external/http_pagination.rs
+++ b/common/src/api/external/http_pagination.rs
@@ -130,10 +130,7 @@ pub trait ScanParams:
 ///
 /// This is intended for use with [`ScanByName::results_page`] with objects that
 /// impl [`ObjectIdentity`].
-pub fn marker_for_name<S, T: ObjectIdentity>(
-    _: &S,
-    t: &T,
-) -> Name {
+pub fn marker_for_name<S, T: ObjectIdentity>(_: &S, t: &T) -> Name {
     t.identity().name.clone()
 }
 
@@ -141,10 +138,7 @@ pub fn marker_for_name<S, T: ObjectIdentity>(
 ///
 /// This is intended for use with [`ScanById::results_page`] with objects that
 /// impl [`ObjectIdentity`].
-pub fn marker_for_id<S, T: ObjectIdentity>(
-    _: &S,
-    t: &T,
-) -> Uuid {
+pub fn marker_for_id<S, T: ObjectIdentity>(_: &S, t: &T) -> Uuid {
     t.identity().id
 }
 

--- a/common/src/api/external/http_pagination.rs
+++ b/common/src/api/external/http_pagination.rs
@@ -126,22 +126,34 @@ pub trait ScanParams:
     }
 }
 
-// XXX-dap figure out where else to put this
-pub fn marker_for_object_identity_name<S, T: ObjectIdentity>(
+/// Marker function that extracts the "name" from an object
+///
+/// This is intended for use with [`ScanByName::results_page`] with objects that
+/// impl [`ObjectIdentity`].
+pub fn marker_for_name<S, T: ObjectIdentity>(
     _: &S,
     t: &T,
 ) -> Name {
     t.identity().name.clone()
 }
 
-pub fn marker_for_object_identity_id<S, T: ObjectIdentity>(
+/// Marker function that extracts the "id" from an object
+///
+/// This is intended for use with [`ScanById::results_page`] with objects that
+/// impl [`ObjectIdentity`].
+pub fn marker_for_id<S, T: ObjectIdentity>(
     _: &S,
     t: &T,
 ) -> Uuid {
     t.identity().id
 }
 
-pub fn marker_for_object_identity_name_or_id<T: ObjectIdentity>(
+/// Marker function that extracts the "name" or "id" from an object, depending
+/// on the scan in use
+///
+/// This is intended for use with [`ScanByNameOrId::results_page`] with objects
+/// that impl [`ObjectIdentity`].
+pub fn marker_for_name_or_id<T: ObjectIdentity>(
     scan: &ScanByNameOrId,
     item: &T,
 ) -> NameOrIdMarker {
@@ -363,15 +375,6 @@ impl ScanParams for ScanByNameOrId {
         }
     }
 
-    // XXX-dap
-    // fn marker_for_item<T: ObjectIdentity>(&self, item: &T) -> NameOrIdMarker {
-    //     let identity = item.identity();
-    //     match pagination_field_for_scan_params(self) {
-    //         PagField::Name => NameOrIdMarker::Name(identity.name.clone()),
-    //         PagField::Id => NameOrIdMarker::Id(identity.id),
-    //     }
-    // }
-
     fn from_query(
         p: &PaginationParams<Self, PageSelector<Self, Self::MarkerValue>>,
     ) -> Result<&Self, HttpError> {
@@ -473,9 +476,9 @@ mod test {
     use super::data_page_params_nameid_id_limit;
     use super::data_page_params_nameid_name_limit;
     use super::data_page_params_with_limit;
-    use super::marker_for_object_identity_id;
-    use super::marker_for_object_identity_name;
-    use super::marker_for_object_identity_name_or_id;
+    use super::marker_for_id;
+    use super::marker_for_name;
+    use super::marker_for_name_or_id;
     use super::page_selector_for;
     use super::pagination_field_for_scan_params;
     use super::IdSortMode;
@@ -726,7 +729,7 @@ mod test {
             &"thing0".parse().unwrap(),
             &"thing19".parse().unwrap(),
             &scan,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         );
         assert_eq!(scan.direction(), PaginationOrder::Ascending);
 
@@ -766,7 +769,7 @@ mod test {
             &list[0].identity.id,
             &list[list.len() - 1].identity.id,
             &scan,
-            &marker_for_object_identity_id,
+            &marker_for_id,
         );
         assert_eq!(scan.direction(), PaginationOrder::Ascending);
 
@@ -832,7 +835,7 @@ mod test {
             &thing0_marker,
             &thinglast_marker,
             &ScanByNameOrId { sort_by: NameOrIdSortMode::NameAscending },
-            &marker_for_object_identity_name_or_id,
+            &marker_for_name_or_id,
         );
 
         // Verify data pages based on the query params.
@@ -871,7 +874,7 @@ mod test {
             &thing0_marker,
             &thinglast_marker,
             &ScanByNameOrId { sort_by: NameOrIdSortMode::NameAscending },
-            &marker_for_object_identity_name_or_id,
+            &marker_for_name_or_id,
         );
 
         // Verify data pages based on the query params.

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -867,44 +867,15 @@ impl DiskState {
 // These are currently only intended for observability by developers.  We will
 // eventually want to flesh this out into something more observable for end
 // users.
-#[derive(ObjectIdentity, Clone, Debug, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct Saga {
     pub id: Uuid,
     pub state: SagaState,
-    // TODO-cleanup This object contains a fake `IdentityMetadata`.  Why?  We
-    // want to paginate these objects.  http_pagination.rs provides a bunch of
-    // useful facilities -- notably `PaginatedById`.  `PaginatedById`
-    // requires being able to take an arbitrary object in the result set and get
-    // its id.  To do that, it uses the `ObjectIdentity` trait, which expects
-    // to be able to return an `IdentityMetadata` reference from an object.
-    // Finally, the pagination facilities just pull the `id` out of that.
-    //
-    // In this case (as well as others, like sleds and racks), we have ids, and
-    // we want to be able to paginate by id, but we don't have full identity
-    // metadata.  (Or we do, but it's similarly faked up.)  What we should
-    // probably do is create a new trait, say `ObjectId`, that returns _just_
-    // an id.  We can provide a blanket impl for anything that impls
-    // IdentityMetadata.  We can define one-off impls for structs like this
-    // one.  Then the id-only pagination interfaces can require just
-    // `ObjectId`.
-    #[serde(skip)]
-    pub identity: IdentityMetadata,
 }
 
 impl From<steno::SagaView> for Saga {
     fn from(s: steno::SagaView) -> Self {
-        Saga {
-            id: Uuid::from(s.id),
-            state: SagaState::from(s.state),
-            identity: IdentityMetadata {
-                // TODO-cleanup See the note in Saga above.
-                id: Uuid::from(s.id),
-                name: format!("saga-{}", s.id).parse().unwrap(),
-                description: format!("saga {}", s.id),
-                time_created: Utc::now(),
-                time_modified: Utc::now(),
-            },
-        }
+        Saga { id: Uuid::from(s.id), state: SagaState::from(s.state) }
     }
 }
 

--- a/nexus/src/authn/mod.rs
+++ b/nexus/src/authn/mod.rs
@@ -186,7 +186,7 @@ impl Context {
         Context {
             kind: Kind::Authenticated(Details {
                 actor: Actor::SiloUser {
-                    silo_user_id: USER_TEST_PRIVILEGED.identity().id,
+                    silo_user_id: USER_TEST_PRIVILEGED.id(),
                     silo_id: USER_TEST_PRIVILEGED.silo_id,
                 },
             }),
@@ -201,7 +201,7 @@ impl Context {
         Context {
             kind: Kind::Authenticated(Details {
                 actor: Actor::SiloUser {
-                    silo_user_id: USER_TEST_UNPRIVILEGED.identity().id,
+                    silo_user_id: USER_TEST_UNPRIVILEGED.id(),
                     silo_id: USER_TEST_UNPRIVILEGED.silo_id,
                 },
             }),

--- a/nexus/src/db/identity.rs
+++ b/nexus/src/db/identity.rs
@@ -49,14 +49,4 @@ pub trait Asset {
     fn id(&self) -> Uuid;
     fn time_created(&self) -> DateTime<Utc>;
     fn time_modified(&self) -> DateTime<Utc>;
-
-    fn identity(&self) -> external::IdentityMetadata {
-        external::IdentityMetadata {
-            id: self.id(),
-            name: "no-name".parse().unwrap(),
-            description: "no description".to_string(),
-            time_created: self.time_created(),
-            time_modified: self.time_modified(),
-        }
-    }
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -36,6 +36,9 @@ use dropshot::TypedBody;
 use dropshot::WhichPage;
 use omicron_common::api::external::http_pagination::data_page_params_nameid_id;
 use omicron_common::api::external::http_pagination::data_page_params_nameid_name;
+use omicron_common::api::external::http_pagination::marker_for_object_identity_id;
+use omicron_common::api::external::http_pagination::marker_for_object_identity_name;
+use omicron_common::api::external::http_pagination::marker_for_object_identity_name_or_id;
 use omicron_common::api::external::http_pagination::pagination_field_for_scan_params;
 use omicron_common::api::external::http_pagination::PagField;
 use omicron_common::api::external::http_pagination::PaginatedById;
@@ -335,7 +338,11 @@ async fn silos_get(
         .into_iter()
         .map(|p| p.into())
         .collect();
-        Ok(HttpResponseOk(ScanByNameOrId::results_page(&query, silos)?))
+        Ok(HttpResponseOk(ScanByNameOrId::results_page(
+            &query,
+            silos,
+            &marker_for_object_identity_name_or_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -495,6 +502,7 @@ async fn silos_get_identity_providers(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             identity_providers,
+            &marker_for_object_identity_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -603,7 +611,11 @@ async fn organizations_get(
         .into_iter()
         .map(|p| p.into())
         .collect();
-        Ok(HttpResponseOk(ScanByNameOrId::results_page(&query, organizations)?))
+        Ok(HttpResponseOk(ScanByNameOrId::results_page(
+            &query,
+            organizations,
+            &marker_for_object_identity_name_or_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -821,7 +833,11 @@ async fn organization_projects_get(
         .into_iter()
         .map(|p| p.into())
         .collect();
-        Ok(HttpResponseOk(ScanByNameOrId::results_page(&query, projects)?))
+        Ok(HttpResponseOk(ScanByNameOrId::results_page(
+            &query,
+            projects,
+            &marker_for_object_identity_name_or_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1043,7 +1059,11 @@ async fn project_disks_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, disks)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            disks,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1179,7 +1199,11 @@ async fn project_instances_get(
             .into_iter()
             .map(|i| i.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, instances)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            instances,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1488,7 +1512,11 @@ async fn instance_disks_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, disks)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            disks,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1587,7 +1615,11 @@ async fn images_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, images)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            images,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1706,7 +1738,11 @@ async fn project_images_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, images)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            images,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -1858,7 +1894,11 @@ async fn instance_network_interfaces_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, interfaces)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            interfaces,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2044,7 +2084,11 @@ async fn project_snapshots_get(
             .into_iter()
             .map(|d| d.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, snapshots)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            snapshots,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2185,7 +2229,11 @@ async fn project_vpcs_get(
             .map(|p| p.into())
             .collect();
 
-        Ok(HttpResponseOk(ScanByName::results_page(&query, vpcs)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            vpcs,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2347,7 +2395,11 @@ async fn vpc_subnets_get(
             .into_iter()
             .map(|vpc| vpc.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, vpcs)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            vpcs,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2511,7 +2563,11 @@ async fn subnet_network_interfaces_get(
             .into_iter()
             .map(|interfaces| interfaces.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, interfaces)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            interfaces,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2617,7 +2673,11 @@ async fn vpc_routers_get(
             .into_iter()
             .map(|s| s.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, routers)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            routers,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2784,7 +2844,11 @@ async fn routers_routes_get(
             .into_iter()
             .map(|route| route.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, routes)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            routes,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2944,7 +3008,11 @@ async fn hardware_racks_get(
             .racks_list(&opctx, &data_page_params_for(&rqctx, &query)?)
             .await?;
         let view_list = to_list::<db::model::Rack, Rack>(rack_stream).await;
-        Ok(HttpResponseOk(ScanById::results_page(&query, view_list)?))
+        Ok(HttpResponseOk(ScanById::results_page(
+            &query,
+            view_list,
+            &marker_for_object_identity_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -3000,7 +3068,11 @@ async fn hardware_sleds_get(
             .into_iter()
             .map(|s| s.into())
             .collect();
-        Ok(HttpResponseOk(ScanById::results_page(&query, sleds)?))
+        Ok(HttpResponseOk(ScanById::results_page(
+            &query,
+            sleds,
+            &marker_for_object_identity_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -3074,7 +3146,11 @@ async fn sagas_get(
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let saga_stream = nexus.sagas_list(&opctx, &pagparams).await?;
         let view_list = to_list(saga_stream).await;
-        Ok(HttpResponseOk(ScanById::results_page(&query, view_list)?))
+        Ok(HttpResponseOk(ScanById::results_page(
+            &query,
+            view_list,
+            &marker_for_object_identity_id,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -3131,7 +3207,11 @@ async fn users_get(
             .into_iter()
             .map(|i| i.into())
             .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, users)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            users,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -3299,7 +3379,11 @@ async fn sshkeys_get(
             .into_iter()
             .map(SshKey::from)
             .collect::<Vec<SshKey>>();
-        Ok(HttpResponseOk(ScanByName::results_page(&query, ssh_keys)?))
+        Ok(HttpResponseOk(ScanByName::results_page(
+            &query,
+            ssh_keys,
+            &marker_for_object_identity_name,
+        )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -36,9 +36,8 @@ use dropshot::TypedBody;
 use dropshot::WhichPage;
 use omicron_common::api::external::http_pagination::data_page_params_nameid_id;
 use omicron_common::api::external::http_pagination::data_page_params_nameid_name;
-use omicron_common::api::external::http_pagination::marker_for_object_identity_id;
-use omicron_common::api::external::http_pagination::marker_for_object_identity_name;
-use omicron_common::api::external::http_pagination::marker_for_object_identity_name_or_id;
+use omicron_common::api::external::http_pagination::marker_for_name;
+use omicron_common::api::external::http_pagination::marker_for_name_or_id;
 use omicron_common::api::external::http_pagination::pagination_field_for_scan_params;
 use omicron_common::api::external::http_pagination::PagField;
 use omicron_common::api::external::http_pagination::PaginatedById;
@@ -341,7 +340,7 @@ async fn silos_get(
         Ok(HttpResponseOk(ScanByNameOrId::results_page(
             &query,
             silos,
-            &marker_for_object_identity_name_or_id,
+            &marker_for_name_or_id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -502,7 +501,7 @@ async fn silos_get_identity_providers(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             identity_providers,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -614,7 +613,7 @@ async fn organizations_get(
         Ok(HttpResponseOk(ScanByNameOrId::results_page(
             &query,
             organizations,
-            &marker_for_object_identity_name_or_id,
+            &marker_for_name_or_id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -836,7 +835,7 @@ async fn organization_projects_get(
         Ok(HttpResponseOk(ScanByNameOrId::results_page(
             &query,
             projects,
-            &marker_for_object_identity_name_or_id,
+            &marker_for_name_or_id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1062,7 +1061,7 @@ async fn project_disks_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             disks,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1202,7 +1201,7 @@ async fn project_instances_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             instances,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1515,7 +1514,7 @@ async fn instance_disks_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             disks,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1618,7 +1617,7 @@ async fn images_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             images,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1741,7 +1740,7 @@ async fn project_images_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             images,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1897,7 +1896,7 @@ async fn instance_network_interfaces_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             interfaces,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2087,7 +2086,7 @@ async fn project_snapshots_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             snapshots,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2232,7 +2231,7 @@ async fn project_vpcs_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             vpcs,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2398,7 +2397,7 @@ async fn vpc_subnets_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             vpcs,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2566,7 +2565,7 @@ async fn subnet_network_interfaces_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             interfaces,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2676,7 +2675,7 @@ async fn vpc_routers_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             routers,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -2847,7 +2846,7 @@ async fn routers_routes_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             routes,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -3011,7 +3010,7 @@ async fn hardware_racks_get(
         Ok(HttpResponseOk(ScanById::results_page(
             &query,
             view_list,
-            &marker_for_object_identity_id,
+            &|_, rack: &Rack| rack.identity.id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -3071,7 +3070,7 @@ async fn hardware_sleds_get(
         Ok(HttpResponseOk(ScanById::results_page(
             &query,
             sleds,
-            &marker_for_object_identity_id,
+            &|_, sled: &Sled| sled.identity.id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -3149,7 +3148,7 @@ async fn sagas_get(
         Ok(HttpResponseOk(ScanById::results_page(
             &query,
             view_list,
-            &marker_for_object_identity_id,
+            &|_, saga: &Saga| saga.id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -3210,7 +3209,7 @@ async fn users_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             users,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -3382,7 +3381,7 @@ async fn sshkeys_get(
         Ok(HttpResponseOk(ScanByName::results_page(
             &query,
             ssh_keys,
-            &marker_for_object_identity_name,
+            &marker_for_name,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -17,6 +17,33 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddrV6;
 use uuid::Uuid;
 
+// IDENTITY METADATA
+
+/// Identity-related metadata that's included in "asset" public API objects
+/// (which generally have no name or description)
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct AssetIdentityMetadata {
+    /// unique, immutable, system-controlled identifier for each resource
+    pub id: Uuid,
+    /// timestamp when this resource was created
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    /// timestamp when this resource was last modified
+    pub time_modified: chrono::DateTime<chrono::Utc>,
+}
+
+impl<T> From<&T> for AssetIdentityMetadata
+where
+    T: Asset,
+{
+    fn from(t: &T) -> Self {
+        AssetIdentityMetadata {
+            id: t.id(),
+            time_created: t.time_created(),
+            time_modified: t.time_modified(),
+        }
+    }
+}
+
 // SILOS
 
 /// Client view of a ['Silo']
@@ -318,31 +345,34 @@ impl From<model::VpcRouter> for VpcRouter {
 // RACKS
 
 /// Client view of an [`Rack`]
-#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Rack {
     #[serde(flatten)]
-    pub identity: IdentityMetadata,
+    pub identity: AssetIdentityMetadata,
 }
 
 impl From<model::Rack> for Rack {
     fn from(rack: model::Rack) -> Self {
-        Self { identity: rack.identity() }
+        Self { identity: AssetIdentityMetadata::from(&rack) }
     }
 }
 
 // SLEDS
 
 /// Client view of an [`Sled`]
-#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Sled {
     #[serde(flatten)]
-    pub identity: IdentityMetadata,
+    pub identity: AssetIdentityMetadata,
     pub service_address: SocketAddrV6,
 }
 
 impl From<model::Sled> for Sled {
     fn from(sled: model::Sled) -> Self {
-        Self { identity: sled.identity(), service_address: sled.address() }
+        Self {
+            identity: AssetIdentityMetadata::from(&sled),
+            service_address: sled.address(),
+        }
     }
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7523,22 +7523,10 @@
         "description": "Client view of an [`Rack`]",
         "type": "object",
         "properties": {
-          "description": {
-            "description": "human-readable free-form text about a resource",
-            "type": "string"
-          },
           "id": {
             "description": "unique, immutable, system-controlled identifier for each resource",
             "type": "string",
             "format": "uuid"
-          },
-          "name": {
-            "description": "unique, mutable, user-controlled identifier for each resource",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
           },
           "time_created": {
             "description": "timestamp when this resource was created",
@@ -7552,9 +7540,7 @@
           }
         },
         "required": [
-          "description",
           "id",
-          "name",
           "time_created",
           "time_modified"
         ]
@@ -8409,22 +8395,10 @@
         "description": "Client view of an [`Sled`]",
         "type": "object",
         "properties": {
-          "description": {
-            "description": "human-readable free-form text about a resource",
-            "type": "string"
-          },
           "id": {
             "description": "unique, immutable, system-controlled identifier for each resource",
             "type": "string",
             "format": "uuid"
-          },
-          "name": {
-            "description": "unique, mutable, user-controlled identifier for each resource",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
           },
           "service_address": {
             "type": "string"
@@ -8441,9 +8415,7 @@
           }
         },
         "required": [
-          "description",
           "id",
-          "name",
           "service_address",
           "time_created",
           "time_modified"


### PR DESCRIPTION
Fixes #1262 and I consider this a blocker for #1261.

## Background

Most objects in the API have identity metadata (mentioned in RFD 4).  There are two flavors: _asset_ identity metadata includes an id, time_created, and time_modified.  This is used for Racks and Sleds and eventually for anything that it doesn't really make sense for a human to give a "name" to.  _resource_ identity metadata includes the same fields, plus a client-controlled "name" (a unique identifier in the parent collection -- see RFD 192) and "description".

The HTTP pagination module has some canned implementations for things like ScanByName, ScanById, and ScanByNameOrId.  These are oriented around _resources_ -- that is, things with resource identity metadata.  They require that the objects you're listing impl `ObjectIdentity`, which has [one function that returns the `IdentityMetadata` (which means _resource_ identity metadata) for the object](https://github.com/oxidecomputer/omicron/blob/4220e39cdb8100707ffe5df6e24588d1adb60e76/common/src/api/external/mod.rs#L63-L67).

## The problem

The simple problem is that there's not a great way today to use `ScanById` with things that only have asset identity metadata.

* For Racks and Sleds, we worked around this by faking up the fields they don't have.  This is kind of confusing for the reasons mentioned in #1262.
* For Sagas, we worked around this by putting a fake IdentityMetadata into the object, but we used `#[serde(skip)]` so at least clients couldn't tell.
* Under #1261, I need to make this work for Silo Users.  I couldn't use the workaround that we use for Sagas because it doesn't work for types that also impl Deserialize.  (serde needs to put _something_ into the in-memory object on deserialization.  It can supply a default value, but that wouldn't be right for the fake field here -- its id has to match the real id of the object.)  I didn't want to do what we did with Racks and Sleds in part because people would almost certainly expect "name" to mean something on a `User`, so filling in "no-name" for every user seemed especially bad.

## The solution

Another way of stating the problem above is that in order to make HTTP pagination as ergonomic as possible to use, we implemented the `ScanBy{Name,Id,NameOrId}` types to encapsulate the large number of nitty details associated with pagination (defining types for the scan params and pagination params, defining the marker type, defining how to get the marker value from each object, etc.).  But it went a little too far: we basically want to use `ScanById`, but let the caller plug in their own mechanism for mapping an item to its corresponding marker value (rather than assuming everything impls `ObjectIdentity` and using that to produce the marker value).

The solution here is that _all_ callers of `ResultsPage::new` (so, basically all users of pagination) have to supply a new argument for mapping the items in their list to the marker value.  We provide a couple of functions to be used with `ScanByName`, `ScanById`, and `ScanByNameOrId` when the item _does_ impl `ObjectIdentity`.  In other words, it's a _little_ more verbose than it used to be, but still pretty easy to use (and importantly hard to get wrong).  Callers with objects that _don't_ impl `ObjectIdentity` can provide their own closure that gets the id however they want.

I'm not super happy with the proliferation of closures, but I think it's basically fine for the consumers of this API.  If folks have better ways to express this that don't create a huge blast radius, that'd be cool.  (For example, I considered having `ScanParams` take a type argument that you'd use to plug in an impl of a trait that gets the marker value out, but this has a large blast radius, its own ugliness (PhantomData fields), and I think it'd be worse for callers.)  Urgency is a priority at the moment.