### PR TITLE
role policy test: cover more stuff, run faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,11 @@ opt-level = 3
 [profile.dev.package.lalrpop]
 opt-level = 3
 
+# `polar-core` is exercised heavily during the test suite and it's worthwhile to
+# have it built with optimizations.
+[profile.dev.package.polar-core]
+opt-level = 3
+
 # Password hashing is expensive by construction.  Build the hashing libraries
 # with optimizations to significantly speed up tests.
 [profile.dev.package.argon2]

--- a/nexus/src/authz/omicron.polar
+++ b/nexus/src/authz/omicron.polar
@@ -243,13 +243,13 @@ resource SiloUser {
 	# of the only areas of Silo configuration that Fleet Administrators have
 	# permissions on.
 	relations = { parent_silo: Silo, parent_fleet: Fleet };
-	"list_children" if "viewer" on "parent_silo";
-	"read" if "viewer" on "parent_silo";
+	"list_children" if "read" on "parent_silo";
+	"read" if "read" on "parent_silo";
 	"modify" if "admin" on "parent_silo";
 	"create_child" if "admin" on "parent_silo";
-	"list_children" if "admin" on "parent_fleet";
+	"list_children" if "read" on "parent_fleet";
+	"read" if "read" on "parent_fleet";
 	"modify" if "admin" on "parent_fleet";
-	"read" if "admin" on "parent_fleet";
 	"create_child" if "admin" on "parent_fleet";
 }
 has_relation(silo: Silo, "parent_silo", user: SiloUser)
@@ -273,8 +273,8 @@ resource SiloGroup {
 	];
 
 	relations = { parent_silo: Silo };
-	"list_children" if "viewer" on "parent_silo";
-	"read" if "viewer" on "parent_silo";
+	"list_children" if "read" on "parent_silo";
+	"read" if "read" on "parent_silo";
 	"modify" if "admin" on "parent_silo";
 	"create_child" if "admin" on "parent_silo";
 }

--- a/nexus/src/authz/policy_test/resources.rs
+++ b/nexus/src/authz/policy_test/resources.rs
@@ -132,6 +132,18 @@ async fn make_silo(
     }
 
     builder.new_resource(authz::SiloIdentityProviderList::new(silo.clone()));
