### PR TITLE
remove `silo_user_create()` from TestInterfaces

### DIFF
--- a/nexus/db-model/src/silo.rs
+++ b/nexus/db-model/src/silo.rs
@@ -79,7 +79,7 @@ impl From<UserProvisionType> for shared::UserProvisionType {
 }
 
 /// Describes a silo within the database.
-#[derive(Queryable, Insertable, Debug, Resource, Selectable)]
+#[derive(Clone, Queryable, Insertable, Debug, Resource, Selectable)]
 #[diesel(table_name = silo)]
 pub struct Silo {
     #[diesel(embed)]

--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::authz;
 use crate::context::OpContext;
 use crate::db::lookup::LookupPath;
-use crate::db::model::SiloUser;
 use async_trait::async_trait;
 use omicron_common::api::external::Error;
-use omicron_common::api::external::LookupType;
 use sled_agent_client::Client as SledAgentClient;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -34,13 +31,6 @@ pub trait TestInterfaces {
     ) -> Result<Arc<SledAgentClient>, Error>;
 
     async fn set_disk_as_faulted(&self, disk_id: &Uuid) -> Result<bool, Error>;
-
-    async fn silo_user_create(
-        &self,
-        silo_id: Uuid,
-        silo_user_id: Uuid,
-        external_id: String,
-    ) -> Result<SiloUser, Error>;
 
     fn set_samael_max_issue_delay(&self, max_issue_delay: chrono::Duration);
 }
