### PR TITLE
Bootstore message handler implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=51de79fe02b334899be5d5fd8b469f9d140ea887#51de79fe02b334899be5d5fd8b469f9d140ea887"
@@ -352,6 +358,7 @@ dependencies = [
 name = "bootstore"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "bcs",
  "bincode",
  "derive_more",

--- a/bootstore/Cargo.toml
+++ b/bootstore/Cargo.toml
@@ -30,5 +30,6 @@ uuid = { version = "1.1.0", features = [ "serde", "v4" ] }
 vsss-rs = { version = "2.0.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 bincode = "1.3.3"
 omicron-test-utils = { path = "../test-utils" }

--- a/bootstore/src/db/error.rs
+++ b/bootstore/src/db/error.rs
@@ -30,4 +30,19 @@ pub enum Error {
 
     #[error("Already initialized with rack uuid: {0}")]
     AlreadyInitialized(String),
+
+    #[error(
+        "Tried to Prepare a KeyShare with epoch {epoch}, but found one 
+    with later epoch {stored_epoch}"
+    )]
+    OldKeySharePrepare { epoch: i32, stored_epoch: i32 },
+
+    #[error("A distinct key share already exists for epoch {epoch}")]
+    KeyShareAlreadyExists { epoch: i32 },
+
+    #[error("Rack UUID mismatch: Expected: {expected}, Actual: {actual}")]
+    RackUuidMismatch { expected: String, actual: String },
+
+    #[error("Rack not yet initialized")]
+    RackNotInitialized,
 }

