### PR TITLE
Add a Nexus internal API endpoint for disk remove read only parent

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -517,4 +517,26 @@ impl super::Nexus {
         .await?;
         Ok(())
     }
+
+    /// Remove a read only parent from a disk.
+    /// This is just a wrapper around the volume operation of the same
+    /// name, but we provide this interface when all the caller has is
+    /// the disk UUID as the internal volume_id is not exposed.
+    pub async fn disk_remove_read_only_parent(
+        self: &Arc<Self>,
+        opctx: &OpContext,
+        disk_id: Uuid,
+    ) -> DeleteResult {
+        // First get the internal volume ID that is stored in the disk
+        // database entry, once we have that just call the volume method
+        // to remove the read only parent.
+        let (.., db_disk) = LookupPath::new(opctx, &self.db_datastore)
+            .disk_id(disk_id)
+            .fetch()
+            .await?;
+
+        self.volume_remove_read_only_parent(db_disk.volume_id).await?;
+
+        Ok(())
+    }
 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -42,6 +42,7 @@ pub fn internal_api() -> NexusApiDescription {
         api.register(cpapi_instances_put)?;
         api.register(cpapi_disks_put)?;
         api.register(cpapi_volume_remove_read_only_parent)?;
+        api.register(cpapi_disk_remove_read_only_parent)?;
         api.register(cpapi_producers_post)?;
         api.register(cpapi_collectors_post)?;
         api.register(cpapi_metrics_collect)?;
@@ -221,6 +222,31 @@ async fn cpapi_volume_remove_read_only_parent(
 
     let handler = async {
         nexus.volume_remove_read_only_parent(path.volume_id).await?;
+        Ok(HttpResponseUpdatedNoContent())
+    };
+    apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Request removal of a read_only_parent from a disk
+/// This is a thin wrapper around the volume_remove_read_only_parent saga.
+/// All we are doing here is, given a disk UUID, figure out what the
+/// volume_id is for that disk, then use that to call the
+/// volume_remove_read_only_parent saga on it.
+#[endpoint {
+     method = POST,
+     path = "/disk/{disk_id}/remove-read-only-parent",
+ }]
+async fn cpapi_disk_remove_read_only_parent(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    path_params: Path<DiskPathParam>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+
+    let handler = async {
+        let opctx = OpContext::for_internal_api(&rqctx).await;
+        nexus.disk_remove_read_only_parent(&opctx, path.disk_id).await?;
         Ok(HttpResponseUpdatedNoContent())
     };
     apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -59,6 +59,35 @@
         }
       }
     },
+    "/disk/{disk_id}/remove-read-only-parent": {
+      "post": {
+        "summary": "Request removal of a read_only_parent from a disk",
+        "description": "This is a thin wrapper around the volume_remove_read_only_parent saga. All we are doing here is, given a disk UUID, figure out what the volume_id is for that disk, then use that to call the volume_remove_read_only_parent saga on it.",
+        "operationId": "cpapi_disk_remove_read_only_parent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/disks/{disk_id}": {
       "put": {
         "summary": "Report updated state for a disk.",


### PR DESCRIPTION
When we create a disk, the saga generates both a `disk_id` and a `volume_id`
```
        builder.append(Node::action(
            "disk_id",
            "GenerateDiskId",
            ACTION_GENERATE_ID.as_ref(),
        ));
       
        builder.append(Node::action(
            "volume_id",
            "GenerateVolumeId",
            ACTION_GENERATE_ID.as_ref(),
        ));
```

We use both ids when we create the disk database record:
```
    let disk = db::model::Disk::new(
        disk_id,
        params.project_id,
        volume_id,
        params.create_params.clone(),
        block_size,
        db::model::DiskRuntimeState::new(),
    )
```

However, the `volume_id` here is only used as the key to store the volume data
in the database. That volume_id is never exposed to anyone outside Nexus.

For the actual volume data structure and later the VolumeConstructionRequest,
we use the value in the `disk_id`, but call it `volume_id`

This is nice because it means the `volume_id` that propolis receives in the VCR
will match what the console has for a disk uuid, and it means stats will be 
recorded under the same UUID.

However, Propolis (who needs to call Nexus and tell it to remove a read only parent
only has the top level disk UUID.  The internal "volume_id" is not exposed.

This PR adds a new internal API endpoint that will take the disk UUID, then lookup
the volume_id and then call the volume layer remove read only parent saga.  Adding
a layer like this also allows tests that operate only on a volume level to not require
any changes.
