### PR TITLE
Bootstore: Start implementing coordinator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,8 +378,8 @@ dependencies = [
  "serde",
  "sha3",
  "slog",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
- "sprockets-host 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
+ "sprockets-common",
+ "sprockets-host",
  "thiserror",
  "uuid",
  "vsss-rs",
@@ -694,7 +694,8 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "corncobs"
 version = "0.1.1"
-source = "git+https://github.com/cbiffle/corncobs?tag=v0.1.1#06a276928075fd5638802d46ed2d3d0c31d2d0c3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603158882fa02a5f92b3ee716316f0495b962543141597751eaa5992a55f25b"
 
 [[package]]
 name = "cortex-m"
@@ -3144,8 +3145,8 @@ dependencies = [
  "socket2",
  "sp-sim",
  "spdm",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
- "sprockets-host 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "sprockets-common",
+ "sprockets-host",
  "subprocess",
  "tar",
  "tempfile",
@@ -5296,19 +5297,6 @@ dependencies = [
 [[package]]
 name = "sprockets-common"
 version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
-dependencies = [
- "derive_more",
- "hubpack",
- "rand 0.8.5",
- "salty",
- "serde",
- "serde-big-array 0.4.1",
-]
-
-[[package]]
-name = "sprockets-common"
-version = "0.1.0"
 source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "derive_more",
@@ -5317,25 +5305,6 @@ dependencies = [
  "salty",
  "serde",
  "serde-big-array 0.4.1",
-]
-
-[[package]]
-name = "sprockets-host"
-version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
-dependencies = [
- "anyhow",
- "clap",
- "derive_more",
- "futures",
- "pin-project",
- "ring",
- "serde",
- "slog",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
- "sprockets-session 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -5351,8 +5320,8 @@ dependencies = [
  "ring",
  "serde",
  "slog",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
- "sprockets-session 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
+ "sprockets-common",
+ "sprockets-session",
  "thiserror",
  "tokio",
 ]
@@ -5360,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "sprockets-rot"
 version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "corncobs",
  "derive_more",
@@ -5368,28 +5337,8 @@ dependencies = [
  "rand 0.8.5",
  "salty",
  "serde",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "sprockets-common",
  "tinyvec",
-]
-
-[[package]]
-name = "sprockets-session"
-version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
-dependencies = [
- "chacha20poly1305",
- "derive_more",
- "ed25519",
- "ed25519-dalek",
- "hkdf",
- "hmac 0.12.1",
- "hubpack",
- "rand_core 0.6.3",
- "serde",
- "sha3",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -5407,7 +5356,7 @@ dependencies = [
  "rand_core 0.6.3",
  "serde",
  "sha3",
- "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
+ "sprockets-common",
  "x25519-dalek",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,15 +373,17 @@ dependencies = [
  "omicron-test-utils",
  "p256",
  "pq-sys",
+ "proptest",
  "rand 0.8.5",
  "serde",
  "sha3",
  "slog",
- "sprockets-common",
- "sprockets-host",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
+ "sprockets-host 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
  "thiserror",
  "uuid",
  "vsss-rs",
+ "zeroize",
 ]
 
 [[package]]
@@ -478,9 +480,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -490,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
@@ -878,9 +880,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array 0.14.5",
  "rand_core 0.6.3",
@@ -936,9 +938,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -1333,9 +1335,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -3142,8 +3144,8 @@ dependencies = [
  "socket2",
  "sp-sim",
  "spdm",
- "sprockets-common",
- "sprockets-host",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "sprockets-host 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
  "subprocess",
  "tar",
  "tempfile",
@@ -4058,10 +4060,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4206,6 +4234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -4372,7 +4409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -4500,6 +4537,18 @@ source = "git+https://github.com/oxidecomputer/rusty-doors#c9c064efbb686af124264
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -5258,6 +5307,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprockets-common"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
+dependencies = [
+ "derive_more",
+ "hubpack",
+ "rand 0.8.5",
+ "salty",
+ "serde",
+ "serde-big-array 0.4.1",
+]
+
+[[package]]
 name = "sprockets-host"
 version = "0.1.0"
 source = "git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1#0361fd13ff19cda6696242fe40f1325fca30d3d1"
@@ -5270,8 +5332,27 @@ dependencies = [
  "ring",
  "serde",
  "slog",
- "sprockets-common",
- "sprockets-session",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "sprockets-session 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "sprockets-host"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
+dependencies = [
+ "anyhow",
+ "clap",
+ "derive_more",
+ "futures",
+ "pin-project",
+ "ring",
+ "serde",
+ "slog",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
+ "sprockets-session 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
  "thiserror",
  "tokio",
 ]
@@ -5287,7 +5368,7 @@ dependencies = [
  "rand 0.8.5",
  "salty",
  "serde",
- "sprockets-common",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
  "tinyvec",
 ]
 
@@ -5306,7 +5387,27 @@ dependencies = [
  "rand_core 0.6.3",
  "serde",
  "sha3",
- "sprockets-common",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=0361fd13ff19cda6696242fe40f1325fca30d3d1)",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "sprockets-session"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
+dependencies = [
+ "chacha20poly1305",
+ "derive_more",
+ "ed25519",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac 0.12.1",
+ "hubpack",
+ "rand_core 0.6.3",
+ "serde",
+ "sha3",
+ "sprockets-common 0.1.0 (git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9)",
  "x25519-dalek",
  "zeroize",
 ]
@@ -6280,6 +6381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,9 +6705,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/bootstore/Cargo.toml
+++ b/bootstore/Cargo.toml
@@ -23,13 +23,15 @@ rand = { version = "0.8.5", features = ["getrandom"] }
 serde = { version = "1.0", features = [ "derive" ] }
 sha3 = "0.10.4"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
-sprockets-common = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
-sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
+sprockets-common = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
+sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
 thiserror = "1.0"
 uuid = { version = "1.1.0", features = [ "serde", "v4" ] }
 vsss-rs = { version = "2.0.0", default-features = false, features = ["std"] }
+zeroize = { version = "1.5.7", features = ["zeroize_derive", "std"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 bincode = "1.3.3"
 omicron-test-utils = { path = "../test-utils" }
+proptest = "1.0.0"

--- a/bootstore/src/coordinator.rs
+++ b/bootstore/src/coordinator.rs
@@ -1,0 +1,427 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A coordinator for bootstore transactions
+//!
+//! Bootstore transactions are performed via 2-phase commit (2PC), where the
+//! [`Coordinator`] issues Prepare and Accept statements to [`Node`]s. The
+//! coordinator itself does not persist state, but instead receives requests via
+//! its API that are driven ultimately by RSS and Nexus and returns results that
+//! are persisted in CockroachDB.
+
+use crate::messages::{
+    NodeError, NodeOp, NodeOpResult, NodeRequest, NodeResponse,
+};
+use crate::trust_quorum::{
+    RackSecret, SerializableShareDistribution, ShareDistribution,
+};
+use sha3::{Digest, Sha3_256};
+use slog::{error, o, Logger};
+use sprockets_host::Ed25519Certificate;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use uuid::Uuid;
+
+// TODO: It would be nice to have a printable ID in the cert other than
+// the pub key. This will change when we use X509.v3 certs in sprockets.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum Error {
+    #[error("Failed to split secret: {0:?}")]
+    FailedToSplitSecret(vsss_rs::Error),
+
+    #[error("BCS serialization error: {err}")]
+    Bcs { err: String },
+
+    #[error(transparent)]
+    NodeResponseError(#[from] NodeError),
+
+    #[error(
+        "PrepareOk received with wrong rack UUID: Expected: {expected}, \
+    Actual: {actual}"
+    )]
+    PrepareOkBadRackUuid {
+        from: Ed25519Certificate,
+        expected: Uuid,
+        actual: Uuid,
+    },
+
+    #[error(
+        "PrepareOk received with wrong epoch: Expected: {expected}, Actual: \
+{actual}"
+    )]
+    PrepareOkBadEpoch { from: Ed25519Certificate, expected: i32, actual: i32 },
+
+    #[error(
+        "CommitOk received with wrong rack UUID: Expected: {expected}, Actual: \
+{actual}"
+    )]
+    CommitOkBadRackUuid {
+        from: Ed25519Certificate,
+        expected: Uuid,
+        actual: Uuid,
+    },
+
+    #[error(
+        "CommitOk received with wrong epoch: Expected: {expected}, Actual: \
+{actual}"
+    )]
+    CommitOkBadEpoch { from: Ed25519Certificate, expected: i32, actual: i32 },
+
+    #[error("Unexpected share received for epoch {epoch}")]
+    UnexpectedShare { from: Ed25519Certificate, epoch: i32 },
+
+    #[error(
+        "Unexpected PrepareOk received for epoch {epoch} with rack uuid: \
+{rack_uuid}"
+    )]
+    UnexpectedPrepareOk {
+        from: Ed25519Certificate,
+        epoch: i32,
+        rack_uuid: Uuid,
+    },
+
+    #[error(
+        "Unexpected PrepareOk received for epoch {epoch} with rack uuid: \
+{rack_uuid}"
+    )]
+    UnexpectedCommitOk { from: Ed25519Certificate, epoch: i32, rack_uuid: Uuid },
+
+    // Response received from a Node that is not a member
+    #[error(
+        "Response received from node that is not a member for epoch {epoch} \
+with rack uuid: {rack_uuid}"
+    )]
+    NotAMember { from: Ed25519Certificate, epoch: i32, rack_uuid: Uuid },
+}
+
+/// The internal state of a [`Coordinator`] shared among all
+/// [`CoordinatorOperation`]s.
+struct CoordinatorState {
+    // A monotonic counter incremented and maintained by nexus everytime a new
+    // coordinator takes over.
+    id: u64,
+    log: Logger,
+    rack_uuid: Uuid,
+    total_nodes: usize,
+    ackd_prepares: BTreeSet<Ed25519Certificate>,
+    ackd_commits: BTreeSet<Ed25519Certificate>,
+}
+
+impl CoordinatorState {
+    /// Return true if all nodes have acknowledged the prepare
+    pub fn prepare_complete(&self) -> bool {
+        self.ackd_prepares.len() == self.total_nodes
+    }
+
+    /// Return true if all nodes have acknowledged the commit
+    pub fn commit_complete(&self) -> bool {
+        self.ackd_commits.len() == self.total_nodes
+    }
+}
+
+/// A [`Coordinator`] is only used for one transaction
+///
+/// A specific [`CoordinatorOperation`] is used for each transaction.
+trait CoordinatorOperation {
+    fn prepare(
+        &mut self,
+        state: &mut CoordinatorState,
+    ) -> Result<BTreeMap<Ed25519Certificate, NodeOp>, Error>;
+    fn commit(
+        &mut self,
+        state: &mut CoordinatorState,
+    ) -> Result<BTreeMap<Ed25519Certificate, NodeOp>, Error>;
+
+    fn handle(
+        &mut self,
+        state: &mut CoordinatorState,
+        from: Ed25519Certificate,
+        result: NodeOpResult,
+    ) -> Result<bool, Error>;
+}
+
+/// A [`CoordinatorOperation`] for rack initialization
+struct InitializeOperation {
+    members: BTreeSet<Ed25519Certificate>,
+    share_distributions: BTreeMap<Ed25519Certificate, ShareDistribution>,
+}
+
+impl CoordinatorOperation for InitializeOperation {
+    /// Return a [`NodeOp::Initialize`] request for each node that has not yet acked
+    fn prepare(
+        &mut self,
+        state: &mut CoordinatorState,
+    ) -> Result<BTreeMap<Ed25519Certificate, NodeOp>, Error> {
+        Ok(self
+            .share_distributions
+            .iter()
+            .filter(|(cert, _)| !state.ackd_prepares.contains(cert))
+            .map(|(cert, sd)| {
+                (
+                    *cert,
+                    NodeOp::Initialize {
+                        rack_uuid: state.rack_uuid,
+                        share_distribution: sd.clone().into(),
+                    },
+                )
+            })
+            .collect())
+    }
+
+    fn commit(
+        &mut self,
+        state: &mut CoordinatorState,
+    ) -> Result<BTreeMap<Ed25519Certificate, NodeOp>, Error> {
+        let mut output = BTreeMap::new();
+        for (cert, sd) in self
+            .share_distributions
+            .iter()
+            .filter(|(cert, _)| !state.ackd_commits.contains(cert))
+        {
+            let sd: SerializableShareDistribution = sd.clone().into();
+            let bytes = bcs::to_bytes(&sd)
+                .map_err(|err| Error::Bcs { err: err.to_string() })?;
+            let prepare_share_distribution_digest =
+                sprockets_common::Sha3_256Digest(
+                    Sha3_256::digest(&bytes).into(),
+                );
+
+            output.insert(
+                *cert,
+                NodeOp::KeyShareCommit {
+                    rack_uuid: state.rack_uuid,
+                    epoch: 0,
+                    prepare_share_distribution_digest,
+                },
+            );
+        }
+        Ok(output)
+    }
+
+    fn handle(
+        &mut self,
+        state: &mut CoordinatorState,
+        from: Ed25519Certificate,
+        result: NodeOpResult,
+    ) -> Result<bool, Error> {
+        if !self.members.contains(&from) {
+            return Err(Error::NotAMember {
+                from,
+                epoch: 0,
+                rack_uuid: state.rack_uuid,
+            });
+        }
+
+        if !state.prepare_complete() {
+            // We're expecting a `PrepareOk`
+            match result {
+                NodeOpResult::PrepareOk { rack_uuid, epoch } => {
+                    if rack_uuid != state.rack_uuid {
+                        return Err(Error::PrepareOkBadRackUuid {
+                            from,
+                            expected: state.rack_uuid,
+                            actual: rack_uuid,
+                        });
+                    }
+                    if epoch != 0 {
+                        return Err(Error::PrepareOkBadEpoch {
+                            from,
+                            expected: 0,
+                            actual: epoch,
+                        });
+                    }
+                    state.ackd_prepares.insert(from);
+                    return Ok(false);
+                }
+                NodeOpResult::CommitOk { rack_uuid, epoch } => {
+                    return Err(Error::UnexpectedCommitOk {
+                        from,
+                        epoch,
+                        rack_uuid,
+                    });
+                }
+                NodeOpResult::Share { epoch, .. } => {
+                    return Err(Error::UnexpectedShare { from, epoch });
+                }
+            }
+        }
+
+        // Handle CommitOk messages
+        match result {
+            NodeOpResult::CommitOk { rack_uuid, epoch } => {
+                if rack_uuid != state.rack_uuid {
+                    return Err(Error::CommitOkBadRackUuid {
+                        from,
+                        expected: state.rack_uuid,
+                        actual: rack_uuid,
+                    });
+                }
+                if epoch != 0 {
+                    return Err(Error::CommitOkBadEpoch {
+                        from,
+                        expected: 0,
+                        actual: epoch,
+                    });
+                }
+                state.ackd_commits.insert(from);
+            }
+            NodeOpResult::PrepareOk { rack_uuid, epoch } => {
+                return Err(Error::UnexpectedPrepareOk {
+                    from,
+                    epoch,
+                    rack_uuid,
+                });
+            }
+            NodeOpResult::Share { epoch, .. } => {
+                return Err(Error::UnexpectedShare { from, epoch });
+            }
+        }
+
+        Ok(state.commit_complete())
+    }
+}
+
+/// A [`CoordinatorOperation`] for rack reconfiguration
+//
+// TODO: Not used yet
+#[allow(dead_code)]
+struct ReconfigureOperation {
+    old_epoch: i32,
+    old_members: Vec<Ed25519Certificate>,
+    new_epoch: i32,
+    new_members: Vec<Ed25519Certificate>,
+    share_distributions: BTreeMap<Ed25519Certificate, ShareDistribution>,
+}
+
+/// A coordinator for the bootstore's 2PC protocol
+///
+/// The coordinatore is responsible for creating the [`trust_quorum::RackSecret`]
+/// splitting it into share sand distributing those shares along with the
+/// relevant information to the participant nodes.
+pub struct Coordinator {
+    state: CoordinatorState,
+    op: Box<dyn CoordinatorOperation>,
+}
+
+impl Coordinator {
+    /// Create a coordinator used to initialize a rack
+    pub fn new_initialize(
+        log: Logger,
+        rack_uuid: Uuid,
+        members: BTreeSet<Ed25519Certificate>,
+    ) -> Result<Coordinator, Error> {
+        let log = log.new(o!(
+            "component" => "BootstoreCoordinator"
+        ));
+        let total_nodes = members.len();
+        let threshold = Self::threshold(total_nodes);
+        let secret = RackSecret::new();
+        let (shares, verifier) = secret
+            .split(threshold, total_nodes)
+            .map_err(Error::FailedToSplitSecret)?;
+        let share_distributions = members
+            .iter()
+            .cloned()
+            .zip(shares.into_iter().map(|share| ShareDistribution {
+                threshold,
+                verifier: verifier.clone(),
+                share,
+                member_device_id_certs: members.clone(),
+            }))
+            .collect();
+        let state = CoordinatorState {
+            id: 0,
+            log,
+            rack_uuid,
+            total_nodes,
+            ackd_prepares: BTreeSet::new(),
+            ackd_commits: BTreeSet::new(),
+        };
+        Ok(Coordinator {
+            state,
+            op: Box::new(InitializeOperation { members, share_distributions }),
+        })
+    }
+
+    /// Handle responses from nodes.
+    ///
+    /// Return `Ok(true)` if the transaction is complete, `Ok(false)` if
+    /// the response was handled fine, but the transaction is not complete.
+    pub fn handle(
+        &mut self,
+        from: Ed25519Certificate,
+        rsp: NodeResponse,
+    ) -> Result<bool, Error> {
+        // TODO: Should  these conditions be passed up as errors?
+        // If we pass them up, should we also log them?
+        if rsp.version != 1 {
+            error!(
+                self.state.log,
+                "Invalid version for response: {}", rsp.version
+            );
+        }
+
+        if rsp.coordinator_id != self.state.id {
+            error!(
+                self.state.log,
+                "Invalid Coordinator ID. Expected: {}, Actual: {}",
+                self.state.id,
+                rsp.coordinator_id
+            );
+        }
+
+        match rsp.result {
+            Ok(result) => self.op.handle(&mut self.state, from, result),
+            Err(err) => Err(Error::NodeResponseError(err)),
+        }
+    }
+
+    /// Return a set of [`NodeRequests`] to send to all members that haven't acked yet.
+    /// A higher "networking" layer is responsible for sending these messages over
+    /// sprockets channels and receiving responses to be handled by the `Coordinator`.
+    pub fn next_requests(
+        &mut self,
+    ) -> Result<BTreeMap<Ed25519Certificate, NodeRequest>, Error> {
+        let ops = if !self.prepare_complete() {
+            self.op.prepare(&mut self.state)?
+        } else if !self.commit_complete() {
+            self.op.commit(&mut self.state)?
+        } else {
+            // We are done
+            BTreeMap::new()
+        };
+
+        Ok(ops
+            .into_iter()
+            .map(|(cert, op)| {
+                (
+                    cert,
+                    NodeRequest {
+                        version: 1,
+                        coordinator_id: self.state.id,
+                        op,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    pub fn prepare_complete(&self) -> bool {
+        self.state.prepare_complete()
+    }
+
+    pub fn commit_complete(&self) -> bool {
+        self.state.commit_complete()
+    }
+
+    // Return the trust quorum threshold required to unlock the rack.
+    fn threshold(total_nodes: usize) -> usize {
+        assert!(total_nodes > 1);
+        if total_nodes < 6 {
+            2
+        } else {
+            total_nodes / 2 - 1
+        }
+    }
+}

--- a/bootstore/src/db/mod.rs
+++ b/bootstore/src/db/mod.rs
@@ -14,6 +14,7 @@ use diesel::prelude::*;
 use diesel::SqliteConnection;
 use slog::Logger;
 use slog::{info, o};
+use std::cell::RefCell;
 use uuid::Uuid;
 
 use crate::trust_quorum::SerializableShareDistribution;
@@ -25,7 +26,7 @@ use models::Share;
 pub struct Db {
     log: Logger,
 
-    conn: SqliteConnection,
+    conn: RefCell<SqliteConnection>,
 }
 
 // Temporary until the using code is written
@@ -62,7 +63,7 @@ impl Db {
         // Create tables
         c.batch_execute(schema)?;
 
-        Ok(Db { log, conn: c })
+        Ok(Db { log, conn: RefCell::new(c) })
     }
 
     /// Write a KeyShare for epoch a along with the rack UUID
@@ -73,7 +74,7 @@ impl Db {
         rack_uuid: &Uuid,
         share_distribution: SerializableShareDistribution,
     ) -> Result<(), Error> {
-        self.conn.immediate_transaction(|tx| {
+        self.conn.get_mut().immediate_transaction(|tx| {
             if is_initialized(tx)? {
                 // If the rack is initialized, a rack uuid must exist
                 let uuid = get_rack_uuid(tx)?.unwrap();
@@ -114,7 +115,7 @@ impl Db {
         assert_ne!(0, epoch);
         use schema::key_shares::dsl;
         let prepare = KeyShare::new(epoch, share_distribution)?;
-        self.conn.immediate_transaction(|tx| {
+        self.conn.get_mut().immediate_transaction(|tx| {
             // Has the rack been initialized?
             if !is_initialized(tx)? {
                 return Err(Error::RackNotInitialized);
@@ -167,7 +168,7 @@ impl Db {
         digest: sprockets_common::Sha3_256Digest,
     ) -> Result<(), Error> {
         use schema::key_shares::dsl;
-        self.conn.immediate_transaction(|tx| {
+        self.conn.get_mut().immediate_transaction(|tx| {
             // Does the rack_uuid match what's stored?
             validate_rack_uuid(tx, rack_uuid)?;
 
@@ -189,19 +190,53 @@ impl Db {
         })
     }
 
-    pub fn get_committed_share(&mut self, epoch: i32) -> Result<Share, Error> {
-        use schema::key_shares::dsl;
-        let share = dsl::key_shares
-            .select(dsl::share)
-            .filter(dsl::epoch.eq(epoch))
-            .filter(dsl::committed.eq(true))
-            .get_result::<Share>(&mut self.conn)
-            .optional()?;
+    pub fn is_initialized(&self, rack_uuid: &Uuid) -> Result<bool, Error> {
+        self.conn.borrow_mut().immediate_transaction(|tx| {
+            validate_rack_uuid(tx, rack_uuid)?;
+            is_initialized(tx)
+        })
+    }
 
-        match share {
-            Some(share) => Ok(share),
-            None => Err(Error::KeyShareNotCommitted { epoch }),
-        }
+    pub fn get_committed_share(
+        &self,
+        rack_uuid: &Uuid,
+        epoch: i32,
+    ) -> Result<Share, Error> {
+        use schema::key_shares::dsl;
+        self.conn.borrow_mut().immediate_transaction(|tx| {
+            validate_rack_uuid(tx, rack_uuid)?;
+            let share = dsl::key_shares
+                .select(dsl::share)
+                .filter(dsl::epoch.eq(epoch))
+                .filter(dsl::committed.eq(true))
+                .get_result::<Share>(tx)
+                .optional()?;
+
+            match share {
+                Some(share) => Ok(share),
+                None => Err(Error::KeyShareNotCommitted { epoch }),
+            }
+        })
+    }
+
+    /// Return `Ok(true)` if there is a KeyShare that is not yet committed for
+    /// the given epoch.
+    pub fn has_key_share_prepare(
+        &self,
+        rack_uuid: &Uuid,
+        epoch: i32,
+    ) -> Result<bool, Error> {
+        use schema::key_shares::dsl;
+        self.conn.borrow_mut().immediate_transaction(|tx| {
+            validate_rack_uuid(tx, rack_uuid)?;
+            Ok(dsl::key_shares
+                .select(dsl::epoch)
+                .filter(dsl::epoch.eq(epoch))
+                .filter(dsl::committed.eq(false))
+                .get_result::<i32>(tx)
+                .optional()?
+                .is_some())
+        })
     }
 }
 
@@ -306,18 +341,19 @@ pub mod tests {
     use assert_matches::assert_matches;
     use omicron_test_utils::dev::test_setup_log;
     use sha3::{Digest, Sha3_256};
+    use std::collections::BTreeSet;
 
     // This is solely so we can test the non-member functions with a properly
     // initialized DB
     impl Db {
-        fn get_conn(&mut self) -> &mut SqliteConnection {
+        fn get_conn(&mut self) -> &mut RefCell<SqliteConnection> {
             &mut self.conn
         }
     }
 
     // TODO: Fill in with actual member certs
     pub fn new_shares() -> Vec<ShareDistribution> {
-        let member_device_id_certs = vec![];
+        let member_device_id_certs = BTreeSet::new();
         let rack_secret_threshold = 3;
         let total_shares = 5;
         let secret = RackSecret::new();
@@ -343,7 +379,7 @@ pub mod tests {
         let shares = new_shares();
         let epoch = 0;
         let expected: SerializableShareDistribution = shares[0].clone().into();
-        let conn = db.get_conn();
+        let conn = db.get_conn().get_mut();
         insert_prepare(conn, epoch, expected.clone()).unwrap();
         let (share, committed) = dsl::key_shares
             .select((dsl::share, dsl::committed))
@@ -401,7 +437,7 @@ pub mod tests {
         let committed = dsl::key_shares
             .select(dsl::committed)
             .filter(dsl::epoch.eq(epoch))
-            .get_result::<bool>(db.get_conn())
+            .get_result::<bool>(db.get_conn().get_mut())
             .unwrap();
         assert_eq!(true, committed);
         logctx.cleanup_successful();
@@ -415,13 +451,13 @@ pub mod tests {
         // One insert succeeds.
         diesel::insert_into(dsl::rack)
             .values(dsl::uuid.eq(Uuid::new_v4().to_string()))
-            .execute(db.get_conn())
+            .execute(db.get_conn().get_mut())
             .unwrap();
 
         // A second fails
         let err = diesel::insert_into(dsl::rack)
             .values(dsl::uuid.eq(Uuid::new_v4().to_string()))
-            .execute(db.get_conn())
+            .execute(db.get_conn().get_mut())
             .unwrap_err();
         assert_matches!(err, diesel::result::Error::DatabaseError(_, s) => {
             assert_eq!("maximum one rack", s.message());

--- a/bootstore/src/lib.rs
+++ b/bootstore/src/lib.rs
@@ -13,10 +13,16 @@
 //! that information from the trust quorum database, parse it, and write
 //! it to CockroachDB when we start it up.
 
+mod coordinator;
 mod db;
-mod messages;
+
+// Only public for integration tests
+pub mod messages;
+
 mod node;
 mod trust_quorum;
 
+pub use coordinator::Coordinator;
+pub use coordinator::Error;
 pub use node::Config;
 pub use node::Node;

--- a/bootstore/src/node.rs
+++ b/bootstore/src/node.rs
@@ -9,7 +9,6 @@
 
 use slog::Logger;
 use sprockets_common::Sha3_256Digest;
-//use sprockets_host::Ed25519Certificate;
 use uuid::Uuid;
 
 use crate::db::Db;
@@ -18,11 +17,8 @@ use crate::trust_quorum::SerializableShareDistribution;
 
 /// Configuration for an individual node
 pub struct Config {
-    log: Logger,
-    db_path: String,
-    // TODO: This will live inside the certificate eventually
-    //_serial_number: String,
-    //_device_id_cert: Ed25519Certificate,
+    pub log: Logger,
+    pub db_path: String,
 }
 
 /// A node of the bootstore
@@ -56,13 +52,18 @@ impl Node {
         if req.version != 1 {
             return NodeResponse {
                 version: req.version,
-                id: req.id,
+                coordinator_id: req.coordinator_id,
                 result: Err(NodeError::UnsupportedVersion(req.version)),
             };
         }
 
+        // TODO: Check coordinator id before handling requests
+        // This requires storing the coordinator id in the Db
+
         let result = match req.op {
-            NodeOp::GetShare { epoch } => self.handle_get_share(epoch),
+            NodeOp::GetShare { rack_uuid, epoch } => {
+                self.handle_get_share(&rack_uuid, epoch)
+            }
             NodeOp::Initialize { rack_uuid, share_distribution } => {
                 self.handle_initialize(&rack_uuid, share_distribution)
             }
@@ -86,16 +87,35 @@ impl Node {
             ),
         };
 
-        NodeResponse { version: req.version, id: req.id, result }
+        NodeResponse {
+            version: req.version,
+            coordinator_id: req.coordinator_id,
+            result,
+        }
+    }
+
+    pub fn has_key_share_prepare(
+        &self,
+        rack_uuid: &Uuid,
+        epoch: i32,
+    ) -> Result<bool, NodeError> {
+        let res = self.db.has_key_share_prepare(rack_uuid, epoch)?;
+        Ok(res)
+    }
+
+    pub fn is_initialized(&self, rack_uuid: &Uuid) -> Result<bool, NodeError> {
+        let res = self.db.is_initialized(rack_uuid)?;
+        Ok(res)
     }
 
     // Handle `GetShare` messages from another node
     fn handle_get_share(
-        &mut self,
+        &self,
+        rack_uuid: &Uuid,
         epoch: i32,
     ) -> Result<NodeOpResult, NodeError> {
-        let share = self.db.get_committed_share(epoch)?;
-        Ok(NodeOpResult::Share { epoch, share: share.0.share })
+        let share = self.db.get_committed_share(rack_uuid, epoch)?;
+        Ok(NodeOpResult::Share { epoch, share: share.0.share.clone() })
     }
 
     // Handle `Initialize` messages from the coordinator
@@ -105,7 +125,7 @@ impl Node {
         share_distribution: SerializableShareDistribution,
     ) -> Result<NodeOpResult, NodeError> {
         self.db.initialize(rack_uuid, share_distribution)?;
-        Ok(NodeOpResult::CoordinatorAck)
+        Ok(NodeOpResult::PrepareOk { rack_uuid: *rack_uuid, epoch: 0 })
     }
 
     // Handle `KeySharePrepare` messages from the coordinator
@@ -121,7 +141,7 @@ impl Node {
 
         self.db.prepare_share(rack_uuid, epoch, share_distribution)?;
 
-        Ok(NodeOpResult::CoordinatorAck)
+        Ok(NodeOpResult::PrepareOk { rack_uuid: *rack_uuid, epoch })
     }
 
     // Handle `KeyShareCommit` messages from the coordinator
@@ -137,7 +157,7 @@ impl Node {
             prepare_shared_distribution_digest,
         )?;
 
-        Ok(NodeOpResult::CoordinatorAck)
+        Ok(NodeOpResult::CommitOk { rack_uuid: *rack_uuid, epoch })
     }
 }
 
@@ -148,6 +168,7 @@ mod tests {
     use crate::db::models::KeyShare;
     use crate::db::tests::new_shares;
     use crate::trust_quorum::ShareDistribution;
+    use assert_matches::assert_matches;
     use omicron_test_utils::dev::test_setup_log;
     use omicron_test_utils::dev::LogContext;
     use uuid::Uuid;
@@ -165,17 +186,22 @@ mod tests {
         let (logctx, mut node, share_distributions) = setup();
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
-        let expected = Ok(NodeOpResult::CoordinatorAck);
-        assert_eq!(
-            expected,
-            node.handle_initialize(&Uuid::new_v4(), sd.clone())
+        assert_matches!(
+            node.handle_initialize(&Uuid::new_v4(), sd.clone()),
+            Ok(NodeOpResult::PrepareOk { .. })
         );
         // We can re-initialize with a new uuid
         let rack_uuid = Uuid::new_v4();
-        assert_eq!(expected, node.handle_initialize(&rack_uuid, sd.clone()));
+        assert_matches!(
+            node.handle_initialize(&rack_uuid, sd.clone()),
+            Ok(NodeOpResult::PrepareOk { .. })
+        );
 
         // We can re-initialize with the same uuid
-        assert_eq!(expected, node.handle_initialize(&rack_uuid, sd.clone()));
+        assert_matches!(
+            node.handle_initialize(&rack_uuid, sd.clone()),
+            Ok(NodeOpResult::PrepareOk { .. })
+        );
 
         // Committing the key share for epoch 0 means we cannot initialize again
         let epoch = 0;
@@ -197,7 +223,6 @@ mod tests {
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
         let rack_uuid = Uuid::new_v4();
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 0;
@@ -207,25 +232,20 @@ mod tests {
         // as well as a share distribution. In that case we will likely have a separate
         // `InitializeCommit` message and will likely change the `Initialize` message to
         // `InitializePrepare`.
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd));
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_initialize(&rack_uuid, sd).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Let's simulate a successful reconfiguration
         let sd: SerializableShareDistribution = new_shares()[0].clone().into();
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 1;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd)
-        );
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_key_share_prepare(&rack_uuid, epoch, sd).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         logctx.cleanup_successful();
     }
@@ -245,8 +265,7 @@ mod tests {
         );
 
         // Create a prepare, but don't commit it
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd.clone()));
+        assert!(node.handle_initialize(&rack_uuid, sd.clone()).is_ok());
 
         // Try (and fail) to issue a prepare for epoch 1 again. The actual contents of the
         // share distribution doesn't matter.
@@ -264,17 +283,15 @@ mod tests {
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
         let rack_uuid = Uuid::new_v4();
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 0;
 
         // Successful rack initialization
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd.clone()));
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_initialize(&rack_uuid, sd.clone()).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Attempt to prepare with an invalid rack uuid
         let bad_uuid = Uuid::new_v4();
@@ -296,30 +313,26 @@ mod tests {
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
         let rack_uuid = Uuid::new_v4();
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 0;
 
         // Successful rack initialization
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd.clone()));
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_initialize(&rack_uuid, sd.clone()).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Prepare succeeds
         let epoch = 1;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
-        );
+        assert!(node
+            .handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
+            .is_ok());
 
         // Same prepare succeeds
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
-        );
+        assert!(node
+            .handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
+            .is_ok());
 
         logctx.cleanup_successful();
     }
@@ -330,31 +343,27 @@ mod tests {
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
         let rack_uuid = Uuid::new_v4();
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 0;
 
         // Successful rack initialization
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd.clone()));
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_initialize(&rack_uuid, sd.clone()).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Prepare succeeds
         let epoch = 1;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
-        );
+        assert!(node
+            .handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
+            .is_ok());
 
         // Prepare succeeds
         let epoch = 2;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
-        );
+        assert!(node
+            .handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
+            .is_ok());
 
         // Prepare fails
         let epoch = 1;
@@ -369,16 +378,14 @@ mod tests {
 
         // Idempotent prepare still succeeds
         let epoch = 2;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
-        );
+        assert!(node
+            .handle_key_share_prepare(&rack_uuid, epoch, sd.clone())
+            .is_ok());
 
         // Commit the prepare
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Old prepare still fails the same way
         let epoch = 1;
@@ -408,24 +415,19 @@ mod tests {
         let sd: SerializableShareDistribution =
             share_distributions[0].clone().into();
         let rack_uuid = Uuid::new_v4();
-        let ok_ack = Ok(NodeOpResult::CoordinatorAck);
         let sd_digest =
             KeyShare::share_distribution_digest(&sd).unwrap().into();
         let epoch = 0;
 
         // Successful rack initialization
-        assert_eq!(ok_ack, node.handle_initialize(&rack_uuid, sd.clone()));
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_commit(&rack_uuid, epoch, sd_digest)
-        );
+        assert!(node.handle_initialize(&rack_uuid, sd.clone()).is_ok());
+        assert!(node
+            .handle_key_share_commit(&rack_uuid, epoch, sd_digest)
+            .is_ok());
 
         // Prepare succeeds
         let epoch = 1;
-        assert_eq!(
-            ok_ack,
-            node.handle_key_share_prepare(&rack_uuid, epoch, sd)
-        );
+        assert!(node.handle_key_share_prepare(&rack_uuid, epoch, sd).is_ok());
 
         // Prepare with a different share_distribution fails
         let sd2: SerializableShareDistribution =

--- a/bootstore/src/trust_quorum/rack_secret.rs
+++ b/bootstore/src/trust_quorum/rack_secret.rs
@@ -11,6 +11,7 @@ use p256::{NonZeroScalar, ProjectivePoint, Scalar, SecretKey};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use vsss_rs::{Feldman, FeldmanVerifier, Share};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A `RackSecret` is a shared secret used to perform a "rack-level" unlock.
 ///
@@ -40,6 +41,7 @@ use vsss_rs::{Feldman, FeldmanVerifier, Share};
 /// `rack unlock`. The establishment of secure channels and the ability to trust
 /// the validity of a participating peer is outside the scope of this particular
 /// type and orthogonal to its implementation.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct RackSecret {
     secret: NonZeroScalar,
 }
@@ -71,7 +73,6 @@ impl Verifier {
 }
 
 // Temporary until the using code is written
-#[allow(dead_code)]
 impl RackSecret {
     /// Create a secret based on the NIST P-256 curve
     pub fn new() -> RackSecret {
@@ -94,6 +95,7 @@ impl RackSecret {
     }
 
     /// Combine a set of shares and return a RackSecret
+    #[allow(dead_code)] // not used yet
     pub fn combine_shares(
         threshold: usize,
         total_shares: usize,

--- a/bootstore/tests/integration-proptest.rs
+++ b/bootstore/tests/integration-proptest.rs
@@ -1,0 +1,242 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Property based test for bootstore behavior
+
+use assert_matches::assert_matches;
+use bootstore::messages::{NodeOp, NodeOpResult, NodeRequest, NodeResponse};
+use bootstore::{Config, Coordinator, Node};
+use omicron_test_utils::dev::test_setup_log;
+use proptest::prelude::*;
+use sprockets_common::certificates::Ed25519Certificate;
+use sprockets_common::certificates::KeyType;
+use sprockets_common::{Ed25519PublicKey, Ed25519Signature};
+use std::collections::{BTreeMap, BTreeSet};
+use uuid::Uuid;
+
+/// A generator to produce an arbitrary Ed25519 Public Key.
+/// These aren't used for crypto, so a random bag of bytes is fine here.
+fn arb_pub_key() -> impl Strategy<Value = Ed25519PublicKey> {
+    proptest::array::uniform32(0u8..).prop_map(|v| Ed25519PublicKey(v))
+}
+
+/// A generator to produce an arbitrary Ed25519Signature
+/// These aren't used for crypto, so a random bag of bytes is fine here.
+fn arb_sig() -> impl Strategy<Value = Ed25519Signature> {
+    proptest::array::uniform32(0u8..).prop_map(|v| {
+        // Max array size we can generate is 32 bytes. Just use the same array for
+        // the first and second half of the signature.
+        let mut out = [0u8; 64];
+        out[..32].copy_from_slice(&v[..]);
+        out[32..].copy_from_slice(&v[..]);
+        Ed25519Signature(out)
+    })
+}
+
+/// A generator to produce an arbitrary Ed25519Certificate for DeviceIds
+fn arb_device_id_cert() -> impl Strategy<Value = Ed25519Certificate> {
+    (arb_pub_key(), arb_sig()).prop_map(|(key, sig)| Ed25519Certificate {
+        subject_key_type: KeyType::DeviceId,
+        subject_public_key: key,
+        signer_key_type: KeyType::Manufacturing,
+        signature: sig,
+    })
+}
+
+// A generator to produce a vector of Ed25519 DeviceId certs use as trust quroum membership
+// We require uniqueness so we generate a BTreeSet and map it to a Vec
+fn arb_members() -> impl Strategy<Value = BTreeSet<Ed25519Certificate>> {
+    proptest::collection::btree_set(arb_device_id_cert(), 3..8)
+}
+
+// There should be a `NodeOp::Initialize` request for each member  when a
+// new Initializing Coordinator is created and `Coordinator::next_requests`
+// is called.
+fn prop_initialize_for_all_members(
+    rack_uuid: &Uuid,
+    members: &BTreeSet<Ed25519Certificate>,
+    requests: &BTreeMap<Ed25519Certificate, NodeRequest>,
+) -> Result<(), TestCaseError> {
+    prop_assert_eq!(requests.len(), members.len());
+    let destinations: BTreeSet<Ed25519Certificate> =
+        requests.keys().cloned().into_iter().collect();
+    prop_assert_eq!(&destinations, members);
+    for request in requests.values() {
+        prop_assert_eq!(1, request.version);
+        prop_assert_eq!(0, request.coordinator_id);
+        assert_matches!(request.op, NodeOp::Initialize { rack_uuid: msg_rack_uuid, .. } => {
+            prop_assert_eq!(*rack_uuid, msg_rack_uuid);
+        });
+    }
+    Ok(())
+}
+
+// There should be a `NodeOp::KeyShareCommit` request for each member when the
+// prepare phase completes.
+fn prop_key_share_commit_for_all_members(
+    coordinator_id: u64,
+    epoch: i32,
+    rack_uuid: &Uuid,
+    members: &BTreeSet<Ed25519Certificate>,
+    requests: &BTreeMap<Ed25519Certificate, NodeRequest>,
+) -> Result<(), TestCaseError> {
+    prop_assert_eq!(requests.len(), members.len());
+    let destinations: BTreeSet<Ed25519Certificate> =
+        requests.keys().cloned().into_iter().collect();
+    prop_assert_eq!(&destinations, members);
+    for request in requests.values() {
+        prop_assert_eq!(1, request.version);
+        prop_assert_eq!(coordinator_id, request.coordinator_id);
+        assert_matches!(request.op, NodeOp::KeyShareCommit{ rack_uuid: msg_rack_uuid, epoch: msg_epoch, .. } => {
+            prop_assert_eq!(*rack_uuid, msg_rack_uuid);
+            prop_assert_eq!(epoch, msg_epoch);
+        });
+    }
+    Ok(())
+}
+
+// Initialize requests sent to all Nodes should have valid responses
+fn prop_initialize_responses_are_all_valid(
+    rack_uuid: &Uuid,
+    members: &BTreeSet<Ed25519Certificate>,
+    responses: &BTreeMap<Ed25519Certificate, NodeResponse>,
+) -> Result<(), TestCaseError> {
+    prop_assert_eq!(responses.len(), members.len());
+    let sources: BTreeSet<Ed25519Certificate> =
+        responses.keys().cloned().into_iter().collect();
+    prop_assert_eq!(&sources, members);
+    for response in responses.values() {
+        prop_assert_eq!(1, response.version);
+        prop_assert_eq!(0, response.coordinator_id);
+        assert_matches!(response.result, Ok(NodeOpResult::PrepareOk{rack_uuid: msg_rack_uuid, epoch: msg_epoch}) => {
+                prop_assert_eq!(*rack_uuid, msg_rack_uuid);
+                prop_assert_eq!(msg_epoch, 0);
+        });
+    }
+    Ok(())
+}
+
+// KeyShareCommit requests sent to `members` should have valid responses
+fn prop_key_share_commit_responses_are_all_valid(
+    coordinator_id: u64,
+    epoch: i32,
+    rack_uuid: &Uuid,
+    members: &BTreeSet<Ed25519Certificate>,
+    responses: &BTreeMap<Ed25519Certificate, NodeResponse>,
+) -> Result<(), TestCaseError> {
+    prop_assert_eq!(responses.len(), members.len());
+    let sources: BTreeSet<Ed25519Certificate> =
+        responses.keys().cloned().into_iter().collect();
+    prop_assert_eq!(&sources, members);
+    for response in responses.values() {
+        prop_assert_eq!(1, response.version);
+        prop_assert_eq!(coordinator_id, response.coordinator_id);
+        assert_matches!(response.result, Ok(NodeOpResult::CommitOk{rack_uuid: msg_rack_uuid, epoch: msg_epoch}) => {
+                prop_assert_eq!(*rack_uuid, msg_rack_uuid);
+                prop_assert_eq!(msg_epoch, epoch);
+        });
+    }
+    Ok(())
+}
+
+// Ensure that all nodes have KeyShares prepared for epoch 0
+fn prop_initialize_prepared(
+    rack_uuid: &Uuid,
+    nodes: &mut BTreeMap<Ed25519Certificate, Node>,
+) -> Result<(), TestCaseError> {
+    let epoch = 0;
+    for node in nodes.values_mut() {
+        prop_assert!(node.has_key_share_prepare(rack_uuid, epoch)?);
+    }
+    Ok(())
+}
+
+proptest! {
+    // Generate a trust quorum and intialize a set of nodes with a coordinator.
+    // The members of the trust quorum are generated by proptest
+    //
+    // Don't drop any messages and assume everything works perfectly in this test
+    #[test]
+    fn successful_initialization(members in arb_members()) {
+        let logctx = test_setup_log("proptest");
+        let rack_uuid = Uuid::new_v4();
+        // Create a coordinator for rack initialization
+        let mut coordinator = Coordinator::new_initialize(
+            logctx.log.clone(),
+            rack_uuid.clone(),
+            members.clone(),
+        )?;
+
+        // Create a `Node` per member
+        let mut nodes: BTreeMap<Ed25519Certificate, Node> =
+            members.iter().cloned().into_iter().map(|cert| {
+                let config = Config {
+                    log: logctx.log.clone(),
+                    db_path: ":memory:".to_string(),
+                };
+                (cert, Node::new(config))
+            }).collect();
+
+        // There should be a `NodeOp::Initialize` request for each member
+        let requests = coordinator.next_requests()?;
+        prop_initialize_for_all_members(&rack_uuid, &members, &requests)?;
+
+        // Pass an `Initialize` message to each node and gather the response
+        let responses: BTreeMap<_, _> = requests.into_iter().map(|(cert, req)| {
+            (cert, nodes.get_mut(&cert).unwrap().handle(req))
+        }).collect();
+
+        // Verify that all responses are correct
+        prop_initialize_responses_are_all_valid(&rack_uuid, &members, &responses)?;
+
+        // Verify the state of all Nodes to ensure they have the KeySharePrepare
+        prop_initialize_prepared(&rack_uuid, &mut nodes)?;
+
+        // Pass the responses back to the coordinator
+        for (from, response) in responses {
+            // `false` indicates that the transaction is not complete. This is
+            // true because we haven't committed yet.
+            prop_assert_eq!(false, coordinator.handle(from, response)?);
+        }
+
+        // Get the next set of requests from the coordinator which should
+        // be a `KeyShareCommit` for each member
+        let requests = coordinator.next_requests()?;
+        let coordinator_id = 0;
+        let epoch = 0;
+        prop_key_share_commit_for_all_members(
+            coordinator_id, epoch,  &rack_uuid, &members, &requests)?;
+
+        // Handle the commits at the Nodes and get the responses
+        let responses: BTreeMap<_, _> = requests.into_iter().map(|(cert, req)| {
+            (cert, nodes.get_mut(&cert).unwrap().handle(req))
+        }).collect();
+
+
+        // Verify that the responses are correct
+        prop_key_share_commit_responses_are_all_valid(
+            coordinator_id, epoch, &rack_uuid, &members, &responses)?;
+
+        // Verify that initialization is complete at all Nodes
+        for node in nodes.values_mut() {
+            prop_assert!(node.is_initialized(&rack_uuid)?);
+        }
+
+        // Handle the responses at the coordinator
+        // The transaction is only complete after the last response
+        for (i, (from, response)) in responses.into_iter().enumerate() {
+            if i != members.len() -1 {
+                prop_assert_eq!(false, coordinator.handle(from, response)?);
+            } else {
+                prop_assert_eq!(true, coordinator.handle(from, response)?);
+            }
+        }
+
+        // Ensure the coordinator has no more requests to send, since the
+        // transaction is complete.
+        prop_assert!(coordinator.next_requests()?.is_empty());
+
+        logctx.cleanup_successful();
+    }
+}

--- a/bootstore/tests/integration-proptest.rs
+++ b/bootstore/tests/integration-proptest.rs
@@ -163,7 +163,7 @@ proptest! {
         let rack_uuid = Uuid::new_v4();
         // Create a coordinator for rack initialization
         let mut coordinator = Coordinator::new_initialize(
-            logctx.log.clone(),
+            &logctx.log,
             rack_uuid.clone(),
             members.clone(),
         )?;
@@ -196,7 +196,7 @@ proptest! {
         // Pass the responses back to the coordinator
         for (from, response) in responses {
             // `false` indicates that the transaction is not complete. This is
-            // true because we haven't committed yet.
+            // correct because we haven't committed yet.
             prop_assert_eq!(false, coordinator.handle(from, response)?);
         }
 

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -14,7 +14,7 @@ omicron-package = { path = "../package" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 sp-sim = { path = "../sp-sim" }
-sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
+sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
 thiserror = "1.0"
 toml = "0.5.9"
 

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -44,8 +44,8 @@ slog-dtrace = "0.2"
 smf = "0.2"
 spdm = { git = "https://github.com/oxidecomputer/spdm", rev = "9742f6e" }
 sp-sim = { path = "../sp-sim" }
-sprockets-common = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
-sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
+sprockets-common = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
+sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
 socket2 = { version = "0.4", features = [ "all" ] }
 tar = "0.4"
 tempfile = "3.3"

--- a/sled-agent/src/sp/mod.rs
+++ b/sled-agent/src/sp/mod.rs
@@ -131,7 +131,6 @@ impl SpHandle {
         let session = match role {
             SprocketsRole::Client => sprockets_host::Session::new_client(
                 stream,
-                self.manufacturing_public_key(),
                 self.rot_handle(),
                 self.rot_certs(),
                 ROT_TIMEOUT,
@@ -140,7 +139,6 @@ impl SpHandle {
             .map_err(|e| SpError::SprocketsSessionError(e.to_string()))?,
             SprocketsRole::Server => sprockets_host::Session::new_server(
                 stream,
-                self.manufacturing_public_key(),
                 self.rot_handle(),
                 self.rot_certs(),
                 ROT_TIMEOUT,

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -14,7 +14,7 @@ gateway-messages = { path = "../gateway-messages", default-features = false, fea
 hex = { version = "0.4.3", features = ["serde"] }
 omicron-common = { path = "../common" }
 slog-dtrace = "0.2"
-sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "0361fd13ff19cda6696242fe40f1325fca30d3d1" }
+sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
 thiserror = "1.0"
 toml = "0.5.9"
 


### PR DESCRIPTION
This commit introduces the coordinator for the bootstore 2PC protocol. Currently only the rack initialization part of the coordinator is implemented. Reconfiguration is coming later.

A property based test was written that shows a single rack initialization that works perfectly. This is good for demonstration purposes, but a more advanced stateful test will be written in the future to add failures / dropped messages when reconfiguration is implemented.

A smattering of other changes are here as well.

* Sqlite connections now live inside a RefCell to allow logically immutable methods.
* Shares are now zeroized on drop
* Trust quorum membership is now a BTreeSet of certs rather than a Vec