### PR TITLE
Update the dbwipe commands for parity with dbinit

### DIFF
--- a/common/src/sql/dbwipe.sql
+++ b/common/src/sql/dbwipe.sql
@@ -9,4 +9,5 @@
  * initialization code and dbwipe.sql.
  */
 DROP DATABASE IF EXISTS omicron;
+ALTER DEFAULT PRIVILEGES FOR ROLE root REVOKE ALL ON TABLES FROM omicron;
 DROP USER IF EXISTS omicron;


### PR DESCRIPTION
Without this, I see the following error when populating CRDB via the sled agent - which invokes "dbinit.wipe".

```
ERROR: role omicron cannot be dropped because some objects depend on it                                                                                                                                                         
    privileges for default privileges on new relations belonging to role root in database defaultdb                                                                                                                                           
    SQLSTATE: 2BP01                                                                                   
```