### PR TITLE
authz initialization messages should be "info" level

### DIFF
--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -48,7 +48,7 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<Oso, anyhow::Error> {
         ConsoleSessionList::get_polar_class(),
     ];
     for c in classes {
-        trace!(log, "registering Oso class"; "class" => &c.name);
+        info!(log, "registering Oso class"; "class" => &c.name);
         oso.register_class(c).context("registering class")?;
     }
 
@@ -85,11 +85,11 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<Oso, anyhow::Error> {
         .join("\n");
 
     for init in generated_inits {
-        trace!(log, "registering Oso class"; "class" => &init.polar_class.name);
+        info!(log, "registering Oso class"; "class" => &init.polar_class.name);
         oso.register_class(init.polar_class).context("registering class")?;
     }
 
-    trace!(log, "full Oso configuration"; "config" => &polar_config);
+    info!(log, "full Oso configuration"; "config" => &polar_config);
     oso.load_str(&polar_config).context("loading Polar (Oso) config")?;
     Ok(oso)
 }


### PR DESCRIPTION
The authz subsystem emits a bunch of log messages during startup at the "trace" level.  I think they should be "info" level.  There's a constant number of them and it's only at startup time so it's not like this should have a big impact on runtime behavior.  And they're very helpful for getting the ground truth on what Oso policy and environment is set up, which is helpful for authz debugging.

Note one of these messages dumps out the whole Oso policy, which is huge.  Maybe people will find this annoying?  But it's part of what's really helpful to have and I think will be helpful in production if we have unexpected authz issues.