### PR TITLE
MGS: Import `Communicator` and supporting code from mgs repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,12 +2007,11 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2e0b41543425ef374ee08c313dcc25b07b98a05e#2e0b41543425ef374ee08c313dcc25b07b98a05e"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1a27a661d7824712aeb4d1b9801938888139eaa7#1a27a661d7824712aeb4d1b9801938888139eaa7"
 dependencies = [
  "bitflags",
  "hubpack",
  "serde",
- "serde-big-array 0.4.1",
  "serde_repr",
  "smoltcp",
  "static_assertions",
@@ -2023,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2e0b41543425ef374ee08c313dcc25b07b98a05e#2e0b41543425ef374ee08c313dcc25b07b98a05e"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1a27a661d7824712aeb4d1b9801938888139eaa7#1a27a661d7824712aeb4d1b9801938888139eaa7"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2032,12 +2031,10 @@ dependencies = [
  "nix",
  "once_cell",
  "serde",
- "serde_with",
  "slog",
  "thiserror",
  "tlvc",
  "tokio",
- "tokio-stream",
  "usdt",
  "uuid",
  "zip",
@@ -2356,7 +2353,7 @@ dependencies = [
 [[package]]
 name = "hubpack"
 version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
+source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
  "hubpack_derive",
  "serde",
@@ -2365,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "hubpack_derive"
 version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack.git?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
+source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3390,17 +3387,20 @@ dependencies = [
  "hyper",
  "omicron-common",
  "omicron-test-utils",
+ "once_cell",
  "openapi-lint",
  "openapiv3",
  "schemars",
  "serde",
  "serde_json",
+ "serde_with",
  "slog",
  "slog-dtrace",
  "sp-sim",
  "subprocess",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "toml",
  "uuid",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -12,10 +12,13 @@ futures = "0.3.25"
 hex = "0.4"
 http = "0.2.7"
 hyper = "0.14.23"
+once_cell = "1.16.0"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "2.1.0"
 slog-dtrace = "0.2"
 thiserror = "1.0.37"
+tokio-stream = "0.1.11"
 tokio-tungstenite = "0.18"
 toml = "0.5.9"
 uuid = "1.2.2"
@@ -24,13 +27,13 @@ omicron-common = { path = "../common" }
 
 [dependencies.gateway-messages]
 git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "2e0b41543425ef374ee08c313dcc25b07b98a05e"
+rev = "1a27a661d7824712aeb4d1b9801938888139eaa7"
 default-features = false
 features = ["std"]
 
 [dependencies.gateway-sp-comms]
 git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "2e0b41543425ef374ee08c313dcc25b07b98a05e"
+rev = "1a27a661d7824712aeb4d1b9801938888139eaa7"
 
 [dependencies.slog]
 version = "2.7"

--- a/gateway/src/communicator.rs
+++ b/gateway/src/communicator.rs
@@ -1,0 +1,370 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use crate::error::ConfigError;
+use crate::error::SpCommsError;
+use crate::management_switch::ManagementSwitch;
+use crate::management_switch::SpIdentifier;
+use crate::management_switch::SwitchConfig;
+use crate::management_switch::SwitchPort;
+use crate::timeout::Elapsed;
+use crate::timeout::Timeout;
+use futures::stream::FuturesUnordered;
+use futures::Future;
+use futures::Stream;
+use gateway_messages::IgnitionCommand;
+use gateway_messages::IgnitionState;
+use gateway_messages::PowerState;
+use gateway_messages::SpComponent;
+use gateway_messages::SpState;
+use gateway_messages::UpdateStatus;
+use gateway_sp_comms::AttachedSerialConsole;
+use gateway_sp_comms::HostPhase2Provider;
+use gateway_sp_comms::SpInventory;
+use slog::info;
+use slog::o;
+use slog::warn;
+use slog::Logger;
+use uuid::Uuid;
+
+/// Helper trait that allows us to return an `impl FuturesUnordered<_>` where
+/// the caller can call `.is_empty()` without knowing the type of the future
+/// inside the collection.
+pub trait FuturesUnorderedImpl: Stream + Unpin {
+    fn is_empty(&self) -> bool;
+}
+
+impl<Fut> FuturesUnorderedImpl for FuturesUnordered<Fut>
+where
+    Fut: Future,
+{
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+#[derive(Debug)]
+pub struct Communicator {
+    switch: ManagementSwitch,
+    log: Logger,
+}
+
+impl Communicator {
+    pub async fn new<T: HostPhase2Provider + Clone>(
+        config: SwitchConfig,
+        host_phase2_provider: T,
+        log: &Logger,
+    ) -> Result<Self, ConfigError> {
+        let log = log.new(o!("component" => "SpCommunicator"));
+        let switch =
+            ManagementSwitch::new(config, host_phase2_provider, &log).await?;
+
+        info!(&log, "started SP communicator");
+        Ok(Self { switch, log })
+    }
+
+    /// Have we completed the discovery process to know how to map logical SP
+    /// positions to switch ports?
+    pub fn is_discovery_complete(&self) -> bool {
+        self.switch.is_discovery_complete()
+    }
+
+    /// Get the name of our location.
+    ///
+    /// This matches one of the names specified as a possible location in the
+    /// configuration we were given.
+    pub fn location_name(&self) -> Result<&str, SpCommsError> {
+        self.switch.location_name()
+    }
+
+    fn id_to_port(&self, sp: SpIdentifier) -> Result<SwitchPort, SpCommsError> {
+        self.switch.switch_port(sp)?.ok_or(SpCommsError::SpDoesNotExist(sp))
+    }
+
+    fn port_to_id(
+        &self,
+        port: SwitchPort,
+    ) -> Result<SpIdentifier, SpCommsError> {
+        self.switch.switch_port_to_id(port)
+    }
+
+    /// Returns true if we've discovered the IP address of our local ignition
+    /// controller.
+    ///
+    /// This method exists to be polled during test setup (to wait for discovery
+    /// to happen); it should not be called outside tests.
+    pub fn local_ignition_controller_address_known(&self) -> bool {
+        self.switch.ignition_controller().is_some()
+    }
+
+    /// Returns true if we've discovered the IP address of the specified SP.
+    ///
+    /// This method exists to be polled during test setup (to wait for discovery
+    /// to happen); it should not be called outside tests. In particular, it
+    /// panics instead of running an error if `sp` describes an SP that isn't
+    /// known to this communicator or if discovery isn't complete yet.
+    pub fn address_known(&self, sp: SpIdentifier) -> bool {
+        let port = self.switch.switch_port(sp).unwrap().unwrap();
+        self.switch.sp(port).is_some()
+    }
+
+    /// Ask the local ignition controller for the ignition state of a given SP.
+    pub async fn get_ignition_state(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<IgnitionState, SpCommsError> {
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(SpCommsError::LocalIgnitionControllerAddressUnknown)?;
+        let port = self.id_to_port(sp)?;
+        Ok(controller.ignition_state(port.as_ignition_target()).await?)
+    }
+
+    /// Ask the local ignition controller for the ignition state of all SPs.
+    ///
+    /// TODO: This _does not_ return the ignition state for our local ignition
+    /// controller! If this function returns at all, it's on. Is that good
+    /// enough? Should we try to query the other sidecar?
+    pub async fn get_ignition_state_all(
+        &self,
+    ) -> Result<Vec<(SpIdentifier, IgnitionState)>, SpCommsError> {
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(SpCommsError::LocalIgnitionControllerAddressUnknown)?;
+        let bulk_state = controller.bulk_ignition_state().await?;
+
+        // map ignition target indices back to `SpIdentifier`s for our caller
+        bulk_state
+            .into_iter()
+            .enumerate()
+            .filter_map(|(target, state)| {
+                // If the SP returns an ignition target we don't have a port
+                // for, discard it. This _shouldn't_ happen, but may if:
+                //
+                // 1. We're getting bogus messages from the SP.
+                // 2. We're misconfigured and don't know about all ports.
+                //
+                // Case 2 may happen intentionally during development and
+                // testing.
+                match self.switch.switch_port_from_ignition_target(target) {
+                    Some(port) =>
+                        Some(self.port_to_id(port).map(|id| (id, state))),
+                    None => {
+                        warn!(self.log, "ignoring unknown ignition target {target} returned by SP");
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+
+    /// Instruct the local ignition controller to perform the given `command` on
+    /// `target_sp`.
+    pub async fn send_ignition_command(
+        &self,
+        target_sp: SpIdentifier,
+        command: IgnitionCommand,
+    ) -> Result<(), SpCommsError> {
+        let controller = self
+            .switch
+            .ignition_controller()
+            .ok_or(SpCommsError::LocalIgnitionControllerAddressUnknown)?;
+        let target = self.id_to_port(target_sp)?.as_ignition_target();
+        Ok(controller.ignition_command(target, command).await?)
+    }
+
+    /// Attach to the serial console of `sp`.
+    // TODO-cleanup: This currently does not actually contact the target SP; it
+    // sets up the websocket connection in the current process which knows how
+    // to relay any information sent or received on that connection to the SP
+    // via UDP. SPs will continuously broadcast any serial console data, even if
+    // there is no attached client. Maybe this is fine, since the serial console
+    // shouldn't be noisy without a corresponding client driving it?
+    //
+    // TODO Because this method doesn't contact the target SP, it succeeds even
+    // if we don't know the IP address of that SP (yet, or possibly ever)! The
+    // connection will start working if we later discover the address, but this
+    // is probably not the behavior we want.
+    pub async fn serial_console_attach(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+    ) -> Result<AttachedSerialConsole, SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.serial_console_attach(component).await?)
+    }
+
+    /// Detach any existing connection to the given SP component's serial
+    /// console.
+    pub async fn serial_console_detach(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<(), SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        sp.serial_console_detach().await?;
+        Ok(())
+    }
+
+    /// Get the state of a given SP.
+    pub async fn get_state(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<SpState, SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.state().await?)
+    }
+
+    /// Get the inventory of a given SP.
+    pub async fn inventory(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<SpInventory, SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.inventory().await?)
+    }
+
+    /// Start sending an update payload to the given SP.
+    ///
+    /// This function will return before the update is complete! Once the SP
+    /// acknowledges that we want to apply an update, we spawn a background task
+    /// to stream the update to the SP and then return. Poll the status of the
+    /// update via [`Self::update_status()`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `image.is_empty()`.
+    pub async fn start_update(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+        update_id: Uuid,
+        slot: u16,
+        image: Vec<u8>,
+    ) -> Result<(), SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.start_update(component, update_id, slot, image).await?)
+    }
+
+    /// Get the status of an in-progress update.
+    pub async fn update_status(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+    ) -> Result<UpdateStatus, SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.update_status(component).await?)
+    }
+
+    /// Abort an in-progress update.
+    pub async fn update_abort(
+        &self,
+        sp: SpIdentifier,
+        component: SpComponent,
+        update_id: Uuid,
+    ) -> Result<(), SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.update_abort(component, update_id).await?)
+    }
+
+    /// Get the current (SP-controlled) power state.
+    pub async fn power_state(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<PowerState, SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.power_state().await?)
+    }
+
+    /// Set the current (SP-controlled) power state.
+    pub async fn set_power_state(
+        &self,
+        sp: SpIdentifier,
+        power_state: PowerState,
+    ) -> Result<(), SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        Ok(sp.set_power_state(power_state).await?)
+    }
+
+    /// Reset a given SP.
+    pub async fn reset(&self, sp: SpIdentifier) -> Result<(), SpCommsError> {
+        let port = self.id_to_port(sp)?;
+        let sp =
+            self.switch.sp(port).ok_or(SpCommsError::SpAddressUnknown(sp))?;
+        sp.reset_prepare().await?;
+        sp.reset_trigger().await?;
+        Ok(())
+    }
+
+    /// Query all online SPs.
+    ///
+    /// `ignition_state` should be the state returned by a (recent) call to
+    /// [`crate::communicator::Communicator::get_ignition_state_all()`].
+    ///
+    /// All SPs included in `ignition_state` will be yielded by the returned
+    /// stream. The order in which they are yielded is undefined; the offline
+    /// SPs are likely to be first, but even that is not guaranteed. The item
+    /// yielded by offline SPs will be `None`; the item yielded by online SPs
+    /// will be `Some(Ok(_))` if the future returned by `f` for that item
+    /// completed before `timeout` or `Some(Err(_))` if not.
+    ///
+    /// Note that the timeout is be applied to each _element_ of the returned
+    /// stream rather than the stream as a whole, allowing easy access to which
+    /// SPs timed out based on the yielded value associated with those SPs.
+    ///
+    /// TODO: See note above about bulk_ignition_state where our local ignition
+    /// controller is _not_ included in the returned list, and will therefore
+    /// not be queried by this function. Should we explicitly query our local
+    /// ignition controller? If so, can we remove the ignition state from the
+    /// returned futures?
+    pub fn query_all_online_sps<F, T, Fut>(
+        &self,
+        ignition_state: &[(SpIdentifier, IgnitionState)],
+        timeout: Timeout,
+        f: F,
+    ) -> impl FuturesUnorderedImpl<
+        Item = (SpIdentifier, IgnitionState, Option<Result<T, Elapsed>>),
+    >
+    where
+        F: FnMut(SpIdentifier) -> Fut + Clone,
+        Fut: Future<Output = T>,
+    {
+        ignition_state
+            .iter()
+            .copied()
+            .map(move |(id, state)| {
+                let mut f = f.clone();
+                async move {
+                    let val = if state.target.is_some() {
+                        Some(timeout.timeout_at(f(id)).await)
+                    } else {
+                        None
+                    };
+                    (id, state, val)
+                }
+            })
+            .collect::<FuturesUnordered<_>>()
+    }
+}

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -5,8 +5,8 @@
 //! Interfaces for parsing configuration files and working with a gateway server
 //! configuration
 
