### PR TITLE
gateway-messages: Add variants for SP auxflash updates

### DIFF
--- a/gateway-messages/src/sp_impl.rs
+++ b/gateway-messages/src/sp_impl.rs
@@ -6,6 +6,7 @@
 
 use crate::version;
 use crate::BulkIgnitionState;
+use crate::ComponentUpdatePrepare;
 use crate::DiscoverResponse;
 use crate::IgnitionCommand;
 use crate::IgnitionState;
@@ -19,9 +20,9 @@ use crate::SpMessage;
 use crate::SpMessageKind;
 use crate::SpPort;
 use crate::SpState;
+use crate::SpUpdatePrepare;
 use crate::UpdateChunk;
 use crate::UpdateId;
-use crate::UpdatePrepare;
 use crate::UpdateStatus;
 use core::convert::Infallible;
 use core::mem;
@@ -70,11 +71,18 @@ pub trait SpHandler {
         port: SpPort,
     ) -> Result<SpState, ResponseError>;
 
-    fn update_prepare(
+    fn sp_update_prepare(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        update: UpdatePrepare,
+        update: SpUpdatePrepare,
+    ) -> Result<(), ResponseError>;
+
+    fn component_update_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        update: ComponentUpdatePrepare,
     ) -> Result<(), ResponseError>;
 
     fn update_chunk(
@@ -242,9 +250,12 @@ pub fn handle_message<H: SpHandler>(
         RequestKind::SpState => {
             handler.sp_state(sender, port).map(ResponseKind::SpState)
         }
-        RequestKind::UpdatePrepare(update) => handler
-            .update_prepare(sender, port, update)
-            .map(|()| ResponseKind::UpdatePrepareAck),
+        RequestKind::SpUpdatePrepare(update) => handler
+            .sp_update_prepare(sender, port, update)
+            .map(|()| ResponseKind::SpUpdatePrepareAck),
+        RequestKind::ComponentUpdatePrepare(update) => handler
+            .component_update_prepare(sender, port, update)
+            .map(|()| ResponseKind::ComponentUpdatePrepareAck),
         RequestKind::UpdateChunk(chunk) => handler
             .update_chunk(sender, port, chunk, trailing_data)
             .map(|()| ResponseKind::UpdateChunkAck),

--- a/gateway-sp-comms/src/communicator.rs
+++ b/gateway-sp-comms/src/communicator.rs
@@ -354,7 +354,10 @@ pub(crate) trait ResponseKindExt {
 
     fn expect_serial_console_detach_ack(self) -> Result<(), BadResponseType>;
 
-    fn expect_update_prepare_ack(self) -> Result<(), BadResponseType>;
+    fn expect_sp_update_prepare_ack(self) -> Result<(), BadResponseType>;
+
+    fn expect_component_update_prepare_ack(self)
+        -> Result<(), BadResponseType>;
 
     fn expect_update_status(self) -> Result<UpdateStatus, BadResponseType>;
 
@@ -392,8 +395,11 @@ impl ResponseKindExt for ResponseKind {
             ResponseKind::SerialConsoleDetachAck => {
                 response_kind_names::SERIAL_CONSOLE_DETACH_ACK
             }
-            ResponseKind::UpdatePrepareAck => {
-                response_kind_names::UPDATE_PREPARE_ACK
+            ResponseKind::SpUpdatePrepareAck => {
+                response_kind_names::SP_UPDATE_PREPARE_ACK
+            }
+            ResponseKind::ComponentUpdatePrepareAck => {
+                response_kind_names::COMPONENT_UPDATE_PREPARE_ACK
             }
             ResponseKind::UpdateStatus(_) => response_kind_names::UPDATE_STATUS,
             ResponseKind::UpdateAbortAck => {
@@ -496,11 +502,23 @@ impl ResponseKindExt for ResponseKind {
         }
     }
 
-    fn expect_update_prepare_ack(self) -> Result<(), BadResponseType> {
+    fn expect_sp_update_prepare_ack(self) -> Result<(), BadResponseType> {
         match self {
-            ResponseKind::UpdatePrepareAck => Ok(()),
+            ResponseKind::SpUpdatePrepareAck => Ok(()),
             other => Err(BadResponseType {
-                expected: response_kind_names::UPDATE_PREPARE_ACK,
+                expected: response_kind_names::SP_UPDATE_PREPARE_ACK,
+                got: other.name(),
+            }),
+        }
+    }
+
+    fn expect_component_update_prepare_ack(
+        self,
+    ) -> Result<(), BadResponseType> {
+        match self {
+            ResponseKind::ComponentUpdatePrepareAck => Ok(()),
+            other => Err(BadResponseType {
+                expected: response_kind_names::COMPONENT_UPDATE_PREPARE_ACK,
                 got: other.name(),
             }),
         }
@@ -579,7 +597,9 @@ mod response_kind_names {
         "serial_console_write_ack";
     pub(super) const SERIAL_CONSOLE_DETACH_ACK: &str =
         "serial_console_detach_ack";
-    pub(super) const UPDATE_PREPARE_ACK: &str = "update_prepare_ack";
+    pub(super) const SP_UPDATE_PREPARE_ACK: &str = "sp_update_prepare_ack";
+    pub(super) const COMPONENT_UPDATE_PREPARE_ACK: &str =
+        "component_update_prepare_ack";
     pub(super) const UPDATE_STATUS: &str = "update_status";
     pub(super) const UPDATE_ABORT_ACK: &str = "update_abort_ack";
     pub(super) const UPDATE_CHUNK_ACK: &str = "update_chunk_ack";

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -133,6 +133,8 @@ enum SpUpdateStatus {
     Complete { id: Uuid },
     /// The SP has aborted an in-progress update.
     Aborted { id: Uuid },
+    /// The update process failed.
+    Failed { id: Uuid, code: u32 },
 }
 
 /// Progress of an SP preparing to update.

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -36,6 +36,13 @@ impl From<UpdateStatus> for SpUpdateStatus {
                 id: status.id.into(),
                 progress: status.progress.map(Into::into),
             },
+            UpdateStatus::SpUpdateAuxFlashChckScan {
+                id, total_size, ..
+            } => Self::InProgress {
+                id: id.into(),
+                bytes_received: 0,
+                total_bytes: total_size,
+            },
             UpdateStatus::InProgress(status) => Self::InProgress {
                 id: status.id.into(),
                 bytes_received: status.bytes_received,
@@ -43,6 +50,9 @@ impl From<UpdateStatus> for SpUpdateStatus {
             },
             UpdateStatus::Complete(id) => Self::Complete { id: id.into() },
             UpdateStatus::Aborted(id) => Self::Aborted { id: id.into() },
+            UpdateStatus::Failed { id, code } => {
+                Self::Failed { id: id.into(), code }
+            }
         }
     }
 }

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -1307,6 +1307,32 @@
               "id",
               "state"
             ]
+          },
+          {
+            "description": "The update process failed.",
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "failed"
+                ]
+              }
+            },
+            "required": [
+              "code",
+              "id",
+              "state"
+            ]
           }
         ]
       },

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -619,11 +619,27 @@ impl SpHandler for Handler {
         Ok(state)
     }
 
-    fn update_prepare(
+    fn sp_update_prepare(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        update: gateway_messages::UpdatePrepare,
+        update: gateway_messages::SpUpdatePrepare,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update prepare request; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn component_update_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        update: gateway_messages::ComponentUpdatePrepare,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -448,11 +448,27 @@ impl SpHandler for Handler {
         Ok(state)
     }
 
-    fn update_prepare(
+    fn sp_update_prepare(
         &mut self,
         sender: SocketAddrV6,
         port: SpPort,
-        update: gateway_messages::UpdatePrepare,
+        update: gateway_messages::SpUpdatePrepare,
+    ) -> Result<(), ResponseError> {
+        warn!(
+            &self.log,
+            "received update prepare request; not supported by simulated sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "update" => ?update,
+        );
+        Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn component_update_prepare(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        update: gateway_messages::ComponentUpdatePrepare,
     ) -> Result<(), ResponseError> {
         warn!(
             &self.log,


### PR DESCRIPTION
The changes in this PR are mostly mechanical; the actual implementation will come in a followup PR. Changes include:

* The `UpdatePrepare` message has been renamed `ComponentUpdatePrepare`, and there is a new `SpUpdatePrepare` that includes auxflash-specific information (the chck value and the size)
* `UpdateStatus` has two new cases:
    * `Failed` (previously we'd return a `ResponseError`, but that felt wrong - we can successfully respond that an update has failed)
    * `SpUpdateAuxFlashChckScan` - this is only valid for SP updates, and is the state we have to see before starting to send data. It returns whether or not the SP already has the auxflash we want to send it. (If the update has no auxflash at all, this state is skipped.)

The bulk of the PR is just dealing with the fallout of these - adding new arms to matches, etc.