### PR TITLE
impl traits on ServerContext rather than `Arc<ServerContext>`

### DIFF
--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -44,7 +44,7 @@ pub struct ServerContext {
     /// debug log
     pub log: Logger,
     /// authenticator for external HTTP requests
-    pub external_authn: authn::external::Authenticator<Arc<ServerContext>>,
+    pub external_authn: authn::external::Authenticator<ServerContext>,
     /// authentication context used for internal HTTP requests
     pub internal_authn: Arc<authn::Context>,
     /// authorizer
@@ -83,15 +83,15 @@ impl ServerContext {
             .authn
             .schemes_external
             .iter()
-            .map::<Box<dyn HttpAuthnScheme<Arc<ServerContext>>>, _>(|name| {
-                match name {
+            .map::<Box<dyn HttpAuthnScheme<ServerContext>>, _>(
+                |name| match name {
                     config::SchemeName::Spoof => Box::new(HttpAuthnSpoof),
                     config::SchemeName::SessionCookie => {
                         Box::new(HttpAuthnSessionCookie)
                     }
                     config::SchemeName::AccessToken => Box::new(HttpAuthnToken),
-                }
-            })
+                },
+            )
             .collect();
         let external_authn = authn::external::Authenticator::new(nexus_schemes);
         let internal_authn = Arc::new(authn::Context::internal_api());
@@ -534,7 +534,7 @@ mod test {
 }
 
 #[async_trait]
-impl authn::external::SiloUserSilo for Arc<ServerContext> {
+impl authn::external::SiloUserSilo for ServerContext {
     async fn silo_user_silo(
         &self,
         silo_user_id: Uuid,
@@ -545,7 +545,7 @@ impl authn::external::SiloUserSilo for Arc<ServerContext> {
 }
 
 #[async_trait]
-impl authn::external::token::TokenContext for Arc<ServerContext> {
+impl authn::external::token::TokenContext for ServerContext {
     async fn token_actor(
         &self,
         token: String,
@@ -556,7 +556,7 @@ impl authn::external::token::TokenContext for Arc<ServerContext> {
 }
 
 #[async_trait]
-impl SessionStore for Arc<ServerContext> {
+impl SessionStore for ServerContext {
     type SessionModel = ConsoleSessionWithSiloId;
 
     async fn session_fetch(&self, token: String) -> Option<Self::SessionModel> {

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -728,13 +728,13 @@ pub async fn asset(
     Ok(resp.body(file_contents.into())?)
 }
 
-fn cache_control_value(apictx: &Arc<ServerContext>) -> String {
+fn cache_control_value(apictx: &ServerContext) -> String {
     let max_age = apictx.console_config.cache_control_max_age.num_seconds();
     format!("max-age={max_age}")
 }
 
 pub async fn serve_console_index(
-    apictx: &Arc<ServerContext>,
+    apictx: &ServerContext,
 ) -> Result<Response<Body>, HttpError> {
     let static_dir = &apictx
         .console_config


### PR DESCRIPTION
This is pretty minor but it makes it possible to write more functions that accept just `&ServerContext` instead of `Arc<ServerContext>` or `&Arc<ServerContext>`.  This came up in the password-based login work I'm doing.