### PR TITLE
Check if CRDB is telling us to retry the txn

### DIFF
--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -155,7 +155,8 @@ impl super::Nexus {
                 | Error::InternalError { .. }
                 | Error::ServiceUnavailable { .. }
                 | Error::MethodNotAllowed { .. }
-                | Error::TypeVersionMismatch { .. } => {
+                | Error::TypeVersionMismatch { .. }
+                | Error::TooManyRequests { .. } => {
                     Reason::UnknownError { source: error }
                 }
             })?;


### PR DESCRIPTION
Match against DieselDatabaseErrorKind::SerializationFailure and check if it's a case where a CRDB transaction didn't fail but needs to be retried. This can happen if there's too much database contention, and requires clients to retry the request.

Return HTTP 429 in this case to signal to clients that a retry is required.

Closes https://github.com/oxidecomputer/remote-access-preview/issues/23