### PR TITLE
Configure mg-ddm to use both interfaces

### DIFF
--- a/sled-agent/src/bootstrap/maghemite.rs
+++ b/sled-agent/src/bootstrap/maghemite.rs
@@ -45,7 +45,7 @@ fn enable_mg_ddm_service_blocking(
 
     let interface_names: Vec<String> = interfaces
         .iter()
-        .map(|interface| format!(r#""{}""#, interface.to_string()))
+        .map(|interface| format!(r#""{}""#, interface))
         .collect();
     let property_value = format!("({})", interface_names.join(" "));
     info!(log, "Setting mg-ddm interfaces"; "interfaces" => &property_value);

--- a/sled-agent/src/bootstrap/maghemite.rs
+++ b/sled-agent/src/bootstrap/maghemite.rs
@@ -21,6 +21,9 @@ pub enum Error {
 
     #[error("Error starting service: {0}")]
     Join(#[from] tokio::task::JoinError),
+
+    #[error("Argument error: {0}")]
+    Argument(String),
 }
 
 pub async fn enable_mg_ddm_service(
@@ -37,6 +40,12 @@ fn enable_mg_ddm_service_blocking(
     log: Logger,
     interfaces: Vec<AddrObject>,
 ) -> Result<(), Error> {
+    if interfaces.is_empty() {
+        return Err(Error::Argument(
+            "Service mg-ddm requires at least one interface".to_string(),
+        ));
+    }
+
     // TODO-correctness Should we try to shut down / remove any existing mg-ddm
     // service first? This appears to work fine as-is on a restart of the
     // sled-agent service.

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -76,9 +76,6 @@ impl Server {
             );
         }
 
-        // Turn on the maghemite routing service.
-        // TODO-correctness Eventually we need mg-ddm to listen on multiple
-        // interfaces (link-local addresses of both NICs).
         info!(log, "Starting mg-ddm service");
         maghemite::enable_mg_ddm_service(log.clone(), mg_addr_objs.clone())
             .await

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -80,7 +80,7 @@ impl Server {
         // TODO-correctness Eventually we need mg-ddm to listen on multiple
         // interfaces (link-local addresses of both NICs).
         info!(log, "Starting mg-ddm service");
-        maghemite::enable_mg_ddm_service(log.clone(), mg_addr_objs[0].clone())
+        maghemite::enable_mg_ddm_service(log.clone(), mg_addr_objs.clone())
             .await
             .map_err(|err| format!("Failed to start mg-ddm: {err}"))?;
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -941,7 +941,7 @@ mod test {
         let logctx = test_setup_log("transition_before_start");
         let log = &logctx.log;
         let vnic_allocator = VnicAllocator::new(
-            "Test".to_string(),
+            "Test",
             Etherstub("mylink".to_string()),
         );
         let underlay_ip = std::net::Ipv6Addr::new(

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -940,10 +940,8 @@ mod test {
     async fn transition_before_start() {
         let logctx = test_setup_log("transition_before_start");
         let log = &logctx.log;
-        let vnic_allocator = VnicAllocator::new(
-            "Test",
-            Etherstub("mylink".to_string()),
-        );
+        let vnic_allocator =
+            VnicAllocator::new("Test", Etherstub("mylink".to_string()));
         let underlay_ip = std::net::Ipv6Addr::new(
             0xfd00, 0x1de, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         );

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -300,7 +300,7 @@ mod test {
             source_nat: SourceNatConfig {
                 ip: IpAddr::from(Ipv4Addr::new(10, 0, 0, 1)),
                 first_port: 0,
-                last_port: 1 << 14 - 1,
+                last_port: 1 << (14 - 1),
             },
             external_ips: vec![],
             firewall_rules: vec![],

--- a/sled-agent/src/opte/illumos/firewall_rules.rs
+++ b/sled-agent/src/opte/illumos/firewall_rules.rs
@@ -93,11 +93,11 @@ impl FromVpcFirewallRule for VpcFirewallRule {
         }
     }
 
-    fn priority(self: &Self) -> u16 {
+    fn priority(&self) -> u16 {
         self.priority.0
     }
 
-    fn protos(self: &Self) -> Vec<ProtoFilter> {
+    fn protos(&self) -> Vec<ProtoFilter> {
         self.filter_protocols.as_ref().map_or_else(
             || vec![ProtoFilter::Any],
             |protos| {

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -906,9 +906,8 @@ mod test {
         // It's illegal to go straight to attached to a different instance.
         let id2 = uuid::Uuid::new_v4();
         assert_ne!(id, id2);
-        let error = disk
-            .transition(DiskStateRequested::Attached(id2))
-            .unwrap_err();
+        let error =
+            disk.transition(DiskStateRequested::Attached(id2)).unwrap_err();
         if let Error::InvalidRequest { message } = error {
             assert_eq!("disk is already attached", message);
         } else {
@@ -935,15 +934,9 @@ mod test {
         // Verify that it works fine to change directions in the middle of an
         // async transition.
         disk.transition(DiskStateRequested::Attached(id)).unwrap();
-        assert_eq!(
-            disk.object.current().disk_state,
-            DiskState::Attaching(id)
-        );
+        assert_eq!(disk.object.current().disk_state, DiskState::Attaching(id));
         disk.transition(DiskStateRequested::Destroyed).unwrap();
-        assert_eq!(
-            disk.object.current().disk_state,
-            DiskState::Detaching(id)
-        );
+        assert_eq!(disk.object.current().disk_state, DiskState::Detaching(id));
         disk.transition_finish();
         assert_eq!(disk.object.current().disk_state, DiskState::Destroyed);
         logctx.cleanup_successful();
@@ -962,18 +955,11 @@ mod test {
         let id = uuid::Uuid::new_v4();
         disk.transition(DiskStateRequested::Attached(id)).unwrap();
         disk.transition_finish();
-        assert_eq!(
-            disk.object.current().disk_state,
-            DiskState::Attached(id)
-        );
+        assert_eq!(disk.object.current().disk_state, DiskState::Attached(id));
         disk.transition(DiskStateRequested::Faulted).unwrap();
-        assert_eq!(
-            disk.object.current().disk_state,
-            DiskState::Detaching(id)
-        );
-        let error = disk
-            .transition(DiskStateRequested::Attached(id))
-            .unwrap_err();
+        assert_eq!(disk.object.current().disk_state, DiskState::Detaching(id));
+        let error =
+            disk.transition(DiskStateRequested::Attached(id)).unwrap_err();
         if let Error::InvalidRequest { message } = error {
             assert_eq!("cannot attach from detaching", message);
         } else {


### PR DESCRIPTION
It looks like we can pass a tuple-like structure to `mg-ddm` when configuring the `interfaces` property:
```
svccfg -s mg-ddm setprop config/interfaces = astring: '("vioif0/v6" "vioif1/v6")'
```

After updating `sled-agent` to generate a string in the above format:

```
levon@helios:~/omicron/sled-agent$ dladm show-vnic 
LINK         OVER         SPEED    MACADDRESS        MACADDRTYPE         VID
net0         vioif0       1000     2:8:20:8f:ac:c5   random              0
net1         vioif0       1000     2:8:20:7d:2e:b1   random              0
underlay0    stub0        0        2:8:20:4e:55:4e   random              0
```

```
Oct 27 23:52:52.005 INFO starting illumos ddm control plane
Oct 27 23:52:52.031 INFO admin: listening on [::1]:8000
Oct 27 23:52:52.031 INFO discovered neighbor fe80::8:20ff:fe8f:acc5
Oct 27 23:52:52.033 INFO peer: listening on [fe80::8:20ff:fe7d:2eb1]:7632    
Oct 27 23:52:52.033 INFO started peering session for fe80::8:20ff:fe8f:acc5 
Oct 27 23:52:52.033 INFO neigbor discovery finished on Interface { ifnum: 4, ll_addr: fe80::8:20ff:fe7d:2eb1 }
....
Oct 27 23:52:52.131 INFO discovered neighbor fe80::8:20ff:fe7d:2eb1
Oct 27 23:52:52.131 INFO peer: listening on [fe80::8:20ff:fe8f:acc5]:7632
Oct 27 23:52:52.132 INFO started peering session for fe80::8:20ff:fe7d:2eb1
Oct 27 23:52:52.132 INFO neigbor discovery finished on Interface { ifnum: 3, ll_addr: fe80::8:20ff:fe8f:acc5 }

```