### PR TITLE
[docs] recommend against running pfexec cargo run

### DIFF
--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -92,7 +92,7 @@ no changes are needed. If you're running elsewhere, you find the value with:
 
 [source,text]
 ----
-$ arp -an | grep $(netstat -rn | grep default | awk '{ print $2; }')
+$ arp -an | grep $(netstat -rn | awk '{ if ($1 == "default") print $2 }')
 igb0   192.168.1.1          255.255.255.255          74:ac:b9:a4:dc:02
 ----
 

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -92,9 +92,7 @@ no changes are needed. If you're running elsewhere, you find the value with:
 
 [source,text]
 ----
-$ netstat -rn | grep default
-default              192.168.1.1          UG       10     431926 igb0
-$ arp -an | grep -w 192.168.1.1
+$ arp -an | grep $(netstat -rn | grep default | awk '{ print $2; }')
 igb0   192.168.1.1          255.255.255.255          74:ac:b9:a4:dc:02
 ----
 
@@ -122,8 +120,16 @@ may be executed:
 
 [source,text]
 ----
-$ pfexec cargo run --release --bin omicron-package -- install
+$ cargo build --release --bin omicron-package
+$ pfexec ./target/release/omicron-package install
 ----
+
+[NOTE]
+====
+**Do not use `pfexec cargo run` directly**; it will cause files in `~/.cargo` and `target/` to be owned by root, which will cause problems down the road.
+
+If you've done this already, and you wish to recover, run from the root of this repository `pfexec chown -R $USER:$(id -ng $USER) target ${CARGO_HOME:-~/.cargo}`.
+====
 
 This service installs a bootstrap service, which itself loads other
 requested services. The bootstrap service is currently the only
@@ -145,7 +151,8 @@ executed:
 
 [source,text]
 ----
-$ pfexec cargo run --release --bin omicron-package -- uninstall
+$ cargo build --release --bin omicron-package
+$ pfexec ./target/release/omicron-package uninstall
 ----
 
 === Test Environment
@@ -295,4 +302,3 @@ the exact addresses that are available depends on the environment.
 6. Optionally, attach to the proxied propolis server serial console (this requires https://github.com/oxidecomputer/cli/commit/adab246142270778db7208126fb03724f5d35858[this commit] or newer of the CLI.)
 
     oxide instance serial --interactive -p myproj -o myorg myinst
-


### PR DESCRIPTION
This can trash file permissions, as it did for me.

Also add instructions about how to recover if your permissions were
trashed.
