### PR TITLE
[nexus] Remove project_id, rack_id from IP pools

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1109,16 +1109,7 @@ CREATE TABLE omicron.public.ip_pool (
     time_modified TIMESTAMPTZ NOT NULL,
     time_deleted TIMESTAMPTZ,
 
-    /* Optional ID of the project for which this pool is reserved. */
-    project_id UUID,
-
-    /*
-     * Optional rack ID, indicating this is a reserved pool for internal
-     * services on a specific rack.
-     * TODO(https://github.com/oxidecomputer/omicron/issues/1276): This
-     * should probably point to an AZ or fleet, not a rack.
-     */
-    rack_id UUID,
+    internal_only BOOL NOT NULL,
 
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL
@@ -1130,15 +1121,6 @@ CREATE TABLE omicron.public.ip_pool (
 CREATE UNIQUE INDEX ON omicron.public.ip_pool (
     name
 ) WHERE
-    time_deleted IS NULL;
-
-/*
- * Index ensuring uniqueness of IP pools by rack ID
- */
-CREATE UNIQUE INDEX ON omicron.public.ip_pool (
-    rack_id
-) WHERE
-    rack_id IS NOT NULL AND
     time_deleted IS NULL;
 
 /*
@@ -1155,20 +1137,11 @@ CREATE TABLE omicron.public.ip_pool_range (
     /* The range is inclusive of the last address. */
     last_address INET NOT NULL,
     ip_pool_id UUID NOT NULL,
-    /* Optional ID of the project for which this range is reserved.
-     *
-     * NOTE: This denormalizes the tables a bit, since the project_id is
-     * duplicated here and in the parent `ip_pool` table. We're allowing this
-     * for now, since it reduces the complexity of the already-bad IP allocation
-     * query, but we may want to revisit that, and JOIN with the parent table
-     * instead.
-     */
-    project_id UUID,
     /* Tracks child resources, IP addresses allocated out of this range. */
     rcgen INT8 NOT NULL
 );
 
-/* 
+/*
  * These help Nexus enforce that the ranges within an IP Pool do not overlap
  * with any other ranges. See `nexus/src/db/queries/ip_pool.rs` for the actual
  * query which does that.
@@ -1183,14 +1156,6 @@ CREATE UNIQUE INDEX ON omicron.public.ip_pool_range (
 )
 STORING (first_address)
 WHERE time_deleted IS NULL;
-
-/*
- * Index supporting allocation of IPs out of a Pool reserved for a project.
- */
-CREATE INDEX ON omicron.public.ip_pool_range (
-    project_id
-) WHERE
-    time_deleted IS NULL;
 
 
 /* The kind of external IP address. */
@@ -1242,9 +1207,6 @@ CREATE TABLE omicron.public.external_ip (
     /* FK to the `ip_pool_range` table. */
     ip_pool_range_id UUID NOT NULL,
 
-    /* FK to the `project` table. */
-    project_id UUID,
-
     /* FK to the `instance` table. See the constraints below. */
     instance_id UUID,
 
@@ -1259,15 +1221,6 @@ CREATE TABLE omicron.public.external_ip (
 
     /* The last port in the allowed range, also inclusive. */
     last_port INT4 NOT NULL,
-
-    /*
-     * The project can only be NULL for service IPs.
-     * Additionally, the project MUST be NULL for service IPs.
-     */
-    CONSTRAINT null_project CHECK(
-        (kind != 'service' AND project_id IS NOT NULL) OR
-        (kind = 'service' AND project_id IS NULL)
-    ),
 
     /* The name must be non-NULL iff this is a floating IP. */
     CONSTRAINT null_fip_name CHECK (

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1109,7 +1109,9 @@ CREATE TABLE omicron.public.ip_pool (
     time_modified TIMESTAMPTZ NOT NULL,
     time_deleted TIMESTAMPTZ,
 
-    internal_only BOOL NOT NULL,
+
+    /* Identifies if the IP Pool is dedicated to Control Plane services */
+    internal BOOL NOT NULL,
 
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL

--- a/end-to-end-tests/src/bin/bootstrap.rs
+++ b/end-to-end-tests/src/bin/bootstrap.rs
@@ -3,7 +3,7 @@ use end_to_end_tests::helpers::ctx::{build_client, Context};
 use end_to_end_tests::helpers::{generate_name, get_system_ip_pool};
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 use oxide_client::types::{
-    ByteCount, DiskCreate, DiskSource, IpPoolCreate, IpRange, Ipv4Range,
+    ByteCount, DiskCreate, DiskSource, IpRange, Ipv4Range,
 };
 use oxide_client::{ClientDisksExt, ClientOrganizationsExt, ClientSystemExt};
 use std::time::Duration;
@@ -30,21 +30,9 @@ async fn main() -> Result<()> {
     // ===== CREATE IP POOL ===== //
     eprintln!("creating IP pool...");
     let (first, last) = get_system_ip_pool()?;
-    let pool_name = client
-        .ip_pool_create()
-        .body(IpPoolCreate {
-            name: generate_name("ip-pool")?,
-            description: String::new(),
-            organization: None,
-            project: None,
-        })
-        .send()
-        .await?
-        .name
-        .clone();
     client
         .ip_pool_range_add()
-        .pool_name(pool_name)
+        .pool_name("default")
         .body(IpRange::V4(Ipv4Range { first, last }))
         .send()
         .await?;

--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -79,18 +79,6 @@ impl From<ExternalIp> for sled_agent_client::types::SourceNatConfig {
     }
 }
 
-/// Describes where the IP candidates for allocation come from: either
-/// from an IP pool, or from a project.
-///
-/// This ensures that a source is always specified, and a caller cannot
-/// request an external IP allocation without providing at least one of
-/// these options.
-#[derive(Debug, Clone, Copy)]
-pub enum IpSource {
-    Instance { pool_id: Uuid },
-    Service { pool_id: Uuid },
-}
-
 /// An incomplete external IP, used to store state required for issuing the
 /// database query that selects an available IP and stores the resulting record.
 #[derive(Debug, Clone)]
@@ -101,7 +89,7 @@ pub struct IncompleteExternalIp {
     time_created: DateTime<Utc>,
     kind: IpKind,
     instance_id: Option<Uuid>,
-    source: IpSource,
+    pool_id: Uuid,
 }
 
 impl IncompleteExternalIp {
@@ -117,7 +105,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::SNat,
             instance_id: Some(instance_id),
-            source: IpSource::Instance { pool_id },
+            pool_id,
         }
     }
 
@@ -129,7 +117,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::Ephemeral,
             instance_id: Some(instance_id),
-            source: IpSource::Instance { pool_id },
+            pool_id,
         }
     }
 
@@ -146,7 +134,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::Floating,
             instance_id: None,
-            source: IpSource::Instance { pool_id },
+            pool_id,
         }
     }
 
@@ -158,7 +146,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::Service,
             instance_id: None,
-            source: IpSource::Service { pool_id },
+            pool_id,
         }
     }
 
@@ -186,8 +174,8 @@ impl IncompleteExternalIp {
         &self.instance_id
     }
 
-    pub fn source(&self) -> &IpSource {
-        &self.source
+    pub fn pool_id(&self) -> &Uuid {
+        &self.pool_id
     }
 }
 

