### PR TITLE
MGS: Refine serial console messages to/from SP

### DIFF
--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -209,7 +209,17 @@ pub enum SpMessageKind {
 
     /// Data traveling from an SP-attached component (in practice, a CPU) on the
     /// component's serial console.
-    SerialConsole(SpComponent),
+    ///
+    /// Note that SP -> MGS serial console messages are currently _not_
+    /// acknowledged or retried; they are purely "fire and forget" from the SP's
+    /// point of view. Once it sends data in a packet, it discards it from its
+    /// local buffer.
+    SerialConsole {
+        component: SpComponent,
+        /// Offset of the first byte in this packet's data starting from 0 when
+        /// the serial console session was attached.
+        offset: u64,
+    },
 }
 
 #[derive(

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -25,6 +25,8 @@ pub enum SpCommunicationError {
     BadResponseType(#[from] BadResponseType),
     #[error("Error response from SP: {0}")]
     SpError(#[from] ResponseError),
+    #[error("Bogus serial console state; detach and reattach")]
+    BogusSerialConsoleState,
 }
 
 #[derive(Debug, Error)]
@@ -36,10 +38,6 @@ pub enum UpdateError {
     #[error("error sending update chunk at offset {offset}: {err}")]
     Chunk { offset: u32, err: SpCommunicationError },
 }
-
-#[derive(Debug, Error)]
-#[error("serial console already attached")]
-pub struct SerialConsoleAlreadyAttached;
 
 #[derive(Debug, Error)]
 pub enum StartupError {
@@ -77,12 +75,6 @@ pub enum Error {
     UpdateFailed(#[from] UpdateError),
     #[error("serial console is already attached")]
     SerialConsoleAttached,
-}
-
-impl From<SerialConsoleAlreadyAttached> for Error {
-    fn from(_: SerialConsoleAlreadyAttached) -> Self {
-        Self::SerialConsoleAttached
-    }
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -73,8 +73,6 @@ pub enum Error {
     SpCommunicationFailed(#[from] SpCommunicationError),
     #[error("updating SP failed: {0}")]
     UpdateFailed(#[from] UpdateError),
-    #[error("serial console is already attached")]
-    SerialConsoleAttached,
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -8,7 +8,6 @@
 
 use crate::communicator::ResponseKindExt;
 use crate::error::BadResponseType;
-use crate::error::SerialConsoleAlreadyAttached;
 use crate::error::SpCommunicationError;
 use crate::error::UpdateError;
 use gateway_messages::sp_impl;
@@ -284,31 +283,37 @@ impl SingleSp {
     pub async fn serial_console_attach(
         &self,
         component: SpComponent,
-    ) -> Result<AttachedSerialConsole, SerialConsoleAlreadyAttached> {
+    ) -> Result<AttachedSerialConsole> {
         let (tx, rx) = oneshot::channel();
 
         // `Inner::run()` doesn't exit until we are dropped, so unwrapping here
         // only panics if it itself panicked.
-        self.cmds_tx.send(InnerCommand::SerialConsoleAttach(tx)).await.unwrap();
+        self.cmds_tx
+            .send(InnerCommand::SerialConsoleAttach(component, tx))
+            .await
+            .unwrap();
 
         let attachment = rx.await.unwrap()?;
 
         Ok(AttachedSerialConsole {
             key: attachment.key,
             rx: attachment.incoming,
-            component,
             inner_tx: self.cmds_tx.clone(),
         })
     }
 
     /// Detach any existing attached serial console connection.
-    pub async fn serial_console_detach(&self) {
+    pub async fn serial_console_detach(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
         // `Inner::run()` doesn't exit until we are dropped, so unwrapping here
         // only panics if it itself panicked.
         self.cmds_tx
-            .send(InnerCommand::SerialConsoleDetach(None))
+            .send(InnerCommand::SerialConsoleDetach(None, tx))
             .await
             .unwrap();
+
+        rx.await.unwrap()
     }
 
     pub(crate) async fn rpc(
@@ -364,7 +369,6 @@ async fn rpc(
 #[derive(Debug)]
 pub struct AttachedSerialConsole {
     key: u64,
-    component: SpComponent,
     rx: mpsc::Receiver<Vec<u8>>,
     inner_tx: mpsc::Sender<InnerCommand>,
 }
@@ -376,7 +380,7 @@ impl AttachedSerialConsole {
         (
             AttachedSerialConsoleSend {
                 key: self.key,
-                component: self.component,
+                tx_offset: 0,
                 inner_tx: self.inner_tx,
             },
             AttachedSerialConsoleRecv { rx: self.rx },
@@ -387,37 +391,66 @@ impl AttachedSerialConsole {
 #[derive(Debug)]
 pub struct AttachedSerialConsoleSend {
     key: u64,
+    tx_offset: u64,
     inner_tx: mpsc::Sender<InnerCommand>,
-    component: SpComponent,
 }
 
 impl AttachedSerialConsoleSend {
     /// Write `data` to the serial console of the SP.
-    pub async fn write(&self, data: Vec<u8>) -> Result<()> {
+    pub async fn write(&mut self, data: Vec<u8>) -> Result<()> {
         let mut data = Cursor::new(data);
-        while !CursorExt::is_empty(&data) {
+        let mut remaining_data = CursorExt::remaining_slice(&data).len();
+        while remaining_data > 0 {
             let (result, new_data) = rpc_with_trailing_data(
                 &self.inner_tx,
-                RequestKind::SerialConsoleWrite(self.component),
+                RequestKind::SerialConsoleWrite { offset: self.tx_offset },
                 data,
             )
             .await;
 
-            result.and_then(|(_peer, response)| {
+            let data_sent = (remaining_data
+                - CursorExt::remaining_slice(&new_data).len())
+                as u64;
+
+            let n = result.and_then(|(_peer, response)| {
                 response.expect_serial_console_write_ack().map_err(Into::into)
             })?;
 
+            // Confirm the ack we got back makes sense; its `n` should be in the
+            // range `[self.tx_offset..self.tx_offset + data_sent]`.
+            if n < self.tx_offset {
+                return Err(SpCommunicationError::BogusSerialConsoleState);
+            }
+            let bytes_accepted = n - self.tx_offset;
+            if bytes_accepted > data_sent {
+                return Err(SpCommunicationError::BogusSerialConsoleState);
+            }
+
             data = new_data;
+
+            // If the SP only accepted part of the data we sent, we need to
+            // rewind our cursor and resend what it couldn't accept.
+            if bytes_accepted < data_sent {
+                let rewind = data_sent - bytes_accepted;
+                data.seek(SeekFrom::Current(-(rewind as i64))).unwrap();
+            }
+
+            self.tx_offset += bytes_accepted;
+            remaining_data = CursorExt::remaining_slice(&data).len();
         }
         Ok(())
     }
 
     /// Detach this serial console connection.
-    pub async fn detach(&self) {
+    pub async fn detach(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
         self.inner_tx
-            .send(InnerCommand::SerialConsoleDetach(Some(self.key)))
+            .send(InnerCommand::SerialConsoleDetach(Some(self.key), tx))
             .await
             .unwrap();
+
+        rx.await.unwrap()
     }
 }
 
@@ -473,16 +506,15 @@ struct SerialConsoleAttachment {
 enum InnerCommand {
     Rpc(RpcRequest),
     SerialConsoleAttach(
-        oneshot::Sender<
-            Result<SerialConsoleAttachment, SerialConsoleAlreadyAttached>,
-        >,
+        SpComponent,
+        oneshot::Sender<Result<SerialConsoleAttachment>>,
     ),
     // The associated value is the connection key; if `Some(_)`, only detach if
     // the currently-attached key number matches. If `None`, detach any current
     // connection. These correspond to "detach the current session" (performed
     // automatically when a connection is closed) and "force-detach any session"
     // (performed by a user).
-    SerialConsoleDetach(Option<u64>),
+    SerialConsoleDetach(Option<u64>, oneshot::Sender<Result<()>>),
 }
 
 struct Inner {
@@ -626,17 +658,6 @@ impl Inner {
         command: InnerCommand,
         incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
     ) {
-        // When a caller attaches to the SP's serial console, we return an
-        // `mpsc::Receiver<_>` on which we send any packets received from the
-        // SP. We have to pick a depth for that channel, and given we're not
-        // able to apply backpressure to the SP / host sending the data, we
-        // choose to drop data if the channel fills. We want something large
-        // enough that hiccups in the receiver doesn't cause data loss, but
-        // small enough that if the receiver stops handling messages we don't
-        // eat a bunch of memory buffering up console data. We'll take a WAG and
-        // pick a depth of 32 for now.
-        const SERIAL_CONSOLE_CHANNEL_DEPTH: usize = 32;
-
         match command {
             InnerCommand::Rpc(mut rpc) => {
                 let result = self
@@ -657,26 +678,21 @@ impl Inner {
                     );
                 }
             }
-            InnerCommand::SerialConsoleAttach(response_tx) => {
-                let resp = if self.serial_console_tx.is_some() {
-                    Err(SerialConsoleAlreadyAttached)
-                } else {
-                    let (tx, rx) = mpsc::channel(SERIAL_CONSOLE_CHANNEL_DEPTH);
-                    self.serial_console_tx = Some(tx);
-                    self.serial_console_connection_key += 1;
-                    Ok(SerialConsoleAttachment {
-                        key: self.serial_console_connection_key,
-                        incoming: rx,
-                    })
-                };
+            InnerCommand::SerialConsoleAttach(component, response_tx) => {
+                let resp = self
+                    .attach_serial_console(sp_addr, component, incoming_buf)
+                    .await;
                 response_tx.send(resp).unwrap();
             }
-            InnerCommand::SerialConsoleDetach(key) => {
-                if key.is_none()
+            InnerCommand::SerialConsoleDetach(key, response_tx) => {
+                let resp = if key.is_none()
                     || key == Some(self.serial_console_connection_key)
                 {
-                    self.serial_console_tx = None;
-                }
+                    self.detach_serial_console(sp_addr, incoming_buf).await
+                } else {
+                    Ok(())
+                };
+                response_tx.send(resp).unwrap();
             }
         }
     }
@@ -882,6 +898,69 @@ impl Inner {
             }
         }
         warn!(self.log, "discarding SP serial console data (no receiver)");
+    }
+
+    async fn attach_serial_console(
+        &mut self,
+        sp_addr: SocketAddrV6,
+        component: SpComponent,
+        incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Result<SerialConsoleAttachment> {
+        // When a caller attaches to the SP's serial console, we return an
+        // `mpsc::Receiver<_>` on which we send any packets received from the
+        // SP. We have to pick a depth for that channel, and given we're not
+        // able to apply backpressure to the SP / host sending the data, we
+        // choose to drop data if the channel fills. We want something large
+        // enough that hiccups in the receiver doesn't cause data loss, but
+        // small enough that if the receiver stops handling messages we don't
+        // eat a bunch of memory buffering up console data. We'll take a WAG and
+        // pick a depth of 32 for now.
+        const SERIAL_CONSOLE_CHANNEL_DEPTH: usize = 32;
+
+        if self.serial_console_tx.is_some() {
+            // Returning an `SpError` here is a little suspect since we didn't
+            // actually talk to an SP, but we already know we're attached to it.
+            // If we asked it to attach again, it would send back this error.
+            return Err(SpCommunicationError::SpError(
+                ResponseError::SerialConsoleAlreadyAttached,
+            ));
+        }
+
+        let (_peer, response) = self
+            .rpc_call(
+                sp_addr,
+                RequestKind::SerialConsoleAttach(component),
+                None,
+                incoming_buf,
+            )
+            .await?;
+        response.expect_serial_console_attach_ack()?;
+
+        let (tx, rx) = mpsc::channel(SERIAL_CONSOLE_CHANNEL_DEPTH);
+        self.serial_console_tx = Some(tx);
+        self.serial_console_connection_key += 1;
+        Ok(SerialConsoleAttachment {
+            key: self.serial_console_connection_key,
+            incoming: rx,
+        })
+    }
+
+    async fn detach_serial_console(
+        &mut self,
+        sp_addr: SocketAddrV6,
+        incoming_buf: &mut [u8; gateway_messages::MAX_SERIALIZED_SIZE],
+    ) -> Result<()> {
+        let (_peer, response) = self
+            .rpc_call(
+                sp_addr,
+                RequestKind::SerialConsoleDetach,
+                None,
+                incoming_buf,
+            )
+            .await?;
+        response.expect_serial_console_detach_ack()?;
+        self.serial_console_tx = None;
+        Ok(())
     }
 }
 

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -61,7 +61,7 @@ switch1 = ["switch", 1]
 
 [switch.port.1]
 data_link_addr = "[::]:33201"
-multicast_addr = "[ff15:0:1de::1%2]:11111"
+multicast_addr = "[ff15:0:1de::1]:33310"
 [switch.port.1.location]
 switch0 = ["sled", 0]
 switch1 = ["sled", 0]

--- a/gateway/faux-mgs/src/main.rs
+++ b/gateway/faux-mgs/src/main.rs
@@ -104,6 +104,9 @@ enum SpCommand {
         stdin_buffer_time_millis: u64,
     },
 
+    /// Detach any other attached USART connection.
+    UsartDetach,
+
     /// Upload a new image to the SP and have it swap banks (requires reset)
     Update { hubris_archive: PathBuf },
 
@@ -188,6 +191,10 @@ async fn main() -> Result<()> {
                 log,
             )
             .await?;
+        }
+        Some(SpCommand::UsartDetach) => {
+            sp.serial_console_detach().await?;
+            info!(log, "SP serial console detached");
         }
         Some(SpCommand::Update { hubris_archive }) => {
             let mut archive = HubrisArchive::open(&hubris_archive)?;

--- a/gateway/faux-mgs/src/usart.rs
+++ b/gateway/faux-mgs/src/usart.rs
@@ -88,14 +88,9 @@ async fn relay_data_to_sp(
     mut console_tx: AttachedSerialConsoleSend,
     mut data_rx: mpsc::Receiver<Vec<u8>>,
 ) -> Result<()> {
-    loop {
-        let data = match data_rx.recv().await {
-            Some(data) => data,
-            None => break,
-        };
+    while let Some(data) = data_rx.recv().await {
         console_tx.write(data).await?;
     }
-
     console_tx.detach().await?;
 
     Ok(())

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -7,7 +7,9 @@
 use std::borrow::Borrow;
 
 use dropshot::HttpError;
+use gateway_messages::ResponseError;
 use gateway_sp_comms::error::Error as SpCommsError;
+use gateway_sp_comms::error::SpCommunicationError;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -53,7 +55,9 @@ where
             Some("InvalidSp".to_string()),
             err.to_string(),
         ),
-        SpCommsError::SerialConsoleAttached => HttpError::for_bad_request(
+        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+            ResponseError::SerialConsoleAlreadyAttached,
+        )) => HttpError::for_bad_request(
             Some("SerialConsoleAttached".to_string()),
             err.to_string(),
         ),

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -326,7 +326,6 @@ async fn sp_list(
                     // These errors should not be possible for the request we
                     // made.
                     SpCommsError::SpDoesNotExist(_)
-                    | SpCommsError::SerialConsoleAttached
                     | SpCommsError::UpdateFailed(_) => {
                         unreachable!("impossible error {}", err)
                     }

--- a/gateway/src/serial_console.rs
+++ b/gateway/src/serial_console.rs
@@ -24,6 +24,7 @@ use slog::info;
 use slog::Logger;
 use std::borrow::Cow;
 use std::ops::Deref;
+use std::ops::DerefMut;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::handshake;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
@@ -222,7 +223,7 @@ impl SerialConsoleTask {
 
     async fn ws_recv_task(
         mut ws_stream: SplitStream<WebSocketStream<Upgraded>>,
-        console_tx: DetachOnDrop,
+        mut console_tx: DetachOnDrop,
         log: Logger,
     ) -> Result<(), SerialTaskError> {
         while let Some(message) = ws_stream.next().await {
@@ -279,5 +280,13 @@ impl Deref for DetachOnDrop {
         // We know from `new()` that we're created with `Some(console)`, and we
         // don't remove it until our `Drop` impl
         self.0.as_ref().unwrap()
+    }
+}
+
+impl DerefMut for DetachOnDrop {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // We know from `new()` that we're created with `Some(console)`, and we
+        // don't remove it until our `Drop` impl
+        self.0.as_mut().unwrap()
     }
 }

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -94,16 +94,7 @@ impl Gimlet {
     pub async fn spawn(gimlet: &GimletConfig, log: Logger) -> Result<Self> {
         info!(log, "setting up simualted gimlet");
 
-        // We want to be able to start without knowing the gateways' socket
-        // addresses, but we're spawning both the primary UDP task (which
-        // receives messages from the gateway) and a helper TCP task (which
-        // emulates a serial console and sends messages to the gateway
-        // unprompted). We'll share a locked `Option<SocketAddrV6>` between the
-        // tasks, and have the UDP task populate it. If the TCP task receives
-        // data but doesn't know either of the gateways addresses, it will just
-        // discard it.
-        let gateway_addresses: Arc<Mutex<[Option<SocketAddrV6>; 2]>> =
-            Arc::default();
+        let attached_mgs = Arc::new(Mutex::new(None));
 
         let mut incoming_console_tx = HashMap::new();
         let mut serial_console_addrs = HashMap::new();
@@ -173,7 +164,7 @@ impl Gimlet {
                             Arc::clone(servers[0].socket()),
                             Arc::clone(servers[1].socket()),
                         ],
-                        Arc::clone(&gateway_addresses),
+                        Arc::clone(&attached_mgs),
                         log.new(slog::o!("serial-console" => name.to_string())),
                     );
                     inner_tasks.push(task::spawn(async move {
@@ -185,7 +176,7 @@ impl Gimlet {
                 [servers[0].local_addr(), servers[1].local_addr()];
             let inner = UdpTask::new(
                 servers,
-                gateway_addresses,
+                attached_mgs,
                 gimlet.common.serial_number,
                 incoming_console_tx,
                 commands_rx,
@@ -221,7 +212,8 @@ struct SerialConsoleTcpTask {
     listener: TcpListener,
     incoming_serial_console: UnboundedReceiver<Vec<u8>>,
     socks: [Arc<UdpSocket>; 2],
-    gateway_addresses: Arc<Mutex<[Option<SocketAddrV6>; 2]>>,
+    attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
+    serial_console_tx_offset: u64,
     component: SpComponent,
     log: Logger,
 }
@@ -232,53 +224,61 @@ impl SerialConsoleTcpTask {
         listener: TcpListener,
         incoming_serial_console: UnboundedReceiver<Vec<u8>>,
         socks: [Arc<UdpSocket>; 2],
-        gateway_addresses: Arc<Mutex<[Option<SocketAddrV6>; 2]>>,
+        attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
         log: Logger,
     ) -> Self {
         Self {
             listener,
             incoming_serial_console,
             socks,
-            gateway_addresses,
+            attached_mgs,
+            serial_console_tx_offset: 0,
             component,
             log,
         }
     }
 
     async fn send_serial_console(&mut self, data: &[u8]) -> Result<()> {
-        let gateway_addrs = *self.gateway_addresses.lock().unwrap();
-        for (i, (sock, &gateway_addr)) in
-            self.socks.iter().zip(&gateway_addrs).enumerate()
-        {
-            let gateway_addr = match gateway_addr {
-                Some(addr) => addr,
+        let (component, sp_port, mgs_addr) =
+            match *self.attached_mgs.lock().unwrap() {
+                Some((component, sp_port, mgs_addr)) => {
+                    (component, sp_port, mgs_addr)
+                }
                 None => {
                     info!(
                         self.log,
-                        concat!(
-                            "MGS address on port {} not known - ",
-                            "not sending it serial console data",
-                        ),
-                        i,
+                        "No attached MGS; discarding serial console data"
                     );
-                    continue;
+                    return Ok(());
                 }
             };
 
-            let mut out = [0; gateway_messages::MAX_SERIALIZED_SIZE];
-            let mut remaining = data;
-            while !remaining.is_empty() {
-                let message = SpMessage {
-                    version: version::V1,
-                    kind: SpMessageKind::SerialConsole(self.component),
-                };
-                let (n, written) =
-                    gateway_messages::serialize_with_trailing_data(
-                        &mut out, &message, remaining,
-                    );
-                sock.send_to(&out[..n], gateway_addr).await?;
-                remaining = &remaining[written..];
-            }
+        if component != self.component {
+            info!(self.log, "MGS is attached to a different component; discarding serial console data");
+            return Ok(());
+        }
+
+        let sock = match sp_port {
+            SpPort::One => &self.socks[0],
+            SpPort::Two => &self.socks[1],
+        };
+
+        let mut out = [0; gateway_messages::MAX_SERIALIZED_SIZE];
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let message = SpMessage {
+                version: version::V1,
+                kind: SpMessageKind::SerialConsole {
+                    component: self.component,
+                    offset: self.serial_console_tx_offset,
+                },
+            };
+            let (n, written) = gateway_messages::serialize_with_trailing_data(
+                &mut out, &message, remaining,
+            );
+            sock.send_to(&out[..n], mgs_addr).await?;
+            remaining = &remaining[written..];
+            self.serial_console_tx_offset += written as u64;
         }
 
         Ok(())
@@ -381,7 +381,7 @@ struct UdpTask {
 impl UdpTask {
     fn new(
         servers: [UdpServer; 2],
-        gateway_addresses: Arc<Mutex<[Option<SocketAddrV6>; 2]>>,
+        attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
         serial_number: SerialNumber,
         incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
         commands: mpsc::UnboundedReceiver<(
@@ -396,7 +396,7 @@ impl UdpTask {
             udp1,
             handler: Handler {
                 log,
-                gateway_addresses,
+                attached_mgs,
                 serial_number,
                 incoming_serial_console,
             },
@@ -456,18 +456,8 @@ impl UdpTask {
 struct Handler {
     log: Logger,
     serial_number: SerialNumber,
-    gateway_addresses: Arc<Mutex<[Option<SocketAddrV6>; 2]>>,
+    attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
     incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
-}
-
-impl Handler {
-    fn update_gateway_address(&self, addr: SocketAddrV6, port: SpPort) {
-        let i = match port {
-            SpPort::One => 0,
-            SpPort::Two => 1,
-        };
-        self.gateway_addresses.lock().unwrap()[i] = Some(addr);
-    }
 }
 
 impl SpHandler for Handler {
@@ -491,7 +481,6 @@ impl SpHandler for Handler {
         port: SpPort,
         target: u8,
     ) -> Result<gateway_messages::IgnitionState, ResponseError> {
-        self.update_gateway_address(sender, port);
         warn!(
             &self.log,
             "received ignition state request; not supported by gimlet";
@@ -507,7 +496,6 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<gateway_messages::BulkIgnitionState, ResponseError> {
-        self.update_gateway_address(sender, port);
         warn!(
             &self.log,
             "received bulk ignition state request; not supported by gimlet";
@@ -524,7 +512,6 @@ impl SpHandler for Handler {
         target: u8,
         command: gateway_messages::IgnitionCommand,
     ) -> Result<(), ResponseError> {
-        self.update_gateway_address(sender, port);
         warn!(
             &self.log,
             "received ignition command; not supported by gimlet";
@@ -536,22 +523,51 @@ impl SpHandler for Handler {
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
-    fn serial_console_write(
+    fn serial_console_attach(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-        data: &[u8],
     ) -> Result<(), ResponseError> {
-        self.update_gateway_address(sender, port);
+        debug!(
+            &self.log,
+            "received serial console attach request";
+            "sender" => %sender,
+            "port" => ?port,
+            "component" => ?component,
+        );
+
+        let mut attached_mgs = self.attached_mgs.lock().unwrap();
+        if attached_mgs.is_some() {
+            return Err(ResponseError::SerialConsoleAlreadyAttached);
+        }
+
+        *attached_mgs = Some((component, port, sender));
+        Ok(())
+    }
+
+    fn serial_console_write(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<u64, ResponseError> {
         debug!(
             &self.log,
             "received serial console packet";
             "sender" => %sender,
             "port" => ?port,
             "len" => data.len(),
-            "component" => ?component,
+            "offset" => offset,
         );
+
+        let component = self
+            .attached_mgs
+            .lock()
+            .unwrap()
+            .map(|(component, _port, _addr)| component)
+            .ok_or(ResponseError::SerialConsoleNotAttached)?;
 
         let incoming_serial_console = self
             .incoming_serial_console
@@ -565,6 +581,21 @@ impl SpHandler for Handler {
         // ignore errors here
         let _ = incoming_serial_console.send(data.to_vec());
 
+        Ok(offset + data.len() as u64)
+    }
+
+    fn serial_console_detach(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), ResponseError> {
+        debug!(
+            &self.log,
+            "received serial console detach request";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        *self.attached_mgs.lock().unwrap() = None;
         Ok(())
     }
 
@@ -573,7 +604,6 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
     ) -> Result<SpState, ResponseError> {
-        self.update_gateway_address(sender, port);
         let state = SpState {
             serial_number: self.serial_number,
             version: SIM_GIMLET_VERSION,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -393,8 +393,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         _component: SpComponent,
-    ) -> Result<(), ResponseError>
-    {
+    ) -> Result<(), ResponseError> {
         warn!(
             &self.log, "received serial console attach; unsupported by sidecar";
             "sender" => %sender,
@@ -422,8 +421,7 @@ impl SpHandler for Handler {
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-    ) -> Result<(), ResponseError>
-    {
+    ) -> Result<(), ResponseError> {
         warn!(
             &self.log, "received serial console detach; unsupported by sidecar";
             "sender" => %sender,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -388,15 +388,44 @@ impl SpHandler for Handler {
         Ok(())
     }
 
-    fn serial_console_write(
+    fn serial_console_attach(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
         _component: SpComponent,
+    ) -> Result<(), ResponseError>
+    {
+        warn!(
+            &self.log, "received serial console attach; unsupported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_write(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        _offset: u64,
         _data: &[u8],
-    ) -> Result<(), ResponseError> {
+    ) -> Result<u64, ResponseError> {
         warn!(
             &self.log, "received serial console write; unsupported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_detach(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), ResponseError>
+    {
+        warn!(
+            &self.log, "received serial console detach; unsupported by sidecar";
             "sender" => %sender,
             "port" => ?port,
         );


### PR DESCRIPTION
This PR allows us to address a few lingering TODOs, particularly on the hubris side of the serial-console-over-UDP process:

1. Attaching and detaching an MGS instance to a particular SP's proxied serial console are now explicit messages; previously attaching was implicit when MGS sent data, and detaching was implicit when a new MGS instance attached, neither of which was ideal.
2. MGS -> SP serial console data packets now include an offset, allowing the SP to detect and ignore any resent UDP packets. Previously if MGS resent a serial console data packet because it missed an ack, the SP had no way to know it had already seen it, and it would forward it along the uart a second time.
3. SP -> MGS serial console data packets now include an offset. We do _not_ ack SP -> MGS messages, both because the logic to do that on the SP would be tricky and because it has very little recourse for unacked messages (it can't apply backpressure on a uart, and it can't buffer data arbitrarily long). As of this PR MGS can at least know and log when data has been lost due to a networking or SP buffering issue.