### PR TITLE
Unrolling saga actions for external IPs and NICs

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -52,10 +52,10 @@ mod sagas;
 
 pub(crate) const MAX_DISKS_PER_INSTANCE: u32 = 8;
 
-pub(crate) const MAX_NICS_PER_INSTANCE: u32 = 8;
+pub(crate) const MAX_NICS_PER_INSTANCE: usize = 8;
 
-// TODO-completness: Support multiple Ephemeral IPs
-pub(crate) const MAX_EPHEMERAL_IPS_PER_INSTANCE: usize = 1;
+// TODO-completness: Support multiple external IPs
+pub(crate) const MAX_EXTERNAL_IPS_PER_INSTANCE: usize = 1;
 
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -6,7 +6,7 @@ use super::{
     impl_authenticated_saga_params, saga_generate_uuid, AuthenticatedSagaParams,
 };
 use crate::app::{
-    MAX_DISKS_PER_INSTANCE, MAX_EPHEMERAL_IPS_PER_INSTANCE,
+    MAX_DISKS_PER_INSTANCE, MAX_EXTERNAL_IPS_PER_INSTANCE,
     MAX_NICS_PER_INSTANCE,
 };
 use crate::context::OpContext;
@@ -30,7 +30,7 @@ use serde::Serialize;
 use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
 use slog::warn;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
 use steno::new_action_noop_undo;
@@ -107,77 +107,51 @@ fn saga_instance_create() -> SagaTemplate<SagaInstanceCreate> {
         ),
     );
 
-    // NOTE: The separation of the ID-allocation and NIC creation nodes is
-    // intentional.
-    //
-    // The Nexus API supports creating multiple network interfaces at the time
-    // an instance is provisioned. However, each NIC creation is independent,
-    // and each can fail. For example, someone might specify multiple NICs with
-    // the same IP address. The first will be created successfully, but the
-    // later ones will fail. We need to handle this case gracefully, and always
-    // delete any NICs we create, even if the NIC creation node itself fails.
-    //
-    // To do that, we create an action that only allocates the UUIDs for each
-    // interface. This has an undo action that actually deletes any NICs for the
-    // instance to be provisioned. The forward action is infallible, so this
-    // undo action will always run, even (and especially) if the NIC creation
-    // action fails.
-    //
-    // It's also important that we allocate the UUIDs first. It's possible that
-    // we crash partway through the NIC creation action. In this case, the saga
-    // recovery machinery will pick it up where it left off, without first
-    // destroying the NICs we created before crashing. By allocating the UUIDs
-    // first, we can make the insertion idempotent, by ignoring conflicts on the
-    // UUID.
-    template_builder.append(
-        "network_interface_ids",
-        "NetworkInterfaceIds",
-        ActionFunc::new_action(
-            sic_allocate_network_interface_ids,
-            sic_create_network_interfaces_undo,
-        ),
-    );
+    // Similar to disks (see block comment below), create a sequence of
+    // action-undo pairs for each requested network interface, to make sure we
+    // always unwind after failures.
+    for i in 0..MAX_NICS_PER_INSTANCE {
+        template_builder.append(
+            format!("network_interface{i}").as_str(),
+            "CreateNetworkInterface",
+            ActionFunc::new_action(
+                async move |sagactx| {
+                    sic_create_network_interface(sagactx, i).await
+                },
+                async move |sagactx| {
+                    sic_create_network_interface_undo(sagactx, i).await
+                },
+            ),
+        );
+    }
 
-    template_builder.append(
-        "network_interfaces",
-        "CreateNetworkInterfaces",
-        new_action_noop_undo(sic_create_network_interfaces),
-    );
-
-    // Allocate an external IP address for the default outbound connectivity,
-    // i.e., instance source NAT. We first allocate the ID, for the same reason
-    // we do so in the case of network interfaces.
-    template_builder.append(
-        "snat_ip_id",
-        "SnatIpId",
-        ActionFunc::new_action(
-            sic_allocate_instance_snat_ip_id,
-            sic_allocate_temporary_external_ips_undo,
-        ),
-    );
+    // Allocate an external IP address for the default outbound connectivity
     template_builder.append(
         "snat_ip",
-        "SnatIp",
-        new_action_noop_undo(sic_allocate_instance_snat_ip),
-    );
-
-    // Allocate IDs for each requested _Ephemeral_ IP address.
-    //
-    // While it's not yet implemented, we need to _attach_ existing Floating
-    // IPs, not create new ones.
-    template_builder.append(
-        "ephemeral_ip_ids",
-        "EphemeralIpIds",
+        "CreateSnatIp",
         ActionFunc::new_action(
-            sic_allocate_instance_ephemeral_ip_ids,
-            sic_allocate_temporary_external_ips_undo,
+            sic_allocate_instance_snat_ip,
+            sic_allocate_instance_snat_ip_undo,
         ),
     );
-    template_builder.append(
-        "ephemeral_ips",
-        "EphemeralIps",
-        new_action_noop_undo(sic_allocate_instance_ephemeral_ips),
-    );
+
+    // Similar to disks (see block comment below), create a sequence of
+    // action-undo pairs for each requested external IP, to make sure we always
+    // unwind after failures.
+    for i in 0..MAX_EXTERNAL_IPS_PER_INSTANCE {
+        template_builder.append(
+            format!("external_ip{i}").as_str(),
+            "CreateEphemeralIp",
+            ActionFunc::new_action(
+                async move |sagactx| {
+                    sic_allocate_instance_external_ip(sagactx, i).await
+                },
+                async move |sagactx| {
+                    sic_allocate_instance_external_ip_undo(sagactx, i).await
+                },
+            ),
+        );
+    }
 
     // Saga actions must be atomic - they have to fully complete or fully abort.
     // This is because Steno assumes that the saga actions are atomic and
