### PR TITLE
Bump rust toolchain to nightly-2023-01-19

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (ubuntu-20.04)"
 #: variety = "basic"
 #: target = "ubuntu-20.04"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "nightly-2023-01-19"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,7 +53,7 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
+ptime -m cargo +'nightly-2023-01-19' build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
@@ -63,7 +63,7 @@ ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 # from end-to-end-tests.
 #
 banner test
-ptime -m cargo +'nightly-2022-09-27' test --locked --verbose \
+ptime -m cargo +'nightly-2023-01-19' test --locked --verbose \
     --no-fail-fast
 
 #

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "nightly-2023-01-19"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
@@ -53,7 +53,7 @@ banner build
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
+ptime -m cargo +'nightly-2023-01-19' build --locked --all-targets --verbose
 
 #
 # NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
@@ -63,7 +63,7 @@ ptime -m cargo +'nightly-2022-09-27' build --locked --all-targets --verbose
 # from end-to-end-tests.
 #
 banner test
-ptime -m cargo +'nightly-2022-09-27' test --locked --verbose \
+ptime -m cargo +'nightly-2023-01-19' test --locked --verbose \
     --no-fail-fast
 
 #

--- a/.github/buildomat/jobs/build-end-to-end-tests.sh
+++ b/.github/buildomat/jobs/build-end-to-end-tests.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build-end-to-end-tests"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-04-27"
+#: rust_toolchain = "nightly-2023-01-19"
 #: output_rules = [
 #:	"=/work/*.gz",
 #: ]

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -3,7 +3,7 @@
 #: name = "helios / package"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "nightly-2022-09-27"
+#: rust_toolchain = "nightly-2023-01-19"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
 #:	"=/work/zones/*.tar.gz",

--- a/oximeter/oximeter/src/histogram.rs
+++ b/oximeter/oximeter/src/histogram.rs
@@ -511,9 +511,7 @@ where
     {
         let edges = [
             vec![<T as num_traits::Zero>::zero()],
-            (start_decade..end_decade)
-                .flat_map(|x| x.span_decade())
-                .collect(),
+            (start_decade..end_decade).flat_map(|x| x.span_decade()).collect(),
         ]
         .concat();
         Histogram::new(&edges)

--- a/oximeter/oximeter/src/histogram.rs
+++ b/oximeter/oximeter/src/histogram.rs
@@ -512,7 +512,6 @@ where
         let edges = [
             vec![<T as num_traits::Zero>::zero()],
             (start_decade..end_decade)
-                .into_iter()
                 .flat_map(|x| x.span_decade())
                 .collect(),
         ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,5 +10,5 @@
 [toolchain]
 # NOTE: This toolchain is also specified within .github/buildomat/jobs/{build-and-test,package}.sh.
 # If you update it here, update that file too.
-channel = "nightly-2022-09-27"
+channel = "nightly-2023-01-19"
 profile = "default"

--- a/sled-agent/src/serial.rs
+++ b/sled-agent/src/serial.rs
@@ -100,7 +100,7 @@ impl BufferData {
             ))
         } else if from_end < self.rolling.len() {
             // (apologies to Takenobu Mitsuyoshi)
-            let rolling_start = self.rolling.len() - from_end as usize;
+            let rolling_start = self.rolling.len() - from_end;
             Ok((
                 Box::new(self.rolling.iter().copied().skip(rolling_start)),
                 from_start,

--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -39,7 +39,7 @@ pub fn path_to_executable(cmd_name: &str) -> PathBuf {
 #[track_caller]
 pub fn assert_exit_code(exit_status: ExitStatus, code: u32, stderr_text: &str) {
     if let ExitStatus::Exited(exit_code) = exit_status {
-        assert_eq!(exit_code, code as u32);
+        assert_eq!(exit_code, code);
     } else {
         panic!(
             "expected normal process exit with code {}, got {:?}\n\nprocess stderr:{}",

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -71,7 +71,7 @@ impl ArtifactGetter for WicketdArtifactStore {
                             );
                         })
                         .ok()?;
-            let mut bytes = BytesMut::with_capacity(size as usize);
+            let mut bytes = BytesMut::with_capacity(size);
             bytes.put_bytes(0, size);
             return Some(Body::from(bytes.freeze()));
         }


### PR DESCRIPTION
I need this to access a "raw FD" on illumos in this PR: https://github.com/oxidecomputer/omicron/pull/2176

Apparently this was only a module that was made non-private on illumos rather recently.