### PR TITLE
Update lookup fns introduced in the V1 API to return `lookup::*` over `authz::*`

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -15,6 +15,7 @@ use crate::cidata::InstanceCiData;
 use crate::context::OpContext;
 use crate::db;
 use crate::db::identity::Resource;
+use crate::db::lookup;
 use crate::db::lookup::LookupPath;
 use crate::db::queries::network_interface;
 use crate::external_api::params;
@@ -36,6 +37,7 @@ use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::nexus;
+use ref_cast::RefCast;
 use sled_agent_client::types::InstanceRuntimeStateMigrateParams;
 use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
@@ -54,20 +56,17 @@ use uuid::Uuid;
 const MAX_KEYS_PER_INSTANCE: u32 = 8;
 
 impl super::Nexus {
-    pub async fn instance_lookup(
-        &self,
-        opctx: &OpContext,
-        instance_selector: params::InstanceSelector,
-    ) -> LookupResult<authz::Instance> {
+    pub fn instance_lookup<'a>(
+        &'a self,
+        opctx: &'a OpContext,
+        instance_selector: &'a params::InstanceSelector,
+    ) -> LookupResult<lookup::Instance<'a>> {
         match instance_selector {
             params::InstanceSelector { instance: NameOrId::Id(id), .. } => {
                 // TODO: 400 if project or organization are present
-                let (.., authz_instance) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .instance_id(id)
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_instance)
+                let instance =
+                    LookupPath::new(opctx, &self.db_datastore).instance_id(*id);
+                Ok(instance)
             }
             params::InstanceSelector {
                 instance: NameOrId::Name(instance_name),
@@ -75,41 +74,32 @@ impl super::Nexus {
                 ..
             } => {
                 // TODO: 400 if organization is present
-                let (.., authz_instance) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .project_id(project_id)
-                        .instance_name(&Name(instance_name))
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_instance)
+                let instance = LookupPath::new(opctx, &self.db_datastore)
+                    .project_id(*project_id)
+                    .instance_name(Name::ref_cast(instance_name));
+                Ok(instance)
             }
             params::InstanceSelector {
                 instance: NameOrId::Name(instance_name),
                 project: Some(NameOrId::Name(project_name)),
                 organization: Some(NameOrId::Id(organization_id)),
             } => {
-                let (.., authz_instance) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .organization_id(organization_id)
-                        .project_name(&Name(project_name))
-                        .instance_name(&Name(instance_name.clone()))
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_instance)
+                let instance = LookupPath::new(opctx, &self.db_datastore)
+                    .organization_id(*organization_id)
+                    .project_name(Name::ref_cast(project_name))
+                    .instance_name(Name::ref_cast(instance_name));
+                Ok(instance)
             }
             params::InstanceSelector {
                 instance: NameOrId::Name(instance_name),
                 project: Some(NameOrId::Name(project_name)),
                 organization: Some(NameOrId::Name(organization_name)),
             } => {
-                let (.., authz_instance) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .organization_name(&Name(organization_name))
-                        .project_name(&Name(project_name))
-                        .instance_name(&Name(instance_name.clone()))
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_instance)
+                let instance = LookupPath::new(opctx, &self.db_datastore)
+                    .organization_name(Name::ref_cast(organization_name))
+                    .project_name(Name::ref_cast(project_name))
+                    .instance_name(Name::ref_cast(instance_name));
+                Ok(instance)
             }
             // TODO: Add a better error message
             _ => Err(Error::InvalidRequest {
@@ -269,30 +259,19 @@ impl super::Nexus {
             .await
     }
 
-    pub async fn instance_fetch(
-        &self,
-        opctx: &OpContext,
-        authz_instance: &authz::Instance,
-    ) -> LookupResult<db::model::Instance> {
-        let (.., db_instance) = LookupPath::new(opctx, &self.db_datastore)
-            .instance_id(authz_instance.id())
-            .fetch()
-            .await?;
-        Ok(db_instance)
-    }
-
     // This operation may only occur on stopped instances, which implies that
     // the attached disks do not have any running "upstairs" process running
     // within the sled.
     pub async fn project_destroy_instance(
         &self,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
     ) -> DeleteResult {
         // TODO-robustness We need to figure out what to do with Destroyed
         // instances?  Presumably we need to clean them up at some point, but
         // not right away so that callers can see that they've been destroyed.
-        opctx.authorize(authz::Action::Delete, authz_instance).await?;
+        let (.., authz_instance) =
+            instance_lookup.lookup_for(authz::Action::Delete).await?;
 
         self.db_datastore
             .project_delete_instance(opctx, &authz_instance)
@@ -310,10 +289,11 @@ impl super::Nexus {
     pub async fn project_instance_migrate(
         self: &Arc<Self>,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
         params: params::InstanceMigrate,
     ) -> UpdateResult<db::model::Instance> {
-        opctx.authorize(authz::Action::Modify, authz_instance).await?;
+        let (.., authz_instance) =
+            instance_lookup.lookup_for(authz::Action::Modify).await?;
 
         // Kick off the migration saga
         let saga_params = sagas::instance_migrate::Params {
@@ -367,7 +347,7 @@ impl super::Nexus {
     pub async fn instance_reboot(
         &self,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
     ) -> UpdateResult<db::model::Instance> {
         // To implement reboot, we issue a call to the sled agent to set a
         // runtime state of "reboot". We cannot simply stop the Instance and
@@ -380,11 +360,7 @@ impl super::Nexus {
         // even if the whole rack powered off while this was going on, we would
         // never lose track of the fact that this Instance was supposed to be
         // running.
-        let (.., authz_instance, db_instance) =
-            LookupPath::new(opctx, &self.db_datastore)
-                .instance_id(authz_instance.id())
-                .fetch()
-                .await?;
+        let (.., authz_instance, db_instance) = instance_lookup.fetch().await?;
         let requested = InstanceRuntimeStateRequested {
             run_state: InstanceStateRequested::Reboot,
             migration_params: None,
@@ -403,13 +379,9 @@ impl super::Nexus {
     pub async fn instance_start(
         &self,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
     ) -> UpdateResult<db::model::Instance> {
-        let (.., authz_instance, db_instance) =
-            LookupPath::new(opctx, &self.db_datastore)
-                .instance_id(authz_instance.id())
-                .fetch()
-                .await?;
+        let (.., authz_instance, db_instance) = instance_lookup.fetch().await?;
         let requested = InstanceRuntimeStateRequested {
             run_state: InstanceStateRequested::Running,
             migration_params: None,
@@ -428,13 +400,9 @@ impl super::Nexus {
     pub async fn instance_stop(
         &self,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
     ) -> UpdateResult<db::model::Instance> {
-        let (.., authz_instance, db_instance) =
-            LookupPath::new(opctx, &self.db_datastore)
-                .instance_id(authz_instance.id())
-                .fetch()
-                .await?;
+        let (.., authz_instance, db_instance) = instance_lookup.fetch().await?;
         let requested = InstanceRuntimeStateRequested {
             run_state: InstanceStateRequested::Stopped,
             migration_params: None,
@@ -1126,11 +1094,10 @@ impl super::Nexus {
     /// provided they are still in the sled-agent's cache.
     pub(crate) async fn instance_serial_console_data(
         &self,
-        opctx: &OpContext,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
         params: &params::InstanceSerialConsoleRequest,
     ) -> Result<params::InstanceSerialConsoleData, Error> {
-        let db_instance = self.instance_fetch(opctx, authz_instance).await?;
+        let (.., db_instance) = instance_lookup.fetch().await?;
 
         let sa = self.instance_sled(&db_instance).await?;
         let data = sa
@@ -1152,11 +1119,11 @@ impl super::Nexus {
 
     pub(crate) async fn instance_serial_console_stream(
         &self,
-        opctx: &OpContext,
         conn: dropshot::WebsocketConnection,
-        authz_instance: &authz::Instance,
+        instance_lookup: &lookup::Instance<'_>,
     ) -> Result<(), Error> {
-        let instance = self.instance_fetch(opctx, authz_instance).await?;
+        // TODO: Technically the stream is two way so the user of this method can modify the instance in some way. Should we use different permissions?
+        let (.., instance) = instance_lookup.fetch().await?;
         let ip_addr = instance
             .runtime_state
             .propolis_ip

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -118,10 +118,11 @@ impl super::Nexus {
     pub async fn project_create_instance(
         self: &Arc<Self>,
         opctx: &OpContext,
-        authz_project: &authz::Project,
+        project_lookup: &lookup::Project<'_>,
         params: &params::InstanceCreate,
     ) -> CreateResult<db::model::Instance> {
-        opctx.authorize(authz::Action::CreateChild, authz_project).await?;
+        let (.., authz_project) =
+            project_lookup.lookup_for(authz::Action::CreateChild).await?;
 
         // Validate parameters
         if params.disks.len() > MAX_DISKS_PER_INSTANCE as usize {
@@ -250,10 +251,11 @@ impl super::Nexus {
     pub async fn project_list_instances(
         &self,
         opctx: &OpContext,
-        authz_project: &authz::Project,
+        project_lookup: &lookup::Project<'_>,
         pagparams: &DataPageParams<'_, Name>,
     ) -> ListResultVec<db::model::Instance> {
-        opctx.authorize(authz::Action::ListChildren, authz_project).await?;
+        let (.., authz_project) =
+            project_lookup.lookup_for(authz::Action::ListChildren).await?;
         self.db_datastore
             .project_list_instances(opctx, &authz_project, pagparams)
             .await

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -7,6 +7,7 @@
 use crate::authz;
 use crate::context::OpContext;
 use crate::db;
+use crate::db::lookup;
 use crate::db::lookup::LookupPath;
 use crate::db::model::Name;
 use crate::external_api::params;
@@ -22,47 +23,39 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
+use ref_cast::RefCast;
 use uuid::Uuid;
 
 impl super::Nexus {
-    pub async fn project_lookup(
-        &self,
-        opctx: &OpContext,
-        project_selector: params::ProjectSelector,
-    ) -> LookupResult<authz::Project> {
+    pub fn project_lookup<'a>(
+        &'a self,
+        opctx: &'a OpContext,
+        project_selector: &'a params::ProjectSelector,
+    ) -> LookupResult<lookup::Project<'a>> {
         match project_selector {
             params::ProjectSelector { project: NameOrId::Id(id), .. } => {
                 // TODO: 400 if organization is present
-                let (.., authz_project) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .project_id(id)
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_project)
+                let project =
+                    LookupPath::new(opctx, &self.db_datastore).project_id(*id);
+                Ok(project)
             }
             params::ProjectSelector {
                 project: NameOrId::Name(project_name),
                 organization: Some(NameOrId::Id(organization_id)),
             } => {
-                let (.., authz_project) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .organization_id(organization_id)
-                        .project_name(&Name(project_name))
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_project)
+                let project = LookupPath::new(opctx, &self.db_datastore)
+                    .organization_id(*organization_id)
+                    .project_name(Name::ref_cast(project_name));
+                Ok(project)
             }
             params::ProjectSelector {
                 project: NameOrId::Name(project_name),
                 organization: Some(NameOrId::Name(organization_name)),
             } => {
-                let (.., authz_project) =
-                    LookupPath::new(opctx, &self.db_datastore)
-                        .organization_name(&Name(organization_name))
-                        .project_name(&Name(project_name))
-                        .lookup_for(authz::Action::Read)
-                        .await?;
-                Ok(authz_project)
+                let project = LookupPath::new(opctx, &self.db_datastore)
+                    .organization_name(Name::ref_cast(organization_name))
+                    .project_name(Name::ref_cast(project_name));
+                Ok(project)
             }
             _ => Err(Error::InvalidRequest {
                 message: "


### PR DESCRIPTION
This PR is mostly in response to @davepacheco's feedback on #1957. Special thanks to @smklein for helping work through some rust lifetime issues here. 

Previously the `instance_lookup` and `project_lookup` functions returned a `authz::Instance` or `authz::Project` respectively that was authorized with read permissions. The challenge here is that this meant that in several places we required duplicate lookups to be able to resolve the instance with the right permissions. To avoid that we're passing around the lookup step itself instead. 