### PR TITLE
Fix cargo checking propolis git repo every run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283#a9399a8007f9876e31ce152848e6ecc2a9e14283"
 dependencies = [
  "crucible",
  "reqwest",


### PR DESCRIPTION
Previously fixed in #1436, I think this was accidentally reverted in #1442 (manually resolved merge conflict maybe?).