### PR TITLE
Set instance state to failed on bad instance_put

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -604,25 +604,84 @@ impl super::Nexus {
 
         let sa = self.instance_sled(&db_instance).await?;
 
-        let new_runtime = sa
+        let instance_put_result = sa
             .instance_put(
                 &db_instance.id(),
                 &sled_agent_client::types::InstanceEnsureBody {
                     initial: instance_hardware,
-                    target: requested,
+                    target: requested.clone(),
                     migrate: None,
                 },
             )
-            .await
-            .map_err(Error::from)?;
+            .await;
 
-        let new_runtime: nexus::InstanceRuntimeState =
-            new_runtime.into_inner().into();
+        match instance_put_result {
+            Ok(new_runtime) => {
+                let new_runtime: nexus::InstanceRuntimeState =
+                    new_runtime.into_inner().into();
 
-        self.db_datastore
-            .instance_update_runtime(&db_instance.id(), &new_runtime.into())
-            .await
-            .map(|_| ())
+                self.db_datastore
+                    .instance_update_runtime(
+                        &db_instance.id(),
+                        &new_runtime.into(),
+                    )
+                    .await
+                    .map(|_| ())
+            }
+
+            Err(e) => {
+                // The sled-agent has told us that it can't do what we
+                // requested, but does that mean a failure? One example would be
+                // if we try to "reboot" a stopped instance. That shouldn't
+                // transition the instance to failed. But if the sled-agent
+                // *can't* boot a stopped instance, that should transition
+                // to failed.
+                //
+                // Without a richer error type, let the sled-agent tell Nexus
+                // what to do with status codes.
+                error!(self.log, "saw {} from instance_put!", &e,);
+
+                // this is unfortunate, but sled_agent_client::Error doesn't
+                // implement Copy, and can't be match'ed upon below without this
+                // line.
+                let e = e.into();
+
+                match &e {
+                    // Bad request shouldn't change the instance state.
+                    Error::InvalidRequest { .. } => Err(e),
+
+                    // Internal server error (or anything else) should change
+                    // the instance state to failed, we don't know what state
+                    // the instance is in.
+                    _ => {
+                        let new_runtime = db::model::InstanceRuntimeState {
+                            state: db::model::InstanceState::new(
+                                InstanceState::Failed,
+                            ),
+                            gen: db_instance.runtime_state.gen.next().into(),
+                            ..db_instance.runtime_state.clone()
+                        };
+
+                        // XXX what if this fails?
+                        let result = self
+                            .db_datastore
+                            .instance_update_runtime(
+                                &db_instance.id(),
+                                &new_runtime,
+                            )
+                            .await;
+
+                        error!(
+                            self.log,
+                            "saw {:?} from setting InstanceState::Failed after bad instance_put",
+                            result,
+                        );
+
+                        Err(e)
+                    }
+                }
+            }
+        }
     }
 
     /// Lists disks attached to the instance.

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -639,7 +639,7 @@ impl super::Nexus {
                 //
                 // Without a richer error type, let the sled-agent tell Nexus
                 // what to do with status codes.
-                error!(self.log, "saw {} from instance_put!", &e,);
+                error!(self.log, "saw {} from instance_put!", e);
 
                 // this is unfortunate, but sled_agent_client::Error doesn't
                 // implement Copy, and can't be match'ed upon below without this

--- a/nexus/src/db/datastore/disk.rs
+++ b/nexus/src/db/datastore/disk.rs
@@ -273,6 +273,7 @@ impl DataStore {
         let ok_to_detach_instance_states = vec![
             db::model::InstanceState(api::external::InstanceState::Creating),
             db::model::InstanceState(api::external::InstanceState::Stopped),
+            db::model::InstanceState(api::external::InstanceState::Failed),
         ];
 
         let detached_label = api::external::DiskState::Detached.label();

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1847,6 +1847,11 @@ async fn test_instance_fails_to_boot_with_disk(
             name: Name::try_from(String::from("nfs")).unwrap(),
             description: String::from("probably serving data"),
         },
+        // there's a specific line in the simulated sled agent that will return
+        // a 500 if you try to allocate an instance with more than 16 CPUs. a
+        // 500 error is required to exercise the undo nodes of the instance
+        // create saga (where provision fails, instead of just responding with a
+        // bad request).
         ncpus: InstanceCpuCount::try_from(32).unwrap(),
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -194,6 +194,13 @@ impl SledAgent {
         initial_hardware: InstanceHardware,
         target: InstanceRuntimeStateRequested,
     ) -> Result<InstanceRuntimeState, Error> {
+        let ncpus: i64 = (&initial_hardware.runtime.ncpus).into();
+        if ncpus > 16 {
+            return Err(Error::internal_error(
+                &"instances with more than 16 CPUs not supported!",
+            ));
+        };
+
         for disk in &initial_hardware.disks {
             let initial_state = DiskRuntimeState {
                 disk_state: omicron_common::api::external::DiskState::Attached(

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -194,10 +194,12 @@ impl SledAgent {
         initial_hardware: InstanceHardware,
         target: InstanceRuntimeStateRequested,
     ) -> Result<InstanceRuntimeState, Error> {
+        // respond with a fake 500 level failure if asked to ensure an instance
+        // with more than 16 CPUs.
         let ncpus: i64 = (&initial_hardware.runtime.ncpus).into();
         if ncpus > 16 {
             return Err(Error::internal_error(
-                &"instances with more than 16 CPUs not supported!",
+                &"could not allocate an instance: ran out of CPUs!",
             ));
         };
 


### PR DESCRIPTION
If a call to sled-agent's `instance_put` fails with anything other than a 400 (bad request), set instance's state to failed - we cannot know what state the instance is in.

This exposed another two problems:

- Nexus would only delete network interfaces off instances that were stopped
- Nexus would only detach disks off instances that were creating or stopped.

This commit changes the relevant network interface queries to allow deletion of network interfaces for instances that are either stopped or failed, and adds Failed to the list of ok_to_detach_instance_states for disks. Note that network interface insertion still requires an instance to be stopped, not failed.

Closes https://github.com/oxidecomputer/omicron/issues/1713