### PR TITLE
Include extent information in Crucible VolumeConstructionRequests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a#861a09c350fd0e127b6105c8099e31a0bc3b711a"
+source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1063,9 +1063,9 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=861a09c350fd0e127b6105c8099e31a0bc3b711a#861a09c350fd0e127b6105c8099e31a0bc3b711a"
+source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "schemars",
  "serde",
  "serde_json",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b596e72b6b93bc412d675358f782ae7d53f8bf7a#b596e72b6b93bc412d675358f782ae7d53f8bf7a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=666ded451b13bba0895485c0b34515c0e59c2c6e#666ded451b13bba0895485c0b34515c0e59c2c6e"
 dependencies = [
  "base64 0.13.1",
  "crucible-client-types",
@@ -4568,8 +4568,9 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b596e72b6b93bc412d675358f782ae7d53f8bf7a#b596e72b6b93bc412d675358f782ae7d53f8bf7a"
+source = "git+https://github.com/oxidecomputer/propolis?rev=666ded451b13bba0895485c0b34515c0e59c2c6e#666ded451b13bba0895485c0b34515c0e59c2c6e"
 dependencies = [
+ "schemars",
  "serde",
 ]
 

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.20.0"
 bb8 = "0.8.0"
 clap = { version = "4.0", features = ["derive"] }
 cookie = "0.16"
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec" }
 diesel = { version = "2.0.2", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
 # TODO(luqman): Update once merged & new release is cut
@@ -47,7 +47,7 @@ oximeter-db = { path = "../oximeter/db/" }
 parse-display = "0.7.0"
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b596e72b6b93bc412d675358f782ae7d53f8bf7a", features = [ "generated" ] }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "666ded451b13bba0895485c0b34515c0e59c2c6e", features = [ "generated" ] }
 rand = "0.8.5"
 ref-cast = "1.0"
 reqwest = { version = "0.11.13", features = [ "json" ] }

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -284,6 +284,8 @@ async fn sdc_regions_ensure(
     .await?;
 
     let block_size = datasets_and_regions[0].1.block_size;
+    let blocks_per_extent = datasets_and_regions[0].1.extent_size;
+    let extent_count = datasets_and_regions[0].1.extent_count;
 
     // If a disk source was requested, set the read-only parent of this disk.
     let osagactx = sagactx.user_data();
@@ -409,6 +411,8 @@ async fn sdc_regions_ensure(
         block_size,
         sub_volumes: vec![VolumeConstructionRequest::Region {
             block_size,
+            blocks_per_extent,
+            extent_count: extent_count.try_into().unwrap(),
             gen: 1,
             opts: CrucibleOpts {
                 id: disk_id,
@@ -576,12 +580,20 @@ fn randomize_volume_construction_request_ids(
             })
         }
 
-        VolumeConstructionRequest::Region { block_size, opts, gen } => {
+        VolumeConstructionRequest::Region {
+            block_size,
+            blocks_per_extent,
+            extent_count,
+            opts,
+            gen,
+        } => {
             let mut opts = opts.clone();
             opts.id = Uuid::new_v4();
 
             Ok(VolumeConstructionRequest::Region {
                 block_size: *block_size,
+                blocks_per_extent: *blocks_per_extent,
+                extent_count: *extent_count,
                 opts,
                 gen: *gen,
             })

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -329,6 +329,8 @@ async fn ssc_regions_ensure(
     .await?;
 
     let block_size = datasets_and_regions[0].1.block_size;
+    let blocks_per_extent = datasets_and_regions[0].1.extent_size;
+    let extent_count = datasets_and_regions[0].1.extent_count;
 
     // Create volume construction request
     let mut rng = StdRng::from_entropy();
@@ -337,6 +339,8 @@ async fn ssc_regions_ensure(
         block_size,
         sub_volumes: vec![VolumeConstructionRequest::Region {
             block_size,
+            blocks_per_extent,
+            extent_count: extent_count.try_into().unwrap(),
             gen: 1,
             opts: CrucibleOpts {
                 id: destination_volume_id,
@@ -875,7 +879,13 @@ fn create_snapshot_from_disk(
             })
         }
 
-        VolumeConstructionRequest::Region { block_size, opts, gen } => {
+        VolumeConstructionRequest::Region {
+            block_size,
+            blocks_per_extent,
+            extent_count,
+            opts,
+            gen,
+        } => {
             let mut opts = opts.clone();
 
             if let Some(socket_map) = socket_map {
@@ -895,6 +905,8 @@ fn create_snapshot_from_disk(
 
             Ok(VolumeConstructionRequest::Region {
                 block_size: *block_size,
+                blocks_per_extent: *blocks_per_extent,
+                extent_count: *extent_count,
                 opts,
                 gen: *gen,
             })
@@ -935,6 +947,8 @@ mod test {
                     sub_volumes: vec![
                         VolumeConstructionRequest::Region {
                             block_size: 512,
+                            blocks_per_extent: 10,
+                            extent_count: 20,
                             gen: 1,
                             opts: CrucibleOpts {
                                 id: Uuid::new_v4(),
@@ -959,6 +973,8 @@ mod test {
             sub_volumes: vec![
                 VolumeConstructionRequest::Region {
                     block_size: 512,
+                    blocks_per_extent: 10,
+                    extent_count: 80,
                     gen: 100,
                     opts: CrucibleOpts {
                         id: Uuid::new_v4(),

--- a/nexus/src/db/datastore/volume.rs
+++ b/nexus/src/db/datastore/volume.rs
@@ -775,7 +775,7 @@ impl DataStore {
                         }
                     }
                     VolumeConstructionRequest::File { id: _, block_size: _, path: _ }
-                    | VolumeConstructionRequest::Region { 
+                    | VolumeConstructionRequest::Region {
                         block_size: _,
                         blocks_per_extent: _,
                         extent_count: _,

--- a/nexus/src/db/datastore/volume.rs
+++ b/nexus/src/db/datastore/volume.rs
@@ -229,6 +229,8 @@ impl DataStore {
                             match sv {
                                 VolumeConstructionRequest::Region {
                                     block_size,
+                                    blocks_per_extent,
+                                    extent_count,
                                     opts,
                                     gen,
                                 } => {
@@ -236,6 +238,8 @@ impl DataStore {
                                     new_sv.push(
                                         VolumeConstructionRequest::Region {
                                             block_size,
+                                            blocks_per_extent,
+                                            extent_count,
                                             opts,
                                             gen: gen + 1,
                                         },
@@ -293,6 +297,8 @@ impl DataStore {
                     }
                     VolumeConstructionRequest::Region {
                         block_size: _,
+                        blocks_per_extent: _,
+                        extent_count: _,
                         opts: _,
                         gen: _,
                     } => {
@@ -769,7 +775,12 @@ impl DataStore {
                         }
                     }
                     VolumeConstructionRequest::File { id: _, block_size: _, path: _ }
-                    | VolumeConstructionRequest::Region { block_size: _, opts: _, gen: _ }
+                    | VolumeConstructionRequest::Region { 
+                        block_size: _,
+                        blocks_per_extent: _,
+                        extent_count: _,
+                        opts: _,
+                        gen: _ }
                     | VolumeConstructionRequest::Url { id: _, block_size: _, url: _ } => {
                         // Volume has a format that does not contain ROPs
                         Ok(false)
@@ -840,7 +851,13 @@ fn resources_associated_with_volume(
             // no action required
         }
 
-        VolumeConstructionRequest::Region { block_size: _, opts, gen: _ } => {
+        VolumeConstructionRequest::Region {
+            block_size: _,
+            blocks_per_extent: _,
+            extent_count: _,
+            opts,
+            gen: _,
+        } => {
             for target in &opts.target {
                 if opts.read_only {
                     crucible_targets.read_only_targets.push(target.clone());

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -1741,6 +1741,8 @@ fn create_region(
 ) -> VolumeConstructionRequest {
     VolumeConstructionRequest::Region {
         block_size,
+        blocks_per_extent: 1,
+        extent_count: 1,
         gen,
         opts: CrucibleOpts {
             id,
@@ -1782,6 +1784,8 @@ fn volume_match_gen(
                 match sv {
                     VolumeConstructionRequest::Region {
                         block_size: _,
+                        blocks_per_extent: _,
+                        extent_count: _,
                         gen,
                         opts: _,
                     } => {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1708,6 +1708,16 @@
                 "format": "uint64",
                 "minimum": 0
               },
+              "blocks_per_extent": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "extent_count": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
               "gen": {
                 "type": "integer",
                 "format": "uint64",
@@ -1725,6 +1735,8 @@
             },
             "required": [
               "block_size",
+              "blocks_per_extent",
+              "extent_count",
               "gen",
               "opts",
               "type"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -92,10 +92,10 @@ service_name = "crucible"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
+source.commit = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "f0cefac66b82a377d1460065a838af22aeb0c03c98563f994eca562d2541f551"
+source.sha256 = "7f40883e3785cd50a042dabd8b02f87c72e2c2ae99ff8f137b9c8f39c2b87c97"
 output.type = "zone"
 
 # Refer to
@@ -105,10 +105,10 @@ output.type = "zone"
 service_name = "propolis-server"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "b596e72b6b93bc412d675358f782ae7d53f8bf7a"
+source.commit = "666ded451b13bba0895485c0b34515c0e59c2c6e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "014f21152629e6ec7a5cfe42f6ad0057279456f191a040a7e4f04d4db74b627c"
+source.sha256 = "29b65817eaeb6e9e8f5ce9574f95385ea8f976f352091672a9cde2b2a5103dd3"
 output.type = "zone"
 
 [package.maghemite]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -14,8 +14,8 @@ cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.0", features = ["derive"] }
 # Only used by the simulated sled agent.
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec" }
 ddm-admin-client = { path = "../ddm-admin-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3.25"
@@ -32,7 +32,7 @@ oximeter-producer = { version = "0.1.0", path = "../oximeter/producer" }
 p256 = "0.9.0"
 percent-encoding = "2.2.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b596e72b6b93bc412d675358f782ae7d53f8bf7a", features = [ "generated-migration" ] }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "666ded451b13bba0895485c0b34515c0e59c2c6e", features = [ "generated-migration" ] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = { version = "0.8.10", features = [ "chrono", "uuid1" ] }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -74,7 +74,13 @@ fn extract_targets_from_volume_construction_request(
             // noop
         }
 
-        VolumeConstructionRequest::Region { block_size: _, opts, gen: _ } => {
+        VolumeConstructionRequest::Region {
+            block_size: _,
+            blocks_per_extent: _,
+            extent_count: _,
+            opts,
+            gen: _,
+        } => {
             for target in &opts.target {
                 vec.push(*target);
             }


### PR DESCRIPTION
Pick up the latest definition of `crucible_client_types::VolumeConstructionRequest` and the corresponding Propolis bits. The new definition requires a `VolumeConstructionRequest::Region` to specify the number of extents in the region and the number of blocks in each extent. The disk creation saga already has all this data (it needs it to ask Crucible to create the regions in the first place), so this is just a matter of plumbing that data into the serialized VCR that Nexus saves in its database.

This change is a prerequisite to live migrating instances. See [crucible#557](https://github.com/oxidecomputer/crucible/pull/557) and [propolis#275](https://github.com/oxidecomputer/propolis/pull/275) for more context.

Tests: `cargo test`; installed Omicron locally and boot-tested a couple of instances.