### PR TITLE
Respond to login requests with `""` instead of non-json strings

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -70,7 +70,7 @@ pub async fn spoof_login(
         return Ok(Response::builder()
             .status(StatusCode::UNAUTHORIZED)
             .header(header::SET_COOKIE, clear_session_cookie_header_value())
-            .body("unauthorized".into())?); // TODO: failed login response body?
+            .body("".into())?); // TODO: failed login response body?
     }
 
     let user_id = user_id.unwrap();
@@ -90,7 +90,7 @@ pub async fn spoof_login(
                 apictx.session_idle_timeout(),
             ),
         )
-        .body("ok".into())?) // TODO: what do we return from login?
+        .body("".into())?) // TODO: what do we return from login?
 }
 
 // Silos have one or more identity providers, and an unauthenticated user will
@@ -376,7 +376,7 @@ pub async fn consume_credentials(
             return Ok(Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header(header::SET_COOKIE, clear_session_cookie_header_value())
-                .body("unauthorized".into())?); // TODO: failed login response body?
+                .body("".into())?); // TODO: failed login response body?
         }
 
         let user = user.unwrap();


### PR DESCRIPTION
As the TODO comments indicate, we should give these actual JSON responses — especially the errors — but an empty body is still an improvement on returning strings. The practical reason I'm making this change is: I just improved response handling in the TS client and it does not like when you try to give it a string when it's expecting JSON.