### PR TITLE
Add access_token authentication scheme to Nexus config

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -15,7 +15,7 @@ session_absolute_timeout_minutes = 480
 # working on authentication or authorization.
 [authn]
 # TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
-schemes_external = ["spoof", "session_cookie", "client_token"]
+schemes_external = ["spoof", "session_cookie", "access_token"]
 
 [log]
 # Show log messages of this level and more severe

--- a/nexus/src/config.rs
+++ b/nexus/src/config.rs
@@ -180,7 +180,7 @@ impl Config {
 pub enum SchemeName {
     Spoof,
     SessionCookie,
-    ClientToken,
+    AccessToken,
 }
 
 impl std::str::FromStr for SchemeName {
@@ -190,7 +190,7 @@ impl std::str::FromStr for SchemeName {
         match s {
             "spoof" => Ok(SchemeName::Spoof),
             "session_cookie" => Ok(SchemeName::SessionCookie),
-            "client_token" => Ok(SchemeName::ClientToken),
+            "access_token" => Ok(SchemeName::AccessToken),
             _ => Err(anyhow!("unsupported authn scheme: {:?}", s)),
         }
     }
@@ -201,7 +201,7 @@ impl std::fmt::Display for SchemeName {
         f.write_str(match self {
             SchemeName::Spoof => "spoof",
             SchemeName::SessionCookie => "session_cookie",
-            SchemeName::ClientToken => "client_token",
+            SchemeName::AccessToken => "access_token",
         })
     }
 }

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -89,7 +89,7 @@ impl ServerContext {
                     config::SchemeName::SessionCookie => {
                         Box::new(HttpAuthnSessionCookie)
                     }
-                    config::SchemeName::ClientToken => Box::new(HttpAuthnToken),
+                    config::SchemeName::AccessToken => Box::new(HttpAuthnToken),
                 }
             })
             .collect();

--- a/smf/nexus/config-partial.toml
+++ b/smf/nexus/config-partial.toml
@@ -11,7 +11,7 @@ session_absolute_timeout_minutes = 480
 
 [authn]
 # TODO(https://github.com/oxidecomputer/omicron/issues/372): Remove "spoof".
-schemes_external = ["spoof", "session_cookie"]
+schemes_external = ["spoof", "session_cookie", "access_token"]
 
 [log]
 # Show log messages of this level and more severe


### PR DESCRIPTION
Fixes [CLI#230](https://github.com/oxidecomputer/cli/issues/230). Entry was in `nexus/example/config.toml`, but was missing from `smf/nexus/config-partial.toml`. Also renamed from obsolete name `client_token`.