### PR TITLE
Respect IP Pool when allocating ephemeral addresses for guests

### DIFF
--- a/nexus/src/db/datastore/instance_external_ip.rs
+++ b/nexus/src/db/datastore/instance_external_ip.rs
@@ -12,6 +12,7 @@ use crate::db::error::ErrorHandler;
 use crate::db::model::IncompleteInstanceExternalIp;
 use crate::db::model::InstanceExternalIp;
 use crate::db::model::IpKind;
+use crate::db::model::IpPool;
 use crate::db::model::Name;
 use crate::db::queries::external_ip::NextExternalIp;
 use crate::db::update_and_check::UpdateAndCheck;
@@ -22,6 +23,8 @@ use diesel::prelude::*;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::LookupType;
+use omicron_common::api::external::ResourceType;
 use uuid::Uuid;
 
 impl DataStore {
@@ -50,13 +53,42 @@ impl DataStore {
         ip_id: Uuid,
         project_id: Uuid,
         instance_id: Uuid,
-        _pool_name: Option<Name>,
+        pool_name: Option<Name>,
     ) -> CreateResult<InstanceExternalIp> {
+        let pool_id = if let Some(ref name) = pool_name {
+            // We'd like to add authz checks here, and use the `LookupPath`
+            // methods on the project-scoped view of this resource. It's not
+            // entirely clear how that'll work in the API, so see RFD 288 and
+            // https://github.com/oxidecomputer/omicron/issues/1470 for more
+            // details.
+            use db::schema::ip_pool::dsl;
+            Some(
+                dsl::ip_pool
+                    .filter(dsl::name.eq(name.clone()))
+                    .filter(dsl::time_deleted.is_null())
+                    .select(IpPool::as_select())
+                    .first_async::<IpPool>(self.pool_authorized(opctx).await?)
+                    .await
+                    .map_err(|e| {
+                        public_error_from_diesel_pool(
+                            e,
+                            ErrorHandler::NotFoundByLookup(
+                                ResourceType::IpPool,
+                                LookupType::ByName(name.to_string()),
+                            ),
+                        )
+                    })?
+                    .identity
+                    .id,
+            )
+        } else {
+            None
+        };
         let data = IncompleteInstanceExternalIp::for_ephemeral(
             ip_id,
             project_id,
             instance_id,
-            /* pool_id = */ None,
+            pool_id,
         );
         self.allocate_instance_external_ip(opctx, data).await
     }

--- a/nexus/src/db/datastore/instance_external_ip.rs
+++ b/nexus/src/db/datastore/instance_external_ip.rs
@@ -61,11 +61,19 @@ impl DataStore {
             // entirely clear how that'll work in the API, so see RFD 288 and
             // https://github.com/oxidecomputer/omicron/issues/1470 for more
             // details.
+            //
+            // For now, we just ensure that the pool is either unreserved, or
+            // reserved for the instance's project.
             use db::schema::ip_pool::dsl;
             Some(
                 dsl::ip_pool
                     .filter(dsl::name.eq(name.clone()))
                     .filter(dsl::time_deleted.is_null())
+                    .filter(
+                        dsl::project_id
+                            .is_null()
+                            .or(dsl::project_id.eq(Some(project_id))),
+                    )
                     .select(IpPool::as_select())
                     .first_async::<IpPool>(self.pool_authorized(opctx).await?)
                     .await


### PR DESCRIPTION
- Use IP Pool name provided by clients in the actual allocation query
  and calls using it
- Add test verifying restriction of IPs to the requested pool, when an
  address from another pool would normally be preferred.