### PR TITLE
CI: Clean up further disk space on Linux runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,9 +107,17 @@ jobs:
           echo "Removing android"
           sudo rm -rf /usr/local/lib/android
         fi
-        if [ -d "/opt/ghc" ]; then
+        if [ -d "/usr/local/.ghcup" ]; then
           echo "Removing haskell"
-          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+        fi
+        if [ -d "/opt/hostedtoolcache/CodeQL" ]; then
+          echo "Removing CodeQL"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+        fi
+        if [ -d "/usr/share/swift" ]; then
+          echo "Removing swift"
+          sudo rm -rf /usr/share/swift
         fi
 
         echo "Disk space:"


### PR DESCRIPTION
#880 started removing some directories to reclaim some disk space on the Linux runners for GitHub Actions. However the Linux builds are starting to fail again. This change:

- fixes the path to ghc, which changed
- removes a couple more tools [i found](https://github.com/iliana/there-are-too-many-things-in-the-computer-box/actions) that we'll probably never need

Closes #1380.