### PR TITLE
Undo git dep for fatfs now that 0.3.6 has been released.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,8 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "fatfs"
-version = "0.3.5"
-source = "git+https://github.com/luqmana/rust-fatfs?branch=stable-0.3#af26bc712db9f770294fb87b52f202c88c2a89df"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05669f8e7e2d7badc545c513710f0eba09c2fbef683eb859fd79c46c355048e0"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,10 +117,7 @@ diesel = { version = "2.0.2" }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", rev = "18748d9f76c94e1f4400fbec0859b3e77a221a8d" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 expectorate = "1.0.6"
-# TODO(luqman): Update once merged & new release is cut
-# https://github.com/rafalh/rust-fatfs/pull/76
-fatfs = { git = "https://github.com/luqmana/rust-fatfs", branch = "stable-0.3" }
-#fatfs = "0.3.6"
+fatfs = "0.3.6"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev="1a27a661d7824712aeb4d1b9801938888139eaa7", default-features = false, features = ["std"] }


### PR DESCRIPTION
Cleanup from #1850.