### PR TITLE
Refine update delivery messages from MGS to SP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "omicron-common",
  "omicron-test-utils",
  "once_cell",
+ "rand 0.8.5",
  "serde",
  "serde_with",
  "slog",

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 futures = "0.3.24"
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.0.0"
 thiserror = "1.0.34"

--- a/gateway/faux-mgs/src/main.rs
+++ b/gateway/faux-mgs/src/main.rs
@@ -4,11 +4,13 @@
 
 // Copyright 2022 Oxide Computer Company
 
+use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
+use gateway_messages::SpComponent;
 use gateway_sp_comms::SingleSp;
 use gateway_sp_comms::DISCOVERY_MULTICAST_ADDR;
 use slog::info;
@@ -16,6 +18,7 @@ use slog::o;
 use slog::Drain;
 use slog::Level;
 use slog::Logger;
+use std::fs;
 use std::net::SocketAddrV6;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -110,6 +113,16 @@ enum SpCommand {
     /// Upload a new image to the SP and have it swap banks (requires reset)
     Update { hubris_archive: PathBuf },
 
+    /// Update a component of the SP.
+    UpdateComponent { component: String, slot: u16, image: PathBuf },
+
+    /// Abort an in-progress update.
+    AbortUpdate {
+        /// Component with an update-in-progress to be aborted. Omit to abort
+        /// updates to the SP itself.
+        component: Option<String>,
+    },
+
     /// Instruct the SP to reset.
     Reset,
 }
@@ -199,8 +212,40 @@ async fn main() -> Result<()> {
         Some(SpCommand::Update { hubris_archive }) => {
             let mut archive = HubrisArchive::open(&hubris_archive)?;
             let data = archive.final_bin()?;
-            sp.update(data).await.with_context(|| {
-                format!("updating to {} failed", hubris_archive.display())
+            sp.update(gateway_messages::SpComponent::SP_ITSELF, 0, data)
+                .await
+                .with_context(|| {
+                    format!("updating to {} failed", hubris_archive.display())
+                })?;
+        }
+        Some(SpCommand::UpdateComponent { component, slot, image }) => {
+            let data = fs::read(&image).with_context(|| {
+                format!("failed to read {}", image.display())
+            })?;
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| {
+                    anyhow!("invalid component name: {}", component)
+                })?;
+            sp.update(sp_component, slot, data).await.with_context(|| {
+                format!(
+                    "updating {} slot {} to {} failed",
+                    component,
+                    slot,
+                    image.display()
+                )
+            })?;
+        }
+        Some(SpCommand::AbortUpdate { component }) => {
+            let sp_component = match &component {
+                Some(c) => SpComponent::try_from(c.as_str())
+                    .map_err(|_| anyhow!("invalid component name: {}", c))?,
+                None => SpComponent::SP_ITSELF,
+            };
+            sp.update_abort(sp_component).await.with_context(|| {
+                format!(
+                    "aborting update to {} failed",
+                    component.as_deref().unwrap_or("SP")
+                )
             })?;
         }
         Some(SpCommand::Reset) => {

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -27,6 +27,7 @@ use dropshot::ResultsPage;
 use dropshot::TypedBody;
 use dropshot::WhichPage;
 use gateway_messages::IgnitionCommand;
+use gateway_messages::SpComponent;
 use gateway_sp_comms::error::Error as SpCommsError;
 use gateway_sp_comms::Timeout as SpTimeout;
 use schemars::JsonSchema;
@@ -504,10 +505,17 @@ async fn sp_update(
     let sp = path.into_inner().sp;
     let image = body.into_inner().image;
 
-    comms.update(sp.into(), image).await.map_err(http_err_from_comms_err)?;
+    comms
+        .update(sp.into(), SpComponent::SP_ITSELF, 0, image)
+        .await
+        .map_err(http_err_from_comms_err)?;
 
     Ok(HttpResponseUpdatedNoContent {})
 }
+
+// TODO-completeness: Either add a new endpoint to allow for updating
+// components, or expand the above endpoint to cover that case in addition to
+// updating the SP itself.
 
 /// Reset an SP
 #[endpoint {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -619,18 +619,35 @@ impl SpHandler for Handler {
         Ok(state)
     }
 
-    fn update_start(
+    fn update_prepare(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        update: gateway_messages::UpdateStart,
+        update: gateway_messages::UpdatePrepare,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,
-            "received update start request; not supported by simulated gimlet";
+            "received update prepare request; not supported by simulated gimlet";
             "sender" => %sender,
             "port" => ?port,
             "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_prepare_status(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        request: gateway_messages::UpdatePrepareStatusRequest,
+    ) -> Result<gateway_messages::UpdatePrepareStatusResponse, ResponseError>
+    {
+        warn!(
+            &self.log,
+            "received update prepare status request; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "request" => ?request,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }
@@ -649,6 +666,22 @@ impl SpHandler for Handler {
             "port" => ?port,
             "offset" => chunk.offset,
             "length" => data.len(),
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_abort(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update abort; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "component" => ?component,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -84,7 +84,7 @@ impl SimulatedSp for Sidecar {
         let (tx, rx) = oneshot::channel();
         self.commands
             .send((Command::SetResponsiveness(r), tx))
-            .map_err(|_| "gimlet task died unexpectedly")
+            .map_err(|_| "sidecar task died unexpectedly")
             .unwrap();
         rx.await.unwrap();
     }
@@ -448,18 +448,35 @@ impl SpHandler for Handler {
         Ok(state)
     }
 
-    fn update_start(
+    fn update_prepare(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        update: gateway_messages::UpdateStart,
+        update: gateway_messages::UpdatePrepare,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,
-            "received update start request; not supported by simulated sidecar";
+            "received update prepare request; not supported by simulated sidecar";
             "sender" => %sender,
             "port" => ?port,
             "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_prepare_status(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        request: gateway_messages::UpdatePrepareStatusRequest,
+    ) -> Result<gateway_messages::UpdatePrepareStatusResponse, ResponseError>
+    {
+        warn!(
+            &self.log,
+            "received update prepare status request; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "request" => ?request,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }
@@ -478,6 +495,22 @@ impl SpHandler for Handler {
             "port" => ?port,
             "offset" => chunk.offset,
             "length" => data.len(),
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn update_abort(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update abort; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "component" => ?component,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }


### PR DESCRIPTION
The largest change is that `UpdateStart` has been broken into
`UpdatePrepare` followed by a series of `UpdatePrepareStatus` messages
(until the SP responds that update preparation is done). This allows for
slow update prep process, such as erasing the host boot flash (which can
take multiple minutes).

Minor changes include:

* A new "update abort" message to abandon an in-progress (presumably
  from a failed MGS) update
* Update messages now include a random `stream-id` to allow the SP to
  better correlate them and reject unrelated update packets

In total, these are the changes necessary to support delivering host boot flash updates via faux-mgs. Delivering via MGS proper will require a small subsequent PR to add or modify an API (see the new TODO in `http_entrypoints.rs`).