### PR TITLE
[end-to-end] look for the correct serial output

### DIFF
--- a/end-to-end-tests/src/instance_launch.rs
+++ b/end-to-end-tests/src/instance_launch.rs
@@ -136,7 +136,7 @@ async fn instance_launch() -> Result<()> {
                     .data,
             )
             .into_owned();
-            if data.contains("localshark login:") {
+            if data.contains("-----END SSH HOST KEY KEYS-----") {
                 Ok(data)
             } else {
                 Err(Error::NotYet)


### PR DESCRIPTION
Depending on how systemd chooses to order things and how fast certain block reads happen, we can get a getty prompt (`localshark login:`, in this case) before the SSH keys are available.

We know what we're looking for, so look for that instead.