### PR TITLE
[wicketd-client] don't depend on omicron-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,7 +7128,6 @@ name = "wicketd-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "omicron-common",
  "progenitor",
  "reqwest",
  "schemars",

--- a/wicketd-client/Cargo.toml
+++ b/wicketd-client/Cargo.toml
@@ -13,9 +13,6 @@ schemars = "0.8"
 version = "0.4"
 features = [ "serde" ]
 
-[dependencies.omicron-common]
-path = "../common"
-
 [dependencies.serde]
 version = "1.0"
 features = [ "derive" ]


### PR DESCRIPTION
omicron-common depends on dropshot, and wicketd-client (e.g.
installinator) doesn't need an HTTP server.
