### PR TITLE
update Silo APIs for RFD 321

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -306,7 +306,7 @@ CREATE INDEX on omicron.public.volume (
  */
 
 CREATE TYPE omicron.public.user_provision_type AS ENUM (
-  'fixed',
+  'api_only',
   'jit'
 );
 

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -305,6 +305,11 @@ CREATE INDEX on omicron.public.volume (
  * Silos
  */
 
+CREATE TYPE omicron.public.authentication_mode AS ENUM (
+  'local',
+  'saml'
+);
+
 CREATE TYPE omicron.public.user_provision_type AS ENUM (
   'api_only',
   'jit'
@@ -320,6 +325,7 @@ CREATE TABLE omicron.public.silo (
     time_deleted TIMESTAMPTZ,
 
     discoverable BOOL NOT NULL,
+    authentication_mode omicron.public.authentication_mode NOT NULL,
     user_provision_type omicron.public.user_provision_type NOT NULL,
 
     /* child resource generation number, per RFD 192 */

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -116,8 +116,8 @@ impl Config {
         let child_resources = input.children;
         let parent = input.ancestors.last().map(|s| Resource::for_name(&s));
         // XXX-dap
-        let siloed = resource.name != "SamlIdentityProvider" &&
-            input.ancestors.iter().any(|s| s == "Silo");
+        let siloed = resource.name != "SamlIdentityProvider"
+            && input.ancestors.iter().any(|s| s == "Silo");
 
         Config {
             resource,

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -115,7 +115,9 @@ impl Config {
 
         let child_resources = input.children;
         let parent = input.ancestors.last().map(|s| Resource::for_name(&s));
-        let siloed = input.ancestors.iter().any(|s| s == "Silo");
+        // XXX-dap
+        let siloed = resource.name != "SamlIdentityProvider" &&
+            input.ancestors.iter().any(|s| s == "Silo");
 
         Config {
             resource,

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -196,6 +196,7 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
 
         discoverable -> Bool,
+        authentication_mode -> crate::AuthenticationModeEnum,
         user_provision_type -> crate::UserProvisionTypeEnum,
 
         rcgen -> Int8,

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -181,9 +181,9 @@ impl super::Nexus {
                 // external id. The next action depends on the silo's user
                 // provision type.
                 match db_silo.user_provision_type {
-                    // If the user provision type is fixed, do not a new user if
-                    // one does not exist.
-                    db::model::UserProvisionType::Fixed => {
+                    // If the user provision type is ApiOnly, do not a new user
+                    // if one does not exist.
+                    db::model::UserProvisionType::ApiOnly => {
                         return Ok(None);
                     }
 
@@ -212,7 +212,7 @@ impl super::Nexus {
 
         for group in &authenticated_subject.groups {
             let silo_group = match db_silo.user_provision_type {
-                db::model::UserProvisionType::Fixed => {
+                db::model::UserProvisionType::ApiOnly => {
                     self.db_datastore
                         .silo_group_optional_lookup(
                             opctx,

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -286,17 +286,24 @@ resource IdentityProvider {
 	    "create_child",
 	    "list_children",
 	];
-	relations = { parent_silo: Silo };
+	relations = { parent_silo: Silo, parent_fleet: Fleet };
 
+	# Silo-level roles grant privileges on identity providers.
 	"read" if "viewer" on "parent_silo";
 	"list_children" if "viewer" on "parent_silo";
-
-	# Only silo admins can create silo identity providers
 	"modify" if "admin" on "parent_silo";
 	"create_child" if "admin" on "parent_silo";
+
+	# Fleet-level roles also grant privileges on identity providers.
+	"read" if "viewer" on "parent_fleet";
+	"list_children" if "viewer" on "parent_fleet";
+	"modify" if "admin" on "parent_fleet";
+	"create_child" if "admin" on "parent_fleet";
 }
 has_relation(silo: Silo, "parent_silo", identity_provider: IdentityProvider)
 	if identity_provider.silo = silo;
+has_relation(fleet: Fleet, "parent_fleet", collection: IdentityProvider)
+	if collection.silo.fleet = fleet;
 
 resource SamlIdentityProvider {
 	permissions = [
@@ -305,17 +312,24 @@ resource SamlIdentityProvider {
 	    "create_child",
 	    "list_children",
 	];
-	relations = { parent_silo: Silo };
+	relations = { parent_silo: Silo, parent_fleet: Fleet };
 
-	# Only silo admins have permissions for specific identity provider details
-	"read" if "admin" on "parent_silo";
-	"list_children" if "admin" on "parent_silo";
-
+	# Silo-level roles grant privileges on identity providers.
+	"read" if "viewer" on "parent_silo";
+	"list_children" if "viewer" on "parent_silo";
 	"modify" if "admin" on "parent_silo";
 	"create_child" if "admin" on "parent_silo";
+
+	# Fleet-level roles also grant privileges on identity providers.
+	"read" if "viewer" on "parent_fleet";
+	"list_children" if "viewer" on "parent_fleet";
+	"modify" if "admin" on "parent_fleet";
+	"create_child" if "admin" on "parent_fleet";
 }
 has_relation(silo: Silo, "parent_silo", saml_identity_provider: SamlIdentityProvider)
 	if saml_identity_provider.silo = silo;
+has_relation(fleet: Fleet, "parent_fleet", collection: SamlIdentityProvider)
+	if collection.silo.fleet = fleet;
 
 #
 # SYNTHETIC RESOURCES OUTSIDE THE SILO HIERARCHY

--- a/nexus/src/db/fixed_data/silo.rs
+++ b/nexus/src/db/fixed_data/silo.rs
@@ -19,7 +19,7 @@ lazy_static! {
                 description: "default silo".to_string(),
             },
             discoverable: false,
-            user_provision_type: shared::UserProvisionType::Fixed,
+            identity_mode: shared::SiloIdentityMode::LocalOnly,
             admin_group_name: None,
         }
     );

--- a/nexus/src/db/lookup.rs
+++ b/nexus/src/db/lookup.rs
@@ -495,7 +495,8 @@ lookup_resource! {
     soft_deletes = true,
     primary_key_columns = [
         { column_name = "id", rust_type = Uuid },
-    ]
+    ],
+    visible_outside_silo = true
 }
 
 lookup_resource! {

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -232,7 +232,7 @@ impl RelayState {
 /// to their identity provider.
 #[endpoint {
    method = GET,
-   path = "/login/{silo_name}/{provider_name}",
+   path = "/login/{silo_name}/saml/{provider_name}",
    tags = ["login"],
 }]
 pub async fn login(
@@ -316,7 +316,7 @@ pub async fn login(
 /// data (like a SAMLResponse). Use these to set the user's session cookie.
 #[endpoint {
    method = POST,
-   path = "/login/{silo_name}/{provider_name}",
+   path = "/login/{silo_name}/saml/{provider_name}",
    tags = ["login"],
 }]
 pub async fn consume_credentials(

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -232,8 +232,8 @@ pub fn external_api() -> NexusApiDescription {
         api.register(silo_policy_view)?;
         api.register(silo_policy_update)?;
 
-        api.register(silo_identity_provider_create)?;
-        api.register(silo_identity_provider_view)?;
+        api.register(saml_identity_provider_create)?;
+        api.register(saml_identity_provider_view)?;
 
         api.register(system_image_list)?;
         api.register(system_image_create)?;
@@ -665,10 +665,10 @@ async fn silo_identity_provider_list(
 /// Create a SAML IDP
 #[endpoint {
     method = POST,
-    path = "/system/silos/{silo_name}/saml-identity-providers",
+    path = "/system/silos/{silo_name}/identity-providers/saml",
     tags = ["system"],
 }]
-async fn silo_identity_provider_create(
+async fn saml_identity_provider_create(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SiloPathParam>,
     new_provider: TypedBody<params::SamlIdentityProviderCreate>,
@@ -702,10 +702,10 @@ struct SiloSamlPathParam {
 /// Fetch a SAML IDP
 #[endpoint {
     method = GET,
-    path = "/system/silos/{silo_name}/saml-identity-providers/{provider_name}",
+    path = "/system/silos/{silo_name}/identity-providers/saml/{provider_name}",
     tags = ["system"],
 }]
-async fn silo_identity_provider_view(
+async fn saml_identity_provider_view(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     path_params: Path<SiloSamlPathParam>,
 ) -> Result<HttpResponseOk<views::SamlIdentityProvider>, HttpError> {

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -460,8 +460,8 @@ async fn silo_list(
             }
         }
         .into_iter()
-        .map(|p| p.into())
-        .collect();
+        .map(|p| p.try_into())
+        .collect::<Result<Vec<_>, Error>>()?;
         Ok(HttpResponseOk(ScanByNameOrId::results_page(
             &query,
             silos,
@@ -487,7 +487,7 @@ async fn silo_create(
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let silo =
             nexus.silo_create(&opctx, new_silo_params.into_inner()).await?;
-        Ok(HttpResponseCreated(silo.into()))
+        Ok(HttpResponseCreated(silo.try_into()?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -518,7 +518,7 @@ async fn silo_view(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let silo = nexus.silo_fetch(&opctx, &silo_name).await?;
-        Ok(HttpResponseOk(silo.into()))
+        Ok(HttpResponseOk(silo.try_into()?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -540,7 +540,7 @@ async fn silo_view_by_id(
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let silo = nexus.silo_fetch_by_id(&opctx, id).await?;
-        Ok(HttpResponseOk(silo.into()))
+        Ok(HttpResponseOk(silo.try_into()?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -108,7 +108,7 @@ pub async fn create_silo(
     client: &ClientTestContext,
     silo_name: &str,
     discoverable: bool,
-    user_provision_type: shared::UserProvisionType,
+    identity_mode: shared::SiloIdentityMode,
 ) -> Silo {
     object_create(
         client,
@@ -119,7 +119,7 @@ pub async fn create_silo(
                 description: "a silo".to_string(),
             },
             discoverable,
-            user_provision_type,
+            identity_mode,
             admin_group_name: None,
         },
     )

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -28,9 +28,13 @@ async fn test_cannot_read_others_ssh_keys(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with a two unprivileged users
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let user1 = Uuid::new_v4();
     nexus
@@ -130,9 +134,13 @@ async fn test_global_image_read_for_unpriv(
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with an unprivileged user
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let new_silo_user_id = Uuid::new_v4();
     nexus
@@ -206,9 +214,13 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with an unprivileged user
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let new_silo_user_id = Uuid::new_v4();
     nexus
@@ -217,9 +229,13 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     // Create another silo with another unprivileged user
-    let silo =
-        create_silo(&client, "other", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "other",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     nexus
         .silo_user_create(silo.identity.id, Uuid::new_v4(), "otheruser".into())
@@ -249,9 +265,13 @@ async fn test_list_silo_idps_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with an unprivileged user
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let new_silo_user_id = Uuid::new_v4();
     nexus
@@ -279,9 +299,13 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with an unprivileged user
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let new_silo_user_id = Uuid::new_v4();
     nexus
@@ -306,9 +330,13 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a silo with an unprivileged user
-    let silo =
-        create_silo(&client, "authz", true, shared::UserProvisionType::Fixed)
-            .await;
+    let silo = create_silo(
+        &client,
+        "authz",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     let new_silo_user_id = Uuid::new_v4();
     nexus
@@ -317,9 +345,13 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     // Create another silo
-    let _silo =
-        create_silo(&client, "other", true, shared::UserProvisionType::Fixed)
-            .await;
+    let _silo = create_silo(
+        &client,
+        "other",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
 
     // That user can access their own silo
     let _silo: views::Silo =

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -27,7 +27,6 @@ use omicron_common::api::external::RouterRouteUpdateParams;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_nexus::authn;
 use omicron_nexus::authz;
-use omicron_nexus::db::identity::Asset;
 use omicron_nexus::external_api::params;
 use omicron_nexus::external_api::shared;
 use omicron_nexus::external_api::shared::IpRange;
@@ -59,16 +58,6 @@ lazy_static! {
             discoverable: true,
             identity_mode: shared::SiloIdentityMode::SamlJit,
             admin_group_name: None,
-        };
-    pub static ref DEMO_SILO_POLICY: shared::Policy<authz::SiloRole> =
-        shared::Policy {
-            role_assignments: vec![
-                shared::RoleAssignment {
-                    identity_type: shared::IdentityType::SiloUser,
-                    identity_id: authn::USER_TEST_PRIVILEGED.id(),
-                    role_name: authz::SiloRole::Admin,
-                },
-            ]
         };
 
     // Organization used for testing

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -361,7 +361,7 @@ lazy_static! {
 lazy_static! {
     // Identity providers
     pub static ref IDENTITY_PROVIDERS_URL: String = format!("/system/silos/default-silo/identity-providers");
-    pub static ref SAML_IDENTITY_PROVIDERS_URL: String = format!("/system/silos/default-silo/saml-identity-providers");
+    pub static ref SAML_IDENTITY_PROVIDERS_URL: String = format!("/system/silos/default-silo/identity-providers/saml");
 
     pub static ref DEMO_SAML_IDENTITY_PROVIDER_NAME: Name = "demo-saml-provider".parse().unwrap();
     pub static ref SPECIFIC_SAML_IDENTITY_PROVIDER_URL: String = format!("{}/{}", *SAML_IDENTITY_PROVIDERS_URL, *DEMO_SAML_IDENTITY_PROVIDER_NAME);

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -56,7 +56,7 @@ lazy_static! {
                 description: String::from(""),
             },
             discoverable: true,
-            identity_mode: shared::SiloIdentityMode::LocalOnly,
+            identity_mode: shared::SiloIdentityMode::SamlJit,
             admin_group_name: None,
         };
 

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -56,7 +56,7 @@ lazy_static! {
                 description: String::from(""),
             },
             discoverable: true,
-            user_provision_type: shared::UserProvisionType::Fixed,
+            identity_mode: shared::SiloIdentityMode::LocalOnly,
             admin_group_name: None,
         };
 

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -32,7 +32,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
     let silo: Silo = NexusRequest::object_get(
         &client,
@@ -151,7 +151,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_truncated(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor = {
@@ -211,7 +211,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_no_redirect_binding(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor = {
@@ -281,7 +281,7 @@ async fn test_create_a_hidden_silo_saml_idp(
 ) {
     let client = &cptestctx.external_client;
 
-    create_silo(&client, "hidden", false, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, "hidden", false, shared::SiloIdentityMode::SamlJit)
         .await;
 
     // Valid IdP descriptor
@@ -350,7 +350,7 @@ async fn test_saml_idp_metadata_url_404(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let server = Server::run();
@@ -404,7 +404,7 @@ async fn test_saml_idp_metadata_url_invalid(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     NexusRequest::new(
@@ -465,7 +465,7 @@ async fn test_saml_idp_reject_keypair(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let test_cases = vec![
@@ -560,7 +560,7 @@ async fn test_saml_idp_rsa_keypair_ok(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     NexusRequest::new(

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -32,7 +32,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
     let silo: Silo = NexusRequest::object_get(
         &client,
@@ -151,7 +151,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_truncated(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     let saml_idp_descriptor = {
@@ -211,7 +211,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_no_redirect_binding(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     let saml_idp_descriptor = {
@@ -281,7 +281,7 @@ async fn test_create_a_hidden_silo_saml_idp(
 ) {
     let client = &cptestctx.external_client;
 
-    create_silo(&client, "hidden", false, shared::UserProvisionType::Fixed)
+    create_silo(&client, "hidden", false, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     // Valid IdP descriptor
@@ -350,7 +350,7 @@ async fn test_saml_idp_metadata_url_404(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     let server = Server::run();
@@ -404,7 +404,7 @@ async fn test_saml_idp_metadata_url_invalid(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     NexusRequest::new(
@@ -465,7 +465,7 @@ async fn test_saml_idp_reject_keypair(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     let test_cases = vec![
@@ -560,7 +560,7 @@ async fn test_saml_idp_rsa_keypair_ok(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Fixed)
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::LocalOnly)
         .await;
 
     NexusRequest::new(
@@ -932,7 +932,8 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Jit).await;
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+        .await;
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
@@ -1028,7 +1029,8 @@ async fn test_post_saml_response_with_relay_state(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::UserProvisionType::Jit).await;
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+        .await;
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -55,7 +55,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
 
     let silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -124,7 +124,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
             client,
             Method::GET,
             &format!(
-                "/login/{}/{}",
+                "/login/{}/saml/{}",
                 silo.identity.name, silo_saml_idp.identity.name
             ),
         )
@@ -170,7 +170,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_truncated(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -241,7 +241,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_no_redirect_binding(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -295,7 +295,7 @@ async fn test_create_a_hidden_silo_saml_idp(
 
     let silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        "/system/silos/hidden/saml-identity-providers",
+        "/system/silos/hidden/identity-providers/saml",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -327,7 +327,7 @@ async fn test_create_a_hidden_silo_saml_idp(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!("/login/hidden/{}", silo_saml_idp.identity.name),
+            &format!("/login/hidden/saml/{}", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )
@@ -363,7 +363,7 @@ async fn test_saml_idp_metadata_url_404(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -411,7 +411,7 @@ async fn test_saml_idp_metadata_url_invalid(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -510,7 +510,7 @@ async fn test_saml_idp_reject_keypair(cptestctx: &ControlPlaneTestContext) {
             RequestBuilder::new(
                 client,
                 Method::POST,
-                &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+                &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
             )
             .body(Some(&params::SamlIdentityProviderCreate {
                 identity: IdentityMetadataCreateParams {
@@ -567,7 +567,7 @@ async fn test_saml_idp_rsa_keypair_ok(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -936,7 +936,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -976,7 +976,10 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/login/{}/some-totally-real-saml-provider", SILO_NAME),
+            &format!(
+                "/login/{}/saml/some-totally-real-saml-provider",
+                SILO_NAME
+            ),
         )
         .raw_body(Some(
             serde_urlencoded::to_string(SamlLoginPost {
@@ -1029,7 +1032,7 @@ async fn test_post_saml_response_with_relay_state(
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -1069,7 +1072,10 @@ async fn test_post_saml_response_with_relay_state(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/login/{}/some-totally-real-saml-provider", SILO_NAME),
+            &format!(
+                "/login/{}/saml/some-totally-real-saml-provider",
+                SILO_NAME
+            ),
         )
         .raw_body(Some(
             serde_urlencoded::to_string(SamlLoginPost {

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -326,7 +326,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
 
     let silo_saml_idp_1: SamlIdentityProvider = object_create(
         client,
-        &"/system/silos/default-silo/saml-identity-providers",
+        &"/system/silos/default-silo/identity-providers/saml",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -355,7 +355,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
 
     let silo_saml_idp_2: SamlIdentityProvider = object_create(
         client,
-        &"/system/silos/default-silo/saml-identity-providers",
+        &"/system/silos/default-silo/identity-providers/saml",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "another-totally-real-saml-provider"
@@ -417,7 +417,7 @@ async fn test_deleting_a_silo_deletes_the_idp(
 
     let silo_saml_idp: SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -493,7 +493,10 @@ async fn test_deleting_a_silo_deletes_the_idp(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!("/login/{}/{}", SILO_NAME, silo_saml_idp.identity.name),
+            &format!(
+                "/login/{}/saml/{}",
+                SILO_NAME, silo_saml_idp.identity.name
+            ),
         )
         .expect_status(Some(StatusCode::NOT_FOUND)),
     )
@@ -514,7 +517,7 @@ async fn test_saml_idp_metadata_data_valid(
 
     let silo_saml_idp: SamlIdentityProvider = object_create(
         client,
-        "/system/silos/blahblah/saml-identity-providers",
+        "/system/silos/blahblah/identity-providers/saml",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -546,7 +549,7 @@ async fn test_saml_idp_metadata_data_valid(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!("/login/blahblah/{}", silo_saml_idp.identity.name),
+            &format!("/login/blahblah/saml/{}", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )
@@ -577,7 +580,7 @@ async fn test_saml_idp_metadata_data_truncated(
         RequestBuilder::new(
             client,
             Method::POST,
-            "/system/silos/blahblah/saml-identity-providers",
+            "/system/silos/blahblah/identity-providers/saml",
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -630,7 +633,7 @@ async fn test_saml_idp_metadata_data_invalid(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/saml-identity-providers", SILO_NAME),
+            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -80,15 +80,6 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .unwrap(),
                 id_routes,
             ),
-            SetupReq::Put { url, body, id_routes } => (
-                url,
-                NexusRequest::object_put(client, url, Some(body))
-                    .authn_as(AuthnMode::PrivilegedUser)
-                    .execute()
-                    .await
-                    .unwrap(),
-                id_routes,
-            ),
         };
 
         setup_results.insert(url, result.clone());
@@ -162,11 +153,6 @@ enum SetupReq {
         body: serde_json::Value,
         id_routes: Vec<&'static str>,
     },
-    Put {
-        url: &'static str,
-        body: serde_json::Value,
-        id_routes: Vec<&'static str>,
-    },
 }
 
 lazy_static! {
@@ -202,13 +188,6 @@ lazy_static! {
             url: "/system/silos",
             body: serde_json::to_value(&*DEMO_SILO_CREATE).unwrap(),
             id_routes: vec!["/system/by-id/silos/{id}"],
-        },
-        // Grant the privileged test user admin privileges on the demo Silo so
-        // that it can see the identity providers.
-        SetupReq::Put {
-            url: &*DEMO_SILO_POLICY_URL,
-            body: serde_json::to_value(&*DEMO_SILO_POLICY).unwrap(),
-            id_routes: vec![],
         },
         // Create an IP pool
         SetupReq::Post {

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -49,8 +49,8 @@ instance_view_by_id                      /by-id/instances/{id}
 
 API operations found with tag "login"
 OPERATION ID                             URL PATH
-consume_credentials                      /login/{silo_name}/{provider_name}
-login                                    /login/{silo_name}/{provider_name}
+consume_credentials                      /login/{silo_name}/saml/{provider_name}
+login                                    /login/{silo_name}/saml/{provider_name}
 
 API operations found with tag "metrics"
 OPERATION ID                             URL PATH
@@ -128,11 +128,11 @@ rack_list                                /system/hardware/racks
 rack_view                                /system/hardware/racks/{rack_id}
 saga_list                                /system/sagas
 saga_view                                /system/sagas/{saga_id}
+saml_identity_provider_create            /system/silos/{silo_name}/identity-providers/saml
+saml_identity_provider_view              /system/silos/{silo_name}/identity-providers/saml/{provider_name}
 silo_create                              /system/silos
 silo_delete                              /system/silos/{silo_name}
-silo_identity_provider_create            /system/silos/{silo_name}/saml-identity-providers
 silo_identity_provider_list              /system/silos/{silo_name}/identity-providers
-silo_identity_provider_view              /system/silos/{silo_name}/saml-identity-providers/{provider_name}
 silo_list                                /system/silos
 silo_policy_update                       /system/silos/{silo_name}/policy
 silo_policy_view                         /system/silos/{silo_name}/policy

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,8 +1,8 @@
 API endpoints with no coverage in authz tests:
-login                                    (get    "/login/{silo_name}/{provider_name}")
+login                                    (get    "/login/{silo_name}/saml/{provider_name}")
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")
 device_access_token                      (post   "/device/token")
 spoof_login                              (post   "/login")
-consume_credentials                      (post   "/login/{silo_name}/{provider_name}")
+consume_credentials                      (post   "/login/{silo_name}/saml/{provider_name}")
 logout                                   (post   "/logout")

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -28,7 +28,7 @@ pub struct SiloCreate {
 
     pub discoverable: bool,
 
-    pub user_provision_type: shared::UserProvisionType,
+    pub identity_mode: shared::SiloIdentityMode,
 
     /// If set, this group will be created during Silo creation and granted the
     /// "Silo Admin" role. Identity providers can assert that users belong to

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -123,7 +123,6 @@ impl SiloIdentityMode {
     }
 }
 
-// XXX-dap remove from "shared"?
 /// How users are authenticated in this Silo
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -135,7 +134,6 @@ pub enum AuthenticationMode {
     Local,
 }
 
-// XXX-dap remove from "shared"?
 /// How users will be provisioned in a silo during authentication.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -108,10 +108,10 @@ pub enum SiloIdentityMode {
 }
 
 impl SiloIdentityMode {
-    pub fn authn_type(&self) -> Option<AuthenticationMode> {
+    pub fn authentication_mode(&self) -> AuthenticationMode {
         match self {
-            SiloIdentityMode::LocalOnly => None,
-            SiloIdentityMode::SamlJit => Some(AuthenticationMode::Saml),
+            SiloIdentityMode::LocalOnly => AuthenticationMode::Local,
+            SiloIdentityMode::SamlJit => AuthenticationMode::Saml,
         }
     }
 
@@ -130,6 +130,9 @@ impl SiloIdentityMode {
 pub enum AuthenticationMode {
     /// Authentication is via SAML using an external authentication provider
     Saml,
+
+    /// Authentication is local to the Oxide system
+    Local,
 }
 
 // XXX-dap remove from "shared"?

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -97,7 +97,8 @@ pub enum IdentityType {
 pub enum SiloIdentityMode {
     /// Users are authenticated with SAML using an external authentication
     /// provider.  The system updates information about users and groups only
-    /// during authentication (i.e,. "JIT provisioning" of users and groups).
+    /// during successful authentication (i.e,. "JIT provisioning" of users and
+    /// groups).
     SamlJit,
 
     /// The system is the source of truth about users.  There is no linkage to

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -90,16 +90,60 @@ pub enum IdentityType {
     SiloGroup,
 }
 
+/// Describes how identities are managed and users are authenticated in this
+/// Silo
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SiloIdentityMode {
+    /// Users are authenticated with SAML using an external authentication
+    /// provider.  The system updates information about users and groups only
+    /// during authentication (i.e,. "JIT provisioning" of users and groups).
+    SamlJit,
+
+    /// The system is the source of truth about users.  There is no linkage to
+    /// an external authentication provider or identity provider.
+    // NOTE: authentication for these users is not supported yet at all.  It
+    // will eventually be password-based.
+    LocalOnly,
+}
+
+impl SiloIdentityMode {
+    pub fn authn_type(&self) -> Option<AuthenticationMode> {
+        match self {
+            SiloIdentityMode::LocalOnly => None,
+            SiloIdentityMode::SamlJit => Some(AuthenticationMode::Saml),
+        }
+    }
+
+    pub fn user_provision_type(&self) -> UserProvisionType {
+        match self {
+            SiloIdentityMode::LocalOnly => UserProvisionType::ApiOnly,
+            SiloIdentityMode::SamlJit => UserProvisionType::Jit,
+        }
+    }
+}
+
+// XXX-dap remove from "shared"?
+/// How users are authenticated in this Silo
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthenticationMode {
+    /// Authentication is via SAML using an external authentication provider
+    Saml,
+}
+
+// XXX-dap remove from "shared"?
 /// How users will be provisioned in a silo during authentication.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum UserProvisionType {
-    /// Do not automatically create users during authentication if they do not
-    /// exist in the database already.
-    Fixed,
+    /// Identities are managed directly by explicit calls to the external API.
+    /// They are not synchronized from any external identity provider nor
+    /// automatically created or updated when a user logs in.
+    ApiOnly,
 
-    /// Create users during authentication if they do not exist in the database
-    /// already, using information provided by the identity provider.
+    /// Users and groups are created or updated during authentication using
+    /// information provided by the authentication provider
     Jit,
 }
 

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -58,8 +58,8 @@ pub struct Silo {
     /// will not be part of the "list all silos" output.
     pub discoverable: bool,
 
-    /// User provision type
-    pub user_provision_type: shared::UserProvisionType,
+    /// How users and groups are managed in this Silo
+    pub identity_mode: shared::SiloIdentityMode,
 }
 
 // IDENTITY PROVIDER

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10592,6 +10592,14 @@
             "type": "string",
             "format": "uuid"
           },
+          "identity_mode": {
+            "description": "How users and groups are managed in this Silo",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SiloIdentityMode"
+              }
+            ]
+          },
           "name": {
             "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
@@ -10609,24 +10617,16 @@
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
-          },
-          "user_provision_type": {
-            "description": "User provision type",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UserProvisionType"
-              }
-            ]
           }
         },
         "required": [
           "description",
           "discoverable",
           "id",
+          "identity_mode",
           "name",
           "time_created",
-          "time_modified",
-          "user_provision_type"
+          "time_modified"
         ]
       },
       "SiloCreate": {
@@ -10644,18 +10644,26 @@
           "discoverable": {
             "type": "boolean"
           },
+          "identity_mode": {
+            "$ref": "#/components/schemas/SiloIdentityMode"
+          },
           "name": {
             "$ref": "#/components/schemas/Name"
-          },
-          "user_provision_type": {
-            "$ref": "#/components/schemas/UserProvisionType"
           }
         },
         "required": [
           "description",
           "discoverable",
-          "name",
-          "user_provision_type"
+          "identity_mode",
+          "name"
+        ]
+      },
+      "SiloIdentityMode": {
+        "description": "Describes how identities are managed and users are authenticated in this Silo",
+        "type": "string",
+        "enum": [
+          "saml_jit",
+          "local_only"
         ]
       },
       "SiloResultsPage": {
@@ -11124,14 +11132,6 @@
         },
         "required": [
           "items"
-        ]
-      },
-      "UserProvisionType": {
-        "description": "How users will be provisioned in a silo during authentication.",
-        "type": "string",
-        "enum": [
-          "fixed",
-          "jit"
         ]
       },
       "UserResultsPage": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -558,7 +558,7 @@
         }
       }
     },
-    "/login/{silo_name}/{provider_name}": {
+    "/login/{silo_name}/saml/{provider_name}": {
       "get": {
         "tags": [
           "login"
@@ -6731,6 +6731,104 @@
         "x-dropshot-pagination": true
       }
     },
+    "/system/silos/{silo_name}/identity-providers/saml": {
+      "post": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Create a SAML IDP",
+        "operationId": "saml_identity_provider_create",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "silo_name",
+            "description": "The silo's unique name.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SamlIdentityProviderCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SamlIdentityProvider"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/system/silos/{silo_name}/identity-providers/saml/{provider_name}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a SAML IDP",
+        "operationId": "saml_identity_provider_view",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_name",
+            "description": "The SAML identity provider's name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "silo_name",
+            "description": "The silo's unique name.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SamlIdentityProvider"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/system/silos/{silo_name}/policy": {
       "get": {
         "tags": [
@@ -6804,104 +6902,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SiloRolePolicy"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/system/silos/{silo_name}/saml-identity-providers": {
-      "post": {
-        "tags": [
-          "system"
-        ],
-        "summary": "Create a SAML IDP",
-        "operationId": "silo_identity_provider_create",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "silo_name",
-            "description": "The silo's unique name.",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SamlIdentityProviderCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SamlIdentityProvider"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/system/silos/{silo_name}/saml-identity-providers/{provider_name}": {
-      "get": {
-        "tags": [
-          "system"
-        ],
-        "summary": "Fetch a SAML IDP",
-        "operationId": "silo_identity_provider_view",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "provider_name",
-            "description": "The SAML identity provider's name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          },
-          {
-            "in": "path",
-            "name": "silo_name",
-            "description": "The silo's unique name.",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "simple"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SamlIdentityProvider"
                 }
               }
             }


### PR DESCRIPTION
This makes a few changes based on the determinations of RFD 321 in preparation for support for password-based login.  I hope there are no surprises here!

Changes here:

* the routes for manipulating SAML IdPs move from `/system/silos/:silo_name/saml-identity-providers` to `/system/silos/:silo_name/identity-providers/saml`
* the routes for logging into SAML Silos move from `/login/:silo_name/:provider_name` to `/login/:silo_name/saml/:provider_name`
* Internally, there's a new AuthenticationMode alongside the UserProvisionType.  AuthenticationMode may be either "SAML" or "Local".
* Externally, the `user_provision_type` / `UserProvisionType` has turned into `silo_identity_mode` / `SiloIdentityMode`, which encapsulates both the authentication mode and the user provision type.

This also renames `UserProvisionType::Fixed` to `UserProvisionType::ApiOnly` for clarity.

This does _not_ implement the "local" identity provider tyep, CRUD for local users, or password login -- those will be in follow-up PRs.

**This will be a breaking change to the API** because of the change to `params::SiloCreate`, `views::Silo`, and the change in route structure.  CC @david-crespo @zephraph @karencfv.

**This will be a breaking change to the [Remote Access Preview](https://github.com/oxidecomputer/meta/blob/master/engineering/remote-access-preview-demo-setup.adoc) procedure (both Mercury and Pluto)** for the same reason.  (Those procedures use these APIs directly.)  Further, if you have a Silo that's already set up with an identity provider (like saml.eng), I'm not sure if it will continue to work because the login URL that the IdP POSTs back to has changed.  I'm not sure if this is recorded anywhere though.  If this is a problem for anyone, I'm happy to dig in further.