### PR TITLE
clippy in CI skips lots of code

### DIFF
--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#:
+#: name = "clippy (helios)"
+#: variety = "basic"
+#: target = "helios-latest"
+#: rust_toolchain = "nightly-2022-09-27"
+#: output_rules = []
+#:
+
+# Run clippy on illumos (not just other systems) because a bunch of our code
+# (that we want to check) is conditionally-compiled on illumos only.
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+# Put tools on our PATH to satisfy install_builder_prerequisites.
+export PATH="$PATH:$PWD/out/cockroachdb/bin:$PWD/out/clickhouse"
+banner prerequisites
+ptime -m bash ./tools/install_builder_prerequisites.sh -y
+
+banner clippy
+# See the corresponding GitHub Actions job for more about these arguments.
+ptime -m cargo +'nightly-2022-09-27' clippy --all-targets -- --deny warnings --allow clippy::style

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
       # override belongs in src/lib.rs, and it is there, but that doesn't
       # reliably work due to rust-lang/rust-clippy#6610.
       #
-      run: cargo clippy -- -D warnings -A clippy::style
+      run: cargo clippy --all-targets -- --deny warnings --allow clippy::style
 
   # This is just a test build of docs.  Publicly available docs are built via
   # the separate "rustdocs" repo.

--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ To build and run the non-simulated version of Omicron, see: xref:docs/how-to-run
 
 You can **format the code** using `cargo fmt`.  Make sure to run this before pushing changes.  The CI checks that the code is correctly formatted.
 
-You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy \-- -D warnings -A clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.
+You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy \--all-targets \-- \--deny warnings \--allow clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.
 
 == Docker image
 

--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ To build and run the non-simulated version of Omicron, see: xref:docs/how-to-run
 
 You can **format the code** using `cargo fmt`.  Make sure to run this before pushing changes.  The CI checks that the code is correctly formatted.
 
-You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy \--all-targets \-- \--deny warnings \--allow clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.
+You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** using `cargo clippy --all-targets \-- --deny warnings --allow clippy::style`.  Make sure to run this before pushing changes.  The CI checks that the code is clippy-clean.
 
 == Docker image
 

--- a/common/src/api/external/http_pagination.rs
+++ b/common/src/api/external/http_pagination.rs
@@ -796,7 +796,7 @@ mod test {
                 panic!("Expected Name pagination, got Id pagination")
             }
         };
-        assert_eq!(data_page.marker, Some(&thinglast_name.into()));
+        assert_eq!(data_page.marker, Some(&thinglast_name));
         assert_eq!(data_page.direction, PaginationOrder::Descending);
         assert_eq!(data_page.limit, limit);
     }
@@ -847,7 +847,7 @@ mod test {
                 panic!("Expected id pagination, got name pagination")
             }
         };
-        assert_eq!(data_page.marker, Some(&thinglast_id.into()));
+        assert_eq!(data_page.marker, Some(&thinglast_id));
         assert_eq!(data_page.direction, PaginationOrder::Ascending);
         assert_eq!(data_page.limit, limit);
     }

--- a/common/src/api/external/http_pagination.rs
+++ b/common/src/api/external/http_pagination.rs
@@ -583,6 +583,7 @@ mod test {
     }
 
     /// Function for running a bunch of tests on a ScanParams type.
+    #[allow(clippy::type_complexity)]
     fn test_scan_param_common<F, S>(
         list: &Vec<MyThing>,
         scan: &S,

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2495,7 +2495,7 @@ mod test {
             "vpc:foo".parse().unwrap()
         );
         assert_eq!(
-            RouteDestination::Subnet(name.clone()),
+            RouteDestination::Subnet(name),
             "subnet:foo".parse().unwrap()
         );
         assert_eq!(

--- a/common/src/nexus_config.rs
+++ b/common/src/nexus_config.rs
@@ -603,7 +603,7 @@ mod test {
                     .to_string()
                     .starts_with("unsupported authn scheme: \"trust-me\""),
                 "error = {}",
-                error.to_string()
+                error
             );
         } else {
             panic!(

--- a/internal-dns/tests/basic_test.rs
+++ b/internal-dns/tests/basic_test.rs
@@ -378,7 +378,7 @@ fn test_config(
             level: dropshot::ConfigLoggingLevel::Info,
         },
         dropshot: dropshot::ConfigDropshot {
-            bind_address: format!("[::1]:0").parse().unwrap(),
+            bind_address: "[::1]:0".to_string().parse().unwrap(),
             request_body_max_bytes: 1024,
             ..Default::default()
         },

--- a/nexus/authz-macros/src/lib.rs
+++ b/nexus/authz-macros/src/lib.rs
@@ -369,15 +369,13 @@ fn do_authz_resource(
 #[cfg(test)]
 #[test]
 fn test_authz_dump() {
-    let output = do_authz_resource(
-        quote! {
-            name = "Organization",
-            parent = "Fleet",
-            primary_key = Uuid,
-            roles_allowed = false,
-            polar_snippet = Custom,
-        },
-    )
+    let output = do_authz_resource(quote! {
+        name = "Organization",
+        parent = "Fleet",
+        primary_key = Uuid,
+        roles_allowed = false,
+        polar_snippet = Custom,
+    })
     .unwrap();
     println!("{}", output);
 }

--- a/nexus/authz-macros/src/lib.rs
+++ b/nexus/authz-macros/src/lib.rs
@@ -376,8 +376,7 @@ fn test_authz_dump() {
             primary_key = Uuid,
             roles_allowed = false,
             polar_snippet = Custom,
-        }
-        .into(),
+        },
     )
     .unwrap();
     println!("{}", output);

--- a/nexus/db-macros/src/lib.rs
+++ b/nexus/db-macros/src/lib.rs
@@ -441,8 +441,7 @@ mod tests {
                     name: String,
                     is_cool: bool,
                 }
-            }
-            .into(),
+            },
             IdentityVariant::Resource,
         );
         assert!(out.is_err());
@@ -464,8 +463,7 @@ mod tests {
                     name: String,
                     is_cool: bool,
                 }
-            }
-            .into(),
+            },
             IdentityVariant::Resource,
         );
         assert!(out.is_err());
@@ -486,8 +484,7 @@ mod tests {
                     Foo,
                     Bar,
                 }
-            }
-            .into(),
+            },
             IdentityVariant::Resource,
         );
         assert!(out.is_err());
@@ -507,8 +504,7 @@ mod tests {
                     name: String,
                     is_cool: bool,
                 }
-            }
-            .into(),
+            },
             IdentityVariant::Resource,
         );
         assert!(out.is_err());
@@ -531,8 +527,7 @@ mod tests {
                     name: String,
                     is_cool: bool,
                 }
-            }
-            .into(),
+            },
             IdentityVariant::Resource,
         );
         assert!(out.is_ok());

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -914,8 +914,7 @@ mod test {
                 lookup_by_name = true,
                 soft_deletes = true,
                 primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            }
-            .into(),
+            },
         )
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
@@ -928,8 +927,7 @@ mod test {
                 lookup_by_name = true,
                 soft_deletes = true,
                 primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            }
-            .into(),
+            },
         )
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
@@ -942,8 +940,7 @@ mod test {
                 lookup_by_name = false,
                 soft_deletes = true,
                 primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            }
