### PR TITLE
Make some uninstall failures not fatal

### DIFF
--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -18,10 +18,10 @@ use omicron_zone_package::target::Target;
 use rayon::prelude::*;
 use ring::digest::{Context as DigestContext, Digest, SHA256};
 use slog::debug;
-use slog::info;
 use slog::o;
 use slog::Drain;
 use slog::Logger;
+use slog::{info, warn};
 use std::env;
 use std::fs::create_dir_all;
 use std::io::Write;
@@ -454,7 +454,14 @@ fn get_all_omicron_datasets() -> Result<Vec<String>> {
 }
 
 fn uninstall_all_omicron_datasets(config: &Config) -> Result<()> {
-    let datasets = get_all_omicron_datasets()?;
+    let datasets = match get_all_omicron_datasets() {
+        Err(e) => {
+            warn!(config.log, "Failed to get omicron datasets: {}", e);
+            return Ok(());
+        }
+        Ok(datasets) => datasets,
+    };
+
     if datasets.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
If the uninstall process can't find any omicron datasets, print a message and continue.  It is possible they don't exist yet and the install steps later will create them if needed.

This is regarding what I saw in https://github.com/oxidecomputer/omicron/issues/1934

Now, when installing on a freshly booted ramdisk, I get this:

```
gimlet-sn21 # ./omicron-package install  
...
Nov 30 00:55:27.032 INFO Removing all Omicron zones
Nov 30 00:55:27.050 INFO Uninstalling all packages
Nov 30 00:55:27.141 INFO Removing networking resources
Nov 30 00:55:27.390 WARN Deleting Omicron underlay VNIC, vnic_name: underlay0
Nov 30 00:55:27.418 WARN Deleting Omicron etherstub, stub_name: stub0
Nov 30 00:55:27.433 INFO Uninstalling Omicron configuration
Nov 30 00:55:27.434 INFO Removing datasets
Nov 30 00:55:27.516 WARN Failed to get omicron datasets: Could not list datasets within zpool rpool/zone: Command [list -d 1 -rHpo name rpool/zone] executed and failed with status: exit status: 1  stdout:   stderr: cannot open 'rpool/zone': dataset does not exist

Nov 30 00:55:27.516 INFO Unpacking service tarball, service_path: /opt/oxide/mg-ddm, tar_path: /opt/oxide/mg-ddm.tar
Nov 30 00:55:27.919 INFO Unpacking service tarball, service_path: /opt/oxide/sled-agent, tar_path: /opt/oxide/sled-agent.tar
Nov 30 00:55:27.965 INFO Installing boostrap service from /opt/oxide/sled-agent/pkg/manifest.xml
```

Instead of stopping with error when  the uninstaller can't find `rpool/zone`, it just prints a message and continues.
The install steps that come next do create `rpool/zone` and future installs don't complain about it.
