### PR TITLE
Increase session timeouts in example Nexus config

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -6,8 +6,8 @@
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "out/console-assets"
 cache_control_max_age_minutes = 10
-session_idle_timeout_minutes = 60
-session_absolute_timeout_minutes = 480
+session_idle_timeout_minutes = 480 # 6 hours
+session_absolute_timeout_minutes = 1440 # 24 hours
 
 # List of authentication schemes to support.
 #


### PR DESCRIPTION
We got some praise in chat last week for how well the login redirect works if your console session expires, but that made me realize there's no reason it should expire so frequently. I'm assuming the dev environments in question are using the example config. If that is not the case this will do nothing.