--- a/bootstore/src/db/error.rs
+++ b/bootstore/src/db/error.rs
@@ -5,6 +5,7 @@
 //! DB related errors
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Error {
@@ -16,6 +17,9 @@ pub enum Error {
 
     #[error("BCS serialization error: {err}")]
     Bcs { err: String },
+
+    #[error("Failed to parse string as UUID: {uuidstr} - {err}")]
+    ParseUuid { uuidstr: String, err: String },
 
     // Temporary until the using code is written
     #[allow(dead_code)]
@@ -29,10 +33,10 @@ pub enum Error {
     DbInvariant(String),
 
     #[error("Already initialized with rack uuid: {0}")]
-    AlreadyInitialized(String),
+    AlreadyInitialized(Uuid),
 
     #[error(
-        "Tried to Prepare a KeyShare with epoch {epoch}, but found one 
+        "Tried to Prepare a KeyShare with epoch {epoch}, but found one \
     with later epoch {stored_epoch}"
     )]
     OldKeySharePrepare { epoch: i32, stored_epoch: i32 },
@@ -41,7 +45,7 @@ pub enum Error {
     KeyShareAlreadyExists { epoch: i32 },
 
     #[error("Rack UUID mismatch: Expected: {expected}, Actual: {actual:?}")]
-    RackUuidMismatch { expected: String, actual: Option<String> },
+    RackUuidMismatch { expected: Uuid, actual: Option<Uuid> },
 
     #[error("Rack not initialized")]
     RackNotInitialized,

--- a/bootstore/src/db/error.rs
+++ b/bootstore/src/db/error.rs
@@ -40,8 +40,8 @@ pub enum Error {
     #[error("A distinct key share already exists for epoch {epoch}")]
     KeyShareAlreadyExists { epoch: i32 },
 
-    #[error("Rack UUID mismatch: Expected: {expected}, Actual: {actual}")]
-    RackUuidMismatch { expected: String, actual: String },
+    #[error("Rack UUID mismatch: Expected: {expected}, Actual: {actual:?}")]
+    RackUuidMismatch { expected: String, actual: Option<String> },
 
     #[error("Rack not initialized")]
     RackNotInitialized,

--- a/bootstore/src/db/error.rs
+++ b/bootstore/src/db/error.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! DB related errors
+
+use diesel::result::ConnectionError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to open db connection to {path}: {err}")]
+    DbOpen { path: String, err: ConnectionError },
+
+    #[error(transparent)]
+    Db(#[from] diesel::result::Error),
+
+    #[error(transparent)]
+    Bcs(#[from] bcs::Error),
+
+    // Temporary until the using code is written
+    #[allow(dead_code)]
+    #[error("Share commit for {epoch} does not match prepare")]
+    CommitHashMismatch { epoch: i32 },
+
+    #[error("No shares have been committed")]
+    NoSharesCommitted,
+
+    #[error("DB invariant violated: {0}")]
+    DbInvariant(String),
+
+    #[error("Already initialized with rack uuid: {0}")]
+    AlreadyInitialized(String),
+}

--- a/bootstore/src/db/macros.rs
+++ b/bootstore/src/db/macros.rs
@@ -4,12 +4,16 @@
 
 //! Macros used to create ToSql and FromSql impls required by Diesel
 
-/// Shamelessly stolen from buildomat/common/src/db.rs
+/// Shamelessly cribbed and mutated from buildomat/common/src/db.rs
 /// Thanks @jmc
 macro_rules! bcs_new_type {
     ($name:ident, $mytype:ty) => {
         #[derive(
-            Clone, Debug, FromSqlRow, diesel::expression::AsExpression,
+            Clone,
+            PartialEq,
+            Debug,
+            FromSqlRow,
+            diesel::expression::AsExpression,
         )]
         #[diesel(sql_type = diesel::sql_types::Binary)]
         pub struct $name(pub $mytype);

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -422,5 +422,6 @@ pub mod tests {
         assert_matches!(err, diesel::result::Error::DatabaseError(_, s) => {
             assert_eq!("maximum one rack", s.message());
         });
+        logctx.cleanup_successful();
     }
 }

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -135,36 +135,23 @@ impl Db {
     pub fn get_latest_committed_share(
         &mut self,
     ) -> Result<(i32, Share), Error> {
-        self.conn.immediate_transaction(|tx| {
-            let epoch = Self::get_latest_committed_share_epoch(tx)?;
-            if epoch.is_none() {
-                return Err(Error::NoSharesCommitted);
-            }
-            let epoch = epoch.unwrap();
-            let share = Self::get_prepared_share(tx, epoch)?;
-            Ok((epoch, share))
-        })
+        use schema::key_shares::dsl;
+        let res = dsl::key_shares
+            .select((dsl::epoch, dsl::share))
+            .order(dsl::epoch.desc())
+            .filter(dsl::committed.eq(true))
+            .get_result::<(i32, Share)>(&mut self.conn)?;
+        Ok(res)
     }
 
-    pub fn get_latest_committed_share_epoch(
-        tx: &mut SqliteConnection,
-    ) -> Result<Option<i32>, Error> {
-        use schema::key_share_commits::dsl;
-        let epoch = dsl::key_share_commits
-            .select(diesel::dsl::max(dsl::epoch))
-            .get_result(tx)?;
-        Ok(epoch)
-    }
-
-    pub fn get_prepared_share(
-        tx: &mut SqliteConnection,
-        epoch: i32,
-    ) -> Result<Share, Error> {
-        use schema::key_share_prepares::dsl;
-        let share = dsl::key_share_prepares
+    pub fn get_committed_share(&mut self, epoch: i32) -> Result<Share, Error> {
+        use schema::key_shares::dsl;
+        let share = dsl::key_shares
             .select(dsl::share)
             .filter(dsl::epoch.eq(epoch))
-            .get_result(tx)?;
+            .filter(dsl::committed.eq(true))
+            .get_result::<Share>(&mut self.conn)?;
+
         Ok(share)
     }
 }

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -6,7 +6,7 @@
 
 mod error;
 mod macros;
-mod models;
+pub(crate) mod models;
 mod schema;
 
 use diesel::connection::SimpleConnection;
@@ -85,7 +85,10 @@ impl Db {
         epoch: i32,
         share: SerializableShareDistribution,
     ) -> Result<(), Error> {
-        info!(self.log, "Writing key share prepare for {epoch} to the Db");
+        info!(
+            self.log,
+            "Writing key share prepare for epoch {epoch} to the Db"
+        );
         use schema::key_shares::dsl;
         let prepare = KeyShare::new(epoch, share)?;
         diesel::insert_into(dsl::key_shares).values(&prepare).execute(tx)?;
@@ -252,14 +255,14 @@ impl Db {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::trust_quorum::{RackSecret, ShareDistribution};
     use omicron_test_utils::dev::test_setup_log;
     use sha3::{Digest, Sha3_256};
 
     // TODO: Fill in with actual member certs
-    fn new_shares() -> Vec<ShareDistribution> {
+    pub fn new_shares() -> Vec<ShareDistribution> {
         let member_device_id_certs = vec![];
         let rack_secret_threshold = 3;
         let total_shares = 5;

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -226,6 +226,8 @@ impl Db {
     // and insert the new one.
     //
     // Return the old rack UUID if one exists
+    //
+    // TODO: Add a DB trigger to ensure only 1 row can exist at a time?
     fn initialize_rack_uuid(
         &self,
         tx: &mut SqliteConnection,

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -228,8 +228,6 @@ fn insert_prepare(
 // and insert the new one.
 //
 // Return the old rack UUID if one exists
-//
-// TODO: Add a DB trigger to ensure only 1 row can exist at a time?
 fn initialize_rack_uuid(
     tx: &mut SqliteConnection,
     new_uuid: &Uuid,

--- a/bootstore/src/db/models.rs
+++ b/bootstore/src/db/models.rs
@@ -101,3 +101,9 @@ impl From<sprockets_common::Sha3_256Digest> for Sha3_256Digest {
         Sha3_256Digest(digest.0)
     }
 }
+
+impl From<Sha3_256Digest> for sprockets_common::Sha3_256Digest {
+    fn from(digest: Sha3_256Digest) -> Self {
+        sprockets_common::Sha3_256Digest(digest.0)
+    }
+}

--- a/bootstore/src/db/models.rs
+++ b/bootstore/src/db/models.rs
@@ -8,6 +8,7 @@ use diesel::deserialize::FromSql;
 use diesel::prelude::*;
 use diesel::serialize::ToSql;
 use diesel::FromSqlRow;
+use uuid::Uuid;
 
 use super::macros::array_new_type;
 use super::macros::bcs_new_type;
@@ -27,14 +28,21 @@ pub struct KeyShare {
     pub committed: bool,
 }
 
-// A chacha20poly1305 secret encrypted by a chacha20poly1305 secret key
-// derived from the rack secret for the given epoch with the given salt
-//
-// The epoch informs which rack secret should be used to derive the
-// encryptiong key used to encrypt this root secret.
-//
-// TODO-security: We probably don't want to log even the encrypted secret, but
-// it's likely useful for debugging right now.
+/// Information about the rack
+#[derive(Debug, Queryable, Insertable)]
+#[diesel(table_name = rack)]
+pub struct Rack {
+    pub uuid: String,
+}
+
+/// A chacha20poly1305 secret encrypted by a chacha20poly1305 secret key
+/// derived from the rack secret for the given epoch with the given salt
+///
+/// The epoch informs which rack secret should be used to derive the
+/// encryptiong key used to encrypt this root secret.
+///
+/// TODO-security: We probably don't want to log even the encrypted secret, but
+/// it's likely useful for debugging right now.
 #[derive(Debug, Queryable, Insertable)]
 pub struct EncryptedRootSecret {
     /// The epoch of the rack secret rotation or rack reconfiguration

--- a/bootstore/src/db/models.rs
+++ b/bootstore/src/db/models.rs
@@ -21,7 +21,9 @@ bcs_new_type!(Share, SerializableShareDistribution);
 /// When a [`KeyShareParepare`] message arrives it is stored in a [`KeyShare`]
 /// When a [`KeyShareCommit`] message arrives the `committed` field/column is
 /// set to true.
-#[derive(Debug, Queryable, Insertable, Identifiable, AsChangeset)]
+#[derive(
+    Debug, PartialEq, Queryable, Insertable, Identifiable, AsChangeset,
+)]
 #[diesel(primary_key(epoch))]
 pub struct KeyShare {
     pub epoch: i32,

--- a/bootstore/src/db/schema.rs
+++ b/bootstore/src/db/schema.rs
@@ -14,6 +14,12 @@ table! {
 }
 
 table! {
+    rack(uuid) {
+        uuid -> Text,
+    }
+}
+
+table! {
     encrypted_root_secrets(epoch) {
         epoch -> Integer,
         salt -> Binary,

--- a/bootstore/src/db/schema.sql
+++ b/bootstore/src/db/schema.sql
@@ -7,6 +7,12 @@ CREATE TABLE IF NOT EXISTS key_shares (
     PRIMARY KEY (epoch)
 );
 
+CREATE TABLE IF NOT EXISTS rack (
+    uuid             TEXT     NOT NULL,
+    
+    PRIMARY KEY (uuid)
+);
+
 CREATE TABLE IF NOT EXISTS encrypted_root_secrets (
     epoch            INTEGER    NOT NULL,
     salt             BLOB       NOT NULL,

--- a/bootstore/src/db/schema.sql
+++ b/bootstore/src/db/schema.sql
@@ -22,3 +22,13 @@ CREATE TABLE IF NOT EXISTS encrypted_root_secrets (
     PRIMARY KEY (epoch)
     FOREIGN KEY (epoch) REFERENCES key_share_prepares (epoch)
 );
+
+-- Ensure there is no more than one rack row
+-- We rollback the whole transaction in the case of a constraint
+-- violation, since we have broken an invariant and should not proceed.
+CREATE TRIGGER ensure_rack_contains_at_most_one_row 
+BEFORE INSERT ON rack
+WHEN (SELECT COUNT(*) FROM rack) >= 1
+BEGIN
+    SELECT RAISE(ROLLBACK, 'maximum one rack');
+END;

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -116,6 +116,12 @@ pub enum NodeError {
     //TODO: Should probably pull out the variants for better matching
     #[error("DB error: {0}")]
     Db(String),
+
+    #[error(
+        "'KeySharePrepare' messages are not allowed for epoch 0.
+Please send an 'Initialize' message"
+    )]
+    KeySharePrepareForEpoch0,
 }
 
 impl From<db::Error> for NodeError {

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -65,7 +65,11 @@ pub enum NodeOp {
 
     /// A request from a [`Coordinator`] for the Commit phase of a
     /// rekey or reconfiguration
-    KeyShareCommit { rack_uuid: Uuid, epoch: i32 },
+    KeyShareCommit {
+        rack_uuid: Uuid,
+        epoch: i32,
+        prepare_share_distribution_digest: sprockets_common::Sha3_256Digest,
+    },
 }
 
 /// A response from a  [`Node`] to another [`Node`] or a [`Coordinator`]

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -112,7 +112,7 @@ pub enum NodeError {
     AlreadyInitialized { rack_uuid: Uuid },
 
     #[error(
-        "No corresponding key share prepare for this commit: rack UUID:
+        "No corresponding key share prepare for this commit: rack UUID: \
 {rack_uuid}, epoch: {epoch}"
     )]
     MissingKeySharePrepare { rack_uuid: Uuid, epoch: i32 },
@@ -121,7 +121,7 @@ pub enum NodeError {
     Db(db::Error),
 
     #[error(
-        "'KeySharePrepare' messages are not allowed for epoch 0.
+        "'KeySharePrepare' messages are not allowed for epoch 0. \
 Please send an 'Initialize' message"
     )]
     KeySharePrepareForEpoch0,

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -90,7 +90,7 @@ pub enum NodeOpResult {
 
 /// Errors returned inside a [`NodeOpResult`]
 #[derive(
-    Debug, Clone, PartialEq, From, Serialize, Deserialize, thiserror::Error,
+    Debug, PartialEq, Clone, From, Serialize, Deserialize, thiserror::Error,
 )]
 pub enum NodeError {
     #[error("Version {0} messages are unsupported.")]
@@ -113,19 +113,12 @@ pub enum NodeError {
     )]
     MissingKeySharePrepare { rack_uuid: Uuid, epoch: i32 },
 
-    //TODO: Should probably pull out the variants for better matching
     #[error("DB error: {0}")]
-    Db(String),
+    Db(db::Error),
 
     #[error(
         "'KeySharePrepare' messages are not allowed for epoch 0.
 Please send an 'Initialize' message"
     )]
     KeySharePrepareForEpoch0,
-}
-
-impl From<db::Error> for NodeError {
-    fn from(err: db::Error) -> Self {
-        NodeError::Db(err.to_string())
-    }
 }

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -83,7 +83,8 @@ pub enum NodeOpResult {
     /// A key share for a given epoch as requested by [`PeerRequest::GetShare`]
     Share { epoch: i32, share: Share },
 
-    /// An ack for the most recent coordinator message
+    /// An ack for the most recent coordinator message, where there is no data
+    /// to return
     CoordinatorAck,
 }
 

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use vsss_rs::Share;
 
+use crate::db;
 use crate::trust_quorum::SerializableShareDistribution;
 
 /// A request sent to a [`Node`] from another [`Node`] or a [`Coordinator`].
@@ -110,4 +111,13 @@ pub enum NodeError {
 {rack_uuid}, epoch: {epoch}"
     )]
     MissingKeySharePrepare { rack_uuid: Uuid, epoch: i32 },
+
+    #[error("DB error: {0}")]
+    Db(String),
+}
+
+impl From<db::Error> for NodeError {
+    fn from(err: db::Error) -> Self {
+        NodeError::Db(err.to_string())
+    }
 }

--- a/bootstore/src/messages.rs
+++ b/bootstore/src/messages.rs
@@ -113,6 +113,7 @@ pub enum NodeError {
     )]
     MissingKeySharePrepare { rack_uuid: Uuid, epoch: i32 },
 
+    //TODO: Should probably pull out the variants for better matching
     #[error("DB error: {0}")]
     Db(String),
 }

--- a/bootstore/src/node.rs
+++ b/bootstore/src/node.rs
@@ -177,9 +177,13 @@ mod tests {
             .commit_share(&mut node.conn, epoch, prepare.share_digest.into())
             .unwrap();
 
-        assert!(node
-            .handle_initialize(&rack_uuid, shares[0].clone().into())
-            .is_err());
+        let expected = Err(NodeError::Db(
+            crate::db::Error::AlreadyInitialized(rack_uuid.to_string()),
+        ));
+        assert_eq!(
+            expected,
+            node.handle_initialize(&rack_uuid, shares[0].clone().into())
+        );
 
         logctx.cleanup_successful();
     }

--- a/bootstore/src/node.rs
+++ b/bootstore/src/node.rs
@@ -185,7 +185,7 @@ mod tests {
         let rack_uuid = Uuid::new_v4();
         assert_eq!(expected, node.handle_initialize(&rack_uuid, sd.clone()));
 
-        // We can re-initialize with a the same uuid
+        // We can re-initialize with the same uuid
         assert_eq!(expected, node.handle_initialize(&rack_uuid, sd.clone()));
 
         // Committing the key share for epoch 0 means we cannot initialize again
@@ -200,9 +200,8 @@ mod tests {
             )
             .unwrap();
 
-        let expected = Err(NodeError::Db(db::Error::AlreadyInitialized(
-            rack_uuid.to_string(),
-        )));
+        let expected =
+            Err(NodeError::Db(db::Error::AlreadyInitialized(rack_uuid)));
         assert_eq!(expected, node.handle_initialize(&rack_uuid, sd));
 
         logctx.cleanup_successful();
@@ -298,8 +297,8 @@ mod tests {
         let epoch = 1;
         assert_eq!(
             Err(NodeError::Db(db::Error::RackUuidMismatch {
-                expected: bad_uuid.to_string(),
-                actual: Some(rack_uuid.to_string())
+                expected: bad_uuid,
+                actual: Some(rack_uuid)
             })),
             node.handle_key_share_prepare(&bad_uuid, epoch, sd.clone())
         );

--- a/bootstore/src/node.rs
+++ b/bootstore/src/node.rs
@@ -12,7 +12,6 @@ use slog::Logger;
 //use sprockets_host::Ed25519Certificate;
 use uuid::Uuid;
 
-use crate::db;
 use crate::db::Db;
 use crate::messages::*;
 use crate::trust_quorum::SerializableShareDistribution;
@@ -93,18 +92,8 @@ impl Node {
         &mut self,
         epoch: i32,
     ) -> Result<NodeOpResult, NodeError> {
-        match self.db.get_committed_share(&mut self.conn, epoch) {
-            Ok(share) => {
-                Ok(NodeOpResult::Share { epoch, share: share.0.share })
-            }
-            Err(err) => {
-                if let db::Error::Db(diesel::result::Error::NotFound) = err {
-                    Err(NodeError::KeyShareDoesNotExist { epoch })
-                } else {
-                    Err(err.into())
-                }
-            }
-        }
+        let share = self.db.get_committed_share(&mut self.conn, epoch)?;
+        Ok(NodeOpResult::Share { epoch, share: share.0.share })
     }
 
     // Handle `Initialize` messages from the coordinator

--- a/bootstore/src/node.rs
+++ b/bootstore/src/node.rs
@@ -111,7 +111,8 @@ impl Node {
         rack_uuid: Uuid,
         share_distribution: SerializableShareDistribution,
     ) -> Result<NodeOpResult, NodeError> {
-        unimplemented!();
+        self.db.initialize(&mut self.conn, &rack_uuid, share_distribution)?;
+        Ok(NodeOpResult::CoordinatorAck)
     }
 
     fn handle_key_share_prepare(

--- a/test-utils/src/dev/mod.rs
+++ b/test-utils/src/dev/mod.rs
@@ -11,7 +11,7 @@ pub mod poll;
 pub mod test_cmds;
 
 use anyhow::Context;
-use dropshot::test_util::LogContext;
+pub use dropshot::test_util::LogContext;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingIfExists;
 use dropshot::ConfigLoggingLevel;


### PR DESCRIPTION
This is the second PR of the `bootstore` implementation. It creates handler methods for all existing messages and their corresponding DB requirements. RFD 238 section 5 will need to be updated to reflect this flow.

The way the flow currently is supposed to work is that there is a coordinator (coming in a follow up PR) that sends the following messages to initialize the trust quorum: 
 * `Initialize`
 * `KeyShareCommit` (for epoch 0)

`Initialize` can be sent multiple times until the `KeyShareCommit` for epoch 0 locks in the configuration and Rack UUID. This allows the initial coordinator (RSS) to die, and even have its local storage or entire sled die, and still allow us to make progress via a new RSS. Importantly, once wired through the system, the coordinator will negotiate (via sled-agent and nexus) to write the `KeyShareCommit` to CockroachDB before sending it to all nodes. This ensures that the rack initialization will complete and CockroachDB only has to be setup once. There are some tricky failure modes here, but none of that is in this PR, so we can move on. The important point here is that once a `KeyShareCommit` for epoch 0 succeeds the rack is initialized.

After initialization, reconfiguration of the trust quorum can take place. Reconfiguration messages must be issued with the same Rack UUID. A reconfiguration consists of a `KeySharePrepare` for an `epoch > 0` followed by a `KeyShareCommit` for the same epoch. After initialization a `KeySharePrepare` can never be mutated. However, to allow for certain failures, such as the failure of a node being prepared to ack (since we require unanimous acknowledgement in 2PC), we allow for new `KeySharePrepare`s at higher epochs to proceed. We keep track of these epochs in CockroachDB to maintain linearizability. Once a node receives a prepare for a higher epoch, it will no longer accept prepare or commit messages for any lower epoch. Once a successful `KeyShareCommit` is handled, the sled is now operating at the new epoch. 

`GetShare` requests are used to unlock trust quorum. They will rely on sprockets at the network level for authentication, confidentiality, integrity, and attestation. Some DeviceId membership validation will also be added to `Node`in future commits as it currently exists in sled agent. 

This is an incremental PR and there is still a lot to do here. Follow up commits will:
 * Add more negative tests (possibly in this PR also)
 * Add code for a coordinator
 * Add a mechanism to store the encrypted (wrapped) root secret for each epoch and likely include it in each `KeySharePrepare`. This is the most straightforward way to transfer wrapped secrets. We can get more sophisticated in the future. Again, this needs to be written up in RFD 238, but I'm likely to just implement it within the next week and see how it works first.
 * Add some key derivation from the root secret such that we can use these keys to encrypt and decrypt storage
 * Add property based tests to simulate a full cluster along with failures and ensure rack unlock works according to the model and ensure that we can *always* unlock encrypted storage while tolerating our prescribed failure conditions within the model.

After that, the `bootstore` will basically be implemented at a non-network level. We'll then likely want to port over the sprockets code from the bootstrap agent to a higher level here, and use the `Node` and `Coordinator` from that level, which will end up interacting with Nexus and CockroachDB via the sled-agent. Multiple tasks will be utilizing the `Node` and its underlying `Db` at this point and so we'll need some concurrency control. I've given this a bit of thought and my current thinking is to have the `Node` running in it's own thread and serialize all operation via a channel. Outside of reconfiguration, all operations are reads, and we can simply cache the current share in memory for rack unlock purposes (e.g. `GetShare`). During reconfiguration, we'll mutate the DB as necessary, and refresh our cache. This strategy avoids the need for mutexes and has the characteristic that the `Node` and `Db` code we run in a single threaded manner in property based tests is actually running the same way in production with just a single DB connection. This strategy isn't set in stone, but in my mind it's the easiest to reason about and also the easiest way to hook async to sync code. 

I tagged @jclulow here because he's a SQLite maven, and wanted a quick look to see if I'm doing things in a sane manner. Any tips would be appreciated. I expect @jgallagher to be my primary logic reviewer for the rest of this :)