### PR TITLE
some database name lengths are not right

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -239,7 +239,7 @@ CREATE TYPE omicron.public.user_provision_type AS ENUM (
 CREATE TABLE omicron.public.silo (
     /* Identity metadata */
     id UUID PRIMARY KEY,
-    name STRING(128) NOT NULL,
+    name STRING(63) NOT NULL,
     description STRING(512) NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
@@ -287,7 +287,7 @@ CREATE TYPE omicron.public.provider_type AS ENUM (
 CREATE TABLE omicron.public.identity_provider (
     /* Identity metadata */
     id UUID PRIMARY KEY,
-    name STRING(128) NOT NULL,
+    name STRING(63) NOT NULL,
     description STRING(512) NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
@@ -315,7 +315,7 @@ CREATE INDEX ON omicron.public.identity_provider (
 CREATE TABLE omicron.public.saml_identity_provider (
     /* Identity metadata */
     id UUID PRIMARY KEY,
-    name STRING(128) NOT NULL,
+    name STRING(63) NOT NULL,
     description STRING(512) NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
@@ -1060,7 +1060,7 @@ CREATE TABLE omicron.public.instance_external_ip (
     id UUID PRIMARY KEY,
 
     /* Name for floating IPs. See the constraints below. */
-    name STRING(128),
+    name STRING(63),
 
     /* Description for floating IPs. See the constraints below. */
     description STRING(512),


### PR DESCRIPTION
RFD 4 says that names must be 1-63 characters long and [we validate this](https://github.com/oxidecomputer/omicron/blob/b270033cd460f4ae429d0f9643b0a92548b39719/common/src/api/external/mod.rs#L140-L142).  In the database schema, most names use `STRING(63)`.  A few were using other lengths so I'm updating them to be consistent.  This prevents us from storing a field that we won't be able to deserialize.  (They might actually deserialize because we don't check that...but that would be a separate bug.)

I skipped two:

- update_available_artifact has a "name" but it's not stored in Rust as a `Name` so I didn't touch it
- saga has a "template_name" but it's going away in #1532