### PR TITLE
fix `test_setup_database_bad_listen_url()`

### DIFF
--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -1176,7 +1176,8 @@ mod test {
     async fn test_setup_database_bad_listen_url() {
         // We don't need to actually run Cockroach for this test, and it's
         // simpler (and faster) if we don't.  But we do need something that
-        // won't exit before we get a chance to trigger an error.
+        // won't exit before we get a chance to trigger an error and that can
+        // also accept the extra arguments that the builder will provide.
         let mut builder = CockroachStarterBuilder::new_raw("bash");
         builder.arg("-c").arg("sleep 60");
         let starter = builder.build().unwrap();


### PR DESCRIPTION
Fixes #2108.

Prior to this, the public constructor was `CockroachStarterBuilder::new()`.  That used `CockroachStarterBuilder::new_with_cmd(COCKROACHDB_BIN)` to do most of the work.  A couple of tests (including the one that's broken) used `CockroachStarterBuilder::new_with_cmd(some_other_cmd)`.  The goal was to use as much of the same machinery as possible (to test it) while overriding the command with one that would make it easier to trigger certain failure modes.

Prior to this, `new_with_cmd()` did three things:

1. initializes the fields of `CockroachStarterBuilder` (which involves a few non-trivial decisions)
2. configures the environment
3. configures the command-line arguments

It's step 3 that's making things difficult for `test_setup_database_bad_listen_url()`.  Steps 2 and 3 are not needed by either of the tests that call `new_with_cmd()` directly.  So I've moved those steps to `CockroachStarterBuilder::new()` so that `new_with_cmd()` only initializes the struct fields.

I also renamed `new_with_cmd()` to `new_raw()` to avoid conveying the idea that it was just like `new()`, but with an overridden command.  I'm looking to convey "the caller is responsible for various details that the regular `new()` takes care of".  I'm open to better names.