### PR TITLE
clean up tempfiles when downloading artifacts

### DIFF
--- a/sled-agent/src/updates.rs
+++ b/sled-agent/src/updates.rs
@@ -76,8 +76,8 @@ pub async fn download_artifact(
                     })
                     .await?;
             }
-            file.sync_all().await.map_err(|err| Error::Io {
-                message: "sync temp file".to_string(),
+            file.flush().await.map_err(|err| Error::Io {
+                message: "flush temp file".to_string(),
                 err,
             })?;
             drop(file);


### PR DESCRIPTION
re: https://github.com/oxidecomputer/omicron/pull/1442#discussion_r922571061 -- uses the tempfile crate to clean up the temporary file we're writing to in case we run into an error before persisting it to the final path.