### PR TITLE
CI: upgrade from ubuntu-18.04

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ name: docker-image
 on: push
 jobs:
   docker-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # actions/checkout@v2
       - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on: [ push, pull_request ]
 
 jobs:
   check-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macos-11 ]
+        os: [ ubuntu-20.04, macos-11 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -39,7 +39,7 @@ jobs:
       run: cargo run --bin omicron-package -- check
 
   clippy-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -64,7 +64,7 @@ jobs:
   # This is just a test build of docs.  Publicly available docs are built via
   # the separate "rustdocs" repo.
   build-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b


### PR DESCRIPTION
Well, apparently [`ubuntu-18.04` is being removed from GitHub Actions in December](https://github.com/actions/runner-images/issues/6002), a few months ahead of [Ubuntu's actual end of standard support](https://wiki.ubuntu.com/Releases). To let everyone know, they _purposely failed jobs_ during a four-hour period today.

Logic behind the changes in this PR: I'm using `ubuntu-latest` for the Docker image build step, which is likely less affected by changes to where "latest" points in the future. Everything else is moving to `ubuntu-20.04` because that's what we're using in Buildomat for the moment, and our Rust compilation steps are a bit more sensitive to the particulars of the OS we're on.

This fortunately doesn't change any required check names for protected branches.

Fixes #1637 