### PR TITLE
Expose propolis' serial console channel in nexus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "schemars",
  "serde",
@@ -1066,8 +1066,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "omicron-zone-package",
- "progenitor",
- "progenitor-client",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "quote",
  "reqwest",
  "serde",
@@ -1744,7 +1744,7 @@ dependencies = [
  "chrono",
  "futures",
  "omicron-common",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "serde",
  "serde_json",
@@ -2297,7 +2297,7 @@ dependencies = [
  "internal-dns",
  "omicron-common",
  "omicron-test-utils",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "serde",
  "serde_json",
@@ -2702,7 +2702,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "serde",
  "serde_json",
@@ -2935,7 +2935,7 @@ dependencies = [
  "ipnetwork",
  "macaddr",
  "parse-display",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -3060,6 +3060,7 @@ dependencies = [
  "oximeter-producer",
  "parse-display",
  "pq-sys",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=da3cfc26e4a6239810e0c7904aefe68443627704)",
  "rand 0.8.5",
  "ref-cast",
  "regex",
@@ -3082,6 +3083,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tokio-tungstenite",
  "toml",
  "tough",
  "usdt",
@@ -3155,8 +3157,8 @@ dependencies = [
  "oximeter-producer",
  "p256",
  "percent-encoding",
- "progenitor",
- "propolis-client",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d8185d7060a20f55df00a72a)",
  "rand 0.8.5",
  "reqwest",
  "schemars",
@@ -3395,13 +3397,16 @@ dependencies = [
 name = "oxide-client"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "futures",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "rand 0.8.5",
  "regress",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 
@@ -3439,7 +3444,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "serde",
  "slog",
@@ -4016,16 +4021,45 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.2.1-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#f9708ef56c3a0b88dc88fc0a0fbf0d8885fdd3e8"
+dependencies = [
+ "anyhow",
+ "clap 4.0.18",
+ "openapiv3",
+ "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "progenitor-macro 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.2.1-dev"
 source = "git+https://github.com/oxidecomputer/progenitor#54382d83d0dec348a56849f4cf8cc55479ffcb48"
 dependencies = [
  "anyhow",
  "clap 4.0.18",
  "openapiv3",
- "progenitor-client",
- "progenitor-impl",
- "progenitor-macro",
+ "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-macro 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.2.1-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#f9708ef56c3a0b88dc88fc0a0fbf0d8885fdd3e8"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
 ]
 
 [[package]]
@@ -4040,6 +4074,28 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.2.1-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#f9708ef56c3a0b88dc88fc0a0fbf0d8885fdd3e8"
+dependencies = [
+ "getopts",
+ "heck 0.4.0",
+ "indexmap",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustfmt-wrapper",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "typify",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4067,11 +4123,26 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.2.1-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#f9708ef56c3a0b88dc88fc0a0fbf0d8885fdd3e8"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "quote",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.2.1-dev"
 source = "git+https://github.com/oxidecomputer/progenitor#54382d83d0dec348a56849f4cf8cc55479ffcb48"
 dependencies = [
  "openapiv3",
  "proc-macro2",
- "progenitor-impl",
+ "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "quote",
  "serde",
  "serde_json",
@@ -4086,7 +4157,8 @@ source = "git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d818
 dependencies = [
  "base64",
  "crucible-client-types",
- "propolis_types",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d8185d7060a20f55df00a72a)",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -4095,6 +4167,28 @@ dependencies = [
  "serde_json",
  "slog",
  "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "propolis-client"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=da3cfc26e4a6239810e0c7904aefe68443627704#da3cfc26e4a6239810e0c7904aefe68443627704"
+dependencies = [
+ "base64",
+ "crucible-client-types",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=da3cfc26e4a6239810e0c7904aefe68443627704)",
+ "rand 0.8.5",
+ "reqwest",
+ "ring",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror",
+ "tokio",
  "uuid",
 ]
 
@@ -4102,6 +4196,14 @@ dependencies = [
 name = "propolis_types"
 version = "0.0.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d8185d7060a20f55df00a72a#9da9cea30adfcce6d8185d7060a20f55df00a72a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "propolis_types"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=da3cfc26e4a6239810e0c7904aefe68443627704#da3cfc26e4a6239810e0c7904aefe68443627704"
 dependencies = [
  "serde",
 ]
@@ -5115,7 +5217,7 @@ dependencies = [
  "chrono",
  "ipnetwork",
  "omicron-common",
- "progenitor",
+ "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "regress",
  "reqwest",
  "serde",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,7 +16,7 @@ hyper = "0.14"
 ipnetwork = "0.20"
 macaddr = { version = "1.0.1", features = [ "serde_std" ] }
 rand = "0.8.4"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 ring = "0.16"
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/ddm-admin-client/Cargo.toml
+++ b/ddm-admin-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.11.12", features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 slog = "2.7"
 

--- a/gateway-client/Cargo.toml
+++ b/gateway-client/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 serde_json = "1.0"
 futures = "0.3.25"
 

--- a/internal-dns-client/Cargo.toml
+++ b/internal-dns-client/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 futures = "0.3.25"
 omicron-common = { path = "../common" }
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 slog = { version = "2.5.0", features = [ "max_level_trace", "release_max_level_debug" ] }

--- a/nexus-client/Cargo.toml
+++ b/nexus-client/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 serde_json = "1.0"
 
 [dependencies.chrono]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -45,6 +45,7 @@ oximeter-db = { path = "../oximeter/db/" }
 parse-display = "0.6.0"
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "da3cfc26e4a6239810e0c7904aefe68443627704", features = [ "generated" ] }
 rand = "0.8.5"
 ref-cast = "1.0"
 reqwest = { version = "0.11.12", features = [ "json" ] }
@@ -58,6 +59,7 @@ slog-dtrace = "0.2"
 steno = "0.2"
 tempfile = "3.3"
 thiserror = "1.0"
+tokio-tungstenite = "0.17.2"
 toml = "0.5.9"
 tough = { version = "0.12", features = [ "http" ] }
 usdt = "0.3.1"

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -394,7 +394,12 @@ async fn verify_endpoint(
     // might find a 404 because of something that actually doesn't exist rather
     // than something that's just hidden from unauthorized users.
     let get_allowed = endpoint.allowed_methods.iter().find(|allowed| {
-        matches!(allowed, AllowedMethod::Get | AllowedMethod::GetUnimplemented)
+        matches!(
+            allowed,
+            AllowedMethod::Get
+                | AllowedMethod::GetUnimplemented
+                | AllowedMethod::GetWebsocket
+        )
     });
     let resource_before = match get_allowed {
         Some(AllowedMethod::Get) => {
@@ -426,6 +431,19 @@ async fn verify_endpoint(
             .execute()
             .await
             .unwrap();
+            None
+        }
+        Some(AllowedMethod::GetWebsocket) => {
+            info!(log, "test: privileged GET WebSocket");
+            record_operation(WhichTest::PrivilegedGet(Some(
+                &http::StatusCode::SWITCHING_PROTOCOLS,
+            )));
+            NexusRequest::object_get(client, uri.as_str())
+                .authn_as(AuthnMode::PrivilegedUser)
+                .websocket_handshake()
+                .execute()
+                .await
+                .unwrap();
             None
         }
         Some(_) => unimplemented!(),
@@ -469,15 +487,16 @@ async fn verify_endpoint(
                 Some(_) => unauthz_status,
                 None => StatusCode::METHOD_NOT_ALLOWED,
             };
-            let response = NexusRequest::new(
+            let mut request = NexusRequest::new(
                 RequestBuilder::new(client, method.clone(), &uri)
                     .body(body.as_ref())
                     .expect_status(Some(expected_status)),
             )
-            .authn_as(AuthnMode::UnprivilegedUser)
-            .execute()
-            .await
-            .unwrap();
+            .authn_as(AuthnMode::UnprivilegedUser);
+            if let Some(&AllowedMethod::GetWebsocket) = allowed {
+                request = request.websocket_handshake();
+            }
+            let response = request.execute().await.unwrap();
             verify_response(&response);
             record_operation(WhichTest::Unprivileged(&expected_status));
         } else {
@@ -491,13 +510,14 @@ async fn verify_endpoint(
             Some(_) => unauthn_status,
             None => StatusCode::METHOD_NOT_ALLOWED,
         };
-        let response =
+        let mut request =
             RequestBuilder::new(client, method.clone(), uri.as_str())
                 .body(body.as_ref())
-                .expect_status(Some(expected_status))
-                .execute()
-                .await
-                .unwrap();
+                .expect_status(Some(expected_status));
+        if let Some(&AllowedMethod::GetWebsocket) = allowed {
+            request = request.expect_websocket_handshake();
+        }
+        let response = request.execute().await.unwrap();
         verify_response(&response);
         record_operation(WhichTest::Unauthenticated(&expected_status));
 
@@ -519,34 +539,36 @@ async fn verify_endpoint(
         // actor.
         info!(log, "test: bogus creds: bad actor"; "method" => ?method);
         let bad_actor_authn_header = &spoof::SPOOF_HEADER_BAD_ACTOR;
-        let response =
+        let mut request =
             RequestBuilder::new(client, method.clone(), uri.as_str())
                 .body(body.as_ref())
                 .expect_status(Some(expected_status))
                 .header(
                     &http::header::AUTHORIZATION,
                     bad_actor_authn_header.0.encode(),
-                )
-                .execute()
-                .await
-                .unwrap();
+                );
+        if let Some(&AllowedMethod::GetWebsocket) = allowed {
+            request = request.expect_websocket_handshake();
+        }
+        let response = request.execute().await.unwrap();
         verify_response(&response);
         record_operation(WhichTest::UnknownUser(&expected_status));
 
         // Now try a syntactically invalid authn header.
         info!(log, "test: bogus creds: bad cred syntax"; "method" => ?method);
         let bad_creds_authn_header = &spoof::SPOOF_HEADER_BAD_CREDS;
-        let response =
+        let mut request =
             RequestBuilder::new(client, method.clone(), uri.as_str())
                 .body(body.as_ref())
                 .expect_status(Some(expected_status))
                 .header(
                     &http::header::AUTHORIZATION,
                     bad_creds_authn_header.0.encode(),
-                )
-                .execute()
-                .await
-                .unwrap();
+                );
+        if let Some(&AllowedMethod::GetWebsocket) = allowed {
+            request = request.expect_websocket_handshake();
+        }
+        let response = request.execute().await.unwrap();
         verify_response(&response);
         record_operation(WhichTest::InvalidHeader(&expected_status));
 
@@ -591,6 +613,10 @@ async fn verify_endpoint(
 
 /// Verifies the body of an HTTP response for status codes 401, 403, 404, or 405
 fn verify_response(response: &TestResponse) {
+    if response.status == StatusCode::SWITCHING_PROTOCOLS {
+        // websocket handshake. avoid trying to parse absent body as json.
+        return;
+    }
     let error: HttpErrorResponseBody = response.parsed_body().unwrap();
     match response.status {
         StatusCode::UNAUTHORIZED => {

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -43,6 +43,7 @@ instance_network_interface_view          /organizations/{organization_name}/proj
 instance_network_interface_view_by_id    /by-id/network-interfaces/{id}
 instance_reboot                          /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot
 instance_serial_console                  /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console
+instance_serial_console_stream           /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console/stream
 instance_start                           /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start
 instance_stop                            /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop
 instance_view                            /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2976,6 +2976,55 @@
         }
       }
     },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console/stream": {
+      "get": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Connect to an instance's serial console",
+        "operationId": "instance_serial_console_stream",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-dropshot-websocket": {}
+      }
+    },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start": {
       "post": {
         "tags": [

--- a/oxide-client/Cargo.toml
+++ b/oxide-client/Cargo.toml
@@ -9,6 +9,8 @@ futures = "0.3.25"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 regress = "0.4.1"
 serde_json = "1.0.87"
+base64 = "0.13"
+rand = "0.8"
 
 [dependencies.chrono]
 version = "0.4"
@@ -22,6 +24,10 @@ features = ["rustls-tls", "stream"]
 [dependencies.serde]
 version = "1.0"
 features = [ "derive" ]
+
+[dependencies.tokio]
+version = "1.20.1"
+features = [ "net" ]
 
 [dependencies.uuid]
 version = "1.2.1"

--- a/oximeter-client/Cargo.toml
+++ b/oximeter-client/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 
 [dependencies.chrono]
 version = "0.4"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -15,7 +15,7 @@ omicron-common = { path = "../common" }
 omicron-sled-agent = { path = "../sled-agent" }
 omicron-zone-package = "0.5.1"
 rayon = "1.5"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls"] }
 ring = "0.16"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/sled-agent-client/Cargo.toml
+++ b/sled-agent-client/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1"
 ipnetwork = "0.20"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 regress = "0.4.1"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 
 [dependencies.chrono]
 version = "0.4"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -31,7 +31,7 @@ oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.2.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "9da9cea30adfcce6d8185d7060a20f55df00a72a" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "9da9cea30adfcce6d8185d7060a20f55df00a72a", features = [ "generated-migration" ] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use super::sled_agent::SledAgent;
 
-use propolis_client::api::VolumeConstructionRequest;
+use crucible_client_types::VolumeConstructionRequest;
 
 type SledApiDescription = ApiDescription<SledAgent>;
 

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -102,7 +102,8 @@ pub struct InstanceHardware {
     /// provided to an instance to allow inbound connectivity.
     pub external_ips: Vec<IpAddr>,
     pub firewall_rules: Vec<VpcFirewallRule>,
-    pub disks: Vec<propolis_client::api::DiskRequest>,
+    // TODO: replace `propolis_client::handmade::*` with locally-modeled request type
+    pub disks: Vec<propolis_client::handmade::api::DiskRequest>,
     pub cloud_init_bytes: Option<String>,
 }
 

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use super::sled_agent::SledAgent;
 
-use propolis_client::api::VolumeConstructionRequest;
+use crucible_client_types::VolumeConstructionRequest;
 
 type SledApiDescription = ApiDescription<Arc<SledAgent>>;
 

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use propolis_client::api::VolumeConstructionRequest;
+use crucible_client_types::VolumeConstructionRequest;
 
 use super::collection::SimCollection;
 use super::config::Config;

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -32,7 +32,7 @@ use std::net::SocketAddrV6;
 use std::process::Command;
 use uuid::Uuid;
 
-use propolis_client::api::VolumeConstructionRequest;
+use crucible_client_types::VolumeConstructionRequest;
 
 #[cfg(not(test))]
 use crate::illumos::{dladm::Dladm, zfs::Zfs, zone::Zones};
@@ -114,20 +114,13 @@ impl From<Error> for dropshot::HttpError {
                         instance_error,
                     ) => match instance_error {
                         crate::instance::Error::Propolis(propolis_error) => {
-                            match propolis_error {
-                                propolis_client::Error::Reqwest(
-                                    reqwest_error,
-                                ) => HttpError::for_internal_error(
-                                    reqwest_error.to_string(),
+                            match propolis_error.status() {
+                                None => HttpError::for_internal_error(
+                                    propolis_error.to_string(),
                                 ),
 
-                                propolis_client::Error::Status(status_code) => {
-                                    HttpError::for_status(
-                                        None,
-                                        status_code.try_into().unwrap_or_else(
-                                            |_| 500.try_into().unwrap(),
-                                        ),
-                                    )
+                                Some(status_code) => {
+                                    HttpError::for_status(None, status_code)
                                 }
                             }
                         }


### PR DESCRIPTION
- Includes updates to progenitor and reqwest 0.11.12 for client support for Dropshot websocket channels.
- Literally only passes through the websocket, does not yet include the serial output buffering done by its parent GET endpoint. (This will be moved from sled-agent to propolis-server in forthcoming PRs)
- Begins migrating sled-agent's propolis-client usage to the new progenitor-generated version (https://github.com/oxidecomputer/propolis/pull/206)
- Adds support for ensuring a websocket endpoint gets upgraded in nexus integration tests (i.e. test_unauthorized).

I'll update how-to-run.adoc after either https://github.com/oxidecomputer/cli/pull/268 lands (or if we implement it in oxide-sdk-rust instead)