### PR TITLE
[nexus] reduce MIN_EXPECTED_PASSWORD_VERIFY_TIME to 650ms

### DIFF
--- a/nexus/passwords/src/lib.rs
+++ b/nexus/passwords/src/lib.rs
@@ -53,7 +53,7 @@ pub const MAX_PASSWORD_LENGTH: usize = 512;
 // takes as long as we think it should on whatever machine the test suite is
 // running on.
 pub const MIN_EXPECTED_PASSWORD_VERIFY_TIME: std::time::Duration =
-    std::time::Duration::from_millis(900);
+    std::time::Duration::from_millis(650);
 
 /// Returns an [`Argon2`] context suitable for hashing passwords the same way
 /// we do for external authentication


### PR DESCRIPTION
On sufficiently fast machines like my Ryzen 7950x, we can go under the
900ms limit.

I tested this by running it a few times, and it appears to work.
