### PR TITLE
Fix AsciiDoc syntax issues in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,13 +8,13 @@ This repo houses the work-in-progress Oxide Rack control plane.
 
 image::https://github.com/oxidecomputer/omicron/workflows/Rust/badge.svg[]
 
-Omicron is open-source.  But we're pretty focused on our own goals for the foreseeable future and not able to help external contributors.  Please see CONTRIBUTING.md for more information.
+Omicron is open-source.  But we're pretty focused on our own goals for the foreseeable future and not able to help external contributors.  Please see xref:CONTRIBUTING.md[] for more information.
 
 == Documentation
 
-https://docs.oxide.computer/api[Docs are automatically generated for the public (externally-facing) API] based on the OpenAPI spec that itself is automatically generated from the server implementation.  You can generate your own docs for either the public API or any of the internal APIs by feeding the corresponding OpenAPI specs (in "./openapi") into an OpenAPI doc generator.
+https://docs.oxide.computer/api[Docs are automatically generated for the public (externally-facing) API] based on the OpenAPI spec that itself is automatically generated from the server implementation.  You can generate your own docs for either the public API or any of the internal APIs by feeding the corresponding OpenAPI specs (in link:./openapi[]) into an OpenAPI doc generator.
 
-There are some internal design docs in the "./docs" directory.
+There are some internal design docs in the link:./docs[] directory.
 
 For more design documentation and internal Rust API docs, see the https://rust.docs.corp.oxide.computer/omicron/[generated Rust documentation].  You can generate this yourself with:
 
@@ -51,17 +51,12 @@ See: xref:docs/how-to-run.adoc[].
 
 == Docker image
 
-This repo includes a Dockerfile that builds an image containing the Nexus and sled agent.  There's a GitHub Actions workflow that builds and publishes the Docker image.  This is used by [cli](https://github.com/oxidecomputer/cli) for testing. This is **not** the way Omicron will be deployed on production systems, but it's a useful vehicle for working with it.
+This repo includes a Dockerfile that builds an image containing the Nexus and sled agent.  There's a GitHub Actions workflow that builds and publishes the Docker image.  This is used by https://github.com/oxidecomputer/cli[cli] for testing. This is **not** the way Omicron will be deployed on production systems, but it's a useful vehicle for working with it.
 
 == Configuration reference
 
 `nexus` requires a TOML configuration file.  There's an example in
-`nexus/examples/config.toml`:
-
-[source,toml]
-----
-include::nexus/examples/config.toml[]
-----
+xref:nexus/examples/config.toml[].
 
 Supported config properties include:
 


### PR DESCRIPTION
Just a few little nits...

I do think replacing the `include` with a simple hyperlink warrants an explanation. This is what I see on my end:
<img width="878" alt="image" src="https://user-images.githubusercontent.com/31445542/201514046-92cb8bec-58fa-4687-b14a-01ec271a2678.png">

I believe that GitHub has its AsciiDoctor safety mode setting set to [`secure`](https://docs.asciidoctor.org/asciidoctor/latest/safe-modes/#secure), which means `include` directives are disabled. I guess Asciidoctor.js generates a link tag in its place, and since this takes place in a code block it doesn't get processed, thus turning into that *weird thing*™.

Actually, it's probably a good thing that the `include` isn't working, as that [example config file](https://github.com/oxidecomputer/omicron/blob/main/nexus/examples/config.toml) is pretty long... (linking to it is more appropriate in my opinion).

Apologies for the long comment on such a trivial change, I felt the need to explain myself given that I'm an outsider :P.