### PR TITLE
Stop abusing OPTE's source NAT configuration for external IPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "illumos-ddi-dki"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=eb9e0c687e3c072dbc7d4782475f4ba5a6f50258#eb9e0c687e3c072dbc7d4782475f4ba5a6f50258"
+source = "git+https://github.com/oxidecomputer/opte?rev=23884d35aa7908e23accaa77f125a370ddf5c606#23884d35aa7908e23accaa77f125a370ddf5c606"
 dependencies = [
  "illumos-sys-hdrs",
 ]
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=eb9e0c687e3c072dbc7d4782475f4ba5a6f50258#eb9e0c687e3c072dbc7d4782475f4ba5a6f50258"
+source = "git+https://github.com/oxidecomputer/opte?rev=23884d35aa7908e23accaa77f125a370ddf5c606#23884d35aa7908e23accaa77f125a370ddf5c606"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=eb9e0c687e3c072dbc7d4782475f4ba5a6f50258#eb9e0c687e3c072dbc7d4782475f4ba5a6f50258"
+source = "git+https://github.com/oxidecomputer/opte?rev=23884d35aa7908e23accaa77f125a370ddf5c606#23884d35aa7908e23accaa77f125a370ddf5c606"
 dependencies = [
  "anymap",
  "cfg-if 0.1.10",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=eb9e0c687e3c072dbc7d4782475f4ba5a6f50258#eb9e0c687e3c072dbc7d4782475f4ba5a6f50258"
+source = "git+https://github.com/oxidecomputer/opte?rev=23884d35aa7908e23accaa77f125a370ddf5c606#23884d35aa7908e23accaa77f125a370ddf5c606"
 dependencies = [
  "libc",
  "libnet",

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -15,13 +15,13 @@ use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use serde::Deserialize;
 use serde::Serialize;
-use sled_agent_client::types::ExternalIp;
 use sled_agent_client::types::InstanceEnsureBody;
 use sled_agent_client::types::InstanceHardware;
 use sled_agent_client::types::InstanceMigrateParams;
 use sled_agent_client::types::InstanceRuntimeStateMigrateParams;
 use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
+use sled_agent_client::types::SourceNatConfig;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
 use steno::new_action_noop_undo;
@@ -189,24 +189,21 @@ async fn sim_instance_migrate(
             .as_str(),
         )));
     }
+    let external_ips =
+        external_ips.into_iter().map(|model| model.ip.ip()).collect();
     if snat_ip.len() != 1 {
         return Err(ActionError::action_failed(Error::internal_error(
             "Expected exactly one SNAT IP address for an instance",
         )));
     }
