### PR TITLE
[sled agent] Compare dladm results with datalink mgmt cache file

### DIFF
--- a/sled-agent/src/opte/illumos/mod.rs
+++ b/sled-agent/src/opte/illumos/mod.rs
@@ -19,6 +19,7 @@ mod port_manager;
 pub use port::Port;
 pub use port_manager::PortManager;
 pub use port_manager::PortTicket;
+pub use port_manager::XDE_LINK_PREFIX;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/sled-agent/src/opte/illumos/port_manager.rs
+++ b/sled-agent/src/opte/illumos/port_manager.rs
@@ -39,7 +39,7 @@ use std::sync::MutexGuard;
 use uuid::Uuid;
 
 // Prefix used to identify xde data links.
-const XDE_LINK_PREFIX: &str = "opte";
+pub const XDE_LINK_PREFIX: &str = "opte";
 
 #[derive(Debug)]
 struct PortManagerInner {
@@ -281,8 +281,17 @@ impl PortManager {
             snat,
             external_ip,
             /* passthru = */ false,
-        )?;
-        debug!(
+        )
+        .map_err(|e| {
+            warn!(
+                self.inner.log,
+                "Failed to create xde device";
+                "port_name" => &port_name,
+                "error" => e.to_string(),
+            );
+            e
+        })?;
+        info!(
             self.inner.log,
             "Created xde device for guest port";
             "port_name" => &port_name,

--- a/sled-agent/src/opte/non_illumos/mod.rs
+++ b/sled-agent/src/opte/non_illumos/mod.rs
@@ -12,6 +12,7 @@ mod port_manager;
 pub use port::Port;
 pub use port_manager::PortManager;
 pub use port_manager::PortTicket;
+pub use port_manager::XDE_LINK_PREFIX;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Vni(u32);

--- a/sled-agent/src/opte/non_illumos/port_manager.rs
+++ b/sled-agent/src/opte/non_illumos/port_manager.rs
@@ -27,7 +27,7 @@ use std::sync::Mutex;
 use uuid::Uuid;
 
 // Prefix used to identify xde data links.
-const XDE_LINK_PREFIX: &str = "opte";
+pub const XDE_LINK_PREFIX: &str = "opte";
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -103,9 +103,7 @@ pub enum Error {
 
     #[error(
         "Unexpected object in dladm cache file which cannot be deleted automatically
-        This is related to https://github.com/oxidecomputer/omicron/issues/1679 ; ideally
-        We'd never leave around this half-deleted objects, and we'd automatically remove
-        them if we ever saw them.
+        This is related to https://github.com/oxidecomputer/omicron/issues/1679 .
         To fix:
         - Delete the line \"{line}\" in {DATALINK_CACHE_FILE}.
         - Run `svcadm restart svc:/network/datalink-management:default`"


### PR DESCRIPTION
This is highly related to https://github.com/oxidecomputer/omicron/issues/1679 , but doesn't fully resolve the problem.
It's also related to https://github.com/oxidecomputer/omicron/issues/1682 , which pokes slightly more at the underlying problem.

Instead, this PR focuses on making that problem much more visible.

Under some circumstances, it's possible for datalink devices to appear in the datalink management cache file, but not in the output of dladm. Regardless of how this happens, it results in a scenario where:
- The sled agent isn't easily able to see the "defunct" datalink
- However, if the sled agent tries re-using that datalink name, an error will be returned -- see #1679 .

This PR attempts to compare the datalink cache file with sled agent's expected state, monitoring for devices that exist, even if they *should* have been deleted.

If this situation is encountered, a fairly verbose error is propagated upwards, with instructions on how-to-fix. If we're confident that we can delete datalinks without resulting in this "zombie" state, we can remove this workaround.