### PR TITLE
fail faster on errors reading CockroachDB listening-url file

### DIFF
--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -315,6 +315,12 @@ impl CockroachStarter {
         self.temp_dir.path()
     }
 
+    /// Returns the path to the listen-url file for this execution
+    #[cfg(test)]
+    pub fn listen_url_file(&self) -> &Path {
+        &self.listen_url_file
+    }
+
     /// Returns the path to the storage directory created for this execution.
     pub fn store_dir(&self) -> &Path {
         self.store_dir.as_path()
@@ -1015,7 +1021,7 @@ mod test {
     #[tokio::test]
     async fn test_bad_cmd() {
         let builder = CockroachStarterBuilder::new_with_cmd("/nonexistent");
-        let _ = test_database_start_failure(builder).await;
+        let _ = test_database_start_failure(builder.build().unwrap()).await;
     }
 
     // Tests what happens if the "cockroach" command exits before writing the
@@ -1025,7 +1031,8 @@ mod test {
     async fn test_cmd_fails() {
         let mut builder = new_builder();
         builder.arg("not-a-valid-argument");
-        let temp_dir = test_database_start_failure(builder).await;
+        let (temp_dir, _) =
+            test_database_start_failure(builder.build().unwrap()).await;
         fs::metadata(&temp_dir).await.expect("temporary directory was deleted");
         // The temporary directory is preserved in this case so that we can
         // debug the failure.  In this case, we injected the failure.  Remove
@@ -1051,9 +1058,8 @@ mod test {
     // caller can decide whether to check if it was cleaned up or not.  The
     // expected behavior depends on the failure mode.
     async fn test_database_start_failure(
-        builder: CockroachStarterBuilder,
-    ) -> PathBuf {
-        let starter = builder.build().unwrap();
+        starter: CockroachStarter,
+    ) -> (PathBuf, CockroachStartError) {
         let temp_dir = starter.temp_dir().to_owned();
         eprintln!("will run: {}", starter.cmdline());
         eprintln!("environment:");
@@ -1063,7 +1069,7 @@ mod test {
         let error =
             starter.start().await.expect_err("unexpectedly started database");
         eprintln!("error: {:?}", error);
-        temp_dir
+        (temp_dir, error)
     }
 
     // Tests when CockroachDB hangs on startup by setting the start timeout
@@ -1149,6 +1155,49 @@ mod test {
                 e
             )
         });
+    }
+
+    // Test what happens if we can't read the listen-url file.  This is a little
+    // obscure, but it has been a problem.
+    #[tokio::test]
+    async fn test_setup_database_bad_listen_url() {
+        // We don't need to actually run Cockroach for this test, and it's
+        // simpler (and faster) if we don't.  But we do need something that
+        // won't exit before we get a chance to trigger an error and that can
+        // also accept the extra arguments that the builder will provide.
+        let mut builder = CockroachStarterBuilder::new_with_cmd("bash");
+        builder.arg("-c").arg("sleep 60");
+        let starter = builder.build().unwrap();
+
+        // We want to inject an error into the code path that reads the
+        // listen-url file.  We do this by precreating that path as a directory.
+        // Then we'll get EISDIR when we try to read it.
+        let listen_url_file = starter.listen_url_file().to_owned();
+        std::fs::create_dir(&listen_url_file)
+            .expect("pre-creating listen-URL path as directory");
+        let (temp_dir, error) = test_database_start_failure(starter).await;
+
+        if let CockroachStartError::Unknown { source } = error {
+            let message = format!("{:#}", source);
+            eprintln!("error message was: {}", message);
+            // Verify the error message refers to the listening file (since
+            // that's what we were operating on) and also reflects the EISDIR
+            // error.
+            assert!(message.starts_with("checking listen file \""));
+            assert!(message.contains("Is a directory"));
+        } else {
+            panic!("unexpected error trying to start database: {:#}", error);
+        }
+
+        // Clean up the temporary directory -- carefully.  Since we know exactly
+        // what should be in it, we opt to remove these items individually
+        // rather than risk blowing away something else inadvertently.
+        fs::remove_dir(&listen_url_file)
+            .await
+            .expect("failed to remove listen-url directory");
+        fs::remove_dir(temp_dir)
+            .await
+            .expect("failed to remove temporary directory");
     }
 
     // Test the happy path using the default store directory.


### PR DESCRIPTION
When starting CockroachDB either as part of the test suite or `omicron-dev db-run`, we wait for it to write out its listening URL to a known file path.  This is asynchronous.  It's the way that we determine when CockroachDB is up.  So we just have to poll on it.  Naturally, if it takes too long, we give up and fail.  In the meantime, if the file doesn't exist or exists but is incomplete, then we want just keep waiting.

The code today continues waiting if it runs into _any_ error reading the file, not just ENOENT.  So for example while I was debugging #1146, I put a `cockroach` executable in my PATH that ran the requested command under `pfexec dtrace -c`, which meant I was running it as root, but the test suite was still running as my normal user.  As a result of either CockroachDB's explicit choice or else the umask in effect at the time, the listen URL file was created with permissions that prevented the test suite from reading it.  Instead of failing immediately and telling me that, it waited for the full timeout period (30 seconds) and then just reported a generic timeout error (saying that CockroachDB hadn't started within the timeout, which wasn't actually true).

This PR changes the error handling here in the specific case that we get an error _other_ than ENOENT when trying to read the file.  In that case, we fail immediately (rather than waiting for the full timeout) and actually print the error.

~~I couldn't think of a good way to test this automatically.~~  I tested it by hand by replicating the problem I had above.  It now fails quickly and prints:

```
thread 'dev::db::test::test_setup_database_default_dir' panicked at 'failed to start database: Unknown { source: checking listen file "/dangerzone/omicron_tmp/.tmplraWmB/listen-url"

Caused by:
    Permission denied (os error 13) }', test-utils/src/dev/db.rs:1247:35
```

full output: <details>

```
$ /home/dap/omicron-iter/target/debug/deps/omicron_test_utils-1a64da54be1ee8cc -- dev::db::test::test_setup_database_default_dir

running 1 test
test dev::db::test::test_setup_database_default_dir ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 26.44s

dap@ivanova omicron-iter $ PATH=$PWD/debug-bin:$PATH /home/dap/omicron-iter/target/debug/deps/omicron_test_utils-1a64da54be1ee8cc -- dev::db::test::test_setup_database_default_dir

running 1 test
test dev::db::test::test_setup_database_default_dir ... FAILED

failures:

---- dev::db::test::test_setup_database_default_dir stdout ----
will run: cockroach start-single-node --insecure --http-addr=:0 --store=path=/dangerzone/omicron_tmp/.tmplraWmB/data,ballast-size=0 --listen-addr 127.0.0.1:0 --listening-url-file /dangerzone/omicron_tmp/.tmplraWmB/listen-url
environment:
    BASH_SILENCE_DEPRECATION_WARNING=1
    BAT_THEME=ansi
    BUNYAN_NO_PAGER=1
    CSCOPEOPTIONS=-r -p8
    EDITOR=vim
    GOTRACEBACK=crash
    HOME=/home/dap
    HOST=ivanova
    LANG=en_US.UTF-8
    LESS=-P ?f%f .line %lb/%L .byte %bB?s/%s. ?e(END):?pB%pB\%..%t
    LOGNAME=dap
    MACH=i386
    MACHINE_THAT_GOES_PING=1
    OLDPWD=/home/dap
    PAGER=less -X
    PATH=/home/dap/omicron-iter/debug-bin:/home/dap/omicron-cockroachdb/maybefixed-bin/bin:/home/dap/.cargo/bin::/home/dap/bin:/home/dap/install/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/gnu/bin:/opt/ooce/bin:/home/dap/tools/cockroachdb/bin:/home/dap/tools/clickhouse
    PS1=\[\033]0;\w (\h)\007\]\u@ivanova \[\]\W\[\] $ 
    PWD=/home/dap/omicron-iter
    RAWPS1=\u@ivanova \[\]\W\[\] $ 
    SHELL=/bin/bash
    SHLVL=1
    SSH_AUTH_SOCK=/tmp/ssh-XXXX_saivR/agent.22185
    SSH_CLIENT=172.20.16.62 50048 22
    SSH_CONNECTION=172.20.16.62 50048 172.20.2.70 22
    SSH_TTY=/dev/pts/2
    TERM=xterm-256color
    TMPDIR=/dangerzone/omicron_tmp
    TZ=US/Pacific
    USER=dap
    VISUAL=vim
    _=/home/dap/omicron-iter/target/debug/deps/omicron_test_utils-1a64da54be1ee8cc
thread 'dev::db::test::test_setup_database_default_dir' panicked at 'failed to start database: Unknown { source: checking listen file "/dangerzone/omicron_tmp/.tmplraWmB/listen-url"

Caused by:
    Permission denied (os error 13) }', test-utils/src/dev/db.rs:1247:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    dev::db::test::test_setup_database_default_dir

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 14 filtered out; finished in 1.95s
```

</details>

Update: I added an automated test, too.