--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -58,7 +58,6 @@ pub struct ExternalIp {
     pub time_deleted: Option<DateTime<Utc>>,
     pub ip_pool_id: Uuid,
     pub ip_pool_range_id: Uuid,
-    pub project_id: Option<Uuid>,
     // This is Some(_) for:
     //  - all instance SNAT IPs
     //  - all ephemeral IPs
@@ -88,7 +87,7 @@ impl From<ExternalIp> for sled_agent_client::types::SourceNatConfig {
 /// these options.
 #[derive(Debug, Clone, Copy)]
 pub enum IpSource {
-    Instance { project_id: Uuid, pool_id: Option<Uuid> },
+    Instance { pool_id: Uuid },
     Service { pool_id: Uuid },
 }
 
@@ -108,9 +107,8 @@ pub struct IncompleteExternalIp {
 impl IncompleteExternalIp {
     pub fn for_instance_source_nat(
         id: Uuid,
-        project_id: Uuid,
         instance_id: Uuid,
-        pool_id: Option<Uuid>,
+        pool_id: Uuid,
     ) -> Self {
         Self {
             id,
@@ -119,16 +117,11 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::SNat,
             instance_id: Some(instance_id),
-            source: IpSource::Instance { project_id, pool_id },
+            source: IpSource::Instance { pool_id },
         }
     }
 
-    pub fn for_ephemeral(
-        id: Uuid,
-        project_id: Uuid,
-        instance_id: Uuid,
-        pool_id: Option<Uuid>,
-    ) -> Self {
+    pub fn for_ephemeral(id: Uuid, instance_id: Uuid, pool_id: Uuid) -> Self {
         Self {
             id,
             name: None,
@@ -136,7 +129,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::Ephemeral,
             instance_id: Some(instance_id),
-            source: IpSource::Instance { project_id, pool_id },
+            source: IpSource::Instance { pool_id },
         }
     }
 
@@ -144,8 +137,7 @@ impl IncompleteExternalIp {
         id: Uuid,
         name: &Name,
         description: &str,
-        project_id: Uuid,
-        pool_id: Option<Uuid>,
+        pool_id: Uuid,
     ) -> Self {
         Self {
             id,
@@ -154,7 +146,7 @@ impl IncompleteExternalIp {
             time_created: Utc::now(),
             kind: IpKind::Floating,
             instance_id: None,
-            source: IpSource::Instance { project_id, pool_id },
+            source: IpSource::Instance { pool_id },
         }
     }
 

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -28,6 +28,10 @@ pub struct IpPool {
     #[diesel(embed)]
     pub identity: IpPoolIdentity,
 
+    /// If true, identifies that this IP pool is dedicated to "Control-Plane
+    /// Services", such as Nexus.
+    ///
+    /// Otherwise, this IP pool is intended for usage by customer VMs.
     pub internal_only: bool,
 
     /// Child resource generation number, for optimistic concurrency control of

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -32,7 +32,7 @@ pub struct IpPool {
     /// Services", such as Nexus.
     ///
     /// Otherwise, this IP pool is intended for usage by customer VMs.
-    pub internal_only: bool,
+    pub internal: bool,
 
     /// Child resource generation number, for optimistic concurrency control of
     /// the contained ranges.
@@ -42,14 +42,14 @@ pub struct IpPool {
 impl IpPool {
     pub fn new(
         pool_identity: &external::IdentityMetadataCreateParams,
-        internal_only: bool,
+        internal: bool,
     ) -> Self {
         Self {
             identity: IpPoolIdentity::new(
                 Uuid::new_v4(),
                 pool_identity.clone(),
             ),
-            internal_only,
+            internal,
             rcgen: 0,
         }
     }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -149,7 +149,7 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
-        internal_only -> Bool,
+        internal -> Bool,
         rcgen -> Int8,
     }
 }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -149,8 +149,7 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
-        project_id -> Nullable<Uuid>,
-        rack_id -> Nullable<Uuid>,
+        internal_only -> Bool,
         rcgen -> Int8,
     }
 }
@@ -164,7 +163,6 @@ table! {
         first_address -> Inet,
         last_address -> Inet,
         ip_pool_id -> Uuid,
-        project_id -> Nullable<Uuid>,
         rcgen -> Int8,
     }
 }
@@ -179,7 +177,6 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
         ip_pool_id -> Uuid,
         ip_pool_range_id -> Uuid,
-        project_id -> Nullable<Uuid>,
         instance_id -> Nullable<Uuid>,
         kind -> crate::IpKindEnum,
         ip -> Inet,

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -175,21 +175,17 @@ impl super::Nexus {
     }
 
     // The "ip_pool_service_..." functions look up IP pools for Oxide service usage,
-    // rather than for VMs. As such, they're identified by rack UUID, not
-    // by pool names.
+    // rather than for VMs.
     //
     // TODO(https://github.com/oxidecomputer/omicron/issues/1276): Should be
-    // AZ UUID, probably.
+    // accessed via AZ UUID, probably.
 
     pub async fn ip_pool_service_fetch(
         &self,
         opctx: &OpContext,
-        rack_id: Uuid,
     ) -> LookupResult<db::model::IpPool> {
-        let (authz_pool, db_pool) = self
-            .db_datastore
-            .ip_pools_lookup_by_rack_id(opctx, rack_id)
-            .await?;
+        let (authz_pool, db_pool) =
+            self.db_datastore.ip_pools_service_lookup(opctx).await?;
         opctx.authorize(authz::Action::Read, &authz_pool).await?;
         Ok(db_pool)
     }
@@ -197,13 +193,10 @@ impl super::Nexus {
     pub async fn ip_pool_service_list_ranges(
         &self,
         opctx: &OpContext,
-        rack_id: Uuid,
         pagparams: &DataPageParams<'_, IpNetwork>,
     ) -> ListResultVec<db::model::IpPoolRange> {
-        let (authz_pool, ..) = self
-            .db_datastore
-            .ip_pools_lookup_by_rack_id(opctx, rack_id)
-            .await?;
+        let (authz_pool, ..) =
+            self.db_datastore.ip_pools_service_lookup(opctx).await?;
         opctx.authorize(authz::Action::Read, &authz_pool).await?;
         self.db_datastore
             .ip_pool_list_ranges(opctx, &authz_pool, pagparams)
@@ -213,13 +206,10 @@ impl super::Nexus {
     pub async fn ip_pool_service_add_range(
         &self,
         opctx: &OpContext,
-        rack_id: Uuid,
         range: &IpRange,
     ) -> UpdateResult<db::model::IpPoolRange> {
-        let (authz_pool, ..) = self
-            .db_datastore
-            .ip_pools_lookup_by_rack_id(opctx, rack_id)
-            .await?;
+        let (authz_pool, ..) =
+            self.db_datastore.ip_pools_service_lookup(opctx).await?;
         opctx.authorize(authz::Action::Modify, &authz_pool).await?;
         self.db_datastore.ip_pool_add_range(opctx, &authz_pool, range).await
     }
@@ -227,13 +217,10 @@ impl super::Nexus {
     pub async fn ip_pool_service_delete_range(
         &self,
         opctx: &OpContext,
-        rack_id: Uuid,
         range: &IpRange,
     ) -> DeleteResult {
-        let (authz_pool, ..) = self
-            .db_datastore
-            .ip_pools_lookup_by_rack_id(opctx, rack_id)
-            .await?;
+        let (authz_pool, ..) =
+            self.db_datastore.ip_pools_service_lookup(opctx).await?;
         opctx.authorize(authz::Action::Modify, &authz_pool).await?;
         self.db_datastore.ip_pool_delete_range(opctx, &authz_pool, range).await
     }

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -29,7 +29,7 @@ impl super::Nexus {
         new_pool: &params::IpPoolCreate,
     ) -> CreateResult<db::model::IpPool> {
         self.db_datastore
-            .ip_pool_create(opctx, new_pool, /* internal_only= */ false)
+            .ip_pool_create(opctx, new_pool, /* internal= */ false)
             .await
     }
 
@@ -39,7 +39,7 @@ impl super::Nexus {
         new_pool: &params::IpPoolCreate,
     ) -> CreateResult<db::model::IpPool> {
         self.db_datastore
-            .ip_pool_create(opctx, new_pool, /* internal_only= */ true)
+            .ip_pool_create(opctx, new_pool, /* internal= */ true)
             .await
     }
 
@@ -122,7 +122,7 @@ impl super::Nexus {
                 .ip_pool_name(pool_name)
                 .fetch_for(authz::Action::ListChildren)
                 .await?;
-        if db_pool.internal_only {
+        if db_pool.internal {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 pool_name,
@@ -145,7 +145,7 @@ impl super::Nexus {
                 .ip_pool_name(pool_name)
                 .fetch_for(authz::Action::Modify)
                 .await?;
-        if db_pool.internal_only {
+        if db_pool.internal {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 pool_name,
@@ -165,7 +165,7 @@ impl super::Nexus {
                 .ip_pool_name(pool_name)
                 .fetch_for(authz::Action::Modify)
                 .await?;
-        if db_pool.internal_only {
+        if db_pool.internal {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 pool_name,

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -624,7 +624,7 @@ mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_ip_pool(&client, "p0", None, None).await;
+        create_ip_pool(&client, "p0", None).await;
         create_organization(&client, ORG_NAME).await;
         let project = create_project(client, ORG_NAME, PROJECT_NAME).await;
         project.identity.id

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -628,7 +628,7 @@ async fn sic_allocate_instance_snat_ip(
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
 
     let (.., pool) = datastore
-        .ip_pools_lookup_by_name_no_auth(&opctx, "default")
+        .ip_pools_fetch_default_for(&opctx, authz::Action::CreateChild)
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -626,13 +626,15 @@ async fn sic_allocate_instance_snat_ip(
         OpContext::for_saga_action(&sagactx, &saga_params.serialized_authn);
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
+
+    let (.., pool) = datastore
+        .ip_pools_lookup_by_name_no_auth(&opctx, "default")
+        .await
+        .map_err(ActionError::action_failed)?;
+    let pool_id = pool.identity.id;
+
     datastore
-        .allocate_instance_snat_ip(
-            &opctx,
-            ip_id,
-            saga_params.project_id,
-            instance_id,
-        )
+        .allocate_instance_snat_ip(&opctx, ip_id, instance_id, pool_id)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())
@@ -684,13 +686,7 @@ async fn sic_allocate_instance_external_ip(
         }
     };
     datastore
-        .allocate_instance_ephemeral_ip(
-            &opctx,
-            ip_id,
-            saga_params.project_id,
-            instance_id,
-            pool_name,
-        )
+        .allocate_instance_ephemeral_ip(&opctx, ip_id, instance_id, pool_name)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())
@@ -992,9 +988,9 @@ mod test {
     use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
     use dropshot::test_util::ClientTestContext;
     use nexus_test_utils::resource_helpers::create_disk;
-    use nexus_test_utils::resource_helpers::create_ip_pool;
     use nexus_test_utils::resource_helpers::create_organization;
     use nexus_test_utils::resource_helpers::create_project;
+    use nexus_test_utils::resource_helpers::populate_ip_pool;
     use nexus_test_utils::resource_helpers::DiskTest;
     use nexus_test_utils_macros::nexus_test;
     use omicron_common::api::external::{
@@ -1011,7 +1007,7 @@ mod test {
     const DISK_NAME: &str = "my-disk";
 
     async fn create_org_project_and_disk(client: &ClientTestContext) -> Uuid {
-        create_ip_pool(&client, "p0", None, None).await;
+        populate_ip_pool(&client, "default", None).await;
         create_organization(&client, ORG_NAME).await;
         let project = create_project(client, ORG_NAME, PROJECT_NAME).await;
         create_disk(&client, ORG_NAME, PROJECT_NAME, DISK_NAME).await;

--- a/nexus/src/db/datastore/external_ip.rs
+++ b/nexus/src/db/datastore/external_ip.rs
@@ -12,7 +12,6 @@ use crate::db::error::ErrorHandler;
 use crate::db::model::ExternalIp;
 use crate::db::model::IncompleteExternalIp;
 use crate::db::model::IpKind;
-use crate::db::model::IpPool;
 use crate::db::model::Name;
 use crate::db::queries::external_ip::NextExternalIp;
 use crate::db::update_and_check::UpdateAndCheck;
@@ -24,8 +23,6 @@ use nexus_types::identity::Resource;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupResult;
-use omicron_common::api::external::LookupType;
-use omicron_common::api::external::ResourceType;
 use uuid::Uuid;
 
 impl DataStore {
@@ -34,14 +31,13 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         ip_id: Uuid,
-        project_id: Uuid,
         instance_id: Uuid,
+        pool_id: Uuid,
     ) -> CreateResult<ExternalIp> {
         let data = IncompleteExternalIp::for_instance_source_nat(
             ip_id,
-            project_id,
             instance_id,
-            /* pool_id = */ None,
+            pool_id,
         );
         self.allocate_external_ip(opctx, data).await
     }
@@ -51,53 +47,29 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         ip_id: Uuid,
-        project_id: Uuid,
         instance_id: Uuid,
         pool_name: Option<Name>,
     ) -> CreateResult<ExternalIp> {
-        let pool_id = if let Some(ref name) = pool_name {
-            // We'd like to add authz checks here, and use the `LookupPath`
-            // methods on the project-scoped view of this resource. It's not
-            // entirely clear how that'll work in the API, so see RFD 288 and
-            // https://github.com/oxidecomputer/omicron/issues/1470 for more
-            // details.
-            //
-            // For now, we just ensure that the pool is either unreserved, or
-            // reserved for the instance's project.
-            use db::schema::ip_pool::dsl;
-            Some(
-                dsl::ip_pool
-                    .filter(dsl::name.eq(name.clone()))
-                    .filter(dsl::time_deleted.is_null())
-                    .filter(
-                        dsl::project_id
-                            .is_null()
-                            .or(dsl::project_id.eq(Some(project_id))),
-                    )
-                    .select(IpPool::as_select())
-                    .first_async::<IpPool>(self.pool_authorized(opctx).await?)
-                    .await
-                    .map_err(|e| {
-                        public_error_from_diesel_pool(
-                            e,
-                            ErrorHandler::NotFoundByLookup(
-                                ResourceType::IpPool,
-                                LookupType::ByName(name.to_string()),
-                            ),
-                        )
-                    })?
-                    .identity
-                    .id,
-            )
+        let name = if let Some(name) = pool_name {
+            name.as_str().to_string()
         } else {
-            None
+            "default".to_string()
         };
-        let data = IncompleteExternalIp::for_ephemeral(
-            ip_id,
-            project_id,
-            instance_id,
-            pool_id,
-        );
+
+        // We'd like to add authz checks here, and use the `LookupPath`
+        // methods on the project-scoped view of this resource. It's not
+        // entirely clear how that'll work in the API, so see RFD 288 and
+        // https://github.com/oxidecomputer/omicron/issues/1470 for more
+        // details.
+        //
+        // For now, we just ensure that the pool is either unreserved, or
+        // reserved for the instance's project.
+        let (.., pool) =
+            self.ip_pools_lookup_by_name_no_auth(opctx, &name).await?;
+        let pool_id = pool.identity.id;
+
+        let data =
+            IncompleteExternalIp::for_ephemeral(ip_id, instance_id, pool_id);
         self.allocate_external_ip(opctx, data).await
     }
 

--- a/nexus/src/db/datastore/external_ip.rs
+++ b/nexus/src/db/datastore/external_ip.rs
@@ -78,10 +78,8 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         ip_id: Uuid,
-        rack_id: Uuid,
     ) -> CreateResult<ExternalIp> {
-        let (.., pool) =
-            self.ip_pools_lookup_by_rack_id(opctx, rack_id).await?;
+        let (.., pool) = self.ip_pools_service_lookup(opctx).await?;
 
         let data = IncompleteExternalIp::for_service(ip_id, pool.id());
         self.allocate_external_ip(opctx, data).await

--- a/nexus/src/db/datastore/ip_pool.rs
+++ b/nexus/src/db/datastore/ip_pool.rs
@@ -121,7 +121,7 @@ impl DataStore {
             .await
             .map_err(|e| match e {
                 Error::Forbidden => {
-                    LookupType::ByCompositeId(format!("Service IP Pool"))
+                    LookupType::ByCompositeId("Service IP Pool".to_string())
                         .into_not_found(ResourceType::IpPool)
                 }
                 _ => e,
@@ -140,7 +140,9 @@ impl DataStore {
                     authz::IpPool::new(
                         authz::FLEET,
                         ip_pool.id(),
-                        LookupType::ByCompositeId(format!("Service IP Pool")),
+                        LookupType::ByCompositeId(
+                            "Service IP Pool".to_string(),
+                        ),
                     ),
                     ip_pool,
                 )

--- a/nexus/src/db/datastore/ip_pool.rs
+++ b/nexus/src/db/datastore/ip_pool.rs
@@ -109,7 +109,7 @@ impl DataStore {
     ///
     /// An index exists to look up pools by rack ID, but it is not a primary
     /// key, which requires this lookup function to be used instead of the
-    /// [`LookupPath`] utility.
+    /// [`crate::db::lookup::LookupPath`] utility.
     pub async fn ip_pools_lookup_by_rack_id(
         &self,
         opctx: &OpContext,

--- a/nexus/src/db/datastore/mod.rs
+++ b/nexus/src/db/datastore/mod.rs
@@ -1085,7 +1085,6 @@ mod test {
                 time_deleted: None,
                 ip_pool_id: Uuid::new_v4(),
                 ip_pool_range_id: Uuid::new_v4(),
-                project_id: Some(Uuid::new_v4()),
                 instance_id: Some(instance_id),
                 kind: IpKind::Ephemeral,
                 ip: ipnetwork::IpNetwork::from(IpAddr::from(Ipv4Addr::new(
@@ -1144,7 +1143,6 @@ mod test {
             time_deleted: None,
             ip_pool_id: Uuid::new_v4(),
             ip_pool_range_id: Uuid::new_v4(),
-            project_id: Some(Uuid::new_v4()),
             instance_id: Some(Uuid::new_v4()),
             kind: IpKind::SNat,
             ip: ipnetwork::IpNetwork::from(IpAddr::from(Ipv4Addr::new(
@@ -1215,7 +1213,6 @@ mod test {
             time_deleted: None,
             ip_pool_id: Uuid::new_v4(),
             ip_pool_range_id: Uuid::new_v4(),
-            project_id: Some(Uuid::new_v4()),
             instance_id: Some(Uuid::new_v4()),
             kind: IpKind::Floating,
             ip: addresses.next().unwrap().into(),

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -594,7 +594,6 @@ mod tests {
     use async_bb8_diesel::AsyncRunQueryDsl;
     use dropshot::test_util::LogContext;
     use nexus_test_utils::db::test_setup_database;
-    use nexus_test_utils::RACK_UUID;
     use omicron_common::api::external::Error;
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_test_utils::dev;
@@ -976,7 +975,6 @@ mod tests {
             TestContext::new("test_next_external_ip_for_service").await;
 
         // Create an IP pool without an associated project.
-        let rack_id = Uuid::parse_str(RACK_UUID).unwrap();
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 2),
@@ -989,7 +987,7 @@ mod tests {
         let id1 = Uuid::new_v4();
         let ip1 = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id1, rack_id)
+            .allocate_service_ip(&context.opctx, id1)
             .await
             .expect("Failed to allocate service IP address");
         assert_eq!(ip1.kind, IpKind::Service);
@@ -1002,7 +1000,7 @@ mod tests {
         let id2 = Uuid::new_v4();
         let ip2 = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id2, rack_id)
+            .allocate_service_ip(&context.opctx, id2)
             .await
             .expect("Failed to allocate service IP address");
         assert_eq!(ip2.kind, IpKind::Service);
@@ -1015,7 +1013,7 @@ mod tests {
         let id3 = Uuid::new_v4();
         let err = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id3, rack_id)
+            .allocate_service_ip(&context.opctx, id3)
             .await
             .expect_err("Should have failed to allocate after pool exhausted");
         assert_eq!(
@@ -1036,7 +1034,6 @@ mod tests {
         .await;
 
         // Create an IP pool without an associated project.
-        let rack_id = Uuid::parse_str(RACK_UUID).unwrap();
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 2),
@@ -1049,7 +1046,7 @@ mod tests {
         let id = Uuid::new_v4();
         let ip = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id, rack_id)
+            .allocate_service_ip(&context.opctx, id)
             .await
             .expect("Failed to allocate service IP address");
         assert_eq!(ip.kind, IpKind::Service);
@@ -1060,7 +1057,7 @@ mod tests {
 
         let ip_again = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id, rack_id)
+            .allocate_service_ip(&context.opctx, id)
             .await
             .expect("Failed to allocate service IP address");
 
@@ -1082,7 +1079,6 @@ mod tests {
         .await;
 
         // Create an IP pool without an associated project.
-        let rack_id = Uuid::parse_str(RACK_UUID).unwrap();
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 1),
@@ -1095,7 +1091,7 @@ mod tests {
         let id = Uuid::new_v4();
         let ip = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id, rack_id)
+            .allocate_service_ip(&context.opctx, id)
             .await
             .expect("Failed to allocate service IP address");
         assert_eq!(ip.kind, IpKind::Service);
@@ -1106,7 +1102,7 @@ mod tests {
 
         let ip_again = context
             .db_datastore
-            .allocate_service_ip(&context.opctx, id, rack_id)
+            .allocate_service_ip(&context.opctx, id)
             .await
             .expect("Failed to allocate service IP address");
 

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -9,7 +9,6 @@ use crate::db::model::ExternalIp;
 use crate::db::model::IncompleteExternalIp;
 use crate::db::model::IpKind;
 use crate::db::model::IpKindEnum;
-use crate::db::model::IpSource;
 use crate::db::model::Name;
 use crate::db::pool::DbConnection;
 use crate::db::schema;
@@ -424,18 +423,9 @@ impl NextExternalIp {
         out.push_sql(") AS candidate_ip FROM ");
         IP_POOL_RANGE_FROM_CLAUSE.walk_ast(out.reborrow())?;
         out.push_sql(" WHERE ");
-        match self.ip.source() {
-            IpSource::Instance { pool_id } => {
-                out.push_identifier(dsl::ip_pool_id::NAME)?;
-                out.push_sql(" = ");
-                out.push_bind_param::<sql_types::Uuid, Uuid>(pool_id)?;
-            }
-            IpSource::Service { pool_id } => {
-                out.push_identifier(dsl::ip_pool_id::NAME)?;
-                out.push_sql(" = ");
-                out.push_bind_param::<sql_types::Uuid, Uuid>(pool_id)?;
-            }
-        }
+        out.push_identifier(dsl::ip_pool_id::NAME)?;
+        out.push_sql(" = ");
+        out.push_bind_param::<sql_types::Uuid, Uuid>(self.ip.pool_id())?;
         out.push_sql(" AND ");
         out.push_identifier(dsl::time_deleted::NAME)?;
         out.push_sql(" IS NULL");

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -184,8 +184,7 @@ const MAX_PORT: i32 = u16::MAX as _;
 /// Pool restriction
 /// ----------------
 ///
-/// Clients may optionally request an external address from a specific IP Pool.
-/// If they don't provide a pool, the query is restricted to all IP Pools.
+/// Clients must supply the UUID of an IP pool from which they are allocating.
 #[derive(Debug, Clone)]
 pub struct NextExternalIp {
     ip: IncompleteExternalIp,
@@ -974,7 +973,6 @@ mod tests {
         let context =
             TestContext::new("test_next_external_ip_for_service").await;
 
-        // Create an IP pool without an associated project.
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 2),
@@ -1033,7 +1031,6 @@ mod tests {
         )
         .await;
 
-        // Create an IP pool without an associated project.
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 2),
@@ -1078,7 +1075,6 @@ mod tests {
         )
         .await;
 
-        // Create an IP pool without an associated project.
         let ip_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 1),
@@ -1182,7 +1178,7 @@ mod tests {
             TestContext::new("test_next_external_ip_is_restricted_to_pools")
                 .await;
 
-        // Create two pools, neither project-restricted.
+        // Create two pools
         let first_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 3),
@@ -1227,7 +1223,6 @@ mod tests {
         )
         .await;
 
-        // Create two pools, neither project-restricted.
         let first_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 3),

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -673,7 +673,10 @@ mod tests {
         async fn default_pool_id(&self) -> Uuid {
             let (.., pool) = self
                 .db_datastore
-                .ip_pools_lookup_by_name_no_auth(&self.opctx, "default")
+                .ip_pools_fetch_default_for(
+                    &self.opctx,
+                    crate::authz::Action::ListChildren,
+                )
                 .await
                 .expect("Failed to lookup default ip pool");
             pool.identity.id

--- a/nexus/src/db/queries/external_ip.rs
+++ b/nexus/src/db/queries/external_ip.rs
@@ -628,14 +628,14 @@ mod tests {
             &self,
             name: &str,
             range: IpRange,
-            internal_only: bool,
+            internal: bool,
         ) {
             let pool = IpPool::new(
                 &IdentityMetadataCreateParams {
                     name: String::from(name).parse().unwrap(),
                     description: format!("ip pool {}", name),
                 },
-                internal_only,
+                internal,
             );
 
             diesel::insert_into(crate::db::schema::ip_pool::dsl::ip_pool)
@@ -662,17 +662,12 @@ mod tests {
         }
 
         async fn create_service_ip_pool(&self, name: &str, range: IpRange) {
-            self.create_ip_pool_internal(
-                name, range, /*internal_only=*/ true,
-            )
-            .await;
+            self.create_ip_pool_internal(name, range, /*internal=*/ true).await;
         }
 
         async fn create_ip_pool(&self, name: &str, range: IpRange) {
-            self.create_ip_pool_internal(
-                name, range, /*internal_only=*/ false,
-            )
-            .await;
+            self.create_ip_pool_internal(name, range, /*internal=*/ false)
+                .await;
         }
 
         async fn default_pool_id(&self) -> Uuid {

--- a/nexus/src/db/queries/ip_pool.rs
+++ b/nexus/src/db/queries/ip_pool.rs
@@ -221,8 +221,6 @@ impl QueryFragment<Pg> for FilterOverlappingIpRanges {
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Uuid, Uuid>(&self.range.ip_pool_id)?;
         out.push_sql(", ");
-        out.push_bind_param::<sql_types::Nullable<sql_types::Uuid>, Option<Uuid>>(&self.range.project_id)?;
-        out.push_sql(", ");
         out.push_bind_param::<sql_types::BigInt, i64>(&self.range.rcgen)?;
 
         out.push_sql(" WHERE NOT EXISTS(");

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -107,23 +107,21 @@ pub fn external_api() -> NexusApiDescription {
         api.register(project_policy_view)?;
         api.register(project_policy_update)?;
 
-        // Customer-Accessible IP Pools API
+        // Operator-Accessible IP Pools API
         api.register(ip_pool_list)?;
         api.register(ip_pool_create)?;
         api.register(ip_pool_view)?;
         api.register(ip_pool_view_by_id)?;
         api.register(ip_pool_delete)?;
         api.register(ip_pool_update)?;
-
-        // Operator-Accessible IP Pools API
+        // Variants for internal services
         api.register(ip_pool_service_view)?;
 
-        // Customer-Accessible IP Pool Range API (used by instances)
+        // Operator-Accessible IP Pool Range API
         api.register(ip_pool_range_list)?;
         api.register(ip_pool_range_add)?;
         api.register(ip_pool_range_remove)?;
-
-        // Operator-Accessible IP Pool Range API (used by Oxide services)
+        // Variants for internal services
         api.register(ip_pool_service_range_list)?;
         api.register(ip_pool_service_range_add)?;
         api.register(ip_pool_service_range_remove)?;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1567,23 +1567,20 @@ async fn ip_pool_update(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Fetch an IP pool used for Oxide services.
+/// Fetch the IP pool used for Oxide services.
 #[endpoint {
     method = GET,
-    path = "/system/ip-pools-service/{rack_id}",
+    path = "/system/ip-pools-service",
     tags = ["system"],
 }]
 async fn ip_pool_service_view(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path_params: Path<IpPoolServicePathParam>,
 ) -> Result<HttpResponseOk<views::IpPool>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
-    let path = path_params.into_inner();
-    let rack_id = path.rack_id;
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        let pool = nexus.ip_pool_service_fetch(&opctx, rack_id).await?;
+        let pool = nexus.ip_pool_service_fetch(&opctx).await?;
         Ok(HttpResponseOk(IpPool::from(pool)))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1685,29 +1682,21 @@ async fn ip_pool_range_remove(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-#[derive(Deserialize, JsonSchema)]
-pub struct IpPoolServicePathParam {
-    pub rack_id: Uuid,
-}
-
-/// List ranges for an IP pool used for Oxide services.
+/// List ranges for the IP pool used for Oxide services.
 ///
 /// Ranges are ordered by their first address.
 #[endpoint {
     method = GET,
-    path = "/system/ip-pools-service/{rack_id}/ranges",
+    path = "/system/ip-pools-service/ranges",
     tags = ["system"],
 }]
 async fn ip_pool_service_range_list(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path_params: Path<IpPoolServicePathParam>,
     query_params: Query<IpPoolRangePaginationParams>,
 ) -> Result<HttpResponseOk<ResultsPage<IpPoolRange>>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let query = query_params.into_inner();
-    let path = path_params.into_inner();
-    let rack_id = path.rack_id;
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let marker = match query.page {
@@ -1720,7 +1709,7 @@ async fn ip_pool_service_range_list(
             marker,
         };
         let ranges = nexus
-            .ip_pool_service_list_ranges(&opctx, rack_id, &pag_params)
+            .ip_pool_service_list_ranges(&opctx, &pag_params)
             .await?
             .into_iter()
             .map(|range| range.into())
@@ -1739,23 +1728,19 @@ async fn ip_pool_service_range_list(
 /// Add a range to an IP pool used for Oxide services.
 #[endpoint {
     method = POST,
-    path = "/system/ip-pools-service/{rack_id}/ranges/add",
+    path = "/system/ip-pools-service/ranges/add",
     tags = ["system"],
 }]
 async fn ip_pool_service_range_add(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path_params: Path<IpPoolServicePathParam>,
     range_params: TypedBody<shared::IpRange>,
 ) -> Result<HttpResponseCreated<IpPoolRange>, HttpError> {
     let apictx = &rqctx.context();
     let nexus = &apictx.nexus;
-    let path = path_params.into_inner();
-    let rack_id = path.rack_id;
     let range = range_params.into_inner();
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        let out =
-            nexus.ip_pool_service_add_range(&opctx, rack_id, &range).await?;
+        let out = nexus.ip_pool_service_add_range(&opctx, &range).await?;
         Ok(HttpResponseCreated(out.into()))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1764,22 +1749,19 @@ async fn ip_pool_service_range_add(
 /// Remove a range from an IP pool used for Oxide services.
 #[endpoint {
     method = POST,
-    path = "/system/ip-pools-service/{rack_id}/ranges/remove",
+    path = "/system/ip-pools-service/ranges/remove",
     tags = ["system"],
 }]
 async fn ip_pool_service_range_remove(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
-    path_params: Path<IpPoolServicePathParam>,
     range_params: TypedBody<shared::IpRange>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let apictx = &rqctx.context();
     let nexus = &apictx.nexus;
-    let path = path_params.into_inner();
-    let rack_id = path.rack_id;
     let range = range_params.into_inner();
     let handler = async {
         let opctx = OpContext::for_external_api(&rqctx).await?;
-        nexus.ip_pool_service_delete_range(&opctx, rack_id, &range).await?;
+        nexus.ip_pool_service_delete_range(&opctx, &range).await?;
         Ok(HttpResponseUpdatedNoContent())
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/src/populate.rs
+++ b/nexus/src/populate.rs
@@ -290,7 +290,7 @@ impl Populator for PopulateRack {
                 },
             };
             datastore
-                .ip_pool_create(opctx, &params, /*internal_only=*/ true)
+                .ip_pool_create(opctx, &params, /*internal=*/ true)
                 .await
                 .map(|_| ())
                 .or_else(|e| match e {
@@ -305,7 +305,7 @@ impl Populator for PopulateRack {
                 },
             };
             datastore
-                .ip_pool_create(opctx, &params, /*internal_only=*/ false)
+                .ip_pool_create(opctx, &params, /*internal=*/ false)
                 .await
                 .map(|_| ())
                 .or_else(|e| match e {

--- a/nexus/src/populate.rs
+++ b/nexus/src/populate.rs
@@ -288,16 +288,31 @@ impl Populator for PopulateRack {
                     name: "oxide-service-pool".parse::<Name>().unwrap(),
                     description: String::from("IP Pool for Oxide Services"),
                 },
-                project: None,
             };
             datastore
-                .ip_pool_create(opctx, &params, Some(args.rack_id))
+                .ip_pool_create(opctx, &params, /*internal_only=*/ true)
                 .await
                 .map(|_| ())
                 .or_else(|e| match e {
                     Error::ObjectAlreadyExists { .. } => Ok(()),
                     _ => Err(e),
                 })?;
+
+            let params = params::IpPoolCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: "default".parse::<Name>().unwrap(),
+                    description: String::from("default IP pool"),
+                },
+            };
+            datastore
+                .ip_pool_create(opctx, &params, /*internal_only=*/ false)
+                .await
+                .map(|_| ())
+                .or_else(|e| match e {
+                    Error::ObjectAlreadyExists { .. } => Ok(()),
+                    _ => Err(e),
+                })?;
+
             Ok(())
         }
         .boxed()

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -63,9 +63,31 @@ where
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
-        .expect("failed to make \"create\" request")
+        .expect(&format!("failed to make \"create\" request to {path}"))
         .parsed_body()
         .unwrap()
+}
+
+pub async fn populate_ip_pool(
+    client: &ClientTestContext,
+    pool_name: &str,
+    ip_range: Option<IpRange>,
+) -> IpPoolRange {
+    let ip_range = ip_range.unwrap_or_else(|| {
+        use std::net::Ipv4Addr;
+        IpRange::try_from((
+            Ipv4Addr::new(10, 0, 0, 0),
+            Ipv4Addr::new(10, 0, 255, 255),
+        ))
+        .unwrap()
+    });
+    let range = object_create(
+        client,
+        format!("/system/ip-pools/{}/ranges/add", pool_name).as_str(),
+        &ip_range,
+    )
+    .await;
+    range
 }
 
 /// Create an IP pool with a single range for testing.
@@ -77,16 +99,7 @@ pub async fn create_ip_pool(
     client: &ClientTestContext,
     pool_name: &str,
     ip_range: Option<IpRange>,
-    project_path: Option<params::ProjectPath>,
 ) -> (IpPool, IpPoolRange) {
-    let ip_range = ip_range.unwrap_or_else(|| {
-        use std::net::Ipv4Addr;
-        IpRange::try_from((
-            Ipv4Addr::new(10, 0, 0, 0),
-            Ipv4Addr::new(10, 0, 255, 255),
-        ))
-        .unwrap()
-    });
     let pool = object_create(
         client,
         "/system/ip-pools",
@@ -95,16 +108,10 @@ pub async fn create_ip_pool(
                 name: pool_name.parse().unwrap(),
                 description: String::from("an ip pool"),
             },
-            project: project_path,
         },
     )
     .await;
-    let range = object_create(
-        client,
-        format!("/system/ip-pools/{}/ranges/add", pool_name).as_str(),
-        &ip_range,
-    )
-    .await;
+    let range = populate_ip_pool(client, pool_name, ip_range).await;
     (pool, range)
 }
 

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -73,7 +73,7 @@ fn get_disk_detach_url(instance_name: &str) -> String {
 }
 
 async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_organization(&client, ORG_NAME).await;
     let project = create_project(client, ORG_NAME, PROJECT_NAME).await;
     project.identity.id

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -19,10 +19,10 @@ use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::create_disk;
 use nexus_test_utils::resource_helpers::create_instance;
 use nexus_test_utils::resource_helpers::create_instance_with;
-use nexus_test_utils::resource_helpers::create_ip_pool;
 use nexus_test_utils::resource_helpers::create_organization;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::ByteCount;
@@ -73,7 +73,7 @@ fn get_disk_detach_url(instance_name: &str) -> String {
 }
 
 async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_organization(&client, ORG_NAME).await;
     let project = create_project(client, ORG_NAME, PROJECT_NAME).await;
     project.identity.id

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -355,8 +355,7 @@ lazy_static! {
     pub static ref DEMO_IP_POOL_RANGES_DEL_URL: String = format!("{}/remove", *DEMO_IP_POOL_RANGES_URL);
 
     // IP Pools (Services)
-    pub static ref DEMO_IP_POOLS_SERVICE_URL: &'static str = "/system/ip-pools-service";
-    pub static ref DEMO_IP_POOL_SERVICE_URL: String = format!("{}/{}", *DEMO_IP_POOLS_SERVICE_URL, RACK_UUID);
+    pub static ref DEMO_IP_POOL_SERVICE_URL: &'static str = "/system/ip-pools-service";
     pub static ref DEMO_IP_POOL_SERVICE_RANGES_URL: String = format!("{}/ranges", *DEMO_IP_POOL_SERVICE_URL);
     pub static ref DEMO_IP_POOL_SERVICE_RANGES_ADD_URL: String = format!("{}/add", *DEMO_IP_POOL_SERVICE_RANGES_URL);
     pub static ref DEMO_IP_POOL_SERVICE_RANGES_DEL_URL: String = format!("{}/remove", *DEMO_IP_POOL_SERVICE_RANGES_URL);

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -330,7 +330,7 @@ lazy_static! {
 
     // IP Pools
     pub static ref DEMO_IP_POOLS_URL: &'static str = "/system/ip-pools";
-    pub static ref DEMO_IP_POOL_NAME: Name = "pool0".parse().unwrap();
+    pub static ref DEMO_IP_POOL_NAME: Name = "default".parse().unwrap();
     pub static ref DEMO_IP_POOL_CREATE: params::IpPoolCreate =
         params::IpPoolCreate {
             identity: IdentityMetadataCreateParams {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -263,7 +263,7 @@ lazy_static! {
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![
-                params::ExternalIpCreate::Ephemeral { pool_name: None }
+                params::ExternalIpCreate::Ephemeral { pool_name: Some(DEMO_IP_POOL_NAME.clone()) }
             ],
             disks: vec![],
             start: true,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -337,7 +337,6 @@ lazy_static! {
                 name: DEMO_IP_POOL_NAME.clone(),
                 description: String::from("an IP pool"),
             },
-            project: None,
         };
     pub static ref DEMO_IP_POOL_URL: String = format!("/system/ip-pools/{}", *DEMO_IP_POOL_NAME);
     pub static ref DEMO_IP_POOL_UPDATE: params::IpPoolUpdate =

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -61,7 +61,7 @@ fn get_instances_url() -> String {
 }
 
 async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let project = create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
     project.identity.id
@@ -127,7 +127,7 @@ async fn test_instances_access_before_create_returns_not_found(
 async fn test_v1_instance_access(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     let org = create_organization(&client, ORGANIZATION_NAME).await;
     let project = create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -191,7 +191,7 @@ async fn test_instances_create_reboot_halt(
     let nexus = &apictx.nexus;
 
     // Create an IP pool and  project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -517,7 +517,7 @@ async fn test_instances_create_stopped_start(
     let nexus = &apictx.nexus;
 
     // Create an IP pool and  project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -573,7 +573,7 @@ async fn test_instances_delete_fails_when_running_succeeds_when_stopped(
     let nexus = &apictx.nexus;
 
     // Create an IP pool and project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -698,7 +698,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
     let client = &cptestctx.external_client;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -811,7 +811,7 @@ async fn test_instance_with_single_explicit_ip_address(
     let client = &cptestctx.external_client;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -887,7 +887,7 @@ async fn test_instance_with_new_custom_network_interfaces(
     let client = &cptestctx.external_client;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -1045,7 +1045,7 @@ async fn test_instance_create_delete_network_interface(
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -1296,7 +1296,7 @@ async fn test_instance_update_network_interfaces(
     let nexus = &cptestctx.server.apictx.nexus;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -1784,7 +1784,7 @@ async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
 
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -1878,7 +1878,7 @@ async fn test_instance_fails_to_boot_with_disk(
 
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -2181,7 +2181,7 @@ async fn test_attach_eight_disks_to_instance(
 
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -2396,7 +2396,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
 
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -2533,7 +2533,7 @@ async fn test_disks_detached_when_instance_destroyed(
 
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None, None).await;
+    create_ip_pool(&client, POOL_NAME, None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -2779,7 +2779,7 @@ async fn test_instance_serial(cptestctx: &ControlPlaneTestContext) {
     let nexus = &apictx.nexus;
 
     // Create a project that we'll use for testing.
-    create_ip_pool(client, POOL_NAME, None, None).await;
+    create_ip_pool(client, POOL_NAME, None).await;
     create_organization(client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
@@ -2880,10 +2880,6 @@ async fn test_instance_ephemeral_ip_from_correct_project(
     // Create two IP pools.
     //
     // The first is restricted to the "restricted" project, the second unrestricted.
-    let project_path = params::ProjectPath {
-        organization: Name::try_from(ORGANIZATION_NAME.to_string()).unwrap(),
-        project: Name::try_from("restricted".to_string()).unwrap(),
-    };
     let first_range = IpRange::V4(
         Ipv4Range::new(
             std::net::Ipv4Addr::new(10, 0, 0, 1),
@@ -2898,15 +2894,8 @@ async fn test_instance_ephemeral_ip_from_correct_project(
         )
         .unwrap(),
     );
-    create_ip_pool(
-        &client,
-        "restricted-pool",
-        Some(first_range),
-        Some(project_path),
-    )
-    .await;
-    create_ip_pool(&client, "unrestricted-pool", Some(second_range), None)
-        .await;
+    create_ip_pool(&client, "restricted-pool", Some(first_range)).await;
+    create_ip_pool(&client, "unrestricted-pool", Some(second_range)).await;
 
     // Create an instance in the default project, not the "dummy" project
     let instance_params = params::InstanceCreate {

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -13,6 +13,7 @@ use nexus_test_utils::resource_helpers::create_disk;
 use nexus_test_utils::resource_helpers::create_ip_pool;
 use nexus_test_utils::resource_helpers::object_create;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::resource_helpers::DiskTest;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Disk;
@@ -48,7 +49,6 @@ use nexus_test_utils_macros::nexus_test;
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
 
-static POOL_NAME: &str = "p0";
 static ORGANIZATION_NAME: &str = "test-org";
 static PROJECT_NAME: &str = "springfield-squidport";
 
@@ -61,7 +61,7 @@ fn get_instances_url() -> String {
 }
 
 async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_organization(&client, ORGANIZATION_NAME).await;
     let project = create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
     project.identity.id
@@ -127,7 +127,7 @@ async fn test_instances_access_before_create_returns_not_found(
 async fn test_v1_instance_access(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     let org = create_organization(&client, ORGANIZATION_NAME).await;
     let project = create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
@@ -190,14 +190,11 @@ async fn test_instances_create_reboot_halt(
     let apictx = &cptestctx.server.apictx;
     let nexus = &apictx.nexus;
 
-    // Create an IP pool and  project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create an instance.
     let instance_url = format!("{}/just-rainsticks", url_instances);
@@ -516,14 +513,11 @@ async fn test_instances_create_stopped_start(
     let apictx = &cptestctx.server.apictx;
     let nexus = &apictx.nexus;
 
-    // Create an IP pool and  project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create an instance in a stopped state.
     let instance: Instance = object_create(
@@ -572,14 +566,11 @@ async fn test_instances_delete_fails_when_running_succeeds_when_stopped(
     let apictx = &cptestctx.server.apictx;
     let nexus = &apictx.nexus;
 
-    // Create an IP pool and project that we'll use for testing.
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create an instance.
     let instance_url = format!("{}/just-rainsticks", url_instances);
@@ -698,13 +689,11 @@ async fn test_instance_create_saga_removes_instance_database_record(
     let client = &cptestctx.external_client;
 
     // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // The network interface parameters.
     let default_name = "default".parse::<Name>().unwrap();
@@ -810,14 +799,11 @@ async fn test_instance_with_single_explicit_ip_address(
 ) {
     let client = &cptestctx.external_client;
 
-    // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create the parameters for the interface.
     let default_name = "default".parse::<Name>().unwrap();
@@ -886,14 +872,11 @@ async fn test_instance_with_new_custom_network_interfaces(
 ) {
     let client = &cptestctx.external_client;
 
-    // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create a VPC Subnet other than the default.
     //
@@ -1044,14 +1027,11 @@ async fn test_instance_create_delete_network_interface(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
 
-    // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create the VPC Subnet for the secondary interface
     let secondary_subnet = params::VpcSubnetCreate {
@@ -1295,14 +1275,11 @@ async fn test_instance_update_network_interfaces(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.apictx.nexus;
 
-    // Create test IP pool, organization and project
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Create the VPC Subnet for the secondary interface
     let secondary_subnet = params::VpcSubnetCreate {
@@ -1778,15 +1755,9 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
 async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    const POOL_NAME: &str = "p0";
-    const ORGANIZATION_NAME: &str = "bobs-barrel-of-bytes";
-    const PROJECT_NAME: &str = "bit-barrel";
-
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
-    create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
+    create_org_and_project(&client).await;
 
     // Create the "probablydata" disk
     create_disk(&client, ORGANIZATION_NAME, PROJECT_NAME, "probablydata").await;
@@ -1872,15 +1843,9 @@ async fn test_instance_fails_to_boot_with_disk(
     // see: https://github.com/oxidecomputer/omicron/issues/1713
     let client = &cptestctx.external_client;
 
-    const POOL_NAME: &str = "p0";
-    const ORGANIZATION_NAME: &str = "bobs-barrel-of-bytes";
-    const PROJECT_NAME: &str = "bit-barrel";
-
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
-    create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
+    create_org_and_project(&client).await;
 
     // Create the "probablydata" disk
     create_disk(&client, ORGANIZATION_NAME, PROJECT_NAME, "probablydata").await;
@@ -2175,15 +2140,9 @@ async fn test_attach_eight_disks_to_instance(
 ) {
     let client = &cptestctx.external_client;
 
-    const POOL_NAME: &str = "p0";
-    const ORGANIZATION_NAME: &str = "bobs-barrel-of-bytes";
-    const PROJECT_NAME: &str = "bit-barrel";
-
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
-    create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
+    create_org_and_project(&client).await;
 
     // Make 8 disks
     for i in 0..8 {
@@ -2388,17 +2347,9 @@ async fn test_cannot_attach_nine_disks_to_instance(
 #[nexus_test]
 async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-
-    // Test pre-reqs
-    const POOL_NAME: &str = "p0";
-    const ORGANIZATION_NAME: &str = "bobs-barrel-of-bytes";
-    const PROJECT_NAME: &str = "bit-barrel";
-
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
-    create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
+    create_org_and_project(&client).await;
 
     // Make 8 disks
     for i in 0..8 {
@@ -2527,15 +2478,9 @@ async fn test_disks_detached_when_instance_destroyed(
 ) {
     let client = &cptestctx.external_client;
 
-    const POOL_NAME: &str = "p0";
-    const ORGANIZATION_NAME: &str = "bobs-barrel-of-bytes";
-    const PROJECT_NAME: &str = "bit-barrel";
-
     // Test pre-reqs
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, POOL_NAME, None).await;
-    create_organization(&client, ORGANIZATION_NAME).await;
-    create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
+    create_org_and_project(&client).await;
 
     // Make 8 disks
     for i in 0..8 {
@@ -2778,14 +2723,11 @@ async fn test_instance_serial(cptestctx: &ControlPlaneTestContext) {
     let apictx = &cptestctx.server.apictx;
     let nexus = &apictx.nexus;
 
-    // Create a project that we'll use for testing.
-    create_ip_pool(client, POOL_NAME, None).await;
-    create_organization(client, ORGANIZATION_NAME).await;
+    create_org_and_project(&client).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
-    let _ = create_project(client, ORGANIZATION_NAME, PROJECT_NAME).await;
 
     // Make sure we get a 404 if we try to access the serial console before creation.
     let instance_serial_url =
@@ -2863,23 +2805,23 @@ async fn test_instance_serial(cptestctx: &ControlPlaneTestContext) {
 }
 
 #[nexus_test]
-async fn test_instance_ephemeral_ip_from_correct_project(
+async fn test_instance_ephemeral_ip_from_correct_pool(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
 
-    // Create test organization and two projects.
+    // Create test organization and projects.
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
         "/organizations/{}/projects/{}/instances",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
-    let _ = create_project(&client, ORGANIZATION_NAME, "restricted").await;
 
     // Create two IP pools.
     //
-    // The first is restricted to the "restricted" project, the second unrestricted.
+    // The first is given to the "default" pool, the provided to a distinct
+    // explicit pool.
     let first_range = IpRange::V4(
         Ipv4Range::new(
             std::net::Ipv4Addr::new(10, 0, 0, 1),
@@ -2894,10 +2836,10 @@ async fn test_instance_ephemeral_ip_from_correct_project(
         )
         .unwrap(),
     );
-    create_ip_pool(&client, "restricted-pool", Some(first_range)).await;
-    create_ip_pool(&client, "unrestricted-pool", Some(second_range)).await;
+    populate_ip_pool(&client, "default", Some(first_range)).await;
+    create_ip_pool(&client, "other-pool", Some(second_range)).await;
 
-    // Create an instance in the default project, not the "dummy" project
+    // Create an instance explicitly using the "other-pool".
     let instance_params = params::InstanceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("ip-pool-test")).unwrap(),
@@ -2909,7 +2851,9 @@ async fn test_instance_ephemeral_ip_from_correct_project(
         user_data: vec![],
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
-            pool_name: None,
+            pool_name: Some(
+                Name::try_from(String::from("other-pool")).unwrap(),
+            ),
         }],
         disks: vec![],
         start: true,
@@ -2940,8 +2884,8 @@ async fn test_instance_ephemeral_ip_from_correct_project(
         ips.items[0].ip >= second_range.first_address()
             && ips.items[0].ip <= second_range.last_address(),
         "Expected the Ephemeral IP to come from the second address \
-        range, since the first is reserved for a project different from \
-        the instance's project."
+        range, since the first is reserved for the default pool, not \
+        the requested pool."
     );
 }
 

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -661,8 +661,7 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
 #[nexus_test]
 async fn test_ip_pool_service(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let ip_pool_url =
-        format!("/system/ip-pools-service/{}", nexus_test_utils::RACK_UUID);
+    let ip_pool_url = "/system/ip-pools-service".to_string();
     let ip_pool_ranges_url = format!("{}/ranges", ip_pool_url);
     let ip_pool_add_range_url = format!("{}/add", ip_pool_ranges_url);
     let ip_pool_remove_range_url = format!("{}/remove", ip_pool_ranges_url);

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -99,7 +99,6 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
-        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -295,7 +294,6 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
-        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -477,7 +475,6 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
-        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -579,7 +576,6 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
-        project: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -10,8 +10,8 @@ use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::resource_helpers::{
-    create_disk, create_ip_pool, create_organization, create_project,
-    create_vpc, object_create, project_get, DiskTest,
+    create_disk, create_organization, create_project, create_vpc,
+    object_create, populate_ip_pool, project_get, DiskTest,
 };
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::ByteCount;
@@ -165,7 +165,7 @@ async fn test_project_deletion_with_instance(
     let client = &cptestctx.external_client;
 
     let org_name = "test-org";
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_organization(&client, &org_name).await;
 
     // Create a project that we'll use for testing.

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -59,7 +59,7 @@ async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
 async fn test_snapshot(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -190,7 +190,7 @@ async fn test_snapshot(cptestctx: &ControlPlaneTestContext) {
 async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -289,7 +289,7 @@ async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
 async fn test_delete_snapshot(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -643,7 +643,7 @@ async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
     // Test that snapshots cannot be created if there is no space for the blocks
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -11,10 +11,10 @@ use http::StatusCode;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
-use nexus_test_utils::resource_helpers::create_ip_pool;
 use nexus_test_utils::resource_helpers::create_organization;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::object_create;
+use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external;
@@ -59,7 +59,7 @@ async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
 async fn test_snapshot(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -190,7 +190,7 @@ async fn test_snapshot(cptestctx: &ControlPlaneTestContext) {
 async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -289,7 +289,7 @@ async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
 async fn test_delete_snapshot(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -643,7 +643,7 @@ async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
     // Test that snapshots cannot be created if there is no space for the blocks
     let client = &cptestctx.external_client;
     DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -85,7 +85,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     let project_name = "springfield-squidport";
 
     // Create a project that we'll use for testing.
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_organization(&client, organization_name).await;
     create_project(&client, organization_name, project_name).await;
     let url_instances = format!(

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -14,8 +14,8 @@ use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::resource_helpers::create_instance_with;
-use nexus_test_utils::resource_helpers::create_ip_pool;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::resource_helpers::{create_organization, create_project};
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::{
@@ -85,7 +85,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     let project_name = "springfield-squidport";
 
     // Create a project that we'll use for testing.
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_organization(&client, organization_name).await;
     create_project(&client, organization_name, project_name).await;
     let url_instances = format!(

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -200,7 +200,12 @@ lazy_static! {
                 &*DEMO_SILO_USER_ID_SET_PASSWORD_URL,
             ],
         },
-        // Create an IP pool
+        // Get the default IP pool
+        SetupReq::Get {
+            url: &*DEMO_IP_POOL_URL,
+            id_routes: vec!["/system/by-id/ip-pools/{id}"],
+        },
+        // Create an IP pool range
         SetupReq::Post {
             url: &*DEMO_IP_POOL_RANGES_ADD_URL,
             body: serde_json::to_value(&*DEMO_IP_POOL_RANGE).unwrap(),

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -69,7 +69,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .unwrap(),
+                    .expect(&format!("Failed to GET from URL: {url}")),
                 id_routes,
             ),
             SetupReq::Post { url, body, id_routes } => (
@@ -78,7 +78,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .unwrap(),
+                    .expect(&format!("Failed to POST to URL: {url}")),
                 id_routes,
             ),
         };
@@ -201,12 +201,6 @@ lazy_static! {
             ],
         },
         // Create an IP pool
-        SetupReq::Post {
-            url: &*DEMO_IP_POOLS_URL,
-            body: serde_json::to_value(&*DEMO_IP_POOL_CREATE).unwrap(),
-            id_routes: vec!["/system/by-id/ip-pools/{id}"],
-        },
-        // Create an IP Pool range
         SetupReq::Post {
             url: &*DEMO_IP_POOL_RANGES_ADD_URL,
             body: serde_json::to_value(&*DEMO_IP_POOL_RANGE).unwrap(),
@@ -415,7 +409,7 @@ async fn verify_endpoint(
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .unwrap()
+                    .expect(&format!("Failed to GET: {uri}"))
                     .parsed_body::<serde_json::Value>()
                     .unwrap(),
             )

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -11,10 +11,10 @@ use http::StatusCode;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
-use nexus_test_utils::resource_helpers::create_ip_pool;
 use nexus_test_utils::resource_helpers::create_organization;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::object_create;
+use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::ByteCount;
@@ -53,7 +53,7 @@ async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
 }
 
 async fn create_global_image(client: &ClientTestContext) -> views::GlobalImage {
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
 
     // Define a global image
@@ -461,7 +461,7 @@ async fn test_multiple_disks_multiple_snapshots_order_1(
     // Test multiple disks with multiple snapshots
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -608,7 +608,7 @@ async fn test_multiple_disks_multiple_snapshots_order_2(
     // Test multiple disks with multiple snapshots, varying the delete order
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -894,7 +894,7 @@ async fn test_multiple_layers_of_snapshots_delete_all_disks_first(
     // delete all disks, then delete all snapshots
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;
@@ -935,7 +935,7 @@ async fn test_multiple_layers_of_snapshots_delete_all_snapshots_first(
     // delete all snapshots, then delete all disks
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;
@@ -976,7 +976,7 @@ async fn test_multiple_layers_of_snapshots_random_delete_order(
     // delete snapshots and disks in a random order
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None).await;
+    populate_ip_pool(&client, "default", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -53,7 +53,7 @@ async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
 }
 
 async fn create_global_image(client: &ClientTestContext) -> views::GlobalImage {
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
 
     // Define a global image
@@ -461,7 +461,7 @@ async fn test_multiple_disks_multiple_snapshots_order_1(
     // Test multiple disks with multiple snapshots
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -608,7 +608,7 @@ async fn test_multiple_disks_multiple_snapshots_order_2(
     // Test multiple disks with multiple snapshots, varying the delete order
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
     let disks_url = get_disks_url();
 
@@ -894,7 +894,7 @@ async fn test_multiple_layers_of_snapshots_delete_all_disks_first(
     // delete all disks, then delete all snapshots
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;
@@ -935,7 +935,7 @@ async fn test_multiple_layers_of_snapshots_delete_all_snapshots_first(
     // delete all snapshots, then delete all disks
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;
@@ -976,7 +976,7 @@ async fn test_multiple_layers_of_snapshots_random_delete_order(
     // delete snapshots and disks in a random order
     let client = &cptestctx.external_client;
     let disk_test = DiskTest::new(&cptestctx).await;
-    create_ip_pool(&client, "p0", None, None).await;
+    create_ip_pool(&client, "p0", None).await;
     create_org_and_project(client).await;
 
     prepare_for_test_multiple_layers_of_snapshots(&client).await;

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -14,8 +14,8 @@ use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::resource_helpers::{
-    create_instance, create_ip_pool, create_organization, create_project,
-    create_vpc,
+    create_instance, create_organization, create_project, create_vpc,
+    populate_ip_pool,
 };
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -40,7 +40,7 @@ async fn test_delete_vpc_subnet_with_interfaces_fails(
     let project_name = "springfield-squidport";
     create_organization(&client, &org_name).await;
     let _ = create_project(&client, org_name, project_name).await;
-    create_ip_pool(client, "pool0", None).await;
+    populate_ip_pool(client, "default", None).await;
 
     let vpcs_url =
         format!("/organizations/{}/projects/{}/vpcs", org_name, project_name);

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -40,7 +40,7 @@ async fn test_delete_vpc_subnet_with_interfaces_fails(
     let project_name = "springfield-squidport";
     create_organization(&client, &org_name).await;
     let _ = create_project(&client, org_name, project_name).await;
-    create_ip_pool(client, "pool0", None, None).await;
+    create_ip_pool(client, "pool0", None).await;
 
     let vpcs_url =
         format!("/organizations/{}/projects/{}/vpcs", org_name, project_name);

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -131,10 +131,10 @@ ip_pool_list                             /system/ip-pools
 ip_pool_range_add                        /system/ip-pools/{pool_name}/ranges/add
 ip_pool_range_list                       /system/ip-pools/{pool_name}/ranges
 ip_pool_range_remove                     /system/ip-pools/{pool_name}/ranges/remove
-ip_pool_service_range_add                /system/ip-pools-service/{rack_id}/ranges/add
-ip_pool_service_range_list               /system/ip-pools-service/{rack_id}/ranges
-ip_pool_service_range_remove             /system/ip-pools-service/{rack_id}/ranges/remove
-ip_pool_service_view                     /system/ip-pools-service/{rack_id}
+ip_pool_service_range_add                /system/ip-pools-service/ranges/add
+ip_pool_service_range_list               /system/ip-pools-service/ranges
+ip_pool_service_range_remove             /system/ip-pools-service/ranges/remove
+ip_pool_service_view                     /system/ip-pools-service
 ip_pool_update                           /system/ip-pools/{pool_name}
 ip_pool_view                             /system/ip-pools/{pool_name}
 ip_pool_view_by_id                       /system/by-id/ip-pools/{id}

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -508,14 +508,6 @@ pub struct NetworkInterfaceUpdate {
 
 // IP POOLS
 
-// Type used to identify a Project in request bodies, where one may not have
-// the path in the request URL.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct ProjectPath {
-    pub organization: Name,
-    pub project: Name,
-}
-
 /// Create-time parameters for an IP Pool.
 ///
 /// See [`IpPool`](crate::external_api::views::IpPool)
@@ -523,8 +515,6 @@ pub struct ProjectPath {
 pub struct IpPoolCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    #[serde(flatten)]
-    pub project: Option<ProjectPath>,
 }
 
 /// Parameters for updating an IP Pool

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -271,7 +271,6 @@ pub struct VpcRouter {
 pub struct IpPool {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
-    pub project_id: Option<Uuid>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10340,11 +10340,6 @@
               }
             ]
           },
-          "project_id": {
-            "nullable": true,
-            "type": "string",
-            "format": "uuid"
-          },
           "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
@@ -10372,12 +10367,6 @@
             "type": "string"
           },
           "name": {
-            "$ref": "#/components/schemas/Name"
-          },
-          "organization": {
-            "$ref": "#/components/schemas/Name"
-          },
-          "project": {
             "$ref": "#/components/schemas/Name"
           }
         },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6383,25 +6383,13 @@
         }
       }
     },
-    "/system/ip-pools-service/{rack_id}": {
+    "/system/ip-pools-service": {
       "get": {
         "tags": [
           "system"
         ],
-        "summary": "Fetch an IP pool used for Oxide services.",
+        "summary": "Fetch the IP pool used for Oxide services.",
         "operationId": "ip_pool_service_view",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "rack_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "simple"
-          }
-        ],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -6422,25 +6410,15 @@
         }
       }
     },
-    "/system/ip-pools-service/{rack_id}/ranges": {
+    "/system/ip-pools-service/ranges": {
       "get": {
         "tags": [
           "system"
         ],
-        "summary": "List ranges for an IP pool used for Oxide services.",
+        "summary": "List ranges for the IP pool used for Oxide services.",
         "description": "Ranges are ordered by their first address.",
         "operationId": "ip_pool_service_range_list",
         "parameters": [
-          {
-            "in": "path",
-            "name": "rack_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "simple"
-          },
           {
             "in": "query",
             "name": "limit",
@@ -6485,25 +6463,13 @@
         "x-dropshot-pagination": true
       }
     },
-    "/system/ip-pools-service/{rack_id}/ranges/add": {
+    "/system/ip-pools-service/ranges/add": {
       "post": {
         "tags": [
           "system"
         ],
         "summary": "Add a range to an IP pool used for Oxide services.",
         "operationId": "ip_pool_service_range_add",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "rack_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -6534,25 +6500,13 @@
         }
       }
     },
-    "/system/ip-pools-service/{rack_id}/ranges/remove": {
+    "/system/ip-pools-service/ranges/remove": {
       "post": {
         "tags": [
           "system"
         ],
         "summary": "Remove a range from an IP pool used for Oxide services.",
         "operationId": "ip_pool_service_range_remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "rack_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "style": "simple"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
## Before this PR

- IP Pools could exist in at most one project. IP allocation during instance creation occurred by [either by requesting an IP pool belonging to a project, or by "just looking for any unreserved IP Pool"](https://github.com/oxidecomputer/omicron/blob/79765a4e3b39a29bc9940c0e4a49c4364fbcc9e3/nexus/src/db/queries/external_ip.rs#L186-L212). As discussed in https://github.com/oxidecomputer/omicron/issues/2055 , our intention is for IP pools to be used across multiple projects, and for projects to be able to use multiple IP pools.
- "Service" IP pools were indexed by rack ID, though (as documented in https://github.com/oxidecomputer/omicron/issues/1276 ), they should probably be accessed by AZ instead.

## This PR

- Adds a default IP pool named `default`, which is used for address allocation unless a more specific IP pool is provided
- Removes "project ID" from IP pools (and external IP addresses)
- Removes "rack ID" from IP pool API and DB representation

## In the future

- This PR doesn't provide the many-to-many connection between projects and IP pools that we eventually want, where projects can be configured to use different IP pools for different purposes. However, by removing the not-quite-accurate relationship that an IP pool must belong to a *single* project, the API moves closer towards this direction.
- We probably should access the `service_ip_pool` API with the AZ UUID used for the query, but since AZs don't exist in the API yet, this has been omitted.

Part of #2055 