### PR TITLE
Wicket: Make rack & screen resize consistent

### DIFF
--- a/wicket/src/lib.rs
+++ b/wicket/src/lib.rs
@@ -25,7 +25,6 @@ use std::io::{stdout, Stdout};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{interval, Duration};
 use tui::backend::CrosstermBackend;
-use tui::layout::Rect;
 use tui::Terminal;
 
 pub(crate) mod defaults;
@@ -165,9 +164,7 @@ impl Wizard {
     fn mainloop(&mut self) -> anyhow::Result<()> {
         let rect = self.terminal.get_frame().size();
         // Size the rack for the initial draw
-        self.state
-            .rack_state
-            .resize(&self.terminal.get_frame().size(), &MARGIN);
+        self.state.rack_state.resize(rect.width, rect.height, &MARGIN);
 
         // Draw the initial screen
         let screen = self.screens.get_mut(self.active_screen);
@@ -195,8 +192,7 @@ impl Wizard {
                     self.handle_actions(actions)?;
                 }
                 Event::Term(TermEvent::Resize(width, height)) => {
-                    let rect = Rect { x: 0, y: 0, width, height };
-                    self.state.rack_state.resize(&rect, &MARGIN);
+                    self.state.rack_state.resize(width, height, &MARGIN);
                     screen.resize(&mut self.state, width, height);
                     screen.draw(&self.state, &mut self.terminal)?;
                 }

--- a/wicket/src/widgets/rack.rs
+++ b/wicket/src/widgets/rack.rs
@@ -351,9 +351,9 @@ impl RackState {
     // don't sweat it.
     //
     // The calculations below follow from this logic
-    pub fn resize(&mut self, rect: &Rect, margin: &Height) {
+    pub fn resize(&mut self, width: u16, height: u16, margin: &Height) {
         // Give ourself room for a top margin
-        let max_height = rect.height - margin.0;
+        let max_height = height - margin.0;
 
         // Let's size our components
         let (rack_height, sled_height, other_height): (u16, u16, u16) =
@@ -379,15 +379,13 @@ impl RackState {
                 (component_height * 20, component_height, component_height)
             };
 
-        let mut rect = *rect;
-        rect.height = rack_height;
+        let mut rect = Rect { x: 0, y: 0, width, height: rack_height };
 
         // Center the rack vertically as much as possible
         let extra_margin = (max_height - rack_height) / 2;
         rect.y = margin.0 + extra_margin;
 
         // Scale proportionally and center the rack horizontally
-        let width = rect.width;
         rect.width = make_even(rack_height * 2 / 3);
         rect.x = width / 2 - rect.width / 2;
 


### PR DESCRIPTION
This is a fix based on a comment from @jgallagher in a prior review: https://github.com/oxidecomputer/omicron/pull/1834#discussion_r999881202