### PR TITLE
ci: split out zone tarballs in package job

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -109,6 +109,7 @@ pfexec chown build:build /opt/oxide/work
 cd /opt/oxide/work
 
 ptime -m tar xvzf /input/package/work/package.tar.gz
+cp /input/package/work/zones/* out/
 mkdir tests
 for p in /input/build-end-to-end-tests/work/*.gz; do
 	ptime -m gunzip < "$p" > "tests/$(basename "${p%.gz}")"

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -6,6 +6,7 @@
 #: rust_toolchain = "nightly-2022-09-27"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
+#:	"=/work/zones/*.tar.gz",
 #: ]
 #:
 
@@ -22,10 +23,12 @@ ptime -m ./tools/create_self_signed_cert.sh -yp
 ptime -m cargo run --locked --release --bin omicron-package -- package
 
 files=(
-	out/*.tar{,.gz}
+	out/*.tar
 	package-manifest.toml
 	smf/sled-agent/config.toml
 	target/release/omicron-package
 	tools/create_virtual_hardware.sh
 )
 ptime -m tar cvzf /work/package.tar.gz "${files[@]}"
+mkdir -p /work/zones
+mv out/*.tar.gz /work/zones/


### PR DESCRIPTION
[Does what it says on the tin.](https://github.com/oxidecomputer/omicron/runs/9540802770) This is so we can more easily grab the zone images to shove into an updates repository of some fashion.