### PR TITLE
Use DNS to access Nexus IP from Sled Agent

### DIFF
--- a/common/src/backoff.rs
+++ b/common/src/backoff.rs
@@ -13,13 +13,19 @@ pub use ::backoff::{backoff::Backoff, ExponentialBackoff, Notify};
 /// Return a backoff policy appropriate for retrying internal services
 /// indefinitely.
 pub fn internal_service_policy() -> ::backoff::ExponentialBackoff {
-    const INITIAL_INTERVAL: Duration = Duration::from_millis(250);
     const MAX_INTERVAL: Duration = Duration::from_secs(60 * 60);
+    internal_service_policy_with_max(MAX_INTERVAL)
+}
+
+pub fn internal_service_policy_with_max(
+    max_duration: Duration,
+) -> ::backoff::ExponentialBackoff {
+    const INITIAL_INTERVAL: Duration = Duration::from_millis(250);
     ::backoff::ExponentialBackoff {
         current_interval: INITIAL_INTERVAL,
         initial_interval: INITIAL_INTERVAL,
         multiplier: 2.0,
-        max_interval: MAX_INTERVAL,
+        max_interval: max_duration,
         max_elapsed_time: None,
         ..backoff::ExponentialBackoff::default()
     }

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -6,7 +6,7 @@
 
 use crate::illumos::dladm::Etherstub;
 use crate::illumos::vnic::VnicAllocator;
-use crate::nexus::NexusClient;
+use crate::nexus::LazyNexusClient;
 use crate::opte::OptePortAllocator;
 use crate::params::{
     InstanceHardware, InstanceMigrateParams, InstanceRuntimeStateRequested,
@@ -37,7 +37,7 @@ pub enum Error {
 
 struct InstanceManagerInternal {
     log: Logger,
-    nexus_client: Arc<NexusClient>,
+    lazy_nexus_client: LazyNexusClient,
 
     // TODO: If we held an object representing an enum of "Created OR Running"
     // instance, we could avoid the methods within "instance.rs" that panic
@@ -59,7 +59,7 @@ impl InstanceManager {
     /// Initializes a new [`InstanceManager`] object.
     pub fn new(
         log: Logger,
-        nexus_client: Arc<NexusClient>,
+        lazy_nexus_client: LazyNexusClient,
         etherstub: Etherstub,
         underlay_addr: Ipv6Addr,
         gateway_mac: MacAddr6,
@@ -67,7 +67,7 @@ impl InstanceManager {
         InstanceManager {
             inner: Arc::new(InstanceManagerInternal {
                 log: log.new(o!("component" => "InstanceManager")),
-                nexus_client,
+                lazy_nexus_client,
                 instances: Mutex::new(BTreeMap::new()),
                 vnic_allocator: VnicAllocator::new("Instance", etherstub),
                 underlay_addr,
@@ -126,7 +126,7 @@ impl InstanceManager {
                         self.inner.underlay_addr,
                         self.inner.port_allocator.clone(),
                         initial_hardware,
-                        self.inner.nexus_client.clone(),
+                        self.inner.lazy_nexus_client.clone(),
                     )?;
                     let instance_clone = instance.clone();
                     let old_instance = instances
@@ -225,7 +225,7 @@ mod test {
     use crate::illumos::dladm::Etherstub;
     use crate::illumos::{dladm::MockDladm, zone::MockZones};
     use crate::instance::MockInstance;
-    use crate::mocks::MockNexusClient;
+    use crate::nexus::LazyNexusClient;
     use crate::params::ExternalIp;
     use crate::params::InstanceStateRequested;
     use chrono::Utc;
@@ -281,7 +281,9 @@ mod test {
     #[serial_test::serial]
     async fn ensure_instance() {
         let log = logger();
-        let nexus_client = Arc::new(MockNexusClient::default());
+        let lazy_nexus_client =
+            LazyNexusClient::new(log.clone(), std::net::Ipv6Addr::LOCALHOST)
+                .unwrap();
 
         // Creation of the instance manager incurs some "global" system
         // checks: cleanup of existing zones + vnics.
@@ -294,7 +296,7 @@ mod test {
 
         let im = InstanceManager::new(
             log,
-            nexus_client,
+            lazy_nexus_client,
             Etherstub("mylink".to_string()),
             std::net::Ipv6Addr::new(
                 0xfd00, 0x1de, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
@@ -365,7 +367,9 @@ mod test {
     #[serial_test::serial]
     async fn ensure_instance_repeatedly() {
         let log = logger();
-        let nexus_client = Arc::new(MockNexusClient::default());
+        let lazy_nexus_client =
+            LazyNexusClient::new(log.clone(), std::net::Ipv6Addr::LOCALHOST)
+                .unwrap();
 
         // Instance Manager creation.
 
@@ -377,7 +381,7 @@ mod test {
 
         let im = InstanceManager::new(
             log,
-            nexus_client,
+            lazy_nexus_client,
             Etherstub("mylink".to_string()),
             std::net::Ipv6Addr::new(
                 0xfd00, 0x1de, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -6,3 +6,71 @@
 pub use crate::mocks::MockNexusClient as NexusClient;
 #[cfg(not(test))]
 pub use nexus_client::Client as NexusClient;
+
+use internal_dns_client::{
+    multiclient::{ResolveError, Resolver},
+    names::{ServiceName, SRV},
+};
+use omicron_common::address::NEXUS_INTERNAL_PORT;
+use slog::Logger;
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+
+struct Inner {
+    log: Logger,
+    resolver: Resolver,
+}
+
+/// Wrapper around a [`NexusClient`] object, which allows deferring
+/// the DNS lookup until accessed.
+///
+/// Without the assistance of OS-level DNS lookups, the [`NexusClient`]
+/// interface requires knowledge of the target service IP address.
+/// For some services, like Nexus, this can be painful, as the IP address
+/// may not have even been allocated when the Sled Agent starts.
+///
+/// This structure allows clients to access the client on-demand, performing
+/// the DNS lookup only once it is actually needed.
+#[derive(Clone)]
+pub struct LazyNexusClient {
+    inner: Arc<Inner>,
+}
+
+impl LazyNexusClient {
+    pub fn new(log: Logger, addr: Ipv6Addr) -> Result<Self, ResolveError> {
+        Ok(Self {
+            inner: Arc::new(Inner {
+                log,
+                resolver: Resolver::new_from_ip(addr)?,
+            }),
+        })
+    }
+
+    pub async fn get(&self) -> Result<NexusClient, ResolveError> {
+        let address = self
+            .inner
+            .resolver
+            .lookup_ipv6(SRV::Service(ServiceName::Nexus))
+            .await?;
+
+        Ok(NexusClient::new(
+            &format!("http://[{}]:{}", address, NEXUS_INTERNAL_PORT),
+            self.inner.log.clone(),
+        ))
+    }
+}
+
+// Provides a mock implementation of the [`LazyNexusClient`].
+//
+// This allows tests to use the structure without actually performing
+// any DNS lookups.
+#[cfg(test)]
+mockall::mock! {
+    pub LazyNexusClient {
+        pub fn new(log: Logger, addr: Ipv6Addr) -> Result<Self, ResolveError>;
+        pub async fn get(&self) -> Result<NexusClient, String>;
+    }
+    impl Clone for LazyNexusClient {
+        fn clone(&self) -> Self;
+    }
+}

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -46,12 +46,12 @@ impl LazyNexusClient {
         })
     }
 
+    pub async fn get_ip(&self) -> Result<Ipv6Addr, ResolveError> {
+        self.inner.resolver.lookup_ipv6(SRV::Service(ServiceName::Nexus)).await
+    }
+
     pub async fn get(&self) -> Result<NexusClient, ResolveError> {
-        let address = self
-            .inner
-            .resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Nexus))
-            .await?;
+        let address = self.get_ip().await?;
 
         Ok(NexusClient::new(
             &format!("http://[{}]:{}", address, NEXUS_INTERNAL_PORT),

--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -7,13 +7,12 @@
 use super::config::Config;
 use super::http_entrypoints::api as http_api;
 use super::sled_agent::SledAgent;
-use crate::nexus::NexusClient;
+use crate::nexus::LazyNexusClient;
 use omicron_common::backoff::{
-    internal_service_policy, retry_notify, BackoffError,
+    internal_service_policy_with_max, retry_notify, BackoffError,
 };
 use slog::Logger;
 use std::net::{SocketAddr, SocketAddrV6};
-use std::sync::Arc;
 use uuid::Uuid;
 
 /// Packages up a [`SledAgent`], running the sled agent API under a Dropshot
@@ -43,15 +42,14 @@ impl Server {
         info!(log, "setting up sled agent server");
 
         let client_log = log.new(o!("component" => "NexusClient"));
-        let nexus_client = Arc::new(NexusClient::new(
-            &format!("http://{}", config.nexus_address),
-            client_log,
-        ));
+
+        let lazy_nexus_client = LazyNexusClient::new(client_log, *addr.ip())
+            .map_err(|e| e.to_string())?;
 
         let sled_agent = SledAgent::new(
             &config,
             log.clone(),
-            nexus_client.clone(),
+            lazy_nexus_client.clone(),
             addr,
             rack_id,
         )
@@ -85,6 +83,10 @@ impl Server {
                     log,
                     "contacting server nexus, registering sled: {}", sled_id
                 );
+                let nexus_client = lazy_nexus_client
+                    .get()
+                    .await
+                    .map_err(|err| BackoffError::transient(err.to_string()))?;
                 nexus_client
                     .cpapi_sled_agents_post(
                         &sled_id,
@@ -93,16 +95,18 @@ impl Server {
                         },
                     )
                     .await
-                    .map_err(BackoffError::transient)
+                    .map_err(|err| BackoffError::transient(err.to_string()))
             };
-            let log_notification_failure = |_, delay| {
+            let log_notification_failure = |err, delay| {
                 warn!(
                     log,
-                    "failed to contact nexus, will retry in {:?}", delay;
+                    "failed to notify nexus about sled agent: {}, will retry in {:?}", err, delay;
                 );
             };
             retry_notify(
-                internal_service_policy(),
+                internal_service_policy_with_max(
+                    std::time::Duration::from_secs(1),
+                ),
                 notify_nexus,
                 log_notification_failure,
             )

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -10,7 +10,7 @@ use crate::illumos::vnic::VnicAllocator;
 use crate::illumos::zone::AddressRequest;
 use crate::illumos::zpool::ZpoolName;
 use crate::illumos::{zfs::Mountpoint, zone::ZONE_PREFIX, zpool::ZpoolInfo};
-use crate::nexus::NexusClient;
+use crate::nexus::LazyNexusClient;
 use crate::params::DatasetKind;
 use futures::stream::FuturesOrdered;
 use futures::FutureExt;
@@ -523,9 +523,7 @@ async fn ensure_running_zone(
     }
 }
 
-type NotifyFut = dyn futures::Future<
-        Output = Result<(), nexus_client::Error<nexus_client::types::Error>>,
-    > + Send;
+type NotifyFut = dyn futures::Future<Output = Result<(), String>> + Send;
 
 #[derive(Debug)]
 struct NewFilesystemRequest {
@@ -539,7 +537,7 @@ struct NewFilesystemRequest {
 struct StorageWorker {
     log: Logger,
     sled_id: Uuid,
-    nexus_client: Arc<NexusClient>,
+    lazy_nexus_client: LazyNexusClient,
     pools: Arc<Mutex<HashMap<ZpoolName, Pool>>>,
     new_pools_rx: mpsc::Receiver<ZpoolName>,
     new_filesystems_rx: mpsc::Receiver<NewFilesystemRequest>,
@@ -632,21 +630,23 @@ impl StorageWorker {
         size: ByteCount,
     ) {
         let sled_id = self.sled_id;
-        let nexus = self.nexus_client.clone();
+        let lazy_nexus_client = self.lazy_nexus_client.clone();
         let notify_nexus = move || {
             let zpool_request = ZpoolPutRequest { size: size.into() };
-            let nexus = nexus.clone();
+            let lazy_nexus_client = lazy_nexus_client.clone();
             async move {
-                nexus
+                lazy_nexus_client
+                    .get()
+                    .await
+                    .map_err(|e| {
+                        backoff::BackoffError::transient(e.to_string())
+                    })?
                     .zpool_put(&sled_id, &pool_id, &zpool_request)
                     .await
-                    .map_err(backoff::BackoffError::transient)?;
-                Ok::<
-                    (),
-                    backoff::BackoffError<
-                        nexus_client::Error<nexus_client::types::Error>,
-                    >,
-                >(())
+                    .map_err(|e| {
+                        backoff::BackoffError::transient(e.to_string())
+                    })?;
+                Ok(())
             }
         };
         let log = self.log.clone();
@@ -674,28 +674,25 @@ impl StorageWorker {
         datasets: Vec<(Uuid, SocketAddrV6, DatasetKind)>,
         pool_id: Uuid,
     ) {
-        let nexus = self.nexus_client.clone();
+        let lazy_nexus_client = self.lazy_nexus_client.clone();
         let notify_nexus = move || {
-            let nexus = nexus.clone();
+            let lazy_nexus_client = lazy_nexus_client.clone();
             let datasets = datasets.clone();
             async move {
+                let nexus = lazy_nexus_client.get().await.map_err(|e| {
+                    backoff::BackoffError::transient(e.to_string())
+                })?;
+
                 for (id, address, kind) in datasets {
                     let request = DatasetPutRequest {
                         address: address.to_string(),
                         kind: kind.into(),
                     };
-                    nexus
-                        .dataset_put(&pool_id, &id, &request)
-                        .await
-                        .map_err(backoff::BackoffError::transient)?;
+                    nexus.dataset_put(&pool_id, &id, &request).await.map_err(
+                        |e| backoff::BackoffError::transient(e.to_string()),
+                    )?;
                 }
-
-                Ok::<
-                    (),
-                    backoff::BackoffError<
-                        nexus_client::Error<nexus_client::types::Error>,
-                    >,
-                >(())
+                Ok(())
             }
         };
         let log = self.log.clone();
@@ -905,7 +902,7 @@ impl StorageManager {
     pub async fn new(
         log: &Logger,
         sled_id: Uuid,
-        nexus_client: Arc<NexusClient>,
+        lazy_nexus_client: LazyNexusClient,
         etherstub: Etherstub,
         underlay_address: Ipv6Addr,
     ) -> Self {
@@ -916,7 +913,7 @@ impl StorageManager {
         let mut worker = StorageWorker {
             log,
             sled_id,
-            nexus_client,
+            lazy_nexus_client,
             pools: pools.clone(),
             new_pools_rx,
             new_filesystems_rx,


### PR DESCRIPTION
Utilize a `LazyNexusClient` struct, which allows Sled Agent to create `NexusClient` objects lazily by looking them up through DNS.