### PR TITLE
Rework MGS's config schema for switch zone interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,7 +3620,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_with",
  "slog",
  "slog-dtrace",
  "sp-sim",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -18,7 +18,6 @@ omicron-common.workspace = true
 once_cell.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_with.workspace = true
 slog.workspace = true
 slog-dtrace.workspace = true
 thiserror.workspace = true

--- a/gateway/src/management_switch.rs
+++ b/gateway/src/management_switch.rs
@@ -246,7 +246,7 @@ impl ManagementSwitch {
                 let result = LocationMap::run_discovery(
                     config,
                     port_to_desc,
-                    Arc::clone(&port_to_handle),
+                    port_to_handle,
                     &log,
                 )
                 .await;

--- a/gateway/src/management_switch.rs
+++ b/gateway/src/management_switch.rs
@@ -30,13 +30,10 @@ use gateway_sp_comms::SingleSp;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_with::serde_as;
-use serde_with::DisplayFromStr;
 use slog::o;
 use slog::warn;
 use slog::Logger;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
@@ -44,18 +41,16 @@ use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 
-#[serde_as]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SwitchConfig {
     #[serde(default = "default_udp_listen_port")]
     pub udp_listen_port: u16,
-    pub local_ignition_controller_port: usize,
+    pub local_ignition_controller_interface: String,
     pub rpc_max_attempts: usize,
     pub rpc_per_attempt_timeout_millis: u64,
     pub location: LocationConfig,
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub port: HashMap<usize, SwitchPortDescription>,
+    pub port: Vec<SwitchPortDescription>,
 }
 
 fn default_udp_listen_port() -> u16 {
@@ -90,20 +85,16 @@ pub enum SpType {
 )]
 pub(crate) struct SwitchPort(usize);
 
