### PR TITLE
[nexus] `/session/me` returns a `views::User` (get rid of `views::SessionUser`)

### DIFF
--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -72,6 +72,18 @@ impl super::Nexus {
             .await
     }
 
+    pub async fn silo_user_fetch_by_id(
+        &self,
+        opctx: &OpContext,
+        silo_user_id: &Uuid,
+    ) -> LookupResult<db::model::SiloUser> {
+        let (.., db_silo_user) = LookupPath::new(opctx, &self.db_datastore)
+            .silo_user_id(*silo_user_id)
+            .fetch()
+            .await?;
+        Ok(db_silo_user)
+    }
+
     // Built-in users
 
     pub async fn users_builtin_list(

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -4,7 +4,6 @@
 
 //! Views are response bodies, most of which are public lenses onto DB models.
 
-use crate::authn;
 use crate::db::identity::{Asset, Resource};
 use crate::db::model;
 use crate::external_api::shared::{self, IpRange};
@@ -449,20 +448,6 @@ pub struct UserBuiltin {
 impl From<model::UserBuiltin> for UserBuiltin {
     fn from(user: model::UserBuiltin) -> Self {
         Self { identity: user.identity() }
-    }
-}
-
-/// Client view of currently authed user.
-// TODO: this may end up merged with User once more details about the user are
-// stored in the auth context. Right now there is only the ID.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
-pub struct SessionUser {
-    pub id: Uuid,
-}
-
-impl From<authn::Actor> for SessionUser {
-    fn from(actor: authn::Actor) -> Self {
-        Self { id: actor.actor_id() }
     }
 }
 

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -286,7 +286,7 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         .await
         .unwrap();
 
-    let _session_user: views::SessionUser =
+    let _session_user: views::User =
         NexusRequest::object_get(client, &"/session/me")
             .authn_as(AuthnMode::SiloUser(new_silo_user_id))
             .execute()

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -358,7 +358,7 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         unpriv_user,
         views::User {
             id: USER_TEST_UNPRIVILEGED.id(),
-            display_name: USER_TEST_PRIVILEGED.external_id.clone()
+            display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
         }
     );
 }

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -334,10 +334,16 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::SessionUser>()
+        .parsed_body::<views::User>()
         .unwrap();
 
-    assert_eq!(priv_user, views::SessionUser { id: USER_TEST_PRIVILEGED.id() });
+    assert_eq!(
+        priv_user,
+        views::User {
+            id: USER_TEST_PRIVILEGED.id(),
+            display_name: USER_TEST_PRIVILEGED.external_id.clone()
+        }
+    );
 
     // make sure it returns different things for different users
     let unpriv_user = NexusRequest::object_get(testctx, "/session/me")
@@ -345,12 +351,15 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::SessionUser>()
+        .parsed_body::<views::User>()
         .unwrap();
 
     assert_eq!(
         unpriv_user,
-        views::SessionUser { id: USER_TEST_UNPRIVILEGED.id() }
+        views::User {
+            id: USER_TEST_UNPRIVILEGED.id(),
+            display_name: USER_TEST_PRIVILEGED.external_id.clone()
+        }
     );
 }
 

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -924,7 +924,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     .await
     .expect("expected success");
 
-    let _session_user: views::SessionUser = NexusRequest::new(
+    let _session_user: views::User = NexusRequest::new(
         RequestBuilder::new(client, Method::GET, "/session/me")
             .header(
                 http::header::COOKIE,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5813,7 +5813,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SessionUser"
+                  "$ref": "#/components/schemas/User"
                 }
               }
             }
@@ -9468,19 +9468,6 @@
           "slo_url",
           "sp_client_id",
           "technical_contact_email"
-        ]
-      },
-      "SessionUser": {
-        "description": "Client view of currently authed user.",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "id"
         ]
       },
       "Silo": {


### PR DESCRIPTION
Closes #1308 