@@ -243,71 +217,83 @@ async fn sic_alloc_server(
         .map_err(ActionError::action_failed)
 }
 
-async fn sic_allocate_network_interface_ids(
+/// Create a network interface for an instance, using the parameters at index
+/// `iface_index`, returning the UUID for the NIC (or None).
+async fn sic_create_network_interface(
     sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<Vec<Uuid>, ActionError> {
-    match sagactx.saga_params().create_params.network_interfaces {
-        params::InstanceNetworkInterfaceAttachment::None => Ok(vec![]),
+    nic_index: usize,
+) -> Result<Option<Uuid>, ActionError> {
+    let saga_params = sagactx.saga_params();
+    let interface_params = &saga_params.create_params.network_interfaces;
+    match interface_params {
+        params::InstanceNetworkInterfaceAttachment::None => Ok(None),
         params::InstanceNetworkInterfaceAttachment::Default => {
-            Ok(vec![Uuid::new_v4()])
+            sic_create_default_primary_network_interface(&sagactx, nic_index)
+                .await
         }
         params::InstanceNetworkInterfaceAttachment::Create(
             ref create_params,
-        ) => {
-            if create_params.len() > MAX_NICS_PER_INSTANCE.try_into().unwrap() {
-                return Err(ActionError::action_failed(
-                    Error::invalid_request(
-                        format!(
-                            "Instances may not have more than {}
-                            network interfaces",
-                            MAX_NICS_PER_INSTANCE
-                        )
-                        .as_str(),
-                    ),
-                ));
+        ) => match create_params.get(nic_index) {
+            None => Ok(None),
+            Some(ref prs) => {
+                sic_create_custom_network_interface(&sagactx, prs).await
             }
-            let mut ids = Vec::with_capacity(create_params.len());
-            for _ in 0..create_params.len() {
-                ids.push(Uuid::new_v4());
-            }
-            Ok(ids)
+        },
+    }
+}
+
+/// Delete one network interface, by index.
+async fn sic_create_network_interface_undo(
+    sagactx: ActionContext<SagaInstanceCreate>,
+    iface_index: usize,
+) -> Result<(), anyhow::Error> {
+    let osagactx = sagactx.user_data();
+    let datastore = osagactx.datastore();
+    let saga_params = sagactx.saga_params();
+    let opctx =
+        OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
+    let interface_id = sagactx.lookup::<Option<Uuid>>(
+        format!("network_interface{iface_index}").as_str(),
+    )?;
+    match interface_id {
+        None => Ok(()),
+        Some(id) => {
+            let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
+            let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
+                .instance_id(instance_id)
+                .lookup_for(authz::Action::Modify)
+                .await
+                .map_err(ActionError::action_failed)?;
+            let (.., authz_interface) = LookupPath::new(&opctx, &datastore)
+                .network_interface_id(id)
+                .lookup_for(authz::Action::Delete)
+                .await
+                .map_err(ActionError::action_failed)?;
+            datastore
+                .instance_delete_network_interface(
+                    &opctx,
+                    &authz_instance,
+                    &authz_interface,
+                )
+                .await
+                .map_err(|e| e.into_external())?;
+            Ok(())
         }
     }
 }
 
-async fn sic_create_network_interfaces(
-    sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<(), ActionError> {
-    match sagactx.saga_params().create_params.network_interfaces {
-        params::InstanceNetworkInterfaceAttachment::None => Ok(()),
-        params::InstanceNetworkInterfaceAttachment::Default => {
-            sic_create_default_primary_network_interface(&sagactx).await
-        }
-        params::InstanceNetworkInterfaceAttachment::Create(
-            ref create_params,
-        ) => {
-            sic_create_custom_network_interfaces(&sagactx, &create_params).await
-        }
-    }
-}
-
-/// Create one or more custom (non-default) network interfaces for the provided
-/// instance.
-async fn sic_create_custom_network_interfaces(
+/// Create one custom (non-default) network interfaces for the provided instance.
+async fn sic_create_custom_network_interface(
     sagactx: &ActionContext<SagaInstanceCreate>,
-    interface_params: &[params::NetworkInterfaceCreate],
-) -> Result<(), ActionError> {
-    if interface_params.is_empty() {
-        return Ok(());
-    }
-
+    interface_params: &params::NetworkInterfaceCreate,
+) -> Result<Option<Uuid>, ActionError> {
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let saga_params = sagactx.saga_params();
     let opctx =
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
-    let ids = sagactx.lookup::<Vec<Uuid>>("network_interface_ids")?;
+    let interface_id = Uuid::new_v4();
 
     // Lookup authz objects, used in the call to create the NIC itself.
     let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
@@ -315,104 +301,61 @@ async fn sic_create_custom_network_interfaces(
         .lookup_for(authz::Action::CreateChild)
         .await
         .map_err(ActionError::action_failed)?;
-    let (.., authz_vpc, db_vpc) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_vpc) = LookupPath::new(&opctx, &datastore)
         .project_id(saga_params.project_id)
-        .vpc_name(&db::model::Name::from(interface_params[0].vpc_name.clone()))
-        .fetch()
+        .vpc_name(&db::model::Name::from(interface_params.vpc_name.clone()))
+        .lookup_for(authz::Action::Read)
         .await
         .map_err(ActionError::action_failed)?;
 
-    // Check that all VPC names are the same.
-    //
-    // This isn't strictly necessary, as the queries would fail below, but it's
-    // easier to handle here.
-    if interface_params.iter().any(|p| p.vpc_name != db_vpc.name().0) {
-        return Err(ActionError::action_failed(Error::invalid_request(
-            "All interfaces must be in the same VPC",
-        )));
-    }
-
-    if ids.len() != interface_params.len() {
-        return Err(ActionError::action_failed(Error::internal_error(
-            "found differing number of network interface IDs and interface \
-            parameters",
-        )));
-    }
-    for (interface_id, params) in ids.into_iter().zip(interface_params.iter()) {
-        // TODO-correctness: It seems racy to fetch the subnet and create the
-        // interface in separate requests, but outside of a transaction. This
-        // should probably either be in a transaction, or the
-        // `instance_create_network_interface` function/query needs some JOIN
-        // on the `vpc_subnet` table.
-        let (.., authz_subnet, db_subnet) = LookupPath::new(&opctx, &datastore)
-            .vpc_id(authz_vpc.id())
-            .vpc_subnet_name(&db::model::Name::from(params.subnet_name.clone()))
-            .fetch()
-            .await
-            .map_err(ActionError::action_failed)?;
-        let interface = db::model::IncompleteNetworkInterface::new(
-            interface_id,
-            instance_id,
-            authz_vpc.id(),
-            db_subnet.clone(),
-            params.identity.clone(),
-            params.ip,
+    // TODO-correctness: It seems racy to fetch the subnet and create the
+    // interface in separate requests, but outside of a transaction. This
+    // should probably either be in a transaction, or the
+    // `instance_create_network_interface` function/query needs some JOIN
+    // on the `vpc_subnet` table.
+    let (.., authz_subnet, db_subnet) = LookupPath::new(&opctx, &datastore)
+        .vpc_id(authz_vpc.id())
+        .vpc_subnet_name(&db::model::Name::from(
+            interface_params.subnet_name.clone(),
+        ))
+        .fetch()
+        .await
+        .map_err(ActionError::action_failed)?;
+    let interface = db::model::IncompleteNetworkInterface::new(
+        interface_id,
+        instance_id,
+        authz_vpc.id(),
+        db_subnet.clone(),
+        interface_params.identity.clone(),
+        interface_params.ip,
+    )
+    .map_err(ActionError::action_failed)?;
+    datastore
+        .instance_create_network_interface(
+            &opctx,
+            &authz_subnet,
+            &authz_instance,
+            interface,
         )
-        .map_err(ActionError::action_failed)?;
-        let result = datastore
-            .instance_create_network_interface(
-                &opctx,
-                &authz_subnet,
-                &authz_instance,
-                interface,
-            )
-            .await;
-
-        match result {
-            Ok(_) => Ok(()),
-
-            // Detect the specific error arising from this node being partially
-            // completed.
-            //
-            // The query used to insert network interfaces first checks for an
-            // existing record with the same primary key. It will attempt to
-            // insert that record if it exists, which obviously fails with a
-            // primary key violation. (If the record does _not_ exist, one will
-            // be inserted as usual, see
-            // `db::queries::network_interface::InsertQuery` for details).
-            //
-            // In this one specific case, we're asserting that any primary key
-            // duplicate arises because this saga node ran partway and then
-            // crashed. The saga recovery machinery will replay just this node,
-            // without first unwinding it, so any previously-inserted interfaces
-            // will still exist. This is expected.
-            Err(InsertNicError::DuplicatePrimaryKey(_)) => {
-                // TODO-observability: We should bump a counter here.
-                let log = osagactx.log();
-                warn!(
-                    log,
-                    "Detected duplicate primary key during saga to \
-                    create network interfaces for instance '{}'. \
-                    This likely occurred because \
-                    the saga action 'sic_create_custom_network_interfaces' \
-                    crashed and has been recovered.",
-                    instance_id;
-                    "primary_key" => interface_id.to_string(),
-                );
-                Ok(())
-            }
-            Err(e) => Err(e.into_external()),
-        }
-        .map_err(ActionError::action_failed)?;
-    }
-    Ok(())
+        .await
+        .map_err(|e| ActionError::action_failed(e.into_external()))?;
+    Ok(Some(interface_id))
 }
 
 /// Create a default primary network interface for an instance during the create
 /// saga.
 async fn sic_create_default_primary_network_interface(
     sagactx: &ActionContext<SagaInstanceCreate>,
-) -> Result<(), ActionError> {
+    nic_index: usize,
+) -> Result<Option<Uuid>, ActionError> {
+    // We're statically creating up to MAX_NICS_PER_INSTANCE saga nodes, but
+    // this method only applies to the case where there's exactly one parameter
+    // of type `InstanceNetworkInterfaceAttachment::Default`, so ignore any
+    // later calls.
+    if nic_index > 0 {
+        return Ok(None);
+    }
+
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let saga_params = sagactx.saga_params();
@@ -479,53 +422,20 @@ async fn sic_create_default_primary_network_interface(
         .await
         .map_err(InsertNicError::into_external)
         .map_err(ActionError::action_failed)?;
-    Ok(())
-}
-
-async fn sic_create_network_interfaces_undo(
-    sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<(), anyhow::Error> {
-    // We issue a request to delete any interfaces associated with this instance.
-    // In the case we failed partway through allocating interfaces, we need to
-    // clean up any previously-created interface records from the database.
-    // Just delete every interface that exists, even if there are zero such
-    // records.
-    let osagactx = sagactx.user_data();
-    let datastore = osagactx.datastore();
-    let saga_params = sagactx.saga_params();
-    let opctx =
-        OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
-    let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
-    let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
-        .instance_id(instance_id)
-        .lookup_for(authz::Action::Modify)
-        .await
-        .map_err(ActionError::action_failed)?;
-    datastore
-        .instance_delete_all_network_interfaces(&opctx, &authz_instance)
-        .await
-        .map_err(ActionError::action_failed)?;
-    Ok(())
-}
-
-/// Create an ID for an external IP address for instance source NAT.
-async fn sic_allocate_instance_snat_ip_id(
-    _: ActionContext<SagaInstanceCreate>,
-) -> Result<Uuid, ActionError> {
-    Ok(Uuid::new_v4())
+    Ok(Some(interface_id))
 }
 
 /// Create an external IP address for instance source NAT.
 async fn sic_allocate_instance_snat_ip(
     sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<(), ActionError> {
+) -> Result<Uuid, ActionError> {
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let saga_params = sagactx.saga_params();
     let opctx =
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
-    let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
+    let ip_id = Uuid::new_v4();
     datastore
         .allocate_instance_snat_ip(
             &opctx,
@@ -535,11 +445,11 @@ async fn sic_allocate_instance_snat_ip(
         )
         .await
         .map_err(ActionError::action_failed)?;
-    Ok(())
+    Ok(ip_id)
 }
 
-/// Destroy all allocated _temporary_ external IPs (SNAT or Ephemeral)
-async fn sic_allocate_temporary_external_ips_undo(
+/// Destroy an allocated SNAT IP address for the instance.
+async fn sic_allocate_instance_snat_ip_undo(
     sagactx: ActionContext<SagaInstanceCreate>,
 ) -> Result<(), anyhow::Error> {
     let osagactx = sagactx.user_data();
@@ -547,73 +457,68 @@ async fn sic_allocate_temporary_external_ips_undo(
     let saga_params = sagactx.saga_params();
     let opctx =
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
-    let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
+    let ip_id = sagactx.lookup::<Uuid>("snat_ip")?;
     datastore
-        .deallocate_instance_external_ip_by_instance_id(&opctx, instance_id)
+        .deallocate_instance_external_ip(&opctx, ip_id)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())
 }
 
-/// Create an ID for each external Ephemeral IP address.
-async fn sic_allocate_instance_ephemeral_ip_ids(
+/// Create an external IPs for the instance, using the request parameters at
+/// index `ip_index`, and return its ID if one is created (or None).
+async fn sic_allocate_instance_external_ip(
     sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<Vec<Uuid>, ActionError> {
+    ip_index: usize,
+) -> Result<Option<Uuid>, ActionError> {
+    let osagactx = sagactx.user_data();
+    let datastore = osagactx.datastore();
     let saga_params = sagactx.saga_params();
-    if saga_params.create_params.external_ips.len()
-        > MAX_EPHEMERAL_IPS_PER_INSTANCE as _
-    {
-        return Err(ActionError::action_failed(Error::invalid_request(
-            format!(
-                "At most {} Ephemeral IP(s) are supported",
-                MAX_EPHEMERAL_IPS_PER_INSTANCE
-            )
-            .as_str(),
-        )));
-    }
-    Ok(saga_params
-        .create_params
-        .external_ips
-        .iter()
-        .filter_map(|ip| {
-            if matches!(ip, params::ExternalIpCreate::Ephemeral { .. }) {
-                Some(Uuid::new_v4())
-            } else {
-                None
-            }
-        })
-        .collect())
+    let ip_params = saga_params.create_params.external_ips.get(ip_index);
+    let ip_params = match ip_params {
+        None => {
+            return Ok(None);
+        }
+        Some(ref prs) => prs,
+    };
+    let opctx =
+        OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
+    let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
+
+    // Generate an ID and collect the possible pool name for this IP address
+    let ip_id = Uuid::new_v4();
+    let pool_name = match ip_params {
+        params::ExternalIpCreate::Ephemeral { ref pool_name } => {
+            pool_name.as_ref().map(|name| db::model::Name(name.clone()))
+        }
+    };
+    datastore
+        .allocate_instance_ephemeral_ip(
+            &opctx,
+            ip_id,
+            saga_params.project_id,
+            instance_id,
+            pool_name,
+        )
+        .await
+        .map_err(ActionError::action_failed)?;
+    Ok(Some(ip_id))
 }
 
-/// Create the requested Ephemeral IPs for the instance.
-async fn sic_allocate_instance_ephemeral_ips(
+async fn sic_allocate_instance_external_ip_undo(
     sagactx: ActionContext<SagaInstanceCreate>,
-) -> Result<(), ActionError> {
+    ip_index: usize,
+) -> Result<(), anyhow::Error> {
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let saga_params = sagactx.saga_params();
     let opctx =
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
-    let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
-    let ids = sagactx.lookup::<Vec<Uuid>>("ephemeral_ip_ids")?;
-
-    // Collect the list of all pool names for the Ephemeral IPs.
-    let pool_names = saga_params.create_params.external_ips.iter().map(|ip| {
-        match ip {
-            params::ExternalIpCreate::Ephemeral { ref pool_name } => {
-                pool_name.as_ref().map(|n| db::model::Name(n.clone()))
-            } // TODO-completeness: Implement Floating IPs
-        }
-    });
-    for (id, pool_name) in ids.into_iter().zip(pool_names) {
+    let name = format!("external_ip{ip_index}");
+    let maybe_ip_id = sagactx.lookup::<Option<Uuid>>(name.as_str())?;
+    if let Some(ip_id) = maybe_ip_id {
         datastore
-            .allocate_instance_ephemeral_ip(
-                &opctx,
-                id,
-                saga_params.project_id,
-                instance_id,
-                pool_name,
-            )
+            .deallocate_instance_external_ip(&opctx, ip_id)
             .await
             .map_err(ActionError::action_failed)?;
     }

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -178,12 +178,12 @@ async fn sim_instance_migrate(
         .partition(|ip| ip.kind == IpKind::SNat);
 
     // Sanity checks on the number and kind of each IP address.
-    if external_ips.len() > crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE {
+    if external_ips.len() > crate::app::MAX_EXTERNAL_IPS_PER_INSTANCE {
         return Err(ActionError::action_failed(Error::internal_error(
             format!(
                 "Expected the number of external IPs to be limited to \
-            {}, but found {}",
-                crate::app::MAX_EPHEMERAL_IPS_PER_INSTANCE,
+                {}, but found {}",
+                crate::app::MAX_EXTERNAL_IPS_PER_INSTANCE,
                 external_ips.len(),
             )
             .as_str(),

--- a/nexus/src/db/datastore/network_interface.rs
+++ b/nexus/src/db/datastore/network_interface.rs
@@ -72,8 +72,6 @@ impl DataStore {
     }
 
     /// Delete all network interfaces attached to the given instance.
-    // NOTE: This is mostly useful in the context of sagas, but might be helpful
-    // in other situations, such as moving an instance between VPC Subnets.
     pub async fn instance_delete_all_network_interfaces(
         &self,
         opctx: &OpContext,

--- a/nexus/src/db/queries/network_interface.rs
+++ b/nexus/src/db/queries/network_interface.rs
@@ -505,7 +505,8 @@ impl NextNicSlot {
     pub fn new(instance_id: Uuid) -> Self {
         let generator = DefaultShiftGenerator {
             base: 0,
-            max_shift: i64::from(MAX_NICS_PER_INSTANCE),
+            max_shift: i64::try_from(MAX_NICS_PER_INSTANCE)
+                .expect("Too many network interfaces"),
             min_shift: 0,
         };
         Self { inner: NextItem::new_scoped(generator, instance_id) }
@@ -661,8 +662,7 @@ fn push_ensure_unique_vpc_expression<'a>(
 ///        WHERE
 ///            instance_id = <instance_id> AND
 ///            time_deleted IS NULL AND
-///            subnet_id = <subnet_id> AND
-///            id != <interface_id>
+///            subnet_id = <subnet_id>
 ///     ),
 ///     'non-unique-subnets', -- the literal string "non-unique-subnets",
 ///     '<subnet_id>', -- <subnet_id> as a string,
@@ -673,49 +673,8 @@ fn push_ensure_unique_vpc_expression<'a>(
 /// That is, if the subnet ID provided in the query already exists for an
 /// interface on the target instance, we return the literal string
 /// `'non-unique-subnets'`, which will fail casting to a UUID.
-///
-/// The interface ID check
-/// ----------------------
-///
-/// You'll notice what appears to be an unecessary check on the actual `id`
-/// column, `id != <interface_id>`, in the where clause of the above. This is
-/// unfortunately part of a tradeoff for two situations:
-///
-/// - Re-inserting a network interface as part of retrying a saga action
-/// - The instance's VPC Subnet validation
-///
-/// During a saga replay, we try to insert a NIC with the _exact_ same data,
-/// including the same primary key, as an existing record. This fails,
-/// obviously, but we detect and handle that case specially, since it's only
-/// possible in that one situation.
-///
-/// However, when we do that, we still run the select statement here, even
-/// though this ultimately appears on the "unevaluated" side of a `COALESCE`
-/// statement. I.e.,:
-///
-/// ```sql
-/// SELECT COALESCE(
-///     (subquery run to detect the saga replay),
-///     (subquery run to insert a new NIC)
-/// )
-/// ```
-///
-/// The documentation of the `COALESCE` function clearly indicates that the
-/// second expression will not run if the first evaluates to non-NULL.
-/// Empirically, that's not true. This doesn't appear to be due to `CAST`, since
-/// other queries without that show the same behavior.
-///
-/// This additional, redundant check is to handle the first case, saga replay.
-/// We check that the VPC Subnet for any interfaces _not equal to this one_ are
-/// different. This allows us to do the check on new interfaces, but not fail in
-/// the saga-replay case.
-///
-/// See https://github.com/oxidecomputer/omicron/issues/1166 for more background
-/// on this issue, and https://github.com/cockroachdb/cockroach/issues/82498 for
-/// the related CRDB issue.
 fn push_ensure_unique_vpc_subnet_expression<'a>(
     mut out: AstPass<'_, 'a, Pg>,
-    interface_id: &'a Uuid,
     subnet_id: &'a Uuid,
     subnet_id_str: &'a String,
     instance_id: &'a Uuid,
@@ -734,17 +693,13 @@ fn push_ensure_unique_vpc_subnet_expression<'a>(
     out.push_identifier(dsl::subnet_id::NAME)?;
     out.push_sql(" = ");
     out.push_bind_param::<sql_types::Uuid, Uuid>(subnet_id)?;
-    out.push_sql(" AND ");
-    out.push_identifier(dsl::id::NAME)?;
-    out.push_sql(" != ");
-    out.push_bind_param::<sql_types::Uuid, Uuid>(interface_id)?;
     out.push_sql("), 'non-unique-subnets', ");
     out.push_bind_param::<sql_types::Text, String>(subnet_id_str)?;
     out.push_sql(") AS UUID)");
     Ok(())
 }
 
-/// Push the main instance-validate common-table expression.
+/// Push the main instance-validation common-table expression.
 ///
 /// This generates a CTE that looks like:
 ///
@@ -761,7 +716,6 @@ fn push_ensure_unique_vpc_subnet_expression<'a>(
 #[allow(clippy::too_many_arguments)]
 fn push_instance_validation_cte<'a>(
     mut out: AstPass<'_, 'a, Pg>,
-    interface_id: &'a Uuid,
     vpc_id: &'a Uuid,
     vpc_id_str: &'a String,
     subnet_id: &'a Uuid,
@@ -795,7 +749,6 @@ fn push_instance_validation_cte<'a>(
     out.push_sql(", ");
     push_ensure_unique_vpc_subnet_expression(
         out.reborrow(),
-        interface_id,
         subnet_id,
         subnet_id_str,
         instance_id,
@@ -829,9 +782,9 @@ fn push_instance_validation_cte<'a>(
     Ok(())
 }
 
-/// Subquery used to insert a _new_ `NetworkInterface` from parameters.
+/// Subquery used to insert a new `NetworkInterface` from parameters.
 ///
-/// This function is used to construct a query that allows inserting a
+/// This type is used to construct a query that allows inserting a
 /// `NetworkInterface`, supporting both optionally allocating a new IP address
 /// and verifying that the attached instance's networking is contained within a
 /// single VPC. The general query looks like:
@@ -908,183 +861,6 @@ fn push_instance_validation_cte<'a>(
 /// portion of the query might need to be placed behind a conditional evaluation
 /// expression, such as `IF` or `COALESCE`, which only runs the subquery when
 /// the instance-validation check passes.
-fn push_interface_allocation_subquery<'a>(
-    mut out: AstPass<'_, 'a, Pg>,
-    query: &'a InsertQuery,
-) -> diesel::QueryResult<()> {
-    // Push subqueries that validate the provided instance. This generates a CTE
-    // with the name `validated_instance` and columns:
-    //  - `vpc_id`
-    //  - `subnet_id`
-    //  - `slot`
-    //  - `is_primary`
-    push_instance_validation_cte(
-        out.reborrow(),
-        &query.interface.identity.id,
-        &query.interface.vpc_id,
-        &query.vpc_id_str,
-        &query.interface.subnet.identity.id,
-        &query.subnet_id_str,
-        &query.interface.instance_id,
-        &query.instance_id_str,
-        &query.next_slot_subquery,
-        &query.is_primary_subquery,
-    )?;
-
-    // Push the columns, values and names, that are named directly. These
-    // are known regardless of whether we're allocating an IP address. These
-    // are all written as `SELECT <value1> AS <name1>, <value2> AS <name2>, ...
-    out.push_sql("SELECT ");
-    out.push_bind_param::<sql_types::Uuid, Uuid>(&query.interface.identity.id)?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::id::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Text, db::model::Name>(
-        &query.interface.identity.name,
-    )?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::name::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Text, String>(
-        &query.interface.identity.description,
-    )?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::description::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(&query.now)?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::time_created::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(&query.now)?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::time_modified::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&None)?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::time_deleted::NAME)?;
-    out.push_sql(", ");
-
-    out.push_bind_param::<sql_types::Uuid, Uuid>(&query.interface.instance_id)?;
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::instance_id::NAME)?;
-    out.push_sql(", ");
-
-    // Helper function to push a subquery selecting something from the CTE.
-    fn select_from_cte(
-        mut out: AstPass<Pg>,
-        column: &'static str,
-    ) -> diesel::QueryResult<()> {
-        out.push_sql("(SELECT ");
-        out.push_identifier(column)?;
-        out.push_sql(" FROM validated_instance)");
-        Ok(())
-    }
-
-    select_from_cte(out.reborrow(), dsl::vpc_id::NAME)?;
-    out.push_sql(", ");
-    select_from_cte(out.reborrow(), dsl::subnet_id::NAME)?;
-    out.push_sql(", ");
-
-    // Push the subquery for selecting the a MAC address.
-    out.push_sql("(");
-    query.next_mac_subquery.walk_ast(out.reborrow())?;
-    out.push_sql(") AS ");
-    out.push_identifier(dsl::mac::NAME)?;
-    out.push_sql(", ");
-
-    // If the user specified an IP address, then insert it by value. If they
-    // did not, meaning we're allocating the next available one on their
-    // behalf, then insert that subquery here.
-    if let Some(ref ip) = &query.ip_sql {
-        out.push_bind_param::<sql_types::Inet, IpNetwork>(ip)?;
-    } else {
-        out.push_sql("(");
-        query.next_ipv4_address_subquery.walk_ast(out.reborrow())?;
-        out.push_sql(")");
-    }
-    out.push_sql(" AS ");
-    out.push_identifier(dsl::ip::NAME)?;
-    out.push_sql(", ");
-
-    select_from_cte(out.reborrow(), dsl::slot::NAME)?;
-    out.push_sql(", ");
-    select_from_cte(out.reborrow(), dsl::is_primary::NAME)?;
-
-    Ok(())
-}
-
-/// Type used to insert conditionally insert a network interface.
-///
-/// This type implements a query that does one of two things
-///
-/// - Insert a new network interface, performing validation and possibly IP
-/// allocation
-/// - Return an existing interface record, if it has the same primary key.
-///
-/// The first case is implemented in the [`push_interface_allocation_subquery`]
-/// function. See that function's documentation for the details.
-///
-/// The second case is implemented in this type's `walk_ast` method.
-///
-/// Details
-/// -------
-///
-/// The `push_interface_allocation_subquery` performs a number of validations on
-/// the data provided, such as verifying that a requested IP address isn't
-/// already assigned, or ensuring that the instance that will receive this
-/// interface isn't already associated with another VPC.
-///
-/// However, the query is also meant to run during an instance creation saga. In
-/// that case, the guardrails and unique indexes on this table make it
-/// impossible for the query to both be idempotent and also catch these
-/// constraints.
-///
-/// For example, imaging the instance creation saga crashes partway through
-/// allocation a list of NICs. That node of the saga will be replayed during
-/// saga recovery. This will create a record with exactly the same UUID for each
-/// interface, which will ulimately result in a conflicting primary key error
-/// from the database. This is both intentional and integral to the sagas
-/// correct functioning. We catch this error deliberately, assuming that the
-/// uniqueness of 128-bit UUIDs guarantees that the only practical situation
-/// under which this can occur is a saga node replay after a crash.
-///
-/// Query structure
-/// ---------------
-///
-/// This query looks like the following:
-///
-/// ```text
-/// SELECT (candidate).* FROM (SELECT COALESCE(
-///     <existing interface, if it has the same primary key>,
-///     <subquery to insert new interface, with data validation, and return it>
-/// )
-/// ```
-///
-/// That is, we return the exact record that's already in the database, if there
-/// is one, or run the entire validating query otherwise. In the context of
-/// sagas, this is helpful because we generate the UUIDs for the interfaces in a
-/// separate saga node, prior to inserting any interfaces. So if we have a
-/// record with that exact UUID, we assert that it must be the record from the
-/// saga itself. Note that, at this point, we return only the primary key, since
-/// it's sufficiently unlikely that there's an existing key whose other data
-/// does _not_ match the data we wanted to insert in a saga.
-///
-/// The odd syntax in the initial section, `SELECT (candidate).*` is because the
-/// result of the `COALESCE` expression is a tuple. That is CockroachDB's syntax
-/// for expanding a tuple into its constituent columns.
-///
-/// Note that the result of this expression is ultimately inserted into the
-/// `network_interface` table. The way that fails (VPC-validation, IP
-/// exhaustion, primary key violation), is used for either forwarding an error
-/// on to the client (in the case of IP exhaustion, for example), or continuing
-/// with a saga (for PK uniqueness violations). See [`InsertError`] for a
-/// summary of the error conditions and their meaning, and the functions
-/// constructing the subqueries in this type for more details.
 #[derive(Debug, Clone)]
 pub struct InsertQuery {
     interface: IncompleteNetworkInterface,
@@ -1161,58 +937,116 @@ impl QueryFragment<Pg> for InsertQuery {
         &'a self,
         mut out: AstPass<'_, 'a, Pg>,
     ) -> diesel::QueryResult<()> {
-        let push_columns =
-            |mut out: AstPass<'_, 'a, Pg>| -> diesel::QueryResult<()> {
-                out.push_identifier(dsl::id::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::name::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::description::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::time_created::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::time_modified::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::time_deleted::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::instance_id::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::vpc_id::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::subnet_id::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::mac::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::ip::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::slot::NAME)?;
-                out.push_sql(", ");
-                out.push_identifier(dsl::is_primary::NAME)?;
-                Ok(())
-            };
+        // Push subqueries that validate the provided instance. This generates a CTE
+        // with the name `validated_instance` and columns:
+        //  - `vpc_id`
+        //  - `subnet_id`
+        //  - `slot`
+        //  - `is_primary`
+        push_instance_validation_cte(
+            out.reborrow(),
+            &self.interface.vpc_id,
+            &self.vpc_id_str,
+            &self.interface.subnet.identity.id,
+            &self.subnet_id_str,
+            &self.interface.instance_id,
+            &self.instance_id_str,
+            &self.next_slot_subquery,
+            &self.is_primary_subquery,
+        )?;
 
-        out.push_sql("SELECT (candidate).* FROM (SELECT COALESCE((");
-
-        // Add subquery to find exactly the record we might have already
-        // inserted during a saga.
+        // Push the columns, values and names, that are named directly. These
+        // are known regardless of whether we're allocating an IP address. These
+        // are all written as `SELECT <value1> AS <name1>, <value2> AS <name2>, ...
         out.push_sql("SELECT ");
-        push_columns(out.reborrow())?;
-        out.push_sql(" FROM ");
-        NETWORK_INTERFACE_FROM_CLAUSE.walk_ast(out.reborrow())?;
-        out.push_sql(" WHERE ");
-        out.push_identifier(dsl::id::NAME)?;
-        out.push_sql(" = ");
         out.push_bind_param::<sql_types::Uuid, Uuid>(
             &self.interface.identity.id,
         )?;
-        out.push_sql(" AND ");
-        out.push_identifier(dsl::time_deleted::NAME)?;
-        out.push_sql(" IS NULL)");
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(", ");
 
-        // Push the main, data-validating subquery.
-        out.push_sql(", (");
-        push_interface_allocation_subquery(out.reborrow(), &self)?;
-        out.push_sql(")) AS candidate)");
+        out.push_bind_param::<sql_types::Text, db::model::Name>(
+            &self.interface.identity.name,
+        )?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::name::NAME)?;
+        out.push_sql(", ");
+
+        out.push_bind_param::<sql_types::Text, String>(
+            &self.interface.identity.description,
+        )?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::description::NAME)?;
+        out.push_sql(", ");
+
+        out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(
+            &self.now,
+        )?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::time_created::NAME)?;
+        out.push_sql(", ");
+
+        out.push_bind_param::<sql_types::Timestamptz, DateTime<Utc>>(
+            &self.now,
+        )?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::time_modified::NAME)?;
+        out.push_sql(", ");
+
+        out.push_bind_param::<sql_types::Nullable<sql_types::Timestamptz>, Option<DateTime<Utc>>>(&None)?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::time_deleted::NAME)?;
+        out.push_sql(", ");
+
+        out.push_bind_param::<sql_types::Uuid, Uuid>(
+            &self.interface.instance_id,
+        )?;
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::instance_id::NAME)?;
+        out.push_sql(", ");
+
+        // Helper function to push a subquery selecting something from the CTE.
+        fn select_from_cte(
+            mut out: AstPass<Pg>,
+            column: &'static str,
+        ) -> diesel::QueryResult<()> {
+            out.push_sql("(SELECT ");
+            out.push_identifier(column)?;
+            out.push_sql(" FROM validated_instance)");
+            Ok(())
+        }
+
+        select_from_cte(out.reborrow(), dsl::vpc_id::NAME)?;
+        out.push_sql(", ");
+        select_from_cte(out.reborrow(), dsl::subnet_id::NAME)?;
+        out.push_sql(", ");
+
+        // Push the subquery for selecting the a MAC address.
+        out.push_sql("(");
+        self.next_mac_subquery.walk_ast(out.reborrow())?;
+        out.push_sql(") AS ");
+        out.push_identifier(dsl::mac::NAME)?;
+        out.push_sql(", ");
+
+        // If the user specified an IP address, then insert it by value. If they
+        // did not, meaning we're allocating the next available one on their
+        // behalf, then insert that subquery here.
+        if let Some(ref ip) = &self.ip_sql {
+            out.push_bind_param::<sql_types::Inet, IpNetwork>(ip)?;
+        } else {
+            out.push_sql("(");
+            self.next_ipv4_address_subquery.walk_ast(out.reborrow())?;
+            out.push_sql(")");
+        }
+        out.push_sql(" AS ");
+        out.push_identifier(dsl::ip::NAME)?;
+        out.push_sql(", ");
+
+        select_from_cte(out.reborrow(), dsl::slot::NAME)?;
+        out.push_sql(", ");
+        select_from_cte(out.reborrow(), dsl::is_primary::NAME)?;
+
         Ok(())
     }
 }
@@ -2320,61 +2154,6 @@ mod tests {
         );
     }
 
-    // Test that inserting a record into the database with the same primary key
-    // returns the exact same record.
-    //
-    // This is an explicit test for the first expression within the `COALESCE`
-    // part of the query. That is specifically designed to be executed during
-    // sagas. In that case, we construct the UUIDs of each interface in one
-    // action, and then in the next, create and insert each interface.
-    #[tokio::test]
-    async fn test_insert_with_identical_primary_key() {
-        let context =
-            TestContext::new("test_insert_with_identical_primary_key").await;
-        let instance =
-            context.create_instance(external::InstanceState::Stopped).await;
-        let requested_ip = "172.30.0.5".parse().unwrap();
-        let interface = IncompleteNetworkInterface::new(
-            Uuid::new_v4(),
-            instance.id(),
-            context.net1.vpc_id,
-            context.net1.subnets[0].clone(),
-            IdentityMetadataCreateParams {
-                name: "interface-a".parse().unwrap(),
-                description: String::from("description"),
-            },
-            Some(requested_ip),
-        )
-        .unwrap();
-        let inserted_interface = context
-            .db_datastore
-            .instance_create_network_interface_raw(
-                &context.opctx,
-                interface.clone(),
-            )
-            .await
-            .expect("Failed to insert interface with known-good IP address");
-
-        // Attempt to insert the exact same record again.
-        let result = context
-            .db_datastore
-            .instance_create_network_interface_raw(
-                &context.opctx,
-                interface.clone(),
-            )
-            .await;
-        if let Err(InsertError::DuplicatePrimaryKey(key)) = result {
-            assert_eq!(key, inserted_interface.identity.id);
-        } else {
-            panic!(
-                "Expected a InsertError::DuplicatePrimaryKey \
-                error when inserting the exact same interface, found: {:?}",
-                result,
-            );
-        }
-        context.success().await;
-    }
-
     // Test that we fail to insert an interface if there are no available slots
     // on the instance.
     #[tokio::test]
@@ -2423,8 +2202,8 @@ mod tests {
                 )
                 .await
                 .expect("Should be able to insert up to 8 interfaces");
-            let actual_slot =
-                u32::try_from(inserted_interface.slot).expect("Bad slot index");
+            let actual_slot = usize::try_from(inserted_interface.slot)
+                .expect("Bad slot index");
             assert_eq!(
                 slot, actual_slot,
                 "Failed to allocate next available interface slot"

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -385,6 +385,21 @@ async fn test_instances_create_reboot_halt(
         .await
         .unwrap();
 
+    // Check that the network interfaces for that instance are gone, peeking
+    // at the subnet-scoped URL so we don't 404 at the instance-scoped route.
+    let url_interfaces = format!(
+        "/organizations/{}/projects/{}/vpcs/default/subnets/default/network-interfaces",
+        ORGANIZATION_NAME, PROJECT_NAME,
+    );
+    let interfaces =
+        objects_list_page_authz::<NetworkInterface>(client, &url_interfaces)
+            .await
+            .items;
+    assert!(
+        interfaces.is_empty(),
+        "Expected all network interfaces for the instance to be deleted"
+    );
+
     // TODO-coverage re-add tests that check the server-side state after
     // deleting.  We need to figure out how these actually get cleaned up from
     // the API namespace when this happens.

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1572,7 +1572,9 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
     );
     let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
-    // Create two interfaces, with the same IP addresses.
+    // Create two interfaces, in the same VPC Subnet. This will trigger an
+    // error on creation of the second NIC, and we'll make sure that both are
+    // deleted.
     let default_name = "default".parse::<Name>().unwrap();
     let if0_params = params::NetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
@@ -1590,7 +1592,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         },
         vpc_name: default_name.clone(),
         subnet_name: default_name.clone(),
-        ip: Some("172.30.0.6".parse().unwrap()),
+        ip: Some("172.30.0.7".parse().unwrap()),
     };
     let interface_params =
         params::InstanceNetworkInterfaceAttachment::Create(vec![


### PR DESCRIPTION
Previously, for NICs and external IPs, the saga action that actually
created the records and the corresponding undo were not together in a
saga node. The undo was associated with a preceding action that created
UUIDs for the records. That was because each action may have created
multiple records, where the count was not known when we create the saga
template, and so the forward action performed multiple fallible steps.
To unwind it completely, including reverting the creation of N
resources, in the case where the N + 1th failed, we put the undo in the
preceding step. That worked, but was certainly confusing and bad for
maintenance, since the action and its undo were in different nodes. It
also resulted in a ton of extra complexity in some of the downstream
queries, which now had to be aware of the fact that we might replay a
partially-played saga node. This commit undoes all that.

- Unroll the instance external IP address query
- Unroll the network interface creation query
- Actually delete NICs when we delete the instance, and add test for
  that
- Simplify network interface query. An additional CTE detecting the
  partial-saga replay case is no longer needed, since we don't run the
  saga that way.