### PR TITLE
buildomat: use improved output rule specification

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -4,8 +4,8 @@
 #: variety = "basic"
 #: target = "lab-netdev"
 #: output_rules = [
-#:	"/var/svc/log/system-illumos-sled-agent:default.log",
-#:	"/zone/oxz_nexus/root/var/svc/log/system-illumos-nexus:default.log",
+#:	"%/var/svc/log/system-illumos-sled-agent:default.log",
+#:	"%/zone/oxz_nexus/root/var/svc/log/system-illumos-nexus:default.log",
 #: ]
 #: skip_clone = true
 #:

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -5,7 +5,7 @@
 #: target = "helios-latest"
 #: rust_toolchain = "nightly-2022-04-27"
 #: output_rules = [
-#:	"/work/package.tar.gz",
+#:	"=/work/package.tar.gz",
 #: ]
 #:
 


### PR DESCRIPTION
buildomat now supports more nuance in artefact upload based on output
rules.  The new behaviours are specified by prepending certain sigils to
the output rule, which is still an absolute path with support for glob
characters:

  - the "=" prefix means "this rule must match at least one file",
    as opposed to the default behaviour which allows a rule to match
    0 or more files without failing the job.  This is used to make
    sure that package build job produces an archive with the expected
    name.

  - the "%" prefix means "this file is allowed to change while it is
    being uploaded", as opposed to the default behaviour which fails
    the job if an uploaded file is still being modified in the
    background while the agent tries to upload it.  This is used
    to make best effort uploads of diagnostic log files, like those
    for Nexus and the Sled Agent, which may continue running even
    though the job is nominally complete.