### PR TITLE
Use asynchronous 'zone' API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7435,22 +7435,23 @@ dependencies = [
 
 [[package]]
 name = "zone"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3596bbc963cd9dbaa69b02e349af4d061c56c41d211ba64150a2cedb2f722707"
+checksum = "b0545a42fbd7a81245726d54a0146cb4fd93882ebb6da50d60acf2e37394f198"
 dependencies = [
  "itertools",
  "thiserror",
+ "tokio",
  "zone_cfg_derive",
 ]
 
 [[package]]
 name = "zone_cfg_derive"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ac2a898023d86613a7efa7a4195e4b75240009e559acb17ddd7fa876d19527"
+checksum = "ef224b009d070d3b1adb9e375fcf8ec2f1948a412c3bbf8755c0ef4e3f91ef94"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -419,11 +419,15 @@ async fn do_install(
     do_activate(config, install_dir)
 }
 
-fn uninstall_all_omicron_zones() -> Result<()> {
-    zone::Zones::get()?.into_par_iter().try_for_each(|zone| -> Result<()> {
-        zone::Zones::halt_and_remove(zone.name())?;
-        Ok(())
-    })?;
+async fn uninstall_all_omicron_zones() -> Result<()> {
+    const CONCURRENCY_CAP: usize = 32;
+    futures::stream::iter(zone::Zones::get().await?)
+        .map(Ok::<_, anyhow::Error>)
+        .try_for_each_concurrent(CONCURRENCY_CAP, |zone| async move {
+            zone::Zones::halt_and_remove(zone.name()).await?;
+            Ok(())
+        })
+        .await?;
     Ok(())
 }
 
@@ -538,7 +542,7 @@ fn remove_all_except<P: AsRef<Path>>(
 
 async fn do_deactivate(config: &Config) -> Result<()> {
     info!(&config.log, "Removing all Omicron zones");
-    uninstall_all_omicron_zones()?;
+    uninstall_all_omicron_zones().await?;
     info!(config.log, "Uninstalling all packages");
     uninstall_all_packages(config);
     info!(config.log, "Removing networking resources");

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -56,7 +56,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 toml = "0.5.9"
 uuid = { version = "1.2.1", features = [ "serde", "v4" ] }
 vsss-rs = { version = "2.0.0", default-features = false, features = ["std"] }
-zone = "0.1"
+zone = { version = "0.2", default-features = false, features = ["async"] }
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 illumos-devinfo = { git = "https://github.com/oxidecomputer/illumos-devinfo", rev = "8fca0709e5137a3758374cb41ab1bfc60b03e6a9" }

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -140,10 +140,10 @@ impl Zones {
     ///
     /// Returns the state the zone was in before it was removed, or None if the
     /// zone did not exist.
-    pub fn halt_and_remove(
+    pub async fn halt_and_remove(
         name: &str,
     ) -> Result<Option<zone::State>, AdmError> {
-        match Self::find(name)? {
+        match Self::find(name).await? {
             None => Ok(None),
             Some(zone) => {
                 let state = zone.state();
@@ -158,40 +158,44 @@ impl Zones {
                 };
 
                 if halt {
-                    zone::Adm::new(name).halt().map_err(|err| AdmError {
-                        op: Operation::Halt,
-                        zone: name.to_string(),
-                        err,
+                    zone::Adm::new(name).halt().await.map_err(|err| {
+                        AdmError {
+                            op: Operation::Halt,
+                            zone: name.to_string(),
+                            err,
+                        }
                     })?;
                 }
                 if uninstall {
-                    zone::Adm::new(name).uninstall(/* force= */ true).map_err(
-                        |err| AdmError {
+                    zone::Adm::new(name)
+                        .uninstall(/* force= */ true)
+                        .await
+                        .map_err(|err| AdmError {
                             op: Operation::Uninstall,
                             zone: name.to_string(),
                             err,
-                        },
-                    )?;
+                        })?;
                 }
                 zone::Config::new(name)
                     .delete(/* force= */ true)
                     .run()
+                    .await
                     .map_err(|err| AdmError {
-                        op: Operation::Delete,
-                        zone: name.to_string(),
-                        err,
-                    })?;
+                    op: Operation::Delete,
+                    zone: name.to_string(),
+                    err,
+                })?;
                 Ok(Some(state))
             }
         }
     }
 
     /// Halt and remove the zone, logging the state in which the zone was found.
-    pub fn halt_and_remove_logged(
+    pub async fn halt_and_remove_logged(
         log: &Logger,
         name: &str,
     ) -> Result<(), AdmError> {
-        if let Some(state) = Self::halt_and_remove(name)? {
+        if let Some(state) = Self::halt_and_remove(name).await? {
             info!(
                 log,
                 "halt_and_remove_logged: Previous zone state: {:?}", state
@@ -200,7 +204,7 @@ impl Zones {
         Ok(())
     }
 
-    pub fn install_omicron_zone(
+    pub async fn install_omicron_zone(
         log: &Logger,
         zone_name: &str,
         zone_image: &std::path::Path,
@@ -208,7 +212,7 @@ impl Zones {
         devices: &[zone::Device],
         vnics: Vec<String>,
     ) -> Result<(), AdmError> {
-        if let Some(zone) = Self::find(zone_name)? {
+        if let Some(zone) = Self::find(zone_name).await? {
             info!(
                 log,
                 "install_omicron_zone: Found zone: {} in state {:?}",
@@ -227,7 +231,7 @@ impl Zones {
                     "Invalid state; uninstalling and deleting zone {}",
                     zone_name
                 );
-                Zones::halt_and_remove_logged(log, zone.name())?;
+                Zones::halt_and_remove_logged(log, zone.name()).await?;
             }
         }
 
@@ -257,7 +261,7 @@ impl Zones {
                 ..Default::default()
             });
         }
-        cfg.run().map_err(|err| AdmError {
+        cfg.run().await.map_err(|err| AdmError {
             op: Operation::Configure,
             zone: zone_name.to_string(),
             err,
@@ -265,19 +269,20 @@ impl Zones {
 
         info!(log, "Installing Omicron zone: {}", zone_name);
 
-        zone::Adm::new(zone_name).install(&[zone_image.as_ref()]).map_err(
-            |err| AdmError {
+        zone::Adm::new(zone_name)
+            .install(&[zone_image.as_ref()])
+            .await
+            .map_err(|err| AdmError {
                 op: Operation::Install,
                 zone: zone_name.to_string(),
                 err,
-            },
-        )?;
+            })?;
         Ok(())
     }
 
     /// Boots a zone (named `name`).
-    pub fn boot(name: &str) -> Result<(), AdmError> {
-        zone::Adm::new(name).boot().map_err(|err| AdmError {
+    pub async fn boot(name: &str) -> Result<(), AdmError> {
+        zone::Adm::new(name).boot().await.map_err(|err| AdmError {
             op: Operation::Boot,
             zone: name.to_string(),
             err,
@@ -288,8 +293,9 @@ impl Zones {
     /// Returns all zones that may be managed by the Sled Agent.
     ///
     /// These zones must have names starting with [`ZONE_PREFIX`].
-    pub fn get() -> Result<Vec<zone::Zone>, AdmError> {
+    pub async fn get() -> Result<Vec<zone::Zone>, AdmError> {
         Ok(zone::Adm::list()
+            .await
             .map_err(|err| AdmError {
                 op: Operation::List,
                 zone: "<all>".to_string(),
@@ -304,8 +310,8 @@ impl Zones {
     ///
     /// Can only return zones that start with [`ZONE_PREFIX`], as they
     /// are managed by the Sled Agent.
-    pub fn find(name: &str) -> Result<Option<zone::Zone>, AdmError> {
-        Ok(Self::get()?.into_iter().find(|zone| zone.name() == name))
+    pub async fn find(name: &str) -> Result<Option<zone::Zone>, AdmError> {
+        Ok(Self::get().await?.into_iter().find(|zone| zone.name() == name))
     }
 
     /// Returns the name of the VNIC used to communicate with the control plane.

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -742,7 +742,7 @@ impl Instance {
 
         let zname = propolis_zone_name(inner.propolis_id());
         warn!(inner.log, "Halting and removing zone: {}", zname);
-        Zones::halt_and_remove_logged(&inner.log, &zname).unwrap();
+        Zones::halt_and_remove_logged(&inner.log, &zname).await.unwrap();
 
         // Remove ourselves from the instance manager's map of instances.
         let running_state = inner.running_state.as_mut().unwrap();


### PR DESCRIPTION
This PR updates the `zone` crate to `0.2.0`, incorporating https://github.com/oxidecomputer/zone/pull/11.

### Previously

All `zone` APIs were synchronous, even though they made calls through `std::process::Command` that could take a while. This was a bummer in the `sled-agent`, where most of these calls could be made from an asynchronous context. Blocking asynchronous tasks is not good!

### Now

https://github.com/oxidecomputer/zone/pull/11 introduced feature flags to toggle between the `async` and `sync` variants of the crate. We enable the `async` flavor, and make use of it.

The majority of this PR is bubble-up effects of making previously synchronous functions asynchronous.