### PR TITLE
Break from loop when further attempting to read from propolis serial is pointless

### DIFF
--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -182,12 +182,13 @@ impl SerialConsoleBuffer {
             match connect_future.await {
                 Ok((mut websocket, _)) => loop {
                     match websocket.next().await {
-                        None => {}
+                        None => break,
                         Some(Err(e)) => {
                             error!(
                                 log,
                                 "Reading TTY from {}: {:?}", &ws_uri, e
                             );
+                            break;
                         }
                         Some(Ok(Message::Close(details))) => {
                             info!(
@@ -200,6 +201,7 @@ impl SerialConsoleBuffer {
                                     String::new()
                                 }
                             );
+                            break;
                         }
                         Some(Ok(Message::Text(text))) => {
                             data_inner.write().await.consume(text.into_bytes());


### PR DESCRIPTION
This attempts to address CPU usage issues observed in https://github.com/oxidecomputer/omicron/issues/1264
(and also fixes an oversight wherein the read loop isn't abandoned when the connection is closed)