### PR TITLE
Remove trust quorum shares from sled agent requests

### DIFF
--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -4,7 +4,7 @@
 
 //! Request types for the bootstrap agent
 
-use super::trust_quorum::ShareDistribution;
+use super::trust_quorum::SerializableShareDistribution;
 use omicron_common::address::{Ipv6Subnet, SLED_PREFIX};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -16,38 +16,118 @@ pub struct SledAgentRequest {
     /// Uuid of the Sled Agent to be created.
     pub id: Uuid,
 
-    /// Portion of the IP space to be managed by the Sled Agent.
-    pub subnet: Ipv6Subnet<SLED_PREFIX>,
-
     /// Uuid of the rack to which this sled agent belongs.
     pub rack_id: Uuid,
 
-    /// Share of the rack secret for this Sled Agent.
-    // TODO-cleanup This is currently optional because we don't do trust quorum
-    // shares for single-node deployments (i.e., most dev/test environments),
-    // but eventually this should be required.
-    pub trust_quorum_share: Option<ShareDistribution>,
+    // Note: The order of these fields is load bearing, because we serialize
+    // `SledAgentRequest`s as toml. `subnet` serializes as a TOML table, so it
+    // must come after non-table fields.
+    /// Portion of the IP space to be managed by the Sled Agent.
+    pub subnet: Ipv6Subnet<SLED_PREFIX>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+// We intentionally DO NOT derive `Debug` or `Serialize`; both provide avenues
+// by which we may accidentally log the contents of our `share`. To serialize a
+// request, use `RequestEnvelope::danger_serialize_as_json()`.
+#[derive(Clone, Deserialize, PartialEq)]
 // Clippy wants us to put the SledAgentRequest in a Box, but (a) it's not _that_
 // big (a couple hundred bytes), and (b) that makes matching annoying.
 // `Request`s are relatively rare over the life of a sled agent.
 #[allow(clippy::large_enum_variant)]
 pub enum Request<'a> {
     /// Send configuration information for launching a Sled Agent.
-    SledAgentRequest(Cow<'a, SledAgentRequest>),
+    SledAgentRequest(
+        Cow<'a, SledAgentRequest>,
+        Option<SerializableShareDistribution>,
+    ),
 
     /// Request the sled's share of the rack secret.
     ShareRequest,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Deserialize, PartialEq)]
 pub struct RequestEnvelope<'a> {
     pub version: u32,
     pub request: Request<'a>,
 }
 
+impl RequestEnvelope<'_> {
+    /// On success, the returned `Vec` will contain our raw
+    /// trust quorum share. This method is named `danger_*` to remind the
+    /// caller that they must not log it.
+    pub(crate) fn danger_serialize_as_json(
+        &self,
+    ) -> Result<Vec<u8>, serde_json::Error> {
+        #[derive(Serialize)]
+        #[serde(remote = "Request")]
+        #[allow(clippy::large_enum_variant)]
+        pub enum RequestDef<'a> {
+            /// Send configuration information for launching a Sled Agent.
+            SledAgentRequest(
+                Cow<'a, SledAgentRequest>,
+                Option<SerializableShareDistribution>,
+            ),
+
+            /// Request the sled's share of the rack secret.
+            ShareRequest,
+        }
+
+        #[derive(Serialize)]
+        #[serde(remote = "RequestEnvelope")]
+        struct RequestEnvelopeDef<'a> {
+            version: u32,
+            #[serde(borrow, with = "RequestDef")]
+            request: Request<'a>,
+        }
+
+        let mut writer = Vec::with_capacity(128);
+        let mut serializer = serde_json::Serializer::new(&mut writer);
+        RequestEnvelopeDef::serialize(self, &mut serializer)?;
+        Ok(writer)
+    }
+}
+
 pub(super) mod version {
     pub(crate) const V1: u32 = 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+
+    use super::*;
+    use crate::bootstrap::trust_quorum::RackSecret;
+    use crate::bootstrap::trust_quorum::ShareDistribution;
+
+    #[test]
+    fn json_serialization_round_trips() {
+        let secret = RackSecret::new();
+        let (mut shares, verifier) = secret.split(2, 4).unwrap();
+
+        let envelope = RequestEnvelope {
+            version: 1,
+            request: Request::SledAgentRequest(
+                Cow::Owned(SledAgentRequest {
+                    id: Uuid::new_v4(),
+                    subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
+                    rack_id: Uuid::new_v4(),
+                }),
+                Some(
+                    ShareDistribution {
+                        threshold: 2,
+                        verifier,
+                        share: shares.pop().unwrap(),
+                        member_device_id_certs: vec![],
+                    }
+                    .into(),
+                ),
+            ),
+        };
+
+        let serialized = envelope.danger_serialize_as_json().unwrap();
+        let deserialized: RequestEnvelope =
+            serde_json::from_slice(&serialized).unwrap();
+
+        assert!(envelope == deserialized, "serialization round trip failed");
+    }
 }

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -270,16 +270,20 @@ async fn serve_request_before_quorum_initialization(
     .map_err(|err| format!("Failed to establish sprockets session: {err}"))?;
 
     let response = match read_request(&mut stream).await? {
-        Request::SledAgentRequest(request) => {
-            match bootstrap_agent.request_agent(&*request).await {
+        Request::SledAgentRequest(request, trust_quorum_share) => {
+            let trust_quorum_share =
+                trust_quorum_share.map(ShareDistribution::from);
+            match bootstrap_agent
+                .request_agent(&*request, &trust_quorum_share)
+                .await
+            {
                 Ok(response) => {
                     // If this send fails, it means our caller already received
                     // our share from a different
                     // `serve_request_before_quorum_initialization()` task
                     // (i.e., from another incoming request from RSS). We'll
                     // ignore such failures.
-                    let _ =
-                        tx_share.send(request.trust_quorum_share.clone()).await;
+                    let _ = tx_share.send(trust_quorum_share).await;
 
                     Ok(Response::SledAgentResponse(response))
                 }
@@ -320,7 +324,7 @@ async fn serve_request_after_quorum_initialization(
     .map_err(|err| format!("Failed to establish sprockets session: {err}"))?;
 
     let response = match read_request(&mut stream).await? {
-        Request::SledAgentRequest(request) => {
+        Request::SledAgentRequest(request, _trust_quorum_share) => {
             warn!(
                 log, "Received sled agent request after we're initialized";
                 "request" => ?request,

--- a/sled-agent/src/bootstrap/trust_quorum/mod.rs
+++ b/sled-agent/src/bootstrap/trust_quorum/mod.rs
@@ -16,4 +16,5 @@ mod share_distribution;
 
 pub use error::TrustQuorumError;
 pub use rack_secret::RackSecret;
+pub use share_distribution::SerializableShareDistribution;
 pub use share_distribution::ShareDistribution;

--- a/sled-agent/src/bootstrap/trust_quorum/share_distribution.rs
+++ b/sled-agent/src/bootstrap/trust_quorum/share_distribution.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use sprockets_host::Ed25519Certificate;
 use std::fmt;
 use vsss_rs::Share;
@@ -12,7 +13,9 @@ use super::rack_secret::Verifier;
 /// A ShareDistribution is an individual share of a secret along with all the
 /// metadata required to allow a server in possession of the share to know how
 /// to correctly recreate a split secret.
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+// We intentionally DO NOT derive `Debug` or `Serialize`; both provide avenues
+// by which we may accidentally log the contents of our `share`.
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct ShareDistribution {
     pub threshold: usize,
     pub verifier: Verifier,
@@ -36,5 +39,41 @@ impl fmt::Debug for ShareDistribution {
             .field("share", &"Share")
             .field("member_device_id_certs", &self.member_device_id_certs)
             .finish()
+    }
+}
+
+/// This type is equivalent to `ShareDistribution` but implements `Serialize`.
+/// It should be used _very carefully_; `ShareDistribution` should be preferred
+/// in almost all cases to avoid accidental spillage of our `Share` contents.
+/// This type should only be used to build careful serialization routines that
+/// need to deal with trust quorum shares; e.g.,
+/// `RequestEnvelope::danger_serialize_as_json()`.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct SerializableShareDistribution {
+    pub threshold: usize,
+    pub share: Share,
+    pub member_device_id_certs: Vec<Ed25519Certificate>,
+    pub verifier: Verifier,
+}
+
+impl From<ShareDistribution> for SerializableShareDistribution {
+    fn from(dist: ShareDistribution) -> Self {
+        Self {
+            threshold: dist.threshold,
+            verifier: dist.verifier,
+            share: dist.share,
+            member_device_id_certs: dist.member_device_id_certs,
+        }
+    }
+}
+
+impl From<SerializableShareDistribution> for ShareDistribution {
+    fn from(dist: SerializableShareDistribution) -> Self {
+        Self {
+            threshold: dist.threshold,
+            verifier: dist.verifier,
+            share: dist.share,
+            member_device_id_certs: dist.member_device_id_certs,
+        }
     }
 }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -289,33 +289,7 @@ impl ServiceInner {
         &self,
         config: &Config,
         bootstrap_addrs: Vec<Ipv6Addr>,
-        member_device_id_certs: &[Ed25519Certificate],
     ) -> Result<HashMap<SocketAddrV6, SledAllocation>, SetupServiceError> {
-        // Create a rack secret, unless we're in the single-sled case.
-        let mut maybe_rack_secret_shares = generate_rack_secret(
-            config.rack_secret_threshold,
-            member_device_id_certs,
-            &self.log,
-        )?;
-
-        // Confirm that the returned iterator (if we got one) is the length we
-        // expect.
-        if let Some(rack_secret_shares) = maybe_rack_secret_shares.as_ref() {
-            // TODO-cleanup Asserting here seems fine as long as
-            // `member_device_id_certs` is hard-coded from a config file, but
-            // once we start collecting them over the management network we
-            // should probably attach them at the type level to the bootstrap
-            // addrs, which would remove the need for this assertion.
-            assert_eq!(
-                rack_secret_shares.len(),
-                bootstrap_addrs.len(),
-                concat!(
-                    "Number of trust quorum members does not match ",
-                    "number of bootstrap addresses"
-                )
-            );
-        }
-
         let bootstrap_addrs = bootstrap_addrs.into_iter().enumerate();
         let reserved_rack_subnet = ReservedRackSubnet::new(config.az_subnet());
         let dns_subnets = reserved_rack_subnet.get_dns_subnets();
@@ -382,15 +356,6 @@ impl ServiceInner {
                         id: Uuid::new_v4(),
                         subnet,
                         rack_id,
-                        trust_quorum_share: maybe_rack_secret_shares
-                            .as_mut()
-                            .map(|shares_iter| {
-                                // We asserted when creating
-                                // `maybe_rack_secret_shares` that it contained
-                                // exactly the number of shares as we have
-                                // bootstrap addrs, so we can unwrap here.
-                                shares_iter.next().unwrap()
-                            }),
                     },
                     services_request: request,
                 },
@@ -563,17 +528,45 @@ impl ServiceInner {
             plan
         } else {
             info!(self.log, "Creating new allocation plan");
-            self.create_plan(config, addrs, member_device_id_certs).await?
+            self.create_plan(config, addrs).await?
         };
+
+        // Generate our rack secret, unless we're in the single-sled case.
+        let mut maybe_rack_secret_shares = generate_rack_secret(
+            config.rack_secret_threshold,
+            member_device_id_certs,
+            &self.log,
+        )?;
+
+        // Confirm that the returned iterator (if we got one) is the length we
+        // expect.
+        if let Some(rack_secret_shares) = maybe_rack_secret_shares.as_ref() {
+            // TODO-cleanup Asserting here seems fine as long as
+            // `member_device_id_certs` is hard-coded from a config file, but
+            // once we start collecting them over the management network we
+            // should probably attach them at the type level to the bootstrap
+            // addrs, which would remove the need for this assertion.
+            assert_eq!(
+                rack_secret_shares.len(),
+                plan.len(),
+                concat!(
+                    "Number of trust quorum members does not match ",
+                    "number of sleds in the plan"
+                )
+            );
+        }
 
         // Forward the sled initialization requests to our sled-agent.
         local_bootstrap_agent
             .initialize_sleds(
                 plan.iter()
-                    .map(|(bootstrap_addr, allocation)| {
+                    .map(move |(bootstrap_addr, allocation)| {
                         (
                             *bootstrap_addr,
                             allocation.initialization_request.clone(),
+                            maybe_rack_secret_shares
+                                .as_mut()
+                                .map(|shares| shares.next().unwrap()),
                         )
                     })
                     .collect(),


### PR DESCRIPTION
The primary motivator behind this was to avoid accidentally logging all the trust quorum shares from RSS, so we include some relatively heavy-handed machinery to minimize the chances of reintroducing that in the future.

There are two structural changes here that I believe are correct regardless of the logging issue:

1. The trust quorum share is now structurally separate from `SledAgentRequest`. It's still sent alongside `SledAgentRequest` when RSS initializes a remote sled, but not as part of the same structure.
2. RSS generates trust quorum shares _after_ creating the rack plan instead of _as a part of_ creating the rack plan. This fixes #1361 where all rack shares were written down by RSS as part of the plan.

If you think the avoidance of `#[derive(Serialize)]` and the use of the `danger_serialize_*` functions is overboard, I'm certainly not wedded to them, but I think they're a reasonable starting point for discussion in terms of avoiding accidentally reintroducing leakage of the shares.