### PR TITLE
abandoned end-to-end role test

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -273,6 +273,7 @@ CREATE TABLE omicron.public.organization (
 );
 
 CREATE UNIQUE INDEX ON omicron.public.organization (
+    silo_id,
     name
 ) WHERE
     time_deleted IS NULL;

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -47,6 +47,7 @@ serde_with = "1.13.0"
 sled-agent-client = { path = "../sled-agent-client" }
 slog-dtrace = "0.2"
 structopt = "0.3"
+strum = { version = "0.23", features = [ "derive" ] }
 tempfile = "3.3"
 thiserror = "1.0"
 toml = "0.5.9"
@@ -127,7 +128,6 @@ regex = "1.5.5"
 subprocess = "0.2.9"
 term = "0.7"
 httptest = "0.15.4"
-strum = { version = "0.23", features = [ "derive" ] }
 
 [dev-dependencies.openapi-lint]
 git = "https://github.com/oxidecomputer/openapi-lint"

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -96,7 +96,7 @@ impl super::Nexus {
     ) -> ListResultVec<db::model::Project> {
         let (.., authz_org) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
-            .lookup_for(authz::Action::CreateChild)
+            .lookup_for(authz::Action::ListChildren)
             .await?;
         self.db_datastore
             .projects_list_by_name(opctx, &authz_org, pagparams)
@@ -111,7 +111,7 @@ impl super::Nexus {
     ) -> ListResultVec<db::model::Project> {
         let (.., authz_org) = LookupPath::new(opctx, &self.db_datastore)
             .organization_name(organization_name)
-            .lookup_for(authz::Action::CreateChild)
+            .lookup_for(authz::Action::ListChildren)
             .await?;
         self.db_datastore
             .projects_list_by_id(opctx, &authz_org, pagparams)

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -50,7 +50,6 @@ use parse_display::Display;
 use parse_display::FromStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-#[cfg(test)]
 use strum::EnumIter;
 use uuid::Uuid;
 
@@ -206,9 +205,16 @@ impl ApiResourceWithRolesType for Fleet {
 }
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    Eq,
+    PartialEq,
+    Serialize,
+    JsonSchema,
 )]
-#[cfg_attr(test, derive(EnumIter))]
 #[serde(rename_all = "snake_case")]
 pub enum FleetRoles {
     Admin,
@@ -379,13 +385,13 @@ impl ApiResourceWithRolesType for Organization {
     Debug,
     Deserialize,
     Display,
+    EnumIter,
     Eq,
     FromStr,
     PartialEq,
     Serialize,
     JsonSchema,
 )]
-#[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
 pub enum OrganizationRoles {
@@ -433,13 +439,13 @@ impl ApiResourceWithRolesType for Project {
     Debug,
     Deserialize,
     Display,
+    EnumIter,
     Eq,
     FromStr,
     PartialEq,
     Serialize,
     JsonSchema,
 )]
-#[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
 pub enum ProjectRoles {
@@ -579,13 +585,13 @@ impl ApiResourceWithRolesType for Silo {
     Debug,
     Deserialize,
     Display,
+    EnumIter,
     Eq,
     FromStr,
     PartialEq,
     Serialize,
     JsonSchema,
 )]
-#[cfg_attr(test, derive(EnumIter))]
 #[display(style = "kebab-case")]
 #[serde(rename_all = "snake_case")]
 pub enum SiloRoles {

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -137,16 +137,15 @@ resource Silo {
 	];
 	roles = [ "admin", "collaborator", "viewer" ];
 
-	"list_children" if "viewer";
 	"read" if "viewer";
+	"list_children" if "collaborator";
+	"create_child" if "collaborator";
+	"modify" if "admin";
 
 	"viewer" if "collaborator";
-	"create_child" if "collaborator";
 	"collaborator" if "admin";
-	"modify" if "admin";
 	relations = { parent_fleet: Fleet };
-	"admin" if "admin" on "parent_fleet";
-	"collaborator" if "collaborator" on "parent_fleet";
+	"admin" if "collaborator" on "parent_fleet";
 	"viewer" if "viewer" on "parent_fleet";
 }
 has_relation(fleet: Fleet, "parent_fleet", silo: Silo)
@@ -180,7 +179,9 @@ resource Organization {
 	"modify" if "admin";
 
 	relations = { parent_silo: Silo };
-	"admin" if "admin" on "parent_silo";
+	"admin" if "collaborator" on "parent_silo";
+	"read" if "viewer" on "parent_silo";
+	"list_children" if "viewer" on "parent_silo";
 }
 has_relation(silo: Silo, "parent_silo", organization: Organization)
 	if organization.silo = silo;
@@ -212,7 +213,7 @@ resource Project {
 	"modify" if "admin";
 
 	relations = { parent_organization: Organization };
-	"admin" if "admin" on "parent_organization";
+	"admin" if "collaborator" on "parent_organization";
 }
 has_relation(organization: Organization, "parent_organization", project: Project)
 	if project.organization = organization;