-
-    // For now, we take the Ephemeral IP, if it exists, or the SNAT IP if not.
-    // TODO-correctness: Handle multiple IP addresses, see
-    //  https://github.com/oxidecomputer/omicron/issues/1467
-    let external_ip = ExternalIp::from(
-        external_ips.into_iter().chain(snat_ip).next().unwrap(),
-    );
+    let source_nat = SourceNatConfig::from(snat_ip.into_iter().next().unwrap());
 
     let instance_hardware = InstanceHardware {
         runtime: runtime.into(),
         // TODO: populate NICs
         nics: vec![],
-        external_ip,
+        source_nat,
+        external_ips,
         // TODO: populate disks
         disks: vec![],
         // TODO: populate cloud init bytes

--- a/nexus/src/db/model/external_ip.rs
+++ b/nexus/src/db/model/external_ip.rs
@@ -68,7 +68,7 @@ pub struct InstanceExternalIp {
     pub last_port: SqlU16,
 }
 
-impl From<InstanceExternalIp> for sled_agent_client::types::ExternalIp {
+impl From<InstanceExternalIp> for sled_agent_client::types::SourceNatConfig {
     fn from(eip: InstanceExternalIp) -> Self {
         Self {
             ip: eip.ip.ip(),

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -49,11 +49,7 @@ const INSTANCE_EXTERNAL_IP_FROM_CLAUSE: InstanceExternalIpFromClause =
 // instead to check if a candidate port range has any overlap with an existing
 // port range, which is more complicated. That's deferred until we actually have
 // that situation (which may be as soon as allocating ephemeral IPs).
-//
-// TODO-correctness: We're currently providing the entire port range, even for
-// source NAT. We'd like to chunk this up in to something more like quadrants,
-// e.g., ranges `[0, 16384)`, `[16384, 32768)`, etc.
-const NUM_SOURCE_NAT_PORTS: usize = 1 << 16;
+const NUM_SOURCE_NAT_PORTS: usize = 1 << 14;
 const MAX_PORT: i32 = u16::MAX as _;
 
 /// Select the next available IP address and port range for an instance's

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -709,34 +709,6 @@
           "request_id"
         ]
       },
-      "ExternalIp": {
-        "description": "An external IP address used for external connectivity for an instance.",
-        "type": "object",
-        "properties": {
-          "first_port": {
-            "description": "The first port used for instance NAT, inclusive.",
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
-          },
-          "ip": {
-            "description": "The external address provided to the instance",
-            "type": "string",
-            "format": "ip"
-          },
-          "last_port": {
-            "description": "The last port used for instance NAT, also inclusive.",
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "first_port",
-          "ip",
-          "last_port"
-        ]
-      },
       "Generation": {
         "description": "Generation numbers stored in the database, used for optimistic concurrency control",
         "type": "integer",
@@ -798,8 +770,13 @@
               "$ref": "#/components/schemas/DiskRequest"
             }
           },
-          "external_ip": {
-            "$ref": "#/components/schemas/ExternalIp"
+          "external_ips": {
+            "description": "Zero or more external IP addresses (either floating or ephemeral), provided to an instance to allow inbound connectivity.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
           },
           "nics": {
             "type": "array",
@@ -809,13 +786,17 @@
           },
           "runtime": {
             "$ref": "#/components/schemas/InstanceRuntimeState"
+          },
+          "source_nat": {
+            "$ref": "#/components/schemas/SourceNatConfig"
           }
         },
         "required": [
           "disks",
-          "external_ip",
+          "external_ips",
           "nics",
-          "runtime"
+          "runtime",
+          "source_nat"
         ]
       },
       "InstanceMigrateParams": {
@@ -1235,6 +1216,34 @@
         "type": "integer",
         "format": "uint8",
         "minimum": 0
+      },
+      "SourceNatConfig": {
+        "description": "An IP address and port range used for instance source NAT, i.e., making outbound network connections from guests.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for instance NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance",
+            "type": "string",
+            "format": "ip"
+          },
+          "last_port": {
+            "description": "The last port used for instance NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
       },
       "UpdateArtifact": {
         "description": "Description of a single update artifact.",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -55,8 +55,8 @@ vsss-rs = { version = "2.0.0-pre2", default-features = false, features = ["std"]
 zone = "0.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "eb9e0c687e3c072dbc7d4782475f4ba5a6f50258" }
-opte = { git = "https://github.com/oxidecomputer/opte", rev = "eb9e0c687e3c072dbc7d4782475f4ba5a6f50258", features = [ "api", "std" ] }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "23884d35aa7908e23accaa77f125a370ddf5c606" }
+opte = { git = "https://github.com/oxidecomputer/opte", rev = "23884d35aa7908e23accaa77f125a370ddf5c606", features = [ "api", "std" ] }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -230,8 +230,8 @@ mod test {
     use crate::illumos::{dladm::MockDladm, zone::MockZones};
     use crate::instance::MockInstance;
     use crate::nexus::LazyNexusClient;
-    use crate::params::ExternalIp;
     use crate::params::InstanceStateRequested;
+    use crate::params::SourceNatConfig;
     use chrono::Utc;
     use macaddr::MacAddr6;
     use omicron_common::api::external::{
@@ -271,11 +271,12 @@ mod test {
                 time_updated: Utc::now(),
             },
             nics: vec![],
-            external_ip: ExternalIp {
+            source_nat: SourceNatConfig {
                 ip: IpAddr::from(Ipv4Addr::new(10, 0, 0, 1)),
                 first_port: 0,
                 last_port: 1 << 14 - 1,
             },
+            external_ips: vec![],
             disks: vec![],
             cloud_init_bytes: None,
         }

--- a/sled-agent/src/opte/illumos/port.rs
+++ b/sled-agent/src/opte/illumos/port.rs
@@ -9,7 +9,7 @@ use crate::opte::BoundaryServices;
 use crate::opte::Gateway;
 use crate::opte::PortTicket;
 use crate::opte::Vni;
-use crate::params::ExternalIp;
+use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
 use macaddr::MacAddr6;
 use std::net::IpAddr;
@@ -34,9 +34,12 @@ struct PortInner {
     _vni: Vni,
     // IP address of the hosting sled
     _underlay_ip: Ipv6Addr,
-    // The external IP information for this port, or None if it has no external
-    // connectivity. Only the primary interface has Some(_) here.
-    external_ip: Option<ExternalIp>,
+    // The external IP address and port range provided for this port, to allow
+    // outbound network connectivity.
+    source_nat: Option<SourceNatConfig>,
+    // The external IP addresses provided to this port, to allow _inbound_
+    // network connectivity.
+    external_ips: Option<Vec<IpAddr>>,
     // Information about the virtual gateway, aka OPTE
     _gateway: Gateway,
     // Information about Boundary Services, for forwarding traffic between sleds
@@ -110,7 +113,8 @@ impl Port {
         slot: u8,
         vni: Vni,
         underlay_ip: Ipv6Addr,
-        external_ip: Option<ExternalIp>,
+        source_nat: Option<SourceNatConfig>,
+        external_ips: Option<Vec<IpAddr>>,
         gateway: Gateway,
         boundary_services: BoundaryServices,
         vnic: String,
@@ -125,7 +129,8 @@ impl Port {
                 slot,
                 _vni: vni,
                 _underlay_ip: underlay_ip,
-                external_ip,
+                source_nat,
+                external_ips,
                 _gateway: gateway,
                 _boundary_services: boundary_services,
                 vnic,
@@ -133,8 +138,12 @@ impl Port {
         }
     }
 
-    pub fn external_ip(&self) -> &Option<ExternalIp> {
-        &self.inner.external_ip
+    pub fn source_nat(&self) -> &Option<SourceNatConfig> {
+        &self.inner.source_nat
+    }
+
+    pub fn external_ips(&self) -> &Option<Vec<IpAddr>> {
+        &self.inner.external_ips
     }
 
     pub fn mac(&self) -> &MacAddr6 {

--- a/sled-agent/src/opte/non_illumos/port.rs
+++ b/sled-agent/src/opte/non_illumos/port.rs
@@ -8,7 +8,7 @@ use crate::opte::BoundaryServices;
 use crate::opte::Gateway;
 use crate::opte::PortTicket;
 use crate::opte::Vni;
-use crate::params::ExternalIp;
+use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
 use macaddr::MacAddr6;
 use std::net::IpAddr;
@@ -34,9 +34,12 @@ struct PortInner {
     _vni: Vni,
     // IP address of the hosting sled
     _underlay_ip: Ipv6Addr,
-    // The external IP information for this port, or None if it has no external
-    // connectivity. Only the primary interface has Some(_) here.
-    external_ip: Option<ExternalIp>,
+    // The external IP address and port range provided for this port, to allow
+    // outbound network connectivity.
+    source_nat: Option<SourceNatConfig>,
+    // The external IP addresses provided to this port, to allow _inbound_
+    // network connectivity.
+    external_ips: Option<Vec<IpAddr>>,
     // Information about the virtual gateway, aka OPTE
     _gateway: Gateway,
     // Information about Boundary Services, for forwarding traffic between sleds
@@ -75,7 +78,8 @@ impl Port {
         slot: u8,
         vni: Vni,
         underlay_ip: Ipv6Addr,
-        external_ip: Option<ExternalIp>,
+        source_nat: Option<SourceNatConfig>,
+        external_ips: Option<Vec<IpAddr>>,
         gateway: Gateway,
         boundary_services: BoundaryServices,
         vnic: String,
@@ -90,7 +94,8 @@ impl Port {
                 slot,
                 _vni: vni,
                 _underlay_ip: underlay_ip,
-                external_ip,
+                source_nat,
+                external_ips,
                 _gateway: gateway,
                 _boundary_services: boundary_services,
                 vnic,
@@ -98,8 +103,12 @@ impl Port {
         }
     }
 
-    pub fn external_ip(&self) -> &Option<ExternalIp> {
-        &self.inner.external_ip
+    pub fn source_nat(&self) -> &Option<SourceNatConfig> {
+        &self.inner.source_nat
+    }
+
+    pub fn external_ips(&self) -> &Option<Vec<IpAddr>> {
+        &self.inner.external_ips
     }
 
     pub fn mac(&self) -> &MacAddr6 {

--- a/sled-agent/src/opte/non_illumos/port_manager.rs
+++ b/sled-agent/src/opte/non_illumos/port_manager.rs
@@ -10,8 +10,8 @@ use crate::opte::Error;
 use crate::opte::Gateway;
 use crate::opte::Port;
 use crate::opte::Vni;
-use crate::params::ExternalIp;
 use crate::params::NetworkInterface;
+use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
 use macaddr::MacAddr6;
 use slog::debug;
@@ -109,7 +109,8 @@ impl PortManager {
         &self,
         instance_id: Uuid,
         nic: &NetworkInterface,
-        external_ip: Option<ExternalIp>,
+        source_nat: Option<SourceNatConfig>,
+        external_ips: Option<Vec<IpAddr>>,
     ) -> Result<Port, Error> {
         // TODO-completess: Remove IPv4 restrictions once OPTE supports virtual
         // IPv6 networks.
@@ -157,7 +158,8 @@ impl PortManager {
                 nic.slot,
                 vni,
                 self.inner.underlay_ip,
-                external_ip,
+                source_nat,
+                external_ips,
                 gateway,
                 boundary_services,
                 vnic,

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -26,9 +26,10 @@ pub struct NetworkInterface {
     pub slot: u8,
 }
 
-/// An external IP address used for external connectivity for an instance.
+/// An IP address and port range used for instance source NAT, i.e., making
+/// outbound network connections from guests.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
-pub struct ExternalIp {
+pub struct SourceNatConfig {
     /// The external address provided to the instance
     pub ip: IpAddr,
     /// The first port used for instance NAT, inclusive.
@@ -75,7 +76,10 @@ pub struct DiskEnsureBody {
 pub struct InstanceHardware {
     pub runtime: InstanceRuntimeState,
     pub nics: Vec<NetworkInterface>,
-    pub external_ip: ExternalIp,
+    pub source_nat: SourceNatConfig,
+    /// Zero or more external IP addresses (either floating or ephemeral),
+    /// provided to an instance to allow inbound connectivity.
+    pub external_ips: Vec<IpAddr>,
     pub disks: Vec<propolis_client::api::DiskRequest>,
     pub cloud_init_bytes: Option<String>,
 }

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -122,7 +122,7 @@ function add_publisher {
 # `helios-netdev` provides the xde kernel driver and the `opteadm` userland tool
 # for interacting with it.
 HELIOS_NETDEV_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/opte/repo"
-HELIOS_NETDEV_COMMIT="eb9e0c687e3c072dbc7d4782475f4ba5a6f50258"
+HELIOS_NETDEV_COMMIT="23884d35aa7908e23accaa77f125a370ddf5c606"
 HELIOS_NETDEV_REPO_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p"
 HELIOS_NETDEV_REPO_SHA_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p.sha256"
 HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"


### PR DESCRIPTION
- Update OPTE dep to include the API that allows setting an external IP
  address explicitly, rather than abusing the SNAT configuration for
  that
- Carve up SNAT addresses into port ranges of 16K. We previously used
  the entire port range, since OPTE used the whole range anyway to allow
  inbound connections on any port. This allows 16K outbound connections
  from guests that don't need inbound, which is a reasonable starting
  point.
- Add explicit SNAT and external IP addresses to the sled agent and
  client-library types, as well as the representation of instances and
  OPTE ports.