### PR TITLE
Add cloud ready images to populate-images.sh script

### DIFF
--- a/tools/populate/populate-images.sh
+++ b/tools/populate/populate-images.sh
@@ -20,24 +20,7 @@ oxide api /images --method POST --input - <<EOF
   },
   "source": {
       "type": "url",
-      "url": "http://${CATACOMB_TUNNEL}/media/debian/debian-11-nocloud-amd64-20220503-998.raw"
-  }
-}
-EOF
-
-echo "Populating focal"
-oxide api /images --method POST --input - <<EOF
-{
-  "name": "focal",
-  "description": "focal",
-  "block_size": 512,
-  "distribution": {
-    "name": "focal",
-    "version": "1"
-  },
-  "source": {
-      "type": "url",
-      "url": "http://${CATACOMB_TUNNEL}/media/cloud/focal-server-cloudimg-amd64.raw"
+      "url": "http://${CATACOMB_TUNNEL}/media/cloud/debian-11-genericcloud-amd64.raw"
   }
 }
 EOF
@@ -46,10 +29,61 @@ echo "Populating ubuntu"
 oxide api /images --method POST --input - <<EOF
 {
   "name": "ubuntu",
-  "description": "ubuntu",
+  "description": "Ubuntu",
   "block_size": 512,
   "distribution": {
     "name": "ubuntu",
+    "version": "22.04"
+  },
+  "source": {
+      "type": "url",
+      "url": "http://${CATACOMB_TUNNEL}/media/cloud/focal-server-cloudimg-amd64.raw"
+  }
+}
+EOF
+
+echo "Populating fedora"
+oxide api /images --method POST --input - <<EOF
+{
+  "name": "fedora",
+  "description": "fedora",
+  "block_size": 512,
+  "distribution": {
+    "name": "fedora",
+    "version": "35-1.2"
+  },
+  "source": {
+      "type": "url",
+      "url": "http://${CATACOMB_TUNNEL}/media/cloud/Fedora-Cloud-Base-35-1.2.x86_64.raw"
+  }
+}
+EOF
+
+echo "Populating debian-nocloud"
+oxide api /images --method POST --input - <<EOF
+{
+  "name": "debiannc",
+  "description": "debian-nc",
+  "block_size": 512,
+  "distribution": {
+    "name": "debiannc",
+    "version": "11"
+  },
+  "source": {
+      "type": "url",
+      "url": "http://${CATACOMB_TUNNEL}/media/debian/debian-11-nocloud-amd64-20220503-998.raw"
+  }
+}
+EOF
+
+echo "Populating ubuntu-iso"
+oxide api /images --method POST --input - <<EOF
+{
+  "name": "ubuntuiso",
+  "description": "ubuntu-iso",
+  "block_size": 512,
+  "distribution": {
+    "name": "ubuntuiso",
     "version": "22.04"
   },
   "source": {

--- a/tools/populate/populate-images.sh
+++ b/tools/populate/populate-images.sh
@@ -62,12 +62,12 @@ EOF
 echo "Populating debian-nocloud"
 oxide api /images --method POST --input - <<EOF
 {
-  "name": "debiannc",
-  "description": "debian-nc",
+  "name": "debian-nocloud",
+  "description": "debian nocloud",
   "block_size": 512,
   "distribution": {
-    "name": "debiannc",
-    "version": "11"
+    "name": "debian-nocloud",
+    "version": "nocloud 11"
   },
   "source": {
       "type": "url",
@@ -79,12 +79,12 @@ EOF
 echo "Populating ubuntu-iso"
 oxide api /images --method POST --input - <<EOF
 {
-  "name": "ubuntuiso",
-  "description": "ubuntu-iso",
+  "name": "ubuntu-nocloud-iso",
+  "description": "ubuntu nocloud iso",
   "block_size": 512,
   "distribution": {
-    "name": "ubuntuiso",
-    "version": "22.04"
+    "name": "ubuntu-iso",
+    "version": "iso 22.04"
   },
   "source": {
       "type": "url",


### PR DESCRIPTION
Added the actual cloud-init images for ubuntu, debian, and fedora.  The non-cloud debian image is still present
but renamed, and a ubuntu ISO image has been added

The images list now look like this:
<img width="1059" alt="Images" src="https://user-images.githubusercontent.com/9903989/178850695-7c67d9d6-db68-4397-b9e6-25f2c080209a.png">

I tested all three cloud images (debian, fedora, ubuntu) and they all boot and support SSH keys on startup.
I added an ssh key to my user, then used it to ssh into all three booted instances.

