### PR TITLE
how-to for simulated omicron should talk about the console

### DIFF
--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -137,5 +137,7 @@ Dec 02 18:00:01.093 DEBG registered endpoint, path: /producers, method: POST, lo
 ...
 ----
 
-Once everything is up and running, you can use `curl` directly to hit either of
-the servers.  But it's easier to use the xref:cli.adoc[`oxide` CLI].
+Once everything is up and running, you can use the system in a few ways:
+
+* Use the browser-based console.  The Nexus log output will show what IP address and port it's listening on.  This is also configured in the config file.  If you're using the defaults, you can reach the console at `http://127.0.0.1:12220/orgs`.  Depending on the environment where you're running this, you may need an ssh tunnel or the like to reach this from your browser.
+* Use the xref:cli.adoc[`oxide` CLI].

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -4,7 +4,7 @@
 
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
-static_dir = "nexus/static" # TODO: figure out value
+static_dir = "out/console-assets"
 cache_control_max_age_minutes = 10
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480


### PR DESCRIPTION
This change updates the dev workflow for a simulated stack to go all the way to using the web console.  I didn't realize how easy this was.  `./install_prerequisites` already downloads console assets.  So I just changed the example config file to point at those and updated the docs to say how to reach the console.