### PR TITLE
Change the shape of update nic to be valid PUT

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -2265,7 +2265,7 @@ impl DataStore {
             db::model::InstanceState::new(external::InstanceState::Stopped);
 
         // This is the actual query to update the target interface.
-        let make_primary = matches!(updates.make_primary, Some(true));
+        let primary = matches!(updates.primary, Some(true));
         let update_target_query = diesel::update(dsl::network_interface)
             .filter(dsl::id.eq(interface_id))
             .filter(dsl::time_deleted.is_null())
@@ -2281,7 +2281,7 @@ impl DataStore {
         type TxnError = TransactionError<NetworkInterfaceUpdateError>;
 
         let pool = self.pool_authorized(opctx).await?;
-        if make_primary {
+        if primary {
             pool.transaction(move |conn| {
                 let instance_state =
                     instance_query.get_result(conn)?.runtime_state.state;
@@ -2316,7 +2316,7 @@ impl DataStore {
             })
         } else {
             // In this case, we can just directly apply the updates. By
-            // construction, `updates.make_primary` is `None`, so nothing will
+            // construction, `updates.primary` is `None`, so nothing will
             // be done there. The other columns always need to be updated, and
             // we're only hitting a single row. Note that we still need to
             // verify the instance is stopped.

--- a/nexus/src/db/model/network_interface.rs
+++ b/nexus/src/db/model/network_interface.rs
@@ -85,17 +85,17 @@ pub struct NetworkInterfaceUpdate {
     pub description: Option<String>,
     pub time_modified: DateTime<Utc>,
     #[diesel(column_name = is_primary)]
-    pub make_primary: Option<bool>,
+    pub primary: Option<bool>,
 }
 
 impl From<params::NetworkInterfaceUpdate> for NetworkInterfaceUpdate {
     fn from(params: params::NetworkInterfaceUpdate) -> Self {
-        let make_primary = if params.make_primary { Some(true) } else { None };
+        let primary = if params.primary { Some(true) } else { None };
         Self {
             name: params.identity.name.map(|n| n.into()),
             description: params.identity.description,
             time_modified: Utc::now(),
-            make_primary,
+            primary,
         }
     }
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -307,7 +307,7 @@ pub struct NetworkInterfaceUpdate {
     // change in the primary interface will result in changes to the DNS records
     // for the instance, though not the name.
     #[serde(default)]
-    pub make_primary: bool,
+    pub primary: bool,
 }
 
 // IP POOLS

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -235,7 +235,7 @@ lazy_static! {
                 name: None,
                 description: Some(String::from("an updated description")),
             },
-            make_primary: false,
+            primary: false,
         }
     };
 }

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1244,7 +1244,7 @@ async fn test_instance_update_network_interfaces(
             name: Some(new_name.clone()),
             description: Some(new_description.clone()),
         },
-        make_primary: false,
+        primary: false,
     };
 
     // Verify we fail to update the NIC when the instance is running
@@ -1315,13 +1315,13 @@ async fn test_instance_update_network_interfaces(
     verify_unchanged_attributes(&primary_iface, &updated_primary_iface);
 
     // Try with the same request again, but this time only changing
-    // `make_primary`. This should have no effect.
+    // `primary`. This should have no effect.
     let updates = params::NetworkInterfaceUpdate {
         identity: IdentityMetadataUpdateParams {
             name: None,
             description: None,
         },
-        make_primary: true,
+        primary: true,
     };
     let updated_primary_iface1 = NexusRequest::object_put(
         client,
@@ -1418,7 +1418,7 @@ async fn test_instance_update_network_interfaces(
             name: None,
             description: None,
         },
-        make_primary: true,
+        primary: true,
     };
     let new_primary_iface = NexusRequest::object_put(
         client,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7831,11 +7831,6 @@
             "nullable": true,
             "type": "string"
           },
-          "make_primary": {
-            "description": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error.",
-            "default": false,
-            "type": "boolean"
-          },
           "name": {
             "nullable": true,
             "allOf": [
@@ -7843,6 +7838,11 @@
                 "$ref": "#/components/schemas/Name"
               }
             ]
+          },
+          "primary": {
+            "description": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },


### PR DESCRIPTION
Non-blocking for the demo

---

I'm working on https://github.com/oxidecomputer/console/issues/933 and I noticed that the PUT endpoint for networks have `make_primary` instead of `primary` like the GET endpoint has. While I understand it's invalid to submit `false` for the interface that's already primary and therefore this param is technically functioning as described, it deviates from typical PUT request params by changing the shape of the object being re-posted. Ideally we could take a GET object alter a value and repost it as a PUT. 

Having to change the shape of the object before updating means downstream work for clients which would be nice to avoid. 