### PR TITLE
Update runtime before setting instance to failed

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -692,6 +692,15 @@ impl super::Nexus {
                     // the instance state to failed, we don't know what state
                     // the instance is in.
                     _ => {
+                        // Grab the potentially updated runtime before bumping
+                        // the generation number.
+                        let (.., db_instance) =
+                            LookupPath::new(opctx, &self.db_datastore)
+                                .instance_id(db_instance.id())
+                                .fetch_for(authz::Action::Modify)
+                                .await?;
+
+                        // Update the instance state to failed
                         let new_runtime = db::model::InstanceRuntimeState {
                             state: db::model::InstanceState::new(
                                 InstanceState::Failed,


### PR DESCRIPTION
Grab the potentially updated runtime before bumping the generation number and setting the instance state to failed.

Fixes #1745.