### PR TITLE
MGS: Add endpoints to update and reset SP

### DIFF
--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -14,13 +14,17 @@ use futures::future::Fuse;
 use futures::future::FusedFuture;
 use futures::prelude::*;
 use gateway_client::types::SpType;
+use gateway_client::types::UpdateBody;
 use slog::o;
 use slog::Drain;
 use slog::Level;
 use slog::Logger;
 use std::borrow::Cow;
+use std::fs;
 use std::net::IpAddr;
 use std::net::ToSocketAddrs;
+use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -70,6 +74,13 @@ enum Command {
     },
     #[clap(about = "Detach any existing serial console connection")]
     Detach,
+    #[clap(about = "Update the SP")]
+    Update {
+        #[clap(help = "Path to the new image")]
+        path: PathBuf,
+    },
+    #[clap(about = "Reset the SP")]
+    Reset,
 }
 
 fn level_from_str(s: &str) -> Result<Level> {
@@ -118,6 +129,20 @@ impl Client {
         }
     }
 
+    async fn reset(&self) -> Result<()> {
+        self.inner.sp_reset(self.sp_type, self.sled).await?;
+        Ok(())
+    }
+
+    async fn update(&self, path: &Path) -> Result<()> {
+        let image = fs::read(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        self.inner
+            .sp_update(self.sp_type, self.sled, &UpdateBody { image })
+            .await?;
+        Ok(())
+    }
+
     async fn detach(&self) -> Result<()> {
         self.inner
             .sp_component_serial_console_detach(
@@ -161,6 +186,12 @@ async fn main() -> Result<()> {
         Command::Attach { raw } => raw, // continue; primary use case
         Command::Detach => {
             return client.detach().await;
+        }
+        Command::Update { path } => {
+            return client.update(&path).await;
+        }
+        Command::Reset => {
+            return client.reset().await;
         }
     };
 

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -203,6 +203,26 @@ impl Communicator {
         Ok(sp.state().await?)
     }
 
+    /// Update a given SP.
+    pub async fn update(
+        &self,
+        sp: SpIdentifier,
+        image: &[u8],
+    ) -> Result<(), Error> {
+        let port = self.id_to_port(sp)?;
+        let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
+        Ok(sp.update(image).await?)
+    }
+
+    /// Reset a given SP.
+    pub async fn reset(&self, sp: SpIdentifier) -> Result<(), Error> {
+        let port = self.id_to_port(sp)?;
+        let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
+        sp.reset_prepare().await?;
+        sp.reset_trigger().await?;
+        Ok(())
+    }
+
     /// Query all online SPs.
     ///
     /// `ignition_state` should be the state returned by a (recent) call to

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     BadIgnitionTarget(usize),
     #[error("error communicating with SP: {0}")]
     SpCommunicationFailed(#[from] SpCommunicationError),
+    #[error("updating SP failed: {0}")]
+    UpdateFailed(#[from] UpdateError),
     #[error("serial console is already attached")]
     SerialConsoleAttached,
 }

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -61,7 +61,8 @@ where
         | SpCommsError::Timeout { .. }
         | SpCommsError::BadIgnitionTarget(_)
         | SpCommsError::LocalIgnitionControllerAddressUnknown
-        | SpCommsError::SpCommunicationFailed(_) => {
+        | SpCommsError::SpCommunicationFailed(_)
+        | SpCommsError::UpdateFailed(_) => {
             HttpError::for_internal_error(err.to_string())
         }
     }

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -728,7 +728,7 @@
     "/sp/{type}/{slot}/update": {
       "post": {
         "summary": "Update an SP",
-        "description": "Uploads a new image to the alternate bank of the SP flash.",
+        "description": "Copies a new image to the alternate bank of the SP flash.",
         "operationId": "sp_update",
         "parameters": [
           {

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -685,6 +685,95 @@
           }
         }
       }
+    },
+    "/sp/{type}/{slot}/reset": {
+      "post": {
+        "summary": "Reset an SP",
+        "operationId": "sp_reset",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sp/{type}/{slot}/update": {
+      "post": {
+        "summary": "Update an SP",
+        "description": "Uploads a new image to the alternate bank of the SP flash.",
+        "operationId": "sp_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -937,7 +1026,20 @@
         ]
       },
       "UpdateBody": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          }
+        },
+        "required": [
+          "image"
+        ]
       }
     }
   }


### PR DESCRIPTION
Also extend `gateway-cli` to call the new endpoints.

This functionality already exists in `faux-mgs`, but up until this PR was not available in MGS proper.