-impl SwitchPort {
-    fn as_ignition_target(self) -> u8 {
-        assert!(
-            self.0 <= usize::from(u8::MAX),
-            "cannot exceed 255 ignition targets / switch ports"
-        );
-        self.0 as u8
-    }
-}
-
 #[derive(Debug)]
 pub struct ManagementSwitch {
     local_ignition_controller_port: SwitchPort,
-    sockets: Arc<HashMap<SwitchPort, SingleSp>>,
+    // Both `port_to_*` fields are "keyed" by `SwitchPort`, which are newtype
+    // wrappers around an index into those vecs. Both are guaranteed to have
+    // length equal to our config file's `[[switch.port]]` section, and we only
+    // ever create and hand out `SwitchPort` instances with indices in-range for
+    // that length.
+    port_to_handle: Arc<Vec<SingleSp>>,
+    port_to_ignition_target: Vec<u8>,
     // We create a shared socket in real configs, but never use it after
     // `new()`. We need to hold onto it to prevent it being dropped, though:
     // When it's dropped, it cancels the background tokio task that loops on
@@ -133,7 +124,7 @@ impl ManagementSwitch {
         // Skim over our port configs - either all should be simulated or all
         // should be switch zone interfaces. Reject a mix.
         let mut shared_socket = None;
-        for (i, port_desc) in config.port.values().enumerate() {
+        for (i, port_desc) in config.port.iter().enumerate() {
             if i == 0 {
                 // First item: either create a shared socket (if we're going to
                 // share one socket among multiple switch zone VLAN interfaces)
@@ -173,10 +164,12 @@ impl ManagementSwitch {
         }
 
         // Convert our config into actual SP handles and sockets, keyed by
-        // `SwitchPort` newtypes.
-        let mut sockets = HashMap::with_capacity(config.port.len());
-        let mut ports = HashMap::with_capacity(config.port.len());
-        for (port, port_desc) in config.port {
+        // `SwitchPort` (newtype around an index into `config.port`).
+        let mut port_to_handle = Vec::with_capacity(config.port.len());
+        let mut port_to_desc = Vec::with_capacity(config.port.len());
+        let mut port_to_ignition_target = Vec::with_capacity(config.port.len());
+        let mut interface_to_port = HashMap::with_capacity(config.port.len());
+        for (i, port_desc) in config.port.into_iter().enumerate() {
             let per_attempt_timeout =
                 Duration::from_millis(config.rpc_per_attempt_timeout_millis);
             let single_sp = match &port_desc.config {
@@ -192,7 +185,7 @@ impl ManagementSwitch {
                     )
                     .await
                 }
-                SwitchPortConfig::Simulated { addr } => {
+                SwitchPortConfig::Simulated { addr, .. } => {
                     // Bind a new socket for each simulated switch port.
                     let bind_addr: SocketAddrV6 =
                         SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0);
@@ -212,43 +205,48 @@ impl ManagementSwitch {
                     )
                 }
             };
-            let port = SwitchPort(port);
 
-            sockets.insert(port, single_sp);
-            ports.insert(port, port_desc);
+            let port = SwitchPort(i);
+            interface_to_port
+                .insert(port_desc.config.interface().to_string(), port);
+            port_to_ignition_target.push(port_desc.ignition_target);
+            port_to_handle.push(single_sp);
+            port_to_desc.push(port_desc);
         }
 
-        // sanity check the local ignition controller port is bound
-        let local_ignition_controller_port =
-            SwitchPort(config.local_ignition_controller_port);
-        if !ports.contains_key(&local_ignition_controller_port) {
-            return Err(StartupError::InvalidConfig {
+        // Ensure the local ignition interface was listed in config.port
+        let local_ignition_controller_port = interface_to_port
+            .get(&config.local_ignition_controller_interface)
+            .copied()
+            .ok_or_else(|| StartupError::InvalidConfig {
                 reasons: vec![format!(
-                    "missing local ignition controller port {}",
-                    local_ignition_controller_port.0
+                    "missing port local ignition controller {}",
+                    config.local_ignition_controller_interface
                 )],
-            });
-        }
+            })?;
 
         // Start running discovery to figure out the physical location of
         // ourselves (and therefore all SPs we talk to). We don't block waiting
         // for this, but we won't be able to service requests until it
         // completes (because we won't be able to map "the SP of sled 7" to a
         // correct switch port).
-        let sockets = Arc::new(sockets);
+        let port_to_handle = Arc::new(port_to_handle);
         let location_map = Arc::new(OnceCell::new());
         let discovery_task = {
             let log = log.clone();
-            let sockets = Arc::clone(&sockets);
+            let port_to_handle = Arc::clone(&port_to_handle);
             let location_map = Arc::clone(&location_map);
-            let config =
-                ValidatedLocationConfig::try_from((&ports, config.location))?;
+            let config = ValidatedLocationConfig::validate(
+                &port_to_desc,
+                &interface_to_port,
+                config.location,
+            )?;
 
             tokio::spawn(async move {
                 let result = LocationMap::run_discovery(
                     config,
-                    ports,
-                    Arc::clone(&sockets),
+                    port_to_desc,
+                    Arc::clone(&port_to_handle),
                     &log,
                 )
                 .await;
@@ -263,7 +261,8 @@ impl ManagementSwitch {
             local_ignition_controller_port,
             location_map,
             _shared_socket: shared_socket,
-            sockets,
+            port_to_handle,
+            port_to_ignition_target,
             discovery_task,
             log,
         })
@@ -298,7 +297,7 @@ impl ManagementSwitch {
     /// This is infallible: [`SwitchPort`] is a newtype that we control, and
     /// we only hand out instances that match our configuration.
     fn port_to_sp(&self, port: SwitchPort) -> &SingleSp {
-        self.sockets.get(&port).unwrap()
+        &self.port_to_handle[port.0]
     }
 
     /// Get the switch port associated with the given logical identifier.
@@ -340,7 +339,7 @@ impl ManagementSwitch {
         id: SpIdentifier,
     ) -> Result<u8, SpCommsError> {
         let port = self.get_port(id)?;
-        Ok(port.as_ignition_target())
+        Ok(self.port_to_ignition_target[port.0])
     }
 
     /// Get an iterator providing the ID and handle to communicate with every SP
@@ -366,12 +365,15 @@ impl ManagementSwitch {
         &self,
         target: usize,
     ) -> Option<SwitchPort> {
-        let port = SwitchPort(target);
-        if self.sockets.contains_key(&port) {
-            Some(port)
-        } else {
-            None
+        // We could build an ignition target -> port map, but for the size of
+        // this vec (~36) a scan is probably fine.
+        for (i, port_target) in self.port_to_ignition_target.iter().enumerate()
+        {
+            if target == usize::from(*port_target) {
+                return Some(SwitchPort(i));
+            }
         }
+        None
     }
 
     /// Ask the local ignition controller for the ignition state of all SPs.

--- a/gateway/src/management_switch/location_map.rs
+++ b/gateway/src/management_switch/location_map.rs
@@ -19,7 +19,6 @@ use slog::info;
 use slog::Logger;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::convert::TryFrom;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -29,16 +28,35 @@ use tokio_stream::wrappers::ReceiverStream;
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum SwitchPortConfig {
-    SwitchZoneInterface { interface: String },
-    Simulated { addr: SocketAddrV6 },
+    SwitchZoneInterface {
+        interface: String,
+    },
+    #[serde(rename_all = "kebab-case")]
+    Simulated {
+        fake_interface: String,
+        addr: SocketAddrV6,
+    },
+}
+
+impl SwitchPortConfig {
+    pub fn interface(&self) -> &str {
+        match self {
+            SwitchPortConfig::SwitchZoneInterface { interface } => interface,
+            SwitchPortConfig::Simulated { fake_interface, .. } => {
+                fake_interface
+            }
+        }
+    }
 }
 
 /// Description of the network interface and location of a single switch port.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 // We can't use `#[serde(deny_unknown_fields)]` with `flatten`? Sad
+#[serde(rename_all = "kebab-case")]
 pub struct SwitchPortDescription {
     #[serde(flatten)]
     pub config: SwitchPortConfig,
+    pub ignition_target: u8,
 
     /// Map defining the logical identifier of the SP connected to this port for
     /// each of the possible locations where MGS is running (see
@@ -64,17 +82,17 @@ pub struct LocationConfig {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LocationDeterminationConfig {
-    /// Which port to contact.
-    pub switch_port: usize,
+    /// Interfaces of one or more  SPs to use for determining our location.
+    pub interfaces: Vec<String>,
 
-    /// If the SP on `switch_port` communicates with us on its port 1, we must
-    /// be one of this set of locations (which should be a subset of our parent
-    /// [`LocationConfig`]'s `names).
+    /// If the SP on one of the `interfaces` communicates with us on its port 1,
+    /// we must be one of this set of locations (which should be a subset of our
+    /// parent [`LocationConfig`]'s `names).
     pub sp_port_1: Vec<String>,
 
-    /// If the SP on `switch_port` communicates with us on its port 2, we must
-    /// be one of this set of locations (which should be a subset of our parent
-    /// [`LocationConfig`]'s `names).
+    /// If the SP on one of the `interfaces` communicates with us on its port 2,
+    /// we must be one of this set of locations (which should be a subset of our
+    /// parent [`LocationConfig`]'s `names).
     pub sp_port_2: Vec<String>,
 }
 
@@ -88,8 +106,8 @@ pub(super) struct LocationMap {
 impl LocationMap {
     pub(super) async fn run_discovery(
         config: ValidatedLocationConfig,
-        ports: HashMap<SwitchPort, SwitchPortDescription>,
-        sockets: Arc<HashMap<SwitchPort, SingleSp>>,
+        ports: Vec<SwitchPortDescription>,
+        sockets: Arc<Vec<SingleSp>>,
         log: &Logger,
     ) -> Result<Self, String> {
         // Spawn a task that will send discovery packets on every switch port
@@ -101,11 +119,9 @@ impl LocationMap {
         let (refined_locations_tx, refined_locations) = mpsc::channel(8);
         {
             let log = log.clone();
-            let ports = ports.clone();
             tokio::spawn(async move {
                 discover_sps(
                     &sockets,
-                    ports,
                     location_determination,
                     refined_locations_tx,
                     &log,
@@ -126,7 +142,8 @@ impl LocationMap {
         // map of port <-> logical ID
         let mut port_to_id = HashMap::with_capacity(ports.len());
         let mut id_to_port = HashMap::with_capacity(ports.len());
-        for (port, mut port_config) in ports {
+        for (i, mut port_config) in ports.into_iter().enumerate() {
+            let port = SwitchPort(i);
             // construction of `ValidatedLocationConfig` checked that all port
             // configs have entries for all locations, allowing us to unwrap
             // this `remove()`.
@@ -187,17 +204,12 @@ struct ValidatedLocationDeterminationConfig {
     sp_port_2: HashSet<String>,
 }
 
-impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
-    for ValidatedLocationConfig
-{
-    type Error = StartupError;
-
-    fn try_from(
-        (ports, config): (
-            &HashMap<SwitchPort, SwitchPortDescription>,
-            LocationConfig,
-        ),
-    ) -> Result<Self, Self::Error> {
+impl ValidatedLocationConfig {
+    pub(super) fn validate(
+        ports: &[SwitchPortDescription],
+        interface_to_port: &HashMap<String, SwitchPort>,
+        config: LocationConfig,
+    ) -> Result<Self, StartupError> {
         // Helper function to convert a vec into a hashset, recording an error
         // string in `reasons` if the lengths don't match (i.e., the vec
         // contained at least one duplicate)
@@ -221,25 +233,25 @@ impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
         let mut reasons = Vec::new();
 
         let names = vec_to_hashset(config.names, &mut reasons, || {
-            String::from("location names contains at least one duplicate entry")
+            String::from("location names contain at least one duplicate entry")
         });
 
         // make sure every port has a defined ID for any element of `names`, and
         // no extras
-        for (port, port_config) in ports {
+        for port_desc in ports {
             for name in &names {
-                if !port_config.location.contains_key(name) {
+                if !port_desc.location.contains_key(name) {
                     reasons.push(format!(
-                        "port {} is missing an ID for location {:?}",
-                        port.0, name
+                        "port {:?} is missing an ID for location {name:?}",
+                        port_desc.config.interface()
                     ));
                 }
             }
-            for name in port_config.location.keys() {
+            for name in port_desc.location.keys() {
                 if !names.contains(name) {
                     reasons.push(format!(
-                        "port {} contains unknown name {:?}",
-                        port.0, name
+                        "port {:?} contains unknown location {name:?}",
+                        port_desc.config.interface()
                     ));
                 }
             }
@@ -249,41 +261,28 @@ impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
             .determination
             .into_iter()
             .enumerate()
-            .map(|(i, det)| {
-                // make sure this determination's switch port exists
-                let switch_port = SwitchPort(det.switch_port);
-                if !ports.contains_key(&switch_port) {
-                    reasons.push(format!(
-                        "determination {} references a nonexistent switch port ({})",
-                        i, det.switch_port
-                    ));
-                }
-
+            .flat_map(|(i, det)| {
                 // convert names into hash sets
                 let sp_port_1 = vec_to_hashset(det.sp_port_1, &mut reasons, ||
                     format!(
-                        "determination `{}.sp_port_1` contains duplicate names",
-                        i
+                        "determination `{i}.sp_port_1` contains duplicate names",
                     )
                 );
                 let sp_port_2 = vec_to_hashset(det.sp_port_2, &mut reasons, ||
                     format!(
-                        "determination `{}.sp_port_2` contains duplicate names",
-                        i
+                        "determination `{i}.sp_port_2` contains duplicate names",
                     )
                 );
 
                 // make sure these hash sets only reference known names
                 if !sp_port_1.is_subset(&names) {
                     reasons.push(format!(
-                        "determination `{}.sp_port_1` contains unknown names",
-                        i
+                        "determination `{i}.sp_port_1` contains unknown names",
                     ));
                 }
                 if !sp_port_2.is_subset(&names) {
                     reasons.push(format!(
-                        "determination `{}.sp_port_2` contains unknown names",
-                        i
+                        "determination `{i}.sp_port_2` contains unknown names",
                     ));
                 }
 
@@ -291,22 +290,32 @@ impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
                 // immediate failure of our location resolution
                 if sp_port_1.is_empty() {
                     reasons.push(format!(
-                        "determination `{}.sp_port_1` is empty",
-                        i
+                        "determination `{i}.sp_port_1` is empty",
                     ));
                 }
                 if sp_port_2.is_empty() {
                     reasons.push(format!(
-                        "determination `{}.sp_port_2` is empty",
-                        i
+                        "determination `{i}.sp_port_2` is empty",
                     ));
                 }
 
-                ValidatedLocationDeterminationConfig {
-                    switch_port,
-                    sp_port_1,
-                    sp_port_2,
-                }
+                det.interfaces.into_iter().filter_map(|interface| {
+                    if let Some(switch_port) = interface_to_port
+                        .get(&interface)
+                        .copied()
+                    {
+                        Some(ValidatedLocationDeterminationConfig {
+                            switch_port,
+                            sp_port_1: sp_port_1.clone(),
+                            sp_port_2: sp_port_2.clone(),
+                        })
+                    } else {
+                        reasons.push(format!(
+                            "determination {i} references unknown interface {interface:?}"
+                        ));
+                        None
+                    }
+                }).collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
 
@@ -326,28 +335,27 @@ impl TryFrom<(&'_ HashMap<SwitchPort, SwitchPortDescription>, LocationConfig)>
 /// and the list of locations we could be in based on the SP's response on that
 /// port. Our spawner is responsible for collecting/using those messages.
 async fn discover_sps(
-    sockets: &HashMap<SwitchPort, SingleSp>,
-    port_config: HashMap<SwitchPort, SwitchPortDescription>,
+    sockets: &[SingleSp],
     mut location_determination: Vec<ValidatedLocationDeterminationConfig>,
-    refined_locations: mpsc::Sender<(SwitchPort, HashSet<String>)>,
+    refined_locations: mpsc::Sender<(String, HashSet<String>)>,
     log: &Logger,
 ) {
     // Build a collection of futures representing the results of discovering the
     // SP address for each switch port in `sockets`.
     let mut futs = FuturesUnordered::new();
-    for (switch_port, _config) in port_config {
+    for (i, sp) in sockets.iter().enumerate() {
         futs.push(async move {
-            // all ports in `port_config` also get sockets bound to them;
-            // unwrapping this lookup is fine
-            let sp = sockets.get(&switch_port).unwrap();
-
             let mut addr_watch = sp.sp_addr_watch().clone();
 
             loop {
                 let current = *addr_watch.borrow();
                 match current {
                     Some((_addr, sp_port)) => {
-                        return (switch_port, Some(sp_port))
+                        return (
+                            SwitchPort(i),
+                            sp.interface().to_string(),
+                            sp_port,
+                        )
                     }
                     None => {
                         addr_watch.changed().await.unwrap();
@@ -358,13 +366,7 @@ async fn discover_sps(
     }
 
     // Wait for responses.
-    while let Some((switch_port, sp_port)) = futs.next().await {
-        // Skip switch ports where we failed to start our communicator.
-        let sp_port = match sp_port {
-            Some(sp_port) => sp_port,
-            None => continue,
-        };
-
+    while let Some((switch_port, interface, sp_port)) = futs.next().await {
         // See if this port can participate in location determination.
         let pos = match location_determination
             .iter()
@@ -373,7 +375,7 @@ async fn discover_sps(
             Some(pos) => {
                 info!(
                     log, "received discovery response (used for location)";
-                    "switch_port" => ?switch_port,
+                    "interface" => &interface,
                     "sp_port" => ?sp_port,
                     "pos" => pos,
                 );
@@ -382,7 +384,7 @@ async fn discover_sps(
             None => {
                 info!(
                     log, "received discovery response (not used for location)";
-                    "switch_port" => ?switch_port,
+                    "interface" => interface,
                     "sp_port" => ?sp_port,
                 );
                 continue;
@@ -398,7 +400,7 @@ async fn discover_sps(
         // the only failure possible here is that the receiver is gone; that's
         // harmless for us (e.g., maybe it's already fully determined the
         // location and doesn't care about more messages)
-        let _ = refined_locations.send((switch_port, refined)).await;
+        let _ = refined_locations.send((interface, refined)).await;
     }
 }
 
@@ -424,15 +426,16 @@ async fn resolve_location<S>(
     log: &Logger,
 ) -> Result<String, String>
 where
-    S: Stream<Item = (SwitchPort, HashSet<String>)>,
+    S: Stream<Item = (String, HashSet<String>)>,
 {
     tokio::pin!(determinations);
-    while let Some((port, refined_locations)) = determinations.next().await {
+    while let Some((interface, refined_locations)) = determinations.next().await
+    {
         // we got a successful response from an SP; restrict `locations` to only
         // locations that could be possible given that response.
         debug!(
             log, "received location determination response";
-            "port" => ?port,
+            "interface" => interface,
             "refined_locations" => ?refined_locations,
         );
         locations.retain(|name| refined_locations.contains(name));
@@ -472,19 +475,18 @@ mod tests {
 
     #[test]
     fn test_config_validation() {
-        let bad_ports = HashMap::from([(
-            SwitchPort(0),
-            SwitchPortDescription {
-                config: SwitchPortConfig::Simulated {
-                    addr: "[::1]:0".parse().unwrap(),
-                },
-                location: HashMap::from([
-                    (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
-                    // missing "b", has extraneous "c"
-                    (String::from("c"), SpIdentifier::new(SpType::Sled, 1)),
-                ]),
+        let bad_ports = vec![SwitchPortDescription {
+            config: SwitchPortConfig::Simulated {
+                fake_interface: "fake".to_string(),
+                addr: "[::1]:0".parse().unwrap(),
             },
-        )]);
+            ignition_target: 0,
+            location: HashMap::from([
+                (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
+                // missing "b", has extraneous "c"
+                (String::from("c"), SpIdentifier::new(SpType::Sled, 1)),
+            ]),
+        }];
         let bad_config = LocationConfig {
             names: vec![
                 String::from("a"),
@@ -493,7 +495,7 @@ mod tests {
             ],
             determination: vec![
                 LocationDeterminationConfig {
-                    switch_port: 7, // nonexistent port
+                    interfaces: vec!["nonexistent-interface".to_string()],
                     sp_port_1: vec![
                         String::from("a"),
                         String::from("b"),
@@ -503,7 +505,7 @@ mod tests {
                     sp_port_2: vec![], // empty
                 },
                 LocationDeterminationConfig {
-                    switch_port: 0,
+                    interfaces: vec!["fake".to_string()],
                     sp_port_1: vec![], // empty
                     sp_port_2: vec![
                         String::from("a"),
@@ -515,8 +517,16 @@ mod tests {
             ],
         };
 
-        let err = ValidatedLocationConfig::try_from((&bad_ports, bad_config))
-            .unwrap_err();
+        let mut interface_to_port = HashMap::new();
+        interface_to_port.insert("fake".to_string(), SwitchPort(0));
+        assert_eq!(bad_ports.len(), interface_to_port.len());
+
+        let err = ValidatedLocationConfig::validate(
+            &bad_ports,
+            &interface_to_port,
+            bad_config,
+        )
+        .unwrap_err();
         let reasons = match err {
             StartupError::InvalidConfig { reasons } => reasons,
             StartupError::BindError(err) => panic!("expected error: {err}"),
@@ -525,13 +535,13 @@ mod tests {
         assert_eq!(
             reasons,
             &[
-                "location names contains at least one duplicate entry",
-                "port 0 is missing an ID for location \"b\"",
-                "port 0 contains unknown name \"c\"",
-                "determination 0 references a nonexistent switch port (7)",
+                "location names contain at least one duplicate entry",
+                "port \"fake\" is missing an ID for location \"b\"",
+                "port \"fake\" contains unknown location \"c\"",
                 "determination `0.sp_port_1` contains duplicate names",
                 "determination `0.sp_port_1` contains unknown names",
                 "determination `0.sp_port_2` is empty",
+                "determination 0 references unknown interface \"nonexistent-interface\"",
                 "determination `1.sp_port_2` contains duplicate names",
                 "determination `1.sp_port_2` contains unknown names",
                 "determination `1.sp_port_1` is empty",
@@ -541,37 +551,39 @@ mod tests {
         // repeat the config from above but with all errors fixed; note that
         // this config is still logically nonsense, but it doesn't contain any
         // of the errors we check for (mismatched / typo'd names, etc.).
-        let good_ports = HashMap::from([(
-            SwitchPort(0),
-            SwitchPortDescription {
-                config: SwitchPortConfig::Simulated {
-                    addr: "[::1]:0".parse().unwrap(),
-                },
-                location: HashMap::from([
-                    (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
-                    (String::from("b"), SpIdentifier::new(SpType::Sled, 1)),
-                ]),
+        let good_ports = vec![SwitchPortDescription {
+            config: SwitchPortConfig::Simulated {
+                fake_interface: "fake".to_string(),
+                addr: "[::1]:0".parse().unwrap(),
             },
-        )]);
+            ignition_target: 0,
+            location: HashMap::from([
+                (String::from("a"), SpIdentifier::new(SpType::Sled, 0)),
+                (String::from("b"), SpIdentifier::new(SpType::Sled, 1)),
+            ]),
+        }];
         let good_config = LocationConfig {
             names: vec![String::from("a"), String::from("b")],
             determination: vec![
                 LocationDeterminationConfig {
-                    switch_port: 0,
+                    interfaces: vec!["fake".to_string()],
                     sp_port_1: vec![String::from("a")],
                     sp_port_2: vec![String::from("b")],
                 },
                 LocationDeterminationConfig {
-                    switch_port: 0,
+                    interfaces: vec!["fake".to_string()],
                     sp_port_1: vec![String::from("b")],
                     sp_port_2: vec![String::from("a")],
                 },
             ],
         };
 
-        let config =
-            ValidatedLocationConfig::try_from((&good_ports, good_config))
-                .unwrap();
+        let config = ValidatedLocationConfig::validate(
+            &good_ports,
+            &interface_to_port,
+            good_config,
+        )
+        .unwrap();
 
         assert_eq!(
             config,
@@ -595,23 +607,21 @@ mod tests {
 
     struct Harness {
         names: HashSet<String>,
-        determinations:
-            stream::Iter<vec::IntoIter<(SwitchPort, HashSet<String>)>>,
+        determinations: stream::Iter<vec::IntoIter<(String, HashSet<String>)>>,
     }
 
     impl Harness {
         fn new(names: &[&str], determinations: &[&[&str]]) -> Self {
-            let determinations: Vec<(SwitchPort, HashSet<String>)> =
-                determinations
-                    .iter()
-                    .enumerate()
-                    .map(|(i, names)| {
-                        (
-                            SwitchPort(i),
-                            names.iter().copied().map(String::from).collect(),
-                        )
-                    })
-                    .collect();
+            let determinations: Vec<(String, HashSet<String>)> = determinations
+                .iter()
+                .enumerate()
+                .map(|(i, names)| {
+                    (
+                        format!("harness-interface-{i}"),
+                        names.iter().copied().map(String::from).collect(),
+                    )
+                })
+                .collect();
             Self {
                 names: names.iter().copied().map(String::from).collect(),
                 determinations: stream::iter(determinations),

--- a/gateway/tests/config.test.toml
+++ b/gateway/tests/config.test.toml
@@ -8,11 +8,11 @@
 # config.
 udp_listen_port = 0
 
-# which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
-# our contact to the ignition controller)
-local_ignition_controller_port = 0
+# Which interface is connected to our local sidecar SP (i.e., the SP that acts
+# as our contact to the ignition controller)?
+local_ignition_controller_interface = "fake-switch0"
 
-# when sending UDP RPC packets to an SP, how many total attempts do we make
+# When sending UDP RPC packets to an SP, how many total attempts do we make
 # before giving up?
 rpc_max_attempts = 3
 
@@ -36,12 +36,7 @@ names = ["switch0", "switch1"]
 # if there is a miscabling that results in an unsolvable system (e.g.,
 # determination 0 reports "switch0" and determination 1 reports "switch1").
 [[switch.location.determination]]
-switch_port = 1
-sp_port_1 = ["switch0"]
-sp_port_2 = ["switch1"]
-
-[[switch.location.determination]]
-switch_port = 2
+interfaces = ["fake-sled0", "fake-sled1"]
 sp_port_1 = ["switch0"]
 sp_port_2 = ["switch1"]
 
@@ -54,33 +49,33 @@ sp_port_2 = ["switch1"]
 # use a single multicast address, target port, and source port, but for now all
 # three are configured on a per-port basis, which allows a single system to
 # simulate a full set of ports and SPs.
-[switch.port.0]
+[[switch.port]]
 kind = "simulated"
+fake-interface = "fake-switch0"
 addr = "[::1]:0"
-[switch.port.0.location]
-switch0 = ["switch", 0]
-switch1 = ["switch", 1]
+ignition-target = 0
+location = { switch0 = ["switch", 0], switch1 = ["switch", 1] }
 
-[switch.port.1]
+[[switch.port]]
 kind = "simulated"
+fake-interface = "fake-switch1"
 addr = "[::1]:0"
-[switch.port.1.location]
-switch0 = ["switch", 1]
-switch1 = ["switch", 0]
+ignition-target = 1
+location = { switch0 = ["switch", 1], switch1 = ["switch", 0] }
 
-[switch.port.2]
+[[switch.port]]
 kind = "simulated"
+fake-interface = "fake-sled0"
 addr = "[::1]:0"
-[switch.port.2.location]
-switch0 = ["sled", 0]
-switch1 = ["sled", 0]
+ignition-target = 2
+location = { switch0 = ["sled", 0], switch1 = ["sled", 0] }
 
-[switch.port.3]
+[[switch.port]]
 kind = "simulated"
+fake-interface = "fake-sled1"
 addr = "[::1]:0"
-[switch.port.3.location]
-switch0 = ["sled", 1]
-switch1 = ["sled", 1]
+ignition-target = 3
+location = { switch0 = ["sled", 1], switch1 = ["sled", 1] }
 
 #
 # NOTE: for the test suite, if mode = "file", the file path MUST be the sentinel

--- a/smf/mgs/config.toml
+++ b/smf/mgs/config.toml
@@ -3,13 +3,13 @@
 #
 
 [switch]
-# which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
-# our contact to the ignition controller)
-local_ignition_controller_port = 0
+# Which interface is connected to our local sidecar SP (i.e., the SP that acts
+# as our contact to the ignition controller)?
+local_ignition_controller_interface = "sidecar0"
 
-# when sending UDP RPC packets to an SP, how many total attempts do we make
+# When sending UDP RPC packets to an SP, how many total attempts do we make
 # before giving up?
-rpc_max_attempts = 15
+rpc_max_attempts = 5
 
 # sleep time between UDP RPC resends (up to `rpc_max_attempts`)
 rpc_per_attempt_timeout_millis = 2000
@@ -31,12 +31,18 @@ names = ["switch0", "switch1"]
 # if there is a miscabling that results in an unsolvable system (e.g.,
 # determination 0 reports "switch0" and determination 1 reports "switch1").
 [[switch.location.determination]]
-switch_port = 1
-sp_port_1 = ["switch0"]
-sp_port_2 = ["switch1"]
-
-[[switch.location.determination]]
-switch_port = 2
+# We can use any gimlet as a determinant for our location - they should either
+# all respond "port 1" or all "port 2", which determines which switch we are.
+interfaces = [
+    "gimlet0", "gimlet1", "gimlet2", "gimlet3",
+    "gimlet4", "gimlet5", "gimlet6", "gimlet7",
+    "gimlet8", "gimlet9", "gimlet10", "gimlet11",
+    "gimlet12", "gimlet13", "gimlet14", "gimlet15",
+    "gimlet16", "gimlet17", "gimlet18", "gimlet19",
+    "gimlet20", "gimlet21", "gimlet22", "gimlet23",
+    "gimlet24", "gimlet25", "gimlet26", "gimlet27",
+    "gimlet28", "gimlet29", "gimlet30", "gimlet31"
+]
 sp_port_1 = ["switch0"]
 sp_port_2 = ["switch1"]
 
@@ -45,29 +51,229 @@ sp_port_2 = ["switch1"]
 # logical ID of the remote SP ("sled 7", "switch 1", etc.), which must have an
 # entry for each member of `[switch.location]` above.
 #
-# TODO This needs to be replaced with information relevant to real vlan
-# datalinks. For now we pick a bunch of arbitrary addresses and ports that don't
-# mean anything unless someone spins up simulated SPs on those ports.
-[switch.port.0]
-data_link_addr = "[::]:33200"
-multicast_addr = "[ff15:0:1de::0]:33300"
-[switch.port.0.location]
-switch0 = ["switch", 0]
-switch1 = ["switch", 1]
+# TODO: These interface names are based on the manual VLAN interfaces used in
+# compliance, which pre-applied port -> cubby mappings. Double-check dendrite
+# will create the interfaces with these names and that mapping applied.
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "sidecar0"
+# TODO: ignition-target 35 does not exist on rev-b sidecar but is coming:
+# https://github.com/oxidecomputer/hardware-sidecar/issues/735. We'll configure
+# it here but know that requests involving it will fail for now.
+ignition-target = 35
+location = { switch0 = ["switch", 0], switch1 = ["switch", 1] }
 
-[switch.port.1]
-data_link_addr = "[::]:33201"
-multicast_addr = "[ff15:0:1de::1]:33310"
-[switch.port.1.location]
-switch0 = ["sled", 0]
-switch1 = ["sled", 1]
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "sidecar1"
+ignition-target = 34
+location = { switch0 = ["switch", 1], switch1 = ["switch", 0] }
 
-[switch.port.2]
-data_link_addr = "[::]:33202"
-multicast_addr = "[ff15:0:1de::2]:33320"
-[switch.port.2.location]
-switch0 = ["sled", 1]
-switch1 = ["sled", 0]
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "psc0"
+ignition-target = 32
+location = { switch0 = ["power", 0], switch1 = ["power", 0] }
+
+# We have an ignition-target set aside for PSC1, but do not create an
+# interface for it since we don't have a second PSC.
+#[[switch.port]]
+#kind = "switch-zone-interface"
+#interface = "psc1"
+#ignition-target = 33
+#location = { switch0 = ["power", 1], switch1 = ["power", 1] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet0"
+ignition-target = 14
+location = { switch0 = ["sled", 0], switch1 = ["sled", 0] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet1"
+ignition-target = 30
+location = { switch0 = ["sled", 1], switch1 = ["sled", 1] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet2"
+ignition-target = 15
+location = { switch0 = ["sled", 2], switch1 = ["sled", 2] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet3"
+ignition-target = 31
+location = { switch0 = ["sled", 3], switch1 = ["sled", 3] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet4"
+ignition-target = 13
+location = { switch0 = ["sled", 4], switch1 = ["sled", 4] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet5"
+ignition-target = 29
+location = { switch0 = ["sled", 5], switch1 = ["sled", 5] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet6"
+ignition-target = 12
+location = { switch0 = ["sled", 6], switch1 = ["sled", 6] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet7"
+ignition-target = 28
+location = { switch0 = ["sled", 7], switch1 = ["sled", 7] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet8"
+ignition-target = 10
+location = { switch0 = ["sled", 8], switch1 = ["sled", 8] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet9"
+ignition-target = 26
+location = { switch0 = ["sled", 9], switch1 = ["sled", 9] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet10"
+ignition-target = 11
+location = { switch0 = ["sled", 10], switch1 = ["sled", 10] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet11"
+ignition-target = 27
+location = { switch0 = ["sled", 11], switch1 = ["sled", 11] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet12"
+ignition-target = 9
+location = { switch0 = ["sled", 12], switch1 = ["sled", 12] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet13"
+ignition-target = 25
+location = { switch0 = ["sled", 13], switch1 = ["sled", 13] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet14"
+ignition-target = 8
+location = { switch0 = ["sled", 14], switch1 = ["sled", 14] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet15"
+ignition-target = 24
+location = { switch0 = ["sled", 15], switch1 = ["sled", 15] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet16"
+ignition-target = 4
+location = { switch0 = ["sled", 16], switch1 = ["sled", 16] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet17"
+ignition-target = 20
+location = { switch0 = ["sled", 17], switch1 = ["sled", 17] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet18"
+ignition-target = 5
+location = { switch0 = ["sled", 18], switch1 = ["sled", 18] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet19"
+ignition-target = 21
+location = { switch0 = ["sled", 19], switch1 = ["sled", 19] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet20"
+ignition-target = 7
+location = { switch0 = ["sled", 20], switch1 = ["sled", 20] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet21"
+ignition-target = 23
+location = { switch0 = ["sled", 21], switch1 = ["sled", 21] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet22"
+ignition-target = 6
+location = { switch0 = ["sled", 22], switch1 = ["sled", 22] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet23"
+ignition-target = 22
+location = { switch0 = ["sled", 23], switch1 = ["sled", 23] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet24"
+ignition-target = 0
+location = { switch0 = ["sled", 24], switch1 = ["sled", 24] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet25"
+ignition-target = 16
+location = { switch0 = ["sled", 25], switch1 = ["sled", 25] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet26"
+ignition-target = 1
+location = { switch0 = ["sled", 26], switch1 = ["sled", 26] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet27"
+ignition-target = 17
+location = { switch0 = ["sled", 27], switch1 = ["sled", 27] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet28"
+ignition-target = 3
+location = { switch0 = ["sled", 28], switch1 = ["sled", 28] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet29"
+ignition-target = 19
+location = { switch0 = ["sled", 29], switch1 = ["sled", 29] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet30"
+ignition-target = 2
+location = { switch0 = ["sled", 30], switch1 = ["sled", 30] }
+
+[[switch.port]]
+kind = "switch-zone-interface"
+interface = "gimlet31"
+ignition-target = 18
+location = { switch0 = ["sled", 31], switch1 = ["sled", 31] }
 
 [log]
 level = "info"


### PR DESCRIPTION
We now have a `[[switch.port]]` list instead of requiring keying by port number, which allows us to remove several `HashMap`s in favor of `Vec`s. Our internal `SwitchPort` type is now purely logical and does not relate to anything physical (it's a newtype around an index into a `Vec<_>` of some type derived from the corresponding `[[switch.port]]` entry). Each `[[switch.port]]` config block now also specifies an explicit `ignition-target` number instead of implicitly assuming the port number and ignition target number matched.

This builds on #2191 and should be merged after it. For review, it may make sense to start by looking at the changes to the `config.toml` files to see the new definitions; all the code changes are fallout from wanting the config to look like it does now.