### PR TITLE
[sagas] Make a macro to simplify declaring saga actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,6 +3464,7 @@ dependencies = [
  "oximeter-instruments",
  "oximeter-producer",
  "parse-display",
+ "paste",
  "petgraph",
  "pq-sys",
  "propolis-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,6 +3452,7 @@ dependencies = [
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
+ "once_cell",
  "openapi-lint",
  "openapiv3",
  "openssl",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -45,6 +45,7 @@ oso = "0.26"
 oximeter-client = { path = "../oximeter-client" }
 oximeter-db = { path = "../oximeter/db/" }
 parse-display = "0.7.0"
+paste = "1.0"
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b596e72b6b93bc412d675358f782ae7d53f8bf7a", features = [ "generated" ] }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -37,6 +37,7 @@ newtype_derive = "0.1.6"
 # integration tests.
 nexus-test-interface = { path = "test-interface" }
 num-integer = "0.1.45"
+once_cell = "1.16.0"
 # must match samael's crate!
 openssl = "0.10"
 openssl-sys = "0.9"

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -9,23 +9,20 @@ use super::{
     ActionRegistry, NexusActionContext, NexusSaga, SagaInitError,
     ACTION_GENERATE_ID,
 };
-use crate::app::sagas::NexusAction;
+use crate::app::sagas::declare_saga_actions;
 use crate::context::OpContext;
 use crate::db::identity::{Asset, Resource};
 use crate::db::lookup::LookupPath;
 use crate::external_api::params;
 use crate::{authn, authz, db};
-use lazy_static::lazy_static;
 use omicron_common::api::external::Error;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use serde::Deserialize;
 use serde::Serialize;
 use sled_agent_client::types::{CrucibleOpts, VolumeConstructionRequest};
 use std::convert::TryFrom;
-use std::sync::Arc;
 use steno::ActionError;
-use steno::ActionFunc;
-use steno::{new_action_noop_undo, Node};
+use steno::Node;
 use uuid::Uuid;
 
 // disk create saga: input parameters
@@ -39,31 +36,27 @@ pub struct Params {
 
 // disk create saga: actions
 
-lazy_static! {
-    static ref CREATE_DISK_RECORD: NexusAction = ActionFunc::new_action(
-        "disk-create.create-disk-record",
-        sdc_create_disk_record,
-        sdc_create_disk_record_undo
-    );
-    static ref REGIONS_ALLOC: NexusAction = ActionFunc::new_action(
-        "disk-create.regions-alloc",
-        sdc_alloc_regions,
-        sdc_alloc_regions_undo,
-    );
-    static ref REGIONS_ENSURE: NexusAction = ActionFunc::new_action(
-        "disk-create.regions-ensure",
-        sdc_regions_ensure,
-        sdc_regions_ensure_undo,
-    );
-    static ref CREATE_VOLUME_RECORD: NexusAction = ActionFunc::new_action(
-        "disk-create.create-volume-record",
-        sdc_create_volume_record,
-        sdc_create_volume_record_undo,
-    );
-    static ref FINALIZE_DISK_RECORD: NexusAction = new_action_noop_undo(
-        "disk-create.finalize-disk-record",
-        sdc_finalize_disk_record
-    );
+declare_saga_actions! {
+    disk_create;
+    CREATE_DISK_RECORD -> "created_disk" {
+        + sdc_create_disk_record
+        - sdc_create_disk_record_undo
+    }
+    REGIONS_ALLOC -> "datasets_and_regions" {
+        + sdc_alloc_regions
+        - sdc_alloc_regions_undo
+    }
+    REGIONS_ENSURE -> "regions_ensure" {
+        + sdc_regions_ensure
+        - sdc_regions_ensure_undo
+    }
+    CREATE_VOLUME_RECORD -> "created_volume" {
+        + sdc_create_volume_record
+        - sdc_create_volume_record_undo
+    }
+    FINALIZE_DISK_RECORD -> "disk_runtime" {
+        + sdc_finalize_disk_record
+    }
 }
 
 // disk create saga: definition
@@ -75,11 +68,7 @@ impl NexusSaga for SagaDiskCreate {
     type Params = Params;
 
     fn register_actions(registry: &mut ActionRegistry) {
-        registry.register(Arc::clone(&*CREATE_DISK_RECORD));
-        registry.register(Arc::clone(&*REGIONS_ALLOC));
-        registry.register(Arc::clone(&*REGIONS_ENSURE));
-        registry.register(Arc::clone(&*CREATE_VOLUME_RECORD));
-        registry.register(Arc::clone(&*FINALIZE_DISK_RECORD));
+        disk_create_register_actions(registry);
     }
 
     fn make_saga_dag(
@@ -98,35 +87,11 @@ impl NexusSaga for SagaDiskCreate {
             ACTION_GENERATE_ID.as_ref(),
         ));
 
-        builder.append(Node::action(
-            "created_disk",
-            "CreateDiskRecord",
-            CREATE_DISK_RECORD.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "datasets_and_regions",
-            "RegionsAlloc",
-            REGIONS_ALLOC.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "regions_ensure",
-            "RegionsEnsure",
-            REGIONS_ENSURE.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "created_volume",
-            "CreateVolumeRecord",
-            CREATE_VOLUME_RECORD.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "disk_runtime",
-            "FinalizeDiskRecord",
-            FINALIZE_DISK_RECORD.as_ref(),
-        ));
+        builder.append(create_disk_record_action());
+        builder.append(regions_alloc_action());
+        builder.append(regions_ensure_action());
+        builder.append(create_volume_record_action());
+        builder.append(finalize_disk_record_action());
 
         Ok(builder.build()?)
     }

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{NexusActionContext, NexusSaga, SagaInitError, ACTION_GENERATE_ID};
+use crate::app::sagas::declare_saga_actions;
 use crate::app::sagas::disk_create::{self, SagaDiskCreate};
-use crate::app::sagas::NexusAction;
 use crate::app::{
     MAX_DISKS_PER_INSTANCE, MAX_EXTERNAL_IPS_PER_INSTANCE,
     MAX_NICS_PER_INSTANCE,
@@ -16,7 +16,6 @@ use crate::db::queries::network_interface::InsertError as InsertNicError;
 use crate::external_api::params;
 use crate::{authn, authz, db};
 use chrono::Utc;
-use lazy_static::lazy_static;
 use nexus_defaults::DEFAULT_PRIMARY_NIC_NAME;
 use nexus_types::external_api::params::InstanceDiskAttachment;
 use omicron_common::api::external::Error;
@@ -33,10 +32,7 @@ use slog::warn;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::net::Ipv6Addr;
-use std::sync::Arc;
-use steno::new_action_noop_undo;
 use steno::ActionError;
-use steno::ActionFunc;
 use steno::Node;
 use steno::{DagBuilder, SagaName};
 use uuid::Uuid;
@@ -71,47 +67,40 @@ struct DiskAttachParams {
 
 // instance create saga: actions
 
-lazy_static! {
-    static ref ALLOC_SERVER: NexusAction = new_action_noop_undo(
-        // TODO-robustness This still needs an undo action, and we should really
-        // keep track of resources and reservations, etc.  See the comment on
-        // SagaContext::alloc_server()
-        "instance-create.alloc-server",
-        sic_alloc_server
-    );
-    static ref ALLOC_PROPOLIS_IP: NexusAction = new_action_noop_undo(
-        "instance-create.allocate-propolis-ip",
-        sic_allocate_propolis_ip,
-    );
-    static ref CREATE_INSTANCE_RECORD: NexusAction = ActionFunc::new_action(
-        "instance-create.create-instance-record",
-        sic_create_instance_record,
-        sic_delete_instance_record,
-    );
-    static ref CREATE_NETWORK_INTERFACE: NexusAction = ActionFunc::new_action(
-        "instance-create.create-network-interface",
-        sic_create_network_interface,
-        sic_create_network_interface_undo,
-    );
-    static ref CREATE_SNAT_IP: NexusAction = ActionFunc::new_action(
-        "instance-create.create-snat-ip",
-        sic_allocate_instance_snat_ip,
-        sic_allocate_instance_snat_ip_undo,
-    );
-    static ref CREATE_EXTERNAL_IP: NexusAction = ActionFunc::new_action(
-        "instance-create.create-external-ip",
-        sic_allocate_instance_external_ip,
-        sic_allocate_instance_external_ip_undo,
-    );
-    static ref ATTACH_DISKS_TO_INSTANCE: NexusAction = ActionFunc::new_action(
-        "instance-create.attach-disks-to-instance",
-        sic_attach_disk_to_instance,
-        sic_attach_disk_to_instance_undo,
-    );
-    static ref INSTANCE_ENSURE: NexusAction = new_action_noop_undo(
-        "instance-create.instance-ensure",
-        sic_instance_ensure,
-    );
+declare_saga_actions! {
+    instance_create;
+    // TODO-robustness This still needs an undo action, and we should really
+    // keep track of resources and reservations, etc.  See the comment on
+    // SagaContext::alloc_server()
+    ALLOC_SERVER -> "server_id" {
+        + sic_alloc_server
+    }
+    ALLOC_PROPOLIS_IP -> "propolis_ip" {
+        + sic_allocate_propolis_ip
+    }
+    CREATE_INSTANCE_RECORD -> "instance_name" {
+        + sic_create_instance_record
+        - sic_delete_instance_record
+    }
+    CREATE_NETWORK_INTERFACE -> "output" {
+        + sic_create_network_interface
+        - sic_create_network_interface_undo
+    }
+    CREATE_SNAT_IP -> "snat_ip" {
+        + sic_allocate_instance_snat_ip
+        - sic_allocate_instance_snat_ip_undo
+    }
+    CREATE_EXTERNAL_IP -> "output" {
+        + sic_allocate_instance_external_ip
+        - sic_allocate_instance_external_ip_undo
+    }
+    ATTACH_DISKS_TO_INSTANCE -> "attach_disk_output" {
+        + sic_attach_disk_to_instance
+        - sic_attach_disk_to_instance_undo
+    }
+    INSTANCE_ENSURE -> "instance_ensure" {
+        + sic_instance_ensure
+    }
 }
 
 // instance create saga: definition
@@ -123,14 +112,7 @@ impl NexusSaga for SagaInstanceCreate {
     type Params = Params;
 
     fn register_actions(registry: &mut super::ActionRegistry) {
-        registry.register(Arc::clone(&*ALLOC_SERVER));
-        registry.register(Arc::clone(&*ALLOC_PROPOLIS_IP));
-        registry.register(Arc::clone(&*CREATE_INSTANCE_RECORD));
-        registry.register(Arc::clone(&*CREATE_NETWORK_INTERFACE));
-        registry.register(Arc::clone(&*CREATE_SNAT_IP));
-        registry.register(Arc::clone(&*CREATE_EXTERNAL_IP));
-        registry.register(Arc::clone(&*ATTACH_DISKS_TO_INSTANCE));
-        registry.register(Arc::clone(&*INSTANCE_ENSURE));
+        instance_create_register_actions(registry);
     }
 
     fn make_saga_dag(
@@ -152,23 +134,9 @@ impl NexusSaga for SagaInstanceCreate {
             ACTION_GENERATE_ID.as_ref(),
         ));
 
-        builder.append(Node::action(
-            "server_id",
-            "AllocServer",
-            ALLOC_SERVER.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "propolis_ip",
-            "AllocatePropolisIp",
-            ALLOC_PROPOLIS_IP.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "instance_name",
-            "CreateInstanceRecord",
-            CREATE_INSTANCE_RECORD.as_ref(),
-        ));
+        builder.append(alloc_server_action());
+        builder.append(alloc_propolis_ip_action());
+        builder.append(create_instance_record_action());
 
         // Helper function for appending subsagas to our parent saga.
         fn subsaga_append<S: Serialize>(
@@ -250,11 +218,7 @@ impl NexusSaga for SagaInstanceCreate {
             "CreateSnatIpId",
             ACTION_GENERATE_ID.as_ref(),
         ));
-        builder.append(Node::action(
-            "snat_ip",
-            "CreateSnatIp",
-            CREATE_SNAT_IP.as_ref(),
-        ));
+        builder.append(create_snat_ip_action());
 
         // See the comment above where we add nodes for creating NICs.  We use
         // the same pattern here.
@@ -329,12 +293,7 @@ impl NexusSaga for SagaInstanceCreate {
             )?;
         }
 
-        builder.append(Node::action(
-            "instance_ensure",
-            "InstanceEnsure",
-            INSTANCE_ENSURE.as_ref(),
-        ));
-
+        builder.append(instance_ensure_action());
         Ok(builder.build()?)
     }
 }

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -4,13 +4,12 @@
 
 use super::instance_create::allocate_sled_ipv6;
 use super::{NexusActionContext, NexusSaga, ACTION_GENERATE_ID};
-use crate::app::sagas::NexusAction;
+use crate::app::sagas::declare_saga_actions;
 use crate::authn;
 use crate::context::OpContext;
 use crate::db::identity::Resource;
 use crate::db::model::IpKind;
 use crate::external_api::params;
-use lazy_static::lazy_static;
 use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use serde::Deserialize;
@@ -23,9 +22,8 @@ use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
 use sled_agent_client::types::SourceNatConfig;
 use std::net::Ipv6Addr;
-use std::sync::Arc;
 use steno::ActionError;
-use steno::{new_action_noop_undo, Node};
+use steno::Node;
 use uuid::Uuid;
 
 // instance migrate saga: input parameters
@@ -39,26 +37,23 @@ pub struct Params {
 
 // instance migrate saga: actions
 
-lazy_static! {
-    static ref ALLOCATE_PROPOLIS_IP: NexusAction = new_action_noop_undo(
-        "instance-migrate.allocate-propolis-ip",
-        sim_allocate_propolis_ip
-    );
-    static ref MIGRATE_PREP: NexusAction = new_action_noop_undo(
-        "instance-migrate.migrate-prep",
-        sim_migrate_prep,
-    );
-    static ref INSTANCE_MIGRATE: NexusAction = new_action_noop_undo(
-        "instance-migrate.instance-migrate",
+declare_saga_actions! {
+    instance_migrate;
+    ALLOCATE_PROPOLIS_IP -> "dst_propolis_ip" {
+        + sim_allocate_propolis_ip
+    }
+    MIGRATE_PREP -> "migrate_instance" {
+        + sim_migrate_prep
+    }
+    INSTANCE_MIGRATE -> "instance_migrate" {
         // TODO robustness: This needs an undo action
-        sim_instance_migrate,
-    );
-    static ref CLEANUP_SOURCE: NexusAction = new_action_noop_undo(
-        "instance-migrate.cleanup-source",
+        + sim_instance_migrate
+    }
+    CLEANUP_SOURCE -> "cleanup_source" {
         // TODO robustness: This needs an undo action. Is it even possible
         // to undo at this point?
-        sim_cleanup_source,
-    );
+        + sim_cleanup_source
+    }
 }
 
 // instance migrate saga: definition
@@ -70,10 +65,7 @@ impl NexusSaga for SagaInstanceMigrate {
     type Params = Params;
 
     fn register_actions(registry: &mut super::ActionRegistry) {
-        registry.register(Arc::clone(&*ALLOCATE_PROPOLIS_IP));
-        registry.register(Arc::clone(&*MIGRATE_PREP));
-        registry.register(Arc::clone(&*INSTANCE_MIGRATE));
-        registry.register(Arc::clone(&*CLEANUP_SOURCE));
+        instance_migrate_register_actions(registry);
     }
 
     fn make_saga_dag(
@@ -92,29 +84,10 @@ impl NexusSaga for SagaInstanceMigrate {
             ACTION_GENERATE_ID.as_ref(),
         ));
 
-        builder.append(Node::action(
-            "dst_propolis_ip",
-            "AllocatePropolisIp",
-            ALLOCATE_PROPOLIS_IP.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "migrate_instance",
-            "MigratePrep",
-            MIGRATE_PREP.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "instance_migrate",
-            "InstanceMigrate",
-            INSTANCE_MIGRATE.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "cleanup_source",
-            "CleanupSource",
-            CLEANUP_SOURCE.as_ref(),
-        ));
+        builder.append(allocate_propolis_ip_action());
+        builder.append(migrate_prep_action());
+        builder.append(instance_migrate_action());
+        builder.append(cleanup_source_action());
 
         Ok(builder.build()?)
     }

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -154,7 +154,7 @@ macro_rules! __action_name {
 ///
 /// For this input:
 ///
-/// ```
+/// ```ignore
 /// declare_saga_actions! {
 ///     my_saga;
 ///     SAGA_NODE1 -> "output1" {

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -151,6 +151,13 @@ macro_rules! __action_name {
 
 /// A macro intended to reduce boilerplate when writing saga actions.
 ///
+/// This macro aims to reduce this boilerplate, by requiring only the following:
+/// - The name of the saga
+/// - The name of each action
+/// - The output of each action
+/// - The "forward" action function
+/// - (Optional) The "undo" action function
+///
 /// For this input:
 ///
 /// ```ignore

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -10,7 +10,7 @@
 // easier it will be to test, version, and update in deployed systems.
 
 use crate::saga_interface::SagaContext;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::sync::Arc;
 use steno::new_action_noop_undo;
 use steno::ActionContext;
@@ -79,12 +79,11 @@ impl From<SagaInitError> for omicron_common::api::external::Error {
     }
 }
 
-lazy_static! {
-    pub(super) static ref ACTION_GENERATE_ID: NexusAction =
-        new_action_noop_undo("common.uuid_generate", saga_generate_uuid);
-    pub static ref ACTION_REGISTRY: Arc<ActionRegistry> =
-        Arc::new(make_action_registry());
-}
+pub(super) static ACTION_GENERATE_ID: Lazy<NexusAction> = Lazy::new(|| {
+    new_action_noop_undo("common.uuid_generate", saga_generate_uuid)
+});
+pub static ACTION_REGISTRY: Lazy<Arc<ActionRegistry>> =
+    Lazy::new(|| Arc::new(make_action_registry()));
 
 fn make_action_registry() -> ActionRegistry {
     let mut registry = steno::ActionRegistry::new();
@@ -203,21 +202,23 @@ macro_rules! declare_saga_actions {
     // Basically, everything to the left of "<>" is just us propagating state
     // through the macro, and everything to the right of it is user input.
     (S = $saga:ident $($nodes:ident),* <> $node:ident -> $out:literal { + $a:ident - $u:ident } $($tail:tt)*) => {
-        lazy_static::lazy_static! {
-            static ref $node: crate::app::sagas::NexusAction = ::steno::ActionFunc::new_action(
-                crate::app::sagas::__action_name!($saga, $node), $a, $u,
-            );
-        }
+        static $node: ::once_cell::sync::Lazy<crate::app::sagas::NexusAction> =
+            ::once_cell::sync::Lazy::new(|| {
+                ::steno::ActionFunc::new_action(
+                    crate::app::sagas::__action_name!($saga, $node), $a, $u,
+                )
+            });
         crate::app::sagas::__emit_action!($node, $out);
         declare_saga_actions!(S = $saga $($nodes,)* $node <> $($tail)*);
     };
     // Same as the prior match, but without the undo action.
     (S = $saga:ident $($nodes:ident),* <> $node:ident -> $out:literal { + $a:ident } $($tail:tt)*) => {
-        lazy_static::lazy_static! {
-            static ref $node: crate::app::sagas::NexusAction = ::steno::new_action_noop_undo(
-                crate::app::sagas::__action_name!($saga, $node), $a,
-            );
-        }
+        static $node: ::once_cell::sync::Lazy<crate::app::sagas::NexusAction> =
+            ::once_cell::sync::Lazy::new(|| {
+                ::steno::new_action_noop_undo(
+                    crate::app::sagas::__action_name!($saga, $node), $a,
+                )
+            });
         crate::app::sagas::__emit_action!($node, $out);
         declare_saga_actions!(S = $saga $($nodes,)* $node <> $($tail)*);
     };

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -116,3 +116,129 @@ pub(super) async fn saga_generate_uuid<UserType: SagaType>(
 ) -> Result<Uuid, ActionError> {
     Ok(Uuid::new_v4())
 }
+
+macro_rules! __stringify_ident {
+    ($i:ident) => {
+        stringify!($i)
+    };
+}
+
+macro_rules! __emit_action {
+    ($node:ident, $output:literal) => {
+        paste::paste! {
+            #[allow(dead_code)]
+            fn [<$node:lower _action>]() -> ::steno::Node {
+                ::steno::Node::action(
+                    $output,
+                    crate::app::sagas::__stringify_ident!([<$node:camel>]),
+                    $node.as_ref(),
+                )
+            }
+        }
+    };
+}
+
+macro_rules! __action_name {
+    ($saga:ident, $node:ident) => {
+        paste::paste! {
+            concat!(
+                stringify!($saga),
+                ".",
+                crate::app::sagas::__stringify_ident!([<$node:lower>]),
+            )
+        }
+    };
+}
+
+/// A macro intended to reduce boilerplate when writing saga actions.
+///
+/// For this input:
+///
+/// ```
+/// declare_saga_actions! {
+///     my_saga;
+///     SAGA_NODE1 -> "output1" {
+///         + do1
+///         - undo1
+///     }
+///     SAGA_NODE2 -> "output2" {
+///         + do2
+///     }
+/// }
+/// ```
+///
+/// We generate the following:
+/// - For `SAGA_NODE1`:
+///     - A `NexusAction` labeled "my_saga.saga_node1" (containing "do1" and "undo1").
+///     - `fn saga_node1_action() -> steno::Node` referencing this node, with an
+///     output named "output1".
+/// - For `SAGA_NODE2`:
+///     - A `NexusAction` labeled "my_saga.saga_node2" (containing "do2").
+///     - `fn saga_node2_action() -> steno::Node` referencing this node, with an
+///     output named "output2".
+/// - For `my_saga`:
+///     - `fn my_saga_register_actions(...)`, which can be called to implement
+///     `NexusSaga::register_actions`.
+macro_rules! declare_saga_actions {
+    // The entrypoint to the macro.
+    // We expect the input to be of the form:
+    //
+    //  saga-name;
+    ($saga:ident; $($tail:tt)*) => {
+        declare_saga_actions!(S = $saga <> $($tail)*);
+    };
+    // Subsequent lines of the saga action declaration.
+    // These take the form:
+    //
+    //  ACTION_NAME -> "output" {
+    //      + action
+    //      - undo_action
+    //  }
+    //
+    // However, we also want to propagate the Saga structure and collection of
+    // all node names, so this is *actually* parsed with a hidden prefix:
+    //
+    //  S = SagaName <old nodes> <> ...
+    //
+    // Basically, everything to the left of "<>" is just us propagating state
+    // through the macro, and everything to the right of it is user input.
+    (S = $saga:ident $($nodes:ident),* <> $node:ident -> $out:literal { + $a:ident - $u:ident } $($tail:tt)*) => {
+        lazy_static::lazy_static! {
+            static ref $node: crate::app::sagas::NexusAction = ::steno::ActionFunc::new_action(
+                crate::app::sagas::__action_name!($saga, $node), $a, $u,
+            );
+        }
+        crate::app::sagas::__emit_action!($node, $out);
+        declare_saga_actions!(S = $saga $($nodes,)* $node <> $($tail)*);
+    };
+    // Same as the prior match, but without the undo action.
+    (S = $saga:ident $($nodes:ident),* <> $node:ident -> $out:literal { + $a:ident } $($tail:tt)*) => {
+        lazy_static::lazy_static! {
+            static ref $node: crate::app::sagas::NexusAction = ::steno::new_action_noop_undo(
+                crate::app::sagas::__action_name!($saga, $node), $a,
+            );
+        }
+        crate::app::sagas::__emit_action!($node, $out);
+        declare_saga_actions!(S = $saga $($nodes,)* $node <> $($tail)*);
+    };
+    // The end of the macro, which registers all previous generated saga nodes.
+    //
+    // We generate a new function, rather than implementing
+    // "NexusSaga::register_actions", because traits cannot be partially
+    // implemented, and "make_saga_dag" is not being generated through this
+    // macro.
+    (S = $saga:ident $($nodes:ident),* <>) => {
+        paste::paste! {
+            fn [<$saga _register_actions>](registry: &mut crate::app::sagas::ActionRegistry) {
+                $(
+                    registry.register(::std::sync::Arc::clone(&* $nodes ));
+                )*
+            }
+        }
+    };
+}
+
+pub(crate) use __action_name;
+pub(crate) use __emit_action;
+pub(crate) use __stringify_ident;
+pub(crate) use declare_saga_actions;

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -85,7 +85,7 @@ use super::{
     common_storage::ensure_all_datasets_and_regions, ActionRegistry,
     NexusActionContext, NexusSaga, SagaInitError, ACTION_GENERATE_ID,
 };
-use crate::app::sagas::NexusAction;
+use crate::app::sagas::declare_saga_actions;
 use crate::context::OpContext;
 use crate::db::identity::{Asset, Resource};
 use crate::db::lookup::LookupPath;
@@ -93,7 +93,6 @@ use crate::external_api::params;
 use crate::{authn, authz, db};
 use anyhow::anyhow;
 use crucible_agent_client::{types::RegionId, Client as CrucibleAgentClient};
-use lazy_static::lazy_static;
 use omicron_common::api::external;
 use omicron_common::api::external::Error;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -105,10 +104,7 @@ use sled_agent_client::types::{
 };
 use slog::info;
 use std::collections::BTreeMap;
-use std::sync::Arc;
-use steno::new_action_noop_undo;
 use steno::ActionError;
-use steno::ActionFunc;
 use steno::Node;
 use uuid::Uuid;
 
@@ -125,43 +121,35 @@ pub struct Params {
 
 // snapshot create saga: actions
 
-lazy_static! {
-    static ref REGIONS_ALLOC: NexusAction = new_action_noop_undo(
-        "snapshot-create.regions-alloc",
-        ssc_alloc_regions,
-    );
-    static ref REGIONS_ENSURE: NexusAction = new_action_noop_undo(
-        "snapshot-create.regions-ensure",
-        ssc_regions_ensure,
-    );
-    static ref CREATE_DESTINATION_VOLUME_RECORD: NexusAction =
-        ActionFunc::new_action(
-            "snapshot-create.create-destination-volume-record",
-            ssc_create_destination_volume_record,
-            ssc_create_destination_volume_record_undo,
-        );
-    static ref CREATE_SNAPSHOT_RECORD: NexusAction = ActionFunc::new_action(
-        "snapshot-create.create-snapshot-record",
-        ssc_create_snapshot_record,
-        ssc_create_snapshot_record_undo,
-    );
-    static ref SEND_SNAPSHOT_REQUEST: NexusAction = new_action_noop_undo(
-        "snapshot-create.send-snapshot-request",
-        ssc_send_snapshot_request,
-    );
-    static ref START_RUNNING_SNAPSHOT: NexusAction = new_action_noop_undo(
-        "snapshot-create.start-running-snapshot",
-        ssc_start_running_snapshot,
-    );
-    static ref CREATE_VOLUME_RECORD: NexusAction = ActionFunc::new_action(
-        "snapshot-create.create-volume-record",
-        ssc_create_volume_record,
-        ssc_create_volume_record_undo,
-    );
-    static ref FINALIZE_SNAPSHOT_RECORD: NexusAction = new_action_noop_undo(
-        "snapshot-create.finalize-snapshot-record",
-        ssc_finalize_snapshot_record,
-    );
+declare_saga_actions! {
+    snapshot_create;
+    REGIONS_ALLOC -> "datasets_and_regions" {
+        + ssc_alloc_regions
+    }
+    REGIONS_ENSURE -> "regions_ensure" {
+        + ssc_regions_ensure
+    }
+    CREATE_DESTINATION_VOLUME_RECORD -> "created_destination_volume" {
+        + ssc_create_destination_volume_record
+        - ssc_create_destination_volume_record_undo
+    }
+    CREATE_SNAPSHOT_RECORD -> "created_snapshot" {
+        + ssc_create_snapshot_record
+        - ssc_create_snapshot_record_undo
+    }
+    SEND_SNAPSHOT_REQUEST -> "snapshot_request" {
+        + ssc_send_snapshot_request
+    }
+    START_RUNNING_SNAPSHOT -> "replace_sockets_map" {
+        + ssc_start_running_snapshot
+    }
+    CREATE_VOLUME_RECORD -> "created_volume" {
+        + ssc_create_volume_record
+        - ssc_create_volume_record_undo
+    }
+    FINALIZE_SNAPSHOT_RECORD -> "finalized_snapshot" {
+        + ssc_finalize_snapshot_record
+    }
 }
 
 // snapshot create saga: definition
@@ -173,14 +161,7 @@ impl NexusSaga for SagaSnapshotCreate {
     type Params = Params;
 
     fn register_actions(registry: &mut ActionRegistry) {
-        registry.register(Arc::clone(&*REGIONS_ALLOC));
-        registry.register(Arc::clone(&*REGIONS_ENSURE));
-        registry.register(Arc::clone(&*CREATE_DESTINATION_VOLUME_RECORD));
-        registry.register(Arc::clone(&*CREATE_SNAPSHOT_RECORD));
-        registry.register(Arc::clone(&*SEND_SNAPSHOT_REQUEST));
-        registry.register(Arc::clone(&*START_RUNNING_SNAPSHOT));
-        registry.register(Arc::clone(&*CREATE_VOLUME_RECORD));
-        registry.register(Arc::clone(&*FINALIZE_SNAPSHOT_RECORD));
+        snapshot_create_register_actions(registry);
     }
 
     fn make_saga_dag(
@@ -207,58 +188,17 @@ impl NexusSaga for SagaSnapshotCreate {
         ));
 
         // Allocate region space for snapshot to store blocks post-scrub
-        builder.append(Node::action(
-            "datasets_and_regions",
-            "RegionsAlloc",
-            REGIONS_ALLOC.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "regions_ensure",
-            "RegionsEnsure",
-            REGIONS_ENSURE.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "created_destination_volume",
-            "CreateDestinationVolumeRecord",
-            CREATE_DESTINATION_VOLUME_RECORD.as_ref(),
-        ));
-
-        // Create the Snapshot DB object
-        builder.append(Node::action(
-            "created_snapshot",
-            "CreateSnapshotRecord",
-            CREATE_SNAPSHOT_RECORD.as_ref(),
-        ));
-
-        // Send a snapshot request to a sled-agent
-        builder.append(Node::action(
-            "snapshot_request",
-            "SendSnapshotRequest",
-            SEND_SNAPSHOT_REQUEST.as_ref(),
-        ));
-
+        builder.append(regions_alloc_action());
+        builder.append(regions_ensure_action());
+        builder.append(create_destination_volume_record_action());
+        builder.append(create_snapshot_record_action());
+        builder.append(send_snapshot_request_action());
         // Validate with crucible agent and start snapshot downstairs
-        builder.append(Node::action(
-            "replace_sockets_map",
-            "StartRunningSnapshot",
-            START_RUNNING_SNAPSHOT.as_ref(),
-        ));
-
+        builder.append(start_running_snapshot_action());
         // Copy and modify the disk volume construction request to point to the new
         // running snapshot
-        builder.append(Node::action(
-            "created_volume",
-            "CreateVolumeRecord",
-            CREATE_VOLUME_RECORD.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "finalized_snapshot",
-            "FinalizeSnapshotRecord",
-            FINALIZE_SNAPSHOT_RECORD.as_ref(),
-        ));
+        builder.append(create_volume_record_action());
+        builder.append(finalize_snapshot_record_action());
 
         Ok(builder.build()?)
     }

--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -28,16 +28,12 @@ use super::common_storage::delete_crucible_snapshots;
 use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
-use crate::app::sagas::NexusAction;
+use crate::app::sagas::declare_saga_actions;
 use crate::db::datastore::CrucibleResources;
-use lazy_static::lazy_static;
 use nexus_types::identity::Asset;
 use serde::Deserialize;
 use serde::Serialize;
-use std::sync::Arc;
-use steno::new_action_noop_undo;
 use steno::ActionError;
-use steno::Node;
 use uuid::Uuid;
 
 // volume delete saga: input parameters
@@ -49,7 +45,8 @@ pub struct Params {
 
 // volume delete saga: actions
 
-lazy_static! {
+declare_saga_actions! {
+    volume_delete;
     // TODO(https://github.com/oxidecomputer/omicron/issues/612):
     //
     // We need a way to deal with this operation failing, aside from
@@ -57,31 +54,21 @@ lazy_static! {
     //
     // What if the Sled goes offline? Nexus must ultimately be
     // responsible for reconciling this scenario.
-
-    static ref DECREASE_CRUCIBLE_RESOURCE_COUNT: NexusAction = new_action_noop_undo(
-        "volume-delete.decrease-resource-count",
-        svd_decrease_crucible_resource_count,
-    );
-
-    static ref DELETE_CRUCIBLE_REGIONS: NexusAction = new_action_noop_undo(
-        "volume-delete.delete-crucible-regions",
-        svd_delete_crucible_regions,
-    );
-
-    static ref DELETE_CRUCIBLE_SNAPSHOTS: NexusAction = new_action_noop_undo(
-        "volume-delete.delete-crucible-snapshots",
-        svd_delete_crucible_snapshots,
-    );
-
-    static ref DELETE_FREED_CRUCIBLE_REGIONS: NexusAction = new_action_noop_undo(
-        "volume-delete.delete-freed-crucible-regions",
-        svd_delete_freed_crucible_regions,
-    );
-
-    static ref HARD_DELETE_VOLUME_RECORD: NexusAction = new_action_noop_undo(
-        "volume-delete.hard-delete-volume-record",
-        svd_hard_delete_volume_record,
-    );
+    DECREASE_CRUCIBLE_RESOURCE_COUNT -> "crucible_resources_to_delete" {
+        + svd_decrease_crucible_resource_count
+    }
+    DELETE_CRUCIBLE_REGIONS -> "no_result_1" {
+        + svd_delete_crucible_regions
+    }
+    DELETE_CRUCIBLE_SNAPSHOTS -> "no_result_2" {
+        + svd_delete_crucible_snapshots
+    }
+    DELETE_FREED_CRUCIBLE_REGIONS -> "no_result_3" {
+        + svd_delete_freed_crucible_regions
+    }
+    HARD_DELETE_VOLUME_RECORD -> "final_no_result" {
+        + svd_hard_delete_volume_record
+    }
 }
 
 // volume delete saga: definition
@@ -93,50 +80,23 @@ impl NexusSaga for SagaVolumeDelete {
     type Params = Params;
 
     fn register_actions(registry: &mut ActionRegistry) {
-        registry.register(Arc::clone(&*DECREASE_CRUCIBLE_RESOURCE_COUNT));
-        registry.register(Arc::clone(&*DELETE_CRUCIBLE_REGIONS));
-        registry.register(Arc::clone(&*DELETE_CRUCIBLE_SNAPSHOTS));
-        registry.register(Arc::clone(&*DELETE_FREED_CRUCIBLE_REGIONS));
-        registry.register(Arc::clone(&*HARD_DELETE_VOLUME_RECORD));
+        volume_delete_register_actions(registry);
     }
 
     fn make_saga_dag(
         _params: &Self::Params,
         mut builder: steno::DagBuilder,
     ) -> Result<steno::Dag, super::SagaInitError> {
-        builder.append(Node::action(
-            "crucible_resources_to_delete",
-            "DecreaseCrucibleResources",
-            DECREASE_CRUCIBLE_RESOURCE_COUNT.as_ref(),
-        ));
-
+        builder.append(decrease_crucible_resource_count_action());
         builder.append_parallel(vec![
             // clean up top level regions for volume
-            Node::action(
-                "no_result_1",
-                "DeleteCrucibleRegions",
-                DELETE_CRUCIBLE_REGIONS.as_ref(),
-            ),
+            delete_crucible_regions_action(),
             // clean up snapshots no longer referenced by any volume
-            Node::action(
-                "no_result_2",
-                "DeleteCrucibleSnapshots",
-                DELETE_CRUCIBLE_SNAPSHOTS.as_ref(),
-            ),
+            delete_crucible_snapshots_action(),
         ]);
-
         // clean up regions that were freed by deleting snapshots
-        builder.append(Node::action(
-            "no_result_3",
-            "DeleteFreedCrucibleRegions",
-            DELETE_FREED_CRUCIBLE_REGIONS.as_ref(),
-        ));
-
-        builder.append(Node::action(
-            "final_no_result",
-            "HardDeleteVolumeRecord",
-            HARD_DELETE_VOLUME_RECORD.as_ref(),
-        ));
+        builder.append(delete_freed_crucible_regions_action());
+        builder.append(hard_delete_volume_record_action());
 
         Ok(builder.build()?)
     }


### PR DESCRIPTION
Writing sagas involves a lot of boilerplate:

- When creating `NexusAction` nodes, it's convention to re-state the name of the saga in each label (and also name the label after the variable itself). This is easily machine-generated.
- After defining all the `NexusAction` nodes, they must then all be re-listed in `register_actions`.
- When actually creating the DAG for the saga, each node is re-stated. This is the spot where node "output names" can be defined, but the label is another variation of the `NexusAction` node name (usually camelcased).

This PR introduces (and uses) a macro called `declare_saga_actions`.

This macro aims to reduce this boilerplate, by requiring only the following:
- The name of the saga
- The name of each action
- The output of each action
- The "forward" action function
- (Optional) The "undo" action function

It then generates nodes with names that are automatically "the right format", and produces some helper functions:
- `fn <saga name>_register_actions(registry: &mut ActionRegistry)` to help implement `NexusSaga::register_actions`
- `fn <node>_action() -> Node` to produce a default `Node` implementation when generating the DAG