-            .into(),
+            },
         )
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
@@ -960,8 +957,7 @@ mod test {
                     { column_name = "version", rust_type = i64 },
                     { column_name = "kind", rust_type = UpdateArtifactKind }
                 ]
-            }
-            .into(),
+            },
         )
         .unwrap();
         println!("{}", rustfmt(output).unwrap());

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -906,59 +906,51 @@ mod test {
     #[test]
     #[ignore]
     fn test_lookup_dump() {
-        let output = lookup_resource(
-            quote! {
-                name = "Organization",
-                ancestors = ["Silo"],
-                children = [ "Project" ],
-                lookup_by_name = true,
-                soft_deletes = true,
-                primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            },
-        )
+        let output = lookup_resource(quote! {
+            name = "Organization",
+            ancestors = ["Silo"],
+            children = [ "Project" ],
+            lookup_by_name = true,
+            soft_deletes = true,
+            primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+        })
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
 
-        let output = lookup_resource(
-            quote! {
-                name = "Project",
-                ancestors = ["Organization"],
-                children = [ "Disk", "Instance" ],
-                lookup_by_name = true,
-                soft_deletes = true,
-                primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            },
-        )
+        let output = lookup_resource(quote! {
+            name = "Project",
+            ancestors = ["Organization"],
+            children = [ "Disk", "Instance" ],
+            lookup_by_name = true,
+            soft_deletes = true,
+            primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+        })
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
 
-        let output = lookup_resource(
-            quote! {
-                name = "SiloUser",
-                ancestors = [],
-                children = [],
-                lookup_by_name = false,
-                soft_deletes = true,
-                primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
-            },
-        )
+        let output = lookup_resource(quote! {
+            name = "SiloUser",
+            ancestors = [],
+            children = [],
+            lookup_by_name = false,
+            soft_deletes = true,
+            primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
+        })
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
 
-        let output = lookup_resource(
-            quote! {
-                name = "UpdateAvailableArtifact",
-                ancestors = [],
-                children = [],
-                lookup_by_name = false,
-                soft_deletes = false,
-                primary_key_columns = [
-                    { column_name = "name", rust_type = String },
-                    { column_name = "version", rust_type = i64 },
-                    { column_name = "kind", rust_type = UpdateArtifactKind }
-                ]
-            },
-        )
+        let output = lookup_resource(quote! {
+            name = "UpdateAvailableArtifact",
+            ancestors = [],
+            children = [],
+            lookup_by_name = false,
+            soft_deletes = false,
+            primary_key_columns = [
+                { column_name = "name", rust_type = String },
+                { column_name = "version", rust_type = i64 },
+                { column_name = "kind", rust_type = UpdateArtifactKind }
+            ]
+        })
         .unwrap();
         println!("{}", rustfmt(output).unwrap());
     }

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -184,9 +184,10 @@ mod test {
             assert!(
                 user_code.chars().nth(USER_CODE_WORD_LENGTH).unwrap() == '-'
             );
-            assert!(user_code.chars().filter(|x| *x != '-').all(|x| {
-                USER_CODE_ALPHABET.iter().any(|y| *y == x)
-            }));
+            assert!(user_code
+                .chars()
+                .filter(|x| *x != '-')
+                .all(|x| { USER_CODE_ALPHABET.iter().any(|y| *y == x) }));
             assert!(!codes_seen.contains(&user_code));
             codes_seen.insert(user_code);
         }

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -185,7 +185,7 @@ mod test {
                 user_code.chars().nth(USER_CODE_WORD_LENGTH).unwrap() == '-'
             );
             assert!(user_code.chars().filter(|x| *x != '-').all(|x| {
-                USER_CODE_ALPHABET.iter().find(|y| **y == x).is_some()
+                USER_CODE_ALPHABET.iter().any(|y| *y == x)
             }));
             assert!(!codes_seen.contains(&user_code));
             codes_seen.insert(user_code);

--- a/nexus/passwords/src/lib.rs
+++ b/nexus/passwords/src/lib.rs
@@ -302,7 +302,7 @@ mod test {
         };
         let hash2 = {
             let mut hasher =
-                Hasher::new(external_password_argon(), known_rng.clone());
+                Hasher::new(external_password_argon(), known_rng);
             hasher.create_password(&password).unwrap()
         };
         assert_eq!(hash1, hash2);
@@ -374,7 +374,7 @@ mod test {
         let password = Password::new(PASSWORD_STR).unwrap();
         let password_hash_str = hasher.create_password(&password).unwrap();
         assert!(argon2alt::verify_encoded(
-            &password_hash_str.to_string(),
+            password_hash_str.as_ref(),
             PASSWORD_STR.as_bytes()
         )
         .unwrap());

--- a/nexus/passwords/src/lib.rs
+++ b/nexus/passwords/src/lib.rs
@@ -301,8 +301,7 @@ mod test {
             hasher.create_password(&password).unwrap()
         };
         let hash2 = {
-            let mut hasher =
-                Hasher::new(external_password_argon(), known_rng);
+            let mut hasher = Hasher::new(external_password_argon(), known_rng);
             hasher.create_password(&password).unwrap()
         };
         assert_eq!(hash1, hash2);

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1351,7 +1351,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap().into(),
+            Name::from_str(DISK_NAME).unwrap(),
         );
         let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
         let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
@@ -1446,7 +1446,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap().into(),
+            Name::from_str(DISK_NAME).unwrap(),
         );
         let mut dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
 
@@ -1505,7 +1505,7 @@ mod test {
                 silo_id,
                 project_id,
                 disk_id,
-                Name::from_str(DISK_NAME).unwrap().into(),
+                Name::from_str(DISK_NAME).unwrap(),
             );
             dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
         }

