### PR TITLE
[oximeter] Update running instructions for oximeter in simulated environment

### DIFF
--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -129,7 +129,7 @@ $ cargo run --bin=sled-agent-sim -- $(uuidgen) [::1]:12345 127.0.0.1:12221
 +
 [source,text]
 ----
-$ cargo run --bin=oximeter -- oximeter/collector/config.toml
+$ cargo run --bin=oximeter run --id $(uuidgen) --address [::1]:12223 -- oximeter/collector/config.toml
 Dec 02 18:00:01.062 INFO starting oximeter server
 Dec 02 18:00:01.062 DEBG creating ClickHouse client
 Dec 02 18:00:01.068 DEBG initializing ClickHouse database, component: clickhouse-client, collector_id: 1da65e5b-210c-4859-a7d7-200c1e659972, component: oximeter-agent

--- a/oximeter/collector/config.toml
+++ b/oximeter/collector/config.toml
@@ -1,6 +1,9 @@
 # Example configuration file for running an oximeter collector server
 
+nexus_address = "127.0.0.1:12221"
+
 [db]
+address = "[::1]:8123"
 batch_size = 1000
 batch_interval = 5 # In seconds
 


### PR DESCRIPTION
Fixes: https://github.com/oxidecomputer/omicron/issues/1295 by restoring example configs from #1237

Tested by running:

```
$ cargo run --bin omicron-dev -- db-run
$ cargo run --bin omicron-dev -- ch-run
$ cargo run --bin=nexus -- nexus/examples/config.toml
$ cargo run --bin=sled-agent-sim -- $(uuidgen) [::1]:12345 127.0.0.1:12221
$ cargo run --bin=oximeter run --id $(uuidgen) --address [::1]:12223 -- oximeter/collector/config.toml
```

And observing that registration completes successfully between Nexus / Oximeter.