### PR TITLE
Change `/global/` to `/system/` to reflect RFD-288

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -80,8 +80,8 @@ type NexusApiDescription = ApiDescription<Arc<ServerContext>>;
 /// Returns a description of the external nexus API
 pub fn external_api() -> NexusApiDescription {
     fn register_endpoints(api: &mut NexusApiDescription) -> Result<(), String> {
-        api.register(global_policy_view)?;
-        api.register(global_policy_update)?;
+        api.register(system_policy_view)?;
+        api.register(system_policy_update)?;
 
         api.register(policy_view)?;
         api.register(policy_update)?;
@@ -319,10 +319,10 @@ pub fn external_api() -> NexusApiDescription {
 /// Fetch the top-level IAM policy
 #[endpoint {
     method = GET,
-    path = "/global/policy",
+    path = "/system/policy",
     tags = ["policy"],
 }]
-async fn global_policy_view(
+async fn system_policy_view(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
 ) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {
     let apictx = rqctx.context();
@@ -345,10 +345,10 @@ struct ByIdPathParams {
 /// Update the top-level IAM policy
 #[endpoint {
     method = PUT,
-    path = "/global/policy",
+    path = "/system/policy",
     tags = ["policy"],
 }]
-async fn global_policy_update(
+async fn system_policy_update(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     new_policy: TypedBody<shared::Policy<authz::FleetRole>>,
 ) -> Result<HttpResponseOk<shared::Policy<authz::FleetRole>>, HttpError> {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -41,7 +41,7 @@ lazy_static! {
         format!("/hardware/sleds/{}", SLED_AGENT_UUID);
 
     // Global policy
-    pub static ref GLOBAL_POLICY_URL: &'static str = "/global/policy";
+    pub static ref SYSTEM_POLICY_URL: &'static str = "/system/policy";
 
     // Silo used for testing
     pub static ref DEMO_SILO_NAME: Name = "demo-silo".parse().unwrap();
@@ -525,7 +525,7 @@ lazy_static! {
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
         // Global IAM policy
         VerifyEndpoint {
-            url: *GLOBAL_POLICY_URL,
+            url: *SYSTEM_POLICY_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -108,7 +108,7 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
         const ROLE: Self::RoleType = authz::FleetRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
-            String::from("/global/policy")
+            String::from("/system/policy")
         }
 
         fn verify_initial<'a, 'b, 'c, 'd>(

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -99,8 +99,8 @@ organization_view_by_id                  /by-id/organizations/{id}
 
 API operations found with tag "policy"
 OPERATION ID                             URL PATH
-global_policy_update                     /global/policy
-global_policy_view                       /global/policy
+system_policy_update                     /system/policy
+system_policy_view                       /system/policy
 
 API operations found with tag "projects"
 OPERATION ID                             URL PATH

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -569,68 +569,6 @@
         }
       }
     },
-    "/global/policy": {
-      "get": {
-        "tags": [
-          "policy"
-        ],
-        "summary": "Fetch the top-level IAM policy",
-        "operationId": "global_policy_view",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FleetRolePolicy"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "policy"
-        ],
-        "summary": "Update the top-level IAM policy",
-        "operationId": "global_policy_update",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FleetRolePolicy"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FleetRolePolicy"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/hardware/racks": {
       "get": {
         "tags": [
@@ -6824,6 +6762,68 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SamlIdentityProvider"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/system/policy": {
+      "get": {
+        "tags": [
+          "policy"
+        ],
+        "summary": "Fetch the top-level IAM policy",
+        "operationId": "system_policy_view",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetRolePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "policy"
+        ],
+        "summary": "Update the top-level IAM policy",
+        "operationId": "system_policy_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FleetRolePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetRolePolicy"
                 }
               }
             }


### PR DESCRIPTION
This updates #1573 to reflect the resolution of RFD-288. It's one part of #1675. 