### PR TITLE
[wicket] reduce wicket -> wicketd poll interval to 500ms

### DIFF
--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -13,7 +13,7 @@ use wicketd_client::types::RackV1Inventory;
 
 use crate::wizard::Event;
 
-const WICKETD_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const WICKETD_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const WICKETD_TIMEOUT_MS: u32 = 1000;
 
 // Assume that these requests are periodic on the order of seconds or the


### PR DESCRIPTION
Wicketd runs on localhost and does internal caching, so wicket can poll
wicketd much more frequently.
