### PR TITLE
Use crucible-client-types instead of crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,50 +19,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher",
- "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes-gcm-siv"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ahash"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29661b60bec623f0586702976ff4d0c9942dcb6723161c2df0eea78455cfedfb"
 dependencies = [
  "const-random",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.7",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -91,16 +53,6 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "api_identity"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,44 +766,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible"
-version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2add0de8489f1d4de901bfe98fc28b0a6efcc3ea#2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
-dependencies = [
- "aes-gcm-siv",
- "anyhow",
- "base64",
- "bytes",
- "chrono",
- "crucible-common",
- "crucible-protocol",
- "dropshot",
- "futures",
- "futures-core",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reqwest",
- "ringbuffer",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "toml",
- "tracing",
- "usdt",
- "uuid",
- "version_check",
-]
-
-[[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2add0de8489f1d4de901bfe98fc28b0a6efcc3ea#2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
+source = "git+https://github.com/oxidecomputer/crucible?rev=1d67a53042f19ff7ca30dd20a04da94b7715ed7c#1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -864,34 +781,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible-common"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2add0de8489f1d4de901bfe98fc28b0a6efcc3ea#2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
+name = "crucible-client-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=1d67a53042f19ff7ca30dd20a04da94b7715ed7c#1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
 dependencies = [
- "anyhow",
- "rusqlite",
- "rustls-pemfile",
+ "base64",
+ "schemars",
  "serde",
  "serde_json",
- "tempfile",
- "thiserror",
- "tokio-rustls",
- "toml",
- "twox-hash",
- "uuid",
-]
-
-[[package]]
-name = "crucible-protocol"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2add0de8489f1d4de901bfe98fc28b0a6efcc3ea#2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "crucible-common",
- "serde",
- "tokio-util",
  "uuid",
 ]
 
@@ -973,15 +870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -1478,12 +1366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,7 +1643,7 @@ dependencies = [
  "futures",
  "gateway-client",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "slog",
  "slog-async",
  "slog-term",
@@ -1775,7 +1657,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
- "omicron-common 0.1.0",
+ "omicron-common",
  "progenitor",
  "reqwest",
  "serde",
@@ -1803,7 +1685,7 @@ dependencies = [
  "gateway-messages",
  "http",
  "hyper",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "once_cell",
  "ringbuffer",
@@ -1939,17 +1821,8 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash 0.2.19",
+ "ahash",
  "autocfg 0.1.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1957,15 +1830,6 @@ name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-
-[[package]]
-name = "hashlink"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
-dependencies = [
- "hashbrown 0.11.2",
-]
 
 [[package]]
 name = "headers"
@@ -2336,7 +2200,7 @@ dependencies = [
  "dropshot",
  "futures",
  "internal-dns",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "progenitor",
  "reqwest",
@@ -2486,16 +2350,6 @@ dependencies = [
  "socket2",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2729,22 +2583,7 @@ name = "nexus-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "omicron-common 0.1.0",
- "progenitor",
- "reqwest",
- "serde",
- "serde_json",
- "slog",
- "uuid",
-]
-
-[[package]]
-name = "nexus-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
-dependencies = [
- "chrono",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "omicron-common",
  "progenitor",
  "reqwest",
  "serde",
@@ -2767,7 +2606,7 @@ dependencies = [
  "newtype_derive",
  "nexus-defaults",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "parse-display",
  "rand 0.8.5",
  "ref-cast",
@@ -2785,7 +2624,7 @@ version = "0.1.0"
 dependencies = [
  "ipnetwork",
  "lazy_static",
- "omicron-common 0.1.0",
+ "omicron-common",
  "rand 0.8.5",
  "serde_json",
 ]
@@ -2801,14 +2640,14 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-nexus",
  "omicron-sled-agent",
  "omicron-test-utils",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-collector",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "parse-display",
  "serde",
  "serde_json",
@@ -2831,10 +2670,10 @@ name = "nexus-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "base64",
  "chrono",
- "omicron-common 0.1.0",
+ "omicron-common",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2965,7 +2804,7 @@ name = "omicron-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "backoff",
  "chrono",
  "dropshot",
@@ -2985,41 +2824,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "serde_with",
- "slog",
- "smf",
- "steno",
- "thiserror",
- "tokio",
- "tokio-postgres",
- "toml",
- "uuid",
-]
-
-[[package]]
-name = "omicron-common"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
-dependencies = [
- "anyhow",
- "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "backoff",
- "chrono",
- "dropshot",
- "futures",
- "http",
- "hyper",
- "ipnetwork",
- "macaddr",
- "parse-display",
- "progenitor",
- "rand 0.8.5",
- "reqwest",
- "ring",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
  "serde_with",
  "slog",
  "smf",
@@ -3061,7 +2865,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "openapi-lint",
  "openapiv3",
@@ -3121,7 +2925,7 @@ dependencies = [
  "nexus-test-utils-macros",
  "nexus-types",
  "num-integer",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-rpaths",
  "omicron-test-utils",
  "openapi-lint",
@@ -3130,11 +2934,11 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "oso",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-db",
  "oximeter-instruments",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "parse-display",
  "pq-sys",
  "rand 0.8.5",
@@ -3174,7 +2978,7 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-sled-agent",
  "omicron-zone-package",
  "rayon",
@@ -3209,8 +3013,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap 3.2.16",
- "crucible",
  "crucible-agent-client",
+ "crucible-client-types",
  "ddm-admin-client",
  "dropshot",
  "expectorate",
@@ -3221,15 +3025,15 @@ dependencies = [
  "libc",
  "macaddr",
  "mockall",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-test-utils",
  "openapi-lint",
  "openapiv3",
  "opte",
  "opte-ioctl",
- "oximeter 0.1.0",
- "oximeter-producer 0.1.0",
+ "oximeter",
+ "oximeter-producer",
  "p256",
  "percent-encoding",
  "progenitor",
@@ -3275,7 +3079,7 @@ dependencies = [
  "expectorate",
  "futures",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "postgres-protocol",
  "signal-hook",
  "signal-hook-tokio",
@@ -3482,7 +3286,7 @@ dependencies = [
  "bytes",
  "chrono",
  "num-traits",
- "oximeter-macro-impl 0.1.0",
+ "oximeter-macro-impl",
  "schemars",
  "serde",
  "thiserror",
@@ -3491,26 +3295,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
-dependencies = [
- "bytes",
- "chrono",
- "num-traits",
- "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "schemars",
- "serde",
- "thiserror",
- "uuid",
-]
-
-[[package]]
 name = "oximeter-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "omicron-common 0.1.0",
+ "omicron-common",
  "progenitor",
  "reqwest",
  "serde",
@@ -3526,12 +3315,12 @@ dependencies = [
  "dropshot",
  "expectorate",
  "internal-dns-client",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-test-utils",
  "openapi-lint",
  "openapiv3",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-db",
  "reqwest",
  "serde",
@@ -3557,7 +3346,7 @@ dependencies = [
  "dropshot",
  "itertools",
  "omicron-test-utils",
- "oximeter 0.1.0",
+ "oximeter",
  "regex",
  "reqwest",
  "schemars",
@@ -3580,7 +3369,7 @@ dependencies = [
  "dropshot",
  "futures",
  "http",
- "oximeter 0.1.0",
+ "oximeter",
  "uuid",
 ]
 
@@ -3595,45 +3384,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter-macro-impl"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "oximeter-producer"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "dropshot",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
- "oximeter 0.1.0",
- "reqwest",
- "schemars",
- "serde",
- "slog",
- "slog-dtrace",
- "thiserror",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "oximeter-producer"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#44b326b9ab89a842df3d84fa5ac15b31eeabb9e5"
-dependencies = [
- "chrono",
- "dropshot",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "nexus-client",
+ "omicron-common",
+ "oximeter",
  "reqwest",
  "schemars",
  "serde",
@@ -3951,18 +3709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "opaque-debug 0.3.0",
- "universal-hash",
-]
-
-[[package]]
 name = "postcard"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,9 +3938,10 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=a9399a8007f9876e31ce152848e6ecc2a9e14283#a9399a8007f9876e31ce152848e6ecc2a9e14283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c59b1ac246b19130bd489cdce217e40a4e51c094#c59b1ac246b19130bd489cdce217e40a4e51c094"
 dependencies = [
- "crucible",
+ "crucible-client-types",
+ "propolis_types",
  "reqwest",
  "ring",
  "schemars",
@@ -4203,6 +3950,14 @@ dependencies = [
  "slog",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "propolis_types"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c59b1ac246b19130bd489cdce217e40a4e51c094#c59b1ac246b19130bd489cdce217e40a4e51c094"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4566,21 +4321,6 @@ checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
 dependencies = [
  "lazy_static",
  "regex",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "memchr",
- "smallvec",
 ]
 
 [[package]]
@@ -5176,7 +4916,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "omicron-common 0.1.0",
+ "omicron-common",
  "progenitor",
  "regress",
  "reqwest",
@@ -5360,7 +5100,7 @@ dependencies = [
  "futures",
  "gateway-messages",
  "hex",
- "omicron-common 0.1.0",
+ "omicron-common",
  "serde",
  "slog",
  "slog-dtrace",
@@ -5477,12 +5217,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steno"
@@ -6182,17 +5916,6 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 0.1.10",
- "rand 0.4.6",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,19 +90,18 @@ opt-level = 3
 panic = "abort"
 
 #
-# It's common during development to use a local copy of dropshot, propolis
-# or steno in the parent directory.  If you want to use those, uncomment
-# one of these blocks.
+# It's common during development to use a local copy of dropshot, propolis,
+# crucible, or steno in the parent directory.  If you want to use those,
+# uncomment one of these blocks.
 #
 #[patch."https://github.com/oxidecomputer/dropshot"]
 #dropshot = { path = "../dropshot/dropshot" }
 #[patch."https://github.com/oxidecomputer/steno"]
 #steno = { path = "../steno" }
 #[patch."https://github.com/oxidecomputer/propolis"]
-#propolis-client = { path = "../propolis/client" }
-#propolis-server = { path = "../propolis/server" }
+#propolis-client = { path = "../propolis/lib/propolis-client" }
 #[patch."https://github.com/oxidecomputer/crucible"]
-#crucible = { path = "../crucible/upstairs" }
+#crucible-client-typess = { path = "../crucible/crucible-client-typess" }
 
 #
 # Local client generation during development.

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.13.0"
 bb8 = "0.8.0"
 clap = { version = "3.2", features = ["derive"] }
 cookie = "0.16"
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c" }
 diesel = { version = "2.0.0-rc.1", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "b9262a79db59f0727ca28ca9baed6fc6e3cc31e7" }
 fatfs = "0.3.5"

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -489,6 +489,7 @@ async fn sdc_regions_ensure(
                         // TODO open a control socket for the whole volume, not
                         // in the sub volumes
                         control: None,
+                        read_only: false,
                     },
                 },
             ],

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -302,6 +302,9 @@
           "lossy": {
             "type": "boolean"
           },
+          "read_only": {
+            "type": "boolean"
+          },
           "root_cert_pem": {
             "nullable": true,
             "type": "string"
@@ -316,6 +319,7 @@
         "required": [
           "id",
           "lossy",
+          "read_only",
           "target"
         ]
       },

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -91,10 +91,10 @@ zone = true
 # 3. Use type = "manual" instead of the "prebuilt"
 type = "prebuilt"
 repo = "crucible"
-commit = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
+commit = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-sha256 = "9940df1b070d4eb2305ad0b38380131b4a54cfc23b56e12ea1cbf9946b773fe9"
+sha256 = "d43fcfabc3f6402cfdbe3a0d31d49ae903f76b5ddec955dcee63236e4a60fdb0"
 
 # Refer to
 #   https://github.com/oxidecomputer/propolis/blob/master/package/README.md
@@ -105,10 +105,10 @@ zone = true
 [external_package.propolis-server.source]
 type = "prebuilt"
 repo = "propolis"
-commit = "13e23ff1ea51fc2b98f9e99099a46a40f805834e"
+commit = "c59b1ac246b19130bd489cdce217e40a4e51c094"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-sha256 = "866165e42cc8f969d0f5c758cc3d9971f27fa1f111091e0f2a33ea46b7f0af93"
+sha256 = "0e75d9a22f1ff14b90d04d91e5642d654563cc82f69e2e9cca5a983668d25764"
 
 [external_package.maghemite]
 service_name = "mg-ddm"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -14,12 +14,8 @@ cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "3.2", features = ["derive"] }
 # Only used by the simulated sled agent.
-# TODO: This is probably overkill. We'd like to only depend on
-# the "crucible-agent-client", but the VolumeConstructionRequest object
-# does not exist there.
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea" }
-# Only used by the simulated sled agent.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c" }
 ddm-admin-client = { path = "../ddm-admin-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.21"
@@ -34,7 +30,7 @@ oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "a9399a8007f9876e31ce152848e6ecc2a9e14283" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "c59b1ac246b19130bd489cdce217e40a4e51c094" }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -102,7 +102,10 @@ impl SledAgent {
             let target = DiskStateRequested::Attached(instance_id);
 
             let id = match disk.volume_construction_request {
-                crucible::VolumeConstructionRequest::Volume { id, .. } => id,
+                crucible_client_types::VolumeConstructionRequest::Volume {
+                    id,
+                    ..
+                } => id,
                 _ => panic!("Unexpected construction type"),
             };
             self.disks.sim_ensure(&id, initial_state, target).await?;


### PR DESCRIPTION
Instead of including the entire crucible library, use the new
crucible-client-types crate that exports only the things that
the sled-agent needs.

Update crucible and propolis versions.

Update Cargo.toml comment for propolis-client and crucible-client-types

Added new field for CrucibleOpts