### PR TITLE
Add list of group IDs to `/session/me` response

### DIFF
--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -94,7 +94,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
     ) -> ListResultVec<db::model::SiloGroupMembership> {
-        Ok(self.db_datastore.silo_group_membership_for_self(opctx).await?)
+        self.db_datastore.silo_group_membership_for_self(opctx).await
     }
 
     // Silo groups

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -90,6 +90,13 @@ impl super::Nexus {
         Ok(db_silo_user)
     }
 
+    pub async fn silo_user_fetch_groups(
+        &self,
+        opctx: &OpContext,
+    ) -> ListResultVec<db::model::SiloGroupMembership> {
+        Ok(self.db_datastore.silo_group_membership_for_self(opctx).await?)
+    }
+
     // Silo groups
 
     pub async fn silo_groups_list(

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -90,7 +90,7 @@ impl super::Nexus {
         Ok(db_silo_user)
     }
 
-    pub async fn silo_user_fetch_groups(
+    pub async fn silo_user_fetch_groups_for_self(
         &self,
         opctx: &OpContext,
     ) -> ListResultVec<db::model::SiloGroupMembership> {

--- a/nexus/src/db/datastore/silo_group.rs
+++ b/nexus/src/db/datastore/silo_group.rs
@@ -110,9 +110,9 @@ impl DataStore {
         &self,
         opctx: &OpContext,
     ) -> ListResultVec<SiloGroupMembership> {
-        // no authz check beyond pulling the current actor because current user
-        // can always list their own memberships
-
+        // Similar to session_hard_delete (see comment there), we do not do a
+        // typical authz check, instead effectively encoding the policy here
+        // that any user is allowed to fetch their own group memberships
         let &actor = opctx
             .authn
             .actor_required()

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -592,7 +592,7 @@ pub async fn login_begin(
 }]
 pub async fn session_me(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-) -> Result<HttpResponseOk<views::User>, HttpError> {
+) -> Result<HttpResponseOk<views::SessionMe>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let handler = async {
@@ -601,7 +601,13 @@ pub async fn session_me(
         // not clear what the advantage would be.
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let user = nexus.silo_user_fetch_self(&opctx).await?;
-        Ok(HttpResponseOk(user.into()))
+        let groups = nexus.silo_user_fetch_groups(&opctx).await?;
+        Ok(HttpResponseOk(views::SessionMe {
+            id: user.id(),
+            display_name: user.external_id,
+            silo_id: user.silo_id,
+            group_ids: groups.iter().map(|g| g.silo_group_id).collect(),
+        }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -601,7 +601,7 @@ pub async fn session_me(
         // not clear what the advantage would be.
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let user = nexus.silo_user_fetch_self(&opctx).await?;
-        let groups = nexus.silo_user_fetch_groups(&opctx).await?;
+        let groups = nexus.silo_user_fetch_groups_for_self(&opctx).await?;
         Ok(HttpResponseOk(views::SessionMe {
             id: user.id(),
             display_name: user.external_id,

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -348,8 +348,6 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         }
     );
 
-    // TODO: fails bc user can't pull their own group memberships?
-    // make sure it returns different things for different users
     let unpriv_user = NexusRequest::object_get(testctx, "/session/me")
         .authn_as(AuthnMode::UnprivilegedUser)
         .execute()

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -335,33 +335,36 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::User>()
+        .parsed_body::<views::SessionMe>()
         .unwrap();
 
     assert_eq!(
         priv_user,
-        views::User {
+        views::SessionMe {
             id: USER_TEST_PRIVILEGED.id(),
             display_name: USER_TEST_PRIVILEGED.external_id.clone(),
             silo_id: DEFAULT_SILO.id(),
+            group_ids: vec![],
         }
     );
 
+    // TODO: fails bc user can't pull their own group memberships?
     // make sure it returns different things for different users
     let unpriv_user = NexusRequest::object_get(testctx, "/session/me")
         .authn_as(AuthnMode::UnprivilegedUser)
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::User>()
+        .parsed_body::<views::SessionMe>()
         .unwrap();
 
     assert_eq!(
         unpriv_user,
-        views::User {
+        views::SessionMe {
             id: USER_TEST_UNPRIVILEGED.id(),
             display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
             silo_id: DEFAULT_SILO.id(),
+            group_ids: vec![],
         }
     );
 }

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -322,7 +322,7 @@ pub struct User {
     pub silo_id: Uuid,
 }
 
-/// Client view of a [`User`] with some extra stuff that's useful to the console
+/// Client view of a [`User`] and their groups
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
 pub struct SessionMe {
     pub id: Uuid,

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -322,6 +322,19 @@ pub struct User {
     pub silo_id: Uuid,
 }
 
+/// Client view of a [`User`] with some extra stuff that's useful to the console
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+pub struct SessionMe {
+    pub id: Uuid,
+    /** Human-readable name that can identify the user */
+    pub display_name: String,
+
+    /** Uuid of the silo to which this user belongs */
+    pub silo_id: Uuid,
+
+    pub group_ids: Vec<Uuid>,
+}
+
 // SILO GROUPS
 
 /// Client view of a [`Group`]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11003,7 +11003,7 @@
         ]
       },
       "SessionMe": {
-        "description": "Client view of a [`User`] with some extra stuff that's useful to the console",
+        "description": "Client view of a [`User`] and their groups",
         "type": "object",
         "properties": {
           "display_name": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5202,7 +5202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/SessionMe"
                 }
               }
             }
@@ -11000,6 +11000,38 @@
           "slo_url",
           "sp_client_id",
           "technical_contact_email"
+        ]
+      },
+      "SessionMe": {
+        "description": "Client view of a [`User`] with some extra stuff that's useful to the console",
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "description": "Human-readable name that can identify the user",
+            "type": "string"
+          },
+          "group_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "description": "Uuid of the silo to which this user belongs",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "display_name",
+          "group_ids",
+          "id",
+          "silo_id"
         ]
       },
       "Silo": {


### PR DESCRIPTION
This is meant to be a starting point for figuring out how this should work. It's not particularly good.

## Problem

In the console we would like to hide or disable certain controls when the user does not have permission to use them. For example, a user with only the `viewer` role on an organization does not have the ability to create projects in that organization, and we prefer disabling the button (likely with a tooltip on hover) over letting them click the button and find out they can't create when the API comes back with a 403. So I need to know the user's role on the organization when I render the UI.

I plan to use data for the current user _plus_ the policy for a given resource to determine the user's effective role on the resource. "Effective" is key because they could have roles from multiple sources — e.g., their user ID directly, group A they belong to, group B they belong to, or any of those from the policy on a parent resource 😓  — and the _effective_ role from the API's point of view is the strongest role out of all of those.

Everything required to do that currently exists _except_ there is no way of getting the current user's group memberships. This could be its own endpoint or it could be added to `/session/me`. I did the latter here because I don't really see why anyone would ever want to call one without the other, but I don't feel to strongly about it.

## Questions/issues

### Policy is implicit in app code

The existing endpoint `silo_group_membership_for_user` takes an `authz::Silo` and a user ID, and the auth check is for `ListChildren` on the silo. Assuming we want any user to be able to list their own groups, we cannot stick to this pattern for the "list by groups" endpoint, because the unprivileged user does not necessarily have _any_ permissions on the silo. What I've done here instead is not have any authz check, pulling the user ID off the `opctx`. The implicit policy therefore is that any user can fetch their own groups. However, I noticed that this is only the second time we call `opctx.authn.actor_required()` in any `db/datastore` file. The first is [session delete](https://github.com/oxidecomputer/omicron/blob/5c79f74846e02df1ef9c45fa7693c5d3db9a6375/nexus/src/db/datastore/console_session.rs#L103-L114), which has a helpful comment by @davepacheco: 

```
// We don't do a typical authz check here.  Instead, knowing that every
// user is allowed to delete their own session, the query below filters
// on the session's silo_user_id matching the current actor's id.
//
// We could instead model this more like other authz checks.  That would
// involve fetching the session record from the database, storing the
// associated silo_user_id into the `authz::ConsoleSession`, and having
// an Oso rule saying you can delete a session whose associated silo
// user matches the authenticated actor.  This would be a fair bit more
// complicated and more work at runtime work than what we're doing here.
// The tradeoff is that we're effectively encoding policy here, but it
// seems worth it in this case.
```

I think this logic also applies to what I've written, which means we should have a similar comment and we're ok.

### New `SessionMe` response type

We use the existing `User` in a number of places, not just `/session/me`, and I don't think we want to clutter all those up with lists of groups (or maybe we do?) so we need a new response type for `/session/me`. This isn't that weird and I'm pretty sure we've talked about doing it before, though I can't find that discussion.

### Should we list group IDs or `{ id, name }` objects?

For my purposes in the console (matching against a policy) I only need IDs, but I can certainly see us needing names sometime soon. For example, it might make sense to display a list of my groups on `/settings/profile`, which currently only shows the user's UUID.