### PR TITLE
MGS messaging: Allow multiple slices when serializing drailing data

### DIFF
--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -780,7 +780,7 @@ impl Inner {
                     gateway_messages::serialize_with_trailing_data(
                         &mut outgoing_buf,
                         &request,
-                        CursorExt::remaining_slice(data),
+                        &[CursorExt::remaining_slice(data)],
                     );
                 // `data` is an in-memory cursor; seeking can only fail if we
                 // provide a bogus offset, so it's safe to unwrap here.

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -274,7 +274,9 @@ impl SerialConsoleTcpTask {
                 },
             };
             let (n, written) = gateway_messages::serialize_with_trailing_data(
-                &mut out, &message, remaining,
+                &mut out,
+                &message,
+                &[remaining],
             );
             sock.send_to(&out[..n], mgs_addr).await?;
             remaining = &remaining[written..];


### PR DESCRIPTION
This will allow us to use
[`heapless::Deque`](https://docs.rs/heapless/latest/heapless/struct.Deque.html)
for usart buffers on the SP, which returns its content as [two
slices](https://docs.rs/heapless/latest/heapless/struct.Deque.html#method.as_slices).