### PR TITLE
MGS: Implement endpoint to get SP's component list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=c1484109c394f45e08018e0f35adc4a136cd207d#c1484109c394f45e08018e0f35adc4a136cd207d"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -1729,6 +1730,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=c1484109c394f45e08018e0f35adc4a136cd207d#c1484109c394f45e08018e0f35adc4a136cd207d"
 dependencies = [
  "backoff",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,6 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=90a4a944d35b7250b4ab468b31ae88deaf34ff78#90a4a944d35b7250b4ab468b31ae88deaf34ff78"
 dependencies = [
  "bitflags",
  "hubpack",
@@ -1724,12 +1723,12 @@ dependencies = [
  "smoltcp",
  "static_assertions",
  "uuid",
+ "zerocopy 0.6.1",
 ]
 
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=90a4a944d35b7250b4ab468b31ae88deaf34ff78#90a4a944d35b7250b4ab468b31ae88deaf34ff78"
 dependencies = [
  "backoff",
  "futures",

--- a/deploy/src/bin/sled-agent-overlay-files.rs
+++ b/deploy/src/bin/sled-agent-overlay-files.rs
@@ -40,8 +40,8 @@ fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
                     serial_number: [0; 16],
                     manufacturing_root_cert_seed: [0; 32],
                     device_id_cert_seed: [0; 32],
+                    components: Vec::new(),
                 },
-                components: Vec::new(),
             };
             let len = config.common.serial_number.len();
             config.common.serial_number[len - 4..].copy_from_slice(&id);

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -128,8 +128,8 @@ struct Client {
 
 impl Client {
     fn new(server: IpAddr, port: u16, sled: u32, log: Logger) -> Self {
-        // We currently hardcode `sled` and `sp3`, as that is the only
-        // sptype+component pair that has a serial port.
+        // We currently hardcode `sled` and the SP3 host CPU component, as that
+        // is the only sptype+component pair that has a serial port.
         Self {
             inner: gateway_client::Client::new(
                 &format!("http://{}:{}", server, port),
@@ -139,7 +139,7 @@ impl Client {
             port,
             sled,
             sp_type: SpType::Sled,
-            component: "sp3",
+            component: "sp3-host-cpu",
         }
     }
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -22,16 +22,14 @@ uuid = "1.2.1"
 omicron-common = { path = "../common" }
 
 [dependencies.gateway-messages]
-#git = "https://github.com/oxidecomputer/management-gateway-service"
-#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
-path = "../../management-gateway-service/gateway-messages"
+git = "https://github.com/oxidecomputer/management-gateway-service"
+rev = "c1484109c394f45e08018e0f35adc4a136cd207d"
 default-features = false
 features = ["std"]
 
 [dependencies.gateway-sp-comms]
-#git = "https://github.com/oxidecomputer/management-gateway-service"
-#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
-path = "../../management-gateway-service/gateway-sp-comms"
+git = "https://github.com/oxidecomputer/management-gateway-service"
+rev = "c1484109c394f45e08018e0f35adc4a136cd207d"
 
 [dependencies.slog]
 version = "2.7"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -22,14 +22,16 @@ uuid = "1.2.1"
 omicron-common = { path = "../common" }
 
 [dependencies.gateway-messages]
-git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "90a4a944d35b7250b4ab468b31ae88deaf34ff78"
+#git = "https://github.com/oxidecomputer/management-gateway-service"
+#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
+path = "../../management-gateway-service/gateway-messages"
 default-features = false
 features = ["std"]
 
 [dependencies.gateway-sp-comms]
-git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "90a4a944d35b7250b4ab468b31ae88deaf34ff78"
+#git = "https://github.com/oxidecomputer/management-gateway-service"
+#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
+path = "../../management-gateway-service/gateway-sp-comms"
 
 [dependencies.slog]
 version = "2.7"

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -150,27 +150,27 @@ struct UpdatePreparationProgress {
 }
 
 /// List of components from a single SP.
-#[derive(Serialize, JsonSchema)]
-struct SpComponentList {
-    components: Vec<SpComponentInfo>,
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct SpComponentList {
+    pub components: Vec<SpComponentInfo>,
 }
 
 /// Overview of a single SP component.
-#[derive(Serialize, JsonSchema)]
-struct SpComponentInfo {
-    component: String,
-    device: String,
-    serial_number: Option<String>,
-    description: String,
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct SpComponentInfo {
+    pub component: String,
+    pub device: String,
+    pub serial_number: Option<String>,
+    pub description: String,
     /// `capabilities` is a bitmask; interpret it via
     /// [`gateway_messages::DeviceCapabilities`].
-    capabilities: u32,
-    presence: SpComponentPresence,
+    pub capabilities: u32,
+    pub presence: SpComponentPresence,
 }
 
-#[derive(Serialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-enum SpComponentPresence {
+pub enum SpComponentPresence {
     Present,
     NotPresent,
     Failed,

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -158,24 +158,41 @@ pub struct SpComponentList {
 /// Overview of a single SP component.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct SpComponentInfo {
+    /// The unique identifier for this component.
     pub component: String,
+    /// The name of the physical device.
     pub device: String,
+    /// The component's serial number, if it has one.
     pub serial_number: Option<String>,
+    /// A human-readable description of the component.
     pub description: String,
     /// `capabilities` is a bitmask; interpret it via
     /// [`gateway_messages::DeviceCapabilities`].
     pub capabilities: u32,
+    /// Whether or not the component is present, to the best of the SP's ability
+    /// to judge.
     pub presence: SpComponentPresence,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+/// Description of the presence or absence of a component.
+///
+/// The presence of some components may vary based on the power state of the
+/// sled (e.g., components that time out or appear unavailable if the sled is in
+/// A2 may become present when the sled moves to A0).
 pub enum SpComponentPresence {
+    /// The component is present.
     Present,
+    /// The component is not present.
     NotPresent,
+    /// The component is present but in a failed or faulty state.
     Failed,
+    /// The SP is unable to determine the presence of the component.
     Unavailable,
+    /// The SP's attempt to determine the presence of the component timed out.
     Timeout,
+    /// The SP's attempt to determine the presence of the component failed.
     Error,
 }
 

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -7,6 +7,9 @@
 //! Conversions between externally-defined types and HTTP / JsonSchema types.
 
 use super::PowerState;
+use super::SpComponentInfo;
+use super::SpComponentList;
+use super::SpComponentPresence;
 use super::SpIdentifier;
 use super::SpIgnition;
 use super::SpState;
@@ -146,5 +149,37 @@ impl From<gateway_sp_comms::SpIdentifier> for SpIdentifier {
             // not exceed u32::MAX
             slot: u32::try_from(id.slot).unwrap(),
         }
+    }
+}
+
+impl From<gateway_messages::DevicePresence> for SpComponentPresence {
+    fn from(p: gateway_messages::DevicePresence) -> Self {
+        match p {
+            gateway_messages::DevicePresence::Present => Self::Present,
+            gateway_messages::DevicePresence::NotPresent => Self::NotPresent,
+            gateway_messages::DevicePresence::Failed => Self::Failed,
+            gateway_messages::DevicePresence::Unavailable => Self::Unavailable,
+            gateway_messages::DevicePresence::Timeout => Self::Timeout,
+            gateway_messages::DevicePresence::Error => Self::Error,
+        }
+    }
+}
+
+impl From<gateway_sp_comms::SpDevice> for SpComponentInfo {
+    fn from(d: gateway_sp_comms::SpDevice) -> Self {
+        Self {
+            component: d.component.as_str().unwrap_or("???").to_string(),
+            device: d.device,
+            serial_number: None, // TODO populate when SP provides it
+            description: d.description,
+            capabilities: d.capabilities.bits(),
+            presence: d.presence.into(),
+        }
+    }
+}
+
+impl From<gateway_sp_comms::SpInventory> for SpComponentList {
+    fn from(inv: gateway_sp_comms::SpInventory) -> Self {
+        Self { components: inv.devices.into_iter().map(Into::into).collect() }
     }
 }

--- a/gateway/tests/integration_tests/component_list.rs
+++ b/gateway/tests/integration_tests/component_list.rs
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use super::current_simulator_state;
+use super::setup;
+use super::SpStateExt;
+use dropshot::test_util;
+use gateway_messages::DeviceCapabilities;
+use gateway_messages::SpComponent;
+use gateway_messages::SpPort;
+use omicron_gateway::http_entrypoints::SpComponentInfo;
+use omicron_gateway::http_entrypoints::SpComponentList;
+use omicron_gateway::http_entrypoints::SpComponentPresence;
+use omicron_gateway::http_entrypoints::SpType;
+
+#[tokio::test]
+async fn component_list() {
+    let testctx = setup::test_setup("component_list", SpPort::One).await;
+    let client = &testctx.client;
+    let simrack = &testctx.simrack;
+
+    // Double check that we have at least 1 sidecar and 2 gimlets and that all
+    // SPs are enabled.
+    let sim_state = current_simulator_state(simrack).await;
+    assert!(
+        sim_state.iter().filter(|sp| sp.info.id.typ == SpType::Sled).count()
+            >= 2
+    );
+    assert!(sim_state.iter().any(|sp| sp.info.id.typ == SpType::Switch));
+    assert!(sim_state.iter().all(|sp| sp.details.is_enabled()));
+
+    // Get the component list for sled 0.
+    let url = format!("{}", client.url("/sp/sled/0/component"));
+    let resp: SpComponentList = test_util::object_get(client, &url).await;
+
+    assert_eq!(
+        resp.components,
+        &[
+            SpComponentInfo {
+                component: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
+                device: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
+                serial_number: None,
+                description: "FAKE host cpu".to_string(),
+                capabilities: 0,
+                presence: SpComponentPresence::Present,
+            },
+            SpComponentInfo {
+                component: "dev-0".to_string(),
+                device: "fake-tmp-sensor".to_string(),
+                serial_number: None,
+                description: "FAKE temperature sensor".to_string(),
+                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    .bits(),
+                presence: SpComponentPresence::Failed,
+            }
+        ]
+    );
+
+    // Get the component list for sled 1.
+    let url = format!("{}", client.url("/sp/sled/1/component"));
+    let resp: SpComponentList = test_util::object_get(client, &url).await;
+
+    assert_eq!(
+        resp.components,
+        &[SpComponentInfo {
+            component: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
+            device: SpComponent::SP3_HOST_CPU.const_as_str().to_string(),
+            serial_number: None,
+            description: "FAKE host cpu".to_string(),
+            capabilities: 0,
+            presence: SpComponentPresence::Present,
+        },]
+    );
+
+    // Get the component list for switch 0.
+    let url = format!("{}", client.url("/sp/switch/0/component"));
+    let resp: SpComponentList = test_util::object_get(client, &url).await;
+
+    assert_eq!(
+        resp.components,
+        &[
+            SpComponentInfo {
+                component: "dev-0".to_string(),
+                device: "fake-tmp-sensor".to_string(),
+                serial_number: None,
+                description: "FAKE temperature sensor 1".to_string(),
+                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    .bits(),
+                presence: SpComponentPresence::Present,
+            },
+            SpComponentInfo {
+                component: "dev-1".to_string(),
+                device: "fake-tmp-sensor".to_string(),
+                serial_number: None,
+                description: "FAKE temperature sensor 2".to_string(),
+                capabilities: DeviceCapabilities::HAS_MEASUREMENT_CHANNELS
+                    .bits(),
+                presence: SpComponentPresence::Failed,
+            },
+        ]
+    );
+}

--- a/gateway/tests/integration_tests/component_list.rs
+++ b/gateway/tests/integration_tests/component_list.rs
@@ -102,4 +102,6 @@ async fn component_list() {
             },
         ]
     );
+
+    testctx.teardown().await;
 }

--- a/gateway/tests/integration_tests/mod.rs
+++ b/gateway/tests/integration_tests/mod.rs
@@ -16,6 +16,7 @@ use sp_sim::SimulatedSp;
 
 mod bulk_state_get;
 mod commands;
+mod component_list;
 mod location_discovery;
 mod serial_console;
 mod setup;

--- a/gateway/tests/integration_tests/serial_console.rs
+++ b/gateway/tests/integration_tests/serial_console.rs
@@ -28,7 +28,7 @@ async fn sim_sp_serial_console(
     gimlet: &Gimlet,
 ) -> (mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
     let mut conn =
-        TcpStream::connect(gimlet.serial_console_addr("sp3").unwrap())
+        TcpStream::connect(gimlet.serial_console_addr("sp3-host-cpu").unwrap())
             .await
             .unwrap();
 
@@ -77,7 +77,7 @@ async fn serial_console_communication() {
     // connect to the MGS websocket for this gimlet
     let url = {
         let mut parts = client
-            .url("/sp/sled/0/component/sp3/serial-console/attach")
+            .url("/sp/sled/0/component/sp3-host-cpu/serial-console/attach")
             .into_parts();
         parts.scheme = Some(Scheme::try_from("ws").unwrap());
         Uri::from_parts(parts).unwrap()
@@ -123,7 +123,7 @@ async fn serial_console_detach() {
     // connect to the MGS websocket for this gimlet
     let attach_url = {
         let mut parts = client
-            .url("/sp/sled/0/component/sp3/serial-console/attach")
+            .url("/sp/sled/0/component/sp3-host-cpu/serial-console/attach")
             .into_parts();
         parts.scheme = Some(Scheme::try_from("ws").unwrap());
         Uri::from_parts(parts).unwrap()
@@ -163,7 +163,7 @@ async fn serial_console_detach() {
     // hit the detach endpoint, which should disconnect `ws`
     let detach_url = format!(
         "{}",
-        client.url("/sp/sled/0/component/sp3/serial-console/detach")
+        client.url("/sp/sled/0/component/sp3-host-cpu/serial-console/detach")
     );
     client
         .make_request_no_body(Method::POST, &detach_url, StatusCode::NO_CONTENT)

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -14,6 +14,20 @@ serial_number = "00000000000000000000000000000001"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
 
+[[simulated_sps.sidecar.components]]
+id = "dev-0"
+device = "fake-tmp-sensor"
+description = "FAKE temperature sensor 1"
+capabilities.bits = 0x2
+presence = "Present"
+
+[[simulated_sps.sidecar.components]]
+id = "dev-1"
+device = "fake-tmp-sensor"
+description = "FAKE temperature sensor 2"
+capabilities.bits = 0x2
+presence = "Failed"
+
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
@@ -35,6 +49,13 @@ description = "FAKE host cpu"
 capabilities.bits = 0
 presence = "Present"
 serial_console = "[::1]:0"
+
+[[simulated_sps.gimlet.components]]
+id = "dev-0"
+device = "fake-tmp-sensor"
+description = "FAKE temperature sensor"
+capabilities.bits = 0x2
+presence = "Failed"
 
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -29,7 +29,11 @@ manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 
 [[simulated_sps.gimlet.components]]
-name = "sp3"
+id = "sp3-host-cpu"
+device = "sp3-host-cpu"
+description = "FAKE host cpu"
+capabilities.bits = 0
+presence = "Present"
 serial_console = "[::1]:0"
 
 [[simulated_sps.gimlet]]
@@ -40,7 +44,11 @@ manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000003"
 
 [[simulated_sps.gimlet.components]]
-name = "sp3"
+id = "sp3-host-cpu"
+device = "sp3-host-cpu"
+description = "FAKE host cpu"
+capabilities.bits = 0
+presence = "Present"
 serial_console = "[::1]:0"
 
 #

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -952,19 +952,28 @@
             "minimum": 0
           },
           "component": {
+            "description": "The unique identifier for this component.",
             "type": "string"
           },
           "description": {
+            "description": "A human-readable description of the component.",
             "type": "string"
           },
           "device": {
+            "description": "The name of the physical device.",
             "type": "string"
           },
           "presence": {
-            "$ref": "#/components/schemas/SpComponentPresence"
+            "description": "Whether or not the component is present, to the best of the SP's ability to judge.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpComponentPresence"
+              }
+            ]
           },
           "serial_number": {
             "nullable": true,
+            "description": "The component's serial number, if it has one.",
             "type": "string"
           }
         },
@@ -992,14 +1001,50 @@
         ]
       },
       "SpComponentPresence": {
-        "type": "string",
-        "enum": [
-          "present",
-          "not_present",
-          "failed",
-          "unavailable",
-          "timeout",
-          "error"
+        "description": "Description of the presence or absence of a component.\n\nThe presence of some components may vary based on the power state of the sled (e.g., components that time out or appear unavailable if the sled is in A2 may become present when the sled moves to A0).",
+        "oneOf": [
+          {
+            "description": "The component is present.",
+            "type": "string",
+            "enum": [
+              "present"
+            ]
+          },
+          {
+            "description": "The component is not present.",
+            "type": "string",
+            "enum": [
+              "not_present"
+            ]
+          },
+          {
+            "description": "The component is present but in a failed or faulty state.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The SP is unable to determine the presence of the component.",
+            "type": "string",
+            "enum": [
+              "unavailable"
+            ]
+          },
+          {
+            "description": "The SP's attempt to determine the presence of the component timed out.",
+            "type": "string",
+            "enum": [
+              "timeout"
+            ]
+          },
+          {
+            "description": "The SP's attempt to determine the presence of the component failed.",
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
         ]
       },
       "SpIdentifier": {

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -276,7 +276,7 @@
     "/sp/{type}/{slot}/component": {
       "get": {
         "summary": "List components of an SP",
-        "description": "A component is a distinct entity under an SP's direct control. This lists all those components for a given SP.\nAs communication with SPs may be unreliable, consumers may optionally override the timeout. This interface may return a page of components prior to reaching either the timeout with the expectation that callers will keep calling this interface until the terminal page is reached. If the timeout is reached, the final call will result in an error.",
+        "description": "A component is a distinct entity under an SP's direct control. This lists all those components for a given SP.",
         "operationId": "sp_component_list",
         "parameters": [
           {
@@ -298,39 +298,6 @@
               "$ref": "#/components/schemas/SpType"
             },
             "style": "simple"
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "timeout_millis",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            },
-            "style": "form"
           }
         ],
         "responses": {
@@ -339,7 +306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SpComponentInfoResultsPage"
+                  "$ref": "#/components/schemas/SpComponentList"
                 }
               }
             }
@@ -350,8 +317,7 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        },
-        "x-dropshot-pagination": true
+        }
       }
     },
     "/sp/{type}/{slot}/component/{component}": {
@@ -976,27 +942,64 @@
         ]
       },
       "SpComponentInfo": {
-        "type": "object"
-      },
-      "SpComponentInfoResultsPage": {
-        "description": "A single page of results",
+        "description": "Overview of a single SP component.",
         "type": "object",
         "properties": {
-          "items": {
-            "description": "list of items on this page of results",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpComponentInfo"
-            }
+          "capabilities": {
+            "description": "`capabilities` is a bitmask; interpret it via [`gateway_messages::DeviceCapabilities`].",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           },
-          "next_page": {
+          "component": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "device": {
+            "type": "string"
+          },
+          "presence": {
+            "$ref": "#/components/schemas/SpComponentPresence"
+          },
+          "serial_number": {
             "nullable": true,
-            "description": "token used to fetch the next page of results (if any)",
             "type": "string"
           }
         },
         "required": [
-          "items"
+          "capabilities",
+          "component",
+          "description",
+          "device",
+          "presence"
+        ]
+      },
+      "SpComponentList": {
+        "description": "List of components from a single SP.",
+        "type": "object",
+        "properties": {
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpComponentInfo"
+            }
+          }
+        },
+        "required": [
+          "components"
+        ]
+      },
+      "SpComponentPresence": {
+        "type": "string",
+        "enum": [
+          "present",
+          "not_present",
+          "failed",
+          "unavailable",
+          "timeout",
+          "error"
         ]
       },
       "SpIdentifier": {

--- a/sled-agent/src/sp/simulated.rs
+++ b/sled-agent/src/sp/simulated.rs
@@ -48,6 +48,7 @@ impl SimulatedSp {
             let sp_addr = bind_addrs[0].ip();
             for addr in bind_addrs[1..].iter().copied().chain(
                 sp_config
+                    .common
                     .components
                     .iter()
                     .filter_map(|comp| comp.serial_console),

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -18,8 +18,9 @@ thiserror = "1.0"
 toml = "0.5.9"
 
 [dependencies.gateway-messages]
-git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "90a4a944d35b7250b4ab468b31ae88deaf34ff78"
+#git = "https://github.com/oxidecomputer/management-gateway-service"
+#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
+path = "../../management-gateway-service/gateway-messages"
 default-features = false
 features = ["std"]
 

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -18,9 +18,8 @@ thiserror = "1.0"
 toml = "0.5.9"
 
 [dependencies.gateway-messages]
-#git = "https://github.com/oxidecomputer/management-gateway-service"
-#rev = "ebe45ba3b19aa8a25a138ed23e3eb3c76b4585cf"
-path = "../../management-gateway-service/gateway-messages"
+git = "https://github.com/oxidecomputer/management-gateway-service"
+rev = "c1484109c394f45e08018e0f35adc4a136cd207d"
 default-features = false
 features = ["std"]
 

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -18,7 +18,11 @@ manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
 
 [[simulated_sps.gimlet.components]]
-name = "sp3"
+id = "sp3-host-cpu"
+device = "sp3-host-cpu"
+description = "FAKE host cpu"
+capabilities.bits = 0
+presence = "Present"
 serial_console = "[::1]:33312"
 
 [[simulated_sps.gimlet]]
@@ -29,7 +33,11 @@ manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 
 [[simulated_sps.gimlet.components]]
-name = "sp3"
+id = "sp3-host-cpu"
+device = "sp3-host-cpu"
+description = "FAKE host cpu"
+capabilities.bits = 0
+presence = "Present"
 serial_console = "[::1]:33322"
 
 [log]

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -43,7 +43,8 @@ pub struct SpCommonConfig {
 /// Configuration of a simulated SP component
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SpComponentConfig {
-    /// Must be at most [`SpComponent::MAX_ID_LENGTH`] bytes long.
+    /// Must be at most [`gateway_messages::SpComponent::MAX_ID_LENGTH`] bytes
+    /// long.
     pub id: String,
     pub device: String,
     pub description: String,

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -6,6 +6,8 @@
 //! configuration
 
 use dropshot::ConfigLogging;
+use gateway_messages::DeviceCapabilities;
+use gateway_messages::DevicePresence;
 use gateway_messages::SerialNumber;
 use serde::Deserialize;
 use serde::Serialize;
@@ -33,6 +35,24 @@ pub struct SpCommonConfig {
     /// 32-byte seed to create a Device ID certificate.
     #[serde(with = "hex")]
     pub device_id_cert_seed: [u8; 32],
+    /// Fake components.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub components: Vec<SpComponentConfig>,
+}
+
+/// Configuration of a simulated SP component
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct SpComponentConfig {
+    /// Must be at most [`SpComponent::MAX_ID_LENGTH`] bytes long.
+    pub id: String,
+    pub device: String,
+    pub description: String,
+    pub capabilities: DeviceCapabilities,
+    pub presence: DevicePresence,
+    /// Socket address to emulate a serial console.
+    ///
+    /// Only supported for components inside a [`GimletConfig`].
+    pub serial_console: Option<SocketAddrV6>,
 }
 
 /// Configuration of a simulated sidecar SP
@@ -47,19 +67,6 @@ pub struct SidecarConfig {
 pub struct GimletConfig {
     #[serde(flatten)]
     pub common: SpCommonConfig,
-    /// Attached components
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub components: Vec<SpComponentConfig>,
-}
-
-/// Configuration of a simulated gimlet SP
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct SpComponentConfig {
-    /// Name of the component
-    pub name: String,
-    /// Socket address we'll use to expose this component's serial console
-    /// via TCP.
-    pub serial_console: Option<SocketAddrV6>,
 }
 
 /// Configuration of a set of simulated SPs

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -120,10 +120,10 @@ impl Gimlet {
             .await?;
             let servers = [servers.0, servers.1];
 
-            for component_config in &gimlet.components {
-                let name = component_config.name.as_str();
-                let component = SpComponent::try_from(name)
-                    .map_err(|_| anyhow!("component id {:?} too long", name))?;
+            for component_config in &gimlet.common.components {
+                let id = component_config.id.as_str();
+                let component = SpComponent::try_from(id)
+                    .map_err(|_| anyhow!("component id {:?} too long", id))?;
 
                 if let Some(addr) = component_config.serial_console {
                     let listener =
@@ -166,7 +166,7 @@ impl Gimlet {
                             Arc::clone(servers[1].socket()),
                         ],
                         Arc::clone(&attached_mgs),
-                        log.new(slog::o!("serial-console" => name.to_string())),
+                        log.new(slog::o!("serial-console" => id.to_string())),
                     );
                     inner_tasks.push(task::spawn(async move {
                         serial_console.run().await

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::config::GimletConfig;
+use crate::config::{GimletConfig, SpComponentConfig};
 use crate::rot::RotSprocketExt;
 use crate::server;
 use crate::server::UdpServer;
@@ -177,6 +177,7 @@ impl Gimlet {
                 [servers[0].local_addr(), servers[1].local_addr()];
             let inner = UdpTask::new(
                 servers,
+                gimlet.common.components.clone(),
                 attached_mgs,
                 gimlet.common.serial_number,
                 incoming_console_tx,
@@ -384,6 +385,7 @@ struct UdpTask {
 impl UdpTask {
     fn new(
         servers: [UdpServer; 2],
+        components: Vec<SpComponentConfig>,
         attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
         serial_number: SerialNumber,
         incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
@@ -399,6 +401,7 @@ impl UdpTask {
             udp1,
             handler: Handler {
                 log,
+                components,
                 attached_mgs,
                 serial_number,
                 incoming_serial_console,
@@ -459,6 +462,7 @@ impl UdpTask {
 struct Handler {
     log: Logger,
     serial_number: SerialNumber,
+    components: Vec<SpComponentConfig>,
     attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
     incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
 }
@@ -761,10 +765,17 @@ impl SpHandler for Handler {
     }
 
     fn num_devices(&mut self, _: SocketAddrV6, _: SpPort) -> u32 {
-        0
+        self.components.len().try_into().unwrap()
     }
 
-    fn device_description(&mut self, _: u32) -> DeviceDescription<'_> {
-        panic!("we have no devices");
+    fn device_description(&mut self, index: u32) -> DeviceDescription<'_> {
+        let c = &self.components[index as usize];
+        DeviceDescription {
+            component: SpComponent::try_from(c.id.as_str()).unwrap(),
+            device: &c.device,
+            description: &c.description,
+            capabilities: c.capabilities,
+            presence: c.presence,
+        }
     }
 }

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -10,6 +10,7 @@ use crate::{Responsiveness, SimulatedSp};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use futures::future;
+use gateway_messages::sp_impl::DeviceDescription;
 use gateway_messages::sp_impl::SpHandler;
 use gateway_messages::version;
 use gateway_messages::DiscoverResponse;
@@ -757,5 +758,13 @@ impl SpHandler for Handler {
             "port" => ?port,
         );
         Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn num_devices(&mut self, _: SocketAddrV6, _: SpPort) -> u32 {
+        0
+    }
+
+    fn device_description(&mut self, _: u32) -> DeviceDescription<'_> {
+        panic!("we have no devices");
     }
 }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -13,6 +13,7 @@ use crate::SimulatedSp;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::future;
+use gateway_messages::sp_impl::DeviceDescription;
 use gateway_messages::sp_impl::SpHandler;
 use gateway_messages::BulkIgnitionState;
 use gateway_messages::DiscoverResponse;
@@ -586,5 +587,13 @@ impl SpHandler for Handler {
             "port" => ?port,
         );
         Err(ResponseError::RequestUnsupportedForSp)
+    }
+
+    fn num_devices(&mut self, _: SocketAddrV6, _: SpPort) -> u32 {
+        0
+    }
+
+    fn device_description(&mut self, _: u32) -> DeviceDescription<'_> {
+        panic!("we have no devices");
     }
 }


### PR DESCRIPTION
The bulk of the changes in this PR are to `sp-sim` and integration tests; the most relevant real bits are in `gateway/src/http_entrypoints.rs`, where we flesh out an initial version of `SpComponentInfo` (and related types) and implement the `/sp/{type}/{slot}/component` endpoint.

@ahl I tweaked this from the placeholder we had to remove the client-supplied timeout and pagination of the returned list, primarily in the interest of simplicity; if you think that's shortsighted we can revisit. My light reasoning is:

1. Clients are going to have their own timeouts on the overall request anyway; specifying a shorter timeout to get a portion of results seems complicated if it's not necessary.
2. The total number of components we report from a gimlet today is around 75, which fits in ~5 round trip packets to the SP. If the SP or network is being flaky MGS already has internal retry logic, so the MGS client can just wait longer to get all the results.