### PR TITLE
faux-mgs: Add `update` and `sys-reset`

### DIFF
--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -471,6 +471,15 @@ impl ResponseKindExt for ResponseKind {
             ResponseKind::SerialConsoleWriteAck => {
                 response_kind_names::SERIAL_CONSOLE_WRITE_ACK
             }
+            ResponseKind::UpdateStartAck => {
+                response_kind_names::UPDATE_START_ACK
+            }
+            ResponseKind::UpdateChunkAck => {
+                response_kind_names::UPDATE_CHUNK_ACK
+            }
+            ResponseKind::SysResetPrepareAck => {
+                response_kind_names::SYS_RESET_PREPARE_ACK
+            }
         }
     }
 
@@ -545,4 +554,7 @@ mod response_kind_names {
     pub(super) const SP_STATE: &str = "sp_state";
     pub(super) const SERIAL_CONSOLE_WRITE_ACK: &str =
         "serial_console_write_ack";
+    pub(super) const UPDATE_START_ACK: &str = "update_start_ack";
+    pub(super) const UPDATE_CHUNK_ACK: &str = "update_chunk_ack";
+    pub(super) const SYS_RESET_PREPARE_ACK: &str = "sys_reset_prepare_ack";
 }

--- a/gateway/faux-mgs/src/reset.rs
+++ b/gateway/faux-mgs/src/reset.rs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use crate::recv_sp_message_ignoring_serial_console;
+use crate::request_response;
+use crate::send_request;
+use crate::RecvError;
+use anyhow::bail;
+use anyhow::Result;
+use gateway_messages::RequestKind;
+use gateway_messages::ResponseError;
+use gateway_messages::ResponseKind;
+use slog::info;
+use slog::Logger;
+use std::io;
+use std::net::SocketAddrV6;
+use std::net::UdpSocket;
+
+pub(crate) fn run(
+    log: Logger,
+    socket: UdpSocket,
+    sp: SocketAddrV6,
+) -> Result<()> {
+    // Tell SP to prepare to reset.
+    let response =
+        request_response(&log, &socket, sp, RequestKind::SysResetPrepare)??;
+    match response {
+        ResponseKind::SysResetPrepareAck => (),
+        other => bail!("unexpected SP response: {other:?}"),
+    }
+    info!(log, "SP is prepared to reset");
+
+    // We won't get an ack to a reset trigger; instead, keep sending trigger
+    // resets until we get back the error we expect from sending a reset trigger
+    // to a recently-rebooted SP.
+    for retry in 1..=5 {
+        info!(log, "sending reset trigger (attempt {retry})");
+        send_request(&log, &socket, sp, RequestKind::SysResetTrigger)?;
+
+        let result =
+            match recv_sp_message_ignoring_serial_console(&log, &socket) {
+                Ok((_request_id, result)) => result,
+                Err(RecvError::Io(err))
+                    if err.kind() == io::ErrorKind::WouldBlock =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err.into()),
+            };
+
+        match result {
+            Err(ResponseError::SysResetTriggerWithoutPrepare) => {
+                info!(log, "SP reset complete");
+                return Ok(());
+            }
+            other => bail!("unexpected SP response: {other:?}"),
+        };
+    }
+
+    bail!("failed to confirm reset")
+}

--- a/gateway/faux-mgs/src/update.rs
+++ b/gateway/faux-mgs/src/update.rs
@@ -1,0 +1,137 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use crate::recv_sp_message_ignoring_serial_console;
+use crate::send_request;
+use crate::RecvError;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use gateway_messages::RequestKind;
+use gateway_messages::ResponseError;
+use gateway_messages::ResponseKind;
+use gateway_messages::UpdateChunk;
+use gateway_messages::UpdateStart;
+use slog::debug;
+use slog::info;
+use slog::warn;
+use slog::Logger;
+use std::fs;
+use std::io;
+use std::net::SocketAddrV6;
+use std::net::UdpSocket;
+use std::path::Path;
+
+pub(crate) fn run(
+    log: Logger,
+    socket: UdpSocket,
+    sp: SocketAddrV6,
+    image: &Path,
+) -> Result<()> {
+    let image = fs::read(image)
+        .with_context(|| format!("failed to read image {}", image.display()))?;
+
+    let total_size = image.len().try_into().with_context(|| {
+        format!("image length ({}) overflows total_size field", image.len())
+    })?;
+    let start = UpdateStart { total_size };
+
+    info!(log, "sending UpdateStart to SP");
+    update_with_retry(&log, &socket, sp, RequestKind::UpdateStart(start), 0)
+        .with_context(|| "starting update failed")?;
+    info!(log, "SP acknowledged update start");
+
+    for (i, data) in image.chunks(UpdateChunk::MAX_CHUNK_SIZE).enumerate() {
+        let mut chunk = UpdateChunk {
+            offset: (i * UpdateChunk::MAX_CHUNK_SIZE)
+                .try_into()
+                .with_context(|| "update size overflowed u32")?,
+            chunk_length: data.len() as u16,
+            data: [0; UpdateChunk::MAX_CHUNK_SIZE],
+        };
+        chunk.data[..data.len()].copy_from_slice(data);
+        let end_chunk = chunk.offset + u32::from(chunk.chunk_length);
+
+        update_with_retry(
+            &log,
+            &socket,
+            sp,
+            RequestKind::UpdateChunk(chunk),
+            end_chunk,
+        )
+        .with_context(|| "update failed partially complete")?;
+        debug!(
+            log,
+            "SP update progress ({} of {} bytes)",
+            end_chunk,
+            image.len()
+        );
+    }
+    info!(log, "SP update complete");
+
+    Ok(())
+}
+
+fn update_with_retry(
+    log: &Logger,
+    socket: &UdpSocket,
+    sp: SocketAddrV6,
+    request: RequestKind,
+    expected_progress: u32,
+) -> Result<()> {
+    const MAX_ATTEMPTS: usize = 5;
+
+    for retry in 0..MAX_ATTEMPTS {
+        if retry > 0 {
+            info!(
+                log,
+                "update timeout; retrying ({retry} of {})",
+                MAX_ATTEMPTS - 1
+            );
+        }
+        let request_id = send_request(log, socket, sp, request.clone())?;
+
+        loop {
+            let result =
+                match recv_sp_message_ignoring_serial_console(log, socket) {
+                    Ok((response_id, result)) => {
+                        if request_id == response_id {
+                            result
+                        } else {
+                            warn!(
+                                log, "ignoring unexpected response id";
+                                "response_id" => response_id,
+                            );
+                            continue;
+                        }
+                    }
+                    Err(RecvError::Io(err))
+                        if err.kind() == io::ErrorKind::WouldBlock =>
+                    {
+                        break;
+                    }
+                    Err(err) => return Err(err.into()),
+                };
+
+            match result {
+                Ok(ResponseKind::UpdateStartAck) if expected_progress == 0 => {
+                    return Ok(());
+                }
+                Ok(ResponseKind::UpdateChunkAck) if expected_progress > 0 => {
+                    return Ok(());
+                }
+                Err(ResponseError::UpdateInProgress { bytes_received })
+                    if expected_progress == bytes_received =>
+                {
+                    return Ok(());
+                }
+                other => bail!("unexpected response to update: {other:?}"),
+            }
+        }
+    }
+
+    bail!("update failed (giving up after {MAX_ATTEMPTS} attempts)")
+}

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -36,6 +36,8 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::task::{self, JoinHandle};
 
