### PR TITLE
Update to latest MGS with a single shared UDP socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,10 +2067,10 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1a27a661d7824712aeb4d1b9801938888139eaa7#1a27a661d7824712aeb4d1b9801938888139eaa7"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2220180907345c4a0430503a30955aa38ce19a4a#2220180907345c4a0430503a30955aa38ce19a4a"
 dependencies = [
  "bitflags",
- "hubpack",
+ "hubpack 0.1.1",
  "serde",
  "serde_repr",
  "smoltcp",
@@ -2082,16 +2082,23 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1a27a661d7824712aeb4d1b9801938888139eaa7#1a27a661d7824712aeb4d1b9801938888139eaa7"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2220180907345c4a0430503a30955aa38ce19a4a#2220180907345c4a0430503a30955aa38ce19a4a"
 dependencies = [
  "async-trait",
  "backoff",
  "futures",
+ "fxhash",
  "gateway-messages",
+ "hex",
+ "hubpack 0.1.1",
+ "lru-cache",
  "nix",
  "once_cell",
  "serde",
+ "serde-big-array 0.4.1",
  "slog",
+ "socket2",
+ "string_cache",
  "thiserror",
  "tlvc",
  "tokio",
@@ -2415,7 +2422,17 @@ name = "hubpack"
 version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
- "hubpack_derive",
+ "hubpack_derive 0.1.0",
+ "serde",
+]
+
+[[package]]
+name = "hubpack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8f3c0e51b49dd73e277f8d157f7248e91b3597e3487884181b259682b715d3"
+dependencies = [
+ "hubpack_derive 0.1.1",
  "serde",
 ]
 
@@ -2423,6 +2440,17 @@ dependencies = [
 name = "hubpack_derive"
 version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hubpack_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f928320aff16ee8818ef7309180f8b5897057fd79d9dcb8de3ed1ba6dcc125a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3307,14 +3335,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+version = "0.26.2"
+source = "git+https://github.com/jgallagher/nix?branch=r0.26-illumos#c1a3636db0524f194b714cfd117cd9b637b8b10e"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
+ "pin-utils",
  "static_assertions",
 ]
 
@@ -6081,7 +6109,7 @@ version = "0.1.0"
 source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ffc837ef7468101608aee9#77df31efa5619d0767ffc837ef7468101608aee9"
 dependencies = [
  "derive_more",
- "hubpack",
+ "hubpack 0.1.0",
  "rand 0.8.5",
  "salty",
  "serde",
@@ -6114,7 +6142,7 @@ source = "git+http://github.com/oxidecomputer/sprockets?rev=77df31efa5619d0767ff
 dependencies = [
  "corncobs",
  "derive_more",
- "hubpack",
+ "hubpack 0.1.0",
  "rand 0.8.5",
  "salty",
  "serde",
@@ -6133,7 +6161,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "hmac 0.12.1",
- "hubpack",
+ "hubpack 0.1.0",
  "rand_core 0.6.4",
  "serde",
  "sha3",
@@ -6187,6 +6215,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ expectorate = "1.0.6"
 fatfs = "0.3.6"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev="1a27a661d7824712aeb4d1b9801938888139eaa7", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev="1a27a661d7824712aeb4d1b9801938888139eaa7" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2220180907345c4a0430503a30955aa38ce19a4a", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2220180907345c4a0430503a30955aa38ce19a4a" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/deploy/src/bin/sled-agent-overlay-files.rs
+++ b/deploy/src/bin/sled-agent-overlay-files.rs
@@ -37,7 +37,7 @@ fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
                 common: SpCommonConfig {
                     multicast_addr: None,
                     bind_addrs: None,
-                    serial_number: [0; 16],
+                    serial_number: vec![0; 16],
                     manufacturing_root_cert_seed: [0; 32],
                     device_id_cert_seed: [0; 32],
                     components: Vec::new(),
@@ -59,7 +59,8 @@ fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
                 salty::Keypair::from(&config.manufacturing_root_cert_seed);
             let device_id_keypair =
                 salty::Keypair::from(&config.device_id_cert_seed);
-            let serial_number = SerialNumber(config.serial_number);
+            let serial_number =
+                SerialNumber(config.serial_number.clone().try_into().unwrap());
             let config = RotConfig::bootstrap_for_testing(
                 &manufacturing_keypair,
                 device_id_keypair,

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -9,13 +9,17 @@ use dropshot::HttpError;
 use gateway_messages::SpError;
 use gateway_sp_comms::error::CommunicationError;
 use gateway_sp_comms::error::UpdateError;
+use gateway_sp_comms::BindError;
 use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum ConfigError {
+pub enum StartupError {
     #[error("invalid configuration file: {}", .reasons.join(", "))]
     InvalidConfig { reasons: Vec<String> },
+
+    #[error(transparent)]
+    BindError(#[from] BindError),
 }
 
 #[derive(Debug, Error)]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -12,7 +12,11 @@ pub mod http_entrypoints; // TODO pub only for testing - is this right?
 
 pub use config::Config;
 pub use context::ServerContext;
+pub use management_switch::LocationConfig;
+pub use management_switch::LocationDeterminationConfig;
 pub use management_switch::SpType;
+pub use management_switch::SwitchPortConfig;
+pub use management_switch::SwitchPortDescription;
 
 use dropshot::ConfigDropshot;
 use slog::debug;

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -3,6 +3,11 @@
 #
 
 [switch]
+# For tests, bind to port 0 (i.e., OS chooses an open port) instead of MGS's
+# default port for SP communication. This option should be omitted in the real
+# config.
+udp_listen_port = 0
+
 # which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
 # our contact to the ignition controller)
 local_ignition_controller_port = 0
@@ -50,29 +55,29 @@ sp_port_2 = ["switch1"]
 # three are configured on a per-port basis, which allows a single system to
 # simulate a full set of ports and SPs.
 [switch.port.0]
-data_link_addr = "[::1]:0"
-multicast_addr = "[::1]:0"
+kind = "simulated"
+addr = "[::1]:0"
 [switch.port.0.location]
 switch0 = ["switch", 0]
 switch1 = ["switch", 1]
 
 [switch.port.1]
-data_link_addr = "[::1]:0"
-multicast_addr = "[::1]:0"
+kind = "simulated"
+addr = "[::1]:0"
 [switch.port.1.location]
 switch0 = ["switch", 1]
 switch1 = ["switch", 0]
 
 [switch.port.2]
-data_link_addr = "[::1]:0"
-multicast_addr = "[::1]:0"
+kind = "simulated"
+addr = "[::1]:0"
 [switch.port.2.location]
 switch0 = ["sled", 0]
 switch1 = ["sled", 0]
 
 [switch.port.3]
-data_link_addr = "[::1]:0"
-multicast_addr = "[::1]:0"
+kind = "simulated"
+addr = "[::1]:0"
 [switch.port.3.location]
 switch0 = ["sled", 1]
 switch1 = ["sled", 1]

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -34,8 +34,8 @@ async fn discovery_both_locations() {
     // both instances should report the same serial number for switch 0 and
     // switch 1, and it should match the expected values from the config
     for (switch, expected_serial) in [
-        (0, "00000000000000000000000000000001"),
-        (1, "00000000000000000000000000000002"),
+        (0, "0000000000000000000000000000000100000000000000000000000000000000"),
+        (1, "0000000000000000000000000000000200000000000000000000000000000000"),
     ] {
         for client in [client0, client1] {
             let url =

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -8,7 +8,6 @@
 use dropshot::ConfigLogging;
 use gateway_messages::DeviceCapabilities;
 use gateway_messages::DevicePresence;
-use gateway_messages::SerialNumber;
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::Ipv6Addr;
@@ -28,7 +27,7 @@ pub struct SpCommonConfig {
     pub bind_addrs: Option<[SocketAddrV6; 2]>,
     /// Fake serial number
     #[serde(with = "hex")]
-    pub serial_number: SerialNumber,
+    pub serial_number: Vec<u8>,
     /// 32-byte seed to create a manufacturing root certificate.
     #[serde(with = "hex")]
     pub manufacturing_root_cert_seed: [u8; 32],

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -51,6 +51,17 @@ pub trait SimulatedSp {
     ) -> Result<RotResponseV1, RotSprocketError>;
 }
 
+// Helper function to pad a simulated serial number (stored as a `Vec<u8>`) to
+// the appropriate size for returning in the SpState message.
+fn serial_number_padded(serial_number: &[u8]) -> [u8; 32] {
+    let mut padded = [0; 32];
+    padded
+        .get_mut(0..serial_number.len())
+        .expect("simulated serial number too long")
+        .copy_from_slice(&serial_number);
+    padded
+}
+
 pub struct SimRack {
     pub sidecars: Vec<Sidecar>,
     pub gimlets: Vec<Gimlet>,

--- a/sp-sim/src/rot.rs
+++ b/sp-sim/src/rot.rs
@@ -23,11 +23,17 @@ impl RotSprocketExt for RotSprocket {
     fn bootstrap_from_config(
         config: &SpCommonConfig,
     ) -> (Ed25519PublicKey, Self) {
+        let mut serial_number = [0; 16];
+        serial_number
+            .get_mut(0..config.serial_number.len())
+            .expect("simulated serial number too long")
+            .copy_from_slice(&config.serial_number);
+
         let manufacturing_keypair =
             salty::Keypair::from(&config.manufacturing_root_cert_seed);
         let device_id_keypair =
             salty::Keypair::from(&config.device_id_cert_seed);
-        let serial_number = SerialNumber(config.serial_number);
+        let serial_number = SerialNumber(serial_number);
         let config = RotConfig::bootstrap_for_testing(
             &manufacturing_keypair,
             device_id_keypair,


### PR DESCRIPTION
Most of the changes in this PR are miscellaneous fallout from minor type / API changes made in MGS over the past few weeks. The most substantial changes are in `ManagementSwitch::new()`, which now either creates a `SharedSocket` (for real deployments) or a UDP socket per SP (for sim deployments and tests). This is a little messy but seemed like the most straightforward way to continue to support running MGS proper without being in a real switch zone.