### PR TITLE
Always build optimized versions of a couple slow build deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,15 @@ resolver = "2"
 [profile.dev]
 panic = "abort"
 
+# `bindgen` is used by `samael`'s build script; building it with optimizations
+# makes that build script run ~5x faster, more than offsetting the additional
+# build time added to `bindgen` itself.
 [profile.dev.package.bindgen]
 opt-level = 3
 
+# `lalrpop` is used by `polar-core`'s build script; building it with
+# optimizations makes that build script run ~20x faster, more than offsetting
+# the additional build time added to `lalrpop` itself.
 [profile.dev.package.lalrpop]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ resolver = "2"
 [profile.dev]
 panic = "abort"
 
+[profile.dev.package.bindgen]
+opt-level = 3
+
+[profile.dev.package.lalrpop]
+opt-level = 3
+
 [profile.release]
 panic = "abort"
 


### PR DESCRIPTION
TL;DR: This speeds up clean debug builds of nexus from 2m48s to 2m34s (on my machine, YMMV).

On `main` as of a356cc20, two sore thumbs during a clean build are the build scripts of `samael` and `polar-core` (the yellow bars):

![main-cargo-timing](https://user-images.githubusercontent.com/1435635/179790429-b4958142-9c49-48a7-b8cd-c42d93c1806c.png)

I tried using [cargo profiles](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to optimize build dependencies, but it was a net loss: it shrank the build script runtimes for these two crates, but added considerably more to many more build dependencies, adding almost a full minute to the total build time in net. AFAICT it's not possible to use a cargo profile to specify the build scripts of specific crates; however, in this case we get a bit lucky in that both of the build scripts we're interested in depend on other crates for their heavy lifting. `samael`'s build script depends on `bindgen`, and `polar-core`'s build script depends on `lalrpop`. By optimizing those two crates, we slow down their compilation but speed up the build scripts considerably; it's a clear net win on my machine:

![branch-cargo-timing](https://user-images.githubusercontent.com/1435635/179791299-38d33b5d-ef11-42f8-beab-3448bf314910.png)

(The runtime for `polar-core`'s build script has disappeared due to the filter; its runtime on this branch is 1.3s).