--- a/nexus/src/db/datastore.rs
+++ b/nexus/src/db/datastore.rs
@@ -676,7 +676,7 @@ impl DataStore {
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<Organization> {
         let authz_silo = opctx.authn.silo_required()?;
-        opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
+        opctx.authorize(authz::Action::ListChildren, &authz_silo).await?;
 
         use db::schema::organization::dsl;
         paginated(dsl::organization, dsl::name, pagparams)

--- a/nexus/tests/integration_tests/authz_roles.rs
+++ b/nexus/tests/integration_tests/authz_roles.rs
@@ -1,0 +1,764 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! (Fairly) comprehensive test of authz by creating a hierarchy of resources
+//! and a group of users with various roles on these resources and verifying
+//! that each role grants the privileges we expect.
+
+use anyhow::anyhow;
+use dropshot::test_util::ClientTestContext;
+use futures::future::join_all;
+use http::Method;
+use http::StatusCode;
+use lazy_static::lazy_static;
+use nexus_test_utils::http_testing::AuthnMode;
+use nexus_test_utils::http_testing::NexusRequest;
+use nexus_test_utils::http_testing::RequestBuilder;
+use nexus_test_utils::resource_helpers;
+use nexus_test_utils::ControlPlaneTestContext;
+use nexus_test_utils_macros::nexus_test;
+use omicron_common::api::external::ByteCount;
+use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_common::api::external::IdentityMetadataUpdateParams;
+use omicron_common::api::external::InstanceCpuCount;
+use omicron_nexus::app::test_interfaces::TestInterfaces;
+use omicron_nexus::authz;
+use omicron_nexus::external_api::params;
+use omicron_nexus::external_api::params::InstanceNetworkInterfaceAttachment;
+use omicron_nexus::external_api::shared;
+use omicron_nexus::external_api::shared::IdentityType;
+use std::collections::BTreeMap;
+use std::convert::AsRef;
+use strum::AsRefStr;
+use uuid::Uuid;
+
+struct World {
+    users: BTreeMap<(String, String), Uuid>,
+    resources: Vec<&'static Resource>,
+}
+
+#[nexus_test]
+async fn test_authz_roles(cptestctx: &ControlPlaneTestContext) {
+    let world = setup_hierarchy(cptestctx).await;
+
+    // For each user that we've created, for each resource, for each possible
+    // action, attempt the action.
+    let results = test_operations(cptestctx, &world).await;
+
+    let mut stream = std::io::Cursor::new(Vec::new());
+    dump_results(&mut stream, &results)
+        .expect("failed to write to in-memory buffer");
+    let output = stream.into_inner();
+    print!("{}", String::from_utf8_lossy(&output));
+
+    // XXX-dap add expectorate
+}
+
+#[derive(Debug)]
+struct Resource {
+    resource_type: ResourceType,
+}
+
+impl Resource {
+    fn full_name(&self) -> String {
+        match self.resource_type {
+            ResourceType::Fleet => String::from("fleet"),
+            ResourceType::Silo { name } => format!("{}", name),
+            ResourceType::Organization { name, parent_silo } => {
+                format!("{}{}", parent_silo, name)
+            }
+            ResourceType::Project { name, parent_org, parent_silo } => {
+                format!("{}{}{}", parent_silo, parent_org, name)
+            }
+            ResourceType::Instance {
+                name,
+                parent_project,
+                parent_org,
+                parent_silo,
+            } => format!(
+                "{}{}{}{}",
+                parent_silo, parent_org, parent_project, name
+            ),
+        }
+    }
+
+    fn parent_full_name(&self) -> String {
+        match self.resource_type {
+            ResourceType::Fleet => unimplemented!(),
+            ResourceType::Silo { .. } => unimplemented!(),
+            ResourceType::Organization { parent_silo, .. } => {
+                format!("{}", parent_silo)
+            }
+            ResourceType::Project { parent_org, parent_silo, .. } => {
+                format!("{}{}", parent_silo, parent_org)
+            }
+            ResourceType::Instance {
+                parent_project,
+                parent_org,
+                parent_silo,
+                ..
+            } => format!("{}{}{}", parent_silo, parent_org, parent_project),
+        }
+    }
+
+    fn create_url(&self) -> String {
+        match self.resource_type {
+            ResourceType::Fleet => unimplemented!(),
+            ResourceType::Silo { .. } => format!("/silos"),
+            ResourceType::Organization { .. } => {
+                format!("/organizations")
+            }
+            ResourceType::Project { parent_org, .. } => {
+                format!("/organizations/{}/projects", parent_org)
+            }
+            ResourceType::Instance { parent_project, parent_org, .. } => {
+                format!(
+                    "/organizations/{}/projects/{}/instances",
+                    parent_org, parent_project
+                )
+            }
+        }
+    }
+
+    fn policy_url(&self) -> String {
+        match self.resource_type {
+            ResourceType::Fleet => format!("/policy"),
+            ResourceType::Silo { name } => format!("/silos/{}/policy", name),
+            ResourceType::Organization { name, .. } => {
+                format!("/organizations/{}/policy", name)
+            }
+            ResourceType::Project { name, parent_org, .. } => format!(
+                "/organizations/{}/projects/{}/policy",
+                parent_org, name
+            ),
+            ResourceType::Instance { .. } => unimplemented!(),
+        }
+    }
+
+    fn test_operations<'a>(
+        &self,
+        client: &'a ClientTestContext,
+    ) -> Vec<TestOperation<'a>> {
+        match self.resource_type {
+            // XXX-dap TODO
+            ResourceType::Fleet => vec![],
+            // XXX-dap TODO
+            ResourceType::Silo { .. } => vec![],
+            // XXX-dap TODO
+            ResourceType::Organization { name, .. } => {
+                let resource_url = format!("{}/{}", self.create_url(), name);
+                vec![
+                    TestOperation {
+                        label: "Fetch",
+                        template: NexusRequest::new(RequestBuilder::new(
+                            client,
+                            Method::GET,
+                            &resource_url,
+                        )),
+                    },
+                    TestOperation {
+                        label: "ModifyDescription",
+                        template: NexusRequest::new(
+                            RequestBuilder::new(
+                                client,
+                                Method::PUT,
+                                &resource_url,
+                            )
+                            .body(Some(
+                                &params::OrganizationUpdate {
+                                    identity: IdentityMetadataUpdateParams {
+                                        name: None,
+                                        description: Some(String::from(
+                                            "updated!",
+                                        )),
+                                    },
+                                },
+                            )),
+                        ),
+                    },
+                ]
+            }
+            // XXX-dap TODO
+            ResourceType::Project { .. } => vec![],
+            // XXX-dap TODO
+            ResourceType::Instance { .. } => vec![],
+        }
+    }
+}
+
+#[derive(Debug, AsRefStr)]
+enum ResourceType {
+    Fleet,
+    Silo {
+        name: &'static str,
+    },
+    Organization {
+        name: &'static str,
+        parent_silo: &'static str,
+    },
+    Project {
+        name: &'static str,
+        parent_org: &'static str,
+        parent_silo: &'static str,
+    },
+    Instance {
+        name: &'static str,
+        parent_project: &'static str,
+        parent_org: &'static str,
+        parent_silo: &'static str,
+    },
+}
+
+lazy_static! {
+    // Hierarchy:
+    // fleet
+    // fleet/s1
+    // fleet/s1/o1
+    // fleet/s1/o1/p1
+    // fleet/s1/o1/p1/i1
+    // fleet/s1/o1/p2
+    // fleet/s1/o1/p2/i1
+    // fleet/s1/o2
+    // fleet/s1/o2/p1
+    // fleet/s1/o2/p1/i1
+    // fleet/s2
+    // fleet/s2/o1
+    // fleet/s2/o1/p1
+    // fleet/s2/o1/p1/i1
+
+    static ref FLEET: Resource = Resource { resource_type: ResourceType::Fleet };
+
+    static ref SILO1: Resource =
+        Resource { resource_type: ResourceType::Silo { name: "s1" } };
+    static ref SILO1_ORG1: Resource = Resource {
+        resource_type: ResourceType::Organization {
+            name: "o1",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG1_PROJ1: Resource = Resource {
+        resource_type: ResourceType::Project {
+            name: "p1",
+            parent_org: "o1",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG1_PROJ1_INST: Resource = Resource {
+        resource_type: ResourceType::Instance {
+            name: "i1",
+            parent_project: "p1",
+            parent_org: "o1",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG1_PROJ2: Resource = Resource {
+        resource_type: ResourceType::Project {
+            name: "p2",
+            parent_org: "o1",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG1_PROJ2_INST: Resource = Resource {
+        resource_type: ResourceType::Instance {
+            name: "i1",
+            parent_project: "p2",
+            parent_org: "o1",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG2: Resource = Resource {
+        resource_type: ResourceType::Organization {
+            name: "o2",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG2_PROJ1: Resource = Resource {
+        resource_type: ResourceType::Project {
+            name: "p1",
+            parent_org: "o2",
+            parent_silo: "s1",
+        },
+    };
+    static ref SILO1_ORG2_PROJ1_INST: Resource = Resource {
+        resource_type: ResourceType::Instance {
+            name: "i1",
+            parent_project: "p1",
+            parent_org: "o2",
+            parent_silo: "s1",
+        },
+    };
+
+    static ref SILO2: Resource =
+        Resource { resource_type: ResourceType::Silo { name: "s2" } };
+    static ref SILO2_ORG1: Resource = Resource {
+        resource_type: ResourceType::Organization {
+            name: "o1",
+            parent_silo: "s2",
+        },
+    };
+    static ref SILO2_ORG1_PROJ1: Resource = Resource {
+        resource_type: ResourceType::Project {
+            name: "p1",
+            parent_org: "o1",
+            parent_silo: "s2",
+        },
+    };
+    static ref SILO2_ORG1_PROJ1_INST: Resource = Resource {
+        resource_type: ResourceType::Instance {
+            name: "i1",
+            parent_project: "p1",
+            parent_org: "o1",
+            parent_silo: "s2",
+        },
+    };
+
+    // XXX-dap TODO-doc These are the resources for which: for each role, we
+    // will create a user having that role on this resource.  We will later test
+    // that this user _can_ access the corresponding thing in the corresponding
+    // way, and that they _cannot_ access any _other_ resources in any other
+    // way.
+    // Silos are skipped because we always create their users.
+    static ref RESOURCES_WITH_USERS: Vec<&'static Resource> = vec![
+        &*FLEET,
+        &*SILO1_ORG1,
+        &*SILO1_ORG1_PROJ1,
+    ];
+
+    static ref ALL_RESOURCES: Vec<&'static Resource> = vec![
+        &*FLEET,
+        &*SILO1,
+        &*SILO1_ORG1,
+        &*SILO1_ORG1_PROJ1,
+        &*SILO1_ORG1_PROJ1_INST,
+        &*SILO1_ORG1_PROJ2,
+        &*SILO1_ORG1_PROJ2_INST,
+        &*SILO1_ORG2,
+        &*SILO1_ORG2_PROJ1,
+        &*SILO1_ORG2_PROJ1_INST,
+        &*SILO2,
+        &*SILO2_ORG1,
+        &*SILO2_ORG1_PROJ1,
+        &*SILO2_ORG1_PROJ1_INST,
+    ];
+}
+
+async fn setup_hierarchy(testctx: &ControlPlaneTestContext) -> World {
+    let client = &testctx.external_client;
+    let nexus = &*testctx.server.apictx.nexus;
+    let log = &testctx.logctx.log.new(o!("component" => "SetupHierarchy"));
+
+    // Mapping: (our resource name, role name) -> user id
+    // where "user id" is the id of a user having role "role name" on resource
+    // "our resource name".
+    //
+    // "our resource name" is a string like s1o1 (SILO1_ORG1).
+    let mut users: BTreeMap<(String, String), Uuid> = BTreeMap::new();
+
+    // Mapping: silo name -> silo id
+    let mut silos: BTreeMap<String, Uuid> = BTreeMap::new();
+
+    // We can't use the helpers in `resource_helpers` to create most of these
+    // resources because they always use the "test-privileged" user in the
+    // default Silo.  But in order to create things in other Silos, we need to
+    // use different users.
+    // XXX-dap don't bother creating users except for RESOURCES_WITH_USERS
+    for resource in &*ALL_RESOURCES {
+        let resource = *resource;
+        debug!(log, "creating resource"; "resource" => ?resource);
+        match resource.resource_type {
+            ResourceType::Fleet => (),
+            ResourceType::Silo { name } => {
+                let silo =
+                    resource_helpers::create_silo(client, name, false).await;
+                silos.insert(name.to_string(), silo.identity.id);
+                // We have to create the Silo users here so that we can use the
+                // admin to create the other resources.
+                create_users::<authz::SiloRoles>(
+                    log,
+                    nexus,
+                    client,
+                    name,
+                    silo.identity.id,
+                    &resource.policy_url(),
+                    &mut users,
+                    None,
+                )
+                .await;
+            }
+            ResourceType::Organization { name, parent_silo, .. } => {
+                let caller_id = user_id(&users, &parent_silo, "admin");
+                let full_name = resource.full_name();
+                NexusRequest::objects_post(
+                    client,
+                    &resource.create_url(),
+                    &params::OrganizationCreate {
+                        identity: IdentityMetadataCreateParams {
+                            name: name
+                                .parse()
+                                .expect("generated name was invalid"),
+                            description: full_name.clone(),
+                        },
+                    },
+                )
+                .authn_as(AuthnMode::SiloUser(caller_id))
+                .execute()
+                .await
+                .unwrap_or_else(|_| panic!("failed to create {}", full_name));
+            }
+            ResourceType::Project { name, parent_silo, .. } => {
+                let caller_id = user_id(&users, &parent_silo, "admin");
+                let full_name = resource.full_name();
+                NexusRequest::objects_post(
+                    client,
+                    &resource.create_url(),
+                    &params::ProjectCreate {
+                        identity: IdentityMetadataCreateParams {
+                            name: name
+                                .parse()
+                                .expect("generated name was invalid"),
+                            description: full_name.clone(),
+                        },
+                    },
+                )
+                .authn_as(AuthnMode::SiloUser(caller_id))
+                .execute()
+                .await
+                .unwrap_or_else(|_| panic!("failed to create {}", full_name));
+            }
+            ResourceType::Instance { name, parent_silo, .. } => {
+                let caller_id = user_id(&users, &parent_silo, "admin");
+                let full_name = resource.full_name();
+                NexusRequest::objects_post(
+                    client,
+                    &resource.create_url(),
+                    &params::InstanceCreate {
+                        identity: IdentityMetadataCreateParams {
+                            name: name
+                                .parse()
+                                .expect("generated name was invalid"),
+                            description: full_name.clone(),
+                        },
+                        ncpus: InstanceCpuCount(1),
+                        memory: ByteCount::from_gibibytes_u32(1),
+                        hostname: full_name.clone(),
+                        user_data: vec![],
+                        network_interfaces:
+                            InstanceNetworkInterfaceAttachment::Default,
+                        disks: vec![],
+                    },
+                )
+                .authn_as(AuthnMode::SiloUser(caller_id))
+                .execute()
+                .await
+                .unwrap_or_else(|_| panic!("failed to create {}", full_name));
+            }
+        }
+    }
+
+    for resource in &*RESOURCES_WITH_USERS {
+        match resource.resource_type {
+            // XXX-dap we should be testing fleet users too
+            // We don't create users for Instances.  We already created users
+            // for Silos.
+            ResourceType::Instance { .. } | ResourceType::Silo { .. } => {
+                unimplemented!()
+            }
+            ResourceType::Fleet => {
+                create_users::<authz::OrganizationRoles>(
+                    log,
+                    nexus,
+                    client,
+                    &resource.full_name(),
+                    *omicron_nexus::db::fixed_data::silo::SILO_ID,
+                    &resource.policy_url(),
+                    &mut users,
+                    None,
+                )
+                .await;
+            }
+            ResourceType::Organization { parent_silo, .. } => {
+                let silo_id = silos.get(parent_silo).expect("missing silo");
+                let caller_id =
+                    user_id(&users, &resource.parent_full_name(), "admin");
+                create_users::<authz::OrganizationRoles>(
+                    log,
+                    nexus,
+                    client,
+                    &resource.full_name(),
+                    *silo_id,
+                    &resource.policy_url(),
+                    &mut users,
+                    Some(caller_id),
+                )
+                .await;
+            }
+            ResourceType::Project { parent_silo, .. } => {
+                let silo_id = silos.get(parent_silo).expect("missing silo");
+                let caller_id =
+                    user_id(&users, &resource.parent_full_name(), "admin");
+                create_users::<authz::ProjectRoles>(
+                    log,
+                    nexus,
+                    client,
+                    &resource.full_name(),
+                    *silo_id,
+                    &resource.policy_url(),
+                    &mut users,
+                    Some(caller_id),
+                )
+                .await;
+            }
+        }
+    }
+
+    World { users, resources: ALL_RESOURCES.clone() }
+}
+
+fn user_id(
+    users: &BTreeMap<(String, String), Uuid>,
+    resource_full_name: &str,
+    role_name: &str,
+) -> Uuid {
+    *users
+        .get(&(resource_full_name.to_owned(), role_name.to_owned()))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected user to be created with role {:?} on {:?}",
+                role_name, resource_full_name,
+            )
+        })
+}
+
+/// For a given resource, for each supported role, create a new user with that
+/// role on this resource.
+///
+/// - `nexus`: needed to use the private interface for creating silo users
+/// - `resource_name`: *our* identifier for the resource (e.g., s1o1).  This is
+///   used as the basename of the user's name
+/// - `policy_url`: the URL for the resource's IAM policy
+/// - `users`: a map into which we'll insert the uuids of created users
+/// - `run_as`: executes requests to update resource policy using the given silo
+///   user id.  This lets us, say, create an Organization with a user having
+///   "admin" on the parent Silo, and create a Project with a user having
+///   "admin" on the parent Organization, etc.
+async fn create_users<
+    T: strum::IntoEnumIterator
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + omicron_nexus::db::model::DatabaseString,
+>(
+    log: &slog::Logger,
+    nexus: &dyn TestInterfaces,
+    client: &ClientTestContext,
+    resource_name: &str,
+    silo_id: Uuid,
+    policy_url: &str,
+    users: &mut BTreeMap<(String, String), Uuid>,
+    run_as: Option<Uuid>,
+) {
+    for variant in T::iter() {
+        let role_name = variant.to_database_string();
+        // TODO when silo users get user names, this should go into it.
+        let username = format!("{}-{}", resource_name, role_name);
+        let user_id = Uuid::new_v4();
+        debug!(
+            log,
+            "creating user";
+            "username" => &username,
+            "user_id" => user_id.to_string()
+        );
+        nexus
+            .silo_user_create(silo_id, user_id)
+            .await
+            .unwrap_or_else(|_| panic!("failed to create user {:?}", username));
+        users.insert((resource_name.to_owned(), role_name.to_owned()), user_id);
+
+        debug!(
+            log,
+            "adding role";
+            "username" => username,
+            "user_id" => user_id.to_string(),
+            "role" => role_name,
+        );
+        let authn_mode = run_as
+            .map(|caller_id| AuthnMode::SiloUser(caller_id))
+            .unwrap_or(AuthnMode::PrivilegedUser);
+
+        let existing_policy: shared::Policy<T> =
+            NexusRequest::object_get(client, policy_url)
+                .authn_as(authn_mode.clone())
+                .execute()
+                .await
+                .expect("failed to fetch policy")
+                .parsed_body()
+                .expect("failed to parse policy");
+
+        let new_role_assignment = shared::RoleAssignment {
+            identity_type: IdentityType::SiloUser,
+            identity_id: user_id,
+            role_name: variant,
+        };
+        let new_role_assignments = existing_policy
+            .role_assignments
+            .into_iter()
+            .chain(std::iter::once(new_role_assignment))
+            .collect();
+
+        let new_policy =
+            shared::Policy { role_assignments: new_role_assignments };
+
+        NexusRequest::object_put(client, policy_url, Some(&new_policy))
+            .authn_as(authn_mode)
+            .execute()
+            .await
+            .expect("failed to update policy");
+    }
+}
+
+struct TestOperation<'a> {
+    label: &'static str,
+    template: NexusRequest<'a>,
+}
+
+enum OperationResult {
+    Success,
+    Denied,
+    UnexpectedError(anyhow::Error),
+}
+
+struct ResourceResults {
+    resource: &'static Resource,
+    test_labels: Vec<&'static str>,
+    results: Vec<ResourceUserResults>,
+}
+
+struct ResourceUserResults {
+    username: String,
+    results: Vec<OperationResult>,
+}
+
+async fn test_operations(
+    cptestctx: &ControlPlaneTestContext,
+    world: &World,
+) -> Vec<ResourceResults> {
+    let log = &cptestctx.logctx.log;
+    let client = &cptestctx.external_client;
+    let mut results = Vec::with_capacity(world.resources.len());
+    for resource in &world.resources {
+        let mut user_results = Vec::with_capacity(world.users.len());
+        let mut test_labels: Option<Vec<&'static str>> = None;
+        for ((user_resource_name, user_role_name), user_id) in &world.users {
+            let username = format!("{}-{}", user_resource_name, user_role_name);
+            let log = log.new(o!(
+                "resource" => resource.full_name(),
+                "user" => username.clone(),
+            ));
+
+            let operations = resource.test_operations(client);
+            if test_labels.is_none() {
+                test_labels =
+                    Some(operations.iter().map(|t| t.label).collect());
+            }
+            user_results.push(ResourceUserResults {
+                username,
+                results: join_all(operations.into_iter().map(
+                    |test_operation| {
+                        run_test_operation(&log, test_operation, *user_id)
+                    },
+                ))
+                .await,
+            });
+        }
+
+        let result = if let Some(test_labels) = test_labels {
+            assert!(!user_results.is_empty());
+            ResourceResults { resource, test_labels, results: user_results }
+        } else {
+            assert!(user_results.is_empty());
+            ResourceResults {
+                resource,
+                test_labels: Vec::new(),
+                results: Vec::new(),
+            }
+        };
+        results.push(result);
+    }
+
+    results
+}
+
+async fn run_test_operation<'a>(
+    log: &slog::Logger,
+    to: TestOperation<'a>,
+    user_id: Uuid,
+) -> OperationResult {
+    info!(log, "test operation"; "operation" => to.label);
+    let request = to.template;
+    let response = request
+        .authn_as(AuthnMode::SiloUser(user_id))
+        .execute()
+        .await
+        .expect("failed to execute request");
+    if matches!(response.status, StatusCode::NOT_FOUND | StatusCode::FORBIDDEN)
+    {
+        OperationResult::Denied
+    } else if response.status.is_success() {
+        OperationResult::Success
+    } else {
+        let status = response.status;
+        let error_response: dropshot::HttpErrorResponseBody =
+            response.parsed_body().expect("failed to parse error response");
+        OperationResult::UnexpectedError(anyhow!(
+            "unexpected response: status code {}, message {:?}",
+            status,
+            error_response.message
+        ))
+    }
+}
+
+fn dump_results<W: std::io::Write>(
+    mut out: W,
+    results: &[ResourceResults],
+) -> std::io::Result<()> {
+    for resource_result in results {
+        write!(
+            out,
+            "resource:  {} {:?}",
+            resource_result.resource.resource_type.as_ref(),
+            resource_result.resource.full_name()
+        )?;
+
+        if resource_result.test_labels.is_empty() {
+            write!(out, ": no tests defined\n\n")?;
+            continue;
+        }
+
+        write!(
+            out,
+            "\n  actions: {}\n\n",
+            resource_result.test_labels.join(", ")
+        )?;
+
+        write!(out, "{:20} {}\n", "USER", "RESULTS FOR EACH ACTION")?;
+        for user_result in &resource_result.results {
+            write!(out, "{:20}", user_result.username)?;
+            for op_result in &user_result.results {
+                write!(
+                    out,
+                    " {}",
+                    match op_result {
+                        OperationResult::Success => '\u{2713}',
+                        OperationResult::Denied => '\u{2717}',
+                        OperationResult::UnexpectedError(_) => '\u{26a0}',
+                    }
+                )?;
+            }
+            write!(out, "\n")?;
+        }
+
+        write!(out, "\n")?;
+    }
+
+    Ok(())
+}

--- a/nexus/tests/integration_tests/authz_roles.rs
+++ b/nexus/tests/integration_tests/authz_roles.rs
@@ -5,6 +5,8 @@
 //! (Fairly) comprehensive test of authz by creating a hierarchy of resources
 //! and a group of users with various roles on these resources and verifying
 //! that each role grants the privileges we expect.
+//! XXX-dap it looks like a bug that fleet admins can't see Organizations.  Is
+//! silo.fleet not set up right in Polar?
 
 use anyhow::anyhow;
 use dropshot::test_util::ClientTestContext;

--- a/nexus/tests/integration_tests/authz_roles.rs
+++ b/nexus/tests/integration_tests/authz_roles.rs
@@ -15,7 +15,7 @@
 //
 //   Then we can test these in reverse order.  By the time we get to any
 //   resource, its children should be gone.
-// - figure out how to implement tests for fetching/modifying the policy.  Maybe
+// - figure out how to implement tests for modifying the policy.  Maybe
 //   have a dummy user that we grant/remove privileges for?
 // - do we want to look into performance at all?  It takes a long time.
 // - this test needs a lot of documentation
@@ -195,7 +195,7 @@ impl Resource {
                         template: NexusRequest::new(RequestBuilder::new(
                             client,
                             Method::GET,
-                            "/policy",
+                            &self.policy_url()
                         )),
                         on_success: None,
                     },
@@ -292,6 +292,15 @@ impl Resource {
                         on_success: None,
                     },
                     TestOperation {
+                        label: "FetchPolicy",
+                        template: NexusRequest::new(RequestBuilder::new(
+                            client,
+                            Method::GET,
+                            &self.policy_url()
+                        )),
+                        on_success: None,
+                    },
+                    TestOperation {
                         label: "ListOrganizations",
                         template: NexusRequest::new(RequestBuilder::new(
                             client,
@@ -336,6 +345,15 @@ impl Resource {
                             client,
                             Method::GET,
                             &resource_url,
+                        )),
+                        on_success: None,
+                    },
+                    TestOperation {
+                        label: "FetchPolicy",
+                        template: NexusRequest::new(RequestBuilder::new(
+                            client,
+                            Method::GET,
+                            &self.policy_url()
                         )),
                         on_success: None,
                     },
@@ -414,6 +432,15 @@ impl Resource {
                         on_success: None,
                     },
                     TestOperation {
+                        label: "FetchPolicy",
+                        template: NexusRequest::new(RequestBuilder::new(
+                            client,
+                            Method::GET,
+                            &self.policy_url()
+                        )),
+                        on_success: None,
+                    },
+                    TestOperation {
                         label: "ListVpcs",
                         template: NexusRequest::new(RequestBuilder::new(
                             client,
@@ -487,6 +514,15 @@ impl Resource {
                             client,
                             Method::GET,
                             &resource_url,
+                        )),
+                        on_success: None,
+                    },
+                    TestOperation {
+                        label: "FetchPolicy",
+                        template: NexusRequest::new(RequestBuilder::new(
+                            client,
+                            Method::GET,
+                            &self.policy_url()
                         )),
                         on_success: None,
                     },

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -4,6 +4,7 @@
 //! the way it is.
 
 mod authn_http;
+mod authz_roles;
 mod basic;
 mod commands;
 mod console_api;

--- a/nexus/tests/output/authz-roles-test.txt
+++ b/nexus/tests/output/authz-roles-test.txt
@@ -1,0 +1,280 @@
+resource:  Fleet "fleet"
+  actions: FetchPolicy, ListSagas, ListSleds, ListRacks, ListBuiltinUsers, ListBuiltinRoles, ListSilos, CreateSilo
+  note:    Fleet-level roles apply to everything in the system.  However, even fleet admins have no way to refer to resources in Silos other than the ones they exist in.  This test creates fleet admins in Silo "s1".
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓
+fleet-viewer         ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✗
+s1-admin             ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1-collaborator      ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1-viewer            ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
+
+resource:  Silo "s1"
+  actions: Fetch, ListOrganizations, CreateOrganization
+  note:    All users can view their own Silo.  Roles are required to list and create Organizations.  Note that administrators on "s2" appear to be able to list and create Organizations in the output below, but those are Organizations in "s2".
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓
+fleet-viewer         ✓ ✗ ✗
+s1-admin             ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓
+s1-viewer            ✓ ✗ ✗
+s1o1-admin           ✓ ✗ ✗
+s1o1-collaborator    ✓ ✗ ✗
+s1o1p1-admin         ✓ ✗ ✗
+s1o1p1-collaborator  ✓ ✗ ✗
+s1o1p1-viewer        ✓ ✗ ✗
+s2-admin             ✗ ✓ ✓
+s2-collaborator      ✗ ✓ ✓
+s2-viewer            ✗ ✗ ✗
+
+resource:  Organization "s1o1"
+  actions: Fetch, ListProjects, CreateProject, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✓ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✓ ✗ ✗ ✗
+s1o1-admin           ✓ ✓ ✓ ✓
+s1o1-collaborator    ✓ ✓ ✓ ✗
+s1o1p1-admin         ✓ ✗ ✗ ✗
+s1o1p1-collaborator  ✓ ✗ ✗ ✗
+s1o1p1-viewer        ✓ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Project "s1o1p1"
+  actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✓ ✓ ✓ ✓
+s1o1-collaborator    ✓ ✓ ✓ ✓
+s1o1p1-admin         ✓ ✓ ✓ ✓
+s1o1p1-collaborator  ✓ ✓ ✓ ✗
+s1o1p1-viewer        ✓ ✓ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Vpc "s1o1p1v1"
+  actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✓ ✓ ✓ ✓
+s1o1-collaborator    ✓ ✓ ✓ ✓
+s1o1p1-admin         ✓ ✓ ✓ ✓
+s1o1p1-collaborator  ✓ ✓ ✓ ✓
+s1o1p1-viewer        ✓ ✓ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Project "s1o1p2"
+  actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✓ ✓ ✓ ✓
+s1o1-collaborator    ✓ ✓ ✓ ✓
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Vpc "s1o1p2v1"
+  actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✓ ✓ ✓ ✓
+s1o1-collaborator    ✓ ✓ ✓ ✓
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Organization "s1o2"
+  actions: Fetch, ListProjects, CreateProject, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✓ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✓ ✗ ✗ ✗
+s1o1-admin           ✓ ✗ ✗ ✗
+s1o1-collaborator    ✓ ✗ ✗ ✗
+s1o1p1-admin         ✓ ✗ ✗ ✗
+s1o1p1-collaborator  ✓ ✗ ✗ ✗
+s1o1p1-viewer        ✓ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Project "s1o2p1"
+  actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Vpc "s1o2p1v1"
+  actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓ ✓
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✓ ✓ ✓ ✓
+s1-collaborator      ✓ ✓ ✓ ✓
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✗ ✗ ✗ ✗
+s2-collaborator      ✗ ✗ ✗ ✗
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Silo "s2"
+  actions: Fetch, ListOrganizations, CreateOrganization
+  note:    All users can view their own Silo.  Roles are required to list and create Organizations.  Note that administrators on "s2" appear to be able to list and create Organizations in the output below, but those are Organizations in "s2".
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✓ ✓ ✓
+fleet-collaborator   ✓ ✓ ✓
+fleet-viewer         ✓ ✗ ✗
+s1-admin             ✗ ✓ ✓
+s1-collaborator      ✗ ✓ ✓
+s1-viewer            ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗
+s2-admin             ✓ ✓ ✓
+s2-collaborator      ✓ ✓ ✓
+s2-viewer            ✓ ✗ ✗
+
+resource:  Organization "s2o3"
+  actions: Fetch, ListProjects, CreateProject, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✗ ✗ ✗ ✗
+fleet-collaborator   ✗ ✗ ✗ ✗
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✗ ✗ ✗ ✗
+s1-collaborator      ✗ ✗ ✗ ✗
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✓ ✓ ✓ ✓
+s2-collaborator      ✓ ✓ ✓ ✓
+s2-viewer            ✓ ✗ ✗ ✗
+
+resource:  Project "s2o3p1"
+  actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✗ ✗ ✗ ✗
+fleet-collaborator   ✗ ✗ ✗ ✗
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✗ ✗ ✗ ✗
+s1-collaborator      ✗ ✗ ✗ ✗
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✓ ✓ ✓ ✓
+s2-collaborator      ✓ ✓ ✓ ✓
+s2-viewer            ✗ ✗ ✗ ✗
+
+resource:  Vpc "s2o3p1v1"
+  actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
+  note:    
+
+USER                 RESULTS FOR EACH ACTION
+fleet-admin          ✗ ✗ ✗ ✗
+fleet-collaborator   ✗ ✗ ✗ ✗
+fleet-viewer         ✗ ✗ ✗ ✗
+s1-admin             ✗ ✗ ✗ ✗
+s1-collaborator      ✗ ✗ ✗ ✗
+s1-viewer            ✗ ✗ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
+s2-admin             ✓ ✓ ✓ ✓
+s2-collaborator      ✓ ✓ ✓ ✓
+s2-viewer            ✗ ✗ ✗ ✗
+

--- a/nexus/tests/output/authz-roles-test.txt
+++ b/nexus/tests/output/authz-roles-test.txt
@@ -1,7 +1,5 @@
 resource:  Fleet "fleet"
   actions: FetchPolicy, ListSagas, ListSleds, ListRacks, ListBuiltinUsers, ListBuiltinRoles, ListSilos, CreateSilo
-  note:    Fleet-level roles apply to everything in the system.  However, even fleet admins have no way to refer to resources in Silos other than the ones they exist in.  This test creates fleet admins in Silo "s1".
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓
@@ -20,15 +18,13 @@ s2-viewer            ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗
 
 resource:  Silo "s1"
   actions: Fetch, ListOrganizations, CreateOrganization
-  note:    All users can view their own Silo.  Roles are required to list and create Organizations.  Note that administrators on "s2" appear to be able to list and create Organizations in the output below, but those are Organizations in "s2".
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓
-fleet-viewer         ✓ ✗ ✗
+fleet-viewer         ✓ ✓ ✗
 s1-admin             ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓
-s1-viewer            ✓ ✗ ✗
+s1-viewer            ✓ ✓ ✗
 s1o1-admin           ✓ ✗ ✗
 s1o1-collaborator    ✓ ✗ ✗
 s1o1p1-admin         ✓ ✗ ✗
@@ -36,39 +32,35 @@ s1o1p1-collaborator  ✓ ✗ ✗
 s1o1p1-viewer        ✓ ✗ ✗
 s2-admin             ✗ ✓ ✓
 s2-collaborator      ✗ ✓ ✓
-s2-viewer            ✗ ✗ ✗
+s2-viewer            ✗ ✓ ✗
 
 resource:  Organization "s1o1"
   actions: Fetch, ListProjects, CreateProject, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✓ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✓ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✓ ✓ ✓ ✓
 s1o1-collaborator    ✓ ✓ ✓ ✗
-s1o1p1-admin         ✓ ✗ ✗ ✗
-s1o1p1-collaborator  ✓ ✗ ✗ ✗
-s1o1p1-viewer        ✓ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
 s2-admin             ✗ ✗ ✗ ✗
 s2-collaborator      ✗ ✗ ✗ ✗
 s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Project "s1o1p1"
   actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✓ ✓ ✓ ✓
 s1o1-collaborator    ✓ ✓ ✓ ✓
 s1o1p1-admin         ✓ ✓ ✓ ✓
@@ -80,15 +72,13 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Vpc "s1o1p1v1"
   actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✓ ✓ ✓ ✓
 s1o1-collaborator    ✓ ✓ ✓ ✓
 s1o1p1-admin         ✓ ✓ ✓ ✓
@@ -100,15 +90,13 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Project "s1o1p2"
   actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✓ ✓ ✓ ✓
 s1o1-collaborator    ✓ ✓ ✓ ✓
 s1o1p1-admin         ✗ ✗ ✗ ✗
@@ -120,15 +108,13 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Vpc "s1o1p2v1"
   actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✓ ✓ ✓ ✓
 s1o1-collaborator    ✓ ✓ ✓ ✓
 s1o1p1-admin         ✗ ✗ ✗ ✗
@@ -140,35 +126,31 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Organization "s1o2"
   actions: Fetch, ListProjects, CreateProject, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✓ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✓ ✗ ✗ ✗
-s1o1-admin           ✓ ✗ ✗ ✗
-s1o1-collaborator    ✓ ✗ ✗ ✗
-s1o1p1-admin         ✓ ✗ ✗ ✗
-s1o1p1-collaborator  ✓ ✗ ✗ ✗
-s1o1p1-viewer        ✓ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
+s1o1-admin           ✗ ✗ ✗ ✗
+s1o1-collaborator    ✗ ✗ ✗ ✗
+s1o1p1-admin         ✗ ✗ ✗ ✗
+s1o1p1-collaborator  ✗ ✗ ✗ ✗
+s1o1p1-viewer        ✗ ✗ ✗ ✗
 s2-admin             ✗ ✗ ✗ ✗
 s2-collaborator      ✗ ✗ ✗ ✗
 s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Project "s1o2p1"
   actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✗ ✗ ✗ ✗
 s1o1-collaborator    ✗ ✗ ✗ ✗
 s1o1p1-admin         ✗ ✗ ✗ ✗
@@ -180,15 +162,13 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Vpc "s1o2p1v1"
   actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓ ✓
-fleet-viewer         ✗ ✗ ✗ ✗
+fleet-viewer         ✓ ✓ ✗ ✗
 s1-admin             ✓ ✓ ✓ ✓
 s1-collaborator      ✓ ✓ ✓ ✓
-s1-viewer            ✗ ✗ ✗ ✗
+s1-viewer            ✓ ✓ ✗ ✗
 s1o1-admin           ✗ ✗ ✗ ✗
 s1o1-collaborator    ✗ ✗ ✗ ✗
 s1o1p1-admin         ✗ ✗ ✗ ✗
@@ -200,15 +180,13 @@ s2-viewer            ✗ ✗ ✗ ✗
 
 resource:  Silo "s2"
   actions: Fetch, ListOrganizations, CreateOrganization
-  note:    All users can view their own Silo.  Roles are required to list and create Organizations.  Note that administrators on "s2" appear to be able to list and create Organizations in the output below, but those are Organizations in "s2".
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✓ ✓ ✓
 fleet-collaborator   ✓ ✓ ✓
-fleet-viewer         ✓ ✗ ✗
+fleet-viewer         ✓ ✓ ✗
 s1-admin             ✗ ✓ ✓
 s1-collaborator      ✗ ✓ ✓
-s1-viewer            ✗ ✗ ✗
+s1-viewer            ✗ ✓ ✗
 s1o1-admin           ✗ ✗ ✗
 s1o1-collaborator    ✗ ✗ ✗
 s1o1p1-admin         ✗ ✗ ✗
@@ -216,12 +194,10 @@ s1o1p1-collaborator  ✗ ✗ ✗
 s1o1p1-viewer        ✗ ✗ ✗
 s2-admin             ✓ ✓ ✓
 s2-collaborator      ✓ ✓ ✓
-s2-viewer            ✓ ✗ ✗
+s2-viewer            ✓ ✓ ✗
 
 resource:  Organization "s2o3"
   actions: Fetch, ListProjects, CreateProject, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✗ ✗ ✗ ✗
 fleet-collaborator   ✗ ✗ ✗ ✗
@@ -236,12 +212,10 @@ s1o1p1-collaborator  ✗ ✗ ✗ ✗
 s1o1p1-viewer        ✗ ✗ ✗ ✗
 s2-admin             ✓ ✓ ✓ ✓
 s2-collaborator      ✓ ✓ ✓ ✓
-s2-viewer            ✓ ✗ ✗ ✗
+s2-viewer            ✓ ✓ ✗ ✗
 
 resource:  Project "s2o3p1"
   actions: Fetch, ListVpcs, CreateVpc, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✗ ✗ ✗ ✗
 fleet-collaborator   ✗ ✗ ✗ ✗
@@ -256,12 +230,10 @@ s1o1p1-collaborator  ✗ ✗ ✗ ✗
 s1o1p1-viewer        ✗ ✗ ✗ ✗
 s2-admin             ✓ ✓ ✓ ✓
 s2-collaborator      ✓ ✓ ✓ ✓
-s2-viewer            ✗ ✗ ✗ ✗
+s2-viewer            ✓ ✓ ✗ ✗
 
 resource:  Vpc "s2o3p1v1"
   actions: Fetch, ListSubnets, CreateSubnet, ModifyDescription
-  note:    
-
 USER                 RESULTS FOR EACH ACTION
 fleet-admin          ✗ ✗ ✗ ✗
 fleet-collaborator   ✗ ✗ ✗ ✗
@@ -276,5 +248,5 @@ s1o1p1-collaborator  ✗ ✗ ✗ ✗
 s1o1p1-viewer        ✗ ✗ ✗ ✗
 s2-admin             ✓ ✓ ✓ ✓
 s2-collaborator      ✓ ✓ ✓ ✓
-s2-viewer            ✗ ✗ ✗ ✗
+s2-viewer            ✓ ✓ ✗ ✗
 


### PR DESCRIPTION
This seems weird but I'm creating this PR as a record of something I tried and abandoned.  This way when I'm tempted to try it again (or ask why we didn't do it this way) I can go read why not.

This PR was an attempt to create an end-to-end test that verifies the behavior of authz roles.  The idea was to create an actual resource hierarchy using the external API (so, creating a real Organization, Project, Instance, etc.), assign every possible role on each resource in the hierarchy (using separate users), and verify what API calls each user was able to do.  This sounds great, but it has a bunch of problems:

- it's hard to test "DELETE" because, well, you're deleting part of the resource hierarchy that you then need to recreate
- it's hard to test the endpoints that modify the policy itself
- it takes a very long time
- this test doesn't tell us that each role grants the right permissions per se, but rather whether each role was able to successfully complete each API operation.  On the one hand, that's more important: it's no help if we implement the _permissions_ correctly but the API call doesn't check them correctly.  On the other hand, it's possible for the API call to succeed or fail by accident -- e.g., it might fail because it's checking some different permission that the caller _also_ didn't have.

While writing this test, I decided a better approach is to decompose this into two or three problems:

1. does each role grant precisely the permissions that we expect?  I implemented this under #1123.  This test literally just does the authz check for every action on every resource, using a bunch of users representing every possible role.
2. does each API call _check_ precisely the permissions that we expect?  This is covered by #1374 (not yet implemented).
3. for each API call, for each permission that it checks, does it bail out as expected when that permission is missing?  There's not even a ticket for this one yet.

With the first two things tested, we can have a lot of confidence that we're correctly enforcing the authz policy.  There are a few advantages to breaking things down this way:

- In part (1), It's easy to test "Delete" and "ModifyPolicy" because we're not actually deleting or modifying anything -- we're just doing the authz checks.
- I said above that the test in this PR takes a long time.  That's partly because of the exhaustive nature of the test: it requires (number of resources) times (number of actions) checks.  But for each check, we're doing all the work required for an API call just to verify the `authorize()` bit.  Plus we have to do all the database operations to set up (and tear down and re-set-up) the resource hierarchy in the first place.  By separating it as proposed, part (1) doesn't do any of that extra work.  It just does the authz check for each user and resource (rather than a whole API call) and it doesn't need to set up or tear down any database resources.
- Take the case I mentioned above where the end-to-end test succeeds or fails by accident: this can't happen with this approach because we're testing the underlying pieces (the permissions and the checks), not just the end result.

There may still be room for an end-to-end test ((3) above).  For example, it's conceivable that an implementation passes both of the first two tests but that the API call does not correctly bail out on some particular authz check. (e.g., if somebody called `authorize()` but forgot the `?` after it).  This test could probably be limited to verifying only failure cases, which makes things a lot easier.  Much (but not all) of this is in turn covered by the existing "unauthorized" test.