### PR TITLE
Implement service_put

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -106,7 +106,8 @@ CREATE INDEX ON omicron.public.sled (
 CREATE TYPE omicron.public.service_kind AS ENUM (
   'internal_dns',
   'nexus',
-  'oximeter'
+  'oximeter',
+  'dendrite'
 );
 
 CREATE TABLE omicron.public.service (

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -22,6 +22,7 @@ mod role_assignments;
 mod roles_builtin;
 mod router_routes;
 mod saml;
+mod services;
 mod silos;
 mod snapshots;
 mod ssh_keys;

--- a/nexus/tests/integration_tests/services.rs
+++ b/nexus/tests/integration_tests/services.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use http::method::Method;
+use http::StatusCode;
+use omicron_nexus::internal_api::params::{ServiceKind, ServicePutRequest};
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+use uuid::Uuid;
+
+use nexus_test_utils::{ControlPlaneTestContext, SLED_AGENT_UUID};
+use nexus_test_utils_macros::nexus_test;
+
+#[nexus_test]
+async fn test_service_put_success(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.internal_client;
+
+    let all_variants = [
+        ServiceKind::InternalDNS,
+        ServiceKind::Nexus,
+        ServiceKind::Oximeter,
+        ServiceKind::Dendrite,
+    ];
+
+    let mut rng = StdRng::from_entropy();
+
+    for service_kind in all_variants {
+        let rand: u128 = rng.gen();
+        let request = ServicePutRequest {
+            service_id: Uuid::new_v4(),
+            sled_id: SLED_AGENT_UUID.parse().unwrap(),
+            address: rand.into(),
+            kind: service_kind,
+        };
+        client
+            .make_request(
+                Method::PUT,
+                "/service",
+                Some(request),
+                StatusCode::NO_CONTENT,
+            )
+            .await
+            .unwrap();
+    }
+}

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -278,6 +278,33 @@
         }
       }
     },
+    "/service": {
+      "put": {
+        "summary": "Report that a service within a pool has come online.",
+        "operationId": "service_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServicePutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sled-agents/{sled_id}": {
       "post": {
         "summary": "Report that the sled agent for the specified sled has come online.",

--- a/sled-agent/src/mocks/mod.rs
+++ b/sled-agent/src/mocks/mod.rs
@@ -7,8 +7,8 @@
 use mockall::mock;
 use nexus_client::types::{
     DatasetPutRequest, DatasetPutResponse, DiskRuntimeState,
-    InstanceRuntimeState, SledAgentStartupInfo, UpdateArtifactKind,
-    ZpoolPutRequest, ZpoolPutResponse,
+    InstanceRuntimeState, ServicePutRequest, SledAgentStartupInfo,
+    UpdateArtifactKind, ZpoolPutRequest, ZpoolPutResponse,
 };
 use slog::Logger;
 use uuid::Uuid;
@@ -56,5 +56,9 @@ mock! {
             dataset_id: &Uuid,
             info: &DatasetPutRequest,
         ) -> Result<DatasetPutResponse>;
+        pub async fn service_put(
+            &self,
+            service: &ServicePutRequest,
+        ) -> Result<()>;
     }
 }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -445,6 +445,23 @@ impl From<ServiceRequest> for sled_agent_client::types::ServiceRequest {
     }
 }
 
+impl From<ServiceType> for nexus_client::types::ServiceKind {
+    fn from(s: ServiceType) -> Self {
+        match s {
+            ServiceType::InternalDns { .. } => {
+                nexus_client::types::ServiceKind::InternalDNS
+            }
+            ServiceType::Nexus { .. } => {
+                nexus_client::types::ServiceKind::Nexus
+            }
+            ServiceType::Oximeter => nexus_client::types::ServiceKind::Oximeter,
+            ServiceType::Dendrite { .. } => {
+                nexus_client::types::ServiceKind::Dendrite
+            }
+        }
+    }
+}
+
 /// Used to request that the Sled initialize certain services on initialization.
 ///
 /// This may be used to record that certain sleds are responsible for

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -326,12 +326,22 @@ impl SledAgent {
     /// Ensures that particular services should be initialized.
     ///
     /// These services will be instantiated by this function, will be recorded
-    /// to a local file to ensure they start automatically on next boot.
+    /// to a local file to ensure they start automatically on next boot. After
+    /// being recorded to the filesystem, Nexus will be notified
     pub async fn services_ensure(
         &self,
         requested_services: ServiceEnsureBody,
     ) -> Result<(), Error> {
-        self.services.ensure(requested_services).await?;
+        self.services.ensure(requested_services.clone()).await?;
+
+        self.services
+            .notify_running_services(
+                self.id,
+                self.lazy_nexus_client.clone(),
+                requested_services,
+            )
+            .await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
The sled agent now notifies Nexus of services when they have booted using a new "/service" endpoint. `ServicePutRequest` already existed as an internal API type, and `Nexus::upsert_service` already existed, so this commit mostly wires up things that existed before.

Implementation caught a missing enum variant on service_kind, so tests were added to exercise `PUT /service`.