### PR TITLE
Change spoof login response back to 200 + JSON

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -47,9 +47,6 @@ pub struct SpoofLoginBody {
     pub username: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct SpoofLoginResponse {}
-
 // This is just for demo purposes. we will probably end up with a real
 // username/password login endpoint, but I think it will only be for use while
 // setting up the rack
@@ -63,8 +60,7 @@ pub struct SpoofLoginResponse {}
 pub async fn login_spoof(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     params: TypedBody<SpoofLoginBody>,
-) -> Result<HttpResponseHeaders<HttpResponseOk<SpoofLoginResponse>>, HttpError>
-{
+) -> Result<HttpResponseHeaders<HttpResponseUpdatedNoContent>, HttpError> {
     let apictx = rqctx.context();
     let handler = async {
         let nexus = &apictx.nexus;
@@ -89,9 +85,8 @@ pub async fn login_spoof(
         let authn_opctx = nexus.opctx_external_authn();
         let session = nexus.session_create(&authn_opctx, user_id).await?;
 
-        let mut response = HttpResponseHeaders::new_unnamed(HttpResponseOk(
-            SpoofLoginResponse {},
-        ));
+        let mut response =
+            HttpResponseHeaders::new_unnamed(HttpResponseUpdatedNoContent());
         {
             let headers = response.headers_mut();
             headers.append(

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -47,6 +47,9 @@ pub struct SpoofLoginBody {
     pub username: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SpoofLoginResponse {}
+
 // This is just for demo purposes. we will probably end up with a real
 // username/password login endpoint, but I think it will only be for use while
 // setting up the rack
@@ -60,7 +63,8 @@ pub struct SpoofLoginBody {
 pub async fn login_spoof(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
     params: TypedBody<SpoofLoginBody>,
-) -> Result<HttpResponseSeeOther, HttpError> {
+) -> Result<HttpResponseHeaders<HttpResponseOk<SpoofLoginResponse>>, HttpError>
+{
     let apictx = rqctx.context();
     let handler = async {
         let nexus = &apictx.nexus;
@@ -85,7 +89,9 @@ pub async fn login_spoof(
         let authn_opctx = nexus.opctx_external_authn();
         let session = nexus.session_create(&authn_opctx, user_id).await?;
 
-        let mut response = http_response_see_other(String::from("/"))?;
+        let mut response = HttpResponseHeaders::new_unnamed(HttpResponseOk(
+            SpoofLoginResponse {},
+        ));
         {
             let headers = response.headers_mut();
             headers.append(

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -398,7 +398,7 @@ fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {
 async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let login = RequestBuilder::new(&testctx, Method::POST, "/login")
         .body(Some(&SpoofLoginBody { username: "unprivileged".to_string() }))
-        .expect_status(Some(StatusCode::OK))
+        .expect_status(Some(StatusCode::NO_CONTENT))
         .execute()
         .await
         .expect("failed to log in");

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -398,7 +398,7 @@ fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {
 async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let login = RequestBuilder::new(&testctx, Method::POST, "/login")
         .body(Some(&SpoofLoginBody { username: "unprivileged".to_string() }))
-        .expect_status(Some(StatusCode::SEE_OTHER))
+        .expect_status(Some(StatusCode::OK))
         .execute()
         .await
         .expect("failed to log in");

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -547,18 +547,8 @@
           "required": true
         },
         "responses": {
-          "303": {
-            "description": "redirect (see other)",
-            "headers": {
-              "location": {
-                "description": "HTTP \"Location\" header",
-                "style": "simple",
-                "required": true,
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
+          "204": {
+            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"


### PR DESCRIPTION
This is 100% on me because I approved the 303 response after talking about it in great detail with @davepacheco, but the 303 is inconvenient for the console. The console makes the `POST /login` through the generated client like any other API call, and as such it freaks out if the response isn't JSON.

https://github.com/oxidecomputer/oxide.ts/blob/1c4561c83e352513c904c5c5d5b53b65adde88e0/static/http-client.ts#L106

We could try to accommodate this in various ways in the console itself or the generated client, but since AFAIK this endpoint exists solely for the console to use (and may disappear soon enough), it seems a lot easier to just change it back to an empty JSON response.