### PR TITLE
[wicket/wicketd] Retrieve SpComponentList

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7158,6 +7158,7 @@ dependencies = [
  "omicron-common",
  "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
+ "schemars",
  "serde",
  "slog",
  "uuid",

--- a/gateway-client/src/lib.rs
+++ b/gateway-client/src/lib.rs
@@ -46,5 +46,9 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::debug!(log, "client response"; "result" => ?result);
     }),
-    derives = [schemars::JsonSchema]
+    derives = [schemars::JsonSchema],
+    patch =
+        { SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord] },
+          SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord] }
+    }
 );

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -175,8 +175,7 @@
           }
         ]
       },
-      "SpId": {
-        "description": "A local type we can use as a key to a BTreeMap.\n\nThis maps directly to `gateway_client::types::SpIdentifer`, but we create a separate type because the progenitor generated type doesn't derive Ord/PartialOrd.",
+      "SpIdentifier": {
         "type": "object",
         "properties": {
           "slot": {
@@ -264,13 +263,14 @@
         "type": "object",
         "properties": {
           "components": {
+            "nullable": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SpComponentInfo"
             }
           },
           "id": {
-            "$ref": "#/components/schemas/SpId"
+            "$ref": "#/components/schemas/SpIdentifier"
           },
           "ignition": {
             "$ref": "#/components/schemas/SpIgnition"
@@ -280,7 +280,6 @@
           }
         },
         "required": [
-          "components",
           "id",
           "ignition",
           "state"

--- a/wicket/src/inventory.rs
+++ b/wicket/src/inventory.rs
@@ -6,7 +6,9 @@
 
 use anyhow::anyhow;
 use std::collections::BTreeMap;
-use wicketd_client::types::{RackV1Inventory, SpIgnition, SpState, SpType};
+use wicketd_client::types::{
+    RackV1Inventory, SpComponentInfo, SpIgnition, SpState, SpType,
+};
 
 /// Inventory is the most recent information about rack composition as
 /// received from MGS.
@@ -34,7 +36,11 @@ impl Inventory {
         for sp in inventory.sps {
             let i = sp.id.slot;
             let type_ = sp.id.type_;
-            let sp = Sp { ignition: sp.ignition, state: sp.state };
+            let sp = Sp {
+                ignition: sp.ignition,
+                state: sp.state,
+                components: sp.components,
+            };
 
             // Validate and get a ComponentId
             let (id, component) = match type_ {
@@ -76,10 +82,10 @@ impl Inventory {
 pub struct Sp {
     ignition: SpIgnition,
     state: SpState,
+    components: Option<Vec<SpComponentInfo>>,
 }
 
-// XXX: Eventually a Sled will have a host component, and SPs will have
-// `SpComponentInfo` (device inventory)
+// XXX: Eventually a Sled will have a host component.
 #[derive(Debug)]
 pub enum Component {
     Sled(Sp),

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -116,6 +116,7 @@ async fn poll_inventory(
                     if new_inventory != inventory {
                         inventory = new_inventory;
                         let _ = tx.send(inventory.clone()).await;
+                    } else {
                         debug!(log, "No change to inventory");
                     }
                 }

--- a/wicketd-client/Cargo.toml
+++ b/wicketd-client/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "stream"] }
+schemars = "0.8"
 
 [dependencies.chrono]
 version = "0.4"

--- a/wicketd-client/src/lib.rs
+++ b/wicketd-client/src/lib.rs
@@ -4,6 +4,27 @@
 
 //! Interface for making API requests to wicketd
 
-use omicron_common::generate_logging_api;
-
-generate_logging_api!("../openapi/wicketd.json");
+progenitor::generate_api!(
+    spec = "../openapi/wicketd.json",
+    inner_type = slog::Logger,
+    pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
+        slog::debug!(log, "client request";
+            "method" => %request.method(),
+            "uri" => %request.url(),
+            "body" => ?&request.body(),
+        );
+    }),
+    post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
+        slog::debug!(log, "client response"; "result" => ?result);
+    }),
+    derives = [schemars::JsonSchema],
+    patch =
+        {
+        SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord] },
+        SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        SpComponentInfo= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        SpIgnition= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        SpInventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        RackV1Inventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+    }
+);

--- a/wicketd/src/inventory.rs
+++ b/wicketd/src/inventory.rs
@@ -5,28 +5,31 @@
 //! Rack inventory for display by wicket
 
 use gateway_client::types::{
-    SpComponentInfo, SpIdentifier, SpIgnition, SpState, SpType,
+    SpComponentInfo, SpIdentifier, SpIgnition, SpState,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
-use std::fmt::Display;
 
 /// SP related data
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(tag = "sp_inventory", rename_all = "snake_case")]
 pub struct SpInventory {
-    pub id: SpId,
+    pub id: SpIdentifier,
     pub ignition: SpIgnition,
     pub state: SpState,
-    pub components: Vec<SpComponentInfo>,
+    pub components: Option<Vec<SpComponentInfo>>,
 }
 
 impl SpInventory {
     /// The ignition info and state of the SP are retrieved initiailly
     ///
     /// The components are filled in via a separate call
-    pub fn new(id: SpId, ignition: SpIgnition, state: SpState) -> SpInventory {
-        SpInventory { id, ignition, state, components: vec![] }
+    pub fn new(
+        id: SpIdentifier,
+        ignition: SpIgnition,
+        state: SpState,
+    ) -> SpInventory {
+        SpInventory { id, ignition, state, components: None }
     }
 }
 
@@ -35,37 +38,4 @@ impl SpInventory {
 #[serde(tag = "inventory", rename_all = "snake_case")]
 pub struct RackV1Inventory {
     pub sps: Vec<SpInventory>,
-}
-
-/// A local type we can use as a key to a BTreeMap.
-///
-/// This maps directly to `gateway_client::types::SpIdentifer`,
-/// but we create a separate type because the progenitor generated type
-/// doesn't derive Ord/PartialOrd.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, JsonSchema,
-)]
-#[serde(tag = "sp_id", rename_all = "snake_case")]
-pub struct SpId {
-    #[serde(rename = "type")]
-    pub typ: SpType,
-    pub slot: u32,
-}
-
-impl From<SpIdentifier> for SpId {
-    fn from(id: SpIdentifier) -> Self {
-        SpId { typ: id.type_, slot: id.slot }
-    }
-}
-
-impl From<SpId> for SpIdentifier {
-    fn from(id: SpId) -> Self {
-        SpIdentifier { type_: id.typ, slot: id.slot }
-    }
-}
-
-impl Display for SpId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?} {}", self.typ, self.slot)
-    }
 }

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -10,7 +10,7 @@ mod mgs;
 
 pub use config::Config;
 pub(crate) use context::ServerContext;
-pub use inventory::{RackV1Inventory, SpId, SpInventory};
+pub use inventory::{RackV1Inventory, SpInventory};
 pub(crate) use mgs::{MgsHandle, MgsManager};
 
 use dropshot::ConfigDropshot;


### PR DESCRIPTION
Add SpComponentInfo to RackV1Inventory by pulling it from MGS as necessary. We only pull from MGS when the state of the SP has changed or we do not yet have the component info. This is because the info is static except for when the SP is upgraded.

We then expose this information via the wicketd-client with the appropriately derived traits and plumb it up through wicket.