### PR TITLE
Tweak names of device auth params structs as a quick fix for oxide.ts

### DIFF
--- a/nexus/src/external_api/device_auth.rs
+++ b/nexus/src/external_api/device_auth.rs
@@ -47,7 +47,7 @@ where
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct DeviceAuthRequestParams {
+pub struct DeviceAuthRequest {
     pub client_id: Uuid,
 }
 
@@ -64,7 +64,7 @@ pub struct DeviceAuthRequestParams {
 }]
 pub async fn device_auth_request(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: TypedBody<DeviceAuthRequestParams>,
+    params: TypedBody<DeviceAuthRequest>,
 ) -> Result<Response<Body>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -108,7 +108,7 @@ pub async fn device_auth_request(
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct DeviceAuthVerifyParams {
+pub struct DeviceAuthVerify {
     pub user_code: String,
 }
 
@@ -126,7 +126,7 @@ pub struct DeviceAuthVerifyParams {
 }]
 pub async fn device_auth_verify(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: Query<DeviceAuthVerifyParams>,
+    params: Query<DeviceAuthVerify>,
 ) -> Result<Response<Body>, HttpError> {
     // If the user is authenticated, serve the console verification page.
     if let Ok(opctx) = OpContext::for_external_api(&rqctx).await {
@@ -160,7 +160,7 @@ pub async fn device_auth_verify(
 }]
 pub async fn device_auth_confirm(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: TypedBody<DeviceAuthVerifyParams>,
+    params: TypedBody<DeviceAuthVerify>,
 ) -> Result<HttpResponseOk<()>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
@@ -177,7 +177,7 @@ pub async fn device_auth_confirm(
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct DeviceAccessTokenRequestParams {
+pub struct DeviceAccessTokenRequest {
     pub grant_type: String,
     pub device_code: String,
     pub client_id: Uuid,
@@ -202,7 +202,7 @@ pub enum DeviceAccessTokenResponse {
 }]
 pub async fn device_access_token(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: TypedBody<DeviceAccessTokenRequestParams>,
+    params: TypedBody<DeviceAccessTokenRequest>,
 ) -> Result<Response<Body>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -6,8 +6,7 @@ use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
 use omicron_nexus::external_api::device_auth::{
-    DeviceAccessTokenRequestParams, DeviceAuthRequestParams,
-    DeviceAuthVerifyParams,
+    DeviceAccessTokenRequest, DeviceAuthRequest, DeviceAuthVerify,
 };
 use omicron_nexus::external_api::views::{
     DeviceAccessTokenGrant, DeviceAccessTokenType, DeviceAuthResponse,
@@ -36,7 +35,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
         .expect("failed to reject device auth start without client_id");
 
     let client_id = Uuid::new_v4();
-    let authn_params = DeviceAuthRequestParams { client_id };
+    let authn_params = DeviceAuthRequest { client_id };
 
     // Using a JSON encoded body fails.
     RequestBuilder::new(testctx, Method::POST, "/device/auth")
@@ -96,7 +95,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
     .body
     .starts_with(b"<html>"));
 
-    let confirm_params = DeviceAuthVerifyParams { user_code };
+    let confirm_params = DeviceAuthVerify { user_code };
 
     // Confirmation must be authenticated.
     RequestBuilder::new(testctx, Method::POST, "/device/confirm")
@@ -107,7 +106,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
         .await
         .expect("failed to 401 on unauthed confirmation");
 
-    let token_params = DeviceAccessTokenRequestParams {
+    let token_params = DeviceAccessTokenRequest {
         grant_type: "urn:ietf:params:oauth:grant-type:device_code".to_string(),
         device_code,
         client_id,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -22,7 +22,7 @@
           "content": {
             "application/x-www-form-urlencoded": {
               "schema": {
-                "$ref": "#/components/schemas/DeviceAuthRequestParams"
+                "$ref": "#/components/schemas/DeviceAuthRequest"
               }
             }
           },
@@ -52,7 +52,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DeviceAuthVerifyParams"
+                "$ref": "#/components/schemas/DeviceAuthVerify"
               }
             }
           },
@@ -94,7 +94,7 @@
           "content": {
             "application/x-www-form-urlencoded": {
               "schema": {
-                "$ref": "#/components/schemas/DeviceAccessTokenRequestParams"
+                "$ref": "#/components/schemas/DeviceAccessTokenRequest"
               }
             }
           },
@@ -6273,7 +6273,7 @@
           "public_cert"
         ]
       },
-      "DeviceAccessTokenRequestParams": {
+      "DeviceAccessTokenRequest": {
         "type": "object",
         "properties": {
           "client_id": {
@@ -6293,7 +6293,7 @@
           "grant_type"
         ]
       },
-      "DeviceAuthRequestParams": {
+      "DeviceAuthRequest": {
         "type": "object",
         "properties": {
           "client_id": {
@@ -6305,7 +6305,7 @@
           "client_id"
         ]
       },
-      "DeviceAuthVerifyParams": {
+      "DeviceAuthVerify": {
         "type": "object",
         "properties": {
           "user_code": {


### PR DESCRIPTION
oxide.ts needs better namespacing of its types (https://github.com/oxidecomputer/oxide.ts/issues/121), but as a quick fix we can change the names here so they don't create conflicts.