### PR TITLE
Install docker image run-time prereqs from script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /usr/src/omicron
 
 # sudo and path thing are only needed to get prereqs script to run
 ENV PATH=/usr/src/omicron/out/cockroachdb/bin:/usr/src/omicron/out/clickhouse:${PATH} 
-RUN apt-get update && apt-get install -y sudo --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y sudo --no-install-recommends
 RUN tools/install_builder_prerequisites.sh -y
 
 RUN cargo build --release
@@ -30,16 +30,13 @@ RUN cargo build --release
 
 FROM debian:sid-slim
 
-RUN apt-get update && apt-get install -y \
-	ca-certificates \
-	libpq5 \
-	libssl1.1 \
-	libsqlite3-0 \
-	xmlsec1 libxmlsec1-dev libxmlsec1-openssl \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+# Install run-time dependencies
+COPY --from=cargo-build /usr/src/omicron/tools/install_runner_prerequisites.sh /tmp/
+RUN apt-get update && apt-get install -y sudo --no-install-recommends
+RUN /tmp/install_runner_prerequisites.sh -y
+RUN rm -rf /tmp/install_runner_prerequisites.sh /var/lib/apt/lists/*
 
-
+# Copy Omicron executables
 COPY --from=cargo-build /usr/src/omicron/target/release/nexus /usr/bin/nexus
 COPY --from=cargo-build /usr/src/omicron/target/release/omicron-dev /usr/bin/omicron-dev
 COPY --from=cargo-build /usr/src/omicron/target/release/omicron-package /usr/bin/omicron-package

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -87,6 +87,20 @@ if [[ "${HOST_OS}" == "SunOS" ]]; then
   fi
 
   pkg list -v "${packages[@]}"
+elif [[ "${HOST_OS}" == "Linux" ]]; then
+  packages=(
+    'ca-certificates'
+    'libpq5'
+    'libsqlite3-0'
+    'libssl1.1'
+    'libxmlsec1-openssl'
+  )
+  sudo apt-get update
+  if [[ "${ASSUME_YES}" == "true" ]]; then
+    sudo apt-get install -y ${packages[@]}
+  else
+    confirm "Install (or update) [${packages[*]}]?" && sudo apt-get install ${packages[@]}
+  fi
 else
   echo "Unsupported OS: ${HOST_OS}"
   exit -1


### PR DESCRIPTION
Fixes #1387. Our `Dockerfile` builds two images: one to build Omicron, and a second to run it. This patch uses the new `tools/install_runner_prerequisites.sh` script to install the run-time prerequisites in the latter instead of a manual `apt-get install ...`, and augments that script with Linux-specific prerequisites. The advantage here is that there's now only one place where new run-time dependencies need to be added instead of two.