### PR TITLE
MGS: Housekeeping updates on the way to host boot flash updates

### DIFF
--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 futures = "0.3.24"
+once_cell = "1.14.0"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.0.1"
@@ -25,5 +26,4 @@ version = "1.21"
 features = [ "full" ]
 
 [dev-dependencies]
-once_cell = "1.14"
 omicron-test-utils = { path = "../test-utils" }

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -47,12 +47,14 @@ pub enum StartupError {
     InvalidConfig { reasons: Vec<String> },
     #[error("error communicating with SP: {0}")]
     SpCommunicationFailed(#[from] SpCommunicationError),
-    #[error("location discovery failed: {reason}")]
-    DiscoveryFailed { reason: String },
 }
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("discovery process not yet complete")]
+    DiscoveryNotYetComplete,
+    #[error("location discovery failed: {reason}")]
+    DiscoveryFailed { reason: String },
     #[error("nonexistent SP (type {:?}, slot {})", .0.typ, .0.slot)]
     SpDoesNotExist(SpIdentifier),
     #[error("unknown socket address for local ignition controller")]

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -74,7 +74,6 @@ switch0 = ["sled", 1]
 switch1 = ["sled", 1]
 
 [timeouts]
-discovery_millis = 1_000
 bulk_request_default_millis = 5_000
 bulk_request_max_millis = 60_000
 bulk_request_page_millis = 1_000

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -82,7 +82,7 @@ bulk_request_retain_grace_period_millis = 10_000
 [dropshot]
 # IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12222"
