### PR TITLE
Include `external_id` in User view as `display_name`

### DIFF
--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -421,11 +421,12 @@ impl From<model::Sled> for Sled {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 pub struct User {
     pub id: Uuid,
+    pub external_id: String,
 }
 
 impl From<model::SiloUser> for User {
     fn from(user: model::SiloUser) -> Self {
-        Self { id: user.id() }
+        Self { id: user.id(), external_id: user.external_id }
     }
 }
 

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -421,12 +421,13 @@ impl From<model::Sled> for Sled {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 pub struct User {
     pub id: Uuid,
-    pub external_id: String,
+    /** Human-readable name that can identify the user */
+    pub display_name: String,
 }
 
 impl From<model::SiloUser> for User {
     fn from(user: model::SiloUser) -> Self {
-        Self { id: user.id(), external_id: user.external_id }
+        Self { id: user.id(), display_name: user.external_id }
     }
 }
 

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -427,7 +427,11 @@ pub struct User {
 
 impl From<model::SiloUser> for User {
     fn from(user: model::SiloUser) -> Self {
-        Self { id: user.id(), display_name: user.external_id }
+        Self {
+            id: user.id(),
+            // TODO the use of external_id as display_name is temporary
+            display_name: user.external_id,
+        }
     }
 }
 

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -727,8 +727,14 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(
         initial_silo_users,
         vec![
-            views::User { id: USER_TEST_PRIVILEGED.id() },
-            views::User { id: USER_TEST_UNPRIVILEGED.id() },
+            views::User {
+                id: USER_TEST_PRIVILEGED.id(),
+                external_id: USER_TEST_PRIVILEGED.external_id.clone()
+            },
+            views::User {
+                id: USER_TEST_UNPRIVILEGED.id(),
+                external_id: USER_TEST_UNPRIVILEGED.external_id.clone()
+            },
         ]
     );
 
@@ -736,8 +742,13 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     // it, use a small limit to check that pagination is really working.
     let new_silo_user_id =
         "bd75d207-37f3-4769-b808-677ae04eaf23".parse().unwrap();
+    let new_silo_user_external_id = "can_we_see_them?";
     nexus
-        .silo_user_create(*SILO_ID, new_silo_user_id, "can_we_see_them?".into())
+        .silo_user_create(
+            *SILO_ID,
+            new_silo_user_id,
+            new_silo_user_external_id.into(),
+        )
         .await
         .unwrap();
 
@@ -749,9 +760,18 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(
         silo_users,
         vec![
-            views::User { id: USER_TEST_PRIVILEGED.id() },
-            views::User { id: USER_TEST_UNPRIVILEGED.id() },
-            views::User { id: new_silo_user_id },
+            views::User {
+                id: USER_TEST_PRIVILEGED.id(),
+                external_id: USER_TEST_PRIVILEGED.external_id.clone()
+            },
+            views::User {
+                id: USER_TEST_UNPRIVILEGED.id(),
+                external_id: USER_TEST_UNPRIVILEGED.external_id.clone()
+            },
+            views::User {
+                id: new_silo_user_id,
+                external_id: new_silo_user_external_id.into(),
+            },
         ]
     );
 

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -729,11 +729,11 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                external_id: USER_TEST_PRIVILEGED.external_id.clone()
+                display_name: USER_TEST_PRIVILEGED.external_id.clone()
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                external_id: USER_TEST_UNPRIVILEGED.external_id.clone()
+                display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
             },
         ]
     );
@@ -762,15 +762,15 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                external_id: USER_TEST_PRIVILEGED.external_id.clone()
+                display_name: USER_TEST_PRIVILEGED.external_id.clone()
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                external_id: USER_TEST_UNPRIVILEGED.external_id.clone()
+                display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
             },
             views::User {
                 id: new_silo_user_id,
-                external_id: new_silo_user_external_id.into(),
+                display_name: new_silo_user_external_id.into(),
             },
         ]
     );

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9341,12 +9341,17 @@
         "description": "Client view of a [`User`]",
         "type": "object",
         "properties": {
+          "display_name": {
+            "description": "Human-readable name that can identify the user",
+            "type": "string"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
           }
         },
         "required": [
+          "display_name",
           "id"
         ]
       },


### PR DESCRIPTION
As discussed in huddles and syncs, we are temporarily using `external_id` as a display name in the console until we figure out how we want SAML servers to tell us users's display names for real. @jmpesp has our Keycloak thing set up to send usernames as the `external_id`, so this will work nicely for now.

Eventually we will want to store an actual display name for each user that we pull in from the SAML POST when they log in.