### PR TITLE
Catch EEXIST and retry while creating xde devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,6 +3119,7 @@ dependencies = [
  "internal-dns-client",
  "ipnetwork",
  "libc",
+ "libnet",
  "macaddr",
  "mockall",
  "nexus-client",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.24"
 internal-dns-client = { path = "../internal-dns-client" }
 ipnetwork = "0.20"
 libc = "0.2.132"
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }
 macaddr = { version = "1.0.1", features = [ "serde_std" ] }
 nexus-client = { path = "../nexus-client" }
 omicron-common = { path = "../common" }


### PR DESCRIPTION
An alternate implementation of https://github.com/oxidecomputer/omicron/pull/1685 to handle the defunct xde devices.
