### PR TITLE
buildomat: reshape Helios CI jobs

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "helios / build-and-test"
+#: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
 #: rust_toolchain = "nightly-2022-04-27"
@@ -29,7 +29,7 @@ mkdir $TEST_TMPDIR
 export PATH="$PATH:$PWD/out/cockroachdb/bin:$PWD/out/clickhouse"
 
 banner prerequisites
-ptime -m bash ./tools/install_prerequisites.sh -y
+ptime -m bash ./tools/install_builder_prerequisites.sh -y
 
 #
 # We build with:
@@ -50,12 +50,6 @@ export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
 ptime -m cargo +'nightly-2022-04-27' build --locked --all-targets --verbose
-
-#
-# Check that building individual packages as when deploying Omicron succeeds
-#
-banner deploy-check
-ptime -m cargo run --bin omicron-package -- check
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid

--- a/.github/buildomat/jobs/check-omicron-deployment.sh
+++ b/.github/buildomat/jobs/check-omicron-deployment.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#:
+#: name = "check-omicron-deployment (helios)"
+#: variety = "basic"
+#: target = "helios-latest"
+#: rust_toolchain = "nightly-2022-04-27"
+#: output_rules = []
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+#
+# Put "./cockroachdb/bin" and "./clickhouse" on the PATH for the test
+# suite.
+#
+export PATH="$PATH:$PWD/out/cockroachdb/bin:$PWD/out/clickhouse"
+
+banner prerequisites
+ptime -m bash ./tools/install_builder_prerequisites.sh -y
+
+#
+# Check that building individual packages as when deploying Omicron succeeds
+#
+banner deploy-check
+ptime -m cargo run --bin omicron-package -- check


### PR DESCRIPTION
This change splits out the Helios deploy check into a separate job,
"check-omicron-deployment (helios)", which should shorten the critical
path through the build-and-test job where it used to be.  This new job
has a name of the same form as the Actions equivalent on the Linux and
Macintosh side.

In addition, the build and test job should use the new builder-only
prerequisites script; we're not rebooting into the OPTE bits it would
install anyway so this is wasted time.

Finally, we're renaming the build and test job to "build-and-test
(helios)" to align the naming with the Actions jobs.