-request_body_max_bytes = 1048576
+request_body_max_bytes = 67108864 # 64 MiB
 
 [log]
 # Show log messages of this level and more severe

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -14,9 +14,6 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Timeouts {
-    /// Timeout for running the discovery process to determine logical mappings
-    /// of switches/sleds.
-    pub discovery_millis: u64,
     /// Default timeout for requests that collect responses from multiple
     /// targets, if the client doesn't provide one.
     pub bulk_request_default_millis: u64,

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -7,7 +7,6 @@ use gateway_sp_comms::Communicator;
 use gateway_sp_comms::{error::StartupError, SwitchConfig};
 use slog::Logger;
 use std::{sync::Arc, time::Duration};
-use tokio::time::Instant;
 
 /// Shared state used by API request handlers
 pub struct ServerContext {
@@ -49,11 +48,7 @@ impl ServerContext {
         timeouts: crate::config::Timeouts,
         log: &Logger,
     ) -> Result<Arc<Self>, StartupError> {
-        let discovery_deadline =
-            Instant::now() + Duration::from_millis(timeouts.discovery_millis);
-        let comms = Arc::new(
-            Communicator::new(switch_config, discovery_deadline, log).await?,
-        );
+        let comms = Arc::new(Communicator::new(switch_config, log).await?);
         Ok(Arc::new(ServerContext {
             sp_comms: Arc::clone(&comms),
             bulk_sp_state_requests: BulkSpStateRequests::new(comms, log),

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -61,7 +61,12 @@ where
             Some("SerialConsoleAttached".to_string()),
             err.to_string(),
         ),
+        SpCommsError::DiscoveryNotYetComplete => HttpError::for_unavail(
+            Some("DiscoveryNotYetComplete".to_string()),
+            err.to_string(),
+        ),
         SpCommsError::SpAddressUnknown(_)
+        | SpCommsError::DiscoveryFailed { .. }
         | SpCommsError::Timeout { .. }
         | SpCommsError::BadIgnitionTarget(_)
         | SpCommsError::LocalIgnitionControllerAddressUnknown

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -27,7 +27,6 @@ use dropshot::ResultsPage;
 use dropshot::TypedBody;
 use dropshot::WhichPage;
 use gateway_messages::IgnitionCommand;
-use gateway_messages::SpComponent;
 use gateway_sp_comms::error::Error as SpCommsError;
 use gateway_sp_comms::Timeout as SpTimeout;
 use schemars::JsonSchema;
@@ -486,36 +485,12 @@ async fn sp_component_serial_console_detach(
 // TODO: how can we make this generic enough to support any update mechanism?
 #[derive(Deserialize, JsonSchema)]
 pub struct UpdateBody {
+    /// The binary blob containing the update image (component-specific).
     pub image: Vec<u8>,
+    /// The update slot to apply this image to. Supply 0 if the component only
+    /// has one update slot.
+    pub slot: u16,
 }
-
-/// Update an SP
-///
-/// Copies a new image to the alternate bank of the SP flash.
-#[endpoint {
-    method = POST,
-    path = "/sp/{type}/{slot}/update",
-}]
-async fn sp_update(
-    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path: Path<PathSp>,
-    body: TypedBody<UpdateBody>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let comms = &rqctx.context().sp_comms;
-    let sp = path.into_inner().sp;
-    let image = body.into_inner().image;
-
-    comms
-        .update(sp.into(), SpComponent::SP_ITSELF, 0, image)
-        .await
-        .map_err(http_err_from_comms_err)?;
-
-    Ok(HttpResponseUpdatedNoContent {})
-}
-
-// TODO-completeness: Either add a new endpoint to allow for updating
-// components, or expand the above endpoint to cover that case in addition to
-// updating the SP itself.
 
 /// Reset an SP
 #[endpoint {
@@ -545,16 +520,28 @@ async fn sp_reset(
 /// Note that not all components may be updated; components without known
 /// update mechanisms will return an error without any inspection of the
 /// update bundle.
+///
+/// Updating the SP itself is done via the component name `sp`.
 #[endpoint {
     method = POST,
     path = "/sp/{type}/{slot}/component/{component}/update",
 }]
 async fn sp_component_update(
-    _rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    _path: Path<PathSpComponent>,
-    _body: TypedBody<UpdateBody>,
-) -> Result<HttpResponseOk<ResultsPage<SpComponentInfo>>, HttpError> {
-    todo!()
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path: Path<PathSpComponent>,
+    body: TypedBody<UpdateBody>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let comms = &rqctx.context().sp_comms;
+    let PathSpComponent { sp, component } = path.into_inner();
+    let component = component_from_str(&component)?;
+    let UpdateBody { image, slot } = body.into_inner();
+
+    comms
+        .update(sp.into(), component, slot, image)
+        .await
+        .map_err(http_err_from_comms_err)?;
+
+    Ok(HttpResponseUpdatedNoContent {})
 }
 
 /// Power on an SP component
@@ -702,7 +689,6 @@ pub fn api() -> GatewayApiDescription {
     ) -> Result<(), String> {
         api.register(sp_list)?;
         api.register(sp_get)?;
-        api.register(sp_update)?;
         api.register(sp_reset)?;
         api.register(sp_component_list)?;
         api.register(sp_component_get)?;

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -313,22 +313,8 @@ async fn sp_list(
             let details = match result {
                 Ok(details) => details,
                 Err(err) => match &*err {
-                    // TODO Treating "communication failed" and "we don't know
-                    // the IP address" as "unresponsive" may not be right. Do we
-                    // need more refined errors?
-                    SpCommsError::Timeout { .. }
-                    | SpCommsError::SpCommunicationFailed(_)
-                    | SpCommsError::BadIgnitionTarget(_)
-                    | SpCommsError::LocalIgnitionControllerAddressUnknown
-                    | SpCommsError::SpAddressUnknown(_) => {
-                        SpState::Unresponsive
-                    }
-                    // These errors should not be possible for the request we
-                    // made.
-                    SpCommsError::SpDoesNotExist(_)
-                    | SpCommsError::UpdateFailed(_) => {
-                        unreachable!("impossible error {}", err)
-                    }
+                    SpCommsError::Timeout { .. } => SpState::Unresponsive,
+                    _ => return Err(err),
                 },
             };
             Ok(SpInfo {

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -82,7 +82,6 @@ switch0 = ["sled", 1]
 switch1 = ["sled", 1]
 
 [timeouts]
-discovery_millis = 10_000
 bulk_request_default_millis = 10_000
 bulk_request_max_millis = 40_000
 bulk_request_page_millis = 2_000

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -22,8 +22,14 @@ async fn discovery_both_locations() {
 
     // the two instances should've discovered that they were switch0 and
     // switch1, respectively
-    assert_eq!(testctx0.server.apictx.sp_comms.location_name(), "switch0");
-    assert_eq!(testctx1.server.apictx.sp_comms.location_name(), "switch1");
+    assert_eq!(
+        testctx0.server.apictx.sp_comms.location_name().unwrap(),
+        "switch0"
+    );
+    assert_eq!(
+        testctx1.server.apictx.sp_comms.location_name().unwrap(),
+        "switch1"
+    );
 
     // both instances should report the same serial number for switch 0 and
     // switch 1, and it should match the expected values from the config

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -544,7 +544,7 @@
     "/sp/{type}/{slot}/component/{component}/update": {
       "post": {
         "summary": "Update an SP component",
-        "description": "Update a component of an SP according to its specific update mechanism. This interface is generic for all component types, but resolves to a mechanism specific to the given component type. This may fail for a variety of reasons including the update bundle being invalid or improperly specified or due to an error originating from the SP itself.\nNote that not all components may be updated; components without known update mechanisms will return an error without any inspection of the update bundle.",
+        "description": "Update a component of an SP according to its specific update mechanism. This interface is generic for all component types, but resolves to a mechanism specific to the given component type. This may fail for a variety of reasons including the update bundle being invalid or improperly specified or due to an error originating from the SP itself.\nNote that not all components may be updated; components without known update mechanisms will return an error without any inspection of the update bundle.\nUpdating the SP itself is done via the component name `sp`.",
         "operationId": "sp_component_update",
         "parameters": [
           {
@@ -589,15 +589,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpComponentInfoResultsPage"
-                }
-              }
-            }
+          "204": {
+            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -712,56 +705,6 @@
             "style": "simple"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/sp/{type}/{slot}/update": {
-      "post": {
-        "summary": "Update an SP",
-        "description": "Copies a new image to the alternate bank of the SP flash.",
-        "operationId": "sp_update",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "slot",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "type",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SpType"
-            },
-            "style": "simple"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateBody"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "204": {
             "description": "resource updated"
@@ -1029,16 +972,24 @@
         "type": "object",
         "properties": {
           "image": {
+            "description": "The binary blob containing the update image (component-specific).",
             "type": "array",
             "items": {
               "type": "integer",
               "format": "uint8",
               "minimum": 0
             }
+          },
+          "slot": {
+            "description": "The update slot to apply this image to. Supply 0 if the component only has one update slot.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
           }
         },
         "required": [
-          "image"
+          "image",
+          "slot"
         ]
       }
     }


### PR DESCRIPTION
Each of these commits is a bit of a grab bag, so it may make sense to review them individually. This PR's existence is primarily to shrink the size of the one that will follow it. In order:

1. We remove the raw "update the SP" endpoint in favor of handling SP updates via the "update a component of the SP" endpoint with the special component name `sp`. This more closely matches the messages that MGS sends down to the SP, and reduces our API surface a bit in a way that I don't think is too confusing.
2. Remove the deadline for running discovery. This is in preparation for MGS integration into omicron, where I imagine we may have cases or environments where MGS can't run its standard discovery protocol, and I don't want it to just fail to start. Its API endpoints that are dependent on discovery (basically all of them) will return errors if discovery hasn't completed yet.
3. Bump up the max body size in the example config file; MGS needs to handle at least slightly-larger-than-32MiB bodies to accept host phase 1 images in one POST.