### PR TITLE
Move to a new nightly toolchain

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (ubuntu-20.04)"
 #: variety = "basic"
 #: target = "ubuntu-20.04"
-#: rust_toolchain = "nightly-2022-04-27"
+#: rust_toolchain = "nightly-2022-09-27"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,14 +53,14 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-04-27' build --locked --all-targets --verbose
+ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
 # having to rebuild here.
 #
 banner test
-ptime -m cargo +'nightly-2022-04-27' test --workspace --locked --verbose \
+ptime -m cargo +'nightly-2022-09-27' test --workspace --locked --verbose \
     --no-fail-fast
 
 #

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-04-27"
+#: rust_toolchain = "nightly-2022-09-27"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,14 +53,14 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-04-27' build --locked --all-targets --verbose
+ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
 # having to rebuild here.
 #
 banner test
-ptime -m cargo +'nightly-2022-04-27' test --workspace --locked --verbose \
+ptime -m cargo +'nightly-2022-09-27' test --workspace --locked --verbose \
     --no-fail-fast
 
 #

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -3,7 +3,7 @@
 #: name = "helios / package"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-04-27"
+#: rust_toolchain = "nightly-2022-09-27"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
 #: ]

--- a/internal-dns/src/dns_server.rs
+++ b/internal-dns/src/dns_server.rs
@@ -209,7 +209,7 @@ async fn handle_req<'a, 'b, 'c>(
 
     let mresp = rb.build(
         header,
-        response_records.iter().map(|r| &*r).collect::<Vec<&Record>>(),
+        response_records.iter().collect::<Vec<&Record>>(),
         vec![],
         vec![],
         vec![],

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#![feature(async_closure)]
 
 //! Library interface to the Nexus, the heart of the control plane
 

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -50,7 +50,7 @@ impl SagaContext {
     }
 
     pub fn datastore(&self) -> &db::DataStore {
-        &*self.nexus.datastore()
+        self.nexus.datastore()
     }
 
     pub async fn sled_client(

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -37,7 +37,7 @@ pub enum Error {
     #[error("Error running Oximeter collector server: {0}")]
     Server(String),
 
-    #[error("Error collecting metric data from collector id={:0}: {1}")]
+    #[error("Error collecting metric data from collector id={0}: {1}")]
     CollectionError(Uuid, String),
 
     #[error(transparent)]

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -319,7 +319,7 @@ impl Client {
             );
             timeseries.measurements.push(measurement);
         }
-        Ok(timeseries_by_key.into_iter().map(|(_, item)| item).collect())
+        Ok(timeseries_by_key.into_values().collect())
     }
 
     // Initialize ClickHouse with the database and metric table schema.

--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -548,8 +548,8 @@ impl SelectQuery {
                 let mut from_statements = String::new();
                 for (i, subquery) in self
                     .field_selectors
-                    .iter()
-                    .map(|(_, sel)| {
+                    .values()
+                    .map(|sel| {
                         sel.as_query(&self.timeseries_schema.timeseries_name)
                     })
                     .enumerate()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,5 +10,5 @@
 [toolchain]
 # NOTE: This toolchain is also specified within .github/buildomat/jobs/{build-and-test,package}.sh.
 # If you update it here, update that file too.
-channel = "nightly-2022-04-27"
+channel = "nightly-2022-09-27"
 profile = "default"

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -212,7 +212,7 @@ impl Agent {
             let trust_quorum_share =
                 sled_request.trust_quorum_share.map(ShareDistribution::from);
             agent
-                .request_agent(&*sled_request.request, &trust_quorum_share)
+                .request_agent(&sled_request.request, &trust_quorum_share)
                 .await?;
             TrustQuorumMembership::Known(Arc::new(trust_quorum_share))
         } else {

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -306,7 +306,7 @@ async fn serve_request_before_quorum_initialization(
             *initial_share.lock().await = trust_quorum_share.clone();
 
             match bootstrap_agent
-                .request_agent(&*request, &trust_quorum_share)
+                .request_agent(&request, &trust_quorum_share)
                 .await
             {
                 Ok(response) => {

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -59,18 +59,3 @@ impl LazyNexusClient {
         ))
     }
 }
-
-// Provides a mock implementation of the [`LazyNexusClient`].
-//
-// This allows tests to use the structure without actually performing
-// any DNS lookups.
-#[cfg(test)]
-mockall::mock! {
-    pub LazyNexusClient {
-        pub fn new(log: Logger, addr: Ipv6Addr) -> Result<Self, ResolveError>;
-        pub async fn get(&self) -> Result<NexusClient, String>;
-    }
-    impl Clone for LazyNexusClient {
-        fn clone(&self) -> Self;
-    }
-}

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -105,6 +105,9 @@ pub fn default_services_config_path() -> PathBuf {
     Path::new(omicron_common::OMICRON_CONFIG_PATH).join(SERVICE_CONFIG_FILENAME)
 }
 
+// Converts a zone and service name into a full configuration directory path.
+type ConfigDirGetter = Box<dyn Fn(&str, &str) -> PathBuf + Send + Sync>;
+
 /// Configuration parameters which modify the [`ServiceManager`]'s behavior.
 pub struct Config {
     /// An optional internet gateway address for external services.
@@ -116,7 +119,7 @@ pub struct Config {
 
     /// A function which returns the path the directory holding the
     /// service's configuration file.
-    pub get_svc_config_dir: Box<dyn Fn(&str, &str) -> PathBuf + Send + Sync>,
+    pub get_svc_config_dir: ConfigDirGetter,
 }
 
 impl Default for Config {


### PR DESCRIPTION
- Moves to a rust toolchain version that supports https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table , which I'm gonna poke at next
- Fixes compilation warnings
- Remove one nightly feature

Other than the `asm_sym` support for USDT on Mac, we're ready to move to stable.