### PR TITLE
Implement ephemeral IPs

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -958,6 +958,9 @@ CREATE TABLE omicron.public.ip_pool (
     time_modified TIMESTAMPTZ NOT NULL,
     time_deleted TIMESTAMPTZ,
 
+    /* Optional ID of the project for which this pool is reserved. */
+    project_id UUID,
+
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL
 );
@@ -984,6 +987,15 @@ CREATE TABLE omicron.public.ip_pool_range (
     /* The range is inclusive of the last address. */
     last_address INET NOT NULL,
     ip_pool_id UUID NOT NULL,
+    /* Optional ID of the project for which this range is reserved.
+     *
+     * NOTE: This denormalizes the tables a bit, since the project_id is
+     * duplicated here and in the parent `ip_pool` table. We're allowing this
+     * for now, since it reduces the complexity of the already-bad IP allocation
+     * query, but we may want to revisit that, and JOIN with the parent table
+     * instead.
+     */
+    project_id UUID,
     /* Tracks child resources, IP addresses allocated out of this range. */
     rcgen INT8 NOT NULL
 );
@@ -1005,14 +1017,48 @@ STORING (first_address)
 WHERE time_deleted IS NULL;
 
 /*
- * External IP addresses used for instance source NAT.
+ * Index supporting allocation of IPs out of a Pool reserved for a project.
+ */
+CREATE INDEX ON omicron.public.ip_pool_range (
+    project_id
+) WHERE
+    time_deleted IS NULL;
+
+
+/* The kind of external IP address. */
+CREATE TYPE omicron.public.ip_kind AS ENUM (
+    /* Automatic source NAT provided to all guests by default */
+    'snat',
+
+    /*
+     * An ephemeral IP is a fixed, known address whose lifetime is the same as
+     * the instance to which it is attached.
+     */
+    'ephemeral',
+
+    /*
+     * A floating IP is an independent, named API resource. It is a fixed,
+     * known address that can be moved between instances. Its lifetime is not
+     * fixed to any instance.
+     */
+    'floating'
+);
+
+/*
+ * External IP addresses used for guest instances
  *
- * NOTE: This currently stores only address and port information for the
- * automatic source NAT supplied for all guest instances. It does not currently
- * store information about ephemeral or floating IPs.
+ * This includes information about
  */
 CREATE TABLE omicron.public.instance_external_ip (
+    /* Identity metadata */
     id UUID PRIMARY KEY,
+
+    /* Name for floating IPs. See the constraints below. */
+    name STRING(128),
+
+    /* Description for floating IPs. See the constraints below. */
+    description STRING(512),
+
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
     time_deleted TIMESTAMPTZ,
@@ -1023,8 +1069,14 @@ CREATE TABLE omicron.public.instance_external_ip (
     /* FK to the `ip_pool_range` table. */
     ip_pool_range_id UUID NOT NULL,
 
-    /* FK to the `instance` table. */
-    instance_id UUID NOT NULL,
+    /* FK to the `project` table. */
+    project_id UUID NOT NULL,
+
+    /* FK to the `instance` table. See the constraints below. */
+    instance_id UUID,
+
+    /* The kind of external address, e.g., ephemeral. */
+    kind omicron.public.ip_kind NOT NULL,
 
     /* The actual external IP address. */
     ip INET NOT NULL,
@@ -1033,7 +1085,28 @@ CREATE TABLE omicron.public.instance_external_ip (
     first_port INT4 NOT NULL,
 
     /* The last port in the allowed range, also inclusive. */
-    last_port INT4 NOT NULL
+    last_port INT4 NOT NULL,
+
+    /* The name must be non-NULL iff this is a floating IP. */
+    CONSTRAINT null_fip_name CHECK (
+        (kind != 'floating' AND name IS NULL) OR
+        (kind = 'floating' AND name IS NOT NULL)
+    ),
+
+    /* The description must be non-NULL iff this is a floating IP. */
+    CONSTRAINT null_fip_description CHECK (
+        (kind != 'floating' AND description IS NULL) OR
+        (kind = 'floating' AND description IS NOT NULL)
+    ),
+
+    /*
+     * Only nullable if this is a floating IP, which may exist not attached
+     * to any instance.
+     */
+    CONSTRAINT null_non_fip_instance_id CHECK (
+        (kind != 'floating' AND instance_id IS NOT NULL) OR
+        (kind = 'floating')
+    )
 );
 
 /*
@@ -1062,7 +1135,7 @@ CREATE UNIQUE INDEX ON omicron.public.instance_external_ip (
 CREATE INDEX ON omicron.public.instance_external_ip (
     instance_id
 )
-    WHERE time_deleted IS NULL;
+    WHERE instance_id IS NOT NULL AND time_deleted IS NULL;
 
 /*******************************************************************/
 

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1046,8 +1046,6 @@ CREATE TYPE omicron.public.ip_kind AS ENUM (
 
 /*
  * External IP addresses used for guest instances
- *
- * This includes information about
  */
 CREATE TABLE omicron.public.instance_external_ip (
     /* Identity metadata */

--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! External IP addresses for instances
+
+use crate::authz;
+use crate::context::OpContext;
+use crate::db::lookup::LookupPath;
+use crate::db::model::IpKind;
+use crate::db::model::Name;
+use crate::external_api::views::ExternalIp;
+use omicron_common::api::external::ListResultVec;
+
+impl super::Nexus {
+    pub async fn instance_list_external_ips(
+        &self,
+        opctx: &OpContext,
+        organization_name: &Name,
+        project_name: &Name,
+        instance_name: &Name,
+    ) -> ListResultVec<ExternalIp> {
+        let (.., authz_instance) = LookupPath::new(opctx, &self.db_datastore)
+            .organization_name(organization_name)
+            .project_name(project_name)
+            .instance_name(instance_name)
+            .lookup_for(authz::Action::Read)
+            .await?;
+        Ok(self
+            .db_datastore
+            .instance_lookup_external_ips(opctx, authz_instance.id())
+            .await?
+            .into_iter()
+            .filter_map(|ip| {
+                if ip.kind == IpKind::SNat {
+                    None
+                } else {
+                    Some(ip.try_into().unwrap())
+                }
+            })
+            .collect::<Vec<_>>())
+    }
+}

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -217,8 +217,7 @@ impl super::Nexus {
         self.db_datastore
             .project_delete_instance(opctx, &authz_instance)
             .await?;
-        // Ignore the count of addresses deleted, since we're not sure how many
-        // exist at this point.
+        // Ignore the count of addresses deleted
         self.db_datastore
             .deallocate_instance_external_ip_by_instance_id(
                 opctx,
@@ -493,18 +492,38 @@ impl super::Nexus {
             .await?;
 
         // Collect the external IPs for the instance.
-        //
-        // For now, we take the Ephemeral IP, if it exists, or the SNAT IP if not.
-        // TODO-correctness: Handle multiple IP addresses
-        // TODO-correctness: Handle Floating IPs
-        let (ephemeral_ips, snat_ip): (Vec<_>, Vec<_>) = self
+        // TODO-correctness: Handle Floating IPs, see
+        //  https://github.com/oxidecomputer/omicron/issues/1334
+        let (snat_ip, external_ips): (Vec<_>, Vec<_>) = self
             .db_datastore
             .instance_lookup_external_ips(&opctx, authz_instance.id())
             .await?
             .into_iter()
-            .partition(|ip| ip.kind == IpKind::Ephemeral);
+            .partition(|ip| ip.kind == IpKind::SNat);
+
+        // Sanity checks on the number and kind of each IP address.
+        if external_ips.len() > crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE {
+            return Err(Error::internal_error(
+                format!(
+                    "Expected the number of external IPs to be limited to \
+                {}, but found {}",
+                    crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE,
+                    external_ips.len(),
+                )
+                .as_str(),
+            ));
+        }
+        if snat_ip.len() != 1 {
+            return Err(Error::internal_error(
+                "Expected exactly one SNAT IP address for an instance",
+            ));
+        }
+
+        // For now, we take the Ephemeral IP, if it exists, or the SNAT IP if not.
+        // TODO-correctness: Handle multiple IP addresses, see
+        //  https://github.com/oxidecomputer/omicron/issues/1467
         let external_ip = ExternalIp::from(
-            ephemeral_ips.into_iter().chain(snat_ip).next().unwrap(),
+            external_ips.into_iter().chain(snat_ip).next().unwrap(),
         );
 
         // Gather the SSH public keys of the actor make the request so

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -106,11 +106,14 @@ impl super::Nexus {
         pool_name: &Name,
         range: &IpRange,
     ) -> UpdateResult<db::model::IpPoolRange> {
-        let (.., authz_pool) = LookupPath::new(opctx, &self.db_datastore)
-            .ip_pool_name(pool_name)
-            .lookup_for(authz::Action::Modify)
-            .await?;
-        self.db_datastore.ip_pool_add_range(opctx, &authz_pool, range).await
+        let (.., authz_pool, db_pool) =
+            LookupPath::new(opctx, &self.db_datastore)
+                .ip_pool_name(pool_name)
+                .fetch_for(authz::Action::Modify)
+                .await?;
+        self.db_datastore
+            .ip_pool_add_range(opctx, &authz_pool, &db_pool, range)
+            .await
     }
 
     pub async fn ip_pool_delete_range(

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 // by resource.
 mod device_auth;
 mod disk;
+mod external_ip;
 mod iam;
 mod image;
 mod instance;
@@ -52,6 +53,9 @@ mod sagas;
 pub(crate) const MAX_DISKS_PER_INSTANCE: u32 = 8;
 
 pub(crate) const MAX_NICS_PER_INSTANCE: u32 = 8;
+
+// TODO-completness: Support multiple Ephemeral IPs
+pub(crate) const MAX_EPHEMERAL_IPS_PER_INSTANCE: u32 = 1;
 
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -55,7 +55,7 @@ pub(crate) const MAX_DISKS_PER_INSTANCE: u32 = 8;
 pub(crate) const MAX_NICS_PER_INSTANCE: u32 = 8;
 
 // TODO-completness: Support multiple Ephemeral IPs
-pub(crate) const MAX_EPHEMERAL_IPS_PER_INSTANCE: u32 = 1;
+pub(crate) const MAX_EPHEMERAL_IPS_PER_INSTANCE: usize = 1;
 
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -166,19 +166,40 @@ async fn sim_instance_migrate(
     };
 
     // Collect the external IPs for the instance.
-    //
-    // For now, we take the Ephemeral IP, if it exists, or the SNAT IP if not.
-    // TODO-correctness: Handle multiple IP addresses
-    // TODO-correctness: Handle Floating IPs
-    let (ephemeral_ips, snat_ip): (Vec<_>, Vec<_>) = osagactx
+    //  https://github.com/oxidecomputer/omicron/issues/1467
+    // TODO-correctness: Handle Floating IPs, see
+    //  https://github.com/oxidecomputer/omicron/issues/1334
+    let (snat_ip, external_ips): (Vec<_>, Vec<_>) = osagactx
         .datastore()
         .instance_lookup_external_ips(&opctx, instance_id)
         .await
         .map_err(ActionError::action_failed)?
         .into_iter()
-        .partition(|ip| ip.kind == IpKind::Ephemeral);
+        .partition(|ip| ip.kind == IpKind::SNat);
+
+    // Sanity checks on the number and kind of each IP address.
+    if external_ips.len() > crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE {
+        return Err(ActionError::action_failed(Error::internal_error(
+            format!(
+                "Expected the number of external IPs to be limited to \
+            {}, but found {}",
+                crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE,
+                external_ips.len(),
+            )
+            .as_str(),
+        )));
+    }
+    if snat_ip.len() != 1 {
+        return Err(ActionError::action_failed(Error::internal_error(
+            "Expected exactly one SNAT IP address for an instance",
+        )));
+    }
+
+    // For now, we take the Ephemeral IP, if it exists, or the SNAT IP if not.
+    // TODO-correctness: Handle multiple IP addresses, see
+    //  https://github.com/oxidecomputer/omicron/issues/1467
     let external_ip = ExternalIp::from(
-        ephemeral_ips.into_iter().chain(snat_ip).next().unwrap(),
+        external_ips.into_iter().chain(snat_ip).next().unwrap(),
     );
 
     let instance_hardware = InstanceHardware {

--- a/nexus/src/db/datastore/instance_external_ip.rs
+++ b/nexus/src/db/datastore/instance_external_ip.rs
@@ -116,10 +116,9 @@ impl DataStore {
     /// Delete all external IP addresses associated with the provided instance
     /// ID.
     ///
-    /// To support idempotency, such as in saga operations, this method returns
-    /// the number of records deleted, rather than the usual `DeleteResult`.
-    /// Callers should check this to verify their expectations about how many
-    /// records _should_ have been deleted.
+    /// This method returns the number of records deleted, rather than the usual
+    /// `DeleteResult`. That's mostly useful for tests, but could be important
+    /// if callers have some invariants they'd like to check.
     // TODO-correctness: This can't be used for Floating IPs, we'll need a
     // _detatch_ method for that.
     pub async fn deallocate_instance_external_ip_by_instance_id(

--- a/nexus/src/db/datastore/mod.rs
+++ b/nexus/src/db/datastore/mod.rs
@@ -1000,10 +1000,76 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_deallocate_instance_external_ip_is_idempotent() {
+    async fn test_deallocate_instance_external_ip_by_instance_id_is_idempotent()
+    {
+        use crate::db::model::IpKind;
         use crate::db::schema::instance_external_ip::dsl;
 
-        let logctx = dev::test_setup_log("test_table_scan");
+        let logctx = dev::test_setup_log(
+            "test_deallocate_instance_external_ip_by_instance_id_is_idempotent",
+        );
+        let mut db = test_setup_database(&logctx.log).await;
+        let (opctx, datastore) = datastore_test(&logctx, &db).await;
+
+        // Create a few records.
+        let now = Utc::now();
+        let instance_id = Uuid::new_v4();
+        let ips = (0..4)
+            .map(|i| InstanceExternalIp {
+                id: Uuid::new_v4(),
+                name: None,
+                description: None,
+                time_created: now,
+                time_modified: now,
+                time_deleted: None,
+                ip_pool_id: Uuid::new_v4(),
+                ip_pool_range_id: Uuid::new_v4(),
+                project_id: Uuid::new_v4(),
+                instance_id: Some(instance_id),
+                kind: IpKind::Ephemeral,
+                ip: ipnetwork::IpNetwork::from(IpAddr::from(Ipv4Addr::new(
+                    10, 0, 0, i,
+                ))),
+                first_port: crate::db::model::SqlU16(0),
+                last_port: crate::db::model::SqlU16(10),
+            })
+            .collect::<Vec<_>>();
+        diesel::insert_into(dsl::instance_external_ip)
+            .values(ips.clone())
+            .execute_async(datastore.pool())
+            .await
+            .unwrap();
+
+        // Delete everything, make sure we delete all records we made above
+        let count = datastore
+            .deallocate_instance_external_ip_by_instance_id(&opctx, instance_id)
+            .await
+            .expect("Failed to delete instance external IPs");
+        assert_eq!(
+            count,
+            ips.len(),
+            "Expected to delete all IPs for the instance"
+        );
+
+        // Do it again, we should get zero records
+        let count = datastore
+            .deallocate_instance_external_ip_by_instance_id(&opctx, instance_id)
+            .await
+            .expect("Failed to delete instance external IPs");
+        assert_eq!(count, 0, "Expected to delete zero IPs for the instance");
+
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_deallocate_instance_external_ip_is_idempotent() {
+        use crate::db::model::IpKind;
+        use crate::db::schema::instance_external_ip::dsl;
+
+        let logctx = dev::test_setup_log(
+            "test_deallocate_instance_external_ip_is_idempotent",
+        );
         let mut db = test_setup_database(&logctx.log).await;
         let (opctx, datastore) = datastore_test(&logctx, &db).await;
 
@@ -1011,12 +1077,16 @@ mod test {
         let now = Utc::now();
         let ip = InstanceExternalIp {
             id: Uuid::new_v4(),
+            name: None,
+            description: None,
             time_created: now,
             time_modified: now,
             time_deleted: None,
             ip_pool_id: Uuid::new_v4(),
             ip_pool_range_id: Uuid::new_v4(),
-            instance_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            instance_id: Some(Uuid::new_v4()),
+            kind: IpKind::SNat,
             ip: ipnetwork::IpNetwork::from(IpAddr::from(Ipv4Addr::new(
                 10, 0, 0, 1,
             ))),
@@ -1024,7 +1094,7 @@ mod test {
             last_port: crate::db::model::SqlU16(10),
         };
         diesel::insert_into(dsl::instance_external_ip)
-            .values(ip)
+            .values(ip.clone())
             .execute_async(datastore.pool())
             .await
             .unwrap();
@@ -1055,6 +1125,163 @@ mod test {
             .await
             .is_err());
 
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
+    async fn test_external_ip_check_constraints() {
+        use crate::db::model::IpKind;
+        use crate::db::schema::instance_external_ip::dsl;
+        use async_bb8_diesel::ConnectionError::Query;
+        use async_bb8_diesel::PoolError::Connection;
+        use diesel::result::DatabaseErrorKind::CheckViolation;
+        use diesel::result::Error::DatabaseError;
+
+        let logctx = dev::test_setup_log("test_external_ip_check_constraints");
+        let mut db = test_setup_database(&logctx.log).await;
+        let (_opctx, datastore) = datastore_test(&logctx, &db).await;
+        let now = Utc::now();
+
+        // Create a mostly-populated record, for a floating IP
+        let subnet = ipnetwork::IpNetwork::new(
+            IpAddr::from(Ipv4Addr::new(10, 0, 0, 0)),
+            8,
+        )
+        .unwrap();
+        let mut addresses = subnet.iter();
+        let ip = InstanceExternalIp {
+            id: Uuid::new_v4(),
+            name: None,
+            description: None,
+            time_created: now,
+            time_modified: now,
+            time_deleted: None,
+            ip_pool_id: Uuid::new_v4(),
+            ip_pool_range_id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            instance_id: Some(Uuid::new_v4()),
+            kind: IpKind::Floating,
+            ip: addresses.next().unwrap().into(),
+            first_port: crate::db::model::SqlU16(0),
+            last_port: crate::db::model::SqlU16(10),
+        };
+
+        // Combinations of NULL and non-NULL for:
+        // - name
+        // - description
+        // - instance UUID
+        let names = [
+            None,
+            Some(db::model::Name(Name::try_from("foo".to_string()).unwrap())),
+        ];
+        let descriptions = [None, Some("foo".to_string())];
+        let instance_ids = [None, Some(Uuid::new_v4())];
+
+        // For Floating IPs, both name and description must be non-NULL
+        for name in names.iter() {
+            for description in descriptions.iter() {
+                for instance_id in instance_ids.iter() {
+                    let new_ip = InstanceExternalIp {
+                        id: Uuid::new_v4(),
+                        name: name.clone(),
+                        description: description.clone(),
+                        ip: addresses.next().unwrap().into(),
+                        instance_id: *instance_id,
+                        ..ip
+                    };
+                    let res = diesel::insert_into(dsl::instance_external_ip)
+                        .values(new_ip)
+                        .execute_async(datastore.pool())
+                        .await;
+                    if name.is_some() && description.is_some() {
+                        // Name/description must be non-NULL, instance ID can be
+                        // either
+                        res.expect(
+                            "Failed to insert Floating IP with valid \
+                            name, description, and instance ID",
+                        );
+                    } else {
+                        // At least one is not valid, we expect a check violation
+                        let err = res.expect_err(
+                            "Expected a CHECK violation when inserting a \
+                            Floating IP record with NULL name and/or description",
+                        );
+                        assert!(
+                            matches!(
+                                err,
+                                Connection(Query(DatabaseError(
+                                    CheckViolation,
+                                    _
+                                )))
+                            ),
+                            "Expected a CHECK violation when inserting a \
+                        Floating IP record with NULL name and/or description",
+                        );
+                    }
+                }
+            }
+        }
+
+        // For other IP types, both name and description must be NULL
+        for kind in [IpKind::SNat, IpKind::Ephemeral].into_iter() {
+            for name in names.iter() {
+                for description in descriptions.iter() {
+                    for instance_id in instance_ids.iter() {
+                        let new_ip = InstanceExternalIp {
+                            id: Uuid::new_v4(),
+                            name: name.clone(),
+                            description: description.clone(),
+                            kind,
+                            ip: addresses.next().unwrap().into(),
+                            instance_id: *instance_id,
+                            ..ip
+                        };
+                        let res =
+                            diesel::insert_into(dsl::instance_external_ip)
+                                .values(new_ip.clone())
+                                .execute_async(datastore.pool())
+                                .await;
+                        if name.is_none()
+                            && description.is_none()
+                            && instance_id.is_some()
+                        {
+                            // Name/description must be NULL, instance ID cannot
+                            // be NULL.
+                            assert!(
+                                res.is_ok(),
+                                "Failed to insert {:?} IP with valid \
+                                name, description, and instance ID",
+                                kind,
+                            );
+                        } else {
+                            // One is not valid, we expect a check violation
+                            assert!(
+                                res.is_err(),
+                                "Expected a CHECK violation when inserting a \
+                                {:?} IP record with non-NULL name, description, \
+                                and/or instance ID",
+                                kind,
+                            );
+                            let err = res.unwrap_err();
+                            assert!(
+                                matches!(
+                                    err,
+                                    Connection(Query(DatabaseError(
+                                        CheckViolation,
+                                        _
+                                    )))
+                                ),
+                                "Expected a CHECK violation when inserting a \
+                            {:?} IP record with non-NULL name, description, \
+                            and/or instance ID",
+                                kind
+                            );
+                        }
+                    }
+                }
+            }
+        }
         db.cleanup().await.unwrap();
         logctx.cleanup_successful();
     }

--- a/nexus/src/db/model/block_size.rs
+++ b/nexus/src/db/model/block_size.rs
@@ -6,7 +6,6 @@ use super::impl_enum_type;
 use crate::external_api::params;
 use omicron_common::api::external;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 
 impl_enum_type!(
     #[derive(SqlType, Debug, QueryId)]

--- a/nexus/src/db/model/dataset_kind.rs
+++ b/nexus/src/db/model/dataset_kind.rs
@@ -5,7 +5,6 @@
 use super::impl_enum_type;
 use crate::internal_api;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 
 impl_enum_type!(
     #[derive(SqlType, Debug, QueryId)]

--- a/nexus/src/db/model/external_ip.rs
+++ b/nexus/src/db/model/external_ip.rs
@@ -5,25 +5,65 @@
 //! Model types for external IPs, both for instances and externally-facing
 //! services.
 
+use crate::db::model::impl_enum_type;
+use crate::db::model::Name;
 use crate::db::model::SqlU16;
 use crate::db::schema::instance_external_ip;
+use crate::external_api::shared;
+use crate::external_api::views;
 use chrono::DateTime;
 use chrono::Utc;
 use diesel::Queryable;
 use diesel::Selectable;
 use ipnetwork::IpNetwork;
+use omicron_common::api::external::Error;
+use std::convert::TryFrom;
+use std::ops::Deref;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, Selectable, Queryable, Insertable)]
+impl_enum_type!(
+    #[derive(SqlType, Debug, Clone, Copy)]
+    #[diesel(postgres_type(name = "ip_kind"))]
+     pub struct IpKindEnum;
+
+     #[derive(Clone, Copy, Debug, AsExpression, FromSqlRow, PartialEq)]
+     #[diesel(sql_type = IpKindEnum)]
+     pub enum IpKind;
+
+     SNat => b"snat"
+     Ephemeral => b"ephemeral"
+     Floating => b"floating"
+);
+
+/// The main model type for external IP addresses for instances.
+///
+/// This encompasses the three flavors of external IPs: automatic source NAT
+/// IPs, Ephemeral IPs, and Floating IPs. The first two are similar in that they
+/// are anonymous, lacking a name or description, which a Floating IP is a named
+/// API resource. The second two are similar in that they are externally-visible
+/// addresses and port ranges, while source NAT IPs are not discoverable in the
+/// API at all, and only provide outbound connectivity to instances, not
+/// inbound.
+#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
 #[diesel(table_name = instance_external_ip)]
 pub struct InstanceExternalIp {
     pub id: Uuid,
+    // Only Some(_) for Floating IPs
+    pub name: Option<Name>,
+    // Only Some(_) for Floating IPs
+    pub description: Option<String>,
     pub time_created: DateTime<Utc>,
     pub time_modified: DateTime<Utc>,
     pub time_deleted: Option<DateTime<Utc>>,
     pub ip_pool_id: Uuid,
     pub ip_pool_range_id: Uuid,
-    pub instance_id: Uuid,
+    pub project_id: Uuid,
+    // This is Some(_) for:
+    //  - all instance SNAT IPs
+    //  - all ephemeral IPs
+    //  - a floating IP attached to an instance.
+    pub instance_id: Option<Uuid>,
+    pub kind: IpKind,
     pub ip: IpNetwork,
     pub first_port: SqlU16,
     pub last_port: SqlU16,
@@ -39,24 +79,170 @@ impl From<InstanceExternalIp> for sled_agent_client::types::ExternalIp {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+/// An incomplete external IP, used to store state required for issuing the
+/// database query that selects an available IP and stores the resulting record.
+#[derive(Debug, Clone)]
 pub struct IncompleteInstanceExternalIp {
-    pub id: Uuid,
-    pub time_created: DateTime<Utc>,
-    pub time_modified: DateTime<Utc>,
-    pub time_deleted: Option<DateTime<Utc>>,
-    pub instance_id: Uuid,
+    id: Uuid,
+    name: Option<Name>,
+    description: Option<String>,
+    time_created: DateTime<Utc>,
+    kind: IpKind,
+    project_id: Uuid,
+    instance_id: Option<Uuid>,
+    pool_id: Option<Uuid>,
 }
 
 impl IncompleteInstanceExternalIp {
-    pub fn new(instance_id: Uuid) -> Self {
-        let now = Utc::now();
+    pub fn for_instance_source_nat(
+        id: Uuid,
+        project_id: Uuid,
+        instance_id: Uuid,
+        pool_id: Option<Uuid>,
+    ) -> Self {
         Self {
-            id: Uuid::new_v4(),
-            time_created: now,
-            time_modified: now,
-            time_deleted: None,
-            instance_id,
+            id,
+            name: None,
+            description: None,
+            time_created: Utc::now(),
+            kind: IpKind::SNat,
+            project_id,
+            instance_id: Some(instance_id),
+            pool_id,
         }
+    }
+
+    pub fn for_ephemeral(
+        id: Uuid,
+        project_id: Uuid,
+        instance_id: Uuid,
+        pool_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            id,
+            name: None,
+            description: None,
+            time_created: Utc::now(),
+            kind: IpKind::Ephemeral,
+            project_id,
+            instance_id: Some(instance_id),
+            pool_id,
+        }
+    }
+
+    pub fn for_floating(
+        id: Uuid,
+        name: &Name,
+        description: &str,
+        project_id: Uuid,
+        pool_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            id,
+            name: Some(name.clone()),
+            description: Some(description.to_string()),
+            time_created: Utc::now(),
+            kind: IpKind::Floating,
+            project_id,
+            instance_id: None,
+            pool_id,
+        }
+    }
+
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+
+    pub fn name(&self) -> &Option<Name> {
+        &self.name
+    }
+
+    pub fn description(&self) -> &Option<String> {
+        &self.description
+    }
+
+    pub fn time_created(&self) -> &DateTime<Utc> {
+        &self.time_created
+    }
+
+    pub fn kind(&self) -> &IpKind {
+        &self.kind
+    }
+
+    pub fn project_id(&self) -> &Uuid {
+        &self.project_id
+    }
+
+    pub fn instance_id(&self) -> &Option<Uuid> {
+        &self.instance_id
+    }
+
+    pub fn pool_id(&self) -> &Option<Uuid> {
+        &self.pool_id
+    }
+}
+
+impl TryFrom<IpKind> for shared::IpKind {
+    type Error = Error;
+
+    fn try_from(kind: IpKind) -> Result<Self, Self::Error> {
+        match kind {
+            IpKind::Ephemeral => Ok(shared::IpKind::Ephemeral),
+            IpKind::Floating => Ok(shared::IpKind::Floating),
+            _ => Err(Error::internal_error(
+                "SNAT IP addresses should not be exposed in the API",
+            )),
+        }
+    }
+}
+
+impl TryFrom<InstanceExternalIp> for views::ExternalIp {
+    type Error = Error;
+
+    fn try_from(ip: InstanceExternalIp) -> Result<Self, Self::Error> {
+        let kind = ip.kind.try_into()?;
+        Ok(views::ExternalIp { kind, ip: ip.ip.ip() })
+    }
+}
+
+#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
+#[diesel(table_name = instance_external_ip)]
+pub struct InstanceSourceNatIp {
+    #[diesel(embed)]
+    inner: InstanceExternalIp,
+}
+
+impl Deref for InstanceSourceNatIp {
+    type Target = InstanceExternalIp;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
+#[diesel(table_name = instance_external_ip)]
+pub struct EphemeralIp {
+    #[diesel(embed)]
+    inner: InstanceExternalIp,
+}
+
+impl Deref for EphemeralIp {
+    type Target = InstanceExternalIp;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
+#[diesel(table_name = instance_external_ip)]
+pub struct FloatingIp {
+    #[diesel(embed)]
+    inner: InstanceExternalIp,
+}
+
+impl Deref for FloatingIp {
+    type Target = InstanceExternalIp;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/nexus/src/db/model/external_ip.rs
+++ b/nexus/src/db/model/external_ip.rs
@@ -18,7 +18,6 @@ use diesel::Selectable;
 use ipnetwork::IpNetwork;
 use omicron_common::api::external::Error;
 use std::convert::TryFrom;
-use std::ops::Deref;
 use uuid::Uuid;
 
 impl_enum_type!(
@@ -202,47 +201,5 @@ impl TryFrom<InstanceExternalIp> for views::ExternalIp {
     fn try_from(ip: InstanceExternalIp) -> Result<Self, Self::Error> {
         let kind = ip.kind.try_into()?;
         Ok(views::ExternalIp { kind, ip: ip.ip.ip() })
-    }
-}
-
-#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
-#[diesel(table_name = instance_external_ip)]
-pub struct InstanceSourceNatIp {
-    #[diesel(embed)]
-    inner: InstanceExternalIp,
-}
-
-impl Deref for InstanceSourceNatIp {
-    type Target = InstanceExternalIp;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
-#[diesel(table_name = instance_external_ip)]
-pub struct EphemeralIp {
-    #[diesel(embed)]
-    inner: InstanceExternalIp,
-}
-
-impl Deref for EphemeralIp {
-    type Target = InstanceExternalIp;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-#[derive(Debug, Clone, Selectable, Queryable, Insertable)]
-#[diesel(table_name = instance_external_ip)]
-pub struct FloatingIp {
-    #[diesel(embed)]
-    inner: InstanceExternalIp,
-}
-
-impl Deref for FloatingIp {
-    type Target = InstanceExternalIp;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }

--- a/nexus/src/db/model/identity_provider.rs
+++ b/nexus/src/db/model/identity_provider.rs
@@ -7,7 +7,6 @@ use crate::db::schema::{identity_provider, saml_identity_provider};
 use db_macros::Resource;
 
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use uuid::Uuid;
 
 impl_enum_type!(

--- a/nexus/src/db/model/mod.rs
+++ b/nexus/src/db/model/mod.rs
@@ -198,6 +198,7 @@ macro_rules! impl_enum_type {
                 &'a self,
                 out: &mut ::diesel::serialize::Output<'a, '_, ::diesel::pg::Pg>,
             ) -> ::diesel::serialize::Result {
+                use ::std::io::Write;
                 match self {
                     $(
                     $model_type::$enum_item => {

--- a/nexus/src/db/model/role_assignment.rs
+++ b/nexus/src/db/model/role_assignment.rs
@@ -6,7 +6,6 @@ use super::impl_enum_type;
 use crate::db::schema::role_assignment;
 use crate::external_api::shared;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use uuid::Uuid;
 
 impl_enum_type!(

--- a/nexus/src/db/model/service_kind.rs
+++ b/nexus/src/db/model/service_kind.rs
@@ -5,7 +5,6 @@
 use super::impl_enum_type;
 use crate::internal_api;
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 
 impl_enum_type!(
     #[derive(SqlType, Debug, QueryId)]

--- a/nexus/src/db/model/silo.rs
+++ b/nexus/src/db/model/silo.rs
@@ -8,7 +8,6 @@ use crate::db::model::impl_enum_type;
 use crate::db::schema::{organization, silo};
 use crate::external_api::{params, shared};
 use db_macros::Resource;
-use std::io::Write;
 use uuid::Uuid;
 
 impl_enum_type!(

--- a/nexus/src/db/model/vpc_router.rs
+++ b/nexus/src/db/model/vpc_router.rs
@@ -8,7 +8,6 @@ use crate::db::schema::{router_route, vpc_router};
 use crate::external_api::params;
 use chrono::{DateTime, Utc};
 use db_macros::Resource;
-use std::io::Write;
 use uuid::Uuid;
 
 impl_enum_type!(

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -7,6 +7,9 @@
 
 use crate::db::model::IncompleteInstanceExternalIp;
 use crate::db::model::InstanceExternalIp;
+use crate::db::model::IpKind;
+use crate::db::model::IpKindEnum;
+use crate::db::model::Name;
 use crate::db::pool::DbConnection;
 use crate::db::schema;
 use chrono::DateTime;
@@ -78,9 +81,12 @@ const MAX_PORT: i32 = u16::MAX as _;
 ///     (
 ///         SELECT
 ///             <ip_id> AS id,
+///             <name> AS name,
+///             <description> AS description,
 ///             <now> AS time_created,
 ///             <now> AS time_modified,
 ///             NULL AS time_deleted,
+///             <project_id> AS project_id,
 ///             <instance_id> AS instance_id,
 ///             ip_pool_id,
 ///             ip_pool_range_id,
@@ -99,6 +105,8 @@ const MAX_PORT: i32 = u16::MAX as _;
 ///                 FROM
 ///                     ip_pool_range
 ///                 WHERE
+///                     project_id = <project_id> OR
+///                     project_id IS NULL AND
 ///                     time_deleted IS NULL
 ///             )
 ///         CROSS JOIN
@@ -122,23 +130,13 @@ const MAX_PORT: i32 = u16::MAX as _;
 ///             (ip, first_port, time_deleted IS NULL) =
 ///             (candidate_ip, candidate_first_port, TRUE)
 ///         WHERE
-///             ip IS NULL AND
-///             first_port IS NULL AND
-///             time_deleted IS NULL
+///             ip IS NULL
+///         ORDER BY
+///             candidate_ip, candidate_first_port
 ///         LIMIT 1
 ///     )
-///     RETURNING
-///         id,
-///         time_created,
-///         time_modified,
-///         time_deleted,
-///         instance_id,
-///         ip_pool_id,
-///         ip_pool_range_id,
-///         ip,
-///         first_port,
-///         last_port
-///     ),
+///     RETURNING *
+/// ),
 /// updated_pool AS (
 ///     UPDATE SET
 ///         ip_pool_range
@@ -173,7 +171,8 @@ const MAX_PORT: i32 = u16::MAX as _;
 pub struct NextExternalIp {
     // TODO-completeness: Add `ip_pool_id`, and restrict search to it.
     ip: IncompleteInstanceExternalIp,
-    // Number of ports reserved per IP address
+    // Number of ports reserved per IP address. Only applicable if the IP kind
+    // is snat.
     n_ports_per_chunk: i32,
     // The offset from the first port to the last, inclusive. This is required
     // because the ranges must not overlap and `generate_series` is inclusive of
@@ -203,30 +202,44 @@ impl NextExternalIp {
 
         // NOTE: These columns must be selected in the order in which they
         // appear in the table, to avoid needing to push the explicit column
-        // names as well.
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.ip.id)?;
+        // names in the RETURNING clause and final SELECT from the CTE.
+
+        // Id
+        out.push_bind_param::<sql_types::Uuid, Uuid>(self.ip.id())?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::id::NAME)?;
         out.push_sql(", ");
 
+        // Name, possibly null
+        out.push_bind_param::<sql_types::Nullable<sql_types::Text>, Option<Name>>(self.ip.name())?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::name::NAME)?;
+        out.push_sql(", ");
+
+        // Description, possibly null
+        out.push_bind_param::<sql_types::Nullable<sql_types::Text>, Option<String>>(self.ip.description())?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::description::NAME)?;
+        out.push_sql(", ");
+
         // Time-created
         out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(
-            &self.ip.time_created,
+            self.ip.time_created(),
         )?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::time_created::NAME)?;
         out.push_sql(", ");
 
-        // Time-modified
+        // Time-modified, same as created
         out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(
-            &self.ip.time_modified,
+            self.ip.time_created(),
         )?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::time_modified::NAME)?;
         out.push_sql(", ");
 
-        // Time-modified
-        out.push_bind_param::<sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&self.ip.time_deleted)?;
+        // Time-deleted
+        out.push_bind_param::<sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&None)?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::time_deleted::NAME)?;
         out.push_sql(", ");
@@ -239,10 +252,22 @@ impl NextExternalIp {
         out.push_identifier(dsl::ip_pool_range_id::NAME)?;
         out.push_sql(", ");
 
+        // Project ID
+        out.push_bind_param::<sql_types::Uuid, Uuid>(self.ip.project_id())?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::project_id::NAME)?;
+        out.push_sql(", ");
+
         // Instance ID
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.ip.instance_id)?;
+        out.push_bind_param::<sql_types::Nullable<sql_types::Uuid>, Option<Uuid>>(self.ip.instance_id())?;
         out.push_sql(" AS ");
         out.push_identifier(dsl::instance_id::NAME)?;
+        out.push_sql(", ");
+
+        // IP kind
+        out.push_bind_param::<IpKindEnum, IpKind>(self.ip.kind())?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::kind::NAME)?;
         out.push_sql(", ");
 
         // Candidate IP from the subquery
@@ -260,27 +285,97 @@ impl NextExternalIp {
         self.push_port_sequence_subquery(out.reborrow())?;
         out.push_sql(") LEFT OUTER JOIN ");
         INSTANCE_EXTERNAL_IP_FROM_CLAUSE.walk_ast(out.reborrow())?;
-        out.push_sql(" ON (");
+
+        // This is for SNAT IPs. For floating or ephemeral, we don't want to
+        // consider the port in the JOIN, just the address (_any_ port chunk
+        // means we can't use that address for the floating/ephemeral IP).
+        // Something like:
+        //
+        // ON (ip, time_deleted IS NULL) = (candidate_ip, TRUE)
+        //
+        // We'll also need to change how we generate the port sequence subquery.
+        // It should always be 0, basically, but not sure the best way to do
+        // that. SELECT 0? That should work:
+        //
+        // SELECT 0 as candidate_first_port, 65535 as candidate_last_port
+
+        // The JOIN conditions depend on the IP type. For automatic SNAT IP
+        // addresses, we need to consider existing records with their port
+        // ranges. That's because we want to allow providing two different
+        // chunks of ports from the same IP to two different guests.
+        //
+        // However, for Floating and Ephemeral IPs, we need to reserve the
+        // entire port range. Guests may start listening on any port, and we
+        // need to allow inbound connections to that port. (It can't be
+        // rewritten on the way in.)
+        //
+        // In the first case the JOIN conditions look like:
+        //
+        // ```sql
+        // ON
+        //     (ip, first_port, time_deleted IS NULL) =
+        //     (candidate_ip, candidate_first_port, TRUE)
+        // ```
+        //
+        // I.e., we're considering records in the list of possibles to match
+        // when the IP and the first port both match an existing record.
+        //
+        // In the second case, the conditions are:
+        //
+        // ```sql
+        // ON (ip, time_deleted IS NULL) = (candidate_ip, TRUE)
+        // ```
+        //
+        // Here, we don't care what the port is. Any record in the table that
+        // has that IP should be considered a match.
+        //
+        // In either case, we follow this with a filter `WHERE ip IS NULL`,
+        // meaning we select the candidate address and first port that does not
+        // have a matching record in the table already.
+        if matches!(self.ip.kind(), &IpKind::SNat) {
+            out.push_sql(" ON (");
+            out.push_identifier(dsl::ip::NAME)?;
+            out.push_sql(", ");
+            out.push_identifier(dsl::first_port::NAME)?;
+            out.push_sql(", ");
+            out.push_identifier(dsl::time_deleted::NAME)?;
+            out.push_sql(
+                " IS NULL) = (candidate_ip, candidate_first_port, TRUE) ",
+            );
+        } else {
+            out.push_sql(" ON (");
+            out.push_identifier(dsl::ip::NAME)?;
+            out.push_sql(", ");
+            out.push_identifier(dsl::time_deleted::NAME)?;
+            out.push_sql(" IS NULL) = (candidate_ip, TRUE) ");
+        }
+
+        // In all cases, we're selecting rows from the join that don't have a
+        // match in the existing table.
+        //
+        // This is a bit subtle. The join condition considers rows a match if
+        // the `time_deleted` is null. That means that if the record has been
+        // soft-deleted, it won't be considered a match, and thus both the IP
+        // and first port (in the join result) will be null. Note that there
+        // _is_ a record in the `instance_external_ip` table that has that IP
+        // and possibly first port, but since it's been soft-deleted, it's not a
+        // match. In that case, we can get away with _only_ filtering the join
+        // results on the IP from the `instance_external_ip` table being NULL.
+        out.push_sql(" WHERE ");
         out.push_identifier(dsl::ip::NAME)?;
-        out.push_sql(", ");
-        out.push_identifier(dsl::first_port::NAME)?;
-        out.push_sql(", ");
-        out.push_identifier(dsl::time_deleted::NAME)?;
         out.push_sql(
-            " IS NULL) = (candidate_ip, candidate_first_port, TRUE) WHERE ",
+            " IS NULL \
+            ORDER BY candidate_ip, candidate_first_port \
+            LIMIT 1) RETURNING *",
         );
-        out.push_identifier(dsl::ip::NAME)?;
-        out.push_sql(" IS NULL AND ");
-        out.push_identifier(dsl::first_port::NAME)?;
-        out.push_sql(" IS NULL AND ");
-        out.push_identifier(dsl::time_deleted::NAME)?;
-        out.push_sql(" IS NULL LIMIT 1) RETURNING *");
 
         Ok(())
     }
 
     // Push a subquery that selects the sequence of IP addresses, from each range in
-    // each IP Pool, along with the pool/range IDs.
+    // each IP Pool, along with the pool/range IDs. Note that we only allow
+    // allocation out of IP Pools that match the project_id of the instance, or
+    // which have no project ID (the pool is not restricted to a project)
     //
     // ```sql
     // SELECT
@@ -292,6 +387,7 @@ impl NextExternalIp {
     // FROM
     //     ip_pool_range
     // WHERE
+    //     (project_id = <project_id> OR project_id IS NULL) AND
     //     time_deleted IS NULL
     // ```
     fn push_address_sequence_subquery<'a>(
@@ -311,14 +407,27 @@ impl NextExternalIp {
         out.push_identifier(dsl::first_address::NAME)?;
         out.push_sql(") AS candidate_ip FROM ");
         IP_POOL_RANGE_FROM_CLAUSE.walk_ast(out.reborrow())?;
-        out.push_sql(" WHERE ");
+        out.push_sql(" WHERE (");
+        out.push_identifier(dsl::project_id::NAME)?;
+        out.push_sql(" = ");
+        out.push_bind_param::<sql_types::Uuid, Uuid>(self.ip.project_id())?;
+        out.push_sql(" OR ");
+        out.push_identifier(dsl::project_id::NAME)?;
+        out.push_sql(" IS NULL) AND ");
         out.push_identifier(dsl::time_deleted::NAME)?;
         out.push_sql(" IS NULL");
         Ok(())
     }
 
     // Push a subquery that selects the possible values for a first port, based on
-    // the defined spacing.
+    // the defined spacing. Note that there are two forms, depending on whether
+    // the IP type we're allocating for is Floating/Ephemeral, or an SNAT IP
+    // address.
+    //
+    // For SNAT addresses, we want to provide port ranges. Those ranges must not
+    // overlap between different records, but there will be more than one record
+    // with the same IP. This subquery then generates the port-range chunks
+    // sequentially.
     //
     // ```sql
     // SELECT
@@ -330,17 +439,38 @@ impl NextExternalIp {
     //     generate_series(0, <MAX_PORT>, <NUM_SOURCE_NAT_PORTS>)
     //         AS candidate_first_port
     // ```
+    //
+    // For Floating or Ephemeral IP addresses, we reserve the entire port range
+    // for the guest. In this case, we generate the static values 0 and 65535:
+    //
+    // ```sql
+    // SELECT
+    //     0 AS candidate_first_port,
+    //     65535 AS candidate_last_port
+    // ```
     fn push_port_sequence_subquery<'a>(
         &'a self,
         mut out: AstPass<'_, 'a, Pg>,
     ) -> QueryResult<()> {
-        out.push_sql("SELECT candidate_first_port, candidate_first_port + ");
-        out.push_bind_param::<sql_types::Int4, i32>(&self.last_port_offset)?;
-        out.push_sql(" AS candidate_last_port FROM generate_series(0, ");
-        out.push_bind_param::<sql_types::Int4, i32>(&MAX_PORT)?;
-        out.push_sql(", ");
-        out.push_bind_param::<sql_types::Int4, i32>(&self.n_ports_per_chunk)?;
-        out.push_sql(") AS candidate_first_port");
+        if matches!(self.ip.kind(), &IpKind::SNat) {
+            out.push_sql(
+                "SELECT candidate_first_port, candidate_first_port + ",
+            );
+            out.push_bind_param::<sql_types::Int4, i32>(
+                &self.last_port_offset,
+            )?;
+            out.push_sql(" AS candidate_last_port FROM generate_series(0, ");
+            out.push_bind_param::<sql_types::Int4, i32>(&MAX_PORT)?;
+            out.push_sql(", ");
+            out.push_bind_param::<sql_types::Int4, i32>(
+                &self.n_ports_per_chunk,
+            )?;
+            out.push_sql(") AS candidate_first_port");
+        } else {
+            out.push_sql("SELECT 0 AS candidate_first_port, ");
+            out.push_bind_param::<sql_types::Int4, i32>(&MAX_PORT)?;
+            out.push_sql(" AS candidate_last_port");
+        }
         Ok(())
     }
 
@@ -419,6 +549,7 @@ mod tests {
     use crate::context::OpContext;
     use crate::db::datastore::DataStore;
     use crate::db::identity::Resource;
+    use crate::db::model::IpKind;
     use crate::db::model::IpPool;
     use crate::db::model::IpPoolRange;
     use crate::external_api::shared::IpRange;
@@ -454,11 +585,22 @@ mod tests {
             Self { logctx, opctx, db, db_datastore }
         }
 
-        async fn create_ip_pool(&self, name: &str, range: IpRange) {
-            let pool = IpPool::new(&IdentityMetadataCreateParams {
-                name: String::from(name).parse().unwrap(),
-                description: format!("ip pool {}", name),
-            });
+        async fn create_ip_pool(
+            &self,
+            name: &str,
+            range: IpRange,
+            project_id: Option<Uuid>,
+        ) {
+            // Create with no org/project name, set project_id manually.
+            let mut pool = IpPool::new(
+                &IdentityMetadataCreateParams {
+                    name: String::from(name).parse().unwrap(),
+                    description: format!("ip pool {}", name),
+                },
+                None,
+            );
+            pool.project_id = project_id;
+
             diesel::insert_into(crate::db::schema::ip_pool::dsl::ip_pool)
                 .values(pool.clone())
                 .execute_async(
@@ -470,7 +612,7 @@ mod tests {
                 .await
                 .expect("Failed to create IP Pool");
 
-            let pool_range = IpPoolRange::new(&range, pool.id());
+            let pool_range = IpPoolRange::new(&range, pool.id(), project_id);
             diesel::insert_into(
                 crate::db::schema::ip_pool_range::dsl::ip_pool_range,
             )
@@ -498,14 +640,21 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 1),
         ))
         .unwrap();
-        context.create_ip_pool("p0", range).await;
+        context.create_ip_pool("p0", range, None).await;
+        let project_id = Uuid::new_v4();
         for first_port in
             (0..super::MAX_PORT).step_by(super::NUM_SOURCE_NAT_PORTS)
         {
+            let id = Uuid::new_v4();
             let instance_id = Uuid::new_v4();
             let ip = context
                 .db_datastore
-                .allocate_instance_external_ip(&context.opctx, instance_id)
+                .allocate_instance_snat_ip(
+                    &context.opctx,
+                    id,
+                    project_id,
+                    instance_id,
+                )
                 .await
                 .expect("Failed to allocate instance external IP address");
             assert_eq!(ip.ip.ip(), range.first_address());
@@ -520,7 +669,12 @@ mod tests {
         let instance_id = Uuid::new_v4();
         let err = context
             .db_datastore
-            .allocate_instance_external_ip(&context.opctx, instance_id)
+            .allocate_instance_snat_ip(
+                &context.opctx,
+                Uuid::new_v4(),
+                project_id,
+                instance_id,
+            )
             .await
             .expect_err(
                 "An error should be received when the IP pools are exhausted",
@@ -549,7 +703,7 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 3),
         ))
         .unwrap();
-        context.create_ip_pool("p0", range).await;
+        context.create_ip_pool("p0", range, None).await;
 
         // TODO-completess: Implementing Iterator for IpRange would be nice.
         let addresses = [
@@ -562,11 +716,17 @@ mod tests {
 
         // Allocate two addresses
         let mut ips = Vec::with_capacity(2);
+        let project_id = Uuid::new_v4();
         for (expected_ip, expected_first_port) in external_ips.clone().take(2) {
             let instance_id = Uuid::new_v4();
             let ip = context
                 .db_datastore
-                .allocate_instance_external_ip(&context.opctx, instance_id)
+                .allocate_instance_snat_ip(
+                    &context.opctx,
+                    Uuid::new_v4(),
+                    project_id,
+                    instance_id,
+                )
                 .await
                 .expect("Failed to allocate instance external IP address");
             assert_eq!(ip.ip.ip(), expected_ip);
@@ -590,9 +750,15 @@ mod tests {
         let instance_id = Uuid::new_v4();
         let ip = context
             .db_datastore
-            .allocate_instance_external_ip(&context.opctx, instance_id)
+            .allocate_instance_snat_ip(
+                &context.opctx,
+                Uuid::new_v4(),
+                project_id,
+                instance_id,
+            )
             .await
             .expect("Failed to allocate instance external IP address");
+        println!("{:?}\n{:?}", ip, ips[0]);
         assert_eq!(
             ip.ip, ips[0].ip,
             "Expected to reallocate external IPs sequentially"
@@ -611,7 +777,12 @@ mod tests {
         let instance_id = Uuid::new_v4();
         let ip = context
             .db_datastore
-            .allocate_instance_external_ip(&context.opctx, instance_id)
+            .allocate_instance_snat_ip(
+                &context.opctx,
+                Uuid::new_v4(),
+                project_id,
+                instance_id,
+            )
             .await
             .expect("Failed to allocate instance external IP address");
         let (expected_ip, expected_first_port) = external_ips.nth(2).unwrap();
@@ -621,6 +792,115 @@ mod tests {
             + (super::NUM_SOURCE_NAT_PORTS - 1) as i32)
             as u16;
         assert_eq!(ip.last_port.0, expected_last_port);
+
+        context.success().await;
+    }
+
+    #[tokio::test]
+    async fn test_next_external_ip_with_ephemeral_takes_whole_port_range() {
+        let context = TestContext::new(
+            "test_next_external_ip_with_ephemeral_takes_whole_port_range",
+        )
+        .await;
+        let range = IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 3),
+        ))
+        .unwrap();
+        context.create_ip_pool("p0", range, None).await;
+
+        let instance_id = Uuid::new_v4();
+        let project_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        let pool_name = None;
+
+        let ip = context
+            .db_datastore
+            .allocate_instance_ephemeral_ip(
+                &context.opctx,
+                id,
+                project_id,
+                instance_id,
+                pool_name,
+            )
+            .await
+            .expect("Failed to allocate instance ephemeral IP address");
+        assert_eq!(ip.kind, IpKind::Ephemeral);
+        assert_eq!(ip.ip.ip(), range.first_address());
+        assert_eq!(ip.first_port.0, 0);
+        assert_eq!(ip.last_port.0, u16::MAX);
+
+        context.success().await;
+    }
+
+    #[tokio::test]
+    async fn test_next_external_ip_is_restricted_to_projects() {
+        let context =
+            TestContext::new("test_next_external_ip_is_restricted_to_projects")
+                .await;
+
+        // Create one pool restricted to a project, and one not.
+        let project_id = Uuid::new_v4();
+        let first_range = IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 3),
+        ))
+        .unwrap();
+        context.create_ip_pool("p0", first_range, Some(project_id)).await;
+
+        let second_range = IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 4),
+            Ipv4Addr::new(10, 0, 0, 6),
+        ))
+        .unwrap();
+        context.create_ip_pool("p1", second_range, None).await;
+
+        // Allocating an address on an instance in a _different_ project should
+        // get an address from the second pool.
+        let instance_id = Uuid::new_v4();
+        let instance_project_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        let pool_name = None;
+
+        let ip = context
+            .db_datastore
+            .allocate_instance_ephemeral_ip(
+                &context.opctx,
+                id,
+                instance_project_id,
+                instance_id,
+                pool_name,
+            )
+            .await
+            .expect("Failed to allocate instance ephemeral IP address");
+        assert_eq!(ip.kind, IpKind::Ephemeral);
+        assert_eq!(ip.ip.ip(), second_range.first_address());
+        assert_eq!(ip.first_port.0, 0);
+        assert_eq!(ip.last_port.0, u16::MAX);
+        assert_eq!(ip.project_id, instance_project_id);
+
+        // Allocating an address on an instance in the same project should get
+        // an address from the first pool.
+        let instance_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        let pool_name = None;
+
+        let ip = context
+            .db_datastore
+            .allocate_instance_ephemeral_ip(
+                &context.opctx,
+                id,
+                project_id,
+                instance_id,
+                pool_name,
+            )
+            .await
+            .expect("Failed to allocate instance ephemeral IP address");
+        assert_eq!(ip.kind, IpKind::Ephemeral);
+        assert_eq!(ip.ip.ip(), first_range.first_address());
+        assert_eq!(ip.first_port.0, 0);
+        assert_eq!(ip.last_port.0, u16::MAX);
+        assert_eq!(ip.project_id, project_id);
 
         context.success().await;
     }

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -286,19 +286,6 @@ impl NextExternalIp {
         out.push_sql(") LEFT OUTER JOIN ");
         INSTANCE_EXTERNAL_IP_FROM_CLAUSE.walk_ast(out.reborrow())?;
 
-        // This is for SNAT IPs. For floating or ephemeral, we don't want to
-        // consider the port in the JOIN, just the address (_any_ port chunk
-        // means we can't use that address for the floating/ephemeral IP).
-        // Something like:
-        //
-        // ON (ip, time_deleted IS NULL) = (candidate_ip, TRUE)
-        //
-        // We'll also need to change how we generate the port sequence subquery.
-        // It should always be 0, basically, but not sure the best way to do
-        // that. SELECT 0? That should work:
-        //
-        // SELECT 0 as candidate_first_port, 65535 as candidate_last_port
-
         // The JOIN conditions depend on the IP type. For automatic SNAT IP
         // addresses, we need to consider existing records with their port
         // ranges. That's because we want to allow providing two different

--- a/nexus/src/db/queries/ip_pool.rs
+++ b/nexus/src/db/queries/ip_pool.rs
@@ -209,7 +209,7 @@ impl QueryFragment<Pg> for FilterOverlappingIpRanges {
             &self.range.time_modified,
         )?;
         out.push_sql(", ");
-        out.push_bind_param::< sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&self.range.time_deleted)?;
+        out.push_bind_param::<sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&self.range.time_deleted)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Inet, IpNetwork>(
             &self.range.first_address,
@@ -220,6 +220,8 @@ impl QueryFragment<Pg> for FilterOverlappingIpRanges {
         )?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Uuid, Uuid>(&self.range.ip_pool_id)?;
+        out.push_sql(", ");
+        out.push_bind_param::<sql_types::Nullable<sql_types::Uuid>, Option<Uuid>>(&self.range.project_id)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::BigInt, i64>(&self.range.rcgen)?;
 

--- a/nexus/src/db/queries/network_interface.rs
+++ b/nexus/src/db/queries/network_interface.rs
@@ -1715,6 +1715,7 @@ mod tests {
             hostname: "inst".to_string(),
             user_data: vec![],
             network_interfaces: InstanceNetworkInterfaceAttachment::None,
+            external_ips: vec![],
             disks: vec![],
         };
         let runtime = InstanceRuntimeState {

--- a/nexus/src/db/schema.rs
+++ b/nexus/src/db/schema.rs
@@ -143,6 +143,7 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
+        project_id -> Nullable<Uuid>,
         rcgen -> Int8,
     }
 }
@@ -156,6 +157,7 @@ table! {
         first_address -> Inet,
         last_address -> Inet,
         ip_pool_id -> Uuid,
+        project_id -> Nullable<Uuid>,
         rcgen -> Int8,
     }
 }
@@ -163,12 +165,16 @@ table! {
 table! {
     instance_external_ip (id) {
         id -> Uuid,
+        name -> Nullable<Text>,
+        description -> Nullable<Text>,
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
         ip_pool_id -> Uuid,
         ip_pool_range_id -> Uuid,
-        instance_id -> Uuid,
+        project_id -> Uuid,
+        instance_id -> Nullable<Uuid>,
+        kind -> crate::db::model::IpKindEnum,
         ip -> Inet,
         first_port -> Int4,
         last_port -> Int4,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -166,6 +166,8 @@ pub fn external_api() -> NexusApiDescription {
         api.register(instance_network_interface_update)?;
         api.register(instance_network_interface_delete)?;
 
+        api.register(instance_external_ip_list)?;
+
         api.register(vpc_router_list)?;
         api.register(vpc_router_view)?;
         api.register(vpc_router_view_by_id)?;
@@ -2483,6 +2485,39 @@ async fn instance_network_interface_update(
             )
             .await?;
         Ok(HttpResponseOk(NetworkInterface::from(interface)))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+// External IP addresses for instances
+
+/// List external IP addresses associated with an instance
+#[endpoint {
+    method = GET,
+    path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/external-ips",
+    tags = ["instances"],
+}]
+async fn instance_external_ip_list(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path_params: Path<InstancePathParam>,
+) -> Result<HttpResponseOk<Vec<views::ExternalIp>>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+    let organization_name = &path.organization_name;
+    let project_name = &path.project_name;
+    let instance_name = &path.instance_name;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let ips = nexus
+            .instance_list_external_ips(
+                &opctx,
+                organization_name,
+                project_name,
+                instance_name,
+            )
+            .await?;
+        Ok(HttpResponseOk(ips))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/params.rs
+++ b/nexus/src/external_api/params.rs
@@ -315,6 +315,14 @@ pub struct NetworkInterfaceUpdate {
 
 // IP POOLS
 
+// Type used to identify a Project in request bodies, where one may not have
+// the path in the request URL.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ProjectPath {
+    pub organization: Name,
+    pub project: Name,
+}
+
 /// Create-time parameters for an IP Pool.
 ///
 /// See [`IpPool`](omicron_nexus::external_api::views::IpPool)
@@ -322,6 +330,8 @@ pub struct NetworkInterfaceUpdate {
 pub struct IpPoolCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
+    #[serde(flatten)]
+    pub project: Option<ProjectPath>,
 }
 
 /// Parameters for updating an IP Pool
@@ -392,6 +402,17 @@ pub struct InstanceDiskAttach {
     pub name: Name,
 }
 
+/// Parameters for creating an external IP address for instances.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExternalIpCreate {
+    /// An IP address providing both inbound and outbound access. The address is
+    /// automatically-assigned from the provided IP Pool, or all available pools
+    /// if not specified.
+    Ephemeral { pool_name: Option<Name> },
+    // TODO: Add floating IPs: https://github.com/oxidecomputer/omicron/issues/1334
+}
+
 /// Create-time parameters for an [`Instance`](omicron_common::api::external::Instance)
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceCreate {
@@ -418,6 +439,14 @@ pub struct InstanceCreate {
     /// The network interfaces to be created for this instance.
     #[serde(default)]
     pub network_interfaces: InstanceNetworkInterfaceAttachment,
+
+    /// The external IP addresses provided to this instance.
+    ///
+    /// By default, all instances have outbound connectivity, but no inbound
+    /// connectivity. These external addresses can be used to provide a fixed,
+    /// known IP address for making inbound connections to the instance.
+    #[serde(default)]
+    pub external_ips: Vec<ExternalIpCreate>,
 
     /// The disks to be created or attached for this instance.
     #[serde(default)]

--- a/nexus/src/external_api/shared.rs
+++ b/nexus/src/external_api/shared.rs
@@ -317,6 +317,14 @@ impl TryFrom<AnyIpv6Range> for Ipv6Range {
     }
 }
 
+/// The kind of an external IP address for an instance
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpKind {
+    Ephemeral,
+    Floating,
+}
+
 #[cfg(test)]
 mod test {
     use super::IdentityType;

--- a/nexus/src/external_api/views.rs
+++ b/nexus/src/external_api/views.rs
@@ -6,7 +6,7 @@
 
 use crate::db::identity::{Asset, Resource};
 use crate::db::model;
-use crate::external_api::shared::{self, IpRange};
+use crate::external_api::shared::{self, IpKind, IpRange};
 use api_identity::ObjectIdentity;
 use chrono::DateTime;
 use chrono::Utc;
@@ -16,6 +16,7 @@ use omicron_common::api::external::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
 
@@ -351,15 +352,18 @@ impl From<model::VpcRouter> for VpcRouter {
     }
 }
 
+// IP POOLS
+
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct IpPool {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
+    pub project_id: Option<Uuid>,
 }
 
 impl From<model::IpPool> for IpPool {
     fn from(pool: model::IpPool) -> Self {
-        Self { identity: pool.identity() }
+        Self { identity: pool.identity(), project_id: pool.project_id }
     }
 }
 
@@ -378,6 +382,15 @@ impl From<model::IpPoolRange> for IpPoolRange {
             range: IpRange::from(&range),
         }
     }
+}
+
+// INSTANCE EXTERNAL IP ADDRESSES
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ExternalIp {
+    pub ip: IpAddr,
+    pub kind: IpKind,
 }
 
 // RACKS

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -73,6 +73,7 @@ pub async fn create_ip_pool(
     client: &ClientTestContext,
     pool_name: &str,
     ip_range: Option<IpRange>,
+    project_path: Option<params::ProjectPath>,
 ) -> (IpPool, IpPoolRange) {
     let ip_range = ip_range.unwrap_or_else(|| {
         use std::net::Ipv4Addr;
@@ -90,6 +91,7 @@ pub async fn create_ip_pool(
                 name: pool_name.parse().unwrap(),
                 description: String::from("an ip pool"),
             },
+            project: project_path,
         },
     )
     .await;
@@ -228,6 +230,7 @@ pub async fn create_instance_with_nics(
                 b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                     .to_vec(),
             network_interfaces: nics.clone(),
+            external_ips: vec![],
             disks: vec![],
         },
     )

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -63,7 +63,7 @@ fn get_disk_detach_url(instance_name: &str) -> String {
 }
 
 async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-    create_ip_pool(&client, "p0", None).await;
+    create_ip_pool(&client, "p0", None, None).await;
     create_organization(&client, ORG_NAME).await;
     let project = create_project(client, ORG_NAME, PROJECT_NAME).await;
     project.identity.id

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -198,6 +198,8 @@ lazy_static! {
         format!("{}/detach", *DEMO_INSTANCE_DISKS_URL);
     pub static ref DEMO_INSTANCE_NICS_URL: String =
         format!("{}/network-interfaces", *DEMO_INSTANCE_URL);
+    pub static ref DEMO_INSTANCE_EXTERNAL_IPS_URL: String =
+        format!("{}/external-ips", *DEMO_INSTANCE_URL);
     pub static ref DEMO_INSTANCE_SERIAL_URL: String =
         format!("{}/serial-console", *DEMO_INSTANCE_URL);
     pub static ref DEMO_INSTANCE_CREATE: params::InstanceCreate =
@@ -212,6 +214,9 @@ lazy_static! {
             user_data: vec![],
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
+            external_ips: vec![
+                params::ExternalIpCreate::Ephemeral { pool_name: None }
+            ],
             disks: vec![],
         };
 
@@ -284,6 +289,7 @@ lazy_static! {
                 name: DEMO_IP_POOL_NAME.clone(),
                 description: String::from("an IP pool"),
             },
+            project: None,
         };
     pub static ref DEMO_IP_POOL_URL: String = format!("/ip-pools/{}", *DEMO_IP_POOL_NAME);
     pub static ref DEMO_IP_POOL_UPDATE: params::IpPoolUpdate =
@@ -1173,6 +1179,14 @@ lazy_static! {
                     serde_json::to_value(&*DEMO_INSTANCE_NIC_PUT).unwrap()
                 ),
             ],
+        },
+
+        /* Instance external IP addresses */
+        VerifyEndpoint {
+            url: &*DEMO_INSTANCE_EXTERNAL_IPS_URL,
+            visibility: Visibility::Protected,
+            unprivileged_access: UnprivilegedAccess::None,
+            allowed_methods: vec![AllowedMethod::Get],
         },
 
         /* IAM */

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -97,6 +97,7 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -292,6 +293,7 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -473,6 +475,7 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -574,6 +577,7 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -57,6 +57,7 @@ async fn create_instance_expect_failure(
         hostname: name.to_string(),
         user_data: vec![],
         network_interfaces,
+        external_ips: vec![],
         disks: vec![],
     };
 
@@ -81,7 +82,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     let project_name = "springfield-squidport";
 
     // Create a project that we'll use for testing.
-    create_ip_pool(&client, "p0", None).await;
+    create_ip_pool(&client, "p0", None, None).await;
     create_organization(&client, organization_name).await;
     create_project(&client, organization_name, project_name).await;
     let url_instances = format!(

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -45,6 +45,7 @@ instance_delete                          /organizations/{organization_name}/proj
 instance_disk_attach                     /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach
 instance_disk_detach                     /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach
 instance_disk_list                       /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks
+instance_external_ip_list                /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/external-ips
 instance_list                            /organizations/{organization_name}/projects/{project_name}/instances
 instance_migrate                         /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate
 instance_network_interface_create        /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2930,6 +2930,66 @@
         }
       }
     },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/external-ips": {
+      "get": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "List external IP addresses associated with an instance",
+        "operationId": "instance_external_ip_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ExternalIp",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExternalIp"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate": {
       "post": {
         "tags": [
@@ -7157,6 +7217,50 @@
           "request_id"
         ]
       },
+      "ExternalIp": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/IpKind"
+          }
+        },
+        "required": [
+          "ip",
+          "kind"
+        ]
+      },
+      "ExternalIpCreate": {
+        "description": "Parameters for creating an external IP address for instances.",
+        "oneOf": [
+          {
+            "description": "An IP address providing both inbound and outbound access. The address is automatically-assigned from the provided IP Pool, or all available pools if not specified.",
+            "type": "object",
+            "properties": {
+              "pool_name": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Name"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ephemeral"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
       "FieldSchema": {
         "description": "The name and type information for a field of a timeseries schema.",
         "type": "object",
@@ -7804,6 +7908,14 @@
               "$ref": "#/components/schemas/InstanceDiskAttachment"
             }
           },
+          "external_ips": {
+            "description": "The external IP addresses provided to this instance.\n\nBy default, all instances have outbound connectivity, but no inbound connectivity. These external addresses can be used to provide a fixed, known IP address for making inbound connections to the instance.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalIpCreate"
+            }
+          },
           "hostname": {
             "type": "string"
           },
@@ -8044,6 +8156,14 @@
           "destroyed"
         ]
       },
+      "IpKind": {
+        "description": "The kind of an external IP address for an instance",
+        "type": "string",
+        "enum": [
+          "ephemeral",
+          "floating"
+        ]
+      },
       "IpNet": {
         "oneOf": [
           {
@@ -8085,6 +8205,11 @@
               }
             ]
           },
+          "project_id": {
+            "nullable": true,
+            "type": "string",
+            "format": "uuid"
+          },
           "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
@@ -8112,6 +8237,12 @@
             "type": "string"
           },
           "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "project": {
             "$ref": "#/components/schemas/Name"
           }
         },

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -38,8 +38,7 @@ zpools = [
 # this with whatever value they wish to provide inbound connectivity to guests
 # in their local network, using the current workaround methods in OPTE. See
 # how-to-run.adoc for details on how to determine the value for your network.
-# gateway_mac = "00:0d:b9:54:fe:e4"
-gateway_mac = "74:ac:b9:a2:cd:f1"
+gateway_mac = "00:0d:b9:54:fe:e4"
 
 [log]
 level = "info"

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -38,7 +38,8 @@ zpools = [
 # this with whatever value they wish to provide inbound connectivity to guests
 # in their local network, using the current workaround methods in OPTE. See
 # how-to-run.adoc for details on how to determine the value for your network.
-gateway_mac = "00:0d:b9:54:fe:e4"
+# gateway_mac = "00:0d:b9:54:fe:e4"
+gateway_mac = "74:ac:b9:a2:cd:f1"
 
 [log]
 level = "info"


### PR DESCRIPTION
- Updates the current external IP allocation query to handle both
  floating and ephemeral IPs, by assuming that the whole port range is
  already reserved for any existing IP address.
- Add public datastore methods for creating SNAT and Ephemeral IPs,
  delegating to private method for the actual query running/handling
- Updates sagas to include UUID generation for external IPs as separate
  steps, for idempotency, and to create Ephemeral IPs if they're
  requested. Also rework instance creation/migration sagas to select the
  Ephemeral IP address, if one was requested, or the SNAT if not.
- Adds optional restriction of IP Pools to a project. This adds the
  project ID or name in a bunch of places, and updates the external IP
  allocation query to only consider pools which are unrestricted, or
  whose project ID matches the one of the instance we're allocating an
  IP for. This relies on a new index on the `instance_external_ip`
  table, which induces an undesirable sorting (by project, not IP), so
  we add a new sorting criterion to the query.
- Adds tests, especially for the external IP table's check constraints
  which verify integrity of the name / description / instance ID for
  different kinds of addresses, and for restriction of an IP pool to a
  project.
- Plumb the external IPs up to Nexus's public API, including instance
  creation and an endpoint for listing external IPs for an instance.
- Adds integration tests for assignment of Ephemeral IPs and authz tests
  for the endpoint(s)