### PR TITLE
Fix ownership bug in OPTE port management that can lead to deadlock

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -517,14 +517,14 @@ impl Instance {
             } else {
                 (None, None)
             };
-            let port = inner.port_manager.create_port(
+            let (port, port_ticket) = inner.port_manager.create_port(
                 *inner.id(),
                 nic,
                 snat,
                 external_ips,
             )?;
-            port_tickets.push(port.ticket());
             opte_ports.push(port);
+            port_tickets.push(port_ticket);
         }
 
         // Create a zone for the propolis instance, using the previously
@@ -711,13 +711,19 @@ impl Instance {
         running_state.instance_ticket.terminate();
 
         // And remove the OPTE ports from the port manager
+        let mut result = Ok(());
         if let Some(tickets) = running_state.port_tickets.as_mut() {
             for ticket in tickets.iter_mut() {
-                ticket.release()?;
+                // Release the port from the manager, and store any error. We
+                // don't return immediately so that we can try to clean up all
+                // ports, even if early ones fail. Return the last error, which
+                // is OK for now.
+                if let Err(e) = ticket.release() {
+                    result = Err(e.into());
+                }
             }
         }
-
-        Ok(())
+        result
     }
 
     // Monitors propolis until explicitly told to disconnect.

--- a/sled-agent/src/opte/illumos/port.rs
+++ b/sled-agent/src/opte/illumos/port.rs
@@ -7,7 +7,6 @@
 use crate::illumos::dladm::Dladm;
 use crate::opte::BoundaryServices;
 use crate::opte::Gateway;
-use crate::opte::PortTicket;
 use crate::opte::Vni;
 use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
@@ -18,8 +17,6 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 struct PortInner {
-    // Contains instance ID and a pointer to the parent manager
-    ticket: PortTicket,
     // Name of the port as identified by OPTE
     name: String,
     // IP address within the VPC Subnet
@@ -36,7 +33,7 @@ struct PortInner {
     _underlay_ip: Ipv6Addr,
     // The external IP address and port range provided for this port, to allow
     // outbound network connectivity.
-    source_nat: Option<SourceNatConfig>,
+    _source_nat: Option<SourceNatConfig>,
     // The external IP addresses provided to this port, to allow _inbound_
     // network connectivity.
     external_ips: Option<Vec<IpAddr>>,
@@ -105,7 +102,6 @@ pub struct Port {
 impl Port {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        ticket: PortTicket,
         name: String,
         ip: IpAddr,
         subnet: IpNetwork,
@@ -121,7 +117,6 @@ impl Port {
     ) -> Self {
         Self {
             inner: Arc::new(PortInner {
-                ticket,
                 name,
                 _ip: ip,
                 _subnet: subnet,
@@ -129,17 +124,13 @@ impl Port {
                 slot,
                 _vni: vni,
                 _underlay_ip: underlay_ip,
-                source_nat,
+                _source_nat: source_nat,
                 external_ips,
                 _gateway: gateway,
                 _boundary_services: boundary_services,
                 vnic,
             }),
         }
-    }
-
-    pub fn source_nat(&self) -> &Option<SourceNatConfig> {
-        &self.inner.source_nat
     }
 
     pub fn external_ips(&self) -> &Option<Vec<IpAddr>> {
@@ -156,9 +147,5 @@ impl Port {
 
     pub fn slot(&self) -> u8 {
         self.inner.slot
-    }
-
-    pub fn ticket(&self) -> PortTicket {
-        self.inner.ticket.clone()
     }
 }

--- a/sled-agent/src/opte/non_illumos/port.rs
+++ b/sled-agent/src/opte/non_illumos/port.rs
@@ -6,7 +6,6 @@
 
 use crate::opte::BoundaryServices;
 use crate::opte::Gateway;
-use crate::opte::PortTicket;
 use crate::opte::Vni;
 use crate::params::SourceNatConfig;
 use ipnetwork::IpNetwork;
@@ -18,8 +17,6 @@ use std::sync::Arc;
 #[derive(Debug)]
 #[allow(dead_code)]
 struct PortInner {
-    // Contains instance ID and a pointer to the parent manager
-    ticket: PortTicket,
     // Name of the port as identified by OPTE
     name: String,
     // IP address within the VPC Subnet
@@ -70,7 +67,6 @@ pub struct Port {
 impl Port {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        ticket: PortTicket,
         name: String,
         ip: IpAddr,
         subnet: IpNetwork,
@@ -86,7 +82,6 @@ impl Port {
     ) -> Self {
         Self {
             inner: Arc::new(PortInner {
-                ticket,
                 name,
                 _ip: ip,
                 _subnet: subnet,
@@ -103,10 +98,6 @@ impl Port {
         }
     }
 
-    pub fn source_nat(&self) -> &Option<SourceNatConfig> {
-        &self.inner.source_nat
-    }
-
     pub fn external_ips(&self) -> &Option<Vec<IpAddr>> {
         &self.inner.external_ips
     }
@@ -121,9 +112,5 @@ impl Port {
 
     pub fn slot(&self) -> u8 {
         self.inner.slot
-    }
-
-    pub fn ticket(&self) -> PortTicket {
-        self.inner.ticket.clone()
     }
 }


### PR DESCRIPTION
- Remove the `PortInner` and `PortTicket` objects, making `Port` the sole owner of information about the OPTE port.
- Remove the copy of `Port`s that the `PortManager` had previously, obviating all the double-ownership possibilities. The port was only stored here so that secondary MAC addresses can be updated as ports are added / removed. That's entirely part of the external IP address hack in OPTE. Now, the manager stores only the MAC itself. The `Port` has a reference to its manager, and removes its MAC from the managers list when the port is dropped. But there is only a single owner and copy of the `Port` itself, owned by the zone and dropped when that is torn down.