### PR TITLE
Update volume management tests to use /system/images

### DIFF
--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -95,7 +95,7 @@ async fn test_snapshot_then_delete_disk(cptestctx: &ControlPlaneTestContext) {
     };
 
     let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/images", &image_create_params)
+        NexusRequest::objects_post(client, "/system/images", &image_create_params)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await
@@ -224,7 +224,7 @@ async fn test_delete_snapshot_then_disk(cptestctx: &ControlPlaneTestContext) {
     };
 
     let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/images", &image_create_params)
+        NexusRequest::objects_post(client, "/system/images", &image_create_params)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await
@@ -353,7 +353,7 @@ async fn test_multiple_snapshots(cptestctx: &ControlPlaneTestContext) {
     };
 
     let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/images", &image_create_params)
+        NexusRequest::objects_post(client, "/system/images", &image_create_params)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await
@@ -483,7 +483,7 @@ async fn test_snapshot_prevents_other_disk(
     };
 
     let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/images", &image_create_params)
+        NexusRequest::objects_post(client, "/system/images", &image_create_params)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -94,14 +94,17 @@ async fn test_snapshot_then_delete_disk(cptestctx: &ControlPlaneTestContext) {
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
-    let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/system/images", &image_create_params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+    let global_image: views::GlobalImage = NexusRequest::objects_post(
+        client,
+        "/system/images",
+        &image_create_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
 
     // Create a disk from this image
     let disk_size = ByteCount::try_from(2u64 * 1024 * 1024 * 1024).unwrap();
@@ -223,14 +226,17 @@ async fn test_delete_snapshot_then_disk(cptestctx: &ControlPlaneTestContext) {
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
-    let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/system/images", &image_create_params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+    let global_image: views::GlobalImage = NexusRequest::objects_post(
+        client,
+        "/system/images",
+        &image_create_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
 
     // Create a disk from this image
     let disk_size = ByteCount::try_from(2u64 * 1024 * 1024 * 1024).unwrap();
@@ -352,14 +358,17 @@ async fn test_multiple_snapshots(cptestctx: &ControlPlaneTestContext) {
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
-    let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/system/images", &image_create_params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+    let global_image: views::GlobalImage = NexusRequest::objects_post(
+        client,
+        "/system/images",
+        &image_create_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
 
     // Create a disk from this image
     let disk_size = ByteCount::try_from(2u64 * 1024 * 1024 * 1024).unwrap();
@@ -482,14 +491,17 @@ async fn test_snapshot_prevents_other_disk(
         block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
-    let global_image: views::GlobalImage =
-        NexusRequest::objects_post(client, "/system/images", &image_create_params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+    let global_image: views::GlobalImage = NexusRequest::objects_post(
+        client,
+        "/system/images",
+        &image_create_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
 
     // Create a disk from this image
     let disk_size = ByteCount::try_from(2u64 * 1024 * 1024 * 1024).unwrap();


### PR DESCRIPTION
Update the volume tests to use the new path for global images