### PR TITLE
Use full address object name when checking for existence

### DIFF
--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -424,7 +424,7 @@ impl Zones {
         let prefix =
             if let Some(zone) = zone { vec![ZLOGIN, zone] } else { vec![] };
 
-        let interface = format!("{}/", addrobj.interface());
+        let interface = format!("{}", addrobj);
         let show_addr_args =
             &[IPADM, "show-addr", "-p", "-o", "TYPE", &interface];
 


### PR DESCRIPTION
This will help catch https://github.com/oxidecomputer/maghemite/issues/16: if an existing addrconf address object exists on the interface used by sled-agent, but it is _not_ named `$INTERFACE/linklocal`, we will now see an error when starting sled-agent:

```
sled-agent: Failed to ensure link-local address for vioif0/linklocal: Command [/usr/sbin/ipadm create-addr -t -T addrconf vioif0/linklocal] executed and failed with status: exit status: 1. Stdout:
, Stderr: ipadm: Could not create address: Addrconf already in progress
```

instead of seeing apparent success in the sled-agent logs but a panic in `mg-ddm`.