### PR TITLE
Remove internal nexus_address from sled agent

### DIFF
--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
 use serde_with::PickFirst;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -23,8 +23,6 @@ use uuid::Uuid;
 pub struct Config {
     /// Unique id for the sled
     pub id: Uuid,
-    /// Address of Nexus instance
-    pub nexus_address: SocketAddr,
     /// Configuration for the sled agent debug log
     pub log: ConfigLogging,
     /// Optional VLAN ID to be used for tagging guest VNICs.

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -2,11 +2,6 @@
 
 id = "fb0f7546-4d46-40ca-9d56-cbb810684ca7"
 
-# TODO: Remove this address
-
-# Internal address of Nexus
-nexus_address = "[fd00:1122:3344:0101::3]:12221"
-
 # A file-backed zpool can be manually created with the following:
 # # truncate -s 10GB testpool.vdev
 # # zpool create oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b "$PWD/testpool.vdev"


### PR DESCRIPTION
This is a follow-up to https://github.com/oxidecomputer/omicron/pull/1386 ; it removes config info that is no longer used.

The internal Nexus address is looked up via DNS.