+use crate::management_switch::SwitchConfig;
 use dropshot::ConfigLogging;
-use gateway_sp_comms::SwitchConfig;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::path::PathBuf;

--- a/gateway/src/context.rs
+++ b/gateway/src/context.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use gateway_sp_comms::error::ConfigError;
-use gateway_sp_comms::Communicator;
-use gateway_sp_comms::SwitchConfig;
+use crate::communicator::Communicator;
+use crate::error::ConfigError;
+use crate::management_switch::SwitchConfig;
 use slog::Logger;
 use std::{sync::Arc, time::Duration};
 

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -4,13 +4,46 @@
 
 //! Error handling facilities for the management gateway.
 
-use std::borrow::Borrow;
-
+use crate::management_switch::SpIdentifier;
 use dropshot::HttpError;
 use gateway_messages::SpError;
-use gateway_sp_comms::error::Error as SpCommsError;
-use gateway_sp_comms::error::SpCommunicationError;
+use gateway_sp_comms::error::CommunicationError;
 use gateway_sp_comms::error::UpdateError;
+use std::borrow::Borrow;
+use std::time::Duration;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("invalid configuration file: {}", .reasons.join(", "))]
+    InvalidConfig { reasons: Vec<String> },
+}
+
+#[derive(Debug, Error)]
+pub enum SpCommsError {
+    #[error("discovery process not yet complete")]
+    DiscoveryNotYetComplete,
+    #[error("location discovery failed: {reason}")]
+    DiscoveryFailed { reason: String },
+    #[error("nonexistent SP (type {:?}, slot {})", .0.typ, .0.slot)]
+    SpDoesNotExist(SpIdentifier),
+    #[error("unknown socket address for local ignition controller")]
+    LocalIgnitionControllerAddressUnknown,
+    #[error(
+        "unknown socket address for SP (type {:?}, slot {})",
+        .0.typ,
+        .0.slot,
+    )]
+    SpAddressUnknown(SpIdentifier),
+    #[error(
+        "timeout ({timeout:?}) elapsed communicating with {sp:?} on port {port}"
+    )]
+    Timeout { timeout: Duration, port: usize, sp: Option<SpIdentifier> },
+    #[error("error communicating with SP: {0}")]
+    SpCommunicationFailed(#[from] CommunicationError),
+    #[error("updating SP failed: {0}")]
+    UpdateFailed(#[from] UpdateError),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -42,25 +75,25 @@ where
             Some("InvalidSp".to_string()),
             err.to_string(),
         ),
-        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+        SpCommsError::SpCommunicationFailed(CommunicationError::SpError(
             SpError::SerialConsoleAlreadyAttached,
         )) => HttpError::for_bad_request(
             Some("SerialConsoleAttached".to_string()),
             err.to_string(),
         ),
-        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+        SpCommsError::SpCommunicationFailed(CommunicationError::SpError(
             SpError::RequestUnsupportedForSp,
         )) => HttpError::for_bad_request(
             Some("RequestUnsupportedForSp".to_string()),
             err.to_string(),
         ),
-        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+        SpCommsError::SpCommunicationFailed(CommunicationError::SpError(
             SpError::RequestUnsupportedForComponent,
         )) => HttpError::for_bad_request(
             Some("RequestUnsupportedForComponent".to_string()),
             err.to_string(),
         ),
-        SpCommsError::SpCommunicationFailed(SpCommunicationError::SpError(
+        SpCommsError::SpCommunicationFailed(CommunicationError::SpError(
             SpError::InvalidSlotForComponent,
         )) => HttpError::for_bad_request(
             Some("InvalidSlotForComponent".to_string()),
@@ -73,13 +106,13 @@ where
             )
         }
         SpCommsError::UpdateFailed(UpdateError::Communication(
-            SpCommunicationError::SpError(SpError::UpdateSlotBusy),
+            CommunicationError::SpError(SpError::UpdateSlotBusy),
         )) => HttpError::for_unavail(
             Some("UpdateSlotBusy".to_string()),
             err.to_string(),
         ),
         SpCommsError::UpdateFailed(UpdateError::Communication(
-            SpCommunicationError::SpError(SpError::UpdateInProgress { .. }),
+            CommunicationError::SpError(SpError::UpdateInProgress { .. }),
         )) => HttpError::for_unavail(
             Some("UpdateInProgress".to_string()),
             err.to_string(),

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -10,6 +10,8 @@ mod conversions;
 
 use self::conversions::component_from_str;
 use crate::error::http_err_from_comms_err;
+use crate::error::SpCommsError;
+use crate::timeout::Timeout as SpTimeout;
 use crate::ServerContext;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -23,8 +25,6 @@ use dropshot::TypedBody;
 use futures::StreamExt;
 use gateway_messages::ignition;
 use gateway_messages::IgnitionCommand;
-use gateway_sp_comms::error::Error as SpCommsError;
-use gateway_sp_comms::Timeout as SpTimeout;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::warn;

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -130,7 +130,7 @@ impl From<gateway_messages::ignition::SystemType> for SpIgnitionSystemType {
     }
 }
 
-impl From<SpType> for gateway_sp_comms::SpType {
+impl From<SpType> for crate::management_switch::SpType {
     fn from(typ: SpType) -> Self {
         match typ {
             SpType::Sled => Self::Sled,
@@ -140,17 +140,17 @@ impl From<SpType> for gateway_sp_comms::SpType {
     }
 }
 
-impl From<gateway_sp_comms::SpType> for SpType {
-    fn from(typ: gateway_sp_comms::SpType) -> Self {
+impl From<crate::management_switch::SpType> for SpType {
+    fn from(typ: crate::management_switch::SpType) -> Self {
         match typ {
-            gateway_sp_comms::SpType::Sled => Self::Sled,
-            gateway_sp_comms::SpType::Power => Self::Power,
-            gateway_sp_comms::SpType::Switch => Self::Switch,
+            crate::management_switch::SpType::Sled => Self::Sled,
+            crate::management_switch::SpType::Power => Self::Power,
+            crate::management_switch::SpType::Switch => Self::Switch,
         }
     }
 }
 
-impl From<SpIdentifier> for gateway_sp_comms::SpIdentifier {
+impl From<SpIdentifier> for crate::management_switch::SpIdentifier {
     fn from(id: SpIdentifier) -> Self {
         Self {
             typ: id.typ.into(),
@@ -161,12 +161,12 @@ impl From<SpIdentifier> for gateway_sp_comms::SpIdentifier {
     }
 }
 
-impl From<gateway_sp_comms::SpIdentifier> for SpIdentifier {
-    fn from(id: gateway_sp_comms::SpIdentifier) -> Self {
+impl From<crate::management_switch::SpIdentifier> for SpIdentifier {
+    fn from(id: crate::management_switch::SpIdentifier) -> Self {
         Self {
             typ: id.typ.into(),
-            // id.slot comes from a trusted source (gateway_sp_comms) and will
-            // not exceed u32::MAX
+            // id.slot comes from a trusted source (crate::management_switch)
+            // and will not exceed u32::MAX
             slot: u32::try_from(id.slot).unwrap(),
         }
     }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -2,15 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod communicator;
 mod config;
 mod context;
 mod error;
+mod management_switch;
 mod serial_console;
+mod timeout;
 
 pub mod http_entrypoints; // TODO pub only for testing - is this right?
 
 pub use config::Config;
 pub use context::ServerContext;
+pub use management_switch::SpType;
 
 use dropshot::ConfigDropshot;
 use slog::debug;

--- a/gateway/src/management_switch.rs
+++ b/gateway/src/management_switch.rs
@@ -1,0 +1,242 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//!
+//! Long-running task responsible for tracking the topology of the SPs connected
+//! to the management network switch ports.
+//!
+//! See RFD 250 for details.
+//!
+
+mod location_map;
+
+pub use self::location_map::LocationConfig;
+pub use self::location_map::LocationDeterminationConfig;
+use self::location_map::LocationMap;
+pub use self::location_map::SwitchPortDescription;
+use self::location_map::ValidatedLocationConfig;
+
+use crate::error::ConfigError;
+use crate::error::SpCommsError;
+use gateway_sp_comms::HostPhase2Provider;
+use gateway_sp_comms::SingleSp;
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
+use slog::o;
+use slog::Logger;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SwitchConfig {
+    pub local_ignition_controller_port: usize,
+    pub rpc_max_attempts: usize,
+    pub rpc_per_attempt_timeout_millis: u64,
+    pub location: LocationConfig,
+    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+    pub port: HashMap<usize, SwitchPortDescription>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct SpIdentifier {
+    pub typ: SpType,
+    pub slot: usize,
+}
+
+impl SpIdentifier {
+    pub fn new(typ: SpType, slot: usize) -> Self {
+        Self { typ, slot }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SpType {
+    Switch,
+    Sled,
+    Power,
+}
+
+// We derive `Serialize` to be able to send `SwitchPort`s to usdt probes, but
+// critically we do _not_ implement `Deserialize` - the only way to construct a
+// `SwitchPort` should be to receive one from a `ManagementSwitch`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize,
+)]
+pub(crate) struct SwitchPort(usize);
+
+impl SwitchPort {
+    pub(crate) fn as_ignition_target(self) -> u8 {
+        // TODO should we use a u16 to describe ignition targets instead? rack
+        // v1 is limited to 36, unclear what ignition will look like in future
+        // products
+        assert!(
+            self.0 <= usize::from(u8::MAX),
+            "cannot exceed 255 ignition targets / switch ports"
+        );
+        self.0 as u8
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ManagementSwitch {
+    local_ignition_controller_port: SwitchPort,
+    sockets: Arc<HashMap<SwitchPort, SingleSp>>,
+    location_map: Arc<OnceCell<Result<LocationMap, String>>>,
+    discovery_task: JoinHandle<()>,
+}
+
+impl Drop for ManagementSwitch {
+    fn drop(&mut self) {
+        // We should only be dropped in tests, in general, but dont' leave a
+        // stray spawned task running (if it still is).
+        self.discovery_task.abort();
+    }
+}
+
+impl ManagementSwitch {
+    pub(crate) async fn new<T: HostPhase2Provider + Clone>(
+        config: SwitchConfig,
+        host_phase2_provider: T,
+        log: &Logger,
+    ) -> Result<Self, ConfigError> {
+        // begin by binding to all our configured ports; insert them into a map
+        // keyed by the switch port they're listening on
+        let mut sockets = HashMap::with_capacity(config.port.len());
+        // while we're at it, rekey `config.port` to use `SwitchPort` keys
+        // instead of `usize`.
+        let mut ports = HashMap::with_capacity(config.port.len());
+        for (port, port_config) in config.port {
+            let single_sp = SingleSp::new(
+                port_config.config.clone(),
+                config.rpc_max_attempts,
+                Duration::from_millis(config.rpc_per_attempt_timeout_millis),
+                host_phase2_provider.clone(),
+                log.new(o!("switch_port" => port)),
+            );
+            let port = SwitchPort(port);
+
+            sockets.insert(port, single_sp);
+            ports.insert(port, port_config);
+        }
+
+        // sanity check the local ignition controller port is bound
+        let local_ignition_controller_port =
+            SwitchPort(config.local_ignition_controller_port);
+        if !ports.contains_key(&local_ignition_controller_port) {
+            return Err(ConfigError::InvalidConfig {
+                reasons: vec![format!(
+                    "missing local ignition controller port {}",
+                    local_ignition_controller_port.0
+                )],
+            });
+        }
+
+        // Start running discovery to figure out the physical location of
+        // ourselves (and therefore all SPs we talk to). We don't block waiting
+        // for this, but we won't be able to service requests until it
+        // completes (because we won't be able to map "the SP of sled 7" to a
+        // correct switch port).
+        let sockets = Arc::new(sockets);
+        let location_map = Arc::new(OnceCell::new());
+        let discovery_task = {
+            let log = log.clone();
+            let sockets = Arc::clone(&sockets);
+            let location_map = Arc::clone(&location_map);
+            let config =
+                ValidatedLocationConfig::try_from((&ports, config.location))?;
+
+            tokio::spawn(async move {
+                let result = LocationMap::run_discovery(
+                    config,
+                    ports,
+                    Arc::clone(&sockets),
+                    &log,
+                )
+                .await;
+
+                // We are the only setter of the `location_map` once cell; all
+                // other access in this file are `get()`s, so we can unwrap.
+                location_map.set(result).unwrap();
+            })
+        };
+
+        Ok(Self {
+            local_ignition_controller_port,
+            location_map,
+            sockets,
+            discovery_task,
+        })
+    }
+
+    /// Have we completed the discovery process to know how to map logical SP
+    /// positions to switch ports?
+    pub(super) fn is_discovery_complete(&self) -> bool {
+        self.location_map.get().is_some()
+    }
+
+    fn location_map(&self) -> Result<&LocationMap, SpCommsError> {
+        let discovery_result = self
+            .location_map
+            .get()
+            .ok_or(SpCommsError::DiscoveryNotYetComplete)?;
+        discovery_result
+            .as_ref()
+            .map_err(|s| SpCommsError::DiscoveryFailed { reason: s.clone() })
+    }
+
+    /// Get the name of our location.
+    ///
+    /// This matches one of the names specified as a possible location in the
+    /// configuration we were given.
+    pub(super) fn location_name(&self) -> Result<&str, SpCommsError> {
+        self.location_map().map(|m| m.location_name())
+    }
+
+    /// Get the socket to use to communicate with an SP and the socket address
+    /// of that SP.
+    pub(crate) fn sp(&self, port: SwitchPort) -> Option<&SingleSp> {
+        self.sockets.get(&port)
+    }
+
+    /// Get the socket connected to the local ignition controller.
+    pub(crate) fn ignition_controller(&self) -> Option<&SingleSp> {
+        self.sp(self.local_ignition_controller_port)
+    }
+
+    pub(crate) fn switch_port_from_ignition_target(
+        &self,
+        target: usize,
+    ) -> Option<SwitchPort> {
+        let port = SwitchPort(target);
+        if self.sockets.contains_key(&port) {
+            Some(port)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn switch_port(
+        &self,
+        id: SpIdentifier,
+    ) -> Result<Option<SwitchPort>, SpCommsError> {
+        self.location_map().map(|m| m.id_to_port(id))
+    }
+
+    pub(crate) fn switch_port_to_id(
+        &self,
+        port: SwitchPort,
+    ) -> Result<SpIdentifier, SpCommsError> {
+        self.location_map().map(|m| m.port_to_id(port))
+    }
+}

--- a/gateway/src/management_switch/location_map.rs
+++ b/gateway/src/management_switch/location_map.rs
@@ -1,0 +1,662 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use super::SpIdentifier;
+use super::SwitchPort;
+use crate::error::ConfigError;
+use futures::stream::FuturesUnordered;
+use futures::Stream;
+use futures::StreamExt;
+use gateway_messages::SpPort;
+use gateway_sp_comms::SingleSp;
+use gateway_sp_comms::SwitchPortConfig;
+use serde::Deserialize;
+use serde::Serialize;
+use slog::debug;
+use slog::info;
+use slog::warn;
+use slog::Logger;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::convert::TryFrom;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Description of the network interface for a single switch port.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SwitchPortDescription {
+    #[serde(flatten)]
+    pub config: SwitchPortConfig,
+
+    /// Map defining the logical identifier of the SP connected to this port for
+    /// each of the possible locations where MGS is running (see
+    /// [`LocationConfig::names`]).
+    pub location: HashMap<String, SpIdentifier>,
+}
+
+/// Configure the topology of the rack where MGS is running, and describe how we
+/// can determine our own location.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct LocationConfig {
+    /// List of human-readable location names; the actual strings don't matter,
+    /// but they're used in log messages and to sync with the refined locations
+    /// contained in `determination`. For "rack v1" see RFD 250 § 7.2.
+    pub names: Vec<String>,
+
+    /// A list of switch ports that can be used to determine which location (of
+    /// those listed in `names`) we are.
+    pub determination: Vec<LocationDeterminationConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct LocationDeterminationConfig {
+    /// Which port to contact.
+    pub switch_port: usize,
+
+    /// If the SP on `switch_port` communicates with us on its port 1, we must
+    /// be one of this set of locations (which should be a subset of our parent
+    /// [`LocationConfig`]'s `names).
+    pub sp_port_1: Vec<String>,
+
+    /// If the SP on `switch_port` communicates with us on its port 2, we must
+    /// be one of this set of locations (which should be a subset of our parent
+    /// [`LocationConfig`]'s `names).
+    pub sp_port_2: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(super) struct LocationMap {
+    location_name: String,
+    port_to_id: HashMap<SwitchPort, SpIdentifier>,
+    id_to_port: HashMap<SpIdentifier, SwitchPort>,
+}
+
+impl LocationMap {
+    pub(super) async fn run_discovery(
+        config: ValidatedLocationConfig,
+        ports: HashMap<SwitchPort, SwitchPortDescription>,
+        sockets: Arc<HashMap<SwitchPort, SingleSp>>,
+        log: &Logger,
+    ) -> Result<Self, String> {
+        // Spawn a task that will send discovery packets on every switch port
+        // until it hears back from all SPs with exponential backoff to avoid
+        // slamming the network; we expect some ports to never resolve (e.g., if
+        // the cubby at the other end is not populated and therefore there is no
+        // SP to respond).
+        let location_determination = config.determination;
+        let (refined_locations_tx, refined_locations) = mpsc::channel(8);
+        {
+            let log = log.clone();
+            let ports = ports.clone();
+            tokio::spawn(async move {
+                discover_sps(
+                    &sockets,
+                    ports,
+                    location_determination,
+                    refined_locations_tx,
+                    &log,
+                )
+                .await;
+            });
+        }
+
+        // Collect responses and solve for a single location
+        let location = resolve_location(
+            config.names,
+            ReceiverStream::new(refined_locations),
+            log,
+        )
+        .await?;
+
+        // based on the resolved location and the input configuration, build the
+        // map of port <-> logical ID
+        let mut port_to_id = HashMap::with_capacity(ports.len());
+        let mut id_to_port = HashMap::with_capacity(ports.len());
+        for (port, mut port_config) in ports {
+            // construction of `ValidatedLocationConfig` checked that all port
+            // configs have entries for all locations, allowing us to unwrap
+            // this `remove()`.
+            let id = port_config.location.remove(&location).unwrap();
+            port_to_id.insert(port, id);
+            id_to_port.insert(id, port);
+        }
+
+        Ok(Self { location_name: location, port_to_id, id_to_port })
+    }
+
+    /// Get the name of our location.
+    ///
+    /// This matches one of the names specified as a possible location in the
+    /// configuration we were given.
+    pub(super) fn location_name(&self) -> &str {
+        &self.location_name
+    }
+
+    /// Get the ID of a given port.
+    ///
+    /// Panics if `port` was not present in the list of ports provided when
+    /// `self` was created.
+    pub(super) fn port_to_id(&self, port: SwitchPort) -> SpIdentifier {
+        self.port_to_id.get(&port).copied().unwrap()
+    }
+
+    /// Get the port associated with the given ID, if it exists.
+    pub(super) fn id_to_port(&self, id: SpIdentifier) -> Option<SwitchPort> {
+        self.id_to_port.get(&id).copied()
+    }
+}
+
+// This repeats the fields of `LocationConfig` but
+//
+// a) converts `Vec<_>` to `HashSet<_>` (we care about ordering for TOML
+//    serialization, but really want set operations)
+// b) validates that all the fields that reference each other are self
+//    consistent; e.g., there isn't a LocationDeterminationConfig that refers to
+//    a nonexistent switch port.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ValidatedLocationConfig {
+    names: HashSet<String>,
+    determination: Vec<ValidatedLocationDeterminationConfig>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ValidatedLocationDeterminationConfig {
+    switch_port: SwitchPort,
+    sp_port_1: HashSet<String>,
+    sp_port_2: HashSet<String>,
+}
+
+impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
+    for ValidatedLocationConfig
+{
+    type Error = ConfigError;
+
+    fn try_from(
+        (ports, config): (
+            &HashMap<SwitchPort, SwitchPortDescription>,
+            LocationConfig,
+        ),
+    ) -> Result<Self, Self::Error> {
+        // Helper function to convert a vec into a hashset, recording an error
+        // string in `reasons` if the lengths don't match (i.e., the vec
+        // contained at least one duplicate)
+        fn vec_to_hashset<F>(
+            v: Vec<String>,
+            reasons: &mut Vec<String>,
+            msg: F,
+        ) -> HashSet<String>
+        where
+            F: FnOnce() -> String,
+        {
+            let n = v.len();
+            let hs = v.into_iter().collect::<HashSet<_>>();
+            if hs.len() != n {
+                reasons.push(msg());
+            }
+            hs
+        }
+
+        // collection of reasons the config is invalid (if any)
+        let mut reasons = Vec::new();
+
+        let names = vec_to_hashset(config.names, &mut reasons, || {
+            String::from("location names contains at least one duplicate entry")
+        });
+
+        // make sure every port has a defined ID for any element of `names`, and
+        // no extras
+        for (port, port_config) in ports {
+            for name in &names {
+                if !port_config.location.contains_key(name) {
+                    reasons.push(format!(
+                        "port {} is missing an ID for location {:?}",
+                        port.0, name
+                    ));
+                }
+            }
+            for name in port_config.location.keys() {
+                if !names.contains(name) {
+                    reasons.push(format!(
+                        "port {} contains unknown name {:?}",
+                        port.0, name
+                    ));
+                }
+            }
+        }
+
+        let determination = config
+            .determination
+            .into_iter()
+            .enumerate()
+            .map(|(i, det)| {
+                // make sure this determination's switch port exists
+                let switch_port = SwitchPort(det.switch_port);
+                if !ports.contains_key(&switch_port) {
+                    reasons.push(format!(
+                        "determination {} references a nonexistent switch port ({})",
+                        i, det.switch_port
+                    ));
+                }
+
+                // convert names into hash sets
+                let sp_port_1 = vec_to_hashset(det.sp_port_1, &mut reasons, ||
+                    format!(
+                        "determination `{}.sp_port_1` contains duplicate names",
+                        i
+                    )
+                );
+                let sp_port_2 = vec_to_hashset(det.sp_port_2, &mut reasons, ||
+                    format!(
+                        "determination `{}.sp_port_2` contains duplicate names",
+                        i
+                    )
+                );
+
+                // make sure these hash sets only reference known names
+                if !sp_port_1.is_subset(&names) {
+                    reasons.push(format!(
+                        "determination `{}.sp_port_1` contains unknown names",
+                        i
+                    ));
+                }
+                if !sp_port_2.is_subset(&names) {
+                    reasons.push(format!(
+                        "determination `{}.sp_port_2` contains unknown names",
+                        i
+                    ));
+                }
+
+                // determinations should not be empty; that would result in
+                // immediate failure of our location resolution
+                if sp_port_1.is_empty() {
+                    reasons.push(format!(
+                        "determination `{}.sp_port_1` is empty",
+                        i
+                    ));
+                }
+                if sp_port_2.is_empty() {
+                    reasons.push(format!(
+                        "determination `{}.sp_port_2` is empty",
+                        i
+                    ));
+                }
+
+                ValidatedLocationDeterminationConfig {
+                    switch_port,
+                    sp_port_1,
+                    sp_port_2,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if reasons.is_empty() {
+            Ok(Self { names, determination })
+        } else {
+            Err(ConfigError::InvalidConfig { reasons })
+        }
+    }
+}
+
+/// `discovery_sps()` is spawned as a tokio task. It's responsible for sending
+/// discovery packets on all switch ports until it hears back from the SPs at
+/// the other end (if they exist and are able to respond). Any responses we hear
+/// back that correspond to a port used in `location_determination` will result
+/// in a message being send on the `refined_locations` channel with that port
+/// and the list of locations we could be in based on the SP's response on that
+/// port. Our spawner is responsible for collecting/using those messages.
+async fn discover_sps(
+    sockets: &HashMap<SwitchPort, SingleSp>,
+    port_config: HashMap<SwitchPort, SwitchPortDescription>,
+    mut location_determination: Vec<ValidatedLocationDeterminationConfig>,
+    refined_locations: mpsc::Sender<(SwitchPort, HashSet<String>)>,
+    log: &Logger,
+) {
+    // Build a collection of futures representing the results of discovering the
+    // SP address for each switch port in `sockets`.
+    let mut futs = FuturesUnordered::new();
+    for (switch_port, _config) in port_config {
+        let log = log.clone();
+        futs.push(async move {
+            // all ports in `port_config` also get sockets bound to them;
+            // unwrapping this lookup is fine
+            let sp = sockets.get(&switch_port).unwrap();
+
+            // Wait for local startup to complete (finding our interface,
+            // binding a socket, etc.).
+            if let Err(err) = sp.wait_for_startup_completion().await {
+                warn!(
+                    log,
+                    "SP communicator startup failed; giving up on this port";
+                    "switch_port" => ?switch_port,
+                    "err" => %err,
+                );
+                return (switch_port, None);
+            }
+
+            // `sp_addr_watch()` can only fail if startup fails, which we just
+            // checked; this is safe to unwrap.
+            let mut addr_watch = sp.sp_addr_watch().unwrap().clone();
+
+            loop {
+                let current = *addr_watch.borrow();
+                match current {
+                    Some((_addr, sp_port)) => {
+                        return (switch_port, Some(sp_port))
+                    }
+                    None => {
+                        addr_watch.changed().await.unwrap();
+                    }
+                }
+            }
+        });
+    }
+
+    // Wait for responses.
+    while let Some((switch_port, sp_port)) = futs.next().await {
+        // Skip switch ports where we failed to start our communicator.
+        let sp_port = match sp_port {
+            Some(sp_port) => sp_port,
+            None => continue,
+        };
+
+        // See if this port can participate in location determination.
+        let pos = match location_determination
+            .iter()
+            .position(|d| d.switch_port == switch_port)
+        {
+            Some(pos) => pos,
+            None => {
+                info!(
+                    log, "received discovery response (not used for location)";
+                    "switch_port" => ?switch_port,
+                    "sp_port" => ?sp_port,
+                );
+                continue;
+            }
+        };
+        let determination = location_determination.remove(pos);
+
+        let refined = match sp_port {
+            SpPort::One => determination.sp_port_1,
+            SpPort::Two => determination.sp_port_2,
+        };
+
+        // the only failure possible here is that the receiver is gone; that's
+        // harmless for us (e.g., maybe it's already fully determined the
+        // location and doesn't care about more messages)
+        let _ = refined_locations.send((switch_port, refined)).await;
+    }
+
+    // TODO If we're exiting, we've now heard from an SP on every port. Is there
+    // any reason to continue pinging ports with discovery packets? This is TBD
+    // on how we handle sleds being power cycled, replaced, etc.
+}
+
+/// Given a list of possible location names (`locations`) and a stream of
+/// `determinations` (coming from `discover_sps()` above), resolve which element
+/// of `locations` we must be. For example, if `locations` contains `["switch0",
+/// "switch1"]` and we receive a determination of `(SwitchPort(1),
+/// ["switch0"])`, we'll return `Ok("switch0")`. This process can fail if we get
+/// bogus/conflicting determinations or if we exhaust `determinations` without
+/// refining to a single location.
+///
+/// Note that not all bogus/conflicting results will be detected, because this
+/// function will short circuit once it has resolved to a single location. For
+/// example, if `locations` contains `["a", "b"]` and `determinations` will
+/// yield `[(SwitchPort(0), "a"), (SwitchPort(1), "b")]`, we will return
+/// `Ok("a")` upon seeing the first determination without noticing the second.
+/// On the other hand, if `names` contains `["a", "b", "c"]` and
+/// `determinations` will yield `[(SwitchPort(0), ["a", "b"]), (SwitchPort(1),
+/// ["c"])]`, we would notice the empty intersection and fail accordingly.
+async fn resolve_location<S>(
+    mut locations: HashSet<String>,
+    determinations: S,
+    log: &Logger,
+) -> Result<String, String>
+where
+    S: Stream<Item = (SwitchPort, HashSet<String>)>,
+{
+    tokio::pin!(determinations);
+    while let Some((port, refined_locations)) = determinations.next().await {
+        // we got a successful response from an SP; restrict `locations` to only
+        // locations that could be possible given that response.
+        debug!(
+            log, "received location deterimination response";
+            "port" => ?port,
+            "refined_locations" => ?refined_locations,
+        );
+        locations.retain(|name| refined_locations.contains(name));
+
+        // If we're down to 1 location (or 0 if something has gone horribly
+        // wrong), we don't need to wait for the remaining answers; we've
+        // already fully determined our location.
+        if locations.len() <= 1 {
+            break;
+        }
+    }
+
+    match locations.len() {
+        1 => Ok(locations.into_iter().next().unwrap()),
+        0 => Err(String::from(concat!(
+            "could not determine unique location ",
+            "(all possible locations eliminated)",
+        ))),
+
+        _ => {
+            let mut remaining = locations.into_iter().collect::<Vec<_>>();
+            remaining.sort_unstable();
+            Err(format!(
+                "could not determine unique location (remaining set `{:?}`)",
+                remaining,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SpType;
+    use futures::stream;
+    use std::vec;
+
+    #[test]
+    fn test_config_validation() {
+        let bad_ports = HashMap::from([(
+            SwitchPort(0),
+            SwitchPortDescription {
+                config: SwitchPortConfig {
+                    listen_addr: "[::1]:0".parse().unwrap(),
+                    discovery_addr: "[::1]:0".parse().unwrap(),
+                    interface: None,
+                },
+                location: HashMap::from([
+                    (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
+                    // missing "b", has extraneous "c"
+                    (String::from("c"), SpIdentifier::new(SpType::Sled, 1)),
+                ]),
+            },
+        )]);
+        let bad_config = LocationConfig {
+            names: vec![
+                String::from("a"),
+                String::from("b"),
+                String::from("a"), // dupe
+            ],
+            determination: vec![
+                LocationDeterminationConfig {
+                    switch_port: 7, // nonexistent port
+                    sp_port_1: vec![
+                        String::from("a"),
+                        String::from("b"),
+                        String::from("a"), // dupe
+                        String::from("c"), // not listed in `names`
+                    ],
+                    sp_port_2: vec![], // empty
+                },
+                LocationDeterminationConfig {
+                    switch_port: 0,
+                    sp_port_1: vec![], // empty
+                    sp_port_2: vec![
+                        String::from("a"),
+                        String::from("b"),
+                        String::from("b"), // dupe
+                        String::from("d"), // not listed in `names`
+                    ],
+                },
+            ],
+        };
+
+        let err = ValidatedLocationConfig::try_from((&bad_ports, bad_config))
+            .unwrap_err();
+        let reasons = match err {
+            ConfigError::InvalidConfig { reasons } => reasons,
+        };
+
+        assert_eq!(
+            reasons,
+            &[
+                "location names contains at least one duplicate entry",
+                "port 0 is missing an ID for location \"b\"",
+                "port 0 contains unknown name \"c\"",
+                "determination 0 references a nonexistent switch port (7)",
+                "determination `0.sp_port_1` contains duplicate names",
+                "determination `0.sp_port_1` contains unknown names",
+                "determination `0.sp_port_2` is empty",
+                "determination `1.sp_port_2` contains duplicate names",
+                "determination `1.sp_port_2` contains unknown names",
+                "determination `1.sp_port_1` is empty",
+            ]
+        );
+
+        // repeat the config from above but with all errors fixed; note that
+        // this config is still logically nonsense, but it doesn't contain any
+        // of the errors we check for (mismatched / typo'd names, etc.).
+        let good_ports = HashMap::from([(
+            SwitchPort(0),
+            SwitchPortDescription {
+                config: SwitchPortConfig {
+                    listen_addr: "[::1]:0".parse().unwrap(),
+                    discovery_addr: "[::1]:0".parse().unwrap(),
+                    interface: None,
+                },
+                location: HashMap::from([
+                    (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
+                    (String::from("b"), SpIdentifier::new(SpType::Sled, 1)),
+                ]),
+            },
+        )]);
+        let good_config = LocationConfig {
+            names: vec![String::from("a"), String::from("b")],
+            determination: vec![
+                LocationDeterminationConfig {
+                    switch_port: 0,
+                    sp_port_1: vec![String::from("a")],
+                    sp_port_2: vec![String::from("b")],
+                },
+                LocationDeterminationConfig {
+                    switch_port: 0,
+                    sp_port_1: vec![String::from("b")],
+                    sp_port_2: vec![String::from("a")],
+                },
+            ],
+        };
+
+        let config =
+            ValidatedLocationConfig::try_from((&good_ports, good_config))
+                .unwrap();
+
+        assert_eq!(
+            config,
+            ValidatedLocationConfig {
+                names: HashSet::from([String::from("a"), String::from("b")]),
+                determination: vec![
+                    ValidatedLocationDeterminationConfig {
+                        switch_port: SwitchPort(0),
+                        sp_port_1: HashSet::from([String::from("a")]),
+                        sp_port_2: HashSet::from([String::from("b")]),
+                    },
+                    ValidatedLocationDeterminationConfig {
+                        switch_port: SwitchPort(0),
+                        sp_port_1: HashSet::from([String::from("b")]),
+                        sp_port_2: HashSet::from([String::from("a")]),
+                    },
+                ],
+            }
+        );
+    }
+
+    struct Harness {
+        names: HashSet<String>,
+        determinations:
+            stream::Iter<vec::IntoIter<(SwitchPort, HashSet<String>)>>,
+    }
+
+    impl Harness {
+        fn new(names: &[&str], determinations: &[&[&str]]) -> Self {
+            let determinations: Vec<(SwitchPort, HashSet<String>)> =
+                determinations
+                    .iter()
+                    .enumerate()
+                    .map(|(i, names)| {
+                        (
+                            SwitchPort(i),
+                            names.iter().copied().map(String::from).collect(),
+                        )
+                    })
+                    .collect();
+            Self {
+                names: names.iter().copied().map(String::from).collect(),
+                determinations: stream::iter(determinations),
+            }
+        }
+
+        async fn resolve(self, log: &Logger) -> Result<String, String> {
+            resolve_location(self.names, self.determinations, log).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_location() {
+        let log = Logger::root(slog::Discard, slog::o!());
+
+        // basic test - of a/b/c, all determinations report "a"
+        let harness = Harness::new(&["a", "b", "c"], &[&["a"], &["a"], &["a"]]);
+        assert_eq!(harness.resolve(&log).await.unwrap(), "a");
+
+        // slightly more interesting - of a/b/c, all determinations report a
+        // subset, all of which intersect on "b"
+        let harness = Harness::new(
+            &["a", "b", "c"],
+            &[&["a", "b"], &["a", "b", "c"], &["b", "c"]],
+        );
+        assert_eq!(harness.resolve(&log).await.unwrap(), "b");
+
+        // failing to resolve to a single location should give us an error
+        let harness =
+            Harness::new(&["a", "b", "c"], &[&["a", "b"], &["b", "a"]]);
+        let reason = harness.resolve(&log).await.unwrap_err();
+        assert_eq!(
+            reason,
+            concat!(
+                "could not determine unique location ",
+                "(remaining set `[\"a\", \"b\"]`)",
+            )
+        );
+
+        // determinations that have no name in common should give us an error
+        let harness = Harness::new(&["a", "b", "c"], &[&["a", "b"], &["c"]]);
+        let reason = harness.resolve(&log).await.unwrap_err();
+        assert_eq!(
+            reason,
+            concat!(
+                "could not determine unique location ",
+                "(all possible locations eliminated)",
+            )
+        );
+    }
+}

--- a/gateway/src/serial_console.rs
+++ b/gateway/src/serial_console.rs
@@ -4,7 +4,10 @@
 
 // Copyright 2022 Oxide Computer Company
 
+use crate::communicator::Communicator;
 use crate::error::Error;
+use crate::error::SpCommsError;
+use crate::management_switch::SpIdentifier;
 use futures::stream::SplitSink;
 use futures::stream::SplitStream;
 use futures::SinkExt;
@@ -12,8 +15,6 @@ use futures::StreamExt;
 use gateway_messages::SpComponent;
 use gateway_sp_comms::AttachedSerialConsole;
 use gateway_sp_comms::AttachedSerialConsoleSend;
-use gateway_sp_comms::Communicator;
-use gateway_sp_comms::SpIdentifier;
 use http::header;
 use hyper::upgrade;
 use hyper::upgrade::Upgraded;
@@ -232,7 +233,7 @@ impl SerialConsoleTask {
                     console_tx
                         .write(data)
                         .await
-                        .map_err(gateway_sp_comms::error::Error::from)
+                        .map_err(SpCommsError::from)
                         .map_err(Error::from)?;
                 }
                 Ok(Message::Close(_)) => {

--- a/gateway/src/timeout.rs
+++ b/gateway/src/timeout.rs
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use futures::Future;
+use futures::TryFutureExt;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// Error type returned from [`Timeout::timeout_at()`].
+#[derive(Debug, Clone, Copy)]
+pub struct Elapsed(pub Timeout);
+
+impl Elapsed {
+    /// Get the duration of the timeout that elapsed.
+    pub fn duration(&self) -> Duration {
+        self.0.duration()
+    }
+}
+
+/// Representation of a timeout as both its starting time and its duration.
+#[derive(Debug, Clone, Copy)]
+pub struct Timeout {
+    start: Instant,
+    duration: Duration,
+}
+
+impl Timeout {
+    /// Create a new `Timeout` with the given duration starting from
+    /// [`Instant::now()`].
+    pub fn from_now(duration: Duration) -> Self {
+        Self { start: Instant::now(), duration }
+    }
+
+    /// Get the [`Instant`] when this timeout expires.
+    pub fn end(&self) -> Instant {
+        self.start + self.duration
+    }
+
+    /// Get the duration of this timeout.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Wrap a future with this timeout.
+    pub fn timeout_at<T>(
+        self,
+        future: T,
+    ) -> impl Future<Output = Result<T::Output, Elapsed>>
+    where
+        T: Future,
+    {
+        tokio::time::timeout_at(self.end(), future)
+            .map_err(move |_| Elapsed(self))
+    }
+}

--- a/gateway/tests/integration_tests/setup.rs
+++ b/gateway/tests/integration_tests/setup.rs
@@ -7,8 +7,8 @@
 use dropshot::test_util::ClientTestContext;
 use dropshot::test_util::LogContext;
 use gateway_messages::SpPort;
-use gateway_sp_comms::SpType;
 use omicron_gateway::MgsArguments;
+use omicron_gateway::SpType;
 use omicron_test_utils::dev::poll;
 use omicron_test_utils::dev::poll::CondCheckError;
 use slog::o;

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -19,7 +19,7 @@ toml = "0.5.9"
 
 [dependencies.gateway-messages]
 git = "https://github.com/oxidecomputer/management-gateway-service"
-rev = "2e0b41543425ef374ee08c313dcc25b07b98a05e"
+rev = "1a27a661d7824712aeb4d1b9801938888139eaa7"
 default-features = false
 features = ["std"]
 


### PR DESCRIPTION
There are no meaningful changes in this PR, other than touching up import paths and type names from the move. This is just importing code that was moved out to the MGS repo in #1809 (which moved the `gateway-messages` and `gateway-sp-comms` crates in their entirety). The bits being moved back here are directly relevant to MGS proper (e.g., RFD 250-style discovery over all the VLAN interfaces), and are not directly relevant to the communication protocol between MGS and one SP.