### PR TITLE
`/policy` for current silo, `/global/policy` for fleet

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -454,6 +454,16 @@ impl Nexus {
         let mid = self.samael_max_issue_delay.lock().unwrap();
         *mid
     }
+
+    // Convenience function that exists solely because writing
+    // LookupPath::new(&opctx, &nexus.datastore()) in an endpoint handler feels
+    // like too much
+    pub fn db_lookup<'a>(
+        &'a self,
+        opctx: &'a OpContext,
+    ) -> db::lookup::LookupPath {
+        db::lookup::LookupPath::new(opctx, &self.db_datastore)
+    }
 }
 
 /// For unimplemented endpoints, indicates whether the resource identified

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -386,7 +386,7 @@ pub async fn policy_view(
             .internal_context("loading current silo")?;
         let policy =
             nexus.silo_fetch_policy_by_id(&opctx, authz_silo.id()).await?;
-        Ok(HttpResponseOk(policy.into()))
+        Ok(HttpResponseOk(policy))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -80,6 +80,9 @@ type NexusApiDescription = ApiDescription<Arc<ServerContext>>;
 /// Returns a description of the external nexus API
 pub fn external_api() -> NexusApiDescription {
     fn register_endpoints(api: &mut NexusApiDescription) -> Result<(), String> {
+        api.register(global_policy_view)?;
+        api.register(global_policy_update)?;
+
         api.register(policy_view)?;
         api.register(policy_update)?;
 
@@ -316,10 +319,10 @@ pub fn external_api() -> NexusApiDescription {
 /// Fetch the top-level IAM policy
 #[endpoint {
     method = GET,
-    path = "/policy",
+    path = "/global/policy",
     tags = ["policy"],
 }]
-async fn policy_view(
+async fn global_policy_view(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
 ) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {
     let apictx = rqctx.context();
@@ -342,10 +345,10 @@ struct ByIdPathParams {
 /// Update the top-level IAM policy
 #[endpoint {
     method = PUT,
-    path = "/policy",
+    path = "/global/policy",
     tags = ["policy"],
 }]
-async fn policy_update(
+async fn global_policy_update(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     new_policy: TypedBody<shared::Policy<authz::FleetRole>>,
 ) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {
@@ -359,6 +362,61 @@ async fn policy_update(
         bail_unless!(nasgns <= shared::MAX_ROLE_ASSIGNMENTS_PER_RESOURCE);
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let policy = nexus.fleet_update_policy(&opctx, &new_policy).await?;
+        Ok(HttpResponseOk(policy))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Fetch the current silo's IAM policy
+#[endpoint {
+    method = GET,
+    path = "/policy",
+    tags = ["silos"],
+ }]
+pub async fn policy_view(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::SiloRole>>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let handler = async {
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let authz_silo = opctx
+            .authn
+            .silo_required()
+            .internal_context("loading current silo")?;
+        let policy =
+            nexus.silo_fetch_policy_by_id(&opctx, authz_silo.id()).await?;
+        Ok(HttpResponseOk(policy.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Update the current silo's IAM policy
+#[endpoint {
+    method = PUT,
+    path = "/policy",
+    tags = ["silos"],
+}]
+async fn policy_update(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    new_policy: TypedBody<shared::Policy<authz::SiloRole>>,
+) -> Result<HttpResponseOk<shared::Policy<authz::SiloRole>>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let new_policy = new_policy.into_inner();
+
+    let handler = async {
+        let nasgns = new_policy.role_assignments.len();
+        // This should have been validated during parsing.
+        bail_unless!(nasgns <= shared::MAX_ROLE_ASSIGNMENTS_PER_RESOURCE);
+        let opctx = OpContext::for_external_api(&rqctx).await?;
+        let authz_silo = opctx
+            .authn
+            .silo_required()
+            .internal_context("loading current silo")?;
+        let policy = nexus
+            .silo_update_policy_by_id(&opctx, authz_silo.id(), &new_policy)
+            .await?;
         Ok(HttpResponseOk(policy))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -560,7 +560,7 @@ async fn silo_policy_view(
 
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        let policy = nexus.silo_fetch_policy(&opctx, silo_name).await?;
+        let policy = nexus.silo_fetch_policy_by_name(&opctx, silo_name).await?;
         Ok(HttpResponseOk(policy))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -40,7 +40,7 @@ lazy_static! {
         format!("/hardware/sleds/{}", SLED_AGENT_UUID);
 
     // Global policy
-    pub static ref POLICY_URL: &'static str = "/policy";
+    pub static ref POLICY_URL: &'static str = "/global/policy";
 
     // Silo used for testing
     pub static ref DEMO_SILO_NAME: Name = "demo-silo".parse().unwrap();

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -40,7 +40,7 @@ lazy_static! {
         format!("/hardware/sleds/{}", SLED_AGENT_UUID);
 
     // Global policy
-    pub static ref POLICY_URL: &'static str = "/global/policy";
+    pub static ref GLOBAL_POLICY_URL: &'static str = "/global/policy";
 
     // Silo used for testing
     pub static ref DEMO_SILO_NAME: Name = "demo-silo".parse().unwrap();
@@ -520,7 +520,7 @@ lazy_static! {
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
         // Global IAM policy
         VerifyEndpoint {
-            url: *POLICY_URL,
+            url: *GLOBAL_POLICY_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -663,6 +663,21 @@ lazy_static! {
         },
         VerifyEndpoint {
             url: &*DEMO_SILO_POLICY_URL,
+            visibility: Visibility::Protected,
+            unprivileged_access: UnprivilegedAccess::None,
+            allowed_methods: vec![
+                AllowedMethod::Get,
+                AllowedMethod::Put(
+                    serde_json::to_value(
+                        &shared::Policy::<authz::SiloRole> {
+                            role_assignments: vec![]
+                        }
+                    ).unwrap()
+                ),
+            ],
+        },
+        VerifyEndpoint {
+            url: "/policy",
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -678,8 +678,8 @@ lazy_static! {
         },
         VerifyEndpoint {
             url: "/policy",
-            visibility: Visibility::Protected,
-            unprivileged_access: UnprivilegedAccess::None,
+            visibility: Visibility::Public,
+            unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
                 AllowedMethod::Get,
                 AllowedMethod::Put(

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -108,7 +108,7 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
         const ROLE: Self::RoleType = authz::FleetRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
-            String::from("/policy")
+            String::from("/global/policy")
         }
 
         fn verify_initial<'a, 'b, 'c, 'd>(

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -218,6 +218,59 @@ async fn test_role_assignments_silo(cptestctx: &ControlPlaneTestContext) {
     run_test(client, SiloRoleAssignmentTest {}).await;
 }
 
+// same as above except for /policy, where silo is implicit in auth
+#[nexus_test]
+async fn test_role_assignments_silo_implicit(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    struct SiloRoleAssignmentTest;
+    impl RoleAssignmentTest for SiloRoleAssignmentTest {
+        type RoleType = authz::SiloRole;
+        const ROLE: Self::RoleType = authz::SiloRole::Admin;
+        const VISIBLE_TO_UNPRIVILEGED: bool = true;
+        fn policy_url(&self) -> String {
+            "/policy".to_string()
+        }
+
+        fn verify_initial<'a, 'b, 'c, 'd>(
+            &'a self,
+            _: &'b ClientTestContext,
+            _current_policy: &'c shared::Policy<Self::RoleType>,
+        ) -> BoxFuture<'d, ()>
+        where
+            'a: 'd,
+            'b: 'd,
+            'c: 'd,
+        {
+            async {
+                // TODO-coverage TODO-security There is currently nothing that
+                // requires the ability to modify a Silo.  Once there is, we
+                // should test it here.
+            }
+            .boxed()
+        }
+
+        fn verify_privileged<'a, 'b, 'c>(
+            &'a self,
+            _: &'b ClientTestContext,
+        ) -> BoxFuture<'c, ()>
+        where
+            'a: 'c,
+            'b: 'c,
+        {
+            async {
+                // TODO-coverage TODO-security There is currently nothing that
+                // requires the ability to modify a Silo.  Once there is, we
+                // should test it here.
+            }
+            .boxed()
+        }
+    }
+
+    let client = &cptestctx.external_client;
+    run_test(client, SiloRoleAssignmentTest {}).await;
+}
+
 #[nexus_test]
 async fn test_role_assignments_organization(
     cptestctx: &ControlPlaneTestContext,

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -99,8 +99,8 @@ organization_view_by_id                  /by-id/organizations/{id}
 
 API operations found with tag "policy"
 OPERATION ID                             URL PATH
-policy_update                            /policy
-policy_view                              /policy
+global_policy_update                     /global/policy
+global_policy_view                       /global/policy
 
 API operations found with tag "projects"
 OPERATION ID                             URL PATH
@@ -132,6 +132,8 @@ session_sshkey_view                      /session/me/sshkeys/{ssh_key_name}
 
 API operations found with tag "silos"
 OPERATION ID                             URL PATH
+policy_update                            /policy
+policy_view                              /policy
 silo_create                              /silos
 silo_delete                              /silos/{silo_name}
 silo_identity_provider_create            /silos/{silo_name}/saml-identity-providers

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -569,6 +569,68 @@
         }
       }
     },
+    "/global/policy": {
+      "get": {
+        "tags": [
+          "policy"
+        ],
+        "summary": "Fetch the top-level IAM policy",
+        "operationId": "global_policy_view",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetRolePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "policy"
+        ],
+        "summary": "Update the top-level IAM policy",
+        "operationId": "global_policy_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FleetRolePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetRolePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/hardware/racks": {
       "get": {
         "tags": [
@@ -5912,9 +5974,9 @@
     "/policy": {
       "get": {
         "tags": [
-          "policy"
+          "silos"
         ],
-        "summary": "Fetch the top-level IAM policy",
+        "summary": "Fetch current silo's IAM policy",
         "operationId": "policy_view",
         "responses": {
           "200": {
@@ -5922,7 +5984,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FleetRolePolicy"
+                  "$ref": "#/components/schemas/SiloRolePolicy"
                 }
               }
             }
@@ -5937,15 +5999,15 @@
       },
       "put": {
         "tags": [
-          "policy"
+          "silos"
         ],
-        "summary": "Update the top-level IAM policy",
+        "summary": "Update current silo's IAM policy",
         "operationId": "policy_update",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FleetRolePolicy"
+                "$ref": "#/components/schemas/SiloRolePolicy"
               }
             }
           },
@@ -5957,7 +6019,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FleetRolePolicy"
+                  "$ref": "#/components/schemas/SiloRolePolicy"
                 }
               }
             }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5976,7 +5976,7 @@
         "tags": [
           "silos"
         ],
-        "summary": "Fetch current silo's IAM policy",
+        "summary": "Fetch the current silo's IAM policy",
         "operationId": "policy_view",
         "responses": {
           "200": {
@@ -6001,7 +6001,7 @@
         "tags": [
           "silos"
         ],
-        "summary": "Update current silo's IAM policy",
+        "summary": "Update the current silo's IAM policy",
         "operationId": "policy_update",
         "requestBody": {
           "content": {


### PR DESCRIPTION
Fixes #1571 

- Move existing `GET/PUT /policy`, which was previously about the fleet policy, to `/global/policy
- `GET /policy` and `PUT /policy` are now about the user's current silo
- Change `fetch_silo_policy` and `update_silo_policy` to take a `db::lookup::Silo` instead of a name or ID so they are agnostic about whether you're working with name or ID at the call site