--- a/nexus/src/authn/external/token.rs
+++ b/nexus/src/authn/external/token.rs
@@ -106,7 +106,7 @@ mod test {
     /// Returns a value of the `Authorization` header for this actor that will be
     /// accepted using this scheme.
     fn make_header_value(token: &str) -> Authorization<Bearer> {
-        make_header_value_str(&token.to_string()).unwrap()
+        make_header_value_str(token).unwrap()
     }
 
     /// Returns a value of the `Authorization` header with `str` in the place where

--- a/nexus/src/authz/policy_test/coverage.rs
+++ b/nexus/src/authz/policy_test/coverage.rs
@@ -33,7 +33,7 @@ impl Coverage {
 
     /// Record that type `class` is covered by the test
     pub fn covered_class(&mut self, class: oso::Class) {
-        let class_name = class.name.clone();
+        let class_name = class.name;
         debug!(&self.log, "covering"; "class_name" => &class_name);
         self.covered.insert(class_name);
     }

--- a/nexus/src/authz/policy_test/resources.rs
+++ b/nexus/src/authz/policy_test/resources.rs
@@ -62,12 +62,12 @@ pub async fn make_resources<'a>(
     main_silo_id: Uuid,
 ) -> ResourceSet {
     // Global resources
-    builder.new_resource(authz::DATABASE.clone());
-    builder.new_resource_with_users(authz::FLEET.clone()).await;
-    builder.new_resource(authz::CONSOLE_SESSION_LIST.clone());
-    builder.new_resource(authz::DEVICE_AUTH_REQUEST_LIST.clone());
-    builder.new_resource(authz::GLOBAL_IMAGE_LIST.clone());
-    builder.new_resource(authz::IP_POOL_LIST.clone());
+    builder.new_resource(authz::DATABASE);
+    builder.new_resource_with_users(authz::FLEET).await;
+    builder.new_resource(authz::CONSOLE_SESSION_LIST);
+    builder.new_resource(authz::DEVICE_AUTH_REQUEST_LIST);
+    builder.new_resource(authz::GLOBAL_IMAGE_LIST);
+    builder.new_resource(authz::IP_POOL_LIST);
 
     // Silo/organization/project hierarchy
     make_silo(&mut builder, "silo1", main_silo_id, true).await;
@@ -76,14 +76,14 @@ pub async fn make_resources<'a>(
     // Various other resources
     let rack_id = "c037e882-8b6d-c8b5-bef4-97e848eb0a50".parse().unwrap();
     builder.new_resource(authz::Rack::new(
-        authz::FLEET.clone(),
+        authz::FLEET,
         rack_id,
         LookupType::ById(rack_id),
     ));
 
     let sled_id = "8a785566-adaf-c8d8-e886-bee7f9b73ca7".parse().unwrap();
     builder.new_resource(authz::Sled::new(
-        authz::FLEET.clone(),
+        authz::FLEET,
         sled_id,
         LookupType::ById(sled_id),
     ));
@@ -91,21 +91,21 @@ pub async fn make_resources<'a>(
     let global_image_id =
         "b46bf5b5-e6e4-49e6-fe78-8e25d698dabc".parse().unwrap();
     builder.new_resource(authz::GlobalImage::new(
-        authz::FLEET.clone(),
+        authz::FLEET,
         global_image_id,
         LookupType::ById(global_image_id),
     ));
 
     let device_user_code = String::from("a-device-user-code");
     builder.new_resource(authz::DeviceAuthRequest::new(
-        authz::FLEET.clone(),
+        authz::FLEET,
         device_user_code.clone(),
         LookupType::ByName(device_user_code),
     ));
 
     let device_access_token = String::from("a-device-access-token");
     builder.new_resource(authz::DeviceAccessToken::new(
-        authz::FLEET.clone(),
+        authz::FLEET,
         device_access_token.clone(),
         LookupType::ByName(device_access_token),
     ));
@@ -308,6 +308,6 @@ pub fn exempted_authz_classes() -> BTreeSet<String> {
         authz::UserBuiltin::get_polar_class(),
     ]
     .into_iter()
-    .map(|c| c.name.clone())
+    .map(|c| c.name)
     .collect()
 }

--- a/nexus/src/authz/policy_test/resources.rs
+++ b/nexus/src/authz/policy_test/resources.rs
@@ -57,8 +57,8 @@ use uuid::Uuid;
 //   `make_organization()`, etc.)  You'll likely need the `first_branch`
 //   argument that says whether to create users and how many child hierarchies
 //   to create.
-pub async fn make_resources<'a>(
-    mut builder: ResourceBuilder<'a>,
+pub async fn make_resources(
+    mut builder: ResourceBuilder<'_>,
     main_silo_id: Uuid,
 ) -> ResourceSet {
     // Global resources

--- a/nexus/src/db/datastore/mod.rs
+++ b/nexus/src/db/datastore/mod.rs
@@ -472,7 +472,7 @@ mod test {
         let rack_id = Uuid::new_v4();
         let sled_id = Uuid::new_v4();
         let is_scrimlet = false;
-        let sled = Sled::new(sled_id, bogus_addr.clone(), is_scrimlet, rack_id);
+        let sled = Sled::new(sled_id, bogus_addr, is_scrimlet, rack_id);
         datastore.sled_upsert(sled).await.unwrap();
         sled_id
     }

--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -653,7 +653,7 @@ impl<'a> NexusRequest<'a> {
         let mut next_token: Option<String> = None;
         const DEFAULT_PAGE_SIZE: usize = 10;
         let limit = limit.unwrap_or(DEFAULT_PAGE_SIZE);
-        let url_base = if collection_url.contains("?") {
+        let url_base = if collection_url.contains('?') {
             format!("{}&limit={}", collection_url, limit)
         } else {
             format!("{}?limit={}", collection_url, limit)

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -63,7 +63,9 @@ where
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
-        .expect(&format!("failed to make \"create\" request to {path}"))
+        .unwrap_or_else(|_| {
+            panic!("failed to make \"create\" request to {path}")
+        })
         .parsed_body()
         .unwrap()
 }
@@ -73,7 +75,9 @@ pub async fn object_delete(client: &ClientTestContext, path: &str) {
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
-        .expect(&format!("failed to make \"delete\" request to {path}"));
+        .unwrap_or_else(|_| {
+            panic!("failed to make \"delete\" request to {path}")
+        });
 }
 
 pub async fn populate_ip_pool(

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -252,8 +252,7 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         &"otheruser".parse().unwrap(),
         params::UserPassword::InvalidPassword,
     )
-    .await
-    .id;
+    .await;
 
     // Listing users should work
     let users: ResultsPage<views::User> =

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -163,7 +163,7 @@ async fn set_instance_state(
 
 async fn instance_simulate(nexus: &Arc<Nexus>, id: &Uuid) {
     let sa = nexus.instance_sled_by_id(id).await.unwrap();
-    sa.instance_finish_transition(id.clone()).await;
+    sa.instance_finish_transition(*id).await;
 }
 
 #[nexus_test]
@@ -240,13 +240,13 @@ async fn test_disk_create_attach_detach_delete(
     let instance_id = &instance.identity.id;
     assert_eq!(attached_disk.identity.name, disk.identity.name);
     assert_eq!(attached_disk.identity.id, disk.identity.id);
-    assert_eq!(attached_disk.state, DiskState::Attached(instance_id.clone()));
+    assert_eq!(attached_disk.state, DiskState::Attached(*instance_id));
 
     // Attach the disk to the same instance.  This should complete immediately
     // with no state change.
     let disk =
         disk_post(client, &url_instance_attach_disk, disk.identity.name).await;
-    assert_eq!(disk.state, DiskState::Attached(instance_id.clone()));
+    assert_eq!(disk.state, DiskState::Attached(*instance_id));
 
     // Begin detaching the disk.
     let disk = disk_post(
@@ -388,13 +388,13 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let instance_id = &instance.identity.id;
     assert_eq!(attached_disk.identity.name, disk.identity.name);
     assert_eq!(attached_disk.identity.id, disk.identity.id);
-    assert_eq!(attached_disk.state, DiskState::Attached(instance_id.clone()));
+    assert_eq!(attached_disk.state, DiskState::Attached(*instance_id));
 
     // Attach the disk to the same instance.  This should complete immediately
     // with no state change.
     let disk =
         disk_post(client, &url_instance_attach_disk, disk.identity.name).await;
-    assert_eq!(disk.state, DiskState::Attached(instance_id.clone()));
+    assert_eq!(disk.state, DiskState::Attached(*instance_id));
 
     // Create a second instance and try to attach the disk to that.  This should
     // fail and the disk should remain attached to the first instance.
@@ -430,7 +430,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     );
 
     let attached_disk = disk_get(&client, &disk_url).await;
-    assert_eq!(attached_disk.state, DiskState::Attached(instance_id.clone()));
+    assert_eq!(attached_disk.state, DiskState::Attached(*instance_id));
 
     // Begin detaching the disk.
     let disk =
@@ -460,7 +460,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
     let instance2_id = &instance2.identity.id;
     assert_eq!(attached_disk.identity.name, disk.identity.name);
     assert_eq!(attached_disk.identity.id, disk.identity.id);
-    assert_eq!(attached_disk.state, DiskState::Attached(instance2_id.clone()));
+    assert_eq!(attached_disk.state, DiskState::Attached(*instance2_id));
 
     // At this point, it's not legal to attempt to attach it to a different
     // instance (the first one).
@@ -492,7 +492,7 @@ async fn test_disk_move_between_instances(cptestctx: &ControlPlaneTestContext) {
         disk.identity.name.clone(),
     )
     .await;
-    assert_eq!(disk.state, DiskState::Attached(instance2_id.clone()));
+    assert_eq!(disk.state, DiskState::Attached(*instance2_id));
 
     // It's not allowed to delete a disk that's attached.
     let error = NexusRequest::expect_failure(

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -581,7 +581,7 @@ lazy_static! {
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
         // Global IAM policy
         VerifyEndpoint {
-            url: *SYSTEM_POLICY_URL,
+            url: &SYSTEM_POLICY_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -598,7 +598,7 @@ lazy_static! {
 
         // IP Pools top-level endpoint
         VerifyEndpoint {
-            url: *DEMO_IP_POOLS_URL,
+            url: &DEMO_IP_POOLS_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -611,7 +611,7 @@ lazy_static! {
 
         // Single IP Pool endpoint
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_URL,
+            url: &DEMO_IP_POOL_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -625,7 +625,7 @@ lazy_static! {
 
         // IP Pool ranges endpoint
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_RANGES_URL,
+            url: &DEMO_IP_POOL_RANGES_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -635,7 +635,7 @@ lazy_static! {
 
         // IP Pool ranges/add endpoint
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_RANGES_ADD_URL,
+            url: &DEMO_IP_POOL_RANGES_ADD_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -647,7 +647,7 @@ lazy_static! {
 
         // IP Pool ranges/delete endpoint
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_RANGES_DEL_URL,
+            url: &DEMO_IP_POOL_RANGES_DEL_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -659,7 +659,7 @@ lazy_static! {
 
         // IP Pool endpoint (Oxide services)
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_SERVICE_URL,
+            url: &DEMO_IP_POOL_SERVICE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -669,7 +669,7 @@ lazy_static! {
 
         // IP Pool ranges endpoint (Oxide services)
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_SERVICE_RANGES_URL,
+            url: &DEMO_IP_POOL_SERVICE_RANGES_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -679,7 +679,7 @@ lazy_static! {
 
         // IP Pool ranges/add endpoint (Oxide services)
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_SERVICE_RANGES_ADD_URL,
+            url: &DEMO_IP_POOL_SERVICE_RANGES_ADD_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -691,7 +691,7 @@ lazy_static! {
 
         // IP Pool ranges/delete endpoint (Oxide services)
         VerifyEndpoint {
-            url: &*DEMO_IP_POOL_SERVICE_RANGES_DEL_URL,
+            url: &DEMO_IP_POOL_SERVICE_RANGES_DEL_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -722,7 +722,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_SILO_URL,
+            url: &DEMO_SILO_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -731,7 +731,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_SILO_POLICY_URL,
+            url: &DEMO_SILO_POLICY_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -771,14 +771,14 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SILO_USERS_LIST_URL,
+            url: &DEMO_SILO_USERS_LIST_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![ AllowedMethod::Get ],
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SILO_USERS_CREATE_URL,
+            url: &DEMO_SILO_USERS_CREATE_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -791,7 +791,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SILO_USER_ID_GET_URL,
+            url: &DEMO_SILO_USER_ID_GET_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -800,7 +800,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SILO_USER_ID_DELETE_URL,
+            url: &DEMO_SILO_USER_ID_DELETE_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -809,7 +809,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SILO_USER_ID_SET_PASSWORD_URL,
+            url: &DEMO_SILO_USER_ID_SET_PASSWORD_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -843,7 +843,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_ORG_URL,
+            url: &DEMO_ORG_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -861,7 +861,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_ORG_POLICY_URL,
+            url: &DEMO_ORG_POLICY_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -887,7 +887,7 @@ lazy_static! {
         // you have permissions on anything _inside_ the Organization, which is
         // incredibly expensive to determine in general.
         VerifyEndpoint {
-            url: &*DEMO_ORG_PROJECTS_URL,
+            url: &DEMO_ORG_PROJECTS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -899,7 +899,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_URL,
+            url: &DEMO_PROJECT_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -917,7 +917,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_POLICY_URL,
+            url: &DEMO_PROJECT_POLICY_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -934,7 +934,7 @@ lazy_static! {
 
         /* VPCs */
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_URL_VPCS,
+            url: &DEMO_PROJECT_URL_VPCS,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -955,7 +955,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_URL,
+            url: &DEMO_VPC_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -975,7 +975,7 @@ lazy_static! {
 
         /* Firewall rules */
         VerifyEndpoint {
-            url: &*DEMO_VPC_URL_FIREWALL_RULES,
+            url: &DEMO_VPC_URL_FIREWALL_RULES,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -990,7 +990,7 @@ lazy_static! {
 
         /* VPC Subnets */
         VerifyEndpoint {
-            url: &*DEMO_VPC_URL_SUBNETS,
+            url: &DEMO_VPC_URL_SUBNETS,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1011,7 +1011,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_SUBNET_URL,
+            url: &DEMO_VPC_SUBNET_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1029,7 +1029,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_SUBNET_INTERFACES_URL,
+            url: &DEMO_VPC_SUBNET_INTERFACES_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1040,7 +1040,7 @@ lazy_static! {
         /* VPC Routers */
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_URL_ROUTERS,
+            url: &DEMO_VPC_URL_ROUTERS,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1061,7 +1061,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_ROUTER_URL,
+            url: &DEMO_VPC_ROUTER_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1081,7 +1081,7 @@ lazy_static! {
         /* Router Routes */
 
         VerifyEndpoint {
-            url: &*DEMO_VPC_ROUTER_URL_ROUTES,
+            url: &DEMO_VPC_ROUTER_URL_ROUTES,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1102,7 +1102,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_ROUTER_ROUTE_URL,
+            url: &DEMO_ROUTER_ROUTE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1126,7 +1126,7 @@ lazy_static! {
         /* Disks */
 
         VerifyEndpoint {
-            url: &*DEMO_DISKS_URL,
+            url: &DEMO_DISKS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1138,7 +1138,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_DISK_URL,
+            url: &DEMO_DISK_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1148,7 +1148,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_DISK_METRICS_URL,
+            url: &DEMO_DISK_METRICS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1157,7 +1157,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_DISKS_URL,
+            url: &DEMO_INSTANCE_DISKS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1166,7 +1166,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_DISKS_ATTACH_URL,
+            url: &DEMO_INSTANCE_DISKS_ATTACH_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1179,7 +1179,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_DISKS_DETACH_URL,
+            url: &DEMO_INSTANCE_DISKS_DETACH_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1194,7 +1194,7 @@ lazy_static! {
         /* Project images */
 
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_URL_IMAGES,
+            url: &DEMO_PROJECT_URL_IMAGES,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1215,7 +1215,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_IMAGE_URL,
+            url: &DEMO_PROJECT_IMAGE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1227,7 +1227,7 @@ lazy_static! {
         /* Snapshots */
 
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_URL_SNAPSHOTS,
+            url: &DEMO_PROJECT_URL_SNAPSHOTS,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1248,7 +1248,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_SNAPSHOT_URL,
+            url: &DEMO_SNAPSHOT_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1259,7 +1259,7 @@ lazy_static! {
 
         /* Instances */
         VerifyEndpoint {
-            url: &*DEMO_PROJECT_URL_INSTANCES,
+            url: &DEMO_PROJECT_URL_INSTANCES,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1271,7 +1271,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_URL,
+            url: &DEMO_INSTANCE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1281,7 +1281,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_START_URL,
+            url: &DEMO_INSTANCE_START_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1289,7 +1289,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_STOP_URL,
+            url: &DEMO_INSTANCE_STOP_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1297,7 +1297,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_REBOOT_URL,
+            url: &DEMO_INSTANCE_REBOOT_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1305,7 +1305,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_MIGRATE_URL,
+            url: &DEMO_INSTANCE_MIGRATE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1317,7 +1317,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_SERIAL_URL,
+            url: &DEMO_INSTANCE_SERIAL_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1325,7 +1325,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_SERIAL_STREAM_URL,
+            url: &DEMO_INSTANCE_SERIAL_STREAM_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1335,7 +1335,7 @@ lazy_static! {
 
         /* Instance NICs */
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_NICS_URL,
+            url: &DEMO_INSTANCE_NICS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1356,7 +1356,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_NIC_URL,
+            url: &DEMO_INSTANCE_NIC_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1370,7 +1370,7 @@ lazy_static! {
 
         /* Instance external IP addresses */
         VerifyEndpoint {
-            url: &*DEMO_INSTANCE_EXTERNAL_IPS_URL,
+            url: &DEMO_INSTANCE_EXTERNAL_IPS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1398,7 +1398,7 @@ lazy_static! {
             allowed_methods: vec![AllowedMethod::Get],
         },
         VerifyEndpoint {
-            url: &*URL_USERS_DB_INIT,
+            url: &URL_USERS_DB_INIT,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1414,7 +1414,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*HARDWARE_RACK_URL,
+            url: &HARDWARE_RACK_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1428,7 +1428,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*HARDWARE_SLED_URL,
+            url: &HARDWARE_SLED_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1473,7 +1473,7 @@ lazy_static! {
         /* Metrics */
 
         VerifyEndpoint {
-            url: &*DEMO_SYSTEM_METRICS_URL,
+            url: &DEMO_SYSTEM_METRICS_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
@@ -1514,7 +1514,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*DEMO_GLOBAL_IMAGE_URL,
+            url: &DEMO_GLOBAL_IMAGE_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -1526,7 +1526,7 @@ lazy_static! {
         /* Silo identity providers */
 
         VerifyEndpoint {
-            url: &*IDENTITY_PROVIDERS_URL,
+            url: &IDENTITY_PROVIDERS_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::ReadOnly,
             allowed_methods: vec![
@@ -1535,7 +1535,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: &*SAML_IDENTITY_PROVIDERS_URL,
+            url: &SAML_IDENTITY_PROVIDERS_URL,
             // The visibility here deserves some explanation.  In order to
             // create a real SAML identity provider for doing tests, we have to
             // do it in a non-default Silo (because the default one does not
@@ -1550,7 +1550,7 @@ lazy_static! {
             )],
         },
         VerifyEndpoint {
-            url: &*SPECIFIC_SAML_IDENTITY_PROVIDER_URL,
+            url: &SPECIFIC_SAML_IDENTITY_PROVIDER_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1578,7 +1578,7 @@ lazy_static! {
         /* SSH keys */
 
         VerifyEndpoint {
-            url: &*DEMO_SSHKEYS_URL,
+            url: &DEMO_SSHKEYS_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::Full,
             allowed_methods: vec![
@@ -1589,7 +1589,7 @@ lazy_static! {
             ],
         },
         VerifyEndpoint {
-            url: &*DEMO_SPECIFIC_SSHKEY_URL,
+            url: &DEMO_SPECIFIC_SSHKEY_URL,
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::Full,
             allowed_methods: vec![

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -578,11 +578,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
             .await,
             0
         );
-        assert_eq!(query_for_latest_metric(
-            client,
-            &metric_url("ram_provisioned", *id),
-        )
-        .await, 0);
+        assert_eq!(
+            query_for_latest_metric(
+                client,
+                &metric_url("ram_provisioned", *id),
+            )
+            .await,
+            0
+        );
     }
 
     // Create an instance.
@@ -643,11 +646,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
             .await,
             expected_cpus
         );
-        assert_eq!(query_for_latest_metric(
-            client,
-            &metric_url("ram_provisioned", *id),
-        )
-        .await, expected_ram);
+        assert_eq!(
+            query_for_latest_metric(
+                client,
+                &metric_url("ram_provisioned", *id),
+            )
+            .await,
+            expected_ram
+        );
     }
 
     // Stop the instance
@@ -681,11 +687,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
             .await,
             0
         );
-        assert_eq!(query_for_latest_metric(
-            client,
-            &metric_url("ram_provisioned", *id),
-        )
-        .await, 0);
+        assert_eq!(
+            query_for_latest_metric(
+                client,
+                &metric_url("ram_provisioned", *id),
+            )
+            .await,
+            0
+        );
     }
 }
 
@@ -2353,10 +2362,8 @@ async fn test_attach_eight_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(
-                            format!("probablydata{}", i),
-                        )
-                        .unwrap(),
+                        name: Name::try_from(format!("probablydata{}", i))
+                            .unwrap(),
                     },
                 )
             })
@@ -2461,10 +2468,8 @@ async fn test_cannot_attach_nine_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(
-                            format!("probablydata{}", i),
-                        )
-                        .unwrap(),
+                        name: Name::try_from(format!("probablydata{}", i))
+                            .unwrap(),
                     },
                 )
             })
@@ -2585,10 +2590,8 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(
-                            format!("probablydata{}", i),
-                        )
-                        .unwrap(),
+                        name: Name::try_from(format!("probablydata{}", i))
+                            .unwrap(),
                     },
                 )
             })
@@ -2696,10 +2699,8 @@ async fn test_disks_detached_when_instance_destroyed(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(
-                            format!("probablydata{}", i),
-                        )
-                        .unwrap(),
+                        name: Name::try_from(format!("probablydata{}", i))
+                            .unwrap(),
                     },
                 )
             })

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -561,11 +561,11 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
         )
     };
     oximeter.force_collect().await;
-    for id in vec![organization_id, project_id] {
+    for id in &[organization_id, project_id] {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("virtual_disk_space_provisioned", id),
+                &metric_url("virtual_disk_space_provisioned", *id),
             )
             .await,
             0
@@ -573,14 +573,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("cpus_provisioned", id),
+                &metric_url("cpus_provisioned", *id),
             )
             .await,
             0
         );
         assert_eq!(query_for_latest_metric(
             client,
-            &metric_url("ram_provisioned", id),
+            &metric_url("ram_provisioned", *id),
         )
         .await, 0);
     }
@@ -626,11 +626,11 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
         expected_ram
     );
     oximeter.force_collect().await;
-    for id in vec![organization_id, project_id] {
+    for id in &[organization_id, project_id] {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("virtual_disk_space_provisioned", id),
+                &metric_url("virtual_disk_space_provisioned", *id),
             )
             .await,
             0
@@ -638,14 +638,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("cpus_provisioned", id),
+                &metric_url("cpus_provisioned", *id),
             )
             .await,
             expected_cpus
         );
         assert_eq!(query_for_latest_metric(
             client,
-            &metric_url("ram_provisioned", id),
+            &metric_url("ram_provisioned", *id),
         )
         .await, expected_ram);
     }
@@ -664,11 +664,11 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(virtual_provisioning_collection.cpus_provisioned, 0);
     assert_eq!(virtual_provisioning_collection.ram_provisioned.to_bytes(), 0);
     oximeter.force_collect().await;
-    for id in vec![organization_id, project_id] {
+    for id in &[organization_id, project_id] {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("virtual_disk_space_provisioned", id),
+                &metric_url("virtual_disk_space_provisioned", *id),
             )
             .await,
             0
@@ -676,14 +676,14 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
         assert_eq!(
             query_for_latest_metric(
                 client,
-                &metric_url("cpus_provisioned", id),
+                &metric_url("cpus_provisioned", *id),
             )
             .await,
             0
         );
         assert_eq!(query_for_latest_metric(
             client,
-            &metric_url("ram_provisioned", id),
+            &metric_url("ram_provisioned", *id),
         )
         .await, 0);
     }
@@ -2354,7 +2354,7 @@ async fn test_attach_eight_disks_to_instance(
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
                         name: Name::try_from(
-                            format!("probablydata{}", i).to_string(),
+                            format!("probablydata{}", i),
                         )
                         .unwrap(),
                     },
@@ -2462,7 +2462,7 @@ async fn test_cannot_attach_nine_disks_to_instance(
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
                         name: Name::try_from(
-                            format!("probablydata{}", i).to_string(),
+                            format!("probablydata{}", i),
                         )
                         .unwrap(),
                     },
@@ -2586,7 +2586,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
                         name: Name::try_from(
-                            format!("probablydata{}", i).to_string(),
+                            format!("probablydata{}", i),
                         )
                         .unwrap(),
                     },
@@ -2697,7 +2697,7 @@ async fn test_disks_detached_when_instance_destroyed(
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
                         name: Name::try_from(
-                            format!("probablydata{}", i).to_string(),
+                            format!("probablydata{}", i),
                         )
                         .unwrap(),
                     },
@@ -3231,5 +3231,5 @@ fn instances_eq(instance1: &Instance, instance2: &Instance) {
 /// going on.
 pub async fn instance_simulate(nexus: &Arc<Nexus>, id: &Uuid) {
     let sa = nexus.instance_sled_by_id(id).await.unwrap();
-    sa.instance_finish_transition(id.clone()).await;
+    sa.instance_finish_transition(*id).await;
 }

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -453,7 +453,7 @@ async fn expect_login_success(
     assert!(token_cookie.starts_with("session="));
     assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=3600");
     let (_, session_token) = token_cookie
-        .split_once("=")
+        .split_once('=')
         .expect("session cookie: bad cookie header value (missing 'session=')");
 
     // It's not clear how a successful login could ever take less than the

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -182,7 +182,7 @@ async fn test_project_deletion_with_instance(
         &params::InstanceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "my-instance".parse().unwrap(),
-                description: format!("description"),
+                description: "description".to_string(),
             },
             ncpus: InstanceCpuCount(4),
             memory: ByteCount::from_gibibytes_u32(1),

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -177,7 +177,7 @@ async fn test_role_assignments_silo(cptestctx: &ControlPlaneTestContext) {
         fn policy_url(&self) -> String {
             format!(
                 "/system/silos/{}/policy",
-                fixed_data::silo::DEFAULT_SILO.identity().name.to_string()
+                fixed_data::silo::DEFAULT_SILO.identity().name
             )
         }
 

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -539,7 +539,7 @@ async fn test_saml_idp_metadata_data_valid(
 
             idp_metadata_source: params::IdpMetadataSource::Base64EncodedXml {
                 data: base64::engine::general_purpose::STANDARD
-                    .encode(SAML_IDP_DESCRIPTOR.to_string()),
+                    .encode(SAML_IDP_DESCRIPTOR),
             },
 
             idp_entity_id: "entity_id".to_string(),
@@ -820,7 +820,7 @@ async fn test_silo_user_fetch_by_external_id(
         .silo_user_fetch_by_external_id(
             &opctx_external_authn,
             &authz_silo,
-            "123".into(),
+            "123",
         )
         .await;
     assert!(result.is_ok());
@@ -832,7 +832,7 @@ async fn test_silo_user_fetch_by_external_id(
         .silo_user_fetch_by_external_id(
             &opctx_external_authn,
             &authz_silo,
-            "f5513e049dac9468de5bdff36ab17d04f".into(),
+            "f5513e049dac9468de5bdff36ab17d04f",
         )
         .await;
     assert!(result.is_ok());
@@ -1515,9 +1515,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         users_by_id
     };
 
-    let users_by_name = users_by_id
-        .iter()
-        .map(|(_, user)| (user.display_name.to_owned(), *user))
+    let users_by_name = users_by_id.values().map(|user| (user.display_name.to_owned(), *user))
         .collect::<BTreeMap<_, _>>();
 
     // We'll run through a battery of tests:
@@ -1858,7 +1856,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
                 idp_metadata_source:
                     params::IdpMetadataSource::Base64EncodedXml {
                         data: base64::engine::general_purpose::STANDARD
-                            .encode(SAML_IDP_DESCRIPTOR.to_string()),
+                            .encode(SAML_IDP_DESCRIPTOR),
                     },
 
                 idp_entity_id: "entity_id".to_string(),
@@ -1968,7 +1966,7 @@ async fn run_user_tests(
         "/system/silos/{}/identity-providers/local/users",
         silo.identity.name
     );
-    let url_user_create = format!("{}", url_local_idp_users);
+    let url_user_create = url_local_idp_users.to_string();
 
     // Fetch users and verify it matches what the caller expects.
     println!("run_user_tests: as {:?}: fetch all users", authn_mode);

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -1794,7 +1794,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     .await;
 }
 
-async fn verify_local_idp_404<'a>(request: NexusRequest<'a>) {
+async fn verify_local_idp_404(request: NexusRequest<'_>) {
     let error = request
         .execute()
         .await

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -1515,7 +1515,9 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         users_by_id
     };
 
-    let users_by_name = users_by_id.values().map(|user| (user.display_name.to_owned(), *user))
+    let users_by_name = users_by_id
+        .values()
+        .map(|user| (user.display_name.to_owned(), *user))
         .collect::<BTreeMap<_, _>>();
 
     // We'll run through a battery of tests:

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -496,8 +496,7 @@ async fn test_reject_creating_disk_from_snapshot(
                 )
                 .unwrap()
                 .into(),
-            }
-            .into(),
+            },
         )
         .await
         .unwrap();
@@ -549,7 +548,7 @@ async fn test_reject_creating_disk_from_snapshot(
                     snapshot_id: snapshot.id(),
                 },
 
-                size: ByteCount::try_from(1 * params::MIN_DISK_SIZE_BYTES)
+                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES)
                     .unwrap(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
@@ -564,7 +563,7 @@ async fn test_reject_creating_disk_from_snapshot(
         error.message,
         format!(
             "disk size {} must be greater than or equal to snapshot size {}",
-            1 * params::MIN_DISK_SIZE_BYTES,
+            params::MIN_DISK_SIZE_BYTES,
             2 * params::MIN_DISK_SIZE_BYTES,
         )
     );
@@ -653,8 +652,7 @@ async fn test_reject_creating_disk_from_illegal_snapshot(
                 )
                 .unwrap()
                 .into(),
-            }
-            .into(),
+            },
         )
         .await
         .unwrap();

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -548,8 +548,7 @@ async fn test_reject_creating_disk_from_snapshot(
                     snapshot_id: snapshot.id(),
                 },
 
-                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES)
-                    .unwrap(),
+                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES).unwrap(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -69,7 +69,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .expect(&format!("Failed to GET from URL: {url}")),
+                    .unwrap_or_else(|_| panic!("Failed to GET from URL: {url}")),
                 id_routes,
             ),
             SetupReq::Post { url, body, id_routes } => (
@@ -78,7 +78,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .expect(&format!("Failed to POST to URL: {url}")),
+                    .unwrap_or_else(|_| panic!("Failed to POST to URL: {url}")),
                 id_routes,
             ),
         };
@@ -192,7 +192,7 @@ lazy_static! {
         },
         // Create a local User
         SetupReq::Post {
-            url: &*DEMO_SILO_USERS_CREATE_URL,
+            url: &DEMO_SILO_USERS_CREATE_URL,
             body: serde_json::to_value(&*DEMO_USER_CREATE).unwrap(),
             id_routes: vec![
                 &*DEMO_SILO_USER_ID_GET_URL,
@@ -202,12 +202,12 @@ lazy_static! {
         },
         // Get the default IP pool
         SetupReq::Get {
-            url: &*DEMO_IP_POOL_URL,
+            url: &DEMO_IP_POOL_URL,
             id_routes: vec!["/system/by-id/ip-pools/{id}"],
         },
         // Create an IP pool range
         SetupReq::Post {
-            url: &*DEMO_IP_POOL_RANGES_ADD_URL,
+            url: &DEMO_IP_POOL_RANGES_ADD_URL,
             body: serde_json::to_value(&*DEMO_IP_POOL_RANGE).unwrap(),
             id_routes: vec![],
         },
@@ -219,54 +219,54 @@ lazy_static! {
         },
         // Create a Project in the Organization
         SetupReq::Post {
-            url: &*DEMO_ORG_PROJECTS_URL,
+            url: &DEMO_ORG_PROJECTS_URL,
             body: serde_json::to_value(&*DEMO_PROJECT_CREATE).unwrap(),
             id_routes: vec![],
         },
         // Create a VPC in the Project
         SetupReq::Post {
-            url: &*DEMO_PROJECT_URL_VPCS,
+            url: &DEMO_PROJECT_URL_VPCS,
             body: serde_json::to_value(&*DEMO_VPC_CREATE).unwrap(),
             id_routes: vec!["/by-id/vpcs/{id}"],
         },
         // Create a VPC Subnet in the Vpc
         SetupReq::Post {
-            url: &*DEMO_VPC_URL_SUBNETS,
+            url: &DEMO_VPC_URL_SUBNETS,
             body: serde_json::to_value(&*DEMO_VPC_SUBNET_CREATE).unwrap(),
             id_routes: vec!["/by-id/vpc-subnets/{id}"],
         },
         // Create a VPC Router in the Vpc
         SetupReq::Post {
-            url: &*DEMO_VPC_URL_ROUTERS,
+            url: &DEMO_VPC_URL_ROUTERS,
             body: serde_json::to_value(&*DEMO_VPC_ROUTER_CREATE).unwrap(),
             id_routes: vec!["/by-id/vpc-routers/{id}"],
         },
         // Create a VPC Router in the Vpc
         SetupReq::Post {
-            url: &*DEMO_VPC_ROUTER_URL_ROUTES,
+            url: &DEMO_VPC_ROUTER_URL_ROUTES,
             body: serde_json::to_value(&*DEMO_ROUTER_ROUTE_CREATE).unwrap(),
             id_routes: vec!["/by-id/vpc-router-routes/{id}"],
         },
         // Create a Disk in the Project
         SetupReq::Post {
-            url: &*DEMO_DISKS_URL,
+            url: &DEMO_DISKS_URL,
             body: serde_json::to_value(&*DEMO_DISK_CREATE).unwrap(),
             id_routes: vec!["/v1/disks/{id}"],
         },
         // Create an Instance in the Project
         SetupReq::Post {
-            url: &*DEMO_PROJECT_URL_INSTANCES,
+            url: &DEMO_PROJECT_URL_INSTANCES,
             body: serde_json::to_value(&*DEMO_INSTANCE_CREATE).unwrap(),
             id_routes: vec!["/v1/instances/{id}"],
         },
         // Lookup the previously created NIC
         SetupReq::Get {
-            url: &*DEMO_INSTANCE_NIC_URL,
+            url: &DEMO_INSTANCE_NIC_URL,
             id_routes: vec!["/by-id/network-interfaces/{id}"],
         },
         // Create a Snapshot in the Project
         SetupReq::Post {
-            url: &*DEMO_PROJECT_URL_SNAPSHOTS,
+            url: &DEMO_PROJECT_URL_SNAPSHOTS,
             body: serde_json::to_value(&*DEMO_SNAPSHOT_CREATE).unwrap(),
             id_routes: vec!["/by-id/snapshots/{id}"],
         },
@@ -278,13 +278,13 @@ lazy_static! {
         },
         // Create a SAML identity provider
         SetupReq::Post {
-            url: &*SAML_IDENTITY_PROVIDERS_URL,
+            url: &SAML_IDENTITY_PROVIDERS_URL,
             body: serde_json::to_value(&*SAML_IDENTITY_PROVIDER).unwrap(),
             id_routes: vec![],
         },
         // Create a SSH key
         SetupReq::Post {
-            url: &*DEMO_SSHKEYS_URL,
+            url: &DEMO_SSHKEYS_URL,
             body: serde_json::to_value(&*DEMO_SSHKEY_CREATE).unwrap(),
             id_routes: vec![],
         },
@@ -380,7 +380,7 @@ async fn verify_endpoint(
                     .parsed_body::<IdMetadata>()
                     .unwrap()
                     .id
-                    .to_string()
+                    
                     .as_str(),
             ),
             None => endpoint
@@ -414,7 +414,7 @@ async fn verify_endpoint(
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .expect(&format!("Failed to GET: {uri}"))
+                    .unwrap_or_else(|_| panic!("Failed to GET: {uri}"))
                     .parsed_body::<serde_json::Value>()
                     .unwrap(),
             )
@@ -636,7 +636,7 @@ fn verify_response(response: &TestResponse) {
                 error.message.contains(" with name \"")
                     || error.message.contains(" with id \"")
             );
-            assert!(error.message.ends_with("\""));
+            assert!(error.message.ends_with('\"'));
         }
         StatusCode::METHOD_NOT_ALLOWED => {
             assert!(error.error_code.is_none());

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -69,7 +69,9 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
-                    .unwrap_or_else(|_| panic!("Failed to GET from URL: {url}")),
+                    .unwrap_or_else(|_| {
+                        panic!("Failed to GET from URL: {url}")
+                    }),
                 id_routes,
             ),
             SetupReq::Post { url, body, id_routes } => (
@@ -376,12 +378,7 @@ async fn verify_endpoint(
         match setup_response {
             Some(response) => endpoint.url.replace(
                 "{id}",
-                response
-                    .parsed_body::<IdMetadata>()
-                    .unwrap()
-                    .id
-                    
-                    .as_str(),
+                response.parsed_body::<IdMetadata>().unwrap().id.as_str(),
             ),
             None => endpoint
                 .url

--- a/nexus/tests/integration_tests/unauthorized_coverage.rs
+++ b/nexus/tests/integration_tests/unauthorized_coverage.rs
@@ -68,7 +68,7 @@ fn test_unauthorized_coverage() {
             let label = op
                 .operation_id
                 .clone()
-                .unwrap_or(String::from("unknown operation-id"));
+                .unwrap_or_else(|| String::from("unknown operation-id"));
             (Operation { method, path, label }, regex)
         })
         .collect();

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -158,7 +158,7 @@ fn new_tuf_repo(rng: &dyn SecureRandom) -> TempDir {
         roles: HashMap::new(),
         _extra: HashMap::new(),
     };
-    root.keys.insert(key_id.clone(), tuf_key.clone());
+    root.keys.insert(key_id.clone(), tuf_key);
     for role in [
         RoleType::Root,
         RoleType::Snapshot,

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -678,7 +678,7 @@ mod tests {
             .await
             .expect("Failed to initialize timeseries database");
         let sample = test_util::make_sample();
-        client.insert_samples(&vec![sample]).await.unwrap();
+        client.insert_samples(&[sample]).await.unwrap();
 
         let bad_name = name_mismatch::TestTarget {
             name: "first_name".into(),

--- a/oximeter/instruments/src/http.rs
+++ b/oximeter/instruments/src/http.rs
@@ -218,7 +218,7 @@ mod tests {
             id: ID.parse().unwrap(),
         };
         let hist = Histogram::new(&[0.0, 1.0]).unwrap();
-        let tracker = LatencyTracker::new(service, hist.clone());
+        let tracker = LatencyTracker::new(service, hist);
         let request = http::request::Builder::new()
             .method(http::Method::GET)
             .uri("/some/uri")

--- a/oximeter/oximeter-macro-impl/src/lib.rs
+++ b/oximeter/oximeter-macro-impl/src/lib.rs
@@ -265,8 +265,7 @@ mod tests {
                     is_cool: bool,
                     addr: std::net::IpAddr,
                 }
-            }
-            .into(),
+            },
         );
         assert!(out.is_ok());
     }
@@ -277,8 +276,7 @@ mod tests {
             quote! {
                 #[derive(Target)]
                 struct MyTarget;
-            }
-            .into(),
+            },
         );
         assert!(out.is_ok());
     }
@@ -289,8 +287,7 @@ mod tests {
             quote! {
                 #[derive(Target)]
                 struct MyTarget {}
-            }
-            .into(),
+            },
         );
         assert!(out.is_ok());
     }
@@ -304,8 +301,7 @@ mod tests {
                     Bad,
                     NoGood,
                 };
-            }
-            .into(),
+            },
         );
         assert!(out.is_err());
     }

--- a/oximeter/oximeter-macro-impl/src/lib.rs
+++ b/oximeter/oximeter-macro-impl/src/lib.rs
@@ -257,52 +257,44 @@ mod tests {
 
     #[test]
     fn test_target() {
-        let out = target_impl(
-            quote! {
-                #[derive(Target)]
-                struct MyTarget {
-                    name: String,
-                    is_cool: bool,
-                    addr: std::net::IpAddr,
-                }
-            },
-        );
+        let out = target_impl(quote! {
+            #[derive(Target)]
+            struct MyTarget {
+                name: String,
+                is_cool: bool,
+                addr: std::net::IpAddr,
+            }
+        });
         assert!(out.is_ok());
     }
 
     #[test]
     fn test_target_unit_struct() {
-        let out = target_impl(
-            quote! {
-                #[derive(Target)]
-                struct MyTarget;
-            },
-        );
+        let out = target_impl(quote! {
+            #[derive(Target)]
+            struct MyTarget;
+        });
         assert!(out.is_ok());
     }
 
     #[test]
     fn test_target_empty_struct() {
-        let out = target_impl(
-            quote! {
-                #[derive(Target)]
-                struct MyTarget {}
-            },
-        );
+        let out = target_impl(quote! {
+            #[derive(Target)]
+            struct MyTarget {}
+        });
         assert!(out.is_ok());
     }
 
     #[test]
     fn test_target_enum() {
-        let out = target_impl(
-            quote! {
-                #[derive(Target)]
-                enum MyTarget {
-                    Bad,
-                    NoGood,
-                };
-            },
-        );
+        let out = target_impl(quote! {
+            #[derive(Target)]
+            enum MyTarget {
+                Bad,
+                NoGood,
+            };
+        });
         assert!(out.is_err());
     }
 

--- a/oximeter/oximeter/src/histogram.rs
+++ b/oximeter/oximeter/src/histogram.rs
@@ -654,7 +654,7 @@ mod tests {
 
     #[test]
     fn test_histogram() {
-        let mut hist = Histogram::new(&vec![0, 10, 20]).unwrap();
+        let mut hist = Histogram::new(&[0, 10, 20]).unwrap();
         assert_eq!(
             hist.n_bins(),
             4,
@@ -782,7 +782,7 @@ mod tests {
     #[test]
     fn test_histogram_unsorted_bins() {
         assert!(
-            Histogram::new(&vec![0, -10, 1]).is_err(),
+            Histogram::new(&[0, -10, 1]).is_err(),
             "Expected an Err when building a histogram with unsorted bins"
         );
 
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_histogram_unbounded_samples() {
-        let mut hist = Histogram::new(&vec![0.0, 1.0]).unwrap();
+        let mut hist = Histogram::new(&[0.0, 1.0]).unwrap();
         assert!(
             hist.sample(f64::NAN).is_err(),
             "Expected an Err when sampling NaN into a histogram"

--- a/oximeter/oximeter/src/types.rs
+++ b/oximeter/oximeter/src/types.rs
@@ -725,7 +725,7 @@ mod tests {
         assert_eq!(measurement.start_time(), None);
 
         let datum = Cumulative::new(0i64);
-        let measurement = Measurement::new(chrono::Utc::now(), datum.clone());
+        let measurement = Measurement::new(chrono::Utc::now(), datum);
         assert_eq!(measurement.datum(), &Datum::from(datum));
         assert!(measurement.start_time().is_some());
         assert!(measurement.timestamp() >= measurement.start_time().unwrap());

--- a/oximeter/producer/examples/producer.rs
+++ b/oximeter/producer/examples/producer.rs
@@ -94,7 +94,7 @@ async fn main() {
     let logging_config =
         ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug };
     let server_info = ProducerEndpoint {
-        id: Uuid::new_v4().into(),
+        id: Uuid::new_v4(),
         address,
         base_route: "/collect".to_string(),
         interval: Duration::from_secs(10),

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -204,6 +204,7 @@ impl Zones {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn install_omicron_zone(
         log: &Logger,
         zone_name: &str,


### PR DESCRIPTION
We need `--all-targets` to cover tests, examples, etc.

Also by not running this on Helios, I think we're probably not covering the illumos-specific code.

This PR:

- updates the GitHub Actions CI job to run clippy with `--all-targets`
- adds a buildomat job to run clippy the same way
- fixes all the newly-found clippy issues.  I used `--fix` to do a lot of this.