### PR TITLE
Refactor device auth schema

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -518,6 +518,8 @@ pub enum ResourceType {
     SamlIdentityProvider,
     SshKey,
     ConsoleSession,
+    DeviceAuthRequest,
+    DeviceAccessToken,
     GlobalImage,
     Organization,
     Project,

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1272,6 +1272,7 @@ CREATE TABLE omicron.public.device_access_token (
     client_id UUID NOT NULL,
     device_code STRING(40) NOT NULL,
     silo_user_id UUID NOT NULL,
+    time_requested TIMESTAMPTZ NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
     time_expires TIMESTAMPTZ
 );

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1252,22 +1252,18 @@ INSERT INTO omicron.public.user_builtin (
  * OAuth 2.0 Device Authorization Grant (RFC 8628)
  */
 
--- Device authorization requests. In theory these records could
--- (and probably should) be short-lived, and removed as soon as
--- a token is granted.
--- TODO-security: We should not grant a token more than once per record.
+-- Device authorization requests. These records are short-lived,
+-- and removed as soon as a token is granted. This allows us to
+-- use the `user_code` as primary key, despite it not having very
+-- much entropy.
+-- TODO: A background task should remove unused expired records.
 CREATE TABLE omicron.public.device_auth_request (
+    user_code STRING(20) PRIMARY KEY,
     client_id UUID NOT NULL,
     device_code STRING(40) NOT NULL,
-    user_code STRING(63) NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
-    time_expires TIMESTAMPTZ NOT NULL,
-
-    PRIMARY KEY (client_id, device_code)
+    time_expires TIMESTAMPTZ NOT NULL
 );
-
--- Fast lookup by user_code for verification
-CREATE INDEX ON omicron.public.device_auth_request (user_code);
 
 -- Access tokens granted in response to successful device authorization flows.
 -- TODO-security: expire tokens.
@@ -1276,13 +1272,15 @@ CREATE TABLE omicron.public.device_access_token (
     client_id UUID NOT NULL,
     device_code STRING(40) NOT NULL,
     silo_user_id UUID NOT NULL,
-    time_created TIMESTAMPTZ NOT NULL
+    time_created TIMESTAMPTZ NOT NULL,
+    time_expires TIMESTAMPTZ
 );
 
--- Matches the primary key on device authorization records.
--- The UNIQUE constraint is critical for ensuring that at most
+-- This UNIQUE constraint is critical for ensuring that at most
 -- one token is ever created for a given device authorization flow.
-CREATE UNIQUE INDEX ON omicron.public.device_access_token (client_id, device_code);
+CREATE UNIQUE INDEX ON omicron.public.device_access_token (
+    client_id, device_code
+);
 
 /*
  * Roles built into the system

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -103,6 +103,7 @@ impl super::Nexus {
         let token = DeviceAccessToken::new(
             db_request.client_id,
             db_request.device_code,
+            db_request.time_created,
             silo_user_id,
         );
 

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -107,7 +107,12 @@ impl super::Nexus {
             // can get a proper "denied" message on its next poll.
             let token = token.expires(db_request.time_expires);
             self.db_datastore
-                .device_access_token_create(opctx, &authz_request, &authz_user, token)
+                .device_access_token_create(
+                    opctx,
+                    &authz_request,
+                    &authz_user,
+                    token,
+                )
                 .await?;
             Err(Error::InvalidRequest {
                 message: "device authorization request expired".to_string(),
@@ -115,7 +120,12 @@ impl super::Nexus {
         } else {
             // TODO-security: set an expiration time for the valid token.
             self.db_datastore
-                .device_access_token_create(opctx, &authz_request, &authz_user, token)
+                .device_access_token_create(
+                    opctx,
+                    &authz_request,
+                    &authz_user,
+                    token,
+                )
                 .await
         }
     }

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -29,8 +29,8 @@
 //!    automatic case, it may supply the `user_code` as a query parameter.
 //! 5. The user logs in using their configured IdP, then enters or verifies
 //!    the `user_code`.
-//! 6. On successful login, the server is notified and responds to the
-//!    poll started in step 3 with a freshly granted access token.
+//! 6. On successful login, the server responds to the poll started
+//!    in step 3 with a freshly granted access token.
 //!
 //! Note that in this flow, there are actually two distinct sets of
 //! connections made to the server: by the client itself, and by the
@@ -45,44 +45,88 @@
 //! but that may change in the future.
 
 use crate::authn::{Actor, Reason};
+use crate::authz;
 use crate::context::OpContext;
+use crate::db::lookup::LookupPath;
 use crate::db::model::{DeviceAccessToken, DeviceAuthRequest};
 use crate::external_api::device_auth::DeviceAccessTokenResponse;
-use omicron_common::api::external::CreateResult;
+
+use omicron_common::api::external::{CreateResult, Error};
+
+use chrono::Utc;
 use uuid::Uuid;
 
 impl super::Nexus {
     /// Start a device authorization grant flow.
     /// Corresponds to steps 1 & 2 in the flow description above.
-    pub async fn device_auth_request(
+    pub async fn device_auth_request_create(
         &self,
         opctx: &OpContext,
         client_id: Uuid,
     ) -> CreateResult<DeviceAuthRequest> {
+        // TODO-correctness: the `user_code` generated for a new request
+        // is used as a primary key, but may potentially collide with an
+        // existing outstanding request. So we should retry some (small)
+        // number of times if inserting the new request fails.
         let auth_request = DeviceAuthRequest::new(client_id);
-        self.db_datastore.device_auth_start(opctx, auth_request).await
+        self.db_datastore.device_auth_request_create(opctx, auth_request).await
     }
 
-    /// Verify a device authorization grant.
+    /// Verify a device authorization grant, and delete the authorization
+    /// request so that at most one token will be granted per request.
+    /// Invoked in response to a request from the browser, not the client.
     /// Corresponds to step 5 in the flow description above.
-    pub async fn device_auth_verify(
+    pub async fn device_auth_request_verify(
         &self,
         opctx: &OpContext,
         user_code: String,
         silo_user_id: Uuid,
     ) -> CreateResult<DeviceAccessToken> {
-        let auth_request =
-            self.db_datastore.device_auth_get_request(opctx, user_code).await?;
-        let client_id = auth_request.client_id;
-        let device_code = auth_request.device_code;
-        let token =
-            DeviceAccessToken::new(client_id, device_code, silo_user_id);
-        self.db_datastore.device_auth_grant(opctx, token).await
+        let (.., authz_request, db_request) =
+            LookupPath::new(opctx, &self.db_datastore)
+                .device_auth_request(&user_code)
+                .fetch()
+                .await?;
+
+        let (.., authz_user) = LookupPath::new(opctx, &self.datastore())
+            .silo_user_id(silo_user_id)
+            .lookup_for(authz::Action::CreateChild)
+            .await?;
+        assert_eq!(authz_user.id(), silo_user_id);
+
+        // Delete the request regardless of whether it's still valid.
+        self.db_datastore
+            .device_auth_request_hard_delete(opctx, &authz_request)
+            .await?;
+
+        // Create an access token record.
+        let token = DeviceAccessToken::new(
+            db_request.client_id,
+            db_request.device_code,
+            silo_user_id,
+        );
+
+        if db_request.time_expires < Utc::now() {
+            // Store the expired token anyway so that the client
+            // can get a proper "denied" message on its next poll.
+            let token = token.expires(db_request.time_expires);
+            self.db_datastore
+                .device_access_token_create(opctx, &authz_user, token)
+                .await?;
+            Err(Error::InvalidRequest {
+                message: "device authorization request expired".to_string(),
+            })
+        } else {
+            // TODO-security: set an expiration time for the valid token.
+            self.db_datastore
+                .device_access_token_create(opctx, &authz_user, token)
+                .await
+        }
     }
 
     /// Look up a possibly-not-yet-granted device access token.
     /// Corresponds to steps 3 & 6 in the flow description above.
-    pub async fn device_access_token_lookup(
+    pub async fn device_access_token_fetch(
         &self,
         opctx: &OpContext,
         client_id: Uuid,
@@ -91,7 +135,7 @@ impl super::Nexus {
         use DeviceAccessTokenResponse::*;
         match self
             .db_datastore
-            .device_auth_get_token(opctx, client_id, device_code)
+            .device_access_token_fetch(opctx, client_id, device_code)
             .await
         {
             Ok(token) => Ok(Granted(token)),
@@ -107,12 +151,24 @@ impl super::Nexus {
         opctx: &OpContext,
         token: String,
     ) -> Result<Actor, Reason> {
-        match self.db_datastore.device_access_token_actor(opctx, token).await {
-            Ok(actor) => Ok(actor),
-            // TODO: better error handling
-            Err(_) => Err(Reason::UnknownActor {
-                actor: String::from("from bearer token"),
-            }),
-        }
+        let (.., db_access_token) = LookupPath::new(opctx, &self.db_datastore)
+            .device_access_token(&token)
+            .fetch()
+            .await
+            .map_err(|_| Reason::UnknownActor {
+                actor: "from bearer token".to_string(),
+            })?;
+
+        let silo_user_id = db_access_token.silo_user_id;
+        let (.., db_silo_user) = LookupPath::new(opctx, &self.db_datastore)
+            .silo_user_id(silo_user_id)
+            .fetch()
+            .await
+            .map_err(|_| Reason::UnknownActor {
+                actor: silo_user_id.to_string(),
+            })?;
+        let silo_id = db_silo_user.silo_id;
+
+        Ok(Actor::SiloUser { silo_user_id, silo_id })
     }
 }

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -161,8 +161,11 @@ impl super::Nexus {
             .device_access_token(&token)
             .fetch()
             .await
-            .map_err(|_| Reason::UnknownActor {
-                actor: "from bearer token".to_string(),
+            .map_err(|e| match e {
+                Error::ObjectNotFound { .. } => Reason::UnknownActor {
+                    actor: "from device access token".to_string(),
+                },
+                e => Reason::UnknownError { source: e },
             })?;
 
         let silo_user_id = db_access_token.silo_user_id;
@@ -170,8 +173,11 @@ impl super::Nexus {
             .silo_user_id(silo_user_id)
             .fetch()
             .await
-            .map_err(|_| Reason::UnknownActor {
-                actor: silo_user_id.to_string(),
+            .map_err(|e| match e {
+                Error::ObjectNotFound { .. } => {
+                    Reason::UnknownActor { actor: silo_user_id.to_string() }
+                }
+                e => Reason::UnknownError { source: e },
             })?;
         let silo_id = db_silo_user.silo_id;
 

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -239,6 +239,8 @@ impl db::model::DatabaseString for FleetRole {
     }
 }
 
+// TODO: refactor synthetic resources below
+
 /// ConsoleSessionList is a synthetic resource used for modeling who has access
 /// to create sessions.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -398,6 +400,60 @@ impl AuthorizedResource for IpPoolList {
     {
         // There are no roles on the IpPoolList, only permissions. But we still
         // need to load the Fleet-related roles to verify that the actor has the
+        // "admin" role on the Fleet.
+        load_roles_for_resource(
+            opctx,
+            datastore,
+            authn,
+            ResourceType::Fleet,
+            *FLEET_ID,
+            roleset,
+        )
+        .boxed()
+    }
+
+    fn on_unauthorized(
+        &self,
+        _: &Authz,
+        error: Error,
+        _: AnyActor,
+        _: Action,
+    ) -> Error {
+        error
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DeviceAuthRequestList;
+/// Singleton representing the [`DeviceAuthRequestList`] itself for authz purposes
+pub const DEVICE_AUTH_REQUEST_LIST: DeviceAuthRequestList =
+    DeviceAuthRequestList;
+
+impl oso::PolarClass for DeviceAuthRequestList {
+    fn get_polar_class_builder() -> oso::ClassBuilder<Self> {
+        oso::Class::builder()
+            .with_equality_check()
+            .add_attribute_getter("fleet", |_| FLEET)
+    }
+}
+
+impl AuthorizedResource for DeviceAuthRequestList {
+    fn load_roles<'a, 'b, 'c, 'd, 'e, 'f>(
+        &'a self,
+        opctx: &'b OpContext,
+        datastore: &'c DataStore,
+        authn: &'d authn::Context,
+        roleset: &'e mut RoleSet,
+    ) -> futures::future::BoxFuture<'f, Result<(), Error>>
+    where
+        'a: 'f,
+        'b: 'f,
+        'c: 'f,
+        'd: 'f,
+        'e: 'f,
+    {
+        // There are no roles on the DeviceAuthRequestList, only permissions. But we
+        // still need to load the Fleet-related roles to verify that the actor has the
         // "admin" role on the Fleet.
         load_roles_for_resource(
             opctx,
@@ -598,6 +654,22 @@ authz_resource! {
     name = "ConsoleSession",
     parent = "Fleet",
     primary_key = String,
+    roles_allowed = false,
+    polar_snippet = FleetChild,
+}
+
+authz_resource! {
+    name = "DeviceAuthRequest",
+    parent = "Fleet",
+    primary_key = String, // user_code
+    roles_allowed = false,
+    polar_snippet = FleetChild,
+}
+
+authz_resource! {
+    name = "DeviceAccessToken",
+    parent = "Fleet",
+    primary_key = String, // token
     roles_allowed = false,
     polar_snippet = FleetChild,
 }

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -355,6 +355,25 @@ resource ConsoleSessionList {
 has_relation(fleet: Fleet, "parent_fleet", collection: ConsoleSessionList)
 	if collection.fleet = fleet;
 
+# Describes the policy for creating and managing device authorization requests.
+resource DeviceAuthRequestList {
+	permissions = [ "create_child" ];
+	relations = { parent_fleet: Fleet };
+	"create_child" if "external-authenticator" on "parent_fleet";
+}
+has_relation(fleet: Fleet, "parent_fleet", collection: DeviceAuthRequestList)
+	if collection.fleet = fleet;
+
+# Describes the policy for creating and managing device access tokens.
+resource DeviceAccessToken {
+	permissions = [ "read" ];
+        relations = { silo_user: SiloUser };
+
+	"read" if "read" on "silo_user";
+}
+has_relation(user: SiloUser, "silo_user", access_token: DeviceAccessToken)
+	if access_token.silo_user = user;
+
 # These rules grants the external authenticator role the permissions it needs to
 # read silo users and modify their sessions.  This is necessary for login to
 # work.
@@ -362,10 +381,16 @@ has_permission(actor: AuthenticatedActor, "read", silo: Silo)
 	if has_role(actor, "external-authenticator", silo.fleet);
 has_permission(actor: AuthenticatedActor, "read", user: SiloUser)
 	if has_role(actor, "external-authenticator", user.silo.fleet);
+
 has_permission(actor: AuthenticatedActor, "read", session: ConsoleSession)
 	if has_role(actor, "external-authenticator", session.fleet);
 has_permission(actor: AuthenticatedActor, "modify", session: ConsoleSession)
 	if has_role(actor, "external-authenticator", session.fleet);
+
+has_permission(actor: AuthenticatedActor, "read", device_auth: DeviceAuthRequest)
+	if has_role(actor, "external-authenticator", device_auth.fleet);
+has_permission(actor: AuthenticatedActor, "read", device_token: DeviceAccessToken)
+	if has_role(actor, "external-authenticator", device_token.fleet);
 
 has_permission(actor: AuthenticatedActor, "read", identity_provider: IdentityProvider)
 	if has_role(actor, "external-authenticator", identity_provider.silo.fleet);

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -364,16 +364,6 @@ resource DeviceAuthRequestList {
 has_relation(fleet: Fleet, "parent_fleet", collection: DeviceAuthRequestList)
 	if collection.fleet = fleet;
 
-# Describes the policy for creating and managing device access tokens.
-resource DeviceAccessToken {
-	permissions = [ "read" ];
-        relations = { silo_user: SiloUser };
-
-	"read" if "read" on "silo_user";
-}
-has_relation(user: SiloUser, "silo_user", access_token: DeviceAccessToken)
-	if access_token.silo_user = user;
-
 # These rules grants the external authenticator role the permissions it needs to
 # read silo users and modify their sessions.  This is necessary for login to
 # work.

--- a/nexus/src/authz/oso_generic.rs
+++ b/nexus/src/authz/oso_generic.rs
@@ -46,6 +46,7 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<Oso, anyhow::Error> {
         IpPoolList::get_polar_class(),
         GlobalImageList::get_polar_class(),
         ConsoleSessionList::get_polar_class(),
+        DeviceAuthRequestList::get_polar_class(),
     ];
     for c in classes {
         info!(log, "registering Oso class"; "class" => &c.name);
@@ -66,6 +67,8 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<Oso, anyhow::Error> {
         VpcSubnet::init(),
         // Fleet-level resources
         ConsoleSession::init(),
+        DeviceAuthRequest::init(),
+        DeviceAccessToken::init(),
         Rack::init(),
         RoleBuiltin::init(),
         SshKey::init(),

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -4338,7 +4338,12 @@ impl DataStore {
     }
 
     /// Look up a granted device access token.
-    // TODO-security: authz
+    /// Note: since this lookup is not by a primary key or name,
+    /// (though it does use a unique index), it does not fit the
+    /// usual lookup machinery pattern. It therefore does include
+    /// any authz checks. However, the device code is a single-use
+    /// high-entropy random token, and so should not be guessable
+    /// by an attacker.
     pub async fn device_access_token_fetch(
         &self,
         opctx: &OpContext,

--- a/nexus/src/db/lookup.rs
+++ b/nexus/src/db/lookup.rs
@@ -290,6 +290,40 @@ impl<'a> LookupPath<'a> {
         }
     }
 
+    /// Select a resource of type DeviceAuthRequest, identified by its `user_code`
+    pub fn device_auth_request<'b, 'c>(
+        self,
+        user_code: &'b str,
+    ) -> DeviceAuthRequest<'c>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        DeviceAuthRequest {
+            key: DeviceAuthRequestKey::PrimaryKey(
+                Root { lookup_root: self },
+                user_code.to_string(),
+            ),
+        }
+    }
+
+    /// Select a resource of type DeviceAccessToken, identified by its `token`
+    pub fn device_access_token<'b, 'c>(
+        self,
+        token: &'b str,
+    ) -> DeviceAccessToken<'c>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        DeviceAccessToken {
+            key: DeviceAccessTokenKey::PrimaryKey(
+                Root { lookup_root: self },
+                token.to_string(),
+            ),
+        }
+    }
+
     /// Select a resource of type RoleBuiltin, identified by its `name`
     pub fn role_builtin_name(self, name: &str) -> RoleBuiltin<'a> {
         let parts = name.split_once('.');
@@ -557,6 +591,28 @@ lookup_resource! {
 
 lookup_resource! {
     name = "ConsoleSession",
+    ancestors = [],
+    children = [],
+    lookup_by_name = false,
+    soft_deletes = false,
+    primary_key_columns = [
+        { column_name = "token", rust_type = String },
+    ]
+}
+
+lookup_resource! {
+    name = "DeviceAuthRequest",
+    ancestors = [],
+    children = [],
+    lookup_by_name = false,
+    soft_deletes = false,
+    primary_key_columns = [
+        { column_name = "user_code", rust_type = String },
+    ]
+}
+
+lookup_resource! {
+    name = "DeviceAccessToken",
     ancestors = [],
     children = [],
     lookup_by_name = false,

--- a/nexus/src/db/model/device_auth.rs
+++ b/nexus/src/db/model/device_auth.rs
@@ -85,6 +85,10 @@ impl DeviceAuthRequest {
                 + Duration::seconds(CLIENT_AUTHENTICATION_TIMEOUT),
         }
     }
+
+    pub fn id(&self) -> String {
+        self.user_code.clone()
+    }
 }
 
 /// An access token granted in response to a successful device authorization flow.
@@ -97,6 +101,7 @@ pub struct DeviceAccessToken {
     pub device_code: String,
     pub silo_user_id: Uuid,
     pub time_created: DateTime<Utc>,
+    pub time_expires: Option<DateTime<Utc>>,
 }
 
 impl DeviceAccessToken {
@@ -111,7 +116,17 @@ impl DeviceAccessToken {
             device_code,
             silo_user_id,
             time_created: Utc::now(),
+            time_expires: None,
         }
+    }
+
+    pub fn id(&self) -> String {
+        self.token.clone()
+    }
+
+    pub fn expires(mut self, time: DateTime<Utc>) -> Self {
+        self.time_expires = Some(time);
+        self
     }
 }
 

--- a/nexus/src/db/model/device_auth.rs
+++ b/nexus/src/db/model/device_auth.rs
@@ -100,6 +100,7 @@ pub struct DeviceAccessToken {
     pub client_id: Uuid,
     pub device_code: String,
     pub silo_user_id: Uuid,
+    pub time_requested: DateTime<Utc>,
     pub time_created: DateTime<Utc>,
     pub time_expires: Option<DateTime<Utc>>,
 }
@@ -108,14 +109,18 @@ impl DeviceAccessToken {
     pub fn new(
         client_id: Uuid,
         device_code: String,
+        time_requested: DateTime<Utc>,
         silo_user_id: Uuid,
     ) -> Self {
+        let now = Utc::now();
+        assert!(time_requested < now);
         Self {
             token: generate_token(),
             client_id,
             device_code,
             silo_user_id,
-            time_created: Utc::now(),
+            time_requested,
+            time_created: now,
             time_expires: None,
         }
     }

--- a/nexus/src/db/model/device_auth.rs
+++ b/nexus/src/db/model/device_auth.rs
@@ -113,7 +113,7 @@ impl DeviceAccessToken {
         silo_user_id: Uuid,
     ) -> Self {
         let now = Utc::now();
-        assert!(time_requested < now);
+        assert!(time_requested <= now);
         Self {
             token: generate_token(),
             client_id,

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -514,10 +514,10 @@ table! {
 }
 
 table! {
-    device_auth_request (client_id, device_code) {
+    device_auth_request (user_code) {
+        user_code -> Text,
         client_id -> Uuid,
         device_code -> Text,
-        user_code -> Text,
         time_created -> Timestamptz,
         time_expires -> Timestamptz,
     }
@@ -530,6 +530,7 @@ table! {
         device_code -> Text,
         silo_user_id -> Uuid,
         time_created -> Timestamptz,
+        time_expires -> Nullable<Timestamptz>,
     }
 }
 

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -529,6 +529,7 @@ table! {
         client_id -> Uuid,
         device_code -> Text,
         silo_user_id -> Uuid,
+        time_requested -> Timestamptz,
         time_created -> Timestamptz,
         time_expires -> Nullable<Timestamptz>,
     }

--- a/nexus/src/external_api/device_auth.rs
+++ b/nexus/src/external_api/device_auth.rs
@@ -95,7 +95,8 @@ pub async fn device_auth_request(
             },
         };
 
-        let model = nexus.device_auth_request(&opctx, params.client_id).await?;
+        let model =
+            nexus.device_auth_request_create(&opctx, params.client_id).await?;
         build_oauth_response(
             StatusCode::OK,
             &DeviceAuthResponse::from_model(model, host),
@@ -162,7 +163,11 @@ pub async fn device_auth_confirm(
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let &actor = opctx.authn.actor_required()?;
         let _token = nexus
-            .device_auth_verify(&opctx, params.user_code, actor.actor_id())
+            .device_auth_request_verify(
+                &opctx,
+                params.user_code,
+                actor.actor_id(),
+            )
             .await?;
         Ok(HttpResponseOk(()))
     };
@@ -215,7 +220,7 @@ pub async fn device_access_token(
         let opctx = nexus.opctx_external_authn();
         use DeviceAccessTokenResponse::*;
         match nexus
-            .device_access_token_lookup(
+            .device_access_token_fetch(
                 &opctx,
                 params.client_id,
                 params.device_code,


### PR DESCRIPTION
Fixes #1255 and fixes #1285.

Records in the `device_auth_request` table are now short-lived so that we can use `user_code` as a primary key.

Datastore authz is implemented except for lookups in the `device_access_token` table, since we need lookup by both the `token` (primary key) and the unique combination of `client_id` and `device_code`. The current lookup machinery does not appear to make this easy; suggestions for workarounds would be welcome.