### PR TITLE
Improve `Screen` trait

### DIFF
--- a/wicket/src/lib.rs
+++ b/wicket/src/lib.rs
@@ -162,6 +162,7 @@ impl Wizard {
     }
 
     fn mainloop(&mut self) -> anyhow::Result<()> {
+        let rect = self.terminal.get_frame().size();
         // Size the rack for the initial draw
         self.state
             .rack_state
@@ -169,6 +170,7 @@ impl Wizard {
 
         // Draw the initial screen
         let screen = self.screens.get_mut(self.active_screen);
+        screen.resize(&mut self.state, rect.width, rect.height);
         screen.draw(&self.state, &mut self.terminal)?;
 
         loop {
@@ -194,6 +196,7 @@ impl Wizard {
                 Event::Term(TermEvent::Resize(width, height)) => {
                     let rect = Rect { x: 0, y: 0, width, height };
                     self.state.rack_state.resize(&rect, &MARGIN);
+                    screen.resize(&mut self.state, width, height);
                     screen.draw(&self.state, &mut self.terminal)?;
                 }
                 Event::Term(TermEvent::Mouse(mouse_event)) => {
@@ -247,6 +250,10 @@ impl Wizard {
                 Action::SwitchScreen(id) => {
                     self.active_screen = id;
                     let screen = self.screens.get_mut(id);
+                    let rect = self.terminal.get_frame().size();
+
+                    screen.resize(&mut self.state, rect.width, rect.height);
+
                     // Simulate a mouse movement for the current position
                     // because the mouse may be in a different position when transitioning
                     // between screens.

--- a/wicket/src/screens/mod.rs
+++ b/wicket/src/screens/mod.rs
@@ -10,6 +10,7 @@ use crate::Action;
 use crate::ScreenEvent;
 use crate::State;
 use crate::Term;
+use crate::TermEvent;
 use slog::Logger;
 
 use component::ComponentScreen;
@@ -22,7 +23,6 @@ pub enum ScreenId {
     Splash,
     Rack,
     Component,
-    Update,
 }
 
 impl ScreenId {
@@ -31,7 +31,6 @@ impl ScreenId {
             ScreenId::Splash => "splash",
             ScreenId::Rack => "rack",
             ScreenId::Component => "component",
-            ScreenId::Update => "update",
         }
     }
 
@@ -58,15 +57,21 @@ pub fn make_even(val: u16) -> u16 {
 
 pub trait Screen {
     /// Draw the [`Screen`]
-    fn draw(
-        &mut self,
-        state: &State,
-        terminal: &mut Term,
-    ) -> anyhow::Result<()>;
+    fn draw(&self, state: &State, terminal: &mut Term) -> anyhow::Result<()>;
 
     /// Handle a [`ScreenEvent`] to update internal display state and output
     /// any necessary actions for the system to take.
     fn on(&mut self, state: &mut State, event: ScreenEvent) -> Vec<Action>;
+
+    /// Resize the screen via delivering a `Resize` event
+    fn resize(
+        &mut self,
+        state: &mut State,
+        width: u16,
+        height: u16,
+    ) -> Vec<Action> {
+        self.on(state, ScreenEvent::Term(TermEvent::Resize(width, height)))
+    }
 }
 
 /// All [`Screen`]s for wicket
@@ -90,7 +95,6 @@ impl Screens {
             ScreenId::Splash => &mut self.splash,
             ScreenId::Rack => &mut self.rack,
             ScreenId::Component => &mut self.component,
-            _ => unimplemented!(),
         }
     }
 }

--- a/wicket/src/screens/rack.rs
+++ b/wicket/src/screens/rack.rs
@@ -135,7 +135,7 @@ impl RackScreen {
 
     /// Draw the rack in the center of the screen.
     /// Scale it to look nice.
-    fn draw_rack(&mut self, state: &State, f: &mut Frame) {
+    fn draw_rack(&self, state: &State, f: &mut Frame) {
         let rack = Rack {
             state: &state.rack_state,
             switch_style: Style::default().bg(OX_GRAY_DARK).fg(OX_WHITE),
@@ -277,7 +277,7 @@ impl RackScreen {
 
 impl Screen for RackScreen {
     fn draw(
-        &mut self,
+        &self,
         state: &State,
         terminal: &mut crate::Term,
     ) -> anyhow::Result<()> {

--- a/wicket/src/screens/splash.rs
+++ b/wicket/src/screens/splash.rs
@@ -40,7 +40,7 @@ impl SplashScreen {
 
     // Sweep left to right, painting the banner white, with
     // the x painted green.
-    fn animate_logo(&mut self, f: &mut Frame) {
+    fn animate_logo(&self, f: &mut Frame) {
         // Center the banner
         let mut rect = f.size();
         rect.x = rect.width / 2 - LOGO_WIDTH / 2;
@@ -62,7 +62,7 @@ impl SplashScreen {
 
 impl Screen for SplashScreen {
     fn draw(
-        &mut self,
+        &self,
         _state: &crate::State,
         terminal: &mut crate::Term,
     ) -> anyhow::Result<()> {

--- a/wicket/src/widgets/screen_button.rs
+++ b/wicket/src/widgets/screen_button.rs
@@ -22,16 +22,15 @@ use tui::widgets::Widget;
 pub struct ScreenButtonState {
     control_id: ControlId,
     pub rect: Rect,
-    pub hovered: bool,
     pub screen_id: ScreenId,
 }
 
 impl ScreenButtonState {
-    pub fn new(screen_id: ScreenId, x: u16, y: u16) -> ScreenButtonState {
+    pub fn new(screen_id: ScreenId) -> ScreenButtonState {
+        // Location will get set via [`Screen::resize`]
         ScreenButtonState {
             control_id: get_control_id(),
-            rect: Rect { height: 5, width: Self::width(), x, y },
-            hovered: false,
+            rect: Rect { height: 5, width: Self::width(), x: 0, y: 0 },
             screen_id,
         }
     }


### PR DESCRIPTION
Draw methods are no longer allowed to mutate self. This was achieved by adding a provided `resize` method that performs any necessary state mutations for drawing, and which is called independently of `draw` as necessary.

When we create a `ScreenButtonState`, we don't actually know where it's going to be placed because the constructor doesn't have access to the frame size. With the aformentioned changes we can now simplify the constructor and place it when `resize` is called.