### PR TITLE
bump the number of dependabot PRs to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Dependabot's PR limit is 5 by default. We have a few lingering dependency updates which means that the dependabot PR pipeline is a little clogged up:

- https://github.com/oxidecomputer/omicron/pull/607
- https://github.com/oxidecomputer/omicron/pull/1301
- https://github.com/oxidecomputer/omicron/pull/1351

We should attend to these of course, but there are other dependencies for which dependabot has been unable to create PRs.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit