### PR TITLE
[wicket] fix call to get_prev_component_id

### DIFF
--- a/wicket/src/screens/component.rs
+++ b/wicket/src/screens/component.rs
@@ -103,7 +103,7 @@ impl ComponentScreen {
         // TODO: Some sliding style animation?
         let title = Spans::from(vec![
             Span::styled(
-                state.rack_state.get_next_component_id().name(),
+                state.rack_state.get_prev_component_id().name(),
                 menu_bar_style,
             ),
             Span::raw("   "),


### PR DESCRIPTION
Previously, we were showing the next component ID in both the previous
and next spots.

After this change:

![image](https://user-images.githubusercontent.com/180618/212437192-e640b63d-a928-43eb-b0a8-712821490b75.png)
