### PR TITLE
Add Windows image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,8 +1480,7 @@ dependencies = [
 [[package]]
 name = "fatfs"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18f80a87439240dac45d927fd8f8081b6f1e34c03e97271189fa8a8c2e96c8f"
+source = "git+https://github.com/luqmana/rust-fatfs?branch=stable-0.3#af26bc712db9f770294fb87b52f202c88c2a89df"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bacffd142fc38a01fe255407b0c8d5d0aacfe778#bacffd142fc38a01fe255407b0c8d5d0aacfe778"
+source = "git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561#144d8dafa41715e00b08a5929cc62140ff0eb561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=bacffd142fc38a01fe255407b0c8d5d0aacfe778#bacffd142fc38a01fe255407b0c8d5d0aacfe778"
+source = "git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561#144d8dafa41715e00b08a5929cc62140ff0eb561"
 dependencies = [
  "base64",
  "schemars",
@@ -4082,10 +4082,12 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=c0776be03bf0928651996eb00ad6f3665e99ebe7#c0776be03bf0928651996eb00ad6f3665e99ebe7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d8185d7060a20f55df00a72a#9da9cea30adfcce6d8185d7060a20f55df00a72a"
 dependencies = [
+ "base64",
  "crucible-client-types",
  "propolis_types",
+ "rand 0.8.5",
  "reqwest",
  "ring",
  "schemars",
@@ -4099,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=c0776be03bf0928651996eb00ad6f3665e99ebe7#c0776be03bf0928651996eb00ad6f3665e99ebe7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=9da9cea30adfcce6d8185d7060a20f55df00a72a#9da9cea30adfcce6d8185d7060a20f55df00a72a"
 dependencies = [
  "serde",
 ]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -18,7 +18,10 @@ cookie = "0.16"
 crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778" }
 diesel = { version = "2.0.2", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
-fatfs = "0.3.5"
+# TODO(luqman): Update once merged & new release is cut
+# https://github.com/rafalh/rust-fatfs/pull/76
+fatfs = { git = "https://github.com/luqmana/rust-fatfs", branch = "stable-0.3" }
+#fatfs = "0.3.5"
 futures = "0.3.25"
 headers = "0.3.8"
 hex = "0.4.3"

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.13.1"
 bb8 = "0.8.0"
 clap = { version = "4.0", features = ["derive"] }
 cookie = "0.16"
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
 diesel = { version = "2.0.2", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
 # TODO(luqman): Update once merged & new release is cut

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -92,10 +92,10 @@ service_name = "crucible"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
+source.commit = "144d8dafa41715e00b08a5929cc62140ff0eb561"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "d43fcfabc3f6402cfdbe3a0d31d49ae903f76b5ddec955dcee63236e4a60fdb0"
+source.sha256 = "2de086b0ba27efc638c88ff46a6d110236c2db92499266eccbd2a3ec28acc693"
 output.type = "zone"
 
 # Refer to
@@ -105,10 +105,10 @@ output.type = "zone"
 service_name = "propolis-server"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "c59b1ac246b19130bd489cdce217e40a4e51c094"
+source.commit = "9da9cea30adfcce6d8185d7060a20f55df00a72a"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "0e75d9a22f1ff14b90d04d91e5642d654563cc82f69e2e9cca5a983668d25764"
+source.sha256 = "41d8e20cff02c073b7347bf2d88086c32720031bfdbb10392dcbd5dd8fa158ee"
 output.type = "zone"
 
 [package.maghemite]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -14,8 +14,8 @@ cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.0", features = ["derive"] }
 # Only used by the simulated sled agent.
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778" }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
 ddm-admin-client = { path = "../ddm-admin-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.25"
@@ -31,7 +31,7 @@ oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.2.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "c0776be03bf0928651996eb00ad6f3665e99ebe7" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "9da9cea30adfcce6d8185d7060a20f55df00a72a" }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/tools/populate/populate-images.sh
+++ b/tools/populate/populate-images.sh
@@ -91,3 +91,20 @@ oxide api /system/images --method POST --input - <<EOF
   }
 }
 EOF
+
+echo "Populating windows"
+oxide api /system/images --method POST --input - <<EOF
+{
+  "name": "windows-server-2022",
+  "description": "Windows Server 2022",
+  "block_size": 512,
+  "distribution": {
+    "name": "windows-server",
+    "version": "2022"
+  },
+  "source": {
+      "type": "url",
+      "url": "http://${CATACOMB_TUNNEL}/media/cloud/windows-server-2022-genericcloud-amd64.raw"
+  }
+}
+EOF


### PR DESCRIPTION
This adds a new image to the populate-images script based on `Windows Server 2022 Standard Evaluation (Desktop Experience)` ([scripts used](https://github.com/oxidecomputer/windows-image-builder)).

It has the VirtIO network driver installed so guest networking works (both inbound & outbound). While we use NVMe for storage, it also has the VirtIO block driver installed which is needed for the cloud-init configdrive we expose to guests. Similarly, it also comes with [cloudbase-init](https://cloudbase-init.readthedocs.io/en/latest/intro.html) installed and configured to work with the cloud-init metadata we provide. (There were a few small tweaks made to the in-memory FAT drive we generate for the metadata to get it working.)

First boot can take a few minutes as it begins up in a state as if you had just left the initial Windows Setup. It will skip past the Out of Box Experience (OOBE). After a reboot or two it'll be ready to SSH into. (Subsequent boots will be faster.)

By default it configures an admin user "oxide" with a random password, copies over the SSH key provided by the control plane. It will also update the hostname to match the control plane value. It will also automatically extend the OS partition size (which is ~14G in the base image) to match the configured disk size. RDP is also enabled but you must configure a password first which can be done over SSH by running `net user oxide *`.

This also pulls in a rev of propolis (& crucible) with the updated bootrom.