### PR TITLE
add support for rev b sidecars

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -138,8 +138,8 @@ only_for_targets.switch_variant = "stub"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "77e1268141aab830966b18526cffab8f458a28f9"
-source.sha256 = "76bab69b6a712e3da11de4aba044c90d86b6d374c8ece9ddda98ef2087541276"
+source.commit = "96d1f1da1db4c3b46016e5d3fae331673b9088a1"
+source.sha256 = "40f1c19353b176f5d9b199ae0d0411448c5d2017a0263038e8650300bcb82577"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -156,8 +156,8 @@ only_for_targets.switch_variant = "asic"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "77e1268141aab830966b18526cffab8f458a28f9"
-source.sha256 = "a402001c2e531af4d8b2416a546d5daacb50c69fb81009c6c5cb74aaad7066ac"
+source.commit = "96d1f1da1db4c3b46016e5d3fae331673b9088a1"
+source.sha256 = "423bcda39c026c066f87c068f098fa690756dfc4b87e53efe25a0bfaf4cda544"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -138,8 +138,8 @@ only_for_targets.switch_variant = "stub"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "96d1f1da1db4c3b46016e5d3fae331673b9088a1"
-source.sha256 = "40f1c19353b176f5d9b199ae0d0411448c5d2017a0263038e8650300bcb82577"
+source.commit = "557f9e95a7ac213fe9bafdbbc566e85037085429"
+source.sha256 = "0b2291b797d7f3ae1d6b8af04088a0559faad74334b25da4e1f70602a85b828b"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -156,8 +156,8 @@ only_for_targets.switch_variant = "asic"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "96d1f1da1db4c3b46016e5d3fae331673b9088a1"
-source.sha256 = "423bcda39c026c066f87c068f098fa690756dfc4b87e53efe25a0bfaf4cda544"
+source.commit = "557f9e95a7ac213fe9bafdbbc566e85037085429"
+source.sha256 = "830d082a96417c910c893bb66dd45a7a2a6b6db3316692b0df9abab509117b58"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -741,10 +741,13 @@ impl ServiceManager {
                         &format!("[{}]:{}", address, DENDRITE_PORT,),
                     )?;
                     match *asic {
-                        DendriteAsic::TofinoAsic => smfh.setprop(
-                            "config/port_config",
-                            "/opt/oxide/dendrite/misc/sidecar_config.toml",
-                        )?,
+                        DendriteAsic::TofinoAsic => {
+                            smfh.setprop(
+                                "config/port_config",
+                                "/opt/oxide/dendrite/misc/sidecar_config.toml",
+                            )?;
+                            smfh.setprop("config/board_rev", "rev_a")?;
+                        }
                         DendriteAsic::TofinoStub => smfh.setprop(
                             "config/port_config",
                             "/opt/oxide/dendrite/misc/model_config.toml",


### PR DESCRIPTION
This change supports a new SMF property for the `dendrite` service.  By changing `config/board_rev`, we change which board map `dpd` loads at startup.

This PR doesn't actually change any behavior yet, as it is hardcoded to always set `rev_a`.  We will need some mechanism (presumably a `sled-agent` config setting?) to actually communicate to this code that a different setting should  be applied.  Thus, this change is acting essentially as a comment showing where and how the functional change should appear.

Before integrating this change, the `package-manifest` will need to be updated again to point at the integrated `dendrite` build that supports the new property.  At the moment the manifest in this PR points at a dev branch.