### PR TITLE
use oxide-vpc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "illumos-ddi-dki"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=52176b99cc578f5b7b90f9bae8935013f961086c#52176b99cc578f5b7b90f9bae8935013f961086c"
+source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
 dependencies = [
  "illumos-sys-hdrs",
 ]
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=52176b99cc578f5b7b90f9bae8935013f961086c#52176b99cc578f5b7b90f9bae8935013f961086c"
+source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -3030,8 +3030,8 @@ dependencies = [
  "omicron-test-utils",
  "openapi-lint",
  "openapiv3",
- "opte",
  "opte-ioctl",
+ "oxide-vpc",
  "oximeter",
  "oximeter-producer",
  "p256",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=52176b99cc578f5b7b90f9bae8935013f961086c#52176b99cc578f5b7b90f9bae8935013f961086c"
+source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
 dependencies = [
  "anymap",
  "cfg-if 0.1.10",
@@ -3223,11 +3223,12 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=52176b99cc578f5b7b90f9bae8935013f961086c#52176b99cc578f5b7b90f9bae8935013f961086c"
+source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
 dependencies = [
  "libc",
  "libnet",
  "opte",
+ "oxide-vpc",
  "postcard",
  "serde",
  "thiserror",
@@ -3277,6 +3278,20 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "oxide-vpc"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cstr_core",
+ "illumos-sys-hdrs",
+ "opte",
+ "serde",
+ "smoltcp",
+ "zerocopy 0.6.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "illumos-ddi-dki"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+source = "git+https://github.com/oxidecomputer/opte?rev=ca9d3aa83b46628376886e53b85e13d566d03ceb#ca9d3aa83b46628376886e53b85e13d566d03ceb"
 dependencies = [
  "illumos-sys-hdrs",
 ]
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+source = "git+https://github.com/oxidecomputer/opte?rev=ca9d3aa83b46628376886e53b85e13d566d03ceb#ca9d3aa83b46628376886e53b85e13d566d03ceb"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+source = "git+https://github.com/oxidecomputer/opte?rev=ca9d3aa83b46628376886e53b85e13d566d03ceb#ca9d3aa83b46628376886e53b85e13d566d03ceb"
 dependencies = [
  "anymap",
  "cfg-if 0.1.10",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+source = "git+https://github.com/oxidecomputer/opte?rev=ca9d3aa83b46628376886e53b85e13d566d03ceb#ca9d3aa83b46628376886e53b85e13d566d03ceb"
 dependencies = [
  "libc",
  "libnet",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=de829c931997558eccdf001d108d29e8e516b257#de829c931997558eccdf001d108d29e8e516b257"
+source = "git+https://github.com/oxidecomputer/opte?rev=ca9d3aa83b46628376886e53b85e13d566d03ceb#ca9d3aa83b46628376886e53b85e13d566d03ceb"
 dependencies = [
  "cfg-if 0.1.10",
  "cstr_core",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -58,8 +58,8 @@ vsss-rs = { version = "2.0.0-pre2", default-features = false, features = ["std"]
 zone = "0.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "52176b99cc578f5b7b90f9bae8935013f961086c" }
-opte = { git = "https://github.com/oxidecomputer/opte", rev = "52176b99cc578f5b7b90f9bae8935013f961086c", features = [ "api", "std" ] }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "de829c931997558eccdf001d108d29e8e516b257" }
+oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "de829c931997558eccdf001d108d29e8e516b257" }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -58,8 +58,8 @@ vsss-rs = { version = "2.0.0-pre2", default-features = false, features = ["std"]
 zone = "0.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "de829c931997558eccdf001d108d29e8e516b257" }
-oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "de829c931997558eccdf001d108d29e8e516b257" }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "ca9d3aa83b46628376886e53b85e13d566d03ceb" }
+oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "ca9d3aa83b46628376886e53b85e13d566d03ceb" }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/sled-agent/src/opte/illumos/mod.rs
+++ b/sled-agent/src/opte/illumos/mod.rs
@@ -11,7 +11,7 @@ use slog::Logger;
 use std::fs;
 use std::path::Path;
 
-pub use opte::api::Vni;
+pub use oxide_vpc::api::Vni;
 
 mod port;
 mod port_manager;
@@ -127,7 +127,7 @@ pub fn initialize_xde_driver(log: &Logger) -> Result<(), Error> {
         // those are exactly what we're giving it now.
         Err(opte_ioctl::Error::CommandError(
             _,
-            opte::api::OpteError::System { errno: libc::EEXIST, .. },
+            oxide_vpc::api::OpteError::System { errno: libc::EEXIST, .. },
         )) => Ok(()),
         Err(e) => Err(e.into()),
     }

--- a/sled-agent/src/opte/illumos/port_manager.rs
+++ b/sled-agent/src/opte/illumos/port_manager.rs
@@ -16,14 +16,14 @@ use crate::params::NetworkInterface;
 use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
 use macaddr::MacAddr6;
-use opte::api::IpCidr;
-use opte::api::Ipv4Cidr;
-use opte::api::Ipv4PrefixLen;
-use opte::api::MacAddr;
-use opte::oxide_vpc::api::AddRouterEntryIpv4Req;
-use opte::oxide_vpc::api::RouterTarget;
-use opte::oxide_vpc::api::SNatCfg;
 use opte_ioctl::OpteHdl;
+use oxide_vpc::api::AddRouterEntryIpv4Req;
+use oxide_vpc::api::IpCidr;
+use oxide_vpc::api::Ipv4Cidr;
+use oxide_vpc::api::Ipv4PrefixLen;
+use oxide_vpc::api::MacAddr;
+use oxide_vpc::api::RouterTarget;
+use oxide_vpc::api::SNatCfg;
 use slog::debug;
 use slog::info;
 use slog::warn;
@@ -380,7 +380,8 @@ impl PortManager {
                             e
                         ))
                     })?;
-                let cidr = Ipv4Cidr::new(opte::api::Ipv4Addr::from(ip), prefix);
+                let cidr =
+                    Ipv4Cidr::new(oxide_vpc::api::Ipv4Addr::from(ip), prefix);
                 let route = AddRouterEntryIpv4Req {
                     port_name: port_name.clone(),
                     dest: cidr,

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -122,7 +122,7 @@ function add_publisher {
 # `helios-netdev` provides the xde kernel driver and the `opteadm` userland tool
 # for interacting with it.
 HELIOS_NETDEV_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/opte/repo"
-HELIOS_NETDEV_COMMIT="52176b99cc578f5b7b90f9bae8935013f961086c"
+HELIOS_NETDEV_COMMIT="ca9d3aa83b46628376886e53b85e13d566d03ceb"
 HELIOS_NETDEV_REPO_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p"
 HELIOS_NETDEV_REPO_SHA_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p.sha256"
 HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"


### PR DESCRIPTION
As of oxidecomputer/opte#218 the Oxide VPC implementation now lives in its own crate.