### PR TITLE
External IPs endpoint returns struct with `items` Vec

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2500,7 +2500,7 @@ async fn instance_network_interface_update(
 async fn instance_external_ip_list(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<InstancePathParam>,
-) -> Result<HttpResponseOk<Vec<views::ExternalIp>>, HttpError> {
+) -> Result<HttpResponseOk<ResultsPage<views::ExternalIp>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
@@ -2517,7 +2517,7 @@ async fn instance_external_ip_list(
                 instance_name,
             )
             .await?;
-        Ok(HttpResponseOk(ips))
+        Ok(HttpResponseOk(ResultsPage { items: ips, next_page: None }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -27,7 +27,7 @@ use omicron_common::api::external::NetworkInterface;
 use omicron_nexus::external_api::shared::IpKind;
 use omicron_nexus::external_api::shared::IpRange;
 use omicron_nexus::external_api::shared::Ipv4Range;
-use omicron_nexus::external_api::views::ExternalIp;
+use omicron_nexus::external_api::views;
 use omicron_nexus::TestInterfaces as _;
 use omicron_nexus::{external_api::params, Nexus};
 use sled_agent_client::TestInterfaces as _;
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use dropshot::test_util::ClientTestContext;
-use dropshot::HttpErrorResponseBody;
+use dropshot::{HttpErrorResponseBody, ResultsPage};
 
 use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::{
@@ -2500,13 +2500,13 @@ async fn test_instance_ephemeral_ip_from_correct_project(
         .execute()
         .await
         .expect("Failed to fetch external IPs")
-        .parsed_body::<Vec<ExternalIp>>()
+        .parsed_body::<ResultsPage<views::ExternalIp>>()
         .expect("Failed to parse external IPs");
-    assert_eq!(ips.len(), 1);
-    assert_eq!(ips[0].kind, IpKind::Ephemeral);
+    assert_eq!(ips.items.len(), 1);
+    assert_eq!(ips.items[0].kind, IpKind::Ephemeral);
     assert!(
-        ips[0].ip >= second_range.first_address()
-            && ips[0].ip <= second_range.last_address(),
+        ips.items[0].ip >= second_range.first_address()
+            && ips.items[0].ip <= second_range.last_address(),
         "Expected the Ephemeral IP to come from the second address \
         range, since the first is reserved for a project different from \
         the instance's project."

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2972,11 +2972,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Array_of_ExternalIp",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExternalIp"
-                  }
+                  "$ref": "#/components/schemas/ExternalIpResultsPage"
                 }
               }
             }
@@ -7259,6 +7255,27 @@
               "type"
             ]
           }
+        ]
+      },
+      "ExternalIpResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalIp"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "FieldSchema": {


### PR DESCRIPTION
Ran into this on console because the TS client generator doesn't handle this case well. It could handle it better, but this should still return a struct.