### PR TITLE
RFD-322 PoC Revision 2

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -268,7 +268,7 @@ impl Name {
     }
 }
 
-#[derive(Serialize, Deserialize, Display)]
+#[derive(Serialize, Deserialize, Display, Clone)]
 #[display("{0}")]
 #[serde(untagged)]
 pub enum NameOrId {

--- a/nexus/db-model/src/name.rs
+++ b/nexus/db-model/src/name.rs
@@ -63,14 +63,3 @@ where
         String::from_sql(bytes)?.parse().map(Name).map_err(|e| e.into())
     }
 }
-
-/// Newtype wrapper around [external::NameOrId]. This type isn't actually
-/// stored in the database, but exists as a convenience for the API.
-#[derive(JsonSchema, Serialize, Deserialize, RefCast, Display)]
-#[serde(transparent)]
-#[repr(transparent)]
-#[display("{0}")]
-pub struct NameOrId(pub external::NameOrId);
-
-NewtypeFrom! { () pub struct NameOrId(external::NameOrId); }
-NewtypeDeref! { () pub struct NameOrId(external::NameOrId); }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -18,7 +18,6 @@ use crate::authz;
 use crate::context::OpContext;
 use crate::db;
 use crate::db::model::Name;
-use crate::db::model::NameOrId;
 use crate::external_api::shared;
 use crate::ServerContext;
 use dropshot::ApiDescription;
@@ -61,6 +60,7 @@ use omicron_common::api::external::Disk;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InternalContext;
+use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::NetworkInterface;
 use omicron_common::api::external::RouterRoute;
 use omicron_common::api::external::RouterRouteCreateParams;
@@ -2015,7 +2015,7 @@ struct InstanceListQueryParams {
     #[serde(flatten)]
     pagination: PaginatedByName,
     #[serde(flatten)]
-    selector: params::ProjectSelector,
+    selector: Option<params::ProjectSelector>,
 }
 
 #[endpoint {
