### PR TITLE
Serve console index at `/settings/*`, `/device/verify`, `/device/success`

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -558,7 +558,7 @@ pub async fn session_me(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-async fn console_page_inner(
+pub async fn console_index_or_login_redirect(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
 ) -> Result<Response<Body>, HttpError> {
     let opctx = OpContext::for_external_api(&rqctx).await;
@@ -602,7 +602,7 @@ pub async fn console_page(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     _path_params: Path<RestPathParam>,
 ) -> Result<Response<Body>, HttpError> {
-    console_page_inner(rqctx).await
+    console_index_or_login_redirect(rqctx).await
 }
 
 #[endpoint {
@@ -614,7 +614,7 @@ pub async fn console_settings_page(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     _path_params: Path<RestPathParam>,
 ) -> Result<Response<Body>, HttpError> {
-    console_page_inner(rqctx).await
+    console_index_or_login_redirect(rqctx).await
 }
 
 /// Fetch a static asset from `<static_dir>/assets`. 404 on virtually all

--- a/nexus/src/external_api/device_auth.rs
+++ b/nexus/src/external_api/device_auth.rs
@@ -125,7 +125,18 @@ pub struct DeviceAuthVerify {
 }]
 pub async fn device_auth_verify(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    params: Query<DeviceAuthVerify>,
+    _params: Query<DeviceAuthVerify>,
+) -> Result<Response<Body>, HttpError> {
+    console_index_or_login_redirect(rqctx).await
+}
+
+#[endpoint {
+    method = GET,
+    path = "/device/success",
+    unpublished = true,
+}]
+pub async fn device_auth_success(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
 ) -> Result<Response<Body>, HttpError> {
     console_index_or_login_redirect(rqctx).await
 }

--- a/nexus/src/external_api/device_auth.rs
+++ b/nexus/src/external_api/device_auth.rs
@@ -9,7 +9,7 @@
 //! are for requesting access tokens that will be managed and used by
 //! the client to make other API requests.
 
-use super::console_api::{get_login_url, serve_console_index};
+use super::console_api::console_index_or_login_redirect;
 use super::views::{DeviceAccessTokenGrant, DeviceAuthResponse};
 use crate::context::OpContext;
 use crate::db::model::DeviceAccessToken;
@@ -21,7 +21,6 @@ use http::{header, Response, StatusCode};
 use hyper::Body;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_urlencoded;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -128,24 +127,7 @@ pub async fn device_auth_verify(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     params: Query<DeviceAuthVerify>,
 ) -> Result<Response<Body>, HttpError> {
-    // If the user is authenticated, serve the console verification page.
-    if let Ok(opctx) = OpContext::for_external_api(&rqctx).await {
-        if opctx.authn.actor().is_some() {
-            return serve_console_index(rqctx.context()).await;
-        }
-    }
-
-    // Otherwise, redirect for authentication.
-    let params = params.into_inner();
-    let state_params = serde_urlencoded::to_string(serde_json::json!({
-        "user_code": params.user_code
-    }))
-    .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-    let state = Some(format!("/device/verify?{}", state_params));
-    Ok(Response::builder()
-        .status(StatusCode::FOUND)
-        .header(http::header::LOCATION, get_login_url(state))
-        .body("".into())?)
+    console_index_or_login_redirect(rqctx).await
 }
 
 /// Confirm an OAuth 2.0 Device Authorization Grant

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -228,6 +228,7 @@ pub fn external_api() -> NexusApiDescription {
 
         api.register(device_auth::device_auth_request)?;
         api.register(device_auth::device_auth_verify)?;
+        api.register(device_auth::device_auth_success)?;
         api.register(device_auth::device_auth_confirm)?;
         api.register(device_auth::device_access_token)?;
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -116,7 +116,10 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
     // request to console page route without auth should redirect to IdP
     let _ = RequestBuilder::new(&testctx, Method::GET, "/orgs/irrelevant-path")
         .expect_status(Some(StatusCode::FOUND))
-        .expect_response_header(header::LOCATION, "/spoof_login")
+        .expect_response_header(
+            header::LOCATION,
+            "/spoof_login?state=%2Forgs%2Firrelevant-path",
+        )
         .execute()
         .await
         .expect("failed to redirect to IdP on auth failure");


### PR DESCRIPTION
The following routes all have identical behavior, serving the console `index.html`:

- `/orgs/*` (was already there)
- `/settings/*`
- `/device/verify` (was there but with its own implementation)
- `/device/success`