### PR TITLE
convert `cpapi_artifact_download` to use dropshot / progenitor streaming interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.1.2-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#6ca5670819c88267b657be2f44a15e4f5f22b727"
+source = "git+https://github.com/oxidecomputer/progenitor#5a72e1b8e7c1ac729519447fe424d0179fe42c07"
 dependencies = [
  "anyhow",
  "clap 3.2.12",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "progenitor-client"
 version = "0.1.2-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#6ca5670819c88267b657be2f44a15e4f5f22b727"
+source = "git+https://github.com/oxidecomputer/progenitor#5a72e1b8e7c1ac729519447fe424d0179fe42c07"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "progenitor-impl"
 version = "0.1.2-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#6ca5670819c88267b657be2f44a15e4f5f22b727"
+source = "git+https://github.com/oxidecomputer/progenitor#5a72e1b8e7c1ac729519447fe424d0179fe42c07"
 dependencies = [
  "getopts",
  "heck 0.4.0",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.1.2-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#6ca5670819c88267b657be2f44a15e4f5f22b727"
+source = "git+https://github.com/oxidecomputer/progenitor#5a72e1b8e7c1ac729519447fe424d0179fe42c07"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283#a9399a8007f9876e31ce152848e6ecc2a9e14283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283"
 dependencies = [
  "crucible",
  "reqwest",

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -19,7 +19,6 @@ use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
-use http::{Response, StatusCode};
 use hyper::Body;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -12,6 +12,7 @@ use super::params::{
 };
 use dropshot::endpoint;
 use dropshot::ApiDescription;
+use dropshot::FreeformBody;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
@@ -299,7 +300,7 @@ async fn cpapi_metrics_collect(
 async fn cpapi_artifact_download(
     request_context: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<UpdateArtifact>,
-) -> Result<Response<Body>, HttpError> {
+) -> Result<HttpResponseOk<FreeformBody>, HttpError> {
     let context = request_context.context();
     let nexus = &context.nexus;
     let opctx = OpContext::for_internal_api(&request_context).await;
@@ -307,5 +308,5 @@ async fn cpapi_artifact_download(
     let body =
         nexus.download_artifact(&opctx, path_params.into_inner()).await?;
 
-    Ok(Response::builder().status(StatusCode::OK).body(body.into())?)
+    Ok(HttpResponseOk(Body::from(body).into()))
 }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -45,13 +45,19 @@
           }
         ],
         "responses": {
-          "default": {
+          "200": {
             "description": "",
             "content": {
               "*/*": {
                 "schema": {}
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }

--- a/sled-agent/src/mocks/mod.rs
+++ b/sled-agent/src/mocks/mod.rs
@@ -10,12 +10,11 @@ use nexus_client::types::{
     InstanceRuntimeState, SledAgentStartupInfo, UpdateArtifactKind,
     ZpoolPutRequest, ZpoolPutResponse,
 };
-use reqwest::Response;
 use slog::Logger;
 use uuid::Uuid;
 
 type Result<T> = std::result::Result<
-    T,
+    progenitor::progenitor_client::ResponseValue<T>,
     progenitor::progenitor_client::Error<nexus_client::types::Error>,
 >;
 
@@ -44,7 +43,7 @@ mock! {
             kind: UpdateArtifactKind,
             name: &str,
             version: i64,
-        ) -> Result<Response>;
+        ) -> Result<progenitor::progenitor_client::ByteStream>;
         pub async fn zpool_put(
             &self,
             sled_id: &Uuid,


### PR DESCRIPTION
This lets us turn on `test_write_artifact_to_filesystem` which was previously ignored. I hope this is a good thing.