### PR TITLE
tfportd privs and dpd autoconfig

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -132,14 +132,14 @@ only_for_targets.switch_variant = "stub"
 #
 # 1. Build the zone image manually
 #   1a. cd <dendrite tree>
-#   1b. cargo build --features=tofino_stub
-#   1c. cargo xtask dist -o
+#   1b. cargo build --features=tofino_stub --release
+#   1c. cargo xtask dist -o -r --features tofino_stub
 # 2. Copy dendrite.tar.gz from dendrite/out to omicron/out
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "09c8878be3f78f0a5d384e7f59b93ea66e02e7a4"
-source.sha256 = "e05d33dc5d3deafae7d618c45b019c87ddd97e7a1fff11fa3ffb7593a3e10eaf"
+source.commit = "77e1268141aab830966b18526cffab8f458a28f9"
+source.sha256 = "76bab69b6a712e3da11de4aba044c90d86b6d374c8ece9ddda98ef2087541276"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -150,14 +150,14 @@ only_for_targets.switch_variant = "asic"
 #
 # 1. Build the zone image manually
 #   1a. cd <dendrite tree>
-#   1b. cargo build --features=<tofino_stub|tofino_asic|softnpu>
-#   1c. cargo xtask dist -o
+#   1b. cargo build --features=tofino_asic --release
+#   1c. cargo xtask dist -o -r --features tofino_asic
 # 2. Copy the output zone image from dendrite/out to omicron/out
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "09c8878be3f78f0a5d384e7f59b93ea66e02e7a4"
-source.sha256 = "208ae10a61f834608378eb135e4b6e5993dc363019b8fba75465b6ea5506b635"
+source.commit = "77e1268141aab830966b18526cffab8f458a28f9"
+source.sha256 = "a402001c2e531af4d8b2416a546d5daacb50c69fb81009c6c5cb74aaad7066ac"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/src/illumos/running_zone.rs
+++ b/sled-agent/src/illumos/running_zone.rs
@@ -385,6 +385,7 @@ impl InstalledZone {
         devices: &[zone::Device],
         opte_ports: Vec<Port>,
         link: Option<Link>,
+        limit_priv: Vec<String>,
     ) -> Result<InstalledZone, InstallZoneError> {
         let control_vnic = vnic_allocator.new_control(None).map_err(|err| {
             InstallZoneError::CreateVnic { zone: zone_name.to_string(), err }
@@ -408,6 +409,7 @@ impl InstalledZone {
             &datasets,
             &devices,
             net_device_names,
+            limit_priv,
         )
         .map_err(|err| InstallZoneError::InstallZone {
             zone: full_zone_name.to_string(),

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -207,6 +207,7 @@ impl Zones {
         datasets: &[zone::Dataset],
         devices: &[zone::Device],
         vnics: Vec<String>,
+        limit_priv: Vec<String>,
     ) -> Result<(), AdmError> {
         if let Some(zone) = Self::find(zone_name)? {
             info!(
@@ -244,6 +245,10 @@ impl Zones {
             .set_path(&path)
             .set_autoboot(false)
             .set_ip_type(zone::IpType::Exclusive);
+        if !limit_priv.is_empty() {
+            let limit_priv = std::collections::BTreeSet::from_iter(limit_priv);
+            cfg.get_global().set_limitpriv(limit_priv);
+        }
 
         for dataset in datasets {
             cfg.add_dataset(&dataset);

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -581,6 +581,7 @@ impl Instance {
             opte_ports,
             // physical_nic=
             None,
+            vec![],
         )
         .await?;
 

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -489,6 +489,7 @@ async fn ensure_running_zone(
                 &[],
                 vec![],
                 None,
+                vec![],
             )
             .await?;
 


### PR DESCRIPTION
To allow tfportd to create tfport links, the switch zone needs to be created with the sys_dl_config privilege.
Tfportd needs to be given the IP address on which dpd is listening.
To allow dendrite to autoconfigure switch ports, we need to tell it where to find the platform-specific port info.
