### PR TITLE
[sql] Grant DB privileges in a non-deprecated way

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -37,6 +37,7 @@
  */
 CREATE DATABASE omicron;
 CREATE USER omicron;
+ALTER DEFAULT PRIVILEGES GRANT INSERT, SELECT, UPDATE, DELETE ON TABLES to omicron;
 
 /*
  * Racks
@@ -1347,5 +1348,3 @@ INSERT INTO omicron.public.db_metadata (
 ) VALUES
     ( 'schema_version', '1.0.0' ),
     ( 'schema_time_created', CAST(NOW() AS STRING) );
-
-GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE omicron.public.* to omicron;

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -37,7 +37,6 @@
  */
 CREATE DATABASE omicron;
 CREATE USER omicron;
-GRANT INSERT, SELECT, UPDATE, DELETE ON DATABASE omicron to omicron;
 
 /*
  * Racks
@@ -1348,3 +1347,5 @@ INSERT INTO omicron.public.db_metadata (
 ) VALUES
     ( 'schema_version', '1.0.0' ),
     ( 'schema_time_created', CAST(NOW() AS STRING) );
+
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE omicron.public.* to omicron;


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/1304

For reference, I'm following the advice of https://www.cockroachlabs.com/docs/v21.2/grant.html#grant-privileges-on-all-tables-in-a-database-or-schema

I noticed that using the wildcard `*` only works after the tables have been created, so the statement is moved to the end of `dbinit.sql`.