### PR TITLE
Provision instances to random sleds

### DIFF
--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -337,7 +337,22 @@ async fn sic_alloc_server(
     // See https://rfd.shared.oxide.computer/rfd/0205 for a more complete
     // discussion.
     //
-    // Right now, allocate an instance to any random sled agent.
+    // Right now, allocate an instance to any random sled agent. This has a few
+    // problems:
+    //
+    // - There's no consideration for "health of the sled" here, other than
+    //   "time_deleted = Null". If the sled is rebooting, in a known unhealthy
+    //   state, etc, we'd currently provision it here. I don't think this is a
+    //   trivial fix, but it's work we'll need to account for eventually.
+    //
+    // - This is selecting a random sled from all sleds in the cluster. For
+    //   multi-rack, this is going to fling the sled to an arbitrary system.
+    //   Maybe that's okay, but worth knowing about explicitly.
+    //
+    // - This doesn't take into account anti-affinity - users will want to
+    //   schedule instances that belong to a cluster on different failure
+    //   domains. See https://github.com/oxidecomputer/omicron/issues/1705.
+
     osagactx
         .nexus()
         .random_sled_id()

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -4,7 +4,6 @@
 
 //! Interfaces available to saga actions and undo actions
 
-use crate::external_api::params;
 use crate::Nexus;
 use crate::{authz, db};
 use omicron_common::api::external::Error;
@@ -40,22 +39,6 @@ impl SagaContext {
 
     pub fn log(&self) -> &Logger {
         &self.log
-    }
-
-    // TODO-design This interface should not exist.  Instead, sleds should be
-    // represented in the database.  Reservations will wind up writing to the
-    // database.  Allocating a server will thus be a saga action, complete with
-    // an undo action.  The only thing needed at this layer is a way to read and
-    // write to the database, which we already have.
-    //
-    // Note: the parameters appear here (unused) to make sure callers make sure
-    // to have them available.  They're not used now, but they will be in a real
-    // implementation.
-    pub async fn alloc_server(
-        &self,
-        _params: &params::InstanceCreate,
-    ) -> Result<Uuid, Error> {
-        self.nexus.sled_allocate().await
     }
 
     pub fn authz(&self) -> &Arc<authz::Authz> {


### PR DESCRIPTION
Use a random sled instead of the first sled in the list to provision an
instance. The fixes the bug where multiple sleds are running but
instances only get allocated to the one that is first in the list.