@@ -102,18 +92,6 @@ impl TestInterfaces for super::Nexus {
         self.db_datastore
             .disk_update_runtime(&opctx, &authz_disk, &new_runtime)
             .await
-    }
-
-    async fn silo_user_create(
-        &self,
-        silo_id: Uuid,
-        silo_user_id: Uuid,
-        external_id: String,
-    ) -> Result<SiloUser, Error> {
-        let authz_silo =
-            authz::Silo::new(authz::FLEET, silo_id, LookupType::ById(silo_id));
-        let silo_user = SiloUser::new(silo_id, silo_user_id, external_id);
-        Ok(self.db_datastore.silo_user_create(&authz_silo, silo_user).await?.1)
     }
 
     fn set_samael_max_issue_delay(&self, max_issue_delay: chrono::Duration) {

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -22,6 +22,7 @@ use omicron_nexus::external_api::params::UserId;
 use omicron_nexus::external_api::shared;
 use omicron_nexus::external_api::shared::IdentityType;
 use omicron_nexus::external_api::shared::IpRange;
+use omicron_nexus::external_api::views;
 use omicron_nexus::external_api::views::IpPool;
 use omicron_nexus::external_api::views::IpPoolRange;
 use omicron_nexus::external_api::views::User;
@@ -130,10 +131,11 @@ pub async fn create_silo(
 
 pub async fn create_local_user(
     client: &ClientTestContext,
-    silo_name: &str,
+    silo: &views::Silo,
     username: &UserId,
     password: params::UserPassword,
 ) -> User {
+    let silo_name = &silo.identity.name;
     let url =
         format!("/system/silos/{}/identity-providers/local/users", silo_name);
     object_create(

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -32,15 +32,15 @@ async fn test_local_users(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     let silo_name = Name::from_str("test-silo").unwrap();
-    create_silo(
+    let silo = create_silo(
         client,
         silo_name.as_str(),
         true,
         shared::SiloIdentityMode::LocalOnly,
     )
     .await;
-    test_local_user_basic(client, &silo_name).await;
-    test_local_user_with_no_initial_password(client, &silo_name).await;
+    test_local_user_basic(client, &silo).await;
+    test_local_user_with_no_initial_password(client, &silo).await;
     NexusRequest::object_delete(
         client,
         &format!("/system/silos/{}", silo_name),
@@ -51,7 +51,9 @@ async fn test_local_users(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
 }
 
-async fn test_local_user_basic(client: &ClientTestContext, silo_name: &Name) {
+async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
+    let silo_name = &silo.identity.name;
+
     // First, try logging in with a non-existent user.  This naturally should
     // fail.  It should also take as long as it would take for a valid user.
     // The timing is verified in expect_login_failure().
@@ -70,7 +72,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo_name: &Name) {
 
     let created_user = create_local_user(
         client,
-        silo_name.as_str(),
+        silo,
         &test_user,
         params::UserPassword::Password(test_password.clone()),
     )
@@ -160,7 +162,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo_name: &Name) {
     let admin_password = params::Password::from_str("toodle-ooh").unwrap();
     let admin_user_obj = create_local_user(
         client,
-        silo_name.as_str(),
+        silo,
         &admin_user,
         params::UserPassword::Password(admin_password.clone()),
     )
@@ -298,13 +300,15 @@ async fn test_local_user_basic(client: &ClientTestContext, silo_name: &Name) {
 
 async fn test_local_user_with_no_initial_password(
     client: &ClientTestContext,
-    silo_name: &Name,
+    silo: &views::Silo,
 ) {
+    let silo_name = &silo.identity.name;
+
     // Create a user with no initial password.
     let test_user = params::UserId::from_str("steven-falken").unwrap();
     let created_user = create_local_user(
         client,
-        silo_name.as_str(),
+        silo,
         &test_user,
         params::UserPassword::InvalidPassword,
     )

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -3,15 +3,17 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
-use omicron_common::api::external::{IdentityMetadataCreateParams, Name};
+use omicron_common::api::external::{
+    IdentityMetadataCreateParams, LookupType, Name,
+};
 use omicron_nexus::authn::silos::{AuthenticatedSubject, IdentityProviderType};
 use omicron_nexus::context::OpContext;
+use omicron_nexus::db;
 use omicron_nexus::db::lookup::LookupPath;
 use omicron_nexus::external_api::views::{
     self, IdentityProvider, Organization, SamlIdentityProvider, Silo,
 };
 use omicron_nexus::external_api::{params, shared};
-use omicron_nexus::TestInterfaces as _;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
 use std::str::FromStr;
@@ -19,8 +21,8 @@ use std::str::FromStr;
 use http::method::Method;
 use http::StatusCode;
 use nexus_test_utils::resource_helpers::{
-    create_organization, create_silo, grant_iam, object_create,
-    objects_list_page_authz,
+    create_local_user, create_organization, create_silo, grant_iam,
+    object_create, objects_list_page_authz,
 };
 
 use crate::integration_tests::saml::SAML_IDP_DESCRIPTOR;
@@ -32,7 +34,7 @@ use uuid::Uuid;
 use httptest::{matchers::*, responders::*, Expectation, Server};
 use omicron_common::api::external::ObjectIdentity;
 use omicron_nexus::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
-use omicron_nexus::db::fixed_data::silo::SILO_ID;
+use omicron_nexus::db::fixed_data::silo::{DEFAULT_SILO, SILO_ID};
 use omicron_nexus::db::identity::Asset;
 
 #[nexus_test]
@@ -92,16 +94,14 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(silos[0].identity.name, "discoverable");
 
     // Create a new user in the discoverable silo
-    let new_silo_user_id =
-        "6922f0b2-9a92-659b-da6b-93ad4955a3a3".parse().unwrap();
-    nexus
-        .silo_user_create(
-            silos[0].identity.id, /* silo id */
-            new_silo_user_id,
-            "some_silo_user".into(),
-        )
-        .await
-        .unwrap();
+    let new_silo_user_id = create_local_user(
+        client,
+        &silos[0],
+        &"some-silo-user".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await
+    .id;
 
     // Grant the user "admin" privileges on that Silo.
     grant_iam(
@@ -684,6 +684,7 @@ struct TestSiloUserProvisionTypes {
 async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
+    let datastore = nexus.datastore();
 
     let test_cases: Vec<TestSiloUserProvisionTypes> = vec![
         // A silo configured with a "ApiOnly" user provision type should fetch a
@@ -722,14 +723,20 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
                 .await;
 
         if test_case.existing_silo_user {
-            nexus
-                .silo_user_create(
-                    silo.identity.id,
-                    Uuid::new_v4(),
-                    "external@id.com".into(),
-                )
-                .await
-                .unwrap();
+            match test_case.identity_mode {
+                shared::SiloIdentityMode::SamlJit => {
+                    create_jit_user(datastore, &silo, "external-id-com").await;
+                }
+                shared::SiloIdentityMode::LocalOnly => {
+                    create_local_user(
+                        client,
+                        &silo,
+                        &"external-id-com".parse().unwrap(),
+                        params::UserPassword::InvalidPassword,
+                    )
+                    .await;
+                }
+            };
         }
 
         let authn_opctx = nexus.opctx_external_authn();
@@ -747,7 +754,7 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
                 &authz_silo,
                 &db_silo,
                 &AuthenticatedSubject {
-                    external_id: "external@id.com".into(),
+                    external_id: "external-id-com".into(),
                     groups: vec![],
                 },
             )
@@ -796,14 +803,13 @@ async fn test_silo_user_fetch_by_external_id(
         .unwrap();
 
     // Create a user
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            uuid::Uuid::new_v4(),
-            "5513e049dac9468de5bdff36ab17d04f".into(),
-        )
-        .await
-        .unwrap();
+    create_local_user(
+        client,
+        &silo,
+        &"f5513e049dac9468de5bdff36ab17d04f".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await;
 
     // Fetching by external id that's not in the db should be Ok(None)
     let result = nexus
@@ -823,7 +829,7 @@ async fn test_silo_user_fetch_by_external_id(
         .silo_user_fetch_by_external_id(
             &opctx_external_authn,
             &authz_silo,
-            "5513e049dac9468de5bdff36ab17d04f".into(),
+            "f5513e049dac9468de5bdff36ab17d04f".into(),
         )
         .await;
     assert!(result.is_ok());
@@ -833,7 +839,6 @@ async fn test_silo_user_fetch_by_external_id(
 #[nexus_test]
 async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let nexus = &cptestctx.server.apictx.nexus;
 
     let initial_silo_users: Vec<views::User> =
         NexusRequest::iter_collection_authn(client, "/users", "", None)
@@ -861,26 +866,30 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
 
     // Now create another user and make sure we can see them.  While we're at
     // it, use a small limit to check that pagination is really working.
-    let new_silo_user_id =
-        "bd75d207-37f3-4769-b808-677ae04eaf23".parse().unwrap();
-    let new_silo_user_external_id = "can_we_see_them?";
-    nexus
-        .silo_user_create(
-            *SILO_ID,
-            new_silo_user_id,
-            new_silo_user_external_id.into(),
-        )
-        .await
-        .unwrap();
+    let new_silo_user_external_id = "can-we-see-them";
+    let new_silo_user_id = create_local_user(
+        client,
+        &views::Silo::try_from(DEFAULT_SILO.clone()).unwrap(),
+        &new_silo_user_external_id.parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await
+    .id;
 
-    let silo_users: Vec<views::User> =
+    let mut silo_users: Vec<views::User> =
         NexusRequest::iter_collection_authn(client, "/users", "", Some(1))
             .await
             .expect("failed to list silo users (2)")
             .all_items;
+    silo_users.sort_by(|u1, u2| u1.display_name.cmp(&u2.display_name));
     assert_eq!(
         silo_users,
         vec![
+            views::User {
+                id: new_silo_user_id,
+                display_name: new_silo_user_external_id.into(),
+                silo_id: *SILO_ID,
+            },
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
                 display_name: USER_TEST_PRIVILEGED.external_id.clone(),
@@ -889,11 +898,6 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
                 display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
-                silo_id: *SILO_ID,
-            },
-            views::User {
-                id: new_silo_user_id,
-                display_name: new_silo_user_external_id.into(),
                 silo_id: *SILO_ID,
             },
         ]
@@ -905,17 +909,16 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     let silo =
         create_silo(client, "silo2", true, shared::SiloIdentityMode::LocalOnly)
             .await;
-    let new_silo_user_id =
-        "6922f0b2-9a92-659b-da6b-93ad4955a3a3".parse().unwrap();
-    let new_silo_user_name = String::from("some_silo_user");
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            new_silo_user_id,
-            new_silo_user_name.clone(),
-        )
-        .await
-        .unwrap();
+
+    let new_silo_user_name = String::from("some-silo-user");
+    let new_silo_user_id = create_local_user(
+        client,
+        &silo,
+        &new_silo_user_name.parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await
+    .id;
     grant_iam(
         client,
         "/system/silos/silo2",
@@ -944,11 +947,12 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
 
     // The "test-privileged" user also shouldn't see the user in this other
     // Silo.
-    let new_silo_users: Vec<views::User> =
+    let mut new_silo_users: Vec<views::User> =
         NexusRequest::iter_collection_authn(client, "/users", "", Some(1))
             .await
             .expect("failed to list silo users (2)")
             .all_items;
+    new_silo_users.sort_by(|u1, u2| u1.display_name.cmp(&u2.display_name));
     assert_eq!(silo_users, new_silo_users,);
 
     // TODO-coverage When we have a way to remove or invalidate Silo Users, we
@@ -959,6 +963,7 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
 async fn test_silo_groups_jit(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
+    let datastore = nexus.datastore();
 
     let silo = create_silo(
         &client,
@@ -969,15 +974,7 @@ async fn test_silo_groups_jit(cptestctx: &ControlPlaneTestContext) {
     .await;
 
     // Create a user in advance
-    let silo_user_id = Uuid::new_v4();
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            silo_user_id,
-            "external@id.com".into(),
-        )
-        .await
-        .unwrap();
+    create_jit_user(datastore, &silo, "external@id.com").await;
 
     let authn_opctx = nexus.opctx_external_authn();
 
@@ -1045,15 +1042,13 @@ async fn test_silo_groups_fixed(cptestctx: &ControlPlaneTestContext) {
     .await;
 
     // Create a user in advance
-    let silo_user_id = Uuid::new_v4();
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            silo_user_id,
-            "external@id.com".into(),
-        )
-        .await
-        .unwrap();
+    create_local_user(
+        client,
+        &silo,
+        &"external-id-com".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await;
 
     let authn_opctx = nexus.opctx_external_authn();
 
@@ -1071,7 +1066,7 @@ async fn test_silo_groups_fixed(cptestctx: &ControlPlaneTestContext) {
             &authz_silo,
             &db_silo,
             &AuthenticatedSubject {
-                external_id: "external@id.com".into(),
+                external_id: "external-id-com".into(),
                 groups: vec!["a-group".into(), "b-group".into()],
             },
         )
@@ -1098,6 +1093,7 @@ async fn test_silo_groups_remove_from_one_group(
 ) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
+    let datastore = nexus.datastore();
 
     let silo = create_silo(
         &client,
@@ -1108,15 +1104,7 @@ async fn test_silo_groups_remove_from_one_group(
     .await;
 
     // Create a user in advance
-    let silo_user_id = Uuid::new_v4();
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            silo_user_id,
-            "external@id.com".into(),
-        )
-        .await
-        .unwrap();
+    create_jit_user(datastore, &silo, "external@id.com").await;
 
     let authn_opctx = nexus.opctx_external_authn();
 
@@ -1218,6 +1206,7 @@ async fn test_silo_groups_remove_from_both_groups(
 ) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
+    let datastore = nexus.datastore();
 
     let silo = create_silo(
         &client,
@@ -1228,15 +1217,7 @@ async fn test_silo_groups_remove_from_both_groups(
     .await;
 
     // Create a user in advance
-    let silo_user_id = Uuid::new_v4();
-    nexus
-        .silo_user_create(
-            silo.identity.id,
-            silo_user_id,
-            "external@id.com".into(),
-        )
-        .await
-        .unwrap();
+    create_jit_user(datastore, &silo, "external@id.com").await;
 
     let authn_opctx = nexus.opctx_external_authn();
 
@@ -1480,18 +1461,7 @@ async fn test_ensure_same_silo_group(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let nexus = &cptestctx.server.apictx.nexus;
-
-    // We use fixed uuids for this test because the sort order is predictable
-    // and it makes it easier to debug repeated test failures.
-    let silo1_user1_id =
-        "1122f0b2-9a92-659b-da6b-93ad4955a3a3".parse().unwrap();
-    let silo1_user2_id =
-        "120600f5-f7f4-e026-e569-ef312c16a7fc".parse().unwrap();
-    let silo2_user1_id =
-        "214b47a9-fe53-41f4-9c08-f89cc9ac5d33".parse().unwrap();
-    let silo2_user2_id =
-        "22d8d84d-8959-cc32-847e-de69fa8ee944".parse().unwrap();
+    let datastore = cptestctx.server.apictx.nexus.datastore();
 
     // Create the two Silos.
     let silo1 =
@@ -1507,28 +1477,31 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
 
     // Create two users in each Silo.  We need two so that we can verify that an
     // ordinary user can see a user other than themselves in each Silo.
-    let silo1_user1: views::User = nexus
-        .silo_user_create(silo1.identity.id, silo1_user1_id, "user1".into())
-        .await
-        .unwrap()
-        .into();
-    let silo1_user2: views::User = nexus
-        .silo_user_create(silo1.identity.id, silo1_user2_id, "user2".into())
-        .await
-        .unwrap()
-        .into();
-    let silo1_expected_users = [silo1_user1.clone(), silo1_user2.clone()];
-    let silo2_user1: views::User = nexus
-        .silo_user_create(silo2.identity.id, silo2_user1_id, "user1".into())
-        .await
-        .unwrap()
-        .into();
-    let silo2_user2: views::User = nexus
-        .silo_user_create(silo2.identity.id, silo2_user2_id, "user2".into())
-        .await
-        .unwrap()
-        .into();
-    let silo2_expected_users = [silo2_user1.clone(), silo2_user2.clone()];
+    let silo1_user1 = create_jit_user(datastore, &silo1, "silo1-user1").await;
+    let silo1_user1_id = silo1_user1.id;
+    let silo1_user2 = create_jit_user(datastore, &silo1, "silo1-user2").await;
+    let silo1_user2_id = silo1_user2.id;
+    let mut silo1_expected_users = [silo1_user1.clone(), silo1_user2.clone()];
+    silo1_expected_users.sort_by_key(|u| u.id);
+
+    let silo2_user1 = create_local_user(
+        client,
+        &silo2,
+        &"silo2-user1".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await;
+    let silo2_user1_id = silo2_user1.id;
+    let silo2_user2 = create_local_user(
+        client,
+        &silo2,
+        &"silo2-user2".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await;
+    let silo2_user2_id = silo2_user2.id;
+    let mut silo2_expected_users = [silo2_user1.clone(), silo2_user2.clone()];
+    silo2_expected_users.sort_by_key(|u| u.id);
 
     let users_by_id = {
         let mut users_by_id: BTreeMap<Uuid, &views::User> = BTreeMap::new();
@@ -1538,6 +1511,11 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         assert_eq!(users_by_id.insert(silo2_user2_id, &silo2_user2), None);
         users_by_id
     };
+
+    let users_by_name = users_by_id
+        .iter()
+        .map(|(_, user)| (user.display_name.to_owned(), *user))
+        .collect::<BTreeMap<_, _>>();
 
     // We'll run through a battery of tests:
     // - for each of our test silos
@@ -1559,10 +1537,11 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     //   that Silo
     // - that a user with id "foo" in Silo1 cannot be accessed by that id in
     //   Silo 2.  This case is easy to miss but would be very bad to get wrong!
-    let all_callers: Vec<AuthnMode> =
+    let all_callers = {
         std::iter::once(AuthnMode::PrivilegedUser)
-            .chain(users_by_id.keys().map(|k| AuthnMode::SiloUser(*k)))
-            .collect();
+            .chain(users_by_name.values().map(|v| AuthnMode::SiloUser(v.id)))
+            .collect::<Vec<_>>()
+    };
 
     struct TestSilo<'a> {
         silo: &'a views::Silo,
@@ -1583,7 +1562,15 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         write!(&mut output, "SILO: {}\n", silo_name).unwrap();
 
         for calling_user in all_callers.iter() {
-            write!(&mut output, "    test user {:?}:\n", calling_user).unwrap();
+            let caller_label = match calling_user {
+                AuthnMode::PrivilegedUser => "privileged",
+                AuthnMode::SiloUser(silo_user_id) => {
+                    let user = users_by_id.get(silo_user_id).unwrap();
+                    &user.display_name
+                }
+                _ => unimplemented!(),
+            };
+            write!(&mut output, "    test user {}:\n", caller_label).unwrap();
 
             // Test the "list" endpoint.
             write!(&mut output, "        list = ").unwrap();
@@ -1617,14 +1604,9 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
             write!(&mut output, "\n").unwrap();
 
             // Test the "view" endpoint for each user in this Silo.
-            for (user_id, user) in &users_by_id {
-                let label = if user.silo_id == silo1.identity.id {
-                    format!("silo 1 user {}", user.display_name)
-                } else {
-                    assert_eq!(user.silo_id, silo2.identity.id);
-                    format!("silo 2 user {}", user.display_name)
-                };
-                write!(&mut output, "        view {} ({}) = ", user_id, label,)
+            for (_, user) in &users_by_name {
+                let user_id = user.id;
+                write!(&mut output, "        view {:?} = ", user.display_name)
                     .unwrap();
                 let test_response = NexusRequest::new(RequestBuilder::new(
                     client,
@@ -1650,8 +1632,11 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
                     let error = test_response
                         .parsed_body::<dropshot::HttpErrorResponseBody>()
                         .unwrap();
-                    write!(&mut output, " (message = {:?})", error.message)
-                        .unwrap();
+                    // Strip the identifier out of the error message because the
+                    // uuid changes each time.
+                    let pattern = regex::Regex::new("\".*?\"").unwrap();
+                    let message = pattern.replace_all(&error.message, "...");
+                    write!(&mut output, " (message = {:?})", message).unwrap();
                 }
 
                 write!(&mut output, "\n").unwrap();
@@ -1667,34 +1652,50 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     );
 }
 
+/// Create a user in a SamlJit Silo for testing
+///
+/// For local-only Silos, use the real API (via `create_local_user()`).
+async fn create_jit_user(
+    datastore: &db::DataStore,
+    silo: &views::Silo,
+    external_id: &str,
+) -> views::User {
+    assert_eq!(silo.identity_mode, shared::SiloIdentityMode::SamlJit);
+    let silo_id = silo.identity.id;
+    let silo_user_id = Uuid::new_v4();
+    let authz_silo =
+        authz::Silo::new(authz::FLEET, silo_id, LookupType::ById(silo_id));
+    let silo_user =
+        db::model::SiloUser::new(silo_id, silo_user_id, external_id.to_owned());
+    datastore
+        .silo_user_create(&authz_silo, silo_user)
+        .await
+        .expect("failed to create user in SamlJit Silo")
+        .1
+        .into()
+}
+
 /// Tests that LocalOnly-specific endpoints are not available in SamlJit Silos
 #[nexus_test]
 async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
+    let datastore = nexus.datastore();
     let silo =
         create_silo(&client, "jit", true, shared::SiloIdentityMode::SamlJit)
             .await;
 
     // We need one initial user that would in principle have privileges to
     // create other users.
-    let new_silo_user_id =
-        "6922f0b2-9a92-659b-da6b-93ad4955a3a3".parse().unwrap();
-    let admin_user = nexus
-        .silo_user_create(
-            silo.identity.id,
-            new_silo_user_id,
-            "admin-user".into(),
-        )
-        .await
-        .unwrap();
+    let admin_username = "admin-user";
+    let admin_user = create_jit_user(&datastore, &silo, admin_username).await;
 
     // Grant this user "admin" privileges on that Silo.
     grant_iam(
         client,
         "/system/silos/jit",
         SiloRole::Admin,
-        new_silo_user_id,
+        admin_user.id,
         AuthnMode::PrivilegedUser,
     )
     .await;
@@ -1703,7 +1704,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     // ought to be able to create a user via the Silo's local identity provider
     // (because that provider does not exist).
     for caller in
-        [AuthnMode::PrivilegedUser, AuthnMode::SiloUser(new_silo_user_id)]
+        [AuthnMode::PrivilegedUser, AuthnMode::SiloUser(admin_user.id)]
     {
         verify_local_idp_404(
             NexusRequest::expect_failure_with_body(
@@ -1722,11 +1723,8 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     }
 
     // Now create another user, as might happen via JIT.
-    let other_user_id = "57372ebb-ee76-4a2d-fa3e-e1875a8d11c0".parse().unwrap();
-    let _ = nexus
-        .silo_user_create(silo.identity.id, other_user_id, "other-user".into())
-        .await
-        .unwrap();
+    let other_user_id =
+        create_jit_user(datastore, &silo, "other-user").await.id;
     let user_url_delete = format!(
         "/system/silos/jit/identity-providers/local/users/{}",
         other_user_id
@@ -1741,7 +1739,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     // password.
     let password = params::Password::from_str("dummy").unwrap();
     for caller in
-        [AuthnMode::PrivilegedUser, AuthnMode::SiloUser(new_silo_user_id)]
+        [AuthnMode::PrivilegedUser, AuthnMode::SiloUser(admin_user.id)]
     {
         verify_local_idp_404(
             NexusRequest::expect_failure(
@@ -1775,8 +1773,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         Method::POST,
         "/login/jit/local",
         &params::UsernamePasswordCredentials {
-            username: params::UserId::from_str(&admin_user.external_id)
-                .unwrap(),
+            username: params::UserId::from_str(admin_username).unwrap(),
             password: password.clone(),
         },
     ))
@@ -1813,7 +1810,6 @@ async fn verify_local_idp_404<'a>(request: NexusRequest<'a>) {
 #[nexus_test]
 async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a "LocalOnly" Silo with its own admin user.
     let silo = create_silo(
@@ -1823,16 +1819,14 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         shared::SiloIdentityMode::LocalOnly,
     )
     .await;
-    let new_silo_user_id =
-        "5b3564b6-8770-4a30-b538-8ef6ae3efa3b".parse().unwrap();
-    let _ = nexus
-        .silo_user_create(
-            silo.identity.id,
-            new_silo_user_id,
-            "admin-user".into(),
-        )
-        .await
-        .unwrap();
+    let new_silo_user_id = create_local_user(
+        client,
+        &silo,
+        &"admin-user".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await
+    .id;
     grant_iam(
         client,
         "/system/silos/fixed",
@@ -1916,7 +1910,6 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_local_silo_users(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let nexus = &cptestctx.server.apictx.nexus;
 
     // Create a "LocalOnly" Silo for testing.
     let silo1 = create_silo(
@@ -1934,30 +1927,25 @@ async fn test_local_silo_users(cptestctx: &ControlPlaneTestContext) {
     run_user_tests(client, &silo1, &AuthnMode::PrivilegedUser, &[]).await;
 
     // Create a Silo Admin in our test Silo and run through the same tests.
-    let new_silo_user_id =
-        "5b3564b6-8770-4a30-b538-8ef6ae3efa3b".parse().unwrap();
-    let admin_user = views::User::from(
-        nexus
-            .silo_user_create(
-                silo1.identity.id,
-                new_silo_user_id,
-                "admin-user".into(),
-            )
-            .await
-            .unwrap(),
-    );
+    let admin_user = create_local_user(
+        client,
+        &silo1,
+        &"admin-user".parse().unwrap(),
+        params::UserPassword::InvalidPassword,
+    )
+    .await;
     grant_iam(
         client,
         "/system/silos/silo1",
         SiloRole::Admin,
-        new_silo_user_id,
+        admin_user.id,
         AuthnMode::PrivilegedUser,
     )
     .await;
     run_user_tests(
         client,
         &silo1,
-        &AuthnMode::SiloUser(new_silo_user_id),
+        &AuthnMode::SiloUser(admin_user.id),
         &[admin_user.clone()],
     )
     .await;

--- a/nexus/tests/output/silo-user-views-output.txt
+++ b/nexus/tests/output/silo-user-views-output.txt
@@ -1,72 +1,72 @@
 SILO: silo1
-    test user PrivilegedUser:
+    test user privileged:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 200
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 200
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo-user with id \"214b47a9-fe53-41f4-9c08-f89cc9ac5d33\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo-user with id \"22d8d84d-8959-cc32-847e-de69fa8ee944\"")
+        view "silo1-user1" = 200
+        view "silo1-user2" = 200
+        view "silo2-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user2" = 404 (message = "not found: silo-user with id ...")
 
-    test user SiloUser(1122f0b2-9a92-659b-da6b-93ad4955a3a3):
+    test user silo1-user1:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 200
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 200
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo-user with id \"214b47a9-fe53-41f4-9c08-f89cc9ac5d33\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo-user with id \"22d8d84d-8959-cc32-847e-de69fa8ee944\"")
+        view "silo1-user1" = 200
+        view "silo1-user2" = 200
+        view "silo2-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user2" = 404 (message = "not found: silo-user with id ...")
 
-    test user SiloUser(120600f5-f7f4-e026-e569-ef312c16a7fc):
+    test user silo1-user2:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 200
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 200
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo-user with id \"214b47a9-fe53-41f4-9c08-f89cc9ac5d33\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo-user with id \"22d8d84d-8959-cc32-847e-de69fa8ee944\"")
+        view "silo1-user1" = 200
+        view "silo1-user2" = 200
+        view "silo2-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user2" = 404 (message = "not found: silo-user with id ...")
 
-    test user SiloUser(214b47a9-fe53-41f4-9c08-f89cc9ac5d33):
+    test user silo2-user1:
         list = 404 (message = "not found: silo with name \"silo1\"")
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo with name \"silo1\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo with name \"silo1\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo with name \"silo1\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo with name \"silo1\"")
+        view "silo1-user1" = 404 (message = "not found: silo with name ...")
+        view "silo1-user2" = 404 (message = "not found: silo with name ...")
+        view "silo2-user1" = 404 (message = "not found: silo with name ...")
+        view "silo2-user2" = 404 (message = "not found: silo with name ...")
 
-    test user SiloUser(22d8d84d-8959-cc32-847e-de69fa8ee944):
+    test user silo2-user2:
         list = 404 (message = "not found: silo with name \"silo1\"")
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo with name \"silo1\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo with name \"silo1\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo with name \"silo1\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo with name \"silo1\"")
+        view "silo1-user1" = 404 (message = "not found: silo with name ...")
+        view "silo1-user2" = 404 (message = "not found: silo with name ...")
+        view "silo2-user1" = 404 (message = "not found: silo with name ...")
+        view "silo2-user2" = 404 (message = "not found: silo with name ...")
 
 SILO: silo2
-    test user PrivilegedUser:
+    test user privileged:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo-user with id \"1122f0b2-9a92-659b-da6b-93ad4955a3a3\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo-user with id \"120600f5-f7f4-e026-e569-ef312c16a7fc\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 200
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 200
+        view "silo1-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo1-user2" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user1" = 200
+        view "silo2-user2" = 200
 
-    test user SiloUser(1122f0b2-9a92-659b-da6b-93ad4955a3a3):
+    test user silo1-user1:
         list = 404 (message = "not found: silo with name \"silo2\"")
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo with name \"silo2\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo with name \"silo2\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo with name \"silo2\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo with name \"silo2\"")
+        view "silo1-user1" = 404 (message = "not found: silo with name ...")
+        view "silo1-user2" = 404 (message = "not found: silo with name ...")
+        view "silo2-user1" = 404 (message = "not found: silo with name ...")
+        view "silo2-user2" = 404 (message = "not found: silo with name ...")
 
-    test user SiloUser(120600f5-f7f4-e026-e569-ef312c16a7fc):
+    test user silo1-user2:
         list = 404 (message = "not found: silo with name \"silo2\"")
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo with name \"silo2\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo with name \"silo2\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 404 (message = "not found: silo with name \"silo2\"")
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 404 (message = "not found: silo with name \"silo2\"")
+        view "silo1-user1" = 404 (message = "not found: silo with name ...")
+        view "silo1-user2" = 404 (message = "not found: silo with name ...")
+        view "silo2-user1" = 404 (message = "not found: silo with name ...")
+        view "silo2-user2" = 404 (message = "not found: silo with name ...")
 
-    test user SiloUser(214b47a9-fe53-41f4-9c08-f89cc9ac5d33):
+    test user silo2-user1:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo-user with id \"1122f0b2-9a92-659b-da6b-93ad4955a3a3\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo-user with id \"120600f5-f7f4-e026-e569-ef312c16a7fc\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 200
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 200
+        view "silo1-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo1-user2" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user1" = 200
+        view "silo2-user2" = 200
 
-    test user SiloUser(22d8d84d-8959-cc32-847e-de69fa8ee944):
+    test user silo2-user2:
         list = 200
-        view 1122f0b2-9a92-659b-da6b-93ad4955a3a3 (silo 1 user user1) = 404 (message = "not found: silo-user with id \"1122f0b2-9a92-659b-da6b-93ad4955a3a3\"")
-        view 120600f5-f7f4-e026-e569-ef312c16a7fc (silo 1 user user2) = 404 (message = "not found: silo-user with id \"120600f5-f7f4-e026-e569-ef312c16a7fc\"")
-        view 214b47a9-fe53-41f4-9c08-f89cc9ac5d33 (silo 2 user user1) = 200
-        view 22d8d84d-8959-cc32-847e-de69fa8ee944 (silo 2 user user2) = 200
+        view "silo1-user1" = 404 (message = "not found: silo-user with id ...")
+        view "silo1-user2" = 404 (message = "not found: silo-user with id ...")
+        view "silo2-user1" = 200
+        view "silo2-user2" = 200
 

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -92,7 +92,9 @@ pub enum IdentityType {
 
 /// Describes how identities are managed and users are authenticated in this
 /// Silo
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum SiloIdentityMode {
     /// Users are authenticated with SAML using an external authentication


### PR DESCRIPTION
There's a test-only interface on Nexus called `silo_user_create()` (in the `TestInterfaces` trait).  This is used by various tests that need to create Silo Users.  Now that we have a proper API for creating users in LocalOnly Silos, most uses of this function can be replaced with API calls.  There already exists a helper for this in `resource_helpers` called `create_local_user()`.  This change replaces all uses of this function for LocalOnly Silos with calls to `create_local_user()` instead.  This is good because users are now created like any other API resource, instead of being a separate thing that needs this side-door private interface.

After making that change, there are a few remaining callers of `TestInterfaces::silo_user_create()` in the Silo integration tests.  That's because they need to create silo users in _SamlJit_ Silos.  For those, we can't use the API to create the users.  Instead, I basically put the body of `TestInterfaces::silo_user_create()` into this test file.  I also added an assertion so that you cannot use it with LocalOnly Silos.  This way, it's more limited in scope.

The high-level goal here is:

- Most at-large test code does not have to think about the silo type or use the side-door interface for creating users.  It should generally use LocalOnly Silos and then use the API to manage users like any other resource.
- I hope the only code that needs to create users in SamlJit Silos is limited to the Silo integration tests, which now has its own function for doing this.