### PR TITLE
add context for internal error messages

### DIFF
--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -3669,14 +3669,8 @@ impl DataStore {
             .execute_async(self.pool_authorized(opctx).await?)
             .await
             .map(|_rows_deleted| ())
-            .map_err(|e| {
-                // TODO-correctness TODO-availability This should be using
-                // public_error_from_diesel_pool()
-                Error::internal_error(&format!(
-                    "error deleting outdated available artifacts: {:?}",
-                    e
-                ))
-            })
+            .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
+            .internal_context("deleting outdated available artifacts")
     }
 
     /// Create a silo user

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -87,7 +87,7 @@ use diesel::upsert::excluded;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use ipnetwork::IpNetwork;
 use omicron_common::api;
-use omicron_common::api::external;
+use omicron_common::api::external::{self, InternalContext};
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;
@@ -96,6 +96,7 @@ use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
+use omicron_common::api::external::{self, InternalContext};
 use omicron_common::api::external::{
     CreateResult, IdentityMetadataCreateParams,
 };
@@ -4110,6 +4111,7 @@ impl DataStore {
     ) -> CreateResult<SshKey> {
         assert_eq!(authz_user.id(), ssh_key.silo_user_id);
         opctx.authorize(authz::Action::CreateChild, authz_user).await?;
+        let name = ssh_key.name().to_string();
 
         use db::schema::ssh_key::dsl;
         diesel::insert_into(dsl::ssh_key)
@@ -4118,10 +4120,10 @@ impl DataStore {
             .get_result_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| {
-                Error::internal_error(&format!(
-                    "error creating SSH key: {:?}",
-                    e
-                ))
+                public_error_from_diesel_pool(
+                    e,
+                    ErrorHandler::Conflict(ResourceType::SshKey, &name),
+                )
             })
     }
 
@@ -5091,7 +5093,9 @@ mod test {
             .await;
         assert!(matches!(
             duplicate,
-            Err(Error::InternalError { internal_message: _ })
+            Err(Error::ObjectAlreadyExists { type_name, object_name })
+                if type_name == ResourceType::SshKey
+                    && object_name == "sshkey"
         ));
 
         // Delete the key we just created.

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -87,7 +87,6 @@ use diesel::upsert::excluded;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use ipnetwork::IpNetwork;
 use omicron_common::api;
-use omicron_common::api::external::{self, InternalContext};
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;


### PR DESCRIPTION
This change does three things:

1. creates `internal_context()`/`with_internal_context()` inspired by `anyhow::Context`.  These functions are available on `Result<T, Error>` (for the `Error` type that we use everywhere).  They allow you to prepend a message to the internal error that says what you were trying to do.  Copying the example:

```rust
let error: Result<(), Error> = Err(Error::internal_error("boom"));
assert_eq!(
    error.internal_context("uh-oh").unwrap_err().to_string(),
    "Internal Error: uh-oh: boom"
);
```

2. I updated one of the functions in DataStore to use this.  That function was previously incorrectly converting all errors to `InternalError` when it should have been using `public_error_from_diesel_pool` with `ErrorHandler::Server`.  The latter ensures that we produce a 503 if the database is down rather than a 500.  So this fixes that unrelated bug.  I did this in order to _use_ the new `internal_context()` function on the returned error.

3. I fixed a bug where attempting to create an ssh key with a conflicting name failed with a 500 instead of a 400.  This is basically unrelated.  I did this because I _thought_ I would wind up using the new `internal_context()` function here too but then I realized that since we're returning a 400, it has no effect.

----

Or: I added that new `internal_context` and fixed two bugs in the neighborhood, and one of the bug fix sites now uses the new function.