### PR TITLE
[package] Add hints for missing pre-requisites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4371f82156ede0edb2682b42f9f3f3f78fe27429838006eb66f659aa6d0743"
+checksum = "b45da86a08794bc3e038552e9777724f204bdd55c8669f098e6b90df3f5bacd0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -16,6 +16,11 @@ rust.binary_names = ["nexus"]
 rust.release = true
 service_name = "nexus"
 zone = true
+setup_hint = """
+- Run `./tools/ci_download_console` to download the web console assets
+- Run `pkg install library/postgresql-13` to download Postgres libraries
+"""
+
 [[package.omicron-nexus.paths]]
 from = "/opt/ooce/pgsql-13/lib/amd64"
 to = "/opt/ooce/pgsql-13/lib/amd64"
@@ -38,6 +43,7 @@ to = "/var/svc/manifest/site/oximeter"
 [package.clickhouse]
 service_name = "clickhouse"
 zone = true
+setup_hint = "Run `./tools/ci_download_clickhouse` to download the necessary binaries"
 [[package.clickhouse.paths]]
 from = "out/clickhouse"
 to = "/opt/oxide/clickhouse"
@@ -48,6 +54,7 @@ to = "/var/svc/manifest/site/clickhouse"
 [package.cockroachdb]
 service_name = "cockroachdb"
 zone = true
+setup_hint = "Run `./tools/ci_download_cockroachdb` to download the necessary binaries"
 [[package.cockroachdb.paths]]
 from = "out/cockroachdb"
 to = "/opt/oxide/cockroachdb"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -13,7 +13,7 @@ hex = "0.4.3"
 indicatif = { version = "0.16.2", features = ["rayon"] }
 omicron-common = { path = "../common" }
 omicron-sled-agent = { path = "../sled-agent" }
-omicron-zone-package = "0.3.1"
+omicron-zone-package = "0.3.2"
 rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 ring = "0.16"

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -276,7 +276,12 @@ async fn do_package(config: &Config, output_directory: &Path) -> Result<()> {
                     .create_with_progress(&progress, &output_directory)
                     .await
                     .with_context(|| {
-                        format!("failed to create {package_name} in {output_directory:?}")
+                        let msg = format!("failed to create {package_name} in {output_directory:?}");
+                        if let Some(hint) = &package.setup_hint {
+                            format!("{msg}\nHint: {hint}")
+                        } else {
+                            msg
+                        }
                     })?;
                 progress.finish();
                 Ok(())


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/1299

Example error message when running omicron-package without the necessary pre-requisites:

```
Error: failed to create clickhouse in "out"
Hint: Run `./tools/ci_download_clickhouse` to download the necessary binaries

Caused by:
    Cannot add path "out/clickhouse" to package "clickhouse" because it does not exist
```