### PR TITLE
[MGS] Report stringified serial numbers instead of hex

### DIFF
--- a/deploy/src/bin/sled-agent-overlay-files.rs
+++ b/deploy/src/bin/sled-agent-overlay-files.rs
@@ -31,20 +31,18 @@ struct Args {
 // Generate a config file for a simulated SP in each deployment server folder.
 fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
     let local_sp_configs = (1..=(server_dirs.len() as u32))
-        .map(|id| {
-            let id = id.to_be_bytes();
+        .map(|i| {
+            let id = i.to_be_bytes();
             let mut config = GimletConfig {
                 common: SpCommonConfig {
                     multicast_addr: None,
                     bind_addrs: None,
-                    serial_number: vec![0; 16],
+                    serial_number: format!("FakeSp{i:05}"),
                     manufacturing_root_cert_seed: [0; 32],
                     device_id_cert_seed: [0; 32],
                     components: Vec::new(),
                 },
             };
-            let len = config.common.serial_number.len();
-            config.common.serial_number[len - 4..].copy_from_slice(&id);
             let len = config.common.device_id_cert_seed.len();
             config.common.device_id_cert_seed[len - 4..].copy_from_slice(&id);
             config
@@ -59,8 +57,12 @@ fn overlay_sp_configs(server_dirs: &[PathBuf]) -> Result<()> {
                 salty::Keypair::from(&config.manufacturing_root_cert_seed);
             let device_id_keypair =
                 salty::Keypair::from(&config.device_id_cert_seed);
-            let serial_number =
-                SerialNumber(config.serial_number.clone().try_into().unwrap());
+            let mut serial_number = [0; 16];
+            serial_number
+                .get_mut(0..config.serial_number.len())
+                .expect("simulated serial number too long")
+                .copy_from_slice(config.serial_number.as_bytes());
+            let serial_number = SerialNumber(serial_number);
             let config = RotConfig::bootstrap_for_testing(
                 &manufacturing_keypair,
                 device_id_keypair,

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -6,8 +6,6 @@
 
 //! Conversions between externally-defined types and HTTP / JsonSchema types.
 
-use crate::error::SpCommsError;
-
 use super::PowerState;
 use super::SpComponentInfo;
 use super::SpComponentList;
@@ -19,10 +17,12 @@ use super::SpState;
 use super::SpType;
 use super::SpUpdateStatus;
 use super::UpdatePreparationProgress;
+use crate::error::SpCommsError;
 use dropshot::HttpError;
 use gateway_messages::SpComponent;
 use gateway_messages::UpdateStatus;
 use gateway_sp_comms::error::CommunicationError;
+use std::str;
 
 // wrap `SpComponent::try_from(&str)` into a usable form for dropshot endpoints
 pub(super) fn component_from_str(s: &str) -> Result<SpComponent, HttpError> {
@@ -91,11 +91,22 @@ impl From<PowerState> for gateway_messages::PowerState {
     }
 }
 
+fn stringify_serial_number(serial: &[u8]) -> String {
+    // We expect serial numbers to be ASCII and 0-padded: find the first 0 byte
+    // and convert to a string. If that fails, hexlify the entire slice.
+    let first_zero =
+        serial.iter().position(|&b| b == 0).unwrap_or(serial.len());
+
+    str::from_utf8(&serial[..first_zero])
+        .map(|s| s.to_string())
+        .unwrap_or_else(|_err| hex::encode(serial))
+}
+
 impl From<Result<gateway_messages::SpState, SpCommsError>> for SpState {
     fn from(result: Result<gateway_messages::SpState, SpCommsError>) -> Self {
         match result {
             Ok(state) => Self::Enabled {
-                serial_number: hex::encode(&state.serial_number[..]),
+                serial_number: stringify_serial_number(&state.serial_number),
             },
             Err(err) => Self::CommunicationFailed { message: err.to_string() },
         }

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -33,10 +33,7 @@ async fn discovery_both_locations() {
 
     // both instances should report the same serial number for switch 0 and
     // switch 1, and it should match the expected values from the config
-    for (switch, expected_serial) in [
-        (0, "0000000000000000000000000000000100000000000000000000000000000000"),
-        (1, "0000000000000000000000000000000200000000000000000000000000000000"),
-    ] {
+    for (switch, expected_serial) in [(0, "SimSidecar0"), (1, "SimSidecar1")] {
         for client in [client0, client1] {
             let url =
                 format!("{}", client0.url(&format!("/sp/switch/{}", switch)));

--- a/gateway/tests/sp_sim_config.test.toml
+++ b/gateway/tests/sp_sim_config.test.toml
@@ -10,7 +10,7 @@
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = "00000000000000000000000000000001"
+serial_number = "SimSidecar0"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
 
@@ -31,14 +31,14 @@ presence = "Failed"
 [[simulated_sps.sidecar]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = "00000000000000000000000000000002"
+serial_number = "SimSidecar1"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
 
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = "00000000000000000000000000000003"
+serial_number = "SimGimlet00"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 
@@ -60,7 +60,7 @@ presence = "Failed"
 [[simulated_sps.gimlet]]
 multicast_addr = "::1"
 bind_addrs = ["[::1]:0", "[::1]:0"]
-serial_number = "00000000000000000000000000000004"
+serial_number = "SimGimlet01"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000003"
 

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -26,8 +26,7 @@ pub struct SpCommonConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bind_addrs: Option<[SocketAddrV6; 2]>,
     /// Fake serial number
-    #[serde(with = "hex")]
-    pub serial_number: Vec<u8>,
+    pub serial_number: String,
     /// 32-byte seed to create a manufacturing root certificate.
     #[serde(with = "hex")]
     pub manufacturing_root_cert_seed: [u8; 32],

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -52,7 +52,7 @@ pub struct Gimlet {
     rot: Mutex<RotSprocket>,
     manufacturing_public_key: Ed25519PublicKey,
     local_addrs: Option<[SocketAddrV6; 2]>,
-    serial_number: Vec<u8>,
+    serial_number: String,
     serial_console_addrs: HashMap<String, SocketAddrV6>,
     commands:
         mpsc::UnboundedSender<(Command, oneshot::Sender<CommandResponse>)>,
@@ -71,7 +71,7 @@ impl Drop for Gimlet {
 #[async_trait]
 impl SimulatedSp for Gimlet {
     fn serial_number(&self) -> String {
-        hex::encode(&serial_number_padded(&self.serial_number))
+        self.serial_number.clone()
     }
 
     fn manufacturing_public_key(&self) -> Ed25519PublicKey {
@@ -409,7 +409,7 @@ impl UdpTask {
         servers: [UdpServer; 2],
         components: Vec<SpComponentConfig>,
         attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
-        serial_number: Vec<u8>,
+        serial_number: String,
         incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
         commands: mpsc::UnboundedReceiver<(
             Command,
@@ -483,7 +483,7 @@ impl UdpTask {
 
 struct Handler {
     log: Logger,
-    serial_number: Vec<u8>,
+    serial_number: String,
 
     components: Vec<SpComponentConfig>,
     // `SpHandler` wants `&'static str` references when describing components;
@@ -502,7 +502,7 @@ struct Handler {
 
 impl Handler {
     fn new(
-        serial_number: Vec<u8>,
+        serial_number: String,
         components: Vec<SpComponentConfig>,
         attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
         incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -30,7 +30,7 @@ pub enum Responsiveness {
 
 #[async_trait]
 pub trait SimulatedSp {
-    /// Hexlified serial number.
+    /// Serial number.
     fn serial_number(&self) -> String;
 
     /// Public key for the manufacturing cert used to sign this SP's RoT certs.
@@ -51,14 +51,14 @@ pub trait SimulatedSp {
     ) -> Result<RotResponseV1, RotSprocketError>;
 }
 
-// Helper function to pad a simulated serial number (stored as a `Vec<u8>`) to
+// Helper function to pad a simulated serial number (stored as a `String`) to
 // the appropriate size for returning in the SpState message.
-fn serial_number_padded(serial_number: &[u8]) -> [u8; 32] {
+fn serial_number_padded(serial_number: &str) -> [u8; 32] {
     let mut padded = [0; 32];
     padded
         .get_mut(0..serial_number.len())
         .expect("simulated serial number too long")
-        .copy_from_slice(&serial_number);
+        .copy_from_slice(serial_number.as_bytes());
     padded
 }
 

--- a/sp-sim/src/rot.rs
+++ b/sp-sim/src/rot.rs
@@ -27,7 +27,7 @@ impl RotSprocketExt for RotSprocket {
         serial_number
             .get_mut(0..config.serial_number.len())
             .expect("simulated serial number too long")
-            .copy_from_slice(&config.serial_number);
+            .copy_from_slice(config.serial_number.as_bytes());
 
         let manufacturing_keypair =
             salty::Keypair::from(&config.manufacturing_root_cert_seed);

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -61,7 +61,7 @@ pub struct Sidecar {
     rot: Mutex<RotSprocket>,
     manufacturing_public_key: Ed25519PublicKey,
     local_addrs: Option<[SocketAddrV6; 2]>,
-    serial_number: Vec<u8>,
+    serial_number: String,
     commands:
         mpsc::UnboundedSender<(Command, oneshot::Sender<CommandResponse>)>,
     inner_task: Option<JoinHandle<()>>,
@@ -79,7 +79,7 @@ impl Drop for Sidecar {
 #[async_trait]
 impl SimulatedSp for Sidecar {
     fn serial_number(&self) -> String {
-        hex::encode(&serial_number_padded(&self.serial_number))
+        self.serial_number.clone()
     }
 
     fn manufacturing_public_key(&self) -> Ed25519PublicKey {
@@ -207,7 +207,7 @@ impl Inner {
     fn new(
         servers: [UdpServer; 2],
         components: Vec<SpComponentConfig>,
-        serial_number: Vec<u8>,
+        serial_number: String,
         ignition: FakeIgnition,
         commands: mpsc::UnboundedReceiver<(
             Command,
@@ -293,14 +293,14 @@ struct Handler {
     leaked_component_device_strings: Vec<&'static str>,
     leaked_component_description_strings: Vec<&'static str>,
 
-    serial_number: Vec<u8>,
+    serial_number: String,
     ignition: FakeIgnition,
     power_state: PowerState,
 }
 
 impl Handler {
     fn new(
-        serial_number: Vec<u8>,
+        serial_number: String,
         components: Vec<SpComponentConfig>,
         ignition: FakeIgnition,
         log: Logger,


### PR DESCRIPTION
For real gimlets, serial numbers returned by MGS now show up as (e.g.) "BRM42220070" instead of
"42524d3432323230303730000000000000000000000000000000000000000000". Simulated SPs changed similarly and now store the serial number as a `String` instead of a `Vec<u8>`.