### PR TITLE
Add `identity()` method for `AssetIdentityMetadata`, move def to another file

### DIFF
--- a/nexus/db-model/src/rack.rs
+++ b/nexus/db-model/src/rack.rs
@@ -4,7 +4,7 @@
 
 use crate::schema::rack;
 use db_macros::Asset;
-use nexus_types::external_api::views;
+use nexus_types::{external_api::views, identity::Asset};
 use uuid::Uuid;
 
 /// Information about a local rack.
@@ -30,6 +30,6 @@ impl Rack {
 
 impl From<Rack> for views::Rack {
     fn from(rack: Rack) -> Self {
-        Self { identity: views::AssetIdentityMetadata::from(&rack) }
+        Self { identity: rack.identity() }
     }
 }

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -8,7 +8,7 @@ use crate::ipv6;
 use crate::schema::{service, sled, zpool};
 use chrono::{DateTime, Utc};
 use db_macros::Asset;
-use nexus_types::external_api::views;
+use nexus_types::{external_api::views, identity::Asset};
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
@@ -77,10 +77,7 @@ impl Sled {
 
 impl From<Sled> for views::Sled {
     fn from(sled: Sled) -> Self {
-        Self {
-            identity: views::AssetIdentityMetadata::from(&sled),
-            service_address: sled.address(),
-        }
+        Self { identity: sled.identity(), service_address: sled.address() }
     }
 }
 

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -5,7 +5,7 @@
 //! Views are response bodies, most of which are public lenses onto DB models.
 
 use crate::external_api::shared::{self, IpKind, IpRange};
-use crate::identity::Asset;
+use crate::identity::AssetIdentityMetadata;
 use api_identity::ObjectIdentity;
 use chrono::DateTime;
 use chrono::Utc;
@@ -18,33 +18,6 @@ use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
-
-// IDENTITY METADATA
-
-/// Identity-related metadata that's included in "asset" public API objects
-/// (which generally have no name or description)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct AssetIdentityMetadata {
-    /// unique, immutable, system-controlled identifier for each resource
-    pub id: Uuid,
-    /// timestamp when this resource was created
-    pub time_created: chrono::DateTime<chrono::Utc>,
-    /// timestamp when this resource was last modified
-    pub time_modified: chrono::DateTime<chrono::Utc>,
-}
-
-impl<T> From<&T> for AssetIdentityMetadata
-where
-    T: Asset,
-{
-    fn from(t: &T) -> Self {
-        AssetIdentityMetadata {
-            id: t.id(),
-            time_created: t.time_created(),
-            time_modified: t.time_modified(),
-        }
-    }
-}
 
 // SILOS
 

--- a/nexus/types/src/identity.rs
+++ b/nexus/types/src/identity.rs
@@ -9,6 +9,8 @@
 use chrono::{DateTime, Utc};
 use omicron_common::api::external::IdentityMetadata;
 use omicron_common::api::external::Name;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Identity-related accessors for resources.
@@ -39,6 +41,18 @@ pub trait Resource {
     }
 }
 
+/// Identity-related metadata that's included in "asset" public API objects
+/// (which generally have no name or description)
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct AssetIdentityMetadata {
+    /// unique, immutable, system-controlled identifier for each resource
+    pub id: Uuid,
+    /// timestamp when this resource was created
+    pub time_created: DateTime<Utc>,
+    /// timestamp when this resource was last modified
+    pub time_modified: DateTime<Utc>,
+}
+
 /// Identity-related accessors for assets.
 ///
 /// These are objects similar to [`Resource`], but without
@@ -49,4 +63,12 @@ pub trait Asset {
     fn id(&self) -> Uuid;
     fn time_created(&self) -> DateTime<Utc>;
     fn time_modified(&self) -> DateTime<Utc>;
+
+    fn identity(&self) -> AssetIdentityMetadata {
+        AssetIdentityMetadata {
+            id: self.id(),
+            time_created: self.time_created(),
+            time_modified: self.time_modified(),
+        }
+    }
 }


### PR DESCRIPTION
I noticed two things while working on #2100.

1. `AssetIdentityMetadata` is defined in `views.rs`, but it is used by both DB models and views. To me that makes it not primarily a view, so it should go in a different file. I moved it to `nexus/types/src/identity.rs`, where `Asset` is defined.
2. Instead of the `identity()` method for copying around the identity metadata (which `Resource` has), there is a `impl From<T: Asset> for AssetIdentityMetadata`, which is perfectly fine, but I think it's nicer to have them be the same.

As far as I remember, these are accidents of history and not for any particular reason.