@@ -2032,24 +2032,30 @@ async fn v1_instance_list(
     let query = query_params.into_inner();
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        let project_id =
-            nexus.project_lookup_id(&opctx, query.selector).await?;
-        let instances = nexus
-            .project_list_instances(
-                &opctx,
-                project_id,
-                &data_page_params_for(&rqctx, &query.pagination)?
-                    .map_name(|n| Name::ref_cast(n)),
-            )
-            .await?
-            .into_iter()
-            .map(|i| i.into())
-            .collect();
-        Ok(HttpResponseOk(ScanByName::results_page(
-            &query.pagination,
-            instances,
-            &marker_for_name,
-        )?))
+        if let Some(selector) = query.selector {
+            let project_id = nexus.project_lookup_id(&opctx, selector).await?;
+            let instances = nexus
+                .project_list_instances(
+                    &opctx,
+                    project_id,
+                    &data_page_params_for(&rqctx, &query.pagination)?
+                        .map_name(|n| Name::ref_cast(n)),
+                )
+                .await?
+                .into_iter()
+                .map(|i| i.into())
+                .collect();
+            Ok(HttpResponseOk(ScanByName::results_page(
+                &query.pagination,
+                instances,
+                &marker_for_name,
+            )?))
+        } else {
+            Err(HttpError::for_bad_request(
+                Some("missing_param".to_string()),
+                "missing required query parameter: project".to_string(),
+            ))
+        }
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
@@ -2076,9 +2082,11 @@ async fn instance_list(
         let project_id = nexus
             .project_lookup_id(
                 &opctx,
-                params::ProjectSelector::ProjectAndOrg {
-                    project_name: project_name.clone().into(),
-                    organization_name: organization_name.clone().into(),
+                params::ProjectSelector {
+                    project: NameOrId::Name(project_name.clone().into()),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2102,6 +2110,12 @@ async fn instance_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+#[derive(Deserialize, JsonSchema)]
+struct InstanceCreateParams {
+    #[serde(flatten)]
+    selector: params::ProjectSelector,
+}
+
 #[endpoint {
     method = POST,
     path = "/v1/instances",
@@ -2109,7 +2123,7 @@ async fn instance_list(
 }]
 async fn v1_instance_create(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    query_params: Query<InstanceQueryParams>,
+    query_params: Query<InstanceCreateParams>,
     new_instance: TypedBody<params::InstanceCreate>,
 ) -> Result<HttpResponseCreated<Instance>, HttpError> {
     let apictx = rqctx.context();
@@ -2157,9 +2171,11 @@ async fn instance_create(
         let project_id = nexus
             .project_lookup_id(
                 &opctx,
-                params::ProjectSelector::ProjectAndOrg {
-                    project_name: project_name.clone().into(),
-                    organization_name: organization_name.clone().into(),
+                params::ProjectSelector {
+                    project: NameOrId::Name(project_name.clone().into()),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2186,7 +2202,7 @@ struct InstanceLookupPathParam {
 #[derive(Deserialize, JsonSchema)]
 struct InstanceQueryParams {
     #[serde(flatten)]
-    selector: params::ProjectSelector,
+    selector: Option<params::ProjectSelector>,
 }
 
 #[endpoint {
@@ -2208,7 +2224,7 @@ async fn v1_instance_view(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let instance = nexus.instance_fetch(&opctx, &instance_id).await?;
@@ -2246,17 +2262,12 @@ async fn instance_view(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2307,7 +2318,7 @@ async fn v1_instance_delete(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         nexus.project_destroy_instance(&opctx, &instance_id).await?;
@@ -2337,17 +2348,12 @@ async fn instance_delete(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2379,7 +2385,7 @@ async fn v1_instance_migrate(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let instance = nexus
@@ -2418,17 +2424,12 @@ async fn instance_migrate(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2463,7 +2464,7 @@ async fn v1_instance_reboot(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let instance = nexus.instance_reboot(&opctx, instance_id).await?;
@@ -2493,17 +2494,12 @@ async fn instance_reboot(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2533,7 +2529,7 @@ async fn v1_instance_start(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let instance = nexus.instance_start(&opctx, instance_id).await?;
@@ -2563,17 +2559,12 @@ async fn instance_start(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2602,7 +2593,7 @@ async fn v1_instance_stop(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let instance = nexus.instance_stop(&opctx, instance_id).await?;
@@ -2632,17 +2623,12 @@ async fn instance_stop(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2655,7 +2641,7 @@ async fn instance_stop(
 #[derive(Deserialize, JsonSchema)]
 pub struct InstanceSerialConsoleParams {
     #[serde(flatten)]
-    selector: params::ProjectSelector,
+    selector: Option<params::ProjectSelector>,
 
     #[serde(flatten)]
     pub console_params: params::InstanceSerialConsoleRequest,
@@ -2680,7 +2666,7 @@ async fn v1_instance_serial_console(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                query.selector.to_instance_selector(path.instance.into()),
+                params::InstanceSelector::new(path.instance, &query.selector),
             )
             .await?;
         let console = nexus
@@ -2717,17 +2703,12 @@ async fn instance_serial_console(
         let instance_id = nexus
             .instance_lookup_id(
                 &opctx,
-                params::InstanceSelector::InstanceProjectAndOrg {
-                    instance_name: omicron_common::api::external::Name::from(
-                        instance_name.clone(),
-                    ),
-                    project_name: omicron_common::api::external::Name::from(
-                        project_name.clone(),
-                    ),
-                    organization_name:
-                        omicron_common::api::external::Name::from(
-                            organization_name.clone(),
-                        ),
+                params::InstanceSelector {
+                    instance: NameOrId::Name(instance_name.clone().into()),
+                    project: Some(NameOrId::Name(project_name.clone().into())),
+                    organization: Some(NameOrId::Name(
+                        organization_name.clone().into(),
+                    )),
                 },
             )
             .await?;
@@ -2762,7 +2743,7 @@ async fn v1_instance_serial_console_stream(
     let instance_id = nexus
         .instance_lookup_id(
             &opctx,
-            query.selector.to_instance_selector(path.instance.into()),
+            params::InstanceSelector::new(path.instance, &query.selector),
         )
         .await?;
     nexus.instance_serial_console_stream(&opctx, conn, &instance_id).await?;
@@ -2790,16 +2771,12 @@ async fn instance_serial_console_stream(
     let instance_id = nexus
         .instance_lookup_id(
             &opctx,
-            params::InstanceSelector::InstanceProjectAndOrg {
-                instance_name: omicron_common::api::external::Name::from(
-                    instance_name.clone(),
-                ),
-                project_name: omicron_common::api::external::Name::from(
-                    project_name.clone(),
-                ),
-                organization_name: omicron_common::api::external::Name::from(
-                    organization_name.clone(),
-                ),
+            params::InstanceSelector {
+                instance: NameOrId::Name(instance_name.clone().into()),
+                project: Some(NameOrId::Name(project_name.clone().into())),
+                organization: Some(NameOrId::Name(
+                    organization_name.clone().into(),
+                )),
             },
         )
         .await?;

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -149,7 +149,7 @@ async fn test_v1_instance_access(cptestctx: &ControlPlaneTestContext) {
     let fetched_instance = instance_get(
         &client,
         format!(
-            "/v1/instances/{}?project_id={}",
+            "/v1/instances/{}?project={}",
             instance.identity.name, project.identity.id
         )
         .as_str(),
@@ -161,7 +161,7 @@ async fn test_v1_instance_access(cptestctx: &ControlPlaneTestContext) {
     let fetched_instance = instance_get(
         &client,
         format!(
-            "/v1/instances/{}?project_name={}&organization_id={}",
+            "/v1/instances/{}?project={}&organization={}",
             instance.identity.name, project.identity.name, org.identity.id
         )
         .as_str(),
@@ -173,7 +173,7 @@ async fn test_v1_instance_access(cptestctx: &ControlPlaneTestContext) {
     let fetched_instance = instance_get(
         &client,
         format!(
-            "/v1/instances/{}?project_name={}&organization_name={}",
+            "/v1/instances/{}?project={}&organization={}",
             instance.identity.name, project.identity.name, org.identity.name
         )
         .as_str(),

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7675,6 +7675,14 @@
           },
           {
             "in": "query",
+            "name": "organization",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "page_token",
             "description": "Token returned by previous call to retrieve the subsequent page",
             "schema": {
@@ -7685,43 +7693,17 @@
           },
           {
             "in": "query",
+            "name": "project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "sort_by",
             "schema": {
               "$ref": "#/components/schemas/NameSortMode"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_id",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_id",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
             },
             "style": "form"
           }
@@ -7754,35 +7736,18 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
+            "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           }
@@ -7826,35 +7791,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
@@ -7896,35 +7843,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
@@ -7961,35 +7890,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
@@ -8043,35 +7954,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
@@ -8161,35 +8054,17 @@
           },
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           }
@@ -8233,35 +8108,17 @@
           },
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           }
@@ -8289,35 +8146,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
@@ -8361,35 +8200,17 @@
         "parameters": [
           {
             "in": "query",
-            "name": "project_id",
+            "name": "organization",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },
           {
             "in": "query",
-            "name": "organization_id",
+            "name": "project",
             "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "project_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            },
-            "style": "form"
-          },
-          {
-            "in": "query",
-            "name": "organization_name",
-            "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             },
             "style": "form"
           },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7694,6 +7694,7 @@
           {
             "in": "query",
             "name": "project",
+            "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             },


### PR DESCRIPTION
This is an updated approach to #1957 that was spawned from feedback from @ahl. The main feedback here is that we'd like the CLI and API be consistent. In the cli we'll probably use `--project` and `--organization` not `--project_id`, `--project_name`. The over-specification of params and their types didn't actually make the resulting API any simpler... in fact, it introduced extra failure modes where you could have combinations of selectors for the same resource. 

I'm putting this up as a separate PR to merge on the first just so folks can take a peek at it and voice any feedback/concerns before I merge them together. 

## Differences from #1957

- Selectors (`InstanceSelector`, `ProjectSelector`) are structs now instead of enums. 
- Uses `NameOrId` for query parameters reducing `project_id` and `project_name` down to just `project`
- DB newtype wrapper for `NameOrId` is no longer necessary