### PR TITLE
CI: disable build-and-test for macOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-11 ]
+        os: [ ubuntu-18.04 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b


### PR DESCRIPTION
We brought up the unreliability of macOS CI tasks a few control plane syncs ago; failures seem more regular now, mostly caused by [request timeouts while running Nexus's test binary](https://github.com/oxidecomputer/omicron/runs/7549886733?check_suite_focus=true#step:10:1040). To me this seems like resource contention, probably I/O, since each test is starting up a crdb instance.

It's something we could either put engineering resources toward to make better (e.g. in-memory crdb mode for tests on macOS?) but it's not clear we'd significantly benefit, macOS tests are already slower than everything else, and we need to make the red :x: a more reliable signal of actual failure.

This means the only CI we're doing for macOS is the check-omicron-deployment task, which essentially just runs `cargo check` on everything that is part of deployment.