### PR TITLE
MGS: Flesh out host boot flash update (and rework update delivery mechanism)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "termios",
  "thiserror",
  "tokio",
+ "uuid",
  "zip",
 ]
 
@@ -1748,6 +1749,7 @@ dependencies = [
  "serde_repr",
  "smoltcp",
  "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -1759,7 +1761,6 @@ dependencies = [
  "omicron-common",
  "omicron-test-utils",
  "once_cell",
- "rand 0.8.5",
  "serde",
  "serde_with",
  "slog",
@@ -1767,6 +1768,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "usdt",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-tungstenite",
+ "uuid",
 ]
 
 [[package]]

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -13,6 +13,7 @@ slog-async = "2.6"
 slog-term = "2.9"
 tokio = { version = "1.21", features = [ "rt-multi-thread", "macros", "time" ] }
 tokio-tungstenite = "0.17"
+uuid = { version = "1.1", features = [ "v4" ] }
 
 gateway-client = { path = "../gateway-client" }
 omicron-common = { path = "../common" }

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -15,6 +15,7 @@ use futures::future::FusedFuture;
 use futures::prelude::*;
 use gateway_client::types::SpType;
 use gateway_client::types::UpdateBody;
+use slog::info;
 use slog::o;
 use slog::Drain;
 use slog::Level;
