### PR TITLE
steno dep could come from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled-agent-client",
- "steno",
+ "steno 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
 ]
 
@@ -2988,7 +2988,7 @@ dependencies = [
  "serde_with",
  "slog",
  "smf",
- "steno",
+ "steno 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -3023,7 +3023,7 @@ dependencies = [
  "serde_with",
  "slog",
  "smf",
- "steno",
+ "steno 0.2.0 (git+https://github.com/oxidecomputer/steno?branch=main)",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -3151,7 +3151,7 @@ dependencies = [
  "sled-agent-client",
  "slog",
  "slog-dtrace",
- "steno",
+ "steno 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum",
  "subprocess",
  "tempfile",
@@ -5483,6 +5483,28 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "steno"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f695d04f2d9e08f3ed0c72acfa21cddc20eb76698a2ff0961a6758d3566454c2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "lazy_static",
+ "newtype_derive",
+ "petgraph",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "steno"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 serde_with = "2.0.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 smf = "0.2"
-steno = { git = "https://github.com/oxidecomputer/steno", branch = "main" }
+steno = "0.2"
 thiserror = "1.0"
 tokio = { version = "1.20", features = [ "full" ] }
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -52,6 +52,7 @@ serde_urlencoded = "0.7.1"
 serde_with = "2.0.0"
 sled-agent-client = { path = "../sled-agent-client" }
 slog-dtrace = "0.2"
+steno = "0.2"
 tempfile = "3.3"
 thiserror = "1.0"
 toml = "0.5.9"
@@ -100,10 +101,6 @@ features = [ "derive" ]
 [dependencies.slog]
 version = "2.7"
 features = [ "max_level_trace", "release_max_level_debug" ]
-
-[dependencies.steno]
-git = "https://github.com/oxidecomputer/steno"
-branch = "main"
 
 [dependencies.tokio]
 version = "1.20"

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.1.0", features = ["serde", "v4"] }
 
-steno = { git = "https://github.com/oxidecomputer/steno", branch = "main" }
+steno = "0.2"
 
 db-macros = { path = "../db-macros" }
 omicron-common = { path = "../../common" }


### PR DESCRIPTION
I don't think there's a strong reason to use a git dependency here.  The main advantages to using a git dependency I think are privacy (doesn't matter, it's open source) and faster development.  Steno doesn't change that rapidly, and we need to update Cargo.lock in Omicron anyway to pull in changes.  So it's just the Steno release process we're saving.  Now that it's got some release tooling, I'd rather run that more often than deal with the downsides of a git dependency.