### PR TITLE
Add or update roles from authenticated subject

### DIFF
--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -192,6 +192,14 @@ impl super::Nexus {
             let mut policy =
                 self.silo_fetch_policy(opctx, &db_silo.name()).await?;
 
+            warn!(
+                &self.log,
+                "silo user {} gets role {:?} from authenticated subject {:?}",
+                silo_user.id(),
+                silo_role,
+                authenticated_subject
+            );
+
             policy.add_or_update_role_assignment(
                 shared::IdentityType::SiloUser,
                 silo_user.id(),

--- a/nexus/src/authn/silos.rs
+++ b/nexus/src/authn/silos.rs
@@ -448,6 +448,7 @@ pub struct SamlLoginPost {
     pub relay_state: Option<String>,
 }
 
+#[derive(Debug)]
 pub struct AuthenticatedSubject {
     pub external_id: String,
     pub silo_role: Option<authz::SiloRole>,

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -140,6 +140,10 @@ resource Silo {
 	# external authenticator has to create silo users
 	"list_children" if "external-authenticator" on "parent_fleet";
 	"create_child" if "external-authenticator" on "parent_fleet";
+
+	# external authenticator has to read and modify policy
+	"read" if "external-authenticator" on "parent_fleet";
+	"modify" if "external-authenticator" on "parent_fleet";
 }
 
 has_relation(fleet: Fleet, "parent_fleet", silo: Silo)

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -387,10 +387,10 @@ pub async fn consume_credentials(
             if let Some(referer) = &relay_state.referer {
                 referer.clone()
             } else {
-                "/".to_string()
+                "/orgs".to_string()
             }
         } else {
-            "/".to_string()
+            "/orgs".to_string()
         };
 
         debug!(

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -297,7 +297,7 @@ pub async fn grant_iam<T>(
     grant_user: Uuid,
     run_as: AuthnMode,
 ) where
-    T: serde::Serialize + serde::de::DeserializeOwned,
+    T: serde::Serialize + serde::de::DeserializeOwned + std::clone::Clone,
 {
     let policy_url = format!("{}/policy", grant_resource_url);
     let existing_policy: shared::Policy<T> =

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -360,7 +360,7 @@ where
     'a: 'd,
     'b: 'd,
     'c: 'd,
-    T: serde::de::DeserializeOwned,
+    T: serde::de::DeserializeOwned + std::clone::Clone,
 {
     async move {
         // For these resources, the initial policy is totally empty.
@@ -523,7 +523,7 @@ async fn run_test<T: RoleAssignmentTest>(
     test_case.verify_initial(client, &current_policy).await;
 }
 
-async fn policy_fetch<T: serde::de::DeserializeOwned>(
+async fn policy_fetch<T: serde::de::DeserializeOwned + std::clone::Clone>(
     client: &ClientTestContext,
     policy_url: &str,
 ) -> shared::Policy<T> {

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -913,7 +913,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     .await
     .expect("expected success");
 
-    assert_eq!(result.headers["Location"].to_str().unwrap(), "/");
+    assert_eq!(result.headers["Location"].to_str().unwrap(), "/orgs");
 
     // ask whoami
     NexusRequest::new(

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -834,4 +834,33 @@ async fn test_silo_role_from_authenticated_subject(
             .role_name,
         SiloRole::Collaborator,
     );
+
+    // Update their roles if the authenticated subject changes
+    let existing_silo_user = nexus
+        .silo_user_from_authenticated_subject(
+            &authn_opctx,
+            &authz_silo,
+            &db_silo,
+            &AuthenticatedSubject {
+                external_id: "external2@id.com".into(),
+                silo_role: Some(SiloRole::Admin),
+                groups: vec![],
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    let policy =
+        nexus.silo_fetch_policy(&authn_opctx, &silo_name).await.unwrap();
+    assert_eq!(
+        policy
+            .find_role_assignment(
+                IdentityType::SiloUser,
+                existing_silo_user.id()
+            )
+            .unwrap()
+            .role_name,
+        SiloRole::Admin,
+    );
 }


### PR DESCRIPTION
Add or update silo roles from authenticated subject.

Redirect to /orgs instead of / if there's no referer when consuming
credentials.