### PR TITLE
Use strings for update artifact versions

### DIFF
--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -81,7 +81,7 @@ impl ProducerEndpoint {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct UpdateArtifact {
     pub name: String,
-    pub version: i64,
+    pub version: String,
     pub kind: UpdateArtifactKind,
 }
 

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1454,8 +1454,8 @@ CREATE TYPE omicron.public.update_artifact_kind AS ENUM (
 );
 
 CREATE TABLE omicron.public.update_available_artifact (
-    name STRING(40) NOT NULL,
-    version INT NOT NULL,
+    name STRING(63) NOT NULL,
+    version STRING(63) NOT NULL,
     kind omicron.public.update_artifact_kind NOT NULL,
 
     /* the version of the targets.json role this came from */

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -653,7 +653,7 @@ table! {
 table! {
     update_available_artifact (name, version, kind) {
         name -> Text,
-        version -> Int8,
+        version -> Text,
         kind -> crate::UpdateArtifactKindEnum,
         targets_role_version -> Int8,
         valid_until -> Timestamptz,

--- a/nexus/db-model/src/update_artifact.rs
+++ b/nexus/db-model/src/update_artifact.rs
@@ -33,7 +33,7 @@ impl_enum_wrapper!(
 pub struct UpdateAvailableArtifact {
     pub name: String,
     /// Version of the artifact itself
-    pub version: i64,
+    pub version: String,
     pub kind: UpdateArtifactKind,
     /// `version` field of targets.json from the repository
     // FIXME this *should* be a NonZeroU64
@@ -47,7 +47,7 @@ pub struct UpdateAvailableArtifact {
 }
 
 impl UpdateAvailableArtifact {
-    pub fn id(&self) -> (String, i64, UpdateArtifactKind) {
-        (self.name.clone(), self.version, self.kind)
+    pub fn id(&self) -> (String, String, UpdateArtifactKind) {
+        (self.name.clone(), self.version.clone(), self.kind)
     }
 }

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -116,7 +116,7 @@ impl super::Nexus {
                     .update_artifact(
                         &sled_agent_client::types::UpdateArtifact {
                             name: artifact.name.clone(),
-                            version: artifact.version,
+                            version: artifact.version.clone(),
                             kind: artifact.kind.0.into(),
                         },
                     )
@@ -148,7 +148,7 @@ impl super::Nexus {
         let (.., artifact_entry) = LookupPath::new(opctx, &self.db_datastore)
             .update_available_artifact_tuple(
                 &artifact.name,
-                artifact.version,
+                &artifact.version,
                 UpdateArtifactKind(artifact.kind),
             )
             .fetch()

--- a/nexus/src/authz/api_resources.rs
+++ b/nexus/src/authz/api_resources.rs
@@ -958,7 +958,7 @@ authz_resource! {
 authz_resource! {
     name = "UpdateAvailableArtifact",
     parent = "Fleet",
-    primary_key = (String, i64, UpdateArtifactKind),
+    primary_key = (String, String, UpdateArtifactKind),
     roles_allowed = false,
     polar_snippet = FleetChild,
 }

--- a/nexus/src/db/lookup.rs
+++ b/nexus/src/db/lookup.rs
@@ -383,13 +383,13 @@ impl<'a> LookupPath<'a> {
     pub fn update_available_artifact_tuple(
         self,
         name: &str,
-        version: i64,
+        version: &str,
         kind: UpdateArtifactKind,
     ) -> UpdateAvailableArtifact<'a> {
         UpdateAvailableArtifact::PrimaryKey(
             Root { lookup_root: self },
             name.to_string(),
-            version,
+            version.to_string(),
             kind,
         )
     }
@@ -681,7 +681,7 @@ lookup_resource! {
     soft_deletes = false,
     primary_key_columns = [
         { column_name = "name", rust_type = String },
-        { column_name = "version", rust_type = i64 },
+        { column_name = "version", rust_type = String },
         { column_name = "kind", rust_type = UpdateArtifactKind }
     ]
 }

--- a/nexus/src/updates.rs
+++ b/nexus/src/updates.rs
@@ -16,7 +16,7 @@ pub struct ArtifactsDocument {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateArtifact {
     pub name: String,
-    pub version: i64,
+    pub version: String,
     // Future versions of artifacts.json might contain artifact kinds we're not aware of yet. This
     // shouldn't stop us from updating, say, Nexus or the ramdisk that contains sled-agent. When
     // adding artifacts to the database, we skip any unknown kinds.
@@ -112,13 +112,13 @@ mod tests {
                 "artifacts": [
                     {
                         "name": "fksdfjslkfjlsj",
-                        "version": 1u8,
+                        "version": "0.0.0",
                         "kind": "sdkfslfjadkfjasl",
                         "target": "ksdjdslfjljk",
                     },
                     {
                         "name": "kdsfjdljfdlkj",
-                        "version": 1u8,
+                        "version": "0.0.0",
                         "kind": "zone",
                         "target": "sldkfjasldfj",
                     },

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -238,7 +238,7 @@ fn generate_targets() -> (TempDir, Vec<&'static str>) {
     let artifacts = ArtifactsDocument {
         artifacts: vec![UpdateArtifact {
             name: "omicron-test-component".into(),
-            version: 1,
+            version: "0.0.0".into(),
             kind: Some(UpdateArtifactKind::Zone),
             target: "omicron-test-component-1".into(),
         }],

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -36,8 +36,7 @@
             "name": "version",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1606,8 +1606,7 @@
             "type": "string"
           },
           "version": {
-            "type": "integer",
-            "format": "int64"
+            "type": "string"
           }
         },
         "required": [

--- a/sled-agent/src/mocks/mod.rs
+++ b/sled-agent/src/mocks/mod.rs
@@ -42,7 +42,7 @@ mock! {
             &self,
             kind: UpdateArtifactKind,
             name: &str,
-            version: i64,
+            version: &str,
         ) -> Result<progenitor::progenitor_client::ByteStream>;
         pub async fn zpool_put(
             &self,

--- a/sled-agent/src/updates.rs
+++ b/sled-agent/src/updates.rs
@@ -58,7 +58,7 @@ pub async fn download_artifact(
                 .cpapi_artifact_download(
                     nexus_client::types::UpdateArtifactKind::Zone,
                     &artifact.name,
-                    artifact.version,
+                    &artifact.version,
                 )
                 .await
                 .map_err(Error::Response)?;
@@ -111,7 +111,7 @@ mod test {
         let expected_contents = "test_artifact contents";
         let artifact = UpdateArtifact {
             name: expected_name.to_string(),
-            version: 3,
+            version: "0.0.0".to_string(),
             kind: UpdateArtifactKind::Zone,
         };
         let expected_path = PathBuf::from("/var/tmp/zones").join(expected_name);
@@ -124,7 +124,7 @@ mod test {
         nexus_client.expect_cpapi_artifact_download().times(1).return_once(
             move |kind, name, version| {
                 assert_eq!(name, "test_artifact");
-                assert_eq!(version, 3);
+                assert_eq!(version, "0.0.0");
                 assert_eq!(kind.to_string(), "zone");
                 let response = ByteStream::new(Box::pin(
                     futures::stream::once(futures::future::ready(Result::Ok(


### PR DESCRIPTION
This is part 1 for getting TUF repo generation done; this changes a common data structure for updates so I can do some other data type shifting on top of it.

I had initially used integer versions for update artifacts as a bit of a strawman. Over the course of a few meetings on updates that culminated in [RFD 334](https://rfd.shared.oxide.computer/rfd/0334), still in prediscussion, I've been convinced that we need something a bit more nuanced than a monotonically-increasing integer. While RFD 334 still shows a determination that a monotonically-increasing integer is okay, the inability to describe an "in-between" version (for the certainly-likely future case of producing a bug fix on an older, still-supported branch while customers move to the latest branch) is unacceptable.

Semver is the likely version format, but as far as Nexus and Sled Agent talking to each other is concerned, the version could be any string we like as long as it's unique for that name and artifact kind. (Strings also keep the use of `#[derive(JsonSchema)]` simple.)