### PR TITLE
[nexus] Fix missing endpoint summaries, deprecate more that should be

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -663,7 +663,7 @@ async fn silo_policy_update(
 
 // Silo-specific user endpoints
 
-/// List users in a specific Silo
+/// List users in a silo
 #[endpoint {
     method = GET,
     path = "/system/silos/{silo_name}/users/all",
@@ -705,6 +705,7 @@ struct UserPathParam {
     user_id: Uuid,
 }
 
+/// Fetch a user
 #[endpoint {
     method = GET,
     path = "/system/silos/{silo_name}/users/id/{user_id}",
@@ -873,6 +874,7 @@ async fn local_idp_user_create(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Delete a user
 #[endpoint {
     method = DELETE,
     path = "/system/silos/{silo_name}/identity-providers/local/users/{user_id}",

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2645,6 +2645,7 @@ async fn instance_create_v1(
 }
 
 /// Create an instance
+/// Use `POST /v1/instances` instead
 // TODO-correctness This is supposed to be async.  Is that right?  We can create
 // the instance immediately -- it's just not booted yet.  Maybe the boot
 // operation is what's a separate operation_id.  What about the response code
@@ -2654,8 +2655,9 @@ async fn instance_create_v1(
 // resource created?
 #[endpoint {
     method = POST,
-     path = "/organizations/{organization_name}/projects/{project_name}/instances",
+    path = "/organizations/{organization_name}/projects/{project_name}/instances",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_create(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2723,10 +2725,12 @@ struct InstancePathParam {
 }
 
 /// Fetch an instance
+/// Use `GET /v1/instances/{instance}` instead
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_view(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2811,6 +2815,7 @@ async fn instance_delete_v1(
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_delete(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2874,10 +2879,12 @@ async fn instance_migrate_v1(
 
 // TODO should this be in the public API?
 /// Migrate an instance
+/// Use `POST /v1/instances/{instance}/migrate` instead
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_migrate(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2939,10 +2946,12 @@ async fn instance_reboot_v1(
 }
 
 /// Reboot an instance
+/// Use `POST /v1/instances/{instance}/reboot` instead
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_reboot(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -2996,10 +3005,12 @@ async fn instance_start_v1(
 }
 
 /// Boot an instance
+/// Use `POST /v1/instances/{instance}/start` instead
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_start(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -3053,10 +3064,12 @@ async fn instance_stop_v1(
 }
 
 /// Halt an instance
+/// Use `POST /v1/instances/{instance}/stop` instead
 #[endpoint {
     method = POST,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_stop(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -3177,10 +3190,12 @@ async fn instance_serial_console_stream_v1(
 }
 
 /// Connect to an instance's serial console
+/// Use `GET /v1/instances/{instance}/serial-console/stream` instead
 #[channel {
     protocol = WEBSOCKETS,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console/stream",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_serial_console_stream(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -975,7 +975,7 @@ async fn organization_list_v1(
 }
 
 /// List organizations
-/// Use `/v1/organizations` instead
+/// Use `GET /v1/organizations` instead
 #[endpoint {
     method = GET,
     path = "/organizations",
@@ -1065,6 +1065,7 @@ async fn organization_create(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Fetch an organization
 #[endpoint {
     method = GET,
     path = "/v1/organizations/{organization}",
@@ -1160,6 +1161,7 @@ async fn organization_view_by_id(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Delete an organization
 #[endpoint {
     method = DELETE,
     path = "/v1/organizations/{organization}",
@@ -1212,6 +1214,7 @@ async fn organization_delete(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Update an organization
 #[endpoint {
     method = PUT,
     path = "/v1/organizations/{organization}",
@@ -1283,6 +1286,7 @@ async fn organization_update(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Fetch an organization's IAM policy
 #[endpoint {
     method = GET,
     path = "/v1/organizations/{organization}/policy",
@@ -1342,6 +1346,7 @@ async fn organization_policy_view(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Update an organization's IAM policy
 #[endpoint {
     method = PUT,
     path = "/v1/organizations/{organization}/policy",
@@ -1539,6 +1544,7 @@ async fn project_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Create a project
 #[endpoint {
     method = POST,
     path = "/v1/projects",
@@ -1605,6 +1611,7 @@ async fn project_create(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Fetch a project
 #[endpoint {
     method = GET,
     path = "/v1/projects/{project}",
@@ -2528,6 +2535,7 @@ async fn disk_metrics_list(
 
 // Instances
 
+/// List instances
 #[endpoint {
     method = GET,
     path = "/v1/instances",
@@ -2606,6 +2614,7 @@ async fn instance_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Create an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances",
@@ -2676,6 +2685,7 @@ async fn instance_create(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Fetch an instance
 #[endpoint {
     method = GET,
     path = "/v1/instances/{instance}",
@@ -2767,6 +2777,7 @@ async fn instance_view_by_id(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Delete an instance
 #[endpoint {
     method = DELETE,
     path = "/v1/instances/{instance}",
@@ -2824,6 +2835,7 @@ async fn instance_delete(
 }
 
 // TODO should this be in the public API?
+/// Migrate an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances/{instance}/migrate",
@@ -2897,6 +2909,7 @@ async fn instance_migrate(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Reboot an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances/{instance}/reboot",
@@ -3010,6 +3023,7 @@ async fn instance_start(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Stop an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances/{instance}/stop",
@@ -3066,6 +3080,7 @@ async fn instance_stop(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Fetch an instance's serial console
 #[endpoint {
     method = GET,
     path = "/v1/instances/{instance}/serial-console",
@@ -3100,10 +3115,12 @@ async fn instance_serial_console_v1(
 }
 
 /// Fetch an instance's serial console
+/// Use `GET /v1/instances/{instance}/serial-console` instead
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_serial_console(
     rqctx: Arc<RequestContext<Arc<ServerContext>>>,
@@ -3133,6 +3150,7 @@ async fn instance_serial_console(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Stream an instance's serial console
 #[channel {
     protocol = WEBSOCKETS,
     path = "/v1/instances/{instance}/serial-console/stream",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -790,7 +790,7 @@
           "organizations"
         ],
         "summary": "List organizations",
-        "description": "Use `/v1/organizations` instead",
+        "description": "Use `GET /v1/organizations` instead",
         "operationId": "organization_list",
         "parameters": [
           {
@@ -2841,6 +2841,7 @@
           "instances"
         ],
         "summary": "Fetch an instance's serial console",
+        "description": "Use `GET /v1/instances/{instance}/serial-console` instead",
         "operationId": "instance_serial_console",
         "parameters": [
           {
@@ -2918,7 +2919,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console/stream": {
@@ -7309,6 +7311,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "List instances",
         "operationId": "instance_list_v1",
         "parameters": [
           {
@@ -7378,6 +7381,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Create an instance",
         "operationId": "instance_create_v1",
         "parameters": [
           {
@@ -7431,6 +7435,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Fetch an instance",
         "operationId": "instance_view_v1",
         "parameters": [
           {
@@ -7479,6 +7484,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Delete an instance",
         "operationId": "instance_delete_v1",
         "parameters": [
           {
@@ -7522,6 +7528,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Migrate an instance",
         "operationId": "instance_migrate_v1",
         "parameters": [
           {
@@ -7582,6 +7589,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Reboot an instance",
         "operationId": "instance_reboot_v1",
         "parameters": [
           {
@@ -7632,6 +7640,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Fetch an instance's serial console",
         "operationId": "instance_serial_console_v1",
         "parameters": [
           {
@@ -7715,6 +7724,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Stream an instance's serial console",
         "operationId": "instance_serial_console_stream_v1",
         "parameters": [
           {
@@ -7809,6 +7819,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Stop an instance",
         "operationId": "instance_stop_v1",
         "parameters": [
           {
@@ -7951,6 +7962,7 @@
         "tags": [
           "organizations"
         ],
+        "summary": "Fetch an organization",
         "operationId": "organization_view_v1",
         "parameters": [
           {
@@ -7985,6 +7997,7 @@
         "tags": [
           "organizations"
         ],
+        "summary": "Update an organization",
         "operationId": "organization_update_v1",
         "parameters": [
           {
@@ -8029,6 +8042,7 @@
         "tags": [
           "organizations"
         ],
+        "summary": "Delete an organization",
         "operationId": "organization_delete_v1",
         "parameters": [
           {
@@ -8058,6 +8072,7 @@
         "tags": [
           "organizations"
         ],
+        "summary": "Fetch an organization's IAM policy",
         "operationId": "organization_policy_view_v1",
         "parameters": [
           {
@@ -8092,6 +8107,7 @@
         "tags": [
           "organizations"
         ],
+        "summary": "Update an organization's IAM policy",
         "operationId": "organization_policy_update_v1",
         "parameters": [
           {
@@ -8201,6 +8217,7 @@
         "tags": [
           "projects"
         ],
+        "summary": "Create a project",
         "operationId": "project_create_v1",
         "parameters": [
           {
@@ -8247,6 +8264,7 @@
         "tags": [
           "projects"
         ],
+        "summary": "Fetch a project",
         "operationId": "project_view_v1",
         "parameters": [
           {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6720,6 +6720,7 @@
         "tags": [
           "system"
         ],
+        "summary": "Delete a user",
         "operationId": "local_idp_user_delete",
         "parameters": [
           {
@@ -6991,7 +6992,7 @@
         "tags": [
           "system"
         ],
-        "summary": "List users in a specific Silo",
+        "summary": "List users in a silo",
         "operationId": "silo_users_list",
         "parameters": [
           {
@@ -7057,6 +7058,7 @@
         "tags": [
           "system"
         ],
+        "summary": "Fetch a user",
         "operationId": "silo_user_view",
         "parameters": [
           {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1986,6 +1986,7 @@
           "instances"
         ],
         "summary": "Create an instance",
+        "description": "Use `POST /v1/instances` instead",
         "operationId": "instance_create",
         "parameters": [
           {
@@ -2034,7 +2035,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}": {
@@ -2043,6 +2045,7 @@
           "instances"
         ],
         "summary": "Fetch an instance",
+        "description": "Use `GET /v1/instances/{instance}` instead",
         "operationId": "instance_view",
         "parameters": [
           {
@@ -2087,7 +2090,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       },
       "delete": {
         "tags": [
@@ -2131,7 +2135,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks": {
@@ -2400,6 +2405,7 @@
           "instances"
         ],
         "summary": "Migrate an instance",
+        "description": "Use `POST /v1/instances/{instance}/migrate` instead",
         "operationId": "instance_migrate",
         "parameters": [
           {
@@ -2454,7 +2460,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces": {
@@ -2788,6 +2795,7 @@
           "instances"
         ],
         "summary": "Reboot an instance",
+        "description": "Use `POST /v1/instances/{instance}/reboot` instead",
         "operationId": "instance_reboot",
         "parameters": [
           {
@@ -2832,7 +2840,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/serial-console": {
@@ -2929,6 +2938,7 @@
           "instances"
         ],
         "summary": "Connect to an instance's serial console",
+        "description": "Use `GET /v1/instances/{instance}/serial-console/stream` instead",
         "operationId": "instance_serial_console_stream",
         "parameters": [
           {
@@ -2966,6 +2976,7 @@
             }
           }
         },
+        "deprecated": true,
         "x-dropshot-websocket": {}
       }
     },
@@ -2975,6 +2986,7 @@
           "instances"
         ],
         "summary": "Boot an instance",
+        "description": "Use `POST /v1/instances/{instance}/start` instead",
         "operationId": "instance_start",
         "parameters": [
           {
@@ -3019,7 +3031,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop": {
@@ -3028,6 +3041,7 @@
           "instances"
         ],
         "summary": "Halt an instance",
+        "description": "Use `POST /v1/instances/{instance}/stop` instead",
         "operationId": "instance_stop",
         "parameters": [
           {
@@ -3072,7 +3086,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/policy": {


### PR DESCRIPTION
I was updating the docs site to the latest spec and noticed some of the new endpoints have no label in the sidebar or title in the content pane.

I also added `deprecated = true` to a few legacy endpoints that had corresponding `/v1` ones. There are now exactly 24 `/v1` and 24 deprecated.

![2023-01-06-docs-no-summary](https://user-images.githubusercontent.com/3612203/211131616-a0ecd58b-771a-439c-876a-7a8603371e1b.gif)
