### PR TITLE
Remove sanity check from populate-images

### DIFF
--- a/tools/populate/populate-images.sh
+++ b/tools/populate/populate-images.sh
@@ -7,7 +7,6 @@
 
 set -eu
 CATACOMB_TUNNEL="${CATACOMB_TUNNEL:-"[fd00:1122:3344:101::1]:54321"}"
-res=0
 echo "Populating debian"
 oxide api /images --method POST --input - <<EOF
 {
@@ -92,21 +91,3 @@ oxide api /images --method POST --input - <<EOF
   }
 }
 EOF
-
-# A sanity check to see if access is working to catacomb
-curl_test=$(curl -w '%{http_code}\n' -s -o /dev/null http://${CATACOMB_TUNNEL}/media/test.txt)
-if [[ $curl_test -eq 200 ]]; then
-    echo "✔ Curl test to catacomb worked"
-else
-    echo "To use these images, you need to have network access"
-    echo "to the catacomb lab system at ${CATACOMB_TUNNEL}"
-    echo ""
-    echo "For example, I run this from the system \"sock\" to set up a tunnel:"
-    echo "ssh -L ${CATACOMB_TUNNEL}:catacomb:80 catacomb"
-    echo "Leave that running in a different window while access is required"
-    echo ""
-    echo "Test of curl to catacomb failed"
-    echo "curl http://${CATACOMB_TUNNEL}/media/test.txt"
-    res=1
-fi
-exit $res


### PR DESCRIPTION
Let's suppose we have a multi-machine setup:
1. My laptop
2. Folgers (runner)
3. Catacomb (image hosting)

This script is mostly sending requests from machine 1 to machine 2, asking machine 2 to pull images from machine 3.
However, the sanity check at the end checked that machine 1 had access to machine 3. This connectivity may not exist!

In fact, in many demo environments, this connectivity *does not* exist, and the script hangs when doing the sanity check.

To resolve, I'm removing this bit.