### PR TITLE
[wicket] add a state to indicate inventory is unavailable

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -69,7 +69,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RackV1Inventory"
+                  "$ref": "#/components/schemas/GetInventoryResponse"
                 }
               }
             }
@@ -115,6 +115,51 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "GetInventoryResponse": {
+        "description": "The response to a `get_inventory` call: the inventory of artifacts known to wicketd, or a notification that data is unavailable.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "inventory": {
+                    "$ref": "#/components/schemas/RackV1Inventory"
+                  }
+                },
+                "required": [
+                  "inventory"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "response"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unavailable"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
         ]
       },
       "RackV1Inventory": {

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddrV6;
 use std::sync::mpsc::Sender;
 use tokio::sync::mpsc;
 use tokio::time::{interval, Duration, MissedTickBehavior};
-use wicketd_client::types::RackV1Inventory;
+use wicketd_client::types::GetInventoryResponse;
 
 use crate::wizard::Event;
 
@@ -39,7 +39,6 @@ pub struct WicketdManager {
     rx: mpsc::Receiver<Request>,
     wizard_tx: Sender<Event>,
     inventory_client: wicketd_client::Client,
-    inventory: RackV1Inventory,
 }
 
 impl WicketdManager {
@@ -51,10 +50,8 @@ impl WicketdManager {
         let log = log.new(o!("component" => "WicketdManager"));
         let (tx, rx) = tokio::sync::mpsc::channel(CHANNEL_CAPACITY);
         let inventory_client = create_wicketd_client(&log, wicketd_addr);
-        let inventory = RackV1Inventory { sps: vec![] };
         let handle = WicketdHandle { tx };
-        let manager =
-            WicketdManager { log, rx, wizard_tx, inventory_client, inventory };
+        let manager = WicketdManager { log, rx, wizard_tx, inventory_client };
 
         (handle, manager)
     }
@@ -67,8 +64,7 @@ impl WicketdManager {
     ///   that can be utilized by the UI.
     pub async fn run(self) {
         let mut inventory_rx =
-            poll_inventory(&self.log, self.inventory_client, self.inventory)
-                .await;
+            poll_inventory(&self.log, self.inventory_client).await;
 
         // TODO: Eventually there will be a tokio::select! here that also
         // allows issuing updates.
@@ -99,12 +95,12 @@ pub(crate) fn create_wicketd_client(
 async fn poll_inventory(
     log: &Logger,
     client: wicketd_client::Client,
-    mut inventory: RackV1Inventory,
-) -> mpsc::Receiver<RackV1Inventory> {
+) -> mpsc::Receiver<GetInventoryResponse> {
     let log = log.clone();
 
     // We only want one oustanding request at a time
     let (tx, rx) = mpsc::channel(1);
+    let mut state = InventoryState::new(&log, tx);
 
     tokio::spawn(async move {
         let mut ticker = interval(WICKETD_POLL_INTERVAL);
@@ -115,12 +111,7 @@ async fn poll_inventory(
             match client.get_inventory().await {
                 Ok(val) => {
                     let new_inventory = val.into_inner();
-                    if new_inventory != inventory {
-                        inventory = new_inventory;
-                        let _ = tx.send(inventory.clone()).await;
-                    } else {
-                        debug!(log, "No change to inventory");
-                    }
+                    state.send_if_changed(new_inventory).await;
                 }
                 Err(e) => {
                     warn!(log, "{e}");
@@ -130,4 +121,26 @@ async fn poll_inventory(
     });
 
     rx
+}
+
+struct InventoryState {
+    log: Logger,
+    current_inventory: GetInventoryResponse,
+    tx: mpsc::Sender<GetInventoryResponse>,
+}
+
+impl InventoryState {
+    fn new(log: &Logger, tx: mpsc::Sender<GetInventoryResponse>) -> Self {
+        let log = log.new(o!("component" => "InventoryState"));
+        Self { log, current_inventory: GetInventoryResponse::Unavailable, tx }
+    }
+
+    async fn send_if_changed(&mut self, new_inventory: GetInventoryResponse) {
+        if new_inventory != self.current_inventory {
+            self.current_inventory = new_inventory;
+            let _ = self.tx.send(self.current_inventory.clone()).await;
+        } else {
+            debug!(self.log, "No change to inventory");
+        }
+    }
 }

--- a/wicket/src/wizard.rs
+++ b/wicket/src/wizard.rs
@@ -20,12 +20,13 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{interval, Duration};
 use tui::backend::CrosstermBackend;
 use tui::Terminal;
+use wicketd_client::types::GetInventoryResponse;
+use wicketd_client::types::RackV1Inventory;
 
 use crate::inventory::Inventory;
 use crate::screens::{Height, ScreenId, Screens};
 use crate::wicketd::{WicketdHandle, WicketdManager};
 use crate::widgets::RackState;
-use wicketd_client::types::RackV1Inventory;
 
 pub const MARGIN: Height = Height(5);
 
@@ -181,6 +182,14 @@ impl Wizard {
                     self.handle_actions(actions)?;
                 }
                 Event::Inventory(inventory) => {
+                    let inventory = match inventory {
+                        GetInventoryResponse::Response { inventory } => {
+                            inventory
+                        }
+                        GetInventoryResponse::Unavailable => {
+                            RackV1Inventory { sps: vec![] }
+                        }
+                    };
                     if let Err(e) =
                         self.state.inventory.update_inventory(inventory)
                     {
@@ -335,7 +344,7 @@ pub enum Event {
     Term(TermEvent),
 
     /// An Inventory Update Event
-    Inventory(RackV1Inventory),
+    Inventory(GetInventoryResponse),
 
     /// The tick of a Timer
     /// This can be used to draw a frame to the terminal

--- a/wicketd-client/src/lib.rs
+++ b/wicketd-client/src/lib.rs
@@ -27,5 +27,6 @@ progenitor::generate_api!(
         SpIgnitionSystemType= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
         SpInventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
         RackV1Inventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        GetInventoryResponse = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
     }
 );

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -4,7 +4,7 @@
 
 //! HTTP entrypoint functions for wicketd
 
-use crate::RackV1Inventory;
+use crate::mgs::GetInventoryResponse;
 use buf_list::BufList;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -50,9 +50,9 @@ pub fn api() -> WicketdApiDescription {
 }]
 async fn get_inventory(
     rqctx: RequestContext<ServerContext>,
-) -> Result<HttpResponseOk<RackV1Inventory>, HttpError> {
+) -> Result<HttpResponseOk<GetInventoryResponse>, HttpError> {
     match rqctx.context().mgs_handle.get_inventory().await {
-        Ok(inventory) => Ok(HttpResponseOk(inventory)),
+        Ok(response) => Ok(HttpResponseOk(response)),
         Err(_) => {
             Err(HttpError::for_unavail(None, "Server is shutting down".into()))
         }

--- a/wicketd/src/inventory.rs
+++ b/wicketd/src/inventory.rs
@@ -34,7 +34,7 @@ impl SpInventory {
 }
 
 /// The current state of the v1 Rack as known to wicketd
-#[derive(Default, Clone, Debug, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 #[serde(tag = "inventory", rename_all = "snake_case")]
 pub struct RackV1Inventory {
     pub sps: Vec<SpInventory>,


### PR DESCRIPTION
Currently, the inventory being unavailable is indicated by returning
an empty list. While this works for now; in the future, we'd like to be
able to add heartbeat functionality. This is so that wicketd can
return the last time it talked to MGS. With this design, the duration
would naturally fall under the new `GetInventoryResponse::Inventory`
variant.
