### PR TITLE
Use net0 vnic for maghemite

### DIFF
--- a/sled-agent/src/common/mod.rs
+++ b/sled-agent/src/common/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod disk;
 pub mod instance;
+pub mod underlay;
 pub mod vlan;

--- a/sled-agent/src/common/underlay.rs
+++ b/sled-agent/src/common/underlay.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Finding the underlay network physical links and address objects.
+
+use crate::illumos::addrobj;
+use crate::illumos::addrobj::AddrObject;
+use crate::illumos::dladm::PhysicalLink;
+use crate::zone::Zones;
+
+// Names of VNICs used as underlay devices for the xde driver.
+const XDE_VNIC_NAMES: [&str; 2] = ["net0", "net1"];
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(
+        "Failed to create an IPv6 link-local address for underlay devices: {0}"
+    )]
+    UnderlayDeviceAddress(#[from] crate::illumos::ExecutionError),
+
+    #[error(transparent)]
+    BadAddrObj(#[from] addrobj::ParseError),
+}
+
+pub fn find_nics() -> Result<Vec<AddrObject>, Error> {
+    let underlay_nics = find_chelsio_links()?;
+
+    let mut addr_objs = Vec::with_capacity(underlay_nics.len());
+    for nic in underlay_nics {
+        let addrobj = AddrObject::new(&nic.0, "linklocal")?;
+        Zones::ensure_has_link_local_v6_address(None, &addrobj)?;
+        addr_objs.push(addrobj);
+    }
+
+    Ok(addr_objs)
+}
+
+fn find_chelsio_links() -> Result<Vec<PhysicalLink>, Error> {
+    // TODO-correctness: This should eventually be determined by a call to
+    // `Dladm` to get the real Chelsio links on a Gimlet. These will likely be
+    // called `cxgbeN`, but we explicitly call them `netN` to be clear that
+    // they're likely VNICs for the time being.
+    Ok(XDE_VNIC_NAMES
+        .into_iter()
+        .map(|name| PhysicalLink(name.to_string()))
+        .collect())
+}


### PR DESCRIPTION
Following @bnaecker's suggestion in https://github.com/oxidecomputer/omicron/issues/1212#issuecomment-1171745809, this changes bootstrap-agent to pass `net0/linklocal` (i.e., one of the VNICs created by `create_virtual_hardware.sh`) to magehmite instead of creating a `$PHYS/linklocal` (e.g., `igb0/linklocal`).

This mostly involved extracting the bit of code from `opte.rs` that ensures `net{0,1}/linklocal` are set up to somewhere it could be used by both opte and bootstrap-agent. I am not wedded to its new location or names by any means; please don't hesitate to suggest a different place / function name for `underlay::find_nics()`.

While I was here I tried to address the TODO comment about passing multiple interfaces to maghemite, but ran into some issues testing that on my VMs. I'm going to continue poking at that, but will put it in a followup PR once it's working.