+    let idp_id = Uuid::new_v4();
+    builder.new_resource(authz::IdentityProvider::new(
+        silo.clone(),
+        idp_id,
+        LookupType::ByName(format!("{}-identity-provider", silo_name)),
+    ));
+    builder.new_resource(authz::SamlIdentityProvider::new(
+        silo.clone(),
+        idp_id,
+        LookupType::ByName(format!("{}-saml-identity-provider", silo_name)),
+    ));
+
     builder.new_resource(authz::SiloUserList::new(silo.clone()));
     let silo_user_id = Uuid::new_v4();
     let silo_user = authz::SiloUser::new(
@@ -292,8 +304,6 @@ pub fn exempted_authz_classes() -> BTreeSet<String> {
         authz::RouterRoute::get_polar_class(),
         authz::ConsoleSession::get_polar_class(),
         authz::RoleBuiltin::get_polar_class(),
-        authz::IdentityProvider::get_polar_class(),
-        authz::SamlIdentityProvider::get_polar_class(),
         authz::UpdateAvailableArtifact::get_polar_class(),
         authz::UserBuiltin::get_polar_class(),
     ]

--- a/nexus/src/authz/policy_test/resources.rs
+++ b/nexus/src/authz/policy_test/resources.rs
@@ -77,15 +77,37 @@ pub async fn make_resources<'a>(
     let rack_id = "c037e882-8b6d-c8b5-bef4-97e848eb0a50".parse().unwrap();
     builder.new_resource(authz::Rack::new(
         authz::FLEET.clone(),
-        Uuid::new_v4(),
+        rack_id,
         LookupType::ById(rack_id),
     ));
 
     let sled_id = "8a785566-adaf-c8d8-e886-bee7f9b73ca7".parse().unwrap();
     builder.new_resource(authz::Sled::new(
         authz::FLEET.clone(),
-        Uuid::new_v4(),
+        sled_id,
         LookupType::ById(sled_id),
+    ));
+
+    let global_image_id =
+        "b46bf5b5-e6e4-49e6-fe78-8e25d698dabc".parse().unwrap();
+    builder.new_resource(authz::GlobalImage::new(
+        authz::FLEET.clone(),
+        global_image_id,
+        LookupType::ById(global_image_id),
+    ));
+
+    let device_user_code = String::from("a-device-user-code");
+    builder.new_resource(authz::DeviceAuthRequest::new(
+        authz::FLEET.clone(),
+        device_user_code.clone(),
+        LookupType::ByName(device_user_code),
+    ));
+
+    let device_access_token = String::from("a-device-access-token");
+    builder.new_resource(authz::DeviceAccessToken::new(
+        authz::FLEET.clone(),
+        device_access_token.clone(),
+        LookupType::ByName(device_access_token),
     ));
 
     builder.build()
@@ -111,6 +133,25 @@ async fn make_silo(
 
     builder.new_resource(authz::SiloIdentityProviderList::new(silo.clone()));
     builder.new_resource(authz::SiloUserList::new(silo.clone()));
+    let silo_user_id = Uuid::new_v4();
+    let silo_user = authz::SiloUser::new(
+        silo.clone(),
+        silo_user_id,
+        LookupType::ByName(format!("{}-user", silo_name)),
+    );
+    builder.new_resource(silo_user.clone());
+    let ssh_key_id = Uuid::new_v4();
+    builder.new_resource(authz::SshKey::new(
+        silo_user,
+        ssh_key_id,
+        LookupType::ByName(format!("{}-user-ssh-key", silo_name)),
+    ));
+    let silo_group_id = Uuid::new_v4();
+    builder.new_resource(authz::SiloGroup::new(
+        silo.clone(),
+        silo_group_id,
+        LookupType::ByName(format!("{}-group", silo_name)),
+    ));
 
     let norganizations = if first_branch { 2 } else { 1 };
     for i in 0..norganizations {
@@ -250,17 +291,11 @@ pub fn exempted_authz_classes() -> BTreeSet<String> {
         authz::VpcRouter::get_polar_class(),
         authz::RouterRoute::get_polar_class(),
         authz::ConsoleSession::get_polar_class(),
-        authz::DeviceAuthRequest::get_polar_class(),
-        authz::DeviceAccessToken::get_polar_class(),
         authz::RoleBuiltin::get_polar_class(),
-        authz::SshKey::get_polar_class(),
-        authz::SiloUser::get_polar_class(),
-        authz::SiloGroup::get_polar_class(),
         authz::IdentityProvider::get_polar_class(),
         authz::SamlIdentityProvider::get_polar_class(),
         authz::UpdateAvailableArtifact::get_polar_class(),
         authz::UserBuiltin::get_polar_class(),
-        authz::GlobalImage::get_polar_class(),
     ]
     .into_iter()
     .map(|c| c.name.clone())

--- a/nexus/tests/output/authz-roles.out
+++ b/nexus/tests/output/authz-roles.out
@@ -134,6 +134,40 @@ resource: Silo "silo1": identity provider list
   silo1-org1-proj1-viewer          ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
+resource: IdentityProvider "silo1-identity-provider"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  silo1-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SamlIdentityProvider "silo1-saml-identity-provider"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  silo1-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
 resource: Silo "silo1": user list
 
   USER                             Q  R LC RP  M MP CC  D
@@ -616,6 +650,40 @@ resource: Silo "silo2": identity provider list
   fleet-admin                      ✘  ✘  ✔  ✘  ✘  ✘  ✔  ✘
   fleet-collaborator               ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   fleet-viewer                     ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: IdentityProvider "silo2-identity-provider"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SamlIdentityProvider "silo2-saml-identity-provider"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘

--- a/nexus/tests/output/authz-roles.out
+++ b/nexus/tests/output/authz-roles.out
@@ -151,6 +151,57 @@ resource: Silo "silo1": user list
   silo1-org1-proj1-viewer          ✘  ✘  ✔  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
+resource: SiloUser "silo1-user"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  silo1-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SshKey "silo1-user-ssh-key"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  fleet-collaborator               ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-collaborator               ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SiloGroup "silo1-group"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  silo1-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
 resource: Organization "silo1-org1"
 
   USER                             Q  R LC RP  M MP CC  D
@@ -593,6 +644,57 @@ resource: Silo "silo2": user list
   silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
+resource: SiloUser "silo2-user"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SshKey "silo2-user-ssh-key"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  fleet-collaborator               ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: SiloGroup "silo2-group"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
 resource: Organization "silo2-org1"
 
   USER                             Q  R LC RP  M MP CC  D
@@ -747,6 +849,57 @@ resource: Rack id "c037e882-8b6d-c8b5-bef4-97e848eb0a50"
   unauthenticated                  !  !  !  !  !  !  !  !
 
 resource: Sled id "8a785566-adaf-c8d8-e886-bee7f9b73ca7"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: GlobalImage id "b46bf5b5-e6e4-49e6-fe78-8e25d698dabc"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-admin                 ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-collaborator          ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-viewer                ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-admin           ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-collaborator    ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  silo1-org1-proj1-viewer          ✘  ✔  ✘  ✔  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: DeviceAuthRequest "a-device-user-code"
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔
+  fleet-collaborator               ✘  ✔  ✔  ✔  ✔  ✔  ✘  ✔
+  fleet-viewer                     ✘  ✔  ✔  ✔  ✔  ✔  ✘  ✔
+  silo1-admin                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-collaborator               ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-viewer                     ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-admin                 ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-collaborator          ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-viewer                ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-proj1-admin           ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-proj1-collaborator    ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  silo1-org1-proj1-viewer          ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  unauthenticated                  !  !  !  !  !  !  !  !
+
+resource: DeviceAccessToken "a-device-access-token"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔


### PR DESCRIPTION
This change does a few things:

- adds tests for a few more resources to the policy test
- tweaks the policy slightly to better match what I thought was intended
- updates our build config so that `polar-core` is built with optimizations.  On my test system, this reduced the test time from 52-54s to about 16s.