+const SIM_GIMLET_VERSION: u32 = 1;
+
 pub struct Gimlet {
     rot: Mutex<RotSprocket>,
     manufacturing_public_key: Ed25519PublicKey,
@@ -586,7 +588,10 @@ impl SpHandler for Handler {
         port: SpPort,
     ) -> Result<SpState, ResponseError> {
         self.update_gateway_address(sender, port);
-        let state = SpState { serial_number: self.serial_number };
+        let state = SpState {
+            serial_number: self.serial_number,
+            version: SIM_GIMLET_VERSION,
+        };
         debug!(
             &self.log, "received state request";
             "sender" => %sender,
@@ -594,5 +599,64 @@ impl SpHandler for Handler {
             "reply-state" => ?state,
         );
         Ok(state)
+    }
+
+    fn update_start(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        update: gateway_messages::UpdateStart,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update start request; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_chunk(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        chunk: gateway_messages::UpdateChunk,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update chunk; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "offset" => chunk.offset,
+            "length" => chunk.chunk_length,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sys_reset_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log, "received sys-reset prepare request; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sys_reset_trigger(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<std::convert::Infallible, ResponseError> {
+        warn!(
+            &self.log, "received sys-reset trigger request; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
     }
 }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -42,6 +42,8 @@ use tokio::sync::oneshot;
 use tokio::task;
 use tokio::task::JoinHandle;
 
+const SIM_SIDECAR_VERSION: u32 = 1;
+
 pub struct Sidecar {
     rot: Mutex<RotSprocket>,
     manufacturing_public_key: Ed25519PublicKey,
@@ -407,7 +409,10 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<SpState, ResponseError> {
-        let state = SpState { serial_number: self.serial_number };
+        let state = SpState {
+            serial_number: self.serial_number,
+            version: SIM_SIDECAR_VERSION,
+        };
         debug!(
             &self.log, "received state request";
             "sender" => %sender,
@@ -415,5 +420,64 @@ impl SpHandler for Handler {
             "reply-state" => ?state,
         );
         Ok(state)
+    }
+
+    fn update_start(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        update: gateway_messages::UpdateStart,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update start request; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_chunk(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        chunk: gateway_messages::UpdateChunk,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update chunk; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "offset" => chunk.offset,
+            "length" => chunk.chunk_length,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sys_reset_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log, "received sys-reset prepare request; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn sys_reset_trigger(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<std::convert::Infallible, ResponseError> {
+        warn!(
+            &self.log, "received sys-reset trigger request; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
     }
 }


### PR DESCRIPTION
This does _not_ implement update or reset in MGS proper; that will come in a later PR.

There are two other issues that I'd like to fix moving forward:

1. `faux-mgs` shares minimal code with MGS proper
2. The serialization of `UpdateChunk` requires more memory on the SP than it should, because the struct contains an array that is always maximal length

1 is quite annoying; `gateway-sp-communictions` is a separate crate from `gateway` specifically to allow non-MGS consumers to do MGS-like operations, but it's too tightly coupled to MGS as a whole to be useful for faux MGS. This will require some time to rework, but I think it's worth doing.

2 should be relatively straightforward to fix; `hubpack::deserialize()` already supports the notion of leftover data, so we should be able to append the raw data after a header without much pain. After doing this, we should be able to retrofit the same kind of thing onto serial console packets which have the same pattern.