### PR TITLE
silo_user_fetch_by_external_id() does not need `ErrorHandler::NotFound`

### DIFF
--- a/nexus/src/db/datastore/silo_user.rs
+++ b/nexus/src/db/datastore/silo_user.rs
@@ -22,7 +22,6 @@ use diesel::prelude::*;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
-use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use uuid::Uuid;
 

--- a/nexus/src/db/datastore/silo_user.rs
+++ b/nexus/src/db/datastore/silo_user.rs
@@ -73,13 +73,7 @@ impl DataStore {
             .load_async::<SiloUser>(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| {
-                public_error_from_diesel_pool(
-                    e,
-                    ErrorHandler::NotFoundByLookup(
-                        ResourceType::SiloUser,
-                        LookupType::ByName(external_id.to_string()),
-                    ),
-                )
+                public_error_from_diesel_pool(e, ErrorHandler::Server)
             })?
             .pop())
     }


### PR DESCRIPTION
silo_user_fetch_by_external_id uses `ErrorHandler::NotFoundByLookup`.  The main difference between this and `ErrorHandler::Server` (which is more the default case) is that it handles `DieselError::NotFound` explicitly and turns that into a `Error::ObjectNotFound`, which will become a 404. However, I believe that case cannot happen here because we're using `load_async()` (which is async-bb8-diesel's analog of diesel's `load()`), and the [Diesel docs](https://docs.diesel.rs/2.0.x/diesel/result/enum.Error.html#variant.NotFound) say:

> This variant is only returned by `get_result` and `first`. `load` does not treat 0 rows as an error.

Even if it could happen, this handling would be wrong.  This function expects to return `Ok(None)` when no such user is found.  We don't want it to return an error in this case.