### PR TITLE
faux-mgs: Updates expect a hubris archive instead of a raw binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1439,7 @@ dependencies = [
  "termios",
  "thiserror",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -6560,6 +6582,19 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/gateway/faux-mgs/Cargo.toml
+++ b/gateway/faux-mgs/Cargo.toml
@@ -13,6 +13,7 @@ slog-term = "2.9"
 termios = "0.3"
 thiserror = "1.0"
 tokio = { version = "1.20", features = ["full"] }
+zip = { version = "0.6.2", default-features = false, features = ["deflate","bzip2"] }
 
 gateway-messages = { path = "../../gateway-messages", features = ["std"] }
 gateway-sp-comms = { path = "../../gateway-sp-comms" }

--- a/gateway/faux-mgs/src/hubris_archive.rs
+++ b/gateway/faux-mgs/src/hubris_archive.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Minimal parsing of Hubris archives.
+
+use anyhow::Context;
+use anyhow::Result;
+use std::fs;
+use std::io::Cursor;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+use zip::ZipArchive;
+
+pub struct HubrisArchive {
+    archive: ZipArchive<Cursor<Vec<u8>>>,
+    path: PathBuf,
+}
+
+impl HubrisArchive {
+    pub fn open(path: &Path) -> Result<Self> {
+        let data = fs::read(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let cursor = Cursor::new(data);
+        let archive = ZipArchive::new(cursor).with_context(|| {
+            format!(
+                "failed to open {} as a zip file - is it a hubris archive?",
+                path.display()
+            )
+        })?;
+        Ok(Self { archive, path: path.to_owned() })
+    }
+
+    pub fn final_bin(&mut self) -> Result<Vec<u8>> {
+        self.extract_by_name("img/final.bin")
+    }
+
+    fn extract_by_name(&mut self, name: &str) -> Result<Vec<u8>> {
+        let mut f = self.archive.by_name(name).with_context(|| {
+            format!(
+                "failed to find `{}` within {} - is it a hubris archive?",
+                name,
+                self.path.display()
+            )
+        })?;
+        let mut data = Vec::new();
+        f.read_to_end(&mut data).with_context(|| {
+            format!(
+                "failed to extract `{}` within {}",
+                name,
+                self.path.display()
+            )
+        })?;
+        Ok(data)
+    }
+}


### PR DESCRIPTION
This is a pretty modest change in a dev-only utility; no review necessary. Builds on #1645 so I'll wait to merge until it lands.

Fixes #1643.