### PR TITLE
Fix cargo checking propolis git repo every run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283#a9399a8007f9876e31ce152848e6ecc2a9e14283"
 dependencies = [
  "crucible",
  "reqwest",


### PR DESCRIPTION
Before this change, every cargo command checked for updates to the propolis git repo every time; after this, it doesn't. I don't know how we got an entry in the lockfile missing the `#commit-id` fragment, but that's [what Cargo looks for](https://github.com/rust-lang/cargo/blob/d583b21e1494268be2cc8c19950e94f03ae3bce2/src/cargo/core/source/source_id.rs#L129) to determine if the revision is "precise".