@@ -35,6 +36,7 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::WebSocketStream;
+use uuid::Uuid;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -141,6 +143,7 @@ impl Client {
     async fn update(
         &self,
         component: &str,
+        id: Uuid,
         slot: u16,
         path: &Path,
     ) -> Result<()> {
@@ -151,7 +154,7 @@ impl Client {
                 self.sp_type,
                 self.sled,
                 component,
-                &UpdateBody { image, slot },
+                &UpdateBody { id, image, slot },
             )
             .await?;
         Ok(())
@@ -194,7 +197,7 @@ async fn main() -> Result<()> {
     let drain = slog_async::Async::new(drain).build().fuse();
     let log = Logger::root(drain, o!("component" => "gateway-client"));
 
-    let client = Client::new(args.server, args.port, args.sled, log);
+    let client = Client::new(args.server, args.port, args.sled, log.clone());
 
     let term_raw = match args.command {
         Command::Attach { raw } => raw, // continue; primary use case
@@ -202,7 +205,9 @@ async fn main() -> Result<()> {
             return client.detach().await;
         }
         Command::Update { component, slot, path } => {
-            return client.update(&component, slot, &path).await;
+            let id = Uuid::new_v4();
+            info!(log, "generated update ID {id}");
+            return client.update(&component, id, slot, &path).await;
         }
         Command::Reset => {
             return client.reset().await;

--- a/gateway-messages/Cargo.toml
+++ b/gateway-messages/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.144", default-features = false, features = ["derive"] }
 serde-big-array = "0.4.1"
 serde_repr = { version = "0.1" }
 static_assertions = "1.1.0"
+uuid = { version = "1.1", default-features = false }
 
 hubpack = { git = "https://github.com/cbiffle/hubpack", rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25" }
 

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -248,7 +248,11 @@ impl fmt::Display for ResponseError {
                 write!(f, "SP has not received update prepare request")
             }
             ResponseError::InvalidUpdateId { sp_update_id } => {
-                write!(f, "bad update ID (update already in progress, ID {:#04x?})", sp_update_id.0)
+                write!(
+                    f,
+                    "bad update ID (update already in progress, ID {:#04x?})",
+                    sp_update_id.0
+                )
             }
             ResponseError::UpdateInProgress(status) => {
                 write!(f, "update still in progress ({status:?})")

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -437,6 +437,9 @@ impl SpComponent {
     /// The `sp3` host CPU.
     pub const SP3_HOST_CPU: Self = Self { id: *b"sp3-host-cpu\0\0\0\0" };
 
+    /// The host CPU boot flash.
+    pub const HOST_CPU_BOOT_FLASH: Self = Self { id: *b"host-boot-flash\0" };
+
     /// Interpret the component name as a human-readable string.
     ///
     /// Our current expectation of component names is that this should never

--- a/gateway-messages/src/lib.rs
+++ b/gateway-messages/src/lib.rs
@@ -95,6 +95,8 @@ pub enum SpPort {
 
 #[derive(Debug, Clone, Copy, SerializedSize, Serialize, Deserialize)]
 pub enum UpdateStatus {
+    /// The SP has no update status.
+    None,
     /// Returned when the SP is still preparing to apply the update with the
     /// given ID (e.g., erasing a target flash slot).
     Preparing(UpdatePreparationStatus),
@@ -151,7 +153,7 @@ pub enum ResponseKind {
     SpState(SpState),
     UpdatePrepareAck,
     UpdateChunkAck,
-    UpdateStatus(Option<UpdateStatus>),
+    UpdateStatus(UpdateStatus),
     UpdateAbortAck,
     SerialConsoleAttachAck,
     SerialConsoleWriteAck { furthest_ingested_offset: u64 },

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -89,7 +89,7 @@ pub trait SpHandler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-    ) -> Result<Option<UpdateStatus>, ResponseError>;
+    ) -> Result<UpdateStatus, ResponseError>;
 
     fn update_abort(
         &mut self,

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -4,6 +4,8 @@
 
 //! Behavior implemented by both real and simulated SPs.
 
+use crate::UpdateId;
+use crate::UpdateStatus;
 use crate::version;
 use crate::BulkIgnitionState;
 use crate::DiscoverResponse;
@@ -20,8 +22,6 @@ use crate::SpPort;
 use crate::SpState;
 use crate::UpdateChunk;
 use crate::UpdatePrepare;
-use crate::UpdatePrepareStatusRequest;
-use crate::UpdatePrepareStatusResponse;
 use core::convert::Infallible;
 use core::mem;
 
@@ -76,13 +76,6 @@ pub trait SpHandler {
         update: UpdatePrepare,
     ) -> Result<(), ResponseError>;
 
-    fn update_prepare_status(
-        &mut self,
-        sender: SocketAddrV6,
-        port: SpPort,
-        request: UpdatePrepareStatusRequest,
-    ) -> Result<UpdatePrepareStatusResponse, ResponseError>;
-
     fn update_chunk(
         &mut self,
         sender: SocketAddrV6,
@@ -91,11 +84,19 @@ pub trait SpHandler {
         data: &[u8],
     ) -> Result<(), ResponseError>;
 
+    fn update_status(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        component: SpComponent,
+    ) -> Result<Option<UpdateStatus>, ResponseError>;
+
     fn update_abort(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
+        id: UpdateId,
     ) -> Result<(), ResponseError>;
 
     fn serial_console_attach(
@@ -230,14 +231,14 @@ pub fn handle_message<H: SpHandler>(
         RequestKind::UpdatePrepare(update) => handler
             .update_prepare(sender, port, update)
             .map(|()| ResponseKind::UpdatePrepareAck),
-        RequestKind::UpdatePrepareStatus(req) => handler
-            .update_prepare_status(sender, port, req)
-            .map(ResponseKind::UpdatePrepareStatus),
         RequestKind::UpdateChunk(chunk) => handler
             .update_chunk(sender, port, chunk, trailing_data)
             .map(|()| ResponseKind::UpdateChunkAck),
-        RequestKind::UpdateAbort(component) => handler
-            .update_abort(sender, port, component)
+        RequestKind::UpdateStatus(component) => handler
+            .update_status(sender, port, component)
+            .map(ResponseKind::UpdateStatus),
+        RequestKind::UpdateAbort {component, id } => handler
+            .update_abort(sender, port, component, id)
             .map(|()| ResponseKind::UpdateAbortAck),
         RequestKind::SerialConsoleAttach(component) => handler
             .serial_console_attach(sender, port, component)

--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -4,8 +4,6 @@
 
 //! Behavior implemented by both real and simulated SPs.
 
-use crate::UpdateId;
-use crate::UpdateStatus;
 use crate::version;
 use crate::BulkIgnitionState;
 use crate::DiscoverResponse;
@@ -21,7 +19,9 @@ use crate::SpMessageKind;
 use crate::SpPort;
 use crate::SpState;
 use crate::UpdateChunk;
+use crate::UpdateId;
 use crate::UpdatePrepare;
+use crate::UpdateStatus;
 use core::convert::Infallible;
 use core::mem;
 
@@ -237,7 +237,7 @@ pub fn handle_message<H: SpHandler>(
         RequestKind::UpdateStatus(component) => handler
             .update_status(sender, port, component)
             .map(ResponseKind::UpdateStatus),
-        RequestKind::UpdateAbort {component, id } => handler
+        RequestKind::UpdateAbort { component, id } => handler
             .update_abort(sender, port, component, id)
             .map(|()| ResponseKind::UpdateAbortAck),
         RequestKind::SerialConsoleAttach(component) => handler

--- a/gateway-sp-comms/Cargo.toml
+++ b/gateway-sp-comms/Cargo.toml
@@ -7,12 +7,12 @@ license = "MPL-2.0"
 [dependencies]
 futures = "0.3.24"
 once_cell = "1.14.0"
-rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.0.1"
 thiserror = "1.0.34"
 tokio-stream = "0.1.8"
 usdt = "0.3.1"
+uuid = "1.1.0"
 
 gateway-messages = { path = "../gateway-messages", features = ["std"] }
 omicron-common = { path = "../common" }

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -208,7 +208,7 @@ impl Communicator {
         Ok(sp.state().await?)
     }
 
-    /// Update a given SP.
+    /// Send an update payload to a given SP.
     pub async fn update(
         &self,
         sp: SpIdentifier,
@@ -219,6 +219,17 @@ impl Communicator {
         let port = self.id_to_port(sp)?;
         let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
         Ok(sp.update(component, slot, image).await?)
+    }
+
+    /// Abort an in-progress update.
+    pub async fn update_abort(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+    ) -> Result<(), Error> {
+        let port = self.id_to_port(sp)?;
+        let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
+        Ok(sp.update_abort(component).await?)
     }
 
     /// Reset a given SP.

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -214,7 +214,7 @@ impl Communicator {
     /// This function will return before the update is compelte! Once the SP
     /// acknowledges that we want to apply an update, we spawn a background task
     /// to stream the update to the SP and then return. Poll the status of the
-    /// update via [`update_status()`].
+    /// update via [`Self::update_status()`].
     ///
     /// # Panics
     ///

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -237,7 +237,7 @@ impl Communicator {
         &self,
         sp: SpIdentifier,
         component: SpComponent,
-    ) -> Result<Option<UpdateStatus>, Error> {
+    ) -> Result<UpdateStatus, Error> {
         let port = self.id_to_port(sp)?;
         let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
         Ok(sp.update_status(component).await?)
@@ -334,9 +334,7 @@ pub(crate) trait ResponseKindExt {
 
     fn expect_update_prepare_ack(self) -> Result<(), BadResponseType>;
 
-    fn expect_update_status(
-        self,
-    ) -> Result<Option<UpdateStatus>, BadResponseType>;
+    fn expect_update_status(self) -> Result<UpdateStatus, BadResponseType>;
 
     fn expect_update_chunk_ack(self) -> Result<(), BadResponseType>;
 
@@ -478,9 +476,7 @@ impl ResponseKindExt for ResponseKind {
         }
     }
 
-    fn expect_update_status(
-        self,
-    ) -> Result<Option<UpdateStatus>, BadResponseType> {
+    fn expect_update_status(self) -> Result<UpdateStatus, BadResponseType> {
         match self {
             ResponseKind::UpdateStatus(status) => Ok(status),
             other => Err(BadResponseType {

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -211,7 +211,7 @@ impl Communicator {
 
     /// Start sending an update payload to the given SP.
     ///
-    /// This function will return before the update is compelte! Once the SP
+    /// This function will return before the update is complete! Once the SP
     /// acknowledges that we want to apply an update, we spawn a background task
     /// to stream the update to the SP and then return. Poll the status of the
     /// update via [`Self::update_status()`].

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -24,10 +24,11 @@ use gateway_messages::IgnitionState;
 use gateway_messages::ResponseKind;
 use gateway_messages::SpComponent;
 use gateway_messages::SpState;
-use gateway_messages::UpdatePrepareStatusResponse;
+use gateway_messages::UpdateStatus;
 use slog::info;
 use slog::o;
 use slog::Logger;
+use uuid::Uuid;
 
 /// Helper trait that allows us to return an `impl FuturesUnordered<_>` where
 /// the caller can call `.is_empty()` without knowing the type of the future
@@ -208,17 +209,27 @@ impl Communicator {
         Ok(sp.state().await?)
     }
 
-    /// Send an update payload to a given SP.
-    pub async fn update(
+    /// Start sending an update payload to the given SP.
+    ///
+    /// This function will return before the update is compelte! Once the SP
+    /// acknowledges that we want to apply an update, we spawn a background task
+    /// to stream the update to the SP and then return. Poll the status of the
+    /// update via [`update_status()`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `image.is_empty()`.
+    pub async fn start_update(
         &self,
         sp: SpIdentifier,
         component: SpComponent,
+        update_id: Uuid,
         slot: u16,
         image: Vec<u8>,
     ) -> Result<(), Error> {
         let port = self.id_to_port(sp)?;
         let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
-        Ok(sp.update(component, slot, image).await?)
+        Ok(sp.start_update(component, update_id, slot, image).await?)
     }
 
     /// Abort an in-progress update.
@@ -226,10 +237,11 @@ impl Communicator {
         &self,
         sp: SpIdentifier,
         component: SpComponent,
+        update_id: Uuid,
     ) -> Result<(), Error> {
         let port = self.id_to_port(sp)?;
         let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
-        Ok(sp.update_abort(component).await?)
+        Ok(sp.update_abort(component, update_id).await?)
     }
 
     /// Reset a given SP.
@@ -311,9 +323,9 @@ pub(crate) trait ResponseKindExt {
 
     fn expect_update_prepare_ack(self) -> Result<(), BadResponseType>;
 
-    fn expect_update_prepare_status(
+    fn expect_update_status(
         self,
-    ) -> Result<UpdatePrepareStatusResponse, BadResponseType>;
+    ) -> Result<Option<UpdateStatus>, BadResponseType>;
 
     fn expect_update_chunk_ack(self) -> Result<(), BadResponseType>;
 
@@ -348,9 +360,7 @@ impl ResponseKindExt for ResponseKind {
             ResponseKind::UpdatePrepareAck => {
                 response_kind_names::UPDATE_PREPARE_ACK
             }
-            ResponseKind::UpdatePrepareStatus(_) => {
-                response_kind_names::UPDATE_PREPARE_STATUS
-            }
+            ResponseKind::UpdateStatus(_) => response_kind_names::UPDATE_STATUS,
             ResponseKind::UpdateAbortAck => {
                 response_kind_names::UPDATE_ABORT_ACK
             }
@@ -457,13 +467,13 @@ impl ResponseKindExt for ResponseKind {
         }
     }
 
-    fn expect_update_prepare_status(
+    fn expect_update_status(
         self,
-    ) -> Result<UpdatePrepareStatusResponse, BadResponseType> {
+    ) -> Result<Option<UpdateStatus>, BadResponseType> {
         match self {
-            ResponseKind::UpdatePrepareStatus(status) => Ok(status),
+            ResponseKind::UpdateStatus(status) => Ok(status),
             other => Err(BadResponseType {
-                expected: response_kind_names::UPDATE_PREPARE_ACK,
+                expected: response_kind_names::UPDATE_STATUS,
                 got: other.name(),
             }),
         }
@@ -513,7 +523,7 @@ mod response_kind_names {
     pub(super) const SERIAL_CONSOLE_DETACH_ACK: &str =
         "serial_console_detach_ack";
     pub(super) const UPDATE_PREPARE_ACK: &str = "update_prepare_ack";
-    pub(super) const UPDATE_PREPARE_STATUS: &str = "update_prepare_status";
+    pub(super) const UPDATE_STATUS: &str = "update_status";
     pub(super) const UPDATE_ABORT_ACK: &str = "update_abort_ack";
     pub(super) const UPDATE_CHUNK_ACK: &str = "update_chunk_ack";
     pub(super) const SYS_RESET_PREPARE_ACK: &str = "sys_reset_prepare_ack";

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -232,6 +232,17 @@ impl Communicator {
         Ok(sp.start_update(component, update_id, slot, image).await?)
     }
 
+    /// Get the status of an in-progress update.
+    pub async fn update_status(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+    ) -> Result<Option<UpdateStatus>, Error> {
+        let port = self.id_to_port(sp)?;
+        let sp = self.switch.sp(port).ok_or(Error::SpAddressUnknown(sp))?;
+        Ok(sp.update_status(component).await?)
+    }
+
     /// Abort an in-progress update.
     pub async fn update_abort(
         &self,

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -33,10 +33,8 @@ pub enum SpCommunicationError {
 pub enum UpdateError {
     #[error("update image is too large")]
     ImageTooLarge,
-    #[error("error starting update: {0}")]
-    Start(SpCommunicationError),
-    #[error("error sending update chunk at offset {offset}: {err}")]
-    Chunk { offset: u32, err: SpCommunicationError },
+    #[error("failed to send update message to SP: {0}")]
+    Communication(#[from] SpCommunicationError),
 }
 
 #[derive(Debug, Error)]

--- a/gateway-sp-comms/src/error.rs
+++ b/gateway-sp-comms/src/error.rs
@@ -31,6 +31,8 @@ pub enum SpCommunicationError {
 
 #[derive(Debug, Error)]
 pub enum UpdateError {
+    #[error("update image cannot be empty")]
+    ImageEmpty,
     #[error("update image is too large")]
     ImageTooLarge,
     #[error("failed to send update message to SP: {0}")]

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -191,14 +191,10 @@ impl SingleSp {
             "stream_id" => stream_id,
             "total_size" => total_size,
         );
-        self.update_prepare(component, stream_id, slot, total_size)
-            .await
-            .map_err(UpdateError::Start)?;
+        self.update_prepare(component, stream_id, slot, total_size).await?;
 
         // Wait until the SP finishes whatever prep work it needs to do.
-        self.poll_for_update_prepare_status_done(component, stream_id)
-            .await
-            .map_err(UpdateError::Start)?;
+        self.poll_for_update_prepare_status_done(component, stream_id).await?;
         info!(
             self.log, "SP update preparation complete";
             "stream_id" => stream_id,
@@ -214,10 +210,8 @@ impl SingleSp {
                 "offset" => offset,
             );
 
-            image = self
-                .update_chunk(component, stream_id, offset, image)
-                .await
-                .map_err(|err| UpdateError::Chunk { offset, err })?;
+            image =
+                self.update_chunk(component, stream_id, offset, image).await?;
 
             // Update our offset according to how far our cursor advanced.
             offset += (image.position() - prior_pos) as u32;

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -170,10 +170,6 @@ impl SingleSp {
     /// acknowledges that we want to apply an update, we spawn a background task
     /// to stream the update to the SP and then return. Poll the status of the
     /// update via [`update_status()`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `image.is_empty()`.
     pub async fn start_update(
         &self,
         component: SpComponent,
@@ -181,7 +177,10 @@ impl SingleSp {
         slot: u16,
         image: Vec<u8>,
     ) -> Result<(), UpdateError> {
-        assert!(!image.is_empty());
+        if image.is_empty() {
+            return Err(UpdateError::ImageEmpty);
+        }
+
         let total_size = image
             .len()
             .try_into()

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -25,11 +25,11 @@ use gateway_messages::SpMessageKind;
 use gateway_messages::SpPort;
 use gateway_messages::SpState;
 use gateway_messages::UpdateChunk;
+use gateway_messages::UpdateId;
 use gateway_messages::UpdatePrepare;
-use gateway_messages::UpdatePrepareStatusRequest;
+use gateway_messages::UpdateStatus;
 use omicron_common::backoff;
 use omicron_common::backoff::Backoff;
-use rand::Rng;
 use slog::debug;
 use slog::error;
 use slog::info;
@@ -51,6 +51,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time;
 use tokio::time::timeout;
+use uuid::Uuid;
 
 pub const DISCOVERY_MULTICAST_ADDR: Ipv6Addr =
     Ipv6Addr::new(0xff15, 0, 0, 0, 0, 0, 0x1de, 0);
@@ -165,15 +166,18 @@ impl SingleSp {
 
     /// Update a component of the SP (or the SP itself!).
     ///
-    /// This is a bulk operation that will make multiple RPC calls to the SP to
-    /// deliver all of `image`.
+    /// This function will return before the update is compelte! Once the SP
+    /// acknowledges that we want to apply an update, we spawn a background task
+    /// to stream the update to the SP and then return. Poll the status of the
+    /// update via [`update_status()`].
     ///
     /// # Panics
     ///
     /// Panics if `image.is_empty()`.
-    pub async fn update(
+    pub async fn start_update(
         &self,
         component: SpComponent,
+        update_id: Uuid,
         slot: u16,
         image: Vec<u8>,
     ) -> Result<(), UpdateError> {
@@ -183,40 +187,47 @@ impl SingleSp {
             .try_into()
             .map_err(|_err| UpdateError::ImageTooLarge)?;
 
-        let stream_id: u64 = rand::thread_rng().gen();
-
         info!(
             self.log, "starting update";
             "component" => component.as_str(),
-            "stream_id" => stream_id,
+            "id" => %update_id,
             "total_size" => total_size,
         );
-        self.update_prepare(component, stream_id, slot, total_size).await?;
+        let id = update_id.into();
+        self.update_prepare(component, id, slot, total_size).await?;
 
-        // Wait until the SP finishes whatever prep work it needs to do.
-        self.poll_for_update_prepare_status_done(component, stream_id).await?;
-        info!(
-            self.log, "SP update preparation complete";
-            "stream_id" => stream_id,
-        );
+        let log = self.log.clone();
+        let inner = self.cmds_tx.clone();
+        tokio::spawn(async move {
+            let mut image = Cursor::new(image);
+            let mut offset = 0;
+            while !CursorExt::is_empty(&image) {
+                let prior_pos = image.position();
+                debug!(
+                    log, "sending update chunk";
+                    "id" => %update_id,
+                    "offset" => offset,
+                );
 
-        let mut image = Cursor::new(image);
-        let mut offset = 0;
-        while !CursorExt::is_empty(&image) {
-            let prior_pos = image.position();
-            debug!(
-                self.log, "sending update chunk";
-                "stream_id" => stream_id,
-                "offset" => offset,
-            );
+                image = match update_chunk(&inner, component, id, offset, image)
+                    .await
+                {
+                    Ok(image) => image,
+                    Err(err) => {
+                        error!(
+                            log, "update failed";
+                            "id" => %update_id,
+                            "err" => %err,
+                        );
+                        return;
+                    }
+                };
 
-            image =
-                self.update_chunk(component, stream_id, offset, image).await?;
-
-            // Update our offset according to how far our cursor advanced.
-            offset += (image.position() - prior_pos) as u32;
-        }
-        info!(self.log, "update complete");
+                // Update our offset according to how far our cursor advanced.
+                offset += (image.position() - prior_pos) as u32;
+            }
+            info!(log, "update complete"; "id" => %update_id);
+        });
 
         Ok(())
     }
@@ -228,13 +239,13 @@ impl SingleSp {
     async fn update_prepare(
         &self,
         component: SpComponent,
-        stream_id: u64,
+        id: UpdateId,
         slot: u16,
         total_size: u32,
     ) -> Result<()> {
         self.rpc(RequestKind::UpdatePrepare(UpdatePrepare {
             component,
-            stream_id,
+            id,
             slot,
             total_size,
         }))
@@ -244,93 +255,29 @@ impl SingleSp {
         })
     }
 
-    /// Send a steady stream of "update prepare status" messages until the SP
-    /// indicates update prepartion is complete.
-    async fn poll_for_update_prepare_status_done(
+    /// Get the status of any update being applied to the given component.
+    pub async fn update_status(
         &self,
         component: SpComponent,
-        stream_id: u64,
-    ) -> Result<()> {
-        // We expect most update prepartion to be fast, but for some components
-        // (e.g., host boot flash), it can take up to several minutes to prepare
-        // the target flash slot. Send a few status requests with a short
-        // polling interval, then back off to polling every few seconds.
-        //
-        // These choses of durations/number of attempts are all relatively
-        // arbitrary and could be tuned over time or for specific components.
-        const INITIAL_POLL_INTERVAL: Duration = Duration::from_millis(200);
-        const INITIAL_POLL_ATTEMPTS: usize = 5;
-        const SLOW_POLL_INTERVAL: Duration = Duration::from_secs(3);
-
-        let request =
-            RequestKind::UpdatePrepareStatus(UpdatePrepareStatusRequest {
-                component,
-                stream_id,
-            });
-
-        for attempt in 1.. {
-            let status =
-                self.rpc(request).await.and_then(|(_peer, response)| {
-                    response.expect_update_prepare_status().map_err(Into::into)
-                })?;
-            if status.done {
-                return Ok(());
-            }
-            let sleep_time = if attempt <= INITIAL_POLL_ATTEMPTS {
-                INITIAL_POLL_INTERVAL
-            } else {
-                SLOW_POLL_INTERVAL
-            };
-            tokio::time::sleep(sleep_time).await;
-        }
-
-        // We can't break out of the for loop without retrying usize::MAX times,
-        // which isn't phsyically possible (but the compiler doesn't know that).
-        unreachable!();
-    }
-
-    /// Send a portion of an update to the SP.
-    ///
-    /// Must be preceded by a call to `update_start()` (and may be preceded by
-    /// earlier chunks of this update)`.
-    ///
-    /// The completion of an update is implicit, and is detected by the SP based
-    /// on size of the update (specified by the `total_size` given when the
-    /// update starts).
-    ///
-    /// Panics if `chunk.len() > UpdateChunk::MAX_CHUNK_SIZE`.
-    async fn update_chunk(
-        &self,
-        component: SpComponent,
-        stream_id: u64,
-        offset: u32,
-        data: Cursor<Vec<u8>>,
-    ) -> Result<Cursor<Vec<u8>>> {
-        let update_chunk = UpdateChunk { component, stream_id, offset };
-        let (result, data) = self
-            .rpc_with_trailing_data(
-                RequestKind::UpdateChunk(update_chunk),
-                data,
-            )
-            .await;
-
-        result.and_then(|(_peer, response)| {
-            response.expect_update_chunk_ack().map_err(Into::into)
-        })?;
-
-        Ok(data)
+    ) -> Result<Option<UpdateStatus>> {
+        self.rpc(RequestKind::UpdateStatus(component)).await.and_then(
+            |(_peer, response)| {
+                response.expect_update_status().map_err(Into::into)
+            },
+        )
     }
 
     /// Abort an in-progress update.
-    pub async fn update_abort(&self, component: SpComponent) -> Result<()> {
-        // RequestKind::UpdateAbort does not take a `stream_id` argument,
-        // because this command is designed to allow aborts to in-progress
-        // updates that may have been started by other MGS instances.
-        self.rpc(RequestKind::UpdateAbort(component)).await.and_then(
-            |(_peer, response)| {
+    pub async fn update_abort(
+        &self,
+        component: SpComponent,
+        update_id: Uuid,
+    ) -> Result<()> {
+        self.rpc(RequestKind::UpdateAbort { component, id: update_id.into() })
+            .await
+            .and_then(|(_peer, response)| {
                 response.expect_update_abort_ack().map_err(Into::into)
-            },
-        )
+            })
     }
 
     /// Instruct the SP that a reset trigger will be coming.
@@ -416,14 +363,36 @@ impl SingleSp {
     ) -> Result<(SocketAddrV6, ResponseKind)> {
         rpc(&self.cmds_tx, kind, None).await.result
     }
+}
 
-    async fn rpc_with_trailing_data(
-        &self,
-        kind: RequestKind,
-        trailing_data: Cursor<Vec<u8>>,
-    ) -> (Result<(SocketAddrV6, ResponseKind)>, Cursor<Vec<u8>>) {
-        rpc_with_trailing_data(&self.cmds_tx, kind, trailing_data).await
-    }
+/// Send a portion of an update to the SP.
+///
+/// Must be preceded by a call to `update_prepare()` (and may be preceded by
+/// earlier chunks of this update)`.
+///
+/// The completion of an update is implicit, and is detected by the SP based
+/// on size of the update (specified by the `total_size` given when the
+/// update starts).
+async fn update_chunk(
+    inner_tx: &mpsc::Sender<InnerCommand>,
+    component: SpComponent,
+    id: UpdateId,
+    offset: u32,
+    data: Cursor<Vec<u8>>,
+) -> Result<Cursor<Vec<u8>>> {
+    let update_chunk = UpdateChunk { component, id, offset };
+    let (result, data) = rpc_with_trailing_data(
+        inner_tx,
+        RequestKind::UpdateChunk(update_chunk),
+        data,
+    )
+    .await;
+
+    result.and_then(|(_peer, response)| {
+        response.expect_update_chunk_ack().map_err(Into::into)
+    })?;
+
+    Ok(data)
 }
 
 async fn rpc_with_trailing_data(

--- a/gateway-sp-comms/src/single_sp.rs
+++ b/gateway-sp-comms/src/single_sp.rs
@@ -169,7 +169,7 @@ impl SingleSp {
     /// This function will return before the update is compelte! Once the SP
     /// acknowledges that we want to apply an update, we spawn a background task
     /// to stream the update to the SP and then return. Poll the status of the
-    /// update via [`update_status()`].
+    /// update via [`Self::update_status()`].
     pub async fn start_update(
         &self,
         component: SpComponent,

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -82,7 +82,7 @@ bulk_request_retain_grace_period_millis = 10_000
 [dropshot]
 # IP address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12222"
-request_body_max_bytes = 67108864 # 64 MiB
+request_body_max_bytes = 134217728 # 128 MiB
 
 [log]
 # Show log messages of this level and more severe

--- a/gateway/faux-mgs/Cargo.toml
+++ b/gateway/faux-mgs/Cargo.toml
@@ -13,6 +13,7 @@ slog-term = "2.9"
 termios = "0.3"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
+uuid = { version = "1.1", features = ["v4"] }
 zip = { version = "0.6.2", default-features = false, features = ["deflate","bzip2"] }
 
 gateway-messages = { path = "../../gateway-messages", features = ["std"] }

--- a/gateway/faux-mgs/src/main.rs
+++ b/gateway/faux-mgs/src/main.rs
@@ -255,7 +255,7 @@ async fn main() -> Result<()> {
                     )
                 })?;
             match status {
-                Some(UpdateStatus::Preparing(sub_status)) => {
+                UpdateStatus::Preparing(sub_status) => {
                     let id = Uuid::from(sub_status.id);
                     if let Some(progress) = sub_status.progress {
                         info!(
@@ -270,7 +270,7 @@ async fn main() -> Result<()> {
                         );
                     }
                 }
-                Some(UpdateStatus::InProgress(sub_status)) => {
+                UpdateStatus::InProgress(sub_status) => {
                     let id = Uuid::from(sub_status.id);
                     info!(
                         log, "update in progress";
@@ -279,15 +279,15 @@ async fn main() -> Result<()> {
                         "total_size" => sub_status.total_size,
                     );
                 }
-                Some(UpdateStatus::Complete(id)) => {
+                UpdateStatus::Complete(id) => {
                     let id = Uuid::from(id);
                     info!(log, "update complete"; "id" => %id);
                 }
-                Some(UpdateStatus::Aborted(id)) => {
+                UpdateStatus::Aborted(id) => {
                     let id = Uuid::from(id);
                     info!(log, "update aborted"; "id" => %id);
                 }
-                None => {
+                UpdateStatus::None => {
                     info!(log, "no update status available");
                 }
             }
@@ -329,11 +329,10 @@ async fn update(
             .update_status(component)
             .await
             .context("failed to get update status")?;
-        let status = match status {
-            Some(status) => status,
-            None => bail!("no update status returned by SP (did it reset?)"),
-        };
         match status {
+            UpdateStatus::None => {
+                bail!("no update status returned by SP (did it reset?)");
+            }
             UpdateStatus::Preparing(sub_status) => {
                 if sub_status.id != sp_update_id {
                     bail!("different update preparing ({:?})", sub_status.id);

--- a/gateway/faux-mgs/src/main.rs
+++ b/gateway/faux-mgs/src/main.rs
@@ -11,6 +11,8 @@ use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
 use gateway_messages::SpComponent;
+use gateway_messages::UpdateId;
+use gateway_messages::UpdateStatus;
 use gateway_sp_comms::SingleSp;
 use gateway_sp_comms::DISCOVERY_MULTICAST_ADDR;
 use slog::info;
@@ -23,6 +25,7 @@ use std::net::SocketAddrV6;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::net::UdpSocket;
+use uuid::Uuid;
 
 mod hubris_archive;
 mod usart;
@@ -110,17 +113,26 @@ enum SpCommand {
     /// Detach any other attached USART connection.
     UsartDetach,
 
-    /// Upload a new image to the SP and have it swap banks (requires reset)
-    Update { hubris_archive: PathBuf },
+    /// Upload a new image to the SP or one of its components.
+    ///
+    /// To update the SP itself:
+    ///
+    /// 1. Use the component name "sp"
+    /// 2. Specify slot 0 (the SP only has a single updateable slot: its
+    ///    alternate bank).
+    /// 3. Pass the path to a hubris archive as `image`.
+    Update { component: String, slot: u16, image: PathBuf },
 
-    /// Update a component of the SP.
-    UpdateComponent { component: String, slot: u16, image: PathBuf },
+    /// Get the status of an update to the specified component.
+    UpdateStatus { component: String },
 
     /// Abort an in-progress update.
-    AbortUpdate {
+    UpdateAbort {
         /// Component with an update-in-progress to be aborted. Omit to abort
         /// updates to the SP itself.
-        component: Option<String>,
+        component: String,
+        /// ID of the update to abort.
+        update_id: Uuid,
     },
 
     /// Instruct the SP to reset.
@@ -209,44 +221,83 @@ async fn main() -> Result<()> {
             sp.serial_console_detach().await?;
             info!(log, "SP serial console detached");
         }
-        Some(SpCommand::Update { hubris_archive }) => {
-            let mut archive = HubrisArchive::open(&hubris_archive)?;
-            let data = archive.final_bin()?;
-            sp.update(gateway_messages::SpComponent::SP_ITSELF, 0, data)
-                .await
-                .with_context(|| {
-                    format!("updating to {} failed", hubris_archive.display())
-                })?;
-        }
-        Some(SpCommand::UpdateComponent { component, slot, image }) => {
-            let data = fs::read(&image).with_context(|| {
-                format!("failed to read {}", image.display())
-            })?;
+        Some(SpCommand::Update { component, slot, image }) => {
             let sp_component = SpComponent::try_from(component.as_str())
                 .map_err(|_| {
                     anyhow!("invalid component name: {}", component)
                 })?;
-            sp.update(sp_component, slot, data).await.with_context(|| {
-                format!(
-                    "updating {} slot {} to {} failed",
-                    component,
-                    slot,
-                    image.display()
-                )
-            })?;
-        }
-        Some(SpCommand::AbortUpdate { component }) => {
-            let sp_component = match &component {
-                Some(c) => SpComponent::try_from(c.as_str())
-                    .map_err(|_| anyhow!("invalid component name: {}", c))?,
-                None => SpComponent::SP_ITSELF,
+            let data = if sp_component == SpComponent::SP_ITSELF {
+                let mut archive = HubrisArchive::open(&image)?;
+                archive.final_bin()?
+            } else {
+                fs::read(&image).with_context(|| {
+                    format!("failed to read {}", image.display())
+                })?
             };
-            sp.update_abort(sp_component).await.with_context(|| {
-                format!(
-                    "aborting update to {} failed",
-                    component.as_deref().unwrap_or("SP")
-                )
-            })?;
+            update(&log, &sp, sp_component, slot, data).await.with_context(
+                || {
+                    format!(
+                        "updating {} slot {} to {} failed",
+                        component,
+                        slot,
+                        image.display()
+                    )
+                },
+            )?;
+        }
+        Some(SpCommand::UpdateStatus { component }) => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| anyhow!("invalid component name: {component}"))?;
+            let status =
+                sp.update_status(sp_component).await.with_context(|| {
+                    format!(
+                        "failed to get update status to component {component}"
+                    )
+                })?;
+            match status {
+                Some(UpdateStatus::Preparing(sub_status)) => {
+                    let id = Uuid::from(sub_status.id);
+                    if let Some(progress) = sub_status.progress {
+                        info!(
+                            log, "update still preparing (progress: {}/{})",
+                            progress.current, progress.total;
+                            "id" => %id,
+                        );
+                    } else {
+                        info!(
+                            log, "update still preparing (no progress available)";
+                            "id" => %id,
+                        );
+                    }
+                }
+                Some(UpdateStatus::InProgress(sub_status)) => {
+                    let id = Uuid::from(sub_status.id);
+                    info!(
+                        log, "update in progress";
+                        "id" => %id,
+                        "bytes_received" => sub_status.bytes_received,
+                        "total_size" => sub_status.total_size,
+                    );
+                }
+                Some(UpdateStatus::Complete(id)) => {
+                    let id = Uuid::from(id);
+                    info!(log, "update complete"; "id" => %id);
+                }
+                Some(UpdateStatus::Aborted(id)) => {
+                    let id = Uuid::from(id);
+                    info!(log, "update aborted"; "id" => %id);
+                }
+                None => {
+                    info!(log, "no update status available");
+                }
+            }
+        }
+        Some(SpCommand::UpdateAbort { component, update_id }) => {
+            let sp_component = SpComponent::try_from(component.as_str())
+                .map_err(|_| anyhow!("invalid component name: {component}"))?;
+            sp.update_abort(sp_component, update_id).await.with_context(
+                || format!("aborting update to {} failed", component),
+            )?;
         }
         Some(SpCommand::Reset) => {
             sp.reset_prepare().await?;
@@ -257,4 +308,70 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn update(
+    log: &Logger,
+    sp: &SingleSp,
+    component: SpComponent,
+    slot: u16,
+    data: Vec<u8>,
+) -> Result<()> {
+    let update_id = Uuid::new_v4();
+    info!(log, "generated update ID"; "id" => %update_id);
+    sp.start_update(component, update_id, slot, data)
+        .await
+        .context("failed to start update")?;
+
+    let sp_update_id = UpdateId::from(update_id);
+    loop {
+        let status = sp
+            .update_status(component)
+            .await
+            .context("failed to get update status")?;
+        let status = match status {
+            Some(status) => status,
+            None => bail!("no update status returned by SP (did it reset?)"),
+        };
+        match status {
+            UpdateStatus::Preparing(sub_status) => {
+                if sub_status.id != sp_update_id {
+                    bail!("different update preparing ({:?})", sub_status.id);
+                }
+                if let Some(progress) = sub_status.progress {
+                    info!(
+                        log,
+                        "update preparing: {}/{}",
+                        progress.current,
+                        progress.total,
+                    );
+                } else {
+                    info!(log, "update preparing (no progress available)");
+                }
+            }
+            UpdateStatus::InProgress(sub_status) => {
+                if sub_status.id != sp_update_id {
+                    bail!("different update in progress ({:?})", sub_status.id);
+                }
+                info!(
+                    log, "update in progress";
+                    "bytes_received" => sub_status.bytes_received,
+                    "total_size" => sub_status.total_size,
+                );
+            }
+            UpdateStatus::Complete(id) => {
+                if id != sp_update_id {
+                    bail!("different update complete ({id:?})");
+                }
+                return Ok(());
+            }
+            UpdateStatus::Aborted(id) => {
+                if id != sp_update_id {
+                    bail!("different update aborted ({id:?})");
+                }
+                bail!("update aborted");
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 }

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -10,6 +10,7 @@ use dropshot::HttpError;
 use gateway_messages::ResponseError;
 use gateway_sp_comms::error::Error as SpCommsError;
 use gateway_sp_comms::error::SpCommunicationError;
+use gateway_sp_comms::error::UpdateError;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -59,6 +60,44 @@ where
             ResponseError::SerialConsoleAlreadyAttached,
         )) => HttpError::for_bad_request(
             Some("SerialConsoleAttached".to_string()),
+            err.to_string(),
+        ),
+        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+            ResponseError::RequestUnsupportedForSp,
+        )) => HttpError::for_bad_request(
+            Some("RequestUnsupportedForSp".to_string()),
+            err.to_string(),
+        ),
+        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+            ResponseError::RequestUnsupportedForComponent,
+        )) => HttpError::for_bad_request(
+            Some("RequestUnsupportedForComponent".to_string()),
+            err.to_string(),
+        ),
+        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+            ResponseError::InvalidSlotForComponent,
+        )) => HttpError::for_bad_request(
+            Some("InvalidSlotForComponent".to_string()),
+            err.to_string(),
+        ),
+        SpCommsError::UpdateFailed(UpdateError::ImageTooLarge) => {
+            HttpError::for_bad_request(
+                Some("ImageTooLarge".to_string()),
+                err.to_string(),
+            )
+        }
+        SpCommsError::UpdateFailed(UpdateError::Communication(
+            SpCommunicationError::SpError(ResponseError::UpdateSlotBusy),
+        )) => HttpError::for_unavail(
+            Some("UpdateSlotBusy".to_string()),
+            err.to_string(),
+        ),
+        SpCommsError::UpdateFailed(UpdateError::Communication(
+            SpCommunicationError::SpError(ResponseError::UpdateInProgress {
+                ..
+            }),
+        )) => HttpError::for_unavail(
+            Some("UpdateInProgress".to_string()),
             err.to_string(),
         ),
         SpCommsError::DiscoveryNotYetComplete => HttpError::for_unavail(

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -125,23 +125,24 @@ enum SpUpdateStatus {
     /// The SP is preparing to receive an update.
     ///
     /// May or may not include progress, depending on the capabilities of the
-    /// component being updated. If progress is present, the units are defined
-    /// by the SP.
-    Preparing { id: Uuid, progress: Option<Progress> },
+    /// component being updated.
+    Preparing { id: Uuid, progress: Option<UpdatePreparationProgress> },
     /// The SP is currently receiving an update.
-    ///
-    /// The units of `progress` are bytes.
-    InProgress { id: Uuid, progress: Progress },
+    InProgress { id: Uuid, bytes_received: u32, total_bytes: u32 },
     /// The SP has completed receiving an update.
     Complete { id: Uuid },
     /// The SP has aborted an in-progress update.
     Aborted { id: Uuid },
 }
 
-/// Progress of an operation; units of `current` and `total` are defined by the
-/// operation.
+/// Progress of an SP preparing to update.
+///
+/// The units of `current` and `total` are unspecified and defined by the SP;
+/// e.g., if preparing for an update requires erasing a flash device, this may
+/// indicate progress of that erasure without defining units (bytes, pages,
+/// sectors, etc.).
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-struct Progress {
+struct UpdatePreparationProgress {
     current: u32,
     total: u32,
 }

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -610,8 +610,8 @@ async fn sp_component_update_status(
 ///
 /// Aborting an update to the SP itself is done via the component name `sp`.
 ///
-/// If this returns successfully, it does not mean an update was actually
-/// aborted; it only means no update is currently in progress.
+/// On a successful return, the update corresponding to the given UUID will no
+/// longer be in progress (either aborted or applied).
 #[endpoint {
     method = POST,
     path = "/sp/{type}/{slot}/component/{component}/update-abort",

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -29,24 +29,18 @@ pub(super) fn component_from_str(s: &str) -> Result<SpComponent, HttpError> {
 
 impl From<UpdateStatus> for SpUpdateStatus {
     fn from(status: UpdateStatus) -> Self {
-        use super::SpUpdateState;
         match status {
-            UpdateStatus::Preparing(status) => Self {
+            UpdateStatus::None => Self::None,
+            UpdateStatus::Preparing(status) => Self::Preparing {
                 id: status.id.into(),
-                state: SpUpdateState::Preparing {
-                    progress: status.progress.map(Into::into),
-                },
+                progress: status.progress.map(Into::into),
             },
-            UpdateStatus::InProgress(status) => Self {
+            UpdateStatus::InProgress(status) => Self::InProgress {
                 id: status.id.into(),
-                state: SpUpdateState::InProgress { progress: status.into() },
+                progress: status.into(),
             },
-            UpdateStatus::Complete(id) => {
-                Self { id: id.into(), state: SpUpdateState::Complete }
-            }
-            UpdateStatus::Aborted(id) => {
-                Self { id: id.into(), state: SpUpdateState::Aborted }
-            }
+            UpdateStatus::Complete(id) => Self::Complete { id: id.into() },
+            UpdateStatus::Aborted(id) => Self::Aborted { id: id.into() },
         }
     }
 }

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -6,12 +6,12 @@
 
 //! Conversions between externally-defined types and HTTP / JsonSchema types.
 
-use super::Progress;
 use super::SpIdentifier;
 use super::SpIgnition;
 use super::SpState;
 use super::SpType;
 use super::SpUpdateStatus;
+use super::UpdatePreparationProgress;
 use dropshot::HttpError;
 use gateway_messages::IgnitionFlags;
 use gateway_messages::SpComponent;
@@ -37,7 +37,8 @@ impl From<UpdateStatus> for SpUpdateStatus {
             },
             UpdateStatus::InProgress(status) => Self::InProgress {
                 id: status.id.into(),
-                progress: status.into(),
+                bytes_received: status.bytes_received,
+                total_bytes: status.total_size,
             },
             UpdateStatus::Complete(id) => Self::Complete { id: id.into() },
             UpdateStatus::Aborted(id) => Self::Aborted { id: id.into() },
@@ -45,15 +46,11 @@ impl From<UpdateStatus> for SpUpdateStatus {
     }
 }
 
-impl From<gateway_messages::UpdatePreparationProgress> for Progress {
+impl From<gateway_messages::UpdatePreparationProgress>
+    for UpdatePreparationProgress
+{
     fn from(progress: gateway_messages::UpdatePreparationProgress) -> Self {
         Self { current: progress.current, total: progress.total }
-    }
-}
-
-impl From<gateway_messages::UpdateInProgressStatus> for Progress {
-    fn from(progress: gateway_messages::UpdateInProgressStatus) -> Self {
-        Self { current: progress.bytes_received, total: progress.total_size }
     }
 }
 

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -53,19 +53,13 @@ impl From<UpdateStatus> for SpUpdateStatus {
 
 impl From<gateway_messages::UpdatePreparationProgress> for Progress {
     fn from(progress: gateway_messages::UpdatePreparationProgress) -> Self {
-        Self {
-            current: progress.current,
-            total: progress.total,
-        }
+        Self { current: progress.current, total: progress.total }
     }
 }
 
 impl From<gateway_messages::UpdateInProgressStatus> for Progress {
     fn from(progress: gateway_messages::UpdateInProgressStatus) -> Self {
-        Self {
-            current: progress.bytes_received,
-            total: progress.total_size,
-        }
+        Self { current: progress.bytes_received, total: progress.total_size }
     }
 }
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -342,56 +342,6 @@
         }
       }
     },
-    "/sp/{type}/{slot}/component/{component}/abort-update": {
-      "post": {
-        "summary": "Abort any in-progress update an SP component",
-        "description": "Aborting an update to the SP itself is done via the component name `sp`.\nIf this returns successfully, it does not mean an update was actually aborted; it only means no update is currently in progress.",
-        "operationId": "sp_component_abort_update",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "component",
-            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "slot",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "type",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SpType"
-            },
-            "style": "simple"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/sp/{type}/{slot}/component/{component}/power-off": {
       "post": {
         "summary": "Power off an SP component",
@@ -651,6 +601,123 @@
         }
       }
     },
+    "/sp/{type}/{slot}/component/{component}/update-abort": {
+      "post": {
+        "summary": "Abort any in-progress update an SP component",
+        "description": "Aborting an update to the SP itself is done via the component name `sp`.\nIf this returns successfully, it does not mean an update was actually aborted; it only means no update is currently in progress.",
+        "operationId": "sp_component_update_abort",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAbortBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sp/{type}/{slot}/component/{component}/update-status": {
+      "get": {
+        "summary": "Get the status of an update being applied to an SP component",
+        "description": "Getting the status of an update to the SP itself is done via the component name `sp`.",
+        "operationId": "sp_component_update_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpUpdateStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/power-off": {
       "post": {
         "summary": "Power off an SP via Ignition",
@@ -800,6 +867,26 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "Progress": {
+        "description": "Progress of an operation; units of `current` and `total` are defined by the operation.",
+        "type": "object",
+        "properties": {
+          "current": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "current",
+          "total"
         ]
       },
       "SpComponentInfo": {
@@ -1018,9 +1105,119 @@
           "switch"
         ]
       },
+      "SpUpdateState": {
+        "oneOf": [
+          {
+            "description": "The SP is preparing to receive an update.\n\nMay or may not include progress, depending on the capabilities of the component being updated. If progress is present, the units are defined by the SP.",
+            "type": "object",
+            "properties": {
+              "progress": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Progress"
+                  }
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "preparing"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "The SP is currently receiving an update.\n\nThe units of `progress` are bytes.",
+            "type": "object",
+            "properties": {
+              "progress": {
+                "$ref": "#/components/schemas/Progress"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "in_progress"
+                ]
+              }
+            },
+            "required": [
+              "progress",
+              "state"
+            ]
+          },
+          {
+            "description": "The SP has completed receiving an update.",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "complete"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "The SP has aborted an in-progress update.",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "aborted"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          }
+        ]
+      },
+      "SpUpdateStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SpUpdateState"
+          }
+        },
+        "required": [
+          "id",
+          "state"
+        ]
+      },
+      "UpdateAbortBody": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of the update to abort.\n\nIf the SP is currently receiving an update with this ID, it will be aborted.\n\nIf the SP is currently receiving an update with a different ID, the abort request will fail.\n\nIf the SP is not currently receiving any update, the request to abort should succeed but will not have actually done anything.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "UpdateBody": {
         "type": "object",
         "properties": {
+          "id": {
+            "description": "An identifier for this update.\n\nThis ID applies to this single instance of the API call; it is not an ID of `image` itself. Multiple API calls with the same `image` should use different IDs.",
+            "type": "string",
+            "format": "uuid"
+          },
           "image": {
             "description": "The binary blob containing the update image (component-specific).",
             "type": "array",
@@ -1038,6 +1235,7 @@
           }
         },
         "required": [
+          "id",
           "image",
           "slot"
         ]

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -342,6 +342,56 @@
         }
       }
     },
+    "/sp/{type}/{slot}/component/{component}/abort-update": {
+      "post": {
+        "summary": "Abort any in-progress update an SP component",
+        "description": "Aborting an update to the SP itself is done via the component name `sp`.\nIf this returns successfully, it does not mean an update was actually aborted; it only means no update is currently in progress.",
+        "operationId": "sp_component_abort_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/component/{component}/power-off": {
       "post": {
         "summary": "Power off an SP component",

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -869,26 +869,6 @@
           "request_id"
         ]
       },
-      "Progress": {
-        "description": "Progress of an operation; units of `current` and `total` are defined by the operation.",
-        "type": "object",
-        "properties": {
-          "current": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "total": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "current",
-          "total"
-        ]
-      },
       "SpComponentInfo": {
         "type": "object"
       },
@@ -1105,17 +1085,36 @@
           "switch"
         ]
       },
-      "SpUpdateState": {
+      "SpUpdateStatus": {
         "oneOf": [
           {
-            "description": "The SP is preparing to receive an update.\n\nMay or may not include progress, depending on the capabilities of the component being updated. If progress is present, the units are defined by the SP.",
+            "description": "The SP has no update status.",
             "type": "object",
             "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "The SP is preparing to receive an update.\n\nMay or may not include progress, depending on the capabilities of the component being updated.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
               "progress": {
                 "nullable": true,
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Progress"
+                    "$ref": "#/components/schemas/UpdatePreparationProgress"
                   }
                 ]
               },
@@ -1127,32 +1126,50 @@
               }
             },
             "required": [
+              "id",
               "state"
             ]
           },
           {
-            "description": "The SP is currently receiving an update.\n\nThe units of `progress` are bytes.",
+            "description": "The SP is currently receiving an update.",
             "type": "object",
             "properties": {
-              "progress": {
-                "$ref": "#/components/schemas/Progress"
+              "bytes_received": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "id": {
+                "type": "string",
+                "format": "uuid"
               },
               "state": {
                 "type": "string",
                 "enum": [
                   "in_progress"
                 ]
+              },
+              "total_bytes": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
               }
             },
             "required": [
-              "progress",
-              "state"
+              "bytes_received",
+              "id",
+              "state",
+              "total_bytes"
             ]
           },
           {
             "description": "The SP has completed receiving an update.",
             "type": "object",
             "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
               "state": {
                 "type": "string",
                 "enum": [
@@ -1161,6 +1178,7 @@
               }
             },
             "required": [
+              "id",
               "state"
             ]
           },
@@ -1168,6 +1186,10 @@
             "description": "The SP has aborted an in-progress update.",
             "type": "object",
             "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
               "state": {
                 "type": "string",
                 "enum": [
@@ -1176,25 +1198,10 @@
               }
             },
             "required": [
+              "id",
               "state"
             ]
           }
-        ]
-      },
-      "SpUpdateStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "state": {
-            "$ref": "#/components/schemas/SpUpdateState"
-          }
-        },
-        "required": [
-          "id",
-          "state"
         ]
       },
       "UpdateAbortBody": {
@@ -1238,6 +1245,26 @@
           "id",
           "image",
           "slot"
+        ]
+      },
+      "UpdatePreparationProgress": {
+        "description": "Progress of an SP preparing to update.\n\nThe units of `current` and `total` are unspecified and defined by the SP; e.g., if preparing for an update requires erasing a flash device, this may indicate progress of that erasure without defining units (bytes, pages, sectors, etc.).",
+        "type": "object",
+        "properties": {
+          "current": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "current",
+          "total"
         ]
       }
     }

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -604,7 +604,7 @@
     "/sp/{type}/{slot}/component/{component}/update-abort": {
       "post": {
         "summary": "Abort any in-progress update an SP component",
-        "description": "Aborting an update to the SP itself is done via the component name `sp`.\nIf this returns successfully, it does not mean an update was actually aborted; it only means no update is currently in progress.",
+        "description": "Aborting an update to the SP itself is done via the component name `sp`.\nOn a successful return, the update corresponding to the given UUID will no longer be in progress (either aborted or applied).",
         "operationId": "sp_component_update_abort",
         "parameters": [
           {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -640,7 +640,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError> {
+    ) -> Result<gateway_messages::UpdateStatus, ResponseError> {
         warn!(
             &self.log,
             "received update status request; not supported by simulated gimlet";

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -635,19 +635,18 @@ impl SpHandler for Handler {
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
-    fn update_prepare_status(
+    fn update_status(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        request: gateway_messages::UpdatePrepareStatusRequest,
-    ) -> Result<gateway_messages::UpdatePrepareStatusResponse, ResponseError>
-    {
+        component: SpComponent,
+    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError> {
         warn!(
             &self.log,
-            "received update prepare status request; not supported by simulated gimlet";
+            "received update status request; not supported by simulated gimlet";
             "sender" => %sender,
             "port" => ?port,
-            "request" => ?request,
+            "component" => ?component,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }
@@ -675,6 +674,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
+        id: gateway_messages::UpdateId,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,
@@ -682,6 +682,7 @@ impl SpHandler for Handler {
             "sender" => %sender,
             "port" => ?port,
             "component" => ?component,
+            "id" => ?id,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -469,8 +469,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError>
-    {
+    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError> {
         warn!(
             &self.log,
             "received update status request; not supported by simulated sidecar";

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -464,19 +464,19 @@ impl SpHandler for Handler {
         Err(ResponseError::RequestUnsupportedForSp)
     }
 
-    fn update_prepare_status(
+    fn update_status(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        request: gateway_messages::UpdatePrepareStatusRequest,
-    ) -> Result<gateway_messages::UpdatePrepareStatusResponse, ResponseError>
+        component: SpComponent,
+    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError>
     {
         warn!(
             &self.log,
-            "received update prepare status request; not supported by simulated sidecar";
+            "received update status request; not supported by simulated sidecar";
             "sender" => %sender,
             "port" => ?port,
-            "request" => ?request,
+            "component" => ?component,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }
@@ -504,6 +504,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
+        id: gateway_messages::UpdateId,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,
@@ -511,6 +512,7 @@ impl SpHandler for Handler {
             "sender" => %sender,
             "port" => ?port,
             "component" => ?component,
+            "id" => ?id,
         );
         Err(ResponseError::RequestUnsupportedForSp)
     }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -469,7 +469,7 @@ impl SpHandler for Handler {
         sender: SocketAddrV6,
         port: SpPort,
         component: SpComponent,
-    ) -> Result<Option<gateway_messages::UpdateStatus>, ResponseError> {
+    ) -> Result<gateway_messages::UpdateStatus, ResponseError> {
         warn!(
             &self.log,
             "received update status request; not supported by simulated sidecar";


### PR DESCRIPTION
Hopefully this PR is not as big as it looks: about half of it by volume is updating either the OpenAPI spec file or developer-focused CLI apps for interacting with MGS. Ignoring those, the changes included are:

1. New endpoints in MGS:
    a. update-status returns the UUID of the most current update the SP knows about (either the in-progress update, if one is in progress, or the ID of the most recently completed/aborted update); if the update is in progress, it also includes how far along the update is
    b. update-abort aborts an update with a given UUID
2. Modifications to the MGS <-> SP messages:
    a. Removed `UpdatePrepareStatus` in favor of the more general `UpdateStatus`
    b. `Update` and `UpdateAbort` now take 16-byte IDs (i.e., the UUIDs accepted by the MGS endpoints)


Additionally, the delivery of updates from MGS to the SP has changed based on the matrix conversation I had with @andrewjstone and @rmustacc. Briefly summarizing:

When MGS receives a POST to its update endpoint (which must include a client-provided UUID), it tells the SP to begin preparing for an update. If the SP answer's indicates success, MGS spawns a background task to actually deliver the update, and returns successfully immediately to its client. (If the SP's answer indicates an error, that is also returned to the client, but no background task is spawned.) This avoids the problem I was seeing previously where MGS's delivery of an update could be cancelled if the client disconnected while it was underway.

At any time, any client of any MGS instance may ask for the status of an update being delivered to a specific SP. The SP is the source of truth here; MGS always asks the SP what it thinks its update status is (even if it is currently in the process of delivering an update to that SP). As described above, the SP's response includes both the ID of the update (which the client could use to subsequently abort it, if desired) and progress (if the update is still underway, from the SP's point of view). Currently the SP only remembers the most recent update ID: either the currently-in-progress update, or the most recently completed or aborted ID.
