### PR TITLE
dedup progenitor, and update crucible and propolis revs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,18 +1057,6 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561#144d8dafa41715e00b08a5929cc62140ff0eb561"
-dependencies = [
- "base64",
- "schemars",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "crucible-client-types"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a#861a09c350fd0e127b6105c8099e31a0bc3b711a"
 dependencies = [
  "base64",
@@ -3531,7 +3519,7 @@ dependencies = [
  "chrono",
  "clap 4.0.29",
  "crucible-agent-client",
- "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a)",
+ "crucible-client-types",
  "ddm-admin-client",
  "dropshot",
  "expectorate",
@@ -4536,10 +4524,10 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e58937fea67aca6bc2d37a3cc50a72291328ae0e#e58937fea67aca6bc2d37a3cc50a72291328ae0e"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b596e72b6b93bc412d675358f782ae7d53f8bf7a#b596e72b6b93bc412d675358f782ae7d53f8bf7a"
 dependencies = [
  "base64",
- "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561)",
+ "crucible-client-types",
  "progenitor",
  "propolis_types",
  "rand 0.8.5",
@@ -4557,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e58937fea67aca6bc2d37a3cc50a72291328ae0e#e58937fea67aca6bc2d37a3cc50a72291328ae0e"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b596e72b6b93bc412d675358f782ae7d53f8bf7a#b596e72b6b93bc412d675358f782ae7d53f8bf7a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,8 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
-source = "git+https://github.com/bytecodealliance/rustix?rev=99a903ed202432244deb66de7d826262d552aba8#99a903ed202432244deb66de7d826262d552aba8"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "rustix"
 version = "0.36.4"
-source = "git+https://github.com/bytecodealliance/rustix?rev=779e2119e0517d36c01d38451aa8c1304d3bac60#779e2119e0517d36c01d38451aa8c1304d3bac60"
+source = "git+https://github.com/bytecodealliance/rustix?rev=99a903ed202432244deb66de7d826262d552aba8#99a903ed202432244deb66de7d826262d552aba8"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -709,14 +709,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive 4.0.21",
  "clap_lex 0.3.0",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -1042,12 +1042,12 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561#144d8dafa41715e00b08a5929cc62140ff0eb561"
+source = "git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a#861a09c350fd0e127b6105c8099e31a0bc3b711a"
 dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "schemars",
  "serde",
@@ -1058,6 +1058,18 @@ dependencies = [
 name = "crucible-client-types"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561#144d8dafa41715e00b08a5929cc62140ff0eb561"
+dependencies = [
+ "base64",
+ "schemars",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "crucible-client-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a#861a09c350fd0e127b6105c8099e31a0bc3b711a"
 dependencies = [
  "base64",
  "schemars",
@@ -1253,8 +1265,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "omicron-zone-package",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
- "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
+ "progenitor-client",
  "quote",
  "reqwest",
  "serde",
@@ -1676,6 +1688,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "expectorate"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +1981,7 @@ name = "gateway-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "futures",
  "gateway-client",
  "libc",
@@ -1968,7 +2001,7 @@ dependencies = [
  "chrono",
  "futures",
  "omicron-common",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "schemars",
  "serde",
@@ -2201,6 +2234,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -2530,7 +2572,7 @@ name = "internal-dns"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "expectorate",
  "internal-dns-client",
@@ -2565,7 +2607,7 @@ dependencies = [
  "internal-dns",
  "omicron-common",
  "omicron-test-utils",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "serde",
  "serde_json",
@@ -2577,6 +2619,16 @@ dependencies = [
  "trust-dns-proto",
  "trust-dns-resolver",
  "uuid",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2604,6 +2656,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2754,6 +2818,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lock_api"
@@ -2976,7 +3046,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "serde",
  "serde_json",
@@ -3166,7 +3236,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -3258,7 +3328,7 @@ dependencies = [
  "libc",
  "macaddr",
  "parse-display",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -3283,7 +3353,7 @@ name = "omicron-deploy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "crossbeam",
  "omicron-package",
  "omicron-sled-agent",
@@ -3299,7 +3369,7 @@ dependencies = [
 name = "omicron-gateway"
 version = "0.1.0"
 dependencies = [
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "expectorate",
  "futures",
@@ -3337,7 +3407,7 @@ dependencies = [
  "base64",
  "bb8",
  "chrono",
- "clap 4.0.26",
+ "clap 4.0.29",
  "cookie",
  "criterion",
  "crucible-agent-client",
@@ -3421,7 +3491,7 @@ name = "omicron-package"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "futures",
  "hex",
  "indicatif",
@@ -3459,9 +3529,9 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "chrono",
- "clap 4.0.26",
+ "clap 4.0.29",
  "crucible-agent-client",
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a)",
  "ddm-admin-client",
  "dropshot",
  "expectorate",
@@ -3484,7 +3554,7 @@ dependencies = [
  "oximeter-producer",
  "p256",
  "percent-encoding",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "propolis-client",
  "rand 0.8.5",
  "reqwest",
@@ -3522,7 +3592,7 @@ name = "omicron-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "expectorate",
  "futures",
@@ -3727,7 +3797,7 @@ dependencies = [
  "base64",
  "chrono",
  "futures",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "rand 0.8.5",
  "regress",
  "reqwest",
@@ -3771,7 +3841,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "serde",
  "slog",
@@ -3782,7 +3852,7 @@ dependencies = [
 name = "oximeter-collector"
 version = "0.1.0"
 dependencies = [
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "expectorate",
  "internal-dns-client",
@@ -3813,7 +3883,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "itertools",
  "omicron-test-utils",
@@ -4400,29 +4470,14 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#6f23bcb5cdb69b80581ee1eb7f6738b1755488dc"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "openapiv3",
- "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
- "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
- "progenitor-macro 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "progenitor"
-version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
-dependencies = [
- "anyhow",
- "clap 4.0.26",
- "openapiv3",
- "progenitor-client 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
- "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
- "progenitor-macro 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
  "serde",
  "serde_json",
 ]
@@ -4430,21 +4485,7 @@ dependencies = [
 [[package]]
 name = "progenitor-client"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest",
- "serde",
- "serde_json",
- "serde_urlencoded",
-]
-
-[[package]]
-name = "progenitor-client"
-version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#6f23bcb5cdb69b80581ee1eb7f6738b1755488dc"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4458,29 +4499,7 @@ dependencies = [
 [[package]]
 name = "progenitor-impl"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
-dependencies = [
- "getopts",
- "heck 0.4.0",
- "indexmap",
- "openapiv3",
- "proc-macro2",
- "quote",
- "regex",
- "rustfmt-wrapper",
- "schemars",
- "serde",
- "serde_json",
- "syn",
- "thiserror",
- "typify",
- "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-impl"
-version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#6f23bcb5cdb69b80581ee1eb7f6738b1755488dc"
 dependencies = [
  "getopts",
  "heck 0.4.0",
@@ -4502,26 +4521,11 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#6f23bcb5cdb69b80581ee1eb7f6738b1755488dc"
 dependencies = [
  "openapiv3",
  "proc-macro2",
- "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
- "quote",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn",
-]
-
-[[package]]
-name = "progenitor-macro"
-version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor#4b5cef4b105f351c74d14acae5e0b4d69313afb2"
-dependencies = [
- "openapiv3",
- "proc-macro2",
- "progenitor-impl 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-impl",
  "quote",
  "serde",
  "serde_json",
@@ -4535,8 +4539,8 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=e58937fea67aca6bc2d37a3cc50a72291328ae0e#e58937fea67aca6bc2d37a3cc50a72291328ae0e"
 dependencies = [
  "base64",
- "crucible-client-types",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=144d8dafa41715e00b08a5929cc62140ff0eb561)",
+ "progenitor",
  "propolis_types",
  "rand 0.8.5",
  "reqwest",
@@ -5088,6 +5092,20 @@ dependencies = [
  "thiserror",
  "toml",
  "toolchain_find",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5653,7 +5671,7 @@ dependencies = [
  "chrono",
  "ipnetwork",
  "omicron-common",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "regress",
  "reqwest",
  "serde",
@@ -5831,7 +5849,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "futures",
  "gateway-messages",
@@ -6671,7 +6689,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "typify"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#6f20ad934a8da5aa3a94d25d2ab3cca1e60f53d9"
+source = "git+https://github.com/oxidecomputer/typify#55d9fa1ac5c2094668077bcba38b31f422add76b"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -6680,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#6f20ad934a8da5aa3a94d25d2ab3cca1e60f53d9"
+source = "git+https://github.com/oxidecomputer/typify#55d9fa1ac5c2094668077bcba38b31f422add76b"
 dependencies = [
  "heck 0.4.0",
  "log",
@@ -6698,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#6f20ad934a8da5aa3a94d25d2ab3cca1e60f53d9"
+source = "git+https://github.com/oxidecomputer/typify#55d9fa1ac5c2094668077bcba38b31f422add76b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7088,7 +7106,7 @@ name = "wicket"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.29",
  "crossterm",
  "futures",
  "hex",
@@ -7114,7 +7132,7 @@ dependencies = [
 name = "wicketd"
 version = "0.1.0"
 dependencies = [
- "clap 4.0.26",
+ "clap 4.0.29",
  "dropshot",
  "expectorate",
  "futures",
@@ -7145,7 +7163,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor 0.2.1-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
     "test-utils",
     "wicket",
     "wicketd",
-    "wicketd-client"
+    "wicketd-client",
 ]
 
 default-members = [
@@ -116,7 +116,8 @@ panic = "abort"
 #[patch."https://github.com/oxidecomputer/propolis"]
 #propolis-client = { path = "../propolis/lib/propolis-client" }
 #[patch."https://github.com/oxidecomputer/crucible"]
-#crucible-client-typess = { path = "../crucible/crucible-client-typess" }
+#crucible-agent-client = { path = "../crucible/agent-client" }
+#crucible-client-types = { path = "../crucible/crucible-client-types" }
 
 #
 # Local client generation during development.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ panic = "abort"
 git = 'https://github.com/oxidecomputer/pq-sys'
 branch = "oxide/omicron"
 
-# Pick up the fix for https://github.com/bytecodealliance/rustix/pull/468.
+# Pick up the fix for https://github.com/bytecodealliance/rustix/pull/467.
 [patch.crates-io.rustix]
 git = 'https://github.com/bytecodealliance/rustix'
-rev = '779e2119e0517d36c01d38451aa8c1304d3bac60'
+rev = '99a903ed202432244deb66de7d826262d552aba8'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,3 @@ panic = "abort"
 [patch.crates-io.pq-sys]
 git = 'https://github.com/oxidecomputer/pq-sys'
 branch = "oxide/omicron"
-
-# Pick up the fix for https://github.com/bytecodealliance/rustix/pull/467.
-[patch.crates-io.rustix]
-git = 'https://github.com/bytecodealliance/rustix'
-rev = '99a903ed202432244deb66de7d826262d552aba8'

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -32,7 +32,7 @@ tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1
 toml = "0.5.9"
 uuid = { version = "1.2.2", features = [ "serde", "v4" ] }
 parse-display = "0.6.0"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 
 [dev-dependencies]
 expectorate = "1.0.5"

--- a/ddm-admin-client/Cargo.toml
+++ b/ddm-admin-client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 slog = "2.7"
@@ -12,7 +12,7 @@ slog = "2.7"
 [build-dependencies]
 anyhow = "1.0"
 omicron-zone-package = "0.5.1"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 quote = "1.0"
 serde_json = "1.0"
 toml = "0.5"

--- a/gateway-client/Cargo.toml
+++ b/gateway-client/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 futures = "0.3.25"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = "0.8"
 serde_json = "1.0"

--- a/internal-dns-client/Cargo.toml
+++ b/internal-dns-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 futures = "0.3.25"
 omicron-common = { path = "../common" }
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/nexus-client/Cargo.toml
+++ b/nexus-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 serde_json = "1.0"
 

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -47,7 +47,7 @@ oximeter-db = { path = "../oximeter/db/" }
 parse-display = "0.6.0"
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e58937fea67aca6bc2d37a3cc50a72291328ae0e", features = [ "generated" ] }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b596e72b6b93bc412d675358f782ae7d53f8bf7a", features = [ "generated" ] }
 rand = "0.8.5"
 ref-cast = "1.0"
 reqwest = { version = "0.11.13", features = [ "json" ] }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.13.1"
 bb8 = "0.8.0"
 clap = { version = "4.0", features = ["derive"] }
 cookie = "0.16"
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
 diesel = { version = "2.0.2", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
 # TODO(luqman): Update once merged & new release is cut

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -516,13 +516,11 @@ impl super::Nexus {
         for (i, disk) in disks.iter().enumerate() {
             let volume =
                 self.db_datastore.volume_checkout(disk.volume_id).await?;
-            let gen: i64 = (&disk.runtime_state.gen.0).into();
             disk_reqs.push(sled_agent_client::types::DiskRequest {
                 name: disk.name().to_string(),
                 slot: sled_agent_client::types::Slot(i as u8),
                 read_only: false,
                 device: "nvme".to_string(),
-                gen: gen as u64,
                 volume_construction_request: serde_json::from_str(
                     &volume.data(),
                 )?,

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -613,11 +613,6 @@
           "device": {
             "type": "string"
           },
-          "gen": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
           "name": {
             "type": "string"
           },
@@ -633,7 +628,6 @@
         },
         "required": [
           "device",
-          "gen",
           "name",
           "read_only",
           "slot",

--- a/oxide-client/Cargo.toml
+++ b/oxide-client/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 futures = "0.3.25"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 regress = "0.4.1"
 serde_json = "1.0.89"
 base64 = "0.13"

--- a/oximeter-client/Cargo.toml
+++ b/oximeter-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 
 [dependencies.chrono]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -92,10 +92,10 @@ service_name = "crucible"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "144d8dafa41715e00b08a5929cc62140ff0eb561"
+source.commit = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "2de086b0ba27efc638c88ff46a6d110236c2db92499266eccbd2a3ec28acc693"
+source.sha256 = "f0cefac66b82a377d1460065a838af22aeb0c03c98563f994eca562d2541f551"
 output.type = "zone"
 
 # Refer to
@@ -105,10 +105,10 @@ output.type = "zone"
 service_name = "propolis-server"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "e58937fea67aca6bc2d37a3cc50a72291328ae0e"
+source.commit = "b596e72b6b93bc412d675358f782ae7d53f8bf7a"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "00d11a6f669e9f7caa03963c3bd345f2f3a2e6b4ec0e713f2e1dbf94177b4fa9"
+source.sha256 = "014f21152629e6ec7a5cfe42f6ad0057279456f191a040a7e4f04d4db74b627c"
 output.type = "zone"
 
 [package.maghemite]

--- a/sled-agent-client/Cargo.toml
+++ b/sled-agent-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 async-trait = "0.1"
 ipnetwork = "0.20"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 regress = "0.4.1"
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -31,7 +31,7 @@ oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.2.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e58937fea67aca6bc2d37a3cc50a72291328ae0e", features = [ "generated-migration" ] }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b596e72b6b93bc412d675358f782ae7d53f8bf7a", features = [ "generated-migration" ] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -14,8 +14,8 @@ cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.0", features = ["derive"] }
 # Only used by the simulated sled agent.
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "144d8dafa41715e00b08a5929cc62140ff0eb561" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
 ddm-admin-client = { path = "../ddm-admin-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.25"
@@ -30,7 +30,7 @@ oximeter = { version = "0.1.0", path = "../oximeter/oximeter" }
 oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.2.0"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e58937fea67aca6bc2d37a3cc50a72291328ae0e", features = [ "generated-migration" ] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }

--- a/wicketd-client/Cargo.toml
+++ b/wicketd-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = "0.8"
 


### PR DESCRIPTION
This is PR 3 of N in this series. For the earlier ones, see:

* https://github.com/oxidecomputer/crucible/pull/552
* https://github.com/oxidecomputer/propolis/pull/262

Currently, we specify the progenitor dependency as both:

```toml
progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
```

And

```toml
progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
```

Cargo (due to https://github.com/rust-lang/cargo/issues/7497) doesn't dedup these dependencies even
though they resolve to the same branch and hash. This causes issues with
`cargo doc` colliding with itself, as it tries to document both:

```
Documenting progenitor-impl v0.2.1-dev (https://github.com/oxidecomputer/progenitor#4b5cef4b)
Documenting progenitor-impl v0.2.1-dev (https://github.com/oxidecomputer/progenitor?branch=main#4b5cef4b)
```

Fix this by always using the branch name. (We choose this option over
not specifying the branch so to maintain uniformity in cases where a
non-default branch must be used.)

This also requires a crucible update, since that didn't specify a branch
either. And the crucible update necessitates a propolis update to get the versions aligned.

In the future it would be nice to have a lint which ensures that git
dependencies always have the branch name in them.
