### PR TITLE
ci: find ~8-9 GiB more stuff to remove

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,33 +95,28 @@ jobs:
     - name: Report cargo version
       run: cargo --version
     - name: Remove unnecessary software
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
-        echo "Disk space:"
-        df -h
-
-        if [ -d "/usr/share/dotnet" ]; then
-          echo "Removing dotnet"
-          sudo rm -rf /usr/share/dotnet
-        fi
-        if [ -d "/usr/local/lib/android" ]; then
-          echo "Removing android"
-          sudo rm -rf /usr/local/lib/android
-        fi
-        if [ -d "/usr/local/.ghcup" ]; then
-          echo "Removing haskell"
-          sudo rm -rf /usr/local/.ghcup
-        fi
-        if [ -d "/opt/hostedtoolcache/CodeQL" ]; then
-          echo "Removing CodeQL"
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-        fi
-        if [ -d "/usr/share/swift" ]; then
-          echo "Removing swift"
-          sudo rm -rf /usr/share/swift
-        fi
-
-        echo "Disk space:"
-        df -h
+        set -x
+        df -h /
+        sudo systemctl stop docker
+        sudo rm -rf /etc/skel/.rustup
+        sudo rm -rf /home/linuxbrew/.linuxbrew
+        sudo rm -rf /opt/az
+        sudo rm -rf /opt/hostedtoolcache
+        sudo rm -rf /opt/microsoft
+        sudo rm -rf /usr/lib/google-cloud-sdk
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/graalvm
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/local/share/chromium
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /var/lib/docker
+        df -h /
     - name: Update PATH
       run: echo "$PWD/out/cockroachdb/bin:$PWD/out/clickhouse" >> "$GITHUB_PATH"
     - name: Install Pre-Requisites


### PR DESCRIPTION
Yet another [full disk error](https://github.com/oxidecomputer/omicron/runs/7313766930?check_suite_focus=true) prompted this, but this is really scraping the bottom of the barrel for what we can easily remove from the runners at runtime.

This probably won't be the last time we need to worry about this. Some janky ideas for when we inevitably hit the brick wall:
- Move these jobs onto Buildomat-managed Linux VMs. Not sure if this is actually a good idea, but then we're at least controlling how much disk these hosts get.
- Set up a mountpoint on a ZFS or Btrfs disk backed by a file with compression enabled.
- Try to figure out how to reduce the size of the intermediate build artifacts.

Also this updates us to ubuntu-20.04 because I thought it'd be nice to do.

Closes #1380 (again).