### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
 	libpq5 \
 	libssl1.1 \
 	libsqlite3-0 \
+	xmlsec1 libxmlsec1-dev libxmlsec1-openssl \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
As foretold in #1211, the docker image build process is fragile with respect to new dependencies. This PR is an attempt to manually update them, but not fix the underlying fragility. Its purpose is to get a docker image usable by the CLI CI; see [CLI#204](https://github.com/oxidecomputer/cli/issues/204).