### PR TITLE
silo_user functions could use more authz objects

### DIFF
--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -164,7 +164,7 @@ impl super::Nexus {
         opctx.authorize(authz::Action::CreateChild, authz_silo).await?;
         opctx.authorize(authz::Action::ListChildren, authz_silo).await?;
 
-        let existing_silo_user = self
+        let fetch_result = self
             .datastore()
             .silo_user_fetch_by_external_id(
                 opctx,
@@ -173,32 +173,35 @@ impl super::Nexus {
             )
             .await?;
 
-        let silo_user = if let Some(existing_silo_user) = existing_silo_user {
-            existing_silo_user
-        } else {
-            // In this branch, no user exists for the authenticated subject
-            // external id. The next action depends on the silo's user provision
-            // type.
-            match db_silo.user_provision_type {
-                // If the user provision type is fixed, do not a new user if one
-                // does not exist.
-                db::model::UserProvisionType::Fixed => {
-                    return Ok(None);
-                }
+        let (authz_silo_user, db_silo_user) =
+            if let Some(existing_silo_user) = fetch_result {
+                existing_silo_user
+            } else {
+                // In this branch, no user exists for the authenticated subject
+                // external id. The next action depends on the silo's user
+                // provision type.
+                match db_silo.user_provision_type {
+                    // If the user provision type is fixed, do not a new user if
+                    // one does not exist.
+                    db::model::UserProvisionType::Fixed => {
+                        return Ok(None);
+                    }
 
-                // If the user provision type is JIT, then create the user if
-                // one does not exist
-                db::model::UserProvisionType::Jit => {
-                    let silo_user = db::model::SiloUser::new(
-                        authz_silo.id(),
-                        Uuid::new_v4(),
-                        authenticated_subject.external_id.clone(),
-                    );
+                    // If the user provision type is JIT, then create the user if
+                    // one does not exist
+                    db::model::UserProvisionType::Jit => {
+                        let silo_user = db::model::SiloUser::new(
+                            authz_silo.id(),
+                            Uuid::new_v4(),
+                            authenticated_subject.external_id.clone(),
+                        );
 
-                    self.db_datastore.silo_user_create(silo_user).await?
+                        self.db_datastore
+                            .silo_user_create(&authz_silo, silo_user)
+                            .await?
+                    }
                 }
-            }
-        };
+            };
 
         // Gather a list of groups that the user is part of based on what the
         // IdP sent us. Also, if the silo user provision type is Jit, create
@@ -242,12 +245,12 @@ impl super::Nexus {
         self.db_datastore
             .silo_group_membership_replace_for_user(
                 opctx,
-                silo_user.id(),
+                &authz_silo_user,
                 silo_user_group_ids,
             )
             .await?;
 
-        Ok(Some(silo_user))
+        Ok(Some(db_silo_user))
     }
 
     // Silo groups

--- a/nexus/src/authz/policy_test/resource_builder.rs
+++ b/nexus/src/authz/policy_test/resource_builder.rs
@@ -106,10 +106,15 @@ impl<'a> ResourceBuilder<'a> {
             println!("creating user: {}", &username);
             self.users.push((username.clone(), user_id));
 
+            let authz_silo = authz::Silo::new(
+                authz::FLEET,
+                silo_id,
+                LookupType::ById(silo_id),
+            );
             let silo_user =
                 db::model::SiloUser::new(silo_id, user_id, username);
             datastore
-                .silo_user_create(silo_user)
+                .silo_user_create(&authz_silo, silo_user)
                 .await
                 .expect("failed to create silo user");
 

--- a/nexus/src/db/datastore/mod.rs
+++ b/nexus/src/db/datastore/mod.rs
@@ -335,12 +335,20 @@ mod test {
             .unwrap();
 
         // Associate silo with user
+        let authz_silo = authz::Silo::new(
+            authz::FLEET,
+            *SILO_ID,
+            LookupType::ById(*SILO_ID),
+        );
         datastore
-            .silo_user_create(SiloUser::new(
-                *SILO_ID,
-                silo_user_id,
-                "external_id".into(),
-            ))
+            .silo_user_create(
+                &authz_silo,
+                SiloUser::new(
+                    authz_silo.id(),
+                    silo_user_id,
+                    "external_id".into(),
+                ),
+            )
             .await
             .unwrap();
 
@@ -850,13 +858,21 @@ mod test {
         let (opctx, datastore) = datastore_test(&logctx, &db).await;
 
         // Create a new Silo user so that we can lookup their keys.
+        let authz_silo = authz::Silo::new(
+            authz::FLEET,
+            *SILO_ID,
+            LookupType::ById(*SILO_ID),
+        );
         let silo_user_id = Uuid::new_v4();
         datastore
-            .silo_user_create(SiloUser::new(
-                *SILO_ID,
-                silo_user_id,
-                "external@id".into(),
-            ))
+            .silo_user_create(
+                &authz_silo,
+                SiloUser::new(
+                    authz_silo.id(),
+                    silo_user_id,
+                    "external@id".into(),
+                ),
+            )
             .await
             .unwrap();
 

--- a/nexus/src/db/datastore/silo_user.rs
+++ b/nexus/src/db/datastore/silo_user.rs
@@ -10,6 +10,7 @@ use crate::authz;
 use crate::context::OpContext;
 use crate::db;
 use crate::db::datastore::IdentityMetadataCreateParams;
+use crate::db::datastore::LookupType;
 use crate::db::error::public_error_from_diesel_pool;
 use crate::db::error::ErrorHandler;
 use crate::db::model::Name;
@@ -19,6 +20,8 @@ use crate::db::pagination::paginated;
 use crate::external_api::params;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::prelude::*;
+use nexus_types::identity::Asset;
+use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
@@ -29,8 +32,10 @@ impl DataStore {
     /// Create a silo user
     pub async fn silo_user_create(
         &self,
+        authz_silo: &authz::Silo,
         silo_user: SiloUser,
-    ) -> Result<SiloUser, Error> {
+    ) -> CreateResult<(authz::SiloUser, SiloUser)> {
+        // TODO-security This needs an authz check.
         use db::schema::silo_user::dsl;
 
         let silo_user_external_id = silo_user.external_id.clone();
@@ -48,10 +53,20 @@ impl DataStore {
                     ),
                 )
             })
+            .map(|db_silo_user: SiloUser| {
+                let silo_user_id = db_silo_user.id();
+                let authz_silo_user = authz::SiloUser::new(
+                    authz_silo.clone(),
+                    silo_user_id,
+                    LookupType::ById(silo_user_id),
+                );
+                (authz_silo_user, db_silo_user)
+            })
     }
 
     /// Given an external ID, return
-    /// - Ok(Some(SiloUser)) if that external id refers to an existing silo user
+    /// - Ok(Some((authz::SiloUser, SiloUser))) if that external id refers to an
+    ///   existing silo user
     /// - Ok(None) if it does not
     /// - Err(...) if there was an error doing this lookup.
     pub async fn silo_user_fetch_by_external_id(
@@ -59,7 +74,7 @@ impl DataStore {
         opctx: &OpContext,
         authz_silo: &authz::Silo,
         external_id: &str,
-    ) -> Result<Option<SiloUser>, Error> {
+    ) -> Result<Option<(authz::SiloUser, SiloUser)>, Error> {
         opctx.authorize(authz::Action::ListChildren, authz_silo).await?;
 
         use db::schema::silo_user::dsl;
@@ -74,7 +89,15 @@ impl DataStore {
             .map_err(|e| {
                 public_error_from_diesel_pool(e, ErrorHandler::Server)
             })?
-            .pop())
+            .pop()
+            .map(|db_silo_user| {
+                let authz_silo_user = authz::SiloUser::new(
+                    authz_silo.clone(),
+                    db_silo_user.id(),
+                    LookupType::ByName(external_id.to_owned()),
+                );
+                (authz_silo_user, db_silo_user)
+            }))
     }
 
     pub async fn silo_users_list_by_id(


### PR DESCRIPTION
This is a minor change that came out of the local password authn work.  `DataStore::silo_user_create()` and `DataStore::silo_user_fetch_by_external_id()` currently return a `db::model::SiloUser`.  Like the `LookupPath` functions, I think these should return an `authz::SiloUser` as well.  This is often necessary if you want to do anything else with the user object that you just got back.  A side effect of this change is that it saves an extra database lookup during login because we were previously making a separate `LookupPath` query just to do the authz check.  Now, we can check against the authz_user that we have.