### PR TITLE
Give internal API user admin permission on all silos

### DIFF
--- a/nexus/src/app/saga.rs
+++ b/nexus/src/app/saga.rs
@@ -81,8 +81,10 @@ impl super::Nexus {
         };
 
         let saga_id = SagaId(Uuid::new_v4());
-        let saga_logger =
-            self.log.new(o!("saga_name" => saga.saga_name().to_string()));
+        let saga_logger = self.log.new(o!(
+            "saga_name" => saga.saga_name().to_string(),
+            "saga_id" => saga_id.to_string()
+        ));
         let saga_context = Arc::new(Arc::new(SagaContext::new(
             Arc::clone(self),
             saga_logger,

--- a/nexus/src/authz/actor.rs
+++ b/nexus/src/authz/actor.rs
@@ -82,6 +82,14 @@ impl oso::PolarClass for AuthenticatedActor {
                 },
                 "USER_DB_INIT",
             )
+            .add_constant(
+                AuthenticatedActor {
+                    actor_id: authn::USER_INTERNAL_API.id,
+                    silo_id: None,
+                    roles: RoleSet::new(),
+                },
+                "USER_INTERNAL_API",
+            )
             .add_attribute_getter("silo", |a: &AuthenticatedActor| {
                 a.silo_id.map(|silo_id| {
                     super::Silo::new(

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -481,3 +481,6 @@ has_permission(_actor: AuthenticatedActor, "query", _resource: Database);
 # The "db-init" user is the only one with the "modify" permission.
 has_permission(USER_DB_INIT: AuthenticatedActor, "modify", _resource: Database);
 has_permission(USER_DB_INIT: AuthenticatedActor, "create_child", _resource: IpPoolList);
+
+# Allow the internal API admin permissions on all silos.
+has_role(USER_INTERNAL_API: AuthenticatedActor, "admin", _silo: Silo);


### PR DESCRIPTION
This updates the built in user USER_INTERNAL_API to have admin permissions on all silos.

A new constant, USER_INTERNAL_API was added to the PolarClass and a new entry in the 
polar config file was added for this user.

Also, the `saga_id` was added to the logs to assist in tracking a sagas actions through the
authz logs:

```
{
  "msg": "authorize result",
  "v": 0,
  "name": "9ee34684-9643-4cce-b3af-f7b8825042ea",
  "level": 20,
  "time": "2022-09-13T23:44:08.460180604Z",
  "hostname": "atrium",
  "pid": 10225,
  "saga_node": "FinalizeDiskRecord",
  "actor_id": "001de000-05e4-4000-8000-000000004007",
  "authenticated": true,
  "saga_id": "976b0315-cf99-4d17-bbeb-d5c4e9c2fa55",
  "saga_name": "disk-create",
  "component": "ServerContext",
  "result": "Ok(())",
  "resource": "Database",
  "action": "Query",
  "actor": "Some(Actor::SiloUser { silo_user_id: 001de000-05e4-4000-8000-000000004007, silo_id: 001de000-5110-4000-8000-000000000000, .. })"
}
```