### PR TITLE
add tool for printing out retry policy choices

### DIFF
--- a/common/examples/backoff-print.rs
+++ b/common/examples/backoff-print.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Show example retry intervals and times for the internal service policy
+
+use omicron_common::backoff;
+use omicron_common::backoff::Backoff;
+
+fn main() {
+    let mut policy = backoff::retry_policy_long();
+    let mut total_duration = std::time::Duration::from_secs(0);
+    loop {
+        let nmin = total_duration.as_secs() / 60;
+        let nsecs = total_duration.as_secs() % 60;
+        let nmillis = total_duration.as_millis() % 1000;
+        print!("at T={:3}m{:02}.{:03}s: ", nmin, nsecs, nmillis);
+
+        if let Some(next) = policy.next_backoff() {
+            let nmin = next.as_secs() / 60;
+            let nsecs = next.as_secs() % 60;
+            let nmillis = next.as_millis() % 1000;
+            println!("wait {:3}m{:02}.{:03}s", nmin, nsecs, nmillis);
+            total_duration = total_duration + next;
+
+            if nmin >= 60 {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This tool prints out how long `retry_policy_long()` would wait in the face of a continual transient errors.
Example output (which varies because of randomness in the policy):

```
$ cargo run --example=backoff-print
warning: skipping duplicate package `header-check` found at `/Users/dap/.cargo/git/checkouts/propolis-12517f89d3d9f483/e58937f/crates/viona-api/header-check`
   Compiling omicron-common v0.1.0 (/Users/dap/oxide/omicron/common)
    Finished dev [unoptimized + debuginfo] target(s) in 1.51s
     Running `target/debug/examples/backoff-print`
at T=  0m00.000s: wait   0m00.260s
at T=  0m00.260s: wait   0m00.372s
at T=  0m00.633s: wait   0m00.526s
at T=  0m01.159s: wait   0m01.457s
at T=  0m02.617s: wait   0m05.489s
at T=  0m08.106s: wait   0m10.515s
at T=  0m18.622s: wait   0m12.520s
at T=  0m31.143s: wait   0m38.571s
at T=  1m09.714s: wait   1m04.241s
at T=  2m13.955s: wait   2m46.076s
at T=  5m00.032s: wait   4m40.866s
at T=  9m40.899s: wait   6m10.885s
at T= 15m51.784s: wait  17m41.802s
at T= 33m33.587s: wait  20m28.854s
at T= 54m02.442s: wait  37m04.461s
at T= 91m06.903s: wait  53m18.165s
at T=144m25.069s: wait  74m27.066s
```

This could have a lot of options (e.g., when to stop, which policy to use).  I didn't think it was worth spending more time on now, but since I did this much, I thought it was worth checking in.  Thoughts?