### PR TITLE
`/sys/*` route for console system pages

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -639,6 +639,18 @@ pub async fn console_settings_page(
 
 #[endpoint {
    method = GET,
+   path = "/sys/{path:.*}",
+   unpublished = true,
+}]
+pub async fn console_system_page(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    _path_params: Path<RestPathParam>,
+) -> Result<Response<Body>, HttpError> {
+    console_index_or_login_redirect(rqctx).await
+}
+
+#[endpoint {
+   method = GET,
    path = "/",
    unpublished = true,
 }]

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -253,6 +253,7 @@ pub fn external_api() -> NexusApiDescription {
         api.register(console_api::console_page)?;
         api.register(console_api::console_root)?;
         api.register(console_api::console_settings_page)?;
+        api.register(console_api::console_system_page)?;
         api.register(console_api::asset)?;
 
         api.register(console_api::login)?;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -163,6 +163,7 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
         "/",
         "/orgs/irrelevant-path",
         "/settings/irrelevant-path",
+        "/sys/irrelevant-path",
         "/device/success",
         "/device/verify",
     ];

--- a/tools/populate/populate-alpine.sh
+++ b/tools/populate/populate-alpine.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Simple script to install the alpine image included with propolis.
 
-if ! oxide api images > /dev/null; then
-        echo "Problem detected running the oxide CLI"
+if ! oxide api /system/images > /dev/null; then
+    echo "Problem detected running the oxide CLI"
     echo "Please install, set path, or setup authorization"
     exit 1
 fi


### PR DESCRIPTION
See #430. New route analogous to existing `/orgs/*` and `/settings/*`. Can't be `/system/*` because there are API routes that would conflict with it.