### PR TITLE
Current user's groups, paginated this time

### DIFF
--- a/nexus/db-model/src/silo_group.rs
+++ b/nexus/db-model/src/silo_group.rs
@@ -41,6 +41,12 @@ impl SiloGroupMembership {
     }
 }
 
+impl From<SiloGroupMembership> for views::SiloGroupMembership {
+    fn from(gm: SiloGroupMembership) -> Self {
+        Self { silo_group_id: gm.silo_group_id }
+    }
+}
+
 impl From<SiloGroup> for views::Group {
     fn from(group: SiloGroup) -> Self {
         Self {

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -93,8 +93,9 @@ impl super::Nexus {
     pub async fn silo_user_fetch_groups_for_self(
         &self,
         opctx: &OpContext,
+        pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::SiloGroupMembership> {
-        self.db_datastore.silo_group_membership_for_self(opctx).await
+        self.db_datastore.silo_group_membership_for_self(opctx, pagparams).await
     }
 
     // Silo groups

--- a/nexus/src/db/datastore/silo_group.rs
+++ b/nexus/src/db/datastore/silo_group.rs
@@ -109,6 +109,7 @@ impl DataStore {
     pub async fn silo_group_membership_for_self(
         &self,
         opctx: &OpContext,
+        pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<SiloGroupMembership> {
         // Similar to session_hard_delete (see comment there), we do not do a
         // typical authz check, instead effectively encoding the policy here
@@ -119,7 +120,7 @@ impl DataStore {
             .internal_context("fetching current user's group memberships")?;
 
         use db::schema::silo_group_membership::dsl;
-        dsl::silo_group_membership
+        paginated(dsl::silo_group_membership, dsl::silo_group_id, pagparams)
             .filter(dsl::silo_user_id.eq(actor.actor_id()))
             .select(SiloGroupMembership::as_returning())
             .get_results_async(self.pool_authorized(opctx).await?)

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -260,6 +260,7 @@ pub fn external_api() -> NexusApiDescription {
         api.register(console_api::logout)?;
 
         api.register(console_api::session_me)?;
+        api.register(console_api::session_me_groups)?;
         api.register(console_api::console_page)?;
         api.register(console_api::console_root)?;
         api.register(console_api::console_settings_page)?;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use dropshot::test_util::ClientTestContext;
+use dropshot::ResultsPage;
 use http::header::HeaderName;
 use http::{header, method::Method, StatusCode};
 use std::env::current_dir;
@@ -335,16 +336,15 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::SessionMe>()
+        .parsed_body::<views::User>()
         .unwrap();
 
     assert_eq!(
         priv_user,
-        views::SessionMe {
+        views::User {
             id: USER_TEST_PRIVILEGED.id(),
             display_name: USER_TEST_PRIVILEGED.external_id.clone(),
             silo_id: DEFAULT_SILO.id(),
-            group_ids: vec![],
         }
     );
 
@@ -353,18 +353,52 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::SessionMe>()
+        .parsed_body::<views::User>()
         .unwrap();
 
     assert_eq!(
         unpriv_user,
-        views::SessionMe {
+        views::User {
             id: USER_TEST_UNPRIVILEGED.id(),
             display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
             silo_id: DEFAULT_SILO.id(),
-            group_ids: vec![],
         }
     );
+}
+
+#[nexus_test]
+async fn test_session_me_groups(cptestctx: &ControlPlaneTestContext) {
+    let testctx = &cptestctx.external_client;
+
+    // hitting /session/me without being logged in is a 401
+    RequestBuilder::new(&testctx, Method::GET, "/session/me/groups")
+        .expect_status(Some(StatusCode::UNAUTHORIZED))
+        .execute()
+        .await
+        .expect("failed to 401 on unauthed request");
+
+    // now make same request with auth
+    let priv_user_groups =
+        NexusRequest::object_get(testctx, "/session/me/groups")
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .expect("failed to get current user")
+            .parsed_body::<ResultsPage<views::SiloGroupMembership>>()
+            .unwrap();
+
+    assert_eq!(priv_user_groups.items, vec![]);
+
+    let unpriv_user_groups =
+        NexusRequest::object_get(testctx, "/session/me/groups")
+            .authn_as(AuthnMode::UnprivilegedUser)
+            .execute()
+            .await
+            .expect("failed to get current user")
+            .parsed_body::<ResultsPage<views::SiloGroupMembership>>()
+            .unwrap();
+
+    assert_eq!(unpriv_user_groups.items, vec![]);
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::fmt::Debug;
+
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_nexus::authn::silos::{
@@ -19,7 +21,9 @@ use nexus_test_utils::resource_helpers::{create_silo, object_create};
 use nexus_test_utils::ControlPlaneTestContext;
 use nexus_test_utils_macros::nexus_test;
 
+use dropshot::ResultsPage;
 use httptest::{matchers::*, responders::*, Expectation, Server};
+use uuid::Uuid;
 
 // Valid SAML IdP entity descriptor from https://en.wikipedia.org/wiki/SAML_metadata#Identity_provider_metadata
 // note: no signing keys
@@ -959,7 +963,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
 
             signing_keypair: None,
 
-            group_attribute_name: None,
+            group_attribute_name: Some("groups".into()),
         },
     )
     .await;
@@ -984,7 +988,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
         )
         .raw_body(Some(
             serde_urlencoded::to_string(SamlLoginPost {
-                saml_response: base64::encode(SAML_RESPONSE),
+                saml_response: base64::encode(SAML_RESPONSE_WITH_GROUPS),
                 relay_state: None,
             })
             .unwrap(),
@@ -1009,9 +1013,26 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     let session_cookie_value =
         result.headers["Set-Cookie"].to_str().unwrap().to_string();
 
+    let groups: ResultsPage<views::Group> = NexusRequest::new(
+        RequestBuilder::new(client, Method::GET, "/groups")
+            .header(http::header::COOKIE, session_cookie_value.clone())
+            .expect_status(Some(StatusCode::OK)),
+    )
+    .execute()
+    .await
+    .expect("expected success")
+    .parsed_body()
+    .unwrap();
+
+    let silo_group_names: Vec<&str> =
+        groups.items.iter().map(|g| g.display_name.as_str()).collect();
+    let silo_group_ids: Vec<Uuid> = groups.items.iter().map(|g| g.id).collect();
+
+    assert_same_items(silo_group_names, vec!["SRE", "Admins"]);
+
     let session_me: views::User = NexusRequest::new(
         RequestBuilder::new(client, Method::GET, "/session/me")
-            .header(http::header::COOKIE, session_cookie_value)
+            .header(http::header::COOKIE, session_cookie_value.clone())
             .expect_status(Some(StatusCode::OK)),
     )
     .execute()
@@ -1021,6 +1042,31 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
 
     assert_eq!(session_me.display_name, "some@customer.com");
+
+    let session_me: ResultsPage<views::SiloGroupMembership> =
+        NexusRequest::new(
+            RequestBuilder::new(client, Method::GET, "/session/me/groups")
+                .header(http::header::COOKIE, session_cookie_value)
+                .expect_status(Some(StatusCode::OK)),
+        )
+        .execute()
+        .await
+        .expect("expected success")
+        .parsed_body()
+        .unwrap();
+
+    let session_me_group_ids =
+        session_me.items.iter().map(|g| g.silo_group_id).collect::<Vec<_>>();
+
+    assert_same_items(session_me_group_ids, silo_group_ids);
+}
+
+/// Order-agnostic vec equality
+fn assert_same_items<T: PartialEq + Debug>(v1: Vec<T>, v2: Vec<T>) {
+    assert_eq!(v1.len(), v2.len(), "{:?} and {:?} don't match", v1, v2);
+    for item in v1.iter() {
+        assert!(v2.contains(item), "{:?} and {:?} don't match", v1, v2);
+    }
 }
 
 // Test correct SAML response with relay state

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -15,6 +15,7 @@ device_auth_request                      /device/auth
 login_spoof                              /login
 logout                                   /logout
 session_me                               /session/me
+session_me_groups                        /session/me/groups
 
 API operations found with tag "images"
 OPERATION ID                             URL PATH

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -322,19 +322,6 @@ pub struct User {
     pub silo_id: Uuid,
 }
 
-/// Client view of a [`User`] and their groups
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
-pub struct SessionMe {
-    pub id: Uuid,
-    /** Human-readable name that can identify the user */
-    pub display_name: String,
-
-    /** Uuid of the silo to which this user belongs */
-    pub silo_id: Uuid,
-
-    pub group_ids: Vec<Uuid>,
-}
-
 // SILO GROUPS
 
 /// Client view of a [`Group`]
@@ -347,6 +334,12 @@ pub struct Group {
 
     /** Uuid of the silo to which this group belongs */
     pub silo_id: Uuid,
+}
+
+/// Client view of a [`Group`]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+pub struct SiloGroupMembership {
+    pub silo_group_id: Uuid,
 }
 
 // BUILT-IN USERS

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5202,7 +5202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SessionMe"
+                  "$ref": "#/components/schemas/User"
                 }
               }
             }
@@ -5214,6 +5214,66 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      }
+    },
+    "/session/me/groups": {
+      "get": {
+        "tags": [
+          "hidden"
+        ],
+        "summary": "Fetch the silo groups of which the current user is a member",
+        "operationId": "session_me_groups",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiloGroupMembershipResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/session/me/sshkeys": {
@@ -11002,38 +11062,6 @@
           "technical_contact_email"
         ]
       },
-      "SessionMe": {
-        "description": "Client view of a [`User`] and their groups",
-        "type": "object",
-        "properties": {
-          "display_name": {
-            "description": "Human-readable name that can identify the user",
-            "type": "string"
-          },
-          "group_ids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "silo_id": {
-            "description": "Uuid of the silo to which this user belongs",
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "display_name",
-          "group_ids",
-          "id",
-          "silo_id"
-        ]
-      },
       "Silo": {
         "description": "Client view of a ['Silo']",
         "type": "object",
@@ -11115,6 +11143,40 @@
           "discoverable",
           "identity_mode",
           "name"
+        ]
+      },
+      "SiloGroupMembership": {
+        "description": "Client view of a [`Group`]",
+        "type": "object",
+        "properties": {
+          "silo_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "silo_group_id"
+        ]
+      },
+      "SiloGroupMembershipResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiloGroupMembership"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "SiloIdentityMode": {


### PR DESCRIPTION
Followup to #1830, especially https://github.com/oxidecomputer/omicron/pull/1830#discussion_r999775859, which correctly points out that there is no bound in principle on the number of groups a user can be in, which means this endpoint needs to be paginated.

### Why is this a draft

I made a new view `SiloGroupMembership` that just contains the group ID. Using the existing `Group` would require having the `SiloGroup` model on hand in order to get the display name from it. I only have a `SiloGroupMembership` model, which is a join table between users and groups and therefore only has the user ID (not needed) and the group ID.

This is goofy and not really like anything else we do. The response should really be a list of `Group`, not just IDs. I will try changing the datastore function to join on groups so we can do that instead.