### PR TITLE
[sled-agent] Monitor for Tofino driver as factor in 'are we scrimlet' decision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "illumos-devinfo"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/illumos-devinfo?rev=8fca0709e5137a3758374cb41ab1bfc60b03e6a9#8fca0709e5137a3758374cb41ab1bfc60b03e6a9"
+dependencies = [
+ "anyhow",
+ "libc",
+ "num_enum",
+]
+
+[[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=23fdf5856f10f23e2d26865d2d7e2d3bc537bca3#23fdf5856f10f23e2d26865d2d7e2d3bc537bca3"
@@ -3404,6 +3414,7 @@ dependencies = [
  "expectorate",
  "futures",
  "http",
+ "illumos-devinfo",
  "internal-dns-client",
  "ipnetwork",
  "libc",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -59,6 +59,7 @@ vsss-rs = { version = "2.0.0", default-features = false, features = ["std"] }
 zone = "0.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
+illumos-devinfo = { git = "https://github.com/oxidecomputer/illumos-devinfo", rev = "8fca0709e5137a3758374cb41ab1bfc60b03e6a9" }
 opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "23fdf5856f10f23e2d26865d2d7e2d3bc537bca3" }
 
 [dev-dependencies]

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -113,7 +113,7 @@ impl Server {
         // This ordering allows the bootstrap agent to communicate with
         // other bootstrap agents on the rack during the initialization
         // process.
-        if let Err(e) = server.bootstrap_agent.initialize(&config).await {
+        if let Err(e) = server.bootstrap_agent.start_rss(&config).await {
             server.inner.abort();
             return Err(e.to_string());
         }

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub log: ConfigLogging,
     /// Optionally force the sled to self-identify as a scrimlet (or gimlet,
     /// if set to false).
-    pub force_scrimlet: Option<bool>,
+    pub stub_scrimlet: Option<bool>,
     /// Optional VLAN ID to be used for tagging guest VNICs.
     pub vlan: Option<VlanID>,
     /// Optional list of zpools to be used as "discovered disks".

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -19,6 +19,9 @@ pub struct Config {
     pub id: Uuid,
     /// Configuration for the sled agent debug log
     pub log: ConfigLogging,
+    /// Optionally force the sled to self-identify as a scrimlet (or gimlet,
+    /// if set to false).
+    pub force_scrimlet: Option<bool>,
     /// Optional VLAN ID to be used for tagging guest VNICs.
     pub vlan: Option<VlanID>,
     /// Optional list of zpools to be used as "discovered disks".

--- a/sled-agent/src/hardware/illumos/mod.rs
+++ b/sled-agent/src/hardware/illumos/mod.rs
@@ -9,6 +9,38 @@ use std::sync::Mutex;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
+// A snapshot of information about the underlying Tofino device
+struct TofinoSnapshot {
+    exists: bool,
+    driver_loaded: bool,
+}
+
+impl TofinoSnapshot {
+    fn new() -> Self {
+        Self { exists: false, driver_loaded: false }
+    }
+}
+
+// A snapshot of information about the underlying hardware
+struct HardwareSnapshot {
+    tofino: TofinoSnapshot,
+}
+
+impl HardwareSnapshot {
+    fn new() -> Self {
+        Self { tofino: TofinoSnapshot::new() }
+    }
+}
+
+// Describes a view of the Tofino switch.
+enum TofinoView {
+    // The view of the Tofino switch exactly matches the snapshot of hardware.
+    Real(TofinoSnapshot),
+    // The Tofino switch has been "stubbed out", and the underlying hardware is
+    // being ignored.
+    Stub { active: bool },
+}
+
 // A cached copy of "our latest view of what hardware exists".
 //
 // This struct can be expanded arbitrarily, as it's useful for the Sled Agent
@@ -17,10 +49,21 @@ use tokio::task::JoinHandle;
 // Q: Why bother caching this information at all? Why not rely on devinfo for
 // all queries?
 // A: By keeping an in-memory representation, we can "diff" with the information
-// reported from libdevinfo to decide when to send notifications.
-struct HardwareInner {
-    is_scrimlet: bool,
+// reported from libdevinfo to decide when to send notifications and change
+// which services are currently executing.
+struct HardwareView {
+    tofino: TofinoView,
     // TODO: Add U.2s, M.2s, other devices.
+}
+
+impl HardwareView {
+    fn new() -> Self {
+        Self { tofino: TofinoView::Real(TofinoSnapshot::new()) }
+    }
+
+    fn new_stub_tofino(active: bool) -> Self {
+        Self { tofino: TofinoView::Stub { active } }
+    }
 }
 
 /// A representation of the underlying hardware.
@@ -29,47 +72,77 @@ struct HardwareInner {
 /// events.
 pub struct Hardware {
     log: Logger,
-    inner: Arc<Mutex<HardwareInner>>,
+    inner: Arc<Mutex<HardwareView>>,
     tx: broadcast::Sender<super::HardwareUpdate>,
     _worker: JoinHandle<()>,
+}
+
+const TOFINO_SUBSYSTEM_VID: i32 = 0x1d1c;
+const TOFINO_SUBSYSTEM_ID: i32 = 0x100;
+
+fn node_name(subsystem_vid: i32, subsystem_id: i32) -> String {
+    format!("pci{subsystem_vid:x},{subsystem_id:x}")
 }
 
 // Performs a single walk of the device info tree, updating our view of hardware
 // and sending notifications to any subscribers.
 fn poll_device_tree(
     log: &Logger,
-    inner: &Arc<Mutex<HardwareInner>>,
+    inner: &Arc<Mutex<HardwareView>>,
     tx: &broadcast::Sender<super::HardwareUpdate>,
 ) -> Result<(), String> {
+    // Construct a view of hardware by walking the device tree.
     let mut device_info = DevInfo::new().map_err(|e| e.to_string())?;
     let mut node_walker = device_info.walk_node();
+    let mut polled_hw = HardwareSnapshot::new();
     while let Some(node) =
         node_walker.next().transpose().map_err(|e| e.to_string())?
     {
-        if let Some(driver_name) = node.driver_name() {
-            if driver_name == "tofino" {
-                let scrimlet_status_updated = {
-                    let mut inner = inner.lock().unwrap();
-                    if !inner.is_scrimlet {
-                        inner.is_scrimlet = true;
-                        true
-                    } else {
-                        false
-                    }
-                };
-                if scrimlet_status_updated {
-                    info!(log, "Polling device tree: Found tofino driver");
-                    let _ = tx.send(super::HardwareUpdate::TofinoLoaded);
-                }
-            }
+        if node.node_name()
+            == node_name(TOFINO_SUBSYSTEM_VID, TOFINO_SUBSYSTEM_ID)
+        {
+            polled_hw.tofino.exists = true;
+            polled_hw.tofino.driver_loaded =
+                node.driver_name().as_deref() == Some("tofino");
         }
     }
+
+    // After inspecting the device tree, diff with the old view, and provide
+    // necessary updates.
+    let tofino_update = {
+        let mut inner = inner.lock().unwrap();
+        match inner.tofino {
+            TofinoView::Real(TofinoSnapshot { driver_loaded, .. }) => {
+                // Identify if we have an update to perform
+                let tofino_update =
+                    match (driver_loaded, polled_hw.tofino.driver_loaded) {
+                        (false, true) => {
+                            Some(super::HardwareUpdate::TofinoLoaded)
+                        }
+                        (true, false) => {
+                            Some(super::HardwareUpdate::TofinoUnloaded)
+                        }
+                        _ => None,
+                    };
+                // Update our view of the underlying hardware
+                inner.tofino = TofinoView::Real(polled_hw.tofino);
+                tofino_update
+            }
+            TofinoView::Stub { .. } => None,
+        }
+    };
+
+    if let Some(update) = tofino_update {
+        info!(log, "Update from polling device tree: {:?}", update);
+        let _ = tx.send(update);
+    }
+
     Ok(())
 }
 
 async fn hardware_tracking_task(
     log: Logger,
-    inner: Arc<Mutex<HardwareInner>>,
+    inner: Arc<Mutex<HardwareView>>,
     tx: broadcast::Sender<super::HardwareUpdate>,
 ) {
     loop {
@@ -83,9 +156,16 @@ async fn hardware_tracking_task(
 impl Hardware {
     /// Creates a new representation of the underlying hardware, and initialize
     /// a task which periodically updates that representation.
-    pub fn new(log: Logger, is_scrimlet: bool) -> Result<Self, String> {
+    pub fn new(
+        log: Logger,
+        stub_scrimlet: Option<bool>,
+    ) -> Result<Self, String> {
         let (tx, _) = broadcast::channel(1024);
-        let inner = Arc::new(Mutex::new(HardwareInner { is_scrimlet }));
+        let hw = match stub_scrimlet {
+            None => HardwareView::new(),
+            Some(active) => HardwareView::new_stub_tofino(active),
+        };
+        let inner = Arc::new(Mutex::new(hw));
 
         // Force the device tree to be polled at least once before returning.
         // This mitigates issues where the Sled Agent could try to propagate
@@ -105,7 +185,11 @@ impl Hardware {
     }
 
     pub fn is_scrimlet(&self) -> bool {
-        self.inner.lock().unwrap().is_scrimlet
+        let inner = self.inner.lock().unwrap();
+        match inner.tofino {
+            TofinoView::Real(TofinoSnapshot { exists, .. }) => exists,
+            TofinoView::Stub { active } => active,
+        }
     }
 
     pub fn monitor(&self) -> broadcast::Receiver<super::HardwareUpdate> {

--- a/sled-agent/src/hardware/illumos/mod.rs
+++ b/sled-agent/src/hardware/illumos/mod.rs
@@ -1,0 +1,113 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use illumos_devinfo::DevInfo;
+use slog::Logger;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+
+// A cached copy of "our latest view of what hardware exists".
+//
+// This struct can be expanded arbitrarily, as it's useful for the Sled Agent
+// to perceive hardware.
+//
+// Q: Why bother caching this information at all? Why not rely on devinfo for
+// all queries?
+// A: By keeping an in-memory representation, we can "diff" with the information
+// reported from libdevinfo to decide when to send notifications.
+struct HardwareInner {
+    is_scrimlet: bool,
+    // TODO: Add U.2s, M.2s, other devices.
+}
+
+/// A representation of the underlying hardware.
+///
+/// This structure provides interfaces for both querying and for receiving new
+/// events.
+pub struct Hardware {
+    log: Logger,
+    inner: Arc<Mutex<HardwareInner>>,
+    tx: broadcast::Sender<super::HardwareUpdate>,
+    _worker: JoinHandle<()>,
+}
+
+// Performs a single walk of the device info tree, updating our view of hardware
+// and sending notifications to any subscribers.
+fn poll_device_tree(
+    log: &Logger,
+    inner: &Arc<Mutex<HardwareInner>>,
+    tx: &broadcast::Sender<super::HardwareUpdate>,
+) -> Result<(), String> {
+    let mut device_info = DevInfo::new().map_err(|e| e.to_string())?;
+    let mut node_walker = device_info.walk_node();
+    while let Some(node) =
+        node_walker.next().transpose().map_err(|e| e.to_string())?
+    {
+        if let Some(driver_name) = node.driver_name() {
+            if driver_name == "tofino" {
+                let scrimlet_status_updated = {
+                    let mut inner = inner.lock().unwrap();
+                    if !inner.is_scrimlet {
+                        inner.is_scrimlet = true;
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if scrimlet_status_updated {
+                    info!(log, "Polling device tree: Found tofino driver");
+                    let _ = tx.send(super::HardwareUpdate::TofinoLoaded);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn hardware_tracking_task(
+    log: Logger,
+    inner: Arc<Mutex<HardwareInner>>,
+    tx: broadcast::Sender<super::HardwareUpdate>,
+) {
+    loop {
+        if let Err(err) = poll_device_tree(&log, &inner, &tx) {
+            warn!(log, "Failed to query device tree: {err}");
+        }
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+    }
+}
+
+impl Hardware {
+    /// Creates a new representation of the underlying hardware, and initialize
+    /// a task which periodically updates that representation.
+    pub fn new(log: Logger, is_scrimlet: bool) -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        let inner = Arc::new(Mutex::new(HardwareInner { is_scrimlet }));
+
+        let log2 = log.clone();
+        let inner2 = inner.clone();
+        let tx2 = tx.clone();
+        let _worker = tokio::task::spawn(async move {
+            hardware_tracking_task(log2, inner2, tx2).await
+        });
+
+        Self { log, inner, tx, _worker }
+    }
+
+    pub fn is_scrimlet(&self) -> bool {
+        self.inner.lock().unwrap().is_scrimlet
+    }
+
+    pub fn monitor(&self) -> broadcast::Receiver<super::HardwareUpdate> {
+        info!(self.log, "Monitoring for hardware updates");
+        self.tx.subscribe()
+        // TODO: Do we want to send initial messages, based on the existing
+        // state? Or should we leave this responsibility to the caller, to
+        // start monitoring, and then query for the initial state?
+        //
+        // This could simplify the `SledAgent::monitor` function?
+    }
+}

--- a/sled-agent/src/hardware/mod.rs
+++ b/sled-agent/src/hardware/mod.rs
@@ -26,16 +26,11 @@ impl HardwareManager {
         config: &crate::config::Config,
         log: Logger,
     ) -> Result<Self, String> {
-        // Unless explicitly specified, we assume this device is a Gimlet until
-        // told otherwise.
-        let is_scrimlet = if let Some(is_scrimlet) = config.force_scrimlet {
-            is_scrimlet
-        } else {
-            false
-        };
-
         let log = log.new(o!("component" => "HardwareManager"));
-        Ok(Self { _log: log.clone(), inner: Hardware::new(log, is_scrimlet)? })
+        Ok(Self {
+            _log: log.clone(),
+            inner: Hardware::new(log, config.stub_scrimlet)?,
+        })
     }
 
     pub fn is_scrimlet(&self) -> bool {
@@ -54,9 +49,10 @@ impl HardwareManager {
 /// These updates should generally be "non-opinionated" - the higher
 /// layers of the sled agent can make the call to ignore these updates
 /// or not.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum HardwareUpdate {
     TofinoLoaded,
+    TofinoUnloaded,
     // TODO: Notify about disks being added / removed, etc.
 }

--- a/sled-agent/src/hardware/mod.rs
+++ b/sled-agent/src/hardware/mod.rs
@@ -2,44 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use slog::Logger;
-use tokio::sync::broadcast;
-
 cfg_if::cfg_if! {
     if #[cfg(target_os = "illumos")] {
         mod illumos;
-        use illumos::*;
+        pub(crate) use illumos::*;
     } else {
         mod non_illumos;
-        use non_illumos::*;
-    }
-}
-
-/// A platform-independent interface for interacting with the underlying hardware.
-pub(crate) struct HardwareManager {
-    _log: Logger,
-    inner: Hardware,
-}
-
-impl HardwareManager {
-    pub fn new(
-        config: &crate::config::Config,
-        log: Logger,
-    ) -> Result<Self, String> {
-        let log = log.new(o!("component" => "HardwareManager"));
-        Ok(Self {
-            _log: log.clone(),
-            inner: Hardware::new(log, config.stub_scrimlet)?,
-        })
-    }
-
-    pub fn is_scrimlet(&self) -> bool {
-        self.inner.is_scrimlet()
-    }
-
-    // Monitors the underlying hardware for updates.
-    pub fn monitor(&self) -> broadcast::Receiver<HardwareUpdate> {
-        self.inner.monitor()
+        pub(crate) use non_illumos::*;
     }
 }
 
@@ -52,6 +21,7 @@ impl HardwareManager {
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum HardwareUpdate {
+    TofinoDeviceChange,
     TofinoLoaded,
     TofinoUnloaded,
     // TODO: Notify about disks being added / removed, etc.

--- a/sled-agent/src/hardware/mod.rs
+++ b/sled-agent/src/hardware/mod.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use slog::Logger;
+use tokio::sync::broadcast;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "illumos")] {
+        mod illumos;
+        use illumos::*;
+    } else {
+        mod non_illumos;
+        use non_illumos::*;
+    }
+}
+
+/// A platform-independent interface for interacting with the underlying hardware.
+pub(crate) struct HardwareManager {
+    _log: Logger,
+    inner: Hardware,
+}
+
+impl HardwareManager {
+    pub fn new(config: &crate::config::Config, log: Logger) -> Self {
+        // Unless explicitly specified, we assume this device is a Gimlet until
+        // told otherwise.
+        let is_scrimlet = if let Some(is_scrimlet) = config.force_scrimlet {
+            is_scrimlet
+        } else {
+            false
+        };
+
+        let log = log.new(o!("component" => "HardwareManager"));
+        Self { _log: log.clone(), inner: Hardware::new(log, is_scrimlet) }
+    }
+
+    pub fn is_scrimlet(&self) -> bool {
+        self.inner.is_scrimlet()
+    }
+
+    // Monitors the underlying hardware for updates.
+    pub fn monitor(&self) -> broadcast::Receiver<HardwareUpdate> {
+        self.inner.monitor()
+    }
+}
+
+/// Provides information from the underlying hardware about updates
+/// which may require action on behalf of the Sled Agent.
+///
+/// These updates should generally be "non-opinionated" - the higher
+/// layers of the sled agent can make the call to ignore these updates
+/// or not.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum HardwareUpdate {
+    TofinoLoaded,
+    // TODO: Notify about disks being added / removed, etc.
+}

--- a/sled-agent/src/hardware/mod.rs
+++ b/sled-agent/src/hardware/mod.rs
@@ -22,7 +22,10 @@ pub(crate) struct HardwareManager {
 }
 
 impl HardwareManager {
-    pub fn new(config: &crate::config::Config, log: Logger) -> Self {
+    pub fn new(
+        config: &crate::config::Config,
+        log: Logger,
+    ) -> Result<Self, String> {
         // Unless explicitly specified, we assume this device is a Gimlet until
         // told otherwise.
         let is_scrimlet = if let Some(is_scrimlet) = config.force_scrimlet {
@@ -32,7 +35,7 @@ impl HardwareManager {
         };
 
         let log = log.new(o!("component" => "HardwareManager"));
-        Self { _log: log.clone(), inner: Hardware::new(log, is_scrimlet) }
+        Ok(Self { _log: log.clone(), inner: Hardware::new(log, is_scrimlet)? })
     }
 
     pub fn is_scrimlet(&self) -> bool {

--- a/sled-agent/src/hardware/non_illumos/mod.rs
+++ b/sled-agent/src/hardware/non_illumos/mod.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use slog::Logger;
+use std::sync::Mutex;
+use tokio::sync::broadcast;
+
+struct HardwareInner {
+    is_scrimlet: bool,
+}
+
+/// A simulated representation of the underlying hardware.
+///
+/// This is intended for non-illumos systems to have roughly the same interface
+/// as illumos systems.
+pub struct Hardware {
+    log: Logger,
+    inner: Mutex<HardwareInner>,
+    tx: broadcast::Sender<super::HardwareUpdate>,
+}
+
+impl Hardware {
+    pub fn new(log: Logger, is_scrimlet: bool) -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self { log, inner: Mutex::new(HardwareInner { is_scrimlet }), tx }
+    }
+
+    pub fn is_scrimlet(&self) -> bool {
+        self.inner.lock().unwrap().is_scrimlet
+    }
+
+    pub fn monitor(&self) -> broadcast::Receiver<super::HardwareUpdate> {
+        info!(self.log, "Monitoring for hardware updates");
+        self.tx.subscribe()
+    }
+}

--- a/sled-agent/src/hardware/non_illumos/mod.rs
+++ b/sled-agent/src/hardware/non_illumos/mod.rs
@@ -21,9 +21,9 @@ pub struct Hardware {
 }
 
 impl Hardware {
-    pub fn new(log: Logger, is_scrimlet: bool) -> Self {
+    pub fn new(log: Logger, is_scrimlet: bool) -> Result<Self, String> {
         let (tx, _) = broadcast::channel(1024);
-        Self { log, inner: Mutex::new(HardwareInner { is_scrimlet }), tx }
+        Ok(Self { log, inner: Mutex::new(HardwareInner { is_scrimlet }), tx })
     }
 
     pub fn is_scrimlet(&self) -> bool {

--- a/sled-agent/src/hardware/non_illumos/mod.rs
+++ b/sled-agent/src/hardware/non_illumos/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use tokio::sync::broadcast;
 
 struct HardwareInner {
-    is_scrimlet: bool,
+    stub_scrimlet: bool,
 }
 
 /// A simulated representation of the underlying hardware.
@@ -21,13 +21,17 @@ pub struct Hardware {
 }
 
 impl Hardware {
-    pub fn new(log: Logger, is_scrimlet: bool) -> Result<Self, String> {
+    pub fn new(
+        log: Logger,
+        stub_scrimlet: Option<bool>,
+    ) -> Result<Self, String> {
         let (tx, _) = broadcast::channel(1024);
-        Ok(Self { log, inner: Mutex::new(HardwareInner { is_scrimlet }), tx })
+        let stub_scrimlet = stub_scrimlet.unwrap_or(false);
+        Ok(Self { log, inner: Mutex::new(HardwareInner { stub_scrimlet }), tx })
     }
 
     pub fn is_scrimlet(&self) -> bool {
-        self.inner.lock().unwrap().is_scrimlet
+        self.inner.lock().unwrap().stub_scrimlet
     }
 
     pub fn monitor(&self) -> broadcast::Receiver<super::HardwareUpdate> {

--- a/sled-agent/src/hardware/non_illumos/mod.rs
+++ b/sled-agent/src/hardware/non_illumos/mod.rs
@@ -3,39 +3,35 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use slog::Logger;
-use std::sync::Mutex;
 use tokio::sync::broadcast;
 
-struct HardwareInner {
-    stub_scrimlet: bool,
-}
-
-/// A simulated representation of the underlying hardware.
+/// An unimplemented, stub representation of the underlying hardware.
 ///
 /// This is intended for non-illumos systems to have roughly the same interface
-/// as illumos systems.
-pub struct Hardware {
-    log: Logger,
-    inner: Mutex<HardwareInner>,
-    tx: broadcast::Sender<super::HardwareUpdate>,
-}
+/// as illumos systems - it allows compilation to "work" on non-illumos
+/// platforms, which can be handy for editor support.
+///
+/// If you're actually trying to run the Sled Agent on non-illumos platforms,
+/// use the simulated sled agent, which does not attempt to abstract hardware.
+pub struct HardwareManager {}
 
-impl Hardware {
+impl HardwareManager {
     pub fn new(
-        log: Logger,
-        stub_scrimlet: Option<bool>,
+        _log: Logger,
+        _stub_scrimlet: Option<bool>,
     ) -> Result<Self, String> {
-        let (tx, _) = broadcast::channel(1024);
-        let stub_scrimlet = stub_scrimlet.unwrap_or(false);
-        Ok(Self { log, inner: Mutex::new(HardwareInner { stub_scrimlet }), tx })
+        unimplemented!("Accessing hardware unsupported on non-illumos");
     }
 
     pub fn is_scrimlet(&self) -> bool {
-        self.inner.lock().unwrap().stub_scrimlet
+        unimplemented!("Accessing hardware unsupported on non-illumos");
+    }
+
+    pub fn is_scrimlet_driver_loaded(&self) -> bool {
+        unimplemented!("Accessing hardware unsupported on non-illumos");
     }
 
     pub fn monitor(&self) -> broadcast::Receiver<super::HardwareUpdate> {
-        info!(self.log, "Monitoring for hardware updates");
-        self.tx.subscribe()
+        unimplemented!("Accessing hardware unsupported on non-illumos");
     }
 }

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -21,6 +21,7 @@ pub mod common;
 // Modules for the non-simulated sled agent.
 pub mod bootstrap;
 pub mod config;
+mod hardware;
 mod http_entrypoints;
 pub mod illumos;
 mod instance;

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -77,6 +77,13 @@ impl NexusRequestQueue {
     /// Creates a new request queue, along with a worker which executes
     /// any incoming tasks.
     pub fn new() -> Self {
+        // TODO(https://github.com/oxidecomputer/omicron/issues/1917):
+        // In the future, this should basically just be a wrapper around a
+        // generation number, and we shouldn't be serializing requests to Nexus.
+        //
+        // In the meanwhile, we're using an unbounded_channel for simplicity, so
+        // that we don't need to cope with dropped notifications /
+        // retransmissions.
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         let _worker = tokio::spawn(async move {

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -13,8 +13,12 @@ use internal_dns_client::{
 };
 use omicron_common::address::NEXUS_INTERNAL_PORT;
 use slog::Logger;
+use std::future::Future;
 use std::net::Ipv6Addr;
+use std::pin::Pin;
 use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 struct Inner {
     log: Logger,
@@ -57,5 +61,37 @@ impl LazyNexusClient {
             &format!("http://[{}]:{}", address, NEXUS_INTERNAL_PORT),
             self.inner.log.clone(),
         ))
+    }
+}
+
+type NexusRequestFut = dyn Future<Output = ()> + Send;
+type NexusRequest = Pin<Box<NexusRequestFut>>;
+
+/// A queue of futures which represent requests to Nexus.
+pub struct NexusRequestQueue {
+    tx: mpsc::UnboundedSender<NexusRequest>,
+    _worker: JoinHandle<()>,
+}
+
+impl NexusRequestQueue {
+    /// Creates a new request queue, along with a worker which executes
+    /// any incoming tasks.
+    pub fn new() -> Self {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let _worker = tokio::spawn(async move {
+            while let Some(fut) = rx.recv().await {
+                fut.await;
+            }
+        });
+
+        Self { tx, _worker }
+    }
+
+    /// Gets access to the sending portion of the request queue.
+    ///
+    /// Callers can use this to add their own requests.
+    pub fn sender(&self) -> &mpsc::UnboundedSender<NexusRequest> {
+        &self.tx
     }
 }

--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -9,9 +9,6 @@ use super::http_entrypoints::api as http_api;
 use super::sled_agent::SledAgent;
 use crate::bootstrap::params::SledAgentRequest;
 use crate::nexus::LazyNexusClient;
-use omicron_common::backoff::{
-    internal_service_policy_with_max, retry_notify, BackoffError,
-};
 use slog::Logger;
 use std::net::{SocketAddr, SocketAddrV6};
 use uuid::Uuid;
@@ -21,7 +18,6 @@ use uuid::Uuid;
 pub struct Server {
     /// Dropshot server for the API.
     http_server: dropshot::HttpServer<SledAgent>,
-    _nexus_notifier_handle: tokio::task::JoinHandle<()>,
 }
 
 impl Server {
@@ -38,7 +34,6 @@ impl Server {
         config: &Config,
         log: Logger,
         addr: SocketAddrV6,
-        is_scrimlet: bool,
         request: SledAgentRequest,
     ) -> Result<Server, String> {
         info!(log, "setting up sled agent server");
@@ -71,61 +66,7 @@ impl Server {
         .map_err(|error| format!("initializing server: {}", error))?
         .start();
 
-        let sled_address = http_server.local_addr();
-        let sled_id = config.id;
-        let nexus_notifier_handle = tokio::task::spawn(async move {
-            // Notify the control plane that we're up, and continue trying this
-            // until it succeeds. We retry with an randomized, capped exponential
-            // backoff.
-            //
-            // TODO-robustness if this returns a 400 error, we probably want to
-            // return a permanent error from the `notify_nexus` closure.
-            let notify_nexus = || async {
-                info!(
-                    log,
-                    "contacting server nexus, registering sled: {}", sled_id
-                );
-                let role = if is_scrimlet {
-                    nexus_client::types::SledRole::Scrimlet
-                } else {
-                    nexus_client::types::SledRole::Gimlet
-                };
-
-                let nexus_client = lazy_nexus_client
-                    .get()
-                    .await
-                    .map_err(|err| BackoffError::transient(err.to_string()))?;
-                nexus_client
-                    .sled_agent_put(
-                        &sled_id,
-                        &nexus_client::types::SledAgentStartupInfo {
-                            sa_address: sled_address.to_string(),
-                            role,
-                        },
-                    )
-                    .await
-                    .map_err(|err| BackoffError::transient(err.to_string()))
-            };
-            let log_notification_failure = |err, delay| {
-                warn!(
-                    log,
-                    "failed to notify nexus about sled agent: {}, will retry in {:?}", err, delay;
-                );
-            };
-            retry_notify(
-                internal_service_policy_with_max(
-                    std::time::Duration::from_secs(1),
-                ),
-                notify_nexus,
-                log_notification_failure,
-            )
-            .await
-            .expect("Expected an infinite retry loop contacting Nexus");
-        });
-        Ok(Server {
-            http_server,
-            _nexus_notifier_handle: nexus_notifier_handle,
-        })
+        Ok(Server { http_server })
     }
 
     /// Wait for the given server to shut down

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -386,6 +386,9 @@ impl SledAgent {
                 crate::hardware::HardwareUpdate::TofinoLoaded => {
                     self.ensure_scrimlet_services_active(&log).await;
                 }
+                crate::hardware::HardwareUpdate::TofinoUnloaded => {
+                    self.ensure_scrimlet_services_deactive(&log).await;
+                }
             }
         }
     }
@@ -399,6 +402,12 @@ impl SledAgent {
 
         // TODO(https://github.com/oxidecomputer/omicron/issues/823): Launch the switch zone, with
         // Dendrite, MGS, and any other services we want to enable.
+        warn!(log, "Activating scrimlet services not yet implemented");
+    }
+
+    async fn ensure_scrimlet_services_deactive(&self, log: &Logger) {
+        // TODO(https://github.com/oxidecomputer/omicron/issues/823): Terminate the switch zone.
+        warn!(log, "Deactivating scrimlet services not yet implemented");
     }
 
     pub fn id(&self) -> Uuid {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -97,6 +97,9 @@ pub enum Error {
     #[error("Error managing guest networking: {0}")]
     Opte(#[from] crate::opte::Error),
 
+    #[error("Error monitoring hardware: {0}")]
+    Hardware(String),
+
     #[error("Error resolving DNS name: {0}")]
     ResolveError(#[from] internal_dns_client::multiclient::ResolveError),
 }
@@ -319,7 +322,8 @@ impl SledAgent {
             ..Default::default()
         };
 
-        let hardware = HardwareManager::new(&config, parent_log.clone());
+        let hardware = HardwareManager::new(&config, parent_log.clone())
+            .map_err(|e| Error::Hardware(e))?;
 
         let services = ServiceManager::new(
             parent_log.clone(),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -398,6 +398,10 @@ impl SledAgent {
             match hardware_updates.recv().await {
                 Ok(update) => match update {
                     crate::hardware::HardwareUpdate::TofinoDeviceChange => {
+                        // Inform Nexus that we're now a scrimlet, instead of a Gimlet.
+                        //
+                        // This won't block on Nexus responding; it may take while before
+                        // Nexus actually comes online.
                         self.notify_nexus_about_self(&log);
                     }
                     crate::hardware::HardwareUpdate::TofinoLoaded => {
@@ -420,12 +424,6 @@ impl SledAgent {
     }
 
     async fn ensure_scrimlet_services_active(&self, log: &Logger) {
-        // Inform Nexus that we're now a scrimlet, instead of a Gimlet.
-        //
-        // This won't block on Nexus responding; it may take while before
-        // Nexus actually comes online.
-        self.notify_nexus_about_self(log);
-
         // TODO(https://github.com/oxidecomputer/omicron/issues/823): Launch the switch zone, with
         // Dendrite, MGS, and any other services we want to enable.
         warn!(log, "Activating scrimlet services not yet implemented");

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -6,9 +6,10 @@ id = "fb0f7546-4d46-40ca-9d56-cbb810684ca7"
 #
 # If this is set to "true", the sled agent treats itself as a scrimlet.
 # If this is set to "false", the sled agent treats itself as a gimlet.
-# If this is unset, the sled automatically detects whether or not it is a
-# scrimlet.
-# force_scrimlet = true
+# If this is unset:
+# - On illumos, the sled automatically detects whether or not it is a scrimlet.
+# - On all other platforms, the sled assumes it is a gimlet.
+# stub_scrimlet = true
 
 # A file-backed zpool can be manually created with the following:
 # # truncate -s 10GB testpool.vdev

--- a/smf/sled-agent/config.toml
+++ b/smf/sled-agent/config.toml
@@ -2,6 +2,14 @@
 
 id = "fb0f7546-4d46-40ca-9d56-cbb810684ca7"
 
+# Identifies if the sled should be unconditionally treated as a scrimlet.
+#
+# If this is set to "true", the sled agent treats itself as a scrimlet.
+# If this is set to "false", the sled agent treats itself as a gimlet.
+# If this is unset, the sled automatically detects whether or not it is a
+# scrimlet.
+# force_scrimlet = true
+
 # A file-backed zpool can be manually created with the following:
 # # truncate -s 10GB testpool.vdev
 # # zpool create oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b "$PWD/testpool.vdev"


### PR DESCRIPTION
- Adds `hardware` module to Sled Agent for minimally monitoring `devinfo` output. This will certainly evolve, but this PR includes a "bare minimum" real example of tracking the tofino driver.
- Stop relying on `rss-config.toml` to decide if we're running on a scrimlet. Instead...
  - (General case) Rely on monitoring hardware
  - (Testing, manual case) Provide a `force-scrimlet` option to make the sled agent assume that it is a scrimlet

Fixes https://github.com/oxidecomputer/minimum-upgradable-product/issues/19
Part of https://github.com/oxidecomputer/omicron/issues/1917
Part of https://github.com/oxidecomputer/omicron/issues/823
Pre-requisite for https://github.com/oxidecomputer/minimum-upgradable-product/issues/16
Pre-requisite for https://github.com/oxidecomputer/minimum-upgradable-product/issues/18