### PR TITLE
Expose silo_id from `/session/me` endpoint

### DIFF
--- a/nexus/db-model/src/silo_user.rs
+++ b/nexus/db-model/src/silo_user.rs
@@ -33,6 +33,7 @@ impl From<SiloUser> for views::User {
             id: user.id(),
             // TODO the use of external_id as display_name is temporary
             display_name: user.external_id,
+            silo_id: user.silo_id,
         }
     }
 }

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -342,7 +342,8 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         priv_user,
         views::User {
             id: USER_TEST_PRIVILEGED.id(),
-            display_name: USER_TEST_PRIVILEGED.external_id.clone()
+            display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+            silo_id: DEFAULT_SILO.id(),
         }
     );
 
@@ -359,7 +360,8 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         unpriv_user,
         views::User {
             id: USER_TEST_UNPRIVILEGED.id(),
-            display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
+            display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+            silo_id: DEFAULT_SILO.id(),
         }
     );
 }

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -844,11 +844,13 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                display_name: USER_TEST_PRIVILEGED.external_id.clone()
+                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                silo_id: *SILO_ID,
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
+                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                silo_id: *SILO_ID,
             },
         ]
     );
@@ -877,15 +879,18 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                display_name: USER_TEST_PRIVILEGED.external_id.clone()
+                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                silo_id: *SILO_ID,
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                display_name: USER_TEST_UNPRIVILEGED.external_id.clone()
+                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                silo_id: *SILO_ID,
             },
             views::User {
                 id: new_silo_user_id,
                 display_name: new_silo_user_external_id.into(),
+                silo_id: *SILO_ID,
             },
         ]
     );
@@ -929,6 +934,7 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![views::User {
             id: new_silo_user_id,
             display_name: new_silo_user_name,
+            silo_id: silo.identity.id,
         }]
     );
 

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -317,6 +317,9 @@ pub struct User {
     pub id: Uuid,
     /** Human-readable name that can identify the user */
     pub display_name: String,
+
+    /** Uuid of the silo to which this user belongs */
+    pub silo_id: Uuid,
 }
 
 // BUILT-IN USERS

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11188,11 +11188,17 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "silo_id": {
+            "description": "Uuid of the silo to which this user belongs",
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
           "display_name",
-          "id"
+          "id",
+          "silo_id"
         ]
       },
       "UserBuiltin": {


### PR DESCRIPTION
This is intended to be used by https://github.com/oxidecomputer/console/pull/1214 when displaying system metrics