### PR TITLE
[MGS] Bring gateway-cli closer to parity with faux-mgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,9 +2084,12 @@ dependencies = [
  "futures",
  "gateway-client",
  "libc",
+ "serde",
+ "serde_json",
  "slog",
  "slog-async",
  "slog-term",
+ "termios",
  "tokio",
  "tokio-tungstenite",
  "uuid",
@@ -6493,6 +6496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -9,9 +9,12 @@ anyhow.workspace = true
 clap.workspace = true
 futures.workspace = true
 libc.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
+termios.workspace = true
 tokio = { workspace = true, features = [ "rt-multi-thread", "macros", "time" ] }
 tokio-tungstenite.workspace = true
 uuid.workspace = true

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 use anyhow::anyhow;
 use anyhow::bail;
@@ -10,34 +10,30 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
-use futures::future::Fuse;
-use futures::future::FusedFuture;
-use futures::prelude::*;
+use gateway_client::types::PowerState;
+use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpType;
 use gateway_client::types::UpdateAbortBody;
 use gateway_client::types::UpdateBody;
-use slog::info;
+use serde::Serialize;
 use slog::o;
 use slog::Drain;
 use slog::Level;
 use slog::Logger;
-use std::borrow::Cow;
 use std::fs;
-use std::net::IpAddr;
-use std::net::ToSocketAddrs;
-use std::path::Path;
+use std::io;
+use std::net::SocketAddrV6;
 use std::path::PathBuf;
 use std::time::Duration;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::net::TcpStream;
-use tokio::select;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-use tokio_tungstenite::tungstenite::protocol::CloseFrame;
-use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::MaybeTlsStream;
-use tokio_tungstenite::WebSocketStream;
 use uuid::Uuid;
+
+mod picocom_map;
+mod usart;
+
+// MGS's serial console APIs expect a component name, but in practice we only
+// have the one serial console associated with the CPU, so we don't require
+// users of this CLI to specify it.
+const SERIAL_CONSOLE_COMPONENT: &str = "sp3-host-cpu";
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -50,19 +46,11 @@ struct Args {
     )]
     log_level: Level,
 
-    #[clap(
-        short,
-        long,
-        value_parser = resolve_host,
-        help = "IP address of MGS server",
-    )]
-    server: IpAddr,
+    #[clap(short, long, help = "Address of MGS server")]
+    server: SocketAddrV6,
 
-    #[clap(short, long, help = "Port of MGS server", action)]
-    port: u16,
-
-    #[clap(long, help = "Target sled number", action)]
-    sled: u32,
+    #[clap(long, help = "Pretty JSON output")]
+    pretty: bool,
 
     #[clap(subcommand)]
     command: Command,
@@ -70,31 +58,175 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    #[clap(about = "Attach to serial console")]
-    Attach {
-        #[clap(long, help = "Put terminal in raw mode", action)]
+    /// Get state of one (or all) SPs
+    State {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: Option<SpIdentifier>,
+    },
+
+    /// Get ignition state of one (or all) SPs
+    Ignition {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: Option<SpIdentifier>,
+    },
+
+    /// Send an ignition command
+    IgnitionCommand {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Command (power-on, power-off, power-reset)
+        #[clap(value_parser = ignition_command_from_str, action)]
+        command: IgnitionCommand,
+    },
+
+    /// Get or set the active slot of a component
+    ComponentActiveSlot {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component (e.g., host-boot-flash)
+        component: String,
+        /// If provided, set the active slot
+        set_slot: Option<u16>,
+    },
+
+    /// Get or set startup options on an SP.
+    StartupOptions {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        options: Option<u64>,
+    },
+
+    /// Ask SP for its inventory.
+    Inventory {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+    },
+
+    /// Ask SP for details of a component.
+    ComponentDetails {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component name, from this SP's inventory of components
+        component: String,
+    },
+
+    /// Ask SP to clear the state (e.g., reset counters) on a component.
+    ComponentClearStatus {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component name, from this SP's inventory of components
+        component: String,
+    },
+
+    /// Attach to the SP's USART.
+    UsartAttach {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+
+        /// Put the local terminal in raw mode.
+        #[clap(
+            long = "no-raw",
+            help = "do not put terminal in raw mode",
+            action = clap::ArgAction::SetFalse,
+        )]
         raw: bool,
+
+        /// Amount of time to buffer input from stdin before forwarding to SP.
+        #[clap(long, default_value = "500")]
+        stdin_buffer_time_millis: u64,
+
+        /// Specifies the input character map (i.e., special characters to be
+        /// replaced when reading from the serial port). See picocom's manpage.
+        #[clap(long)]
+        imap: Option<String>,
+
+        /// Specifies the output character map (i.e., special characters to be
+        /// replaced when writing to the serial port). See picocom's manpage.
+        #[clap(long)]
+        omap: Option<String>,
+
+        /// Record all input read from the serial port to this logfile (before
+        /// any remapping).
+        #[clap(long)]
+        uart_logfile: Option<PathBuf>,
     },
-    #[clap(about = "Detach any existing serial console connection")]
-    Detach,
-    #[clap(about = "Update the SP or one of its componenets")]
+
+    /// Force-detach any attached USART connection
+    UsartDetach {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+    },
+
+    /// Upload a host phase 2 recovery image to be served on request
+    UploadRecoveryHostPhase2 { path: PathBuf },
+
+    /// Upload a new image to the SP or one of its components.
+    ///
+    /// To update the SP itself:
+    ///
+    /// 1. Use the component name "sp"
+    /// 2. Specify slot 0 (the SP only has a single updateable slot: its
+    ///    alternate bank).
+    /// 3. Pass the path to a hubris archive as `image`.
     Update {
-        #[clap(help = "Component name")]
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component name, from this SP's inventory of components
         component: String,
-        #[clap(help = "Update slot of the component")]
+        /// Slot number to apply the update
         slot: u16,
-        #[clap(help = "Path to the new image")]
-        path: PathBuf,
+        /// Path to the image
+        image: PathBuf,
     },
-    #[clap(about = "Abort an update the SP or one of its componenets")]
-    UpdateAbort {
-        #[clap(help = "Component name")]
+
+    /// Get the status of an update to the specified component.
+    UpdateStatus {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component name, from this SP's inventory of components
         component: String,
-        #[clap(help = "ID of the update to abort")]
-        id: Uuid,
     },
-    #[clap(about = "Reset the SP")]
-    Reset,
+
+    /// Abort an in-progress update.
+    UpdateAbort {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Component with an update-in-progress to be aborted
+        component: String,
+        /// ID of the update to abort (from `update-status`)
+        update_id: Uuid,
+    },
+
+    /// Get or set the power state.
+    PowerState {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// If present, instruct the SP to set this power state. If not present,
+        /// get the current power state instead.
+        #[clap(value_parser = power_state_from_str)]
+        new_power_state: Option<PowerState>,
+    },
+
+    /// Instruct the SP to reset.
+    Reset {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+    },
 }
 
 fn level_from_str(s: &str) -> Result<Level> {
@@ -105,104 +237,65 @@ fn level_from_str(s: &str) -> Result<Level> {
     }
 }
 
-/// Given a string representing an host, attempts to resolve it to a specific IP
-/// address
-fn resolve_host(server: &str) -> Result<IpAddr> {
-    (server, 0)
-        .to_socket_addrs()?
-        .map(|sock_addr| sock_addr.ip())
-        .next()
-        .ok_or_else(|| {
-            anyhow!("failed to resolve server argument '{}'", server)
-        })
+fn sp_identifier_from_str(s: &str) -> Result<SpIdentifier> {
+    const BAD_FORMAT: &str = concat!(
+        "SP identifier must be of the form TYPE/SLOT; ",
+        "e.g., `sled/7`, `switch/1`, `power/0`"
+    );
+    let mut parts = s.split('/');
+    let type_ = parts.next().context(BAD_FORMAT)?;
+    let slot = parts.next().context(BAD_FORMAT)?;
+    if parts.next().is_some() {
+        bail!(BAD_FORMAT);
+    }
+    Ok(SpIdentifier {
+        type_: type_.parse().map_err(|s| {
+            anyhow!("failed to parse {type_} as an SpType: {s}")
+        })?,
+        slot: slot.parse().map_err(|err| {
+            anyhow!("failed to parse slot {slot} as a u32: {err}")
+        })?,
+    })
 }
 
-struct Client {
-    inner: gateway_client::Client,
-    server: IpAddr,
-    port: u16,
-    sp_type: SpType,
-    component: &'static str,
-    sled: u32,
+#[derive(Debug, Clone, Copy)]
+enum IgnitionCommand {
+    PowerOn,
+    PowerOff,
+    PowerReset,
 }
 
-impl Client {
-    fn new(server: IpAddr, port: u16, sled: u32, log: Logger) -> Self {
-        // We currently hardcode `sled` and the SP3 host CPU component, as that
-        // is the only sptype+component pair that has a serial port.
-        Self {
-            inner: gateway_client::Client::new(
-                &format!("http://{}:{}", server, port),
-                log,
-            ),
-            server,
-            port,
-            sled,
-            sp_type: SpType::Sled,
-            component: "sp3-host-cpu",
+fn ignition_command_from_str(s: &str) -> Result<IgnitionCommand> {
+    match s {
+        "power-on" => Ok(IgnitionCommand::PowerOn),
+        "power-off" => Ok(IgnitionCommand::PowerOff),
+        "power-reset" => Ok(IgnitionCommand::PowerReset),
+        _ => Err(anyhow!("Invalid ignition command: {s}")),
+    }
+}
+
+fn power_state_from_str(s: &str) -> Result<PowerState> {
+    match s {
+        "a0" | "A0" => Ok(PowerState::A0),
+        "a1" | "A1" => Ok(PowerState::A1),
+        "a2" | "A2" => Ok(PowerState::A2),
+        _ => Err(anyhow!("Invalid power state: {s}")),
+    }
+}
+
+struct Dumper {
+    pretty: bool,
+}
+
+impl Dumper {
+    fn dump<T: Serialize>(&self, value: &T) -> Result<()> {
+        let stdout = io::stdout().lock();
+        if self.pretty {
+            serde_json::to_writer_pretty(stdout, value)?;
+        } else {
+            serde_json::to_writer(stdout, value)?;
         }
-    }
-
-    async fn reset(&self) -> Result<()> {
-        self.inner.sp_reset(self.sp_type, self.sled).await?;
         Ok(())
-    }
-
-    async fn update(
-        &self,
-        component: &str,
-        id: Uuid,
-        slot: u16,
-        path: &Path,
-    ) -> Result<()> {
-        let image = fs::read(path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        self.inner
-            .sp_component_update(
-                self.sp_type,
-                self.sled,
-                component,
-                &UpdateBody { id, image, slot },
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn update_abort(&self, component: &str, id: Uuid) -> Result<()> {
-        self.inner
-            .sp_component_update_abort(
-                self.sp_type,
-                self.sled,
-                component,
-                &UpdateAbortBody { id },
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn detach(&self) -> Result<()> {
-        self.inner
-            .sp_component_serial_console_detach(
-                self.sp_type,
-                self.sled,
-                self.component,
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn attach(
-        &self,
-    ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
-        // TODO should we be able to attach through the openapi client?
-        let path = format!(
-            "ws://{}:{}/sp/sled/{}/component/sp3/serial-console/attach",
-            self.server, self.port, self.sled
-        );
-        let (ws, _response) = tokio_tungstenite::connect_async(path)
-            .await
-            .with_context(|| "failed to create serial websocket stream")?;
-        Ok(ws)
     }
 }
 
@@ -217,207 +310,144 @@ async fn main() -> Result<()> {
     let drain = slog_async::Async::new(drain).build().fuse();
     let log = Logger::root(drain, o!("component" => "gateway-client"));
 
-    let client = Client::new(args.server, args.port, args.sled, log.clone());
+    let client = gateway_client::Client::new(
+        &format!("http://{}", args.server),
+        log.clone(),
+    );
 
-    let term_raw = match args.command {
-        Command::Attach { raw } => raw, // continue; primary use case
-        Command::Detach => {
-            return client.detach().await;
-        }
-        Command::Update { component, slot, path } => {
-            let id = Uuid::new_v4();
-            info!(log, "generated update ID {id}");
-            return client.update(&component, id, slot, &path).await;
-        }
-        Command::UpdateAbort { component, id } => {
-            return client.update_abort(&component, id).await;
-        }
-        Command::Reset => {
-            return client.reset().await;
-        }
-    };
+    let dumper = Dumper { pretty: args.pretty };
 
-    // TODO Much of the code from this point on is derived from propolis's CLI,
-    // but isn't identical. Can/should we share it, or is this small enough that
-    // having it duplicated is fine?
-
-    let _raw_guard = if term_raw {
-        Some(
-            RawTermiosGuard::stdio_guard()
-                .with_context(|| "failed to set raw mode")?,
-        )
-    } else {
-        None
-    };
-
-    // https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_exact
-    // is not cancel safe! Meaning reads from tokio::io::stdin are not cancel
-    // safe. Spawn a separate task to read and put bytes onto this channel.
-    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
-
-    tokio::spawn(async move {
-        let mut stdin = tokio::io::stdin();
-
-        // next_raw must live outside loop, because Ctrl-A should work across
-        // multiple inbuf reads.
-        let mut next_raw = false;
-        let mut inbuf = [0u8; 1024];
-
-        // We're connected to a websocket which itself is forwarding data we
-        // send it over UDP. If our terminal is in raw mode, our `stdin.read()`
-        // below will happily return a single byte at a time, which would result
-        // in a UDP packet for every byte read. Instead, we'll start a timer any
-        // time we receive a byte and only flush it when that timer fires. This
-        // introduces a human-noticeable delay, but results in overall better
-        // performance. This mechanism is unused in non-raw mode where our
-        // `stdin.read()` blocks until we get a newline.
-        let flush_timeout = Fuse::terminated();
-        futures::pin_mut!(flush_timeout);
-
-        let mut exit = false;
-        let mut outbuf = Vec::new();
-
-        loop {
-            let n = select! {
-                read_result = stdin.read(&mut inbuf) => match read_result {
-                    Err(_) | Ok(0) => if outbuf.is_empty() {
-                        break;
-                    } else {
-                        exit = true;
-                        continue;
-                    }
-                    Ok(n) => n,
-                },
-
-                () = &mut flush_timeout => {
-                    tx.send(outbuf).await.unwrap();
-                    if exit {
-                        break;
-                    } else {
-                        outbuf = Vec::new();
-                        continue;
-                    }
-                }
-            };
-
-            if term_raw {
-                // Put bytes from inbuf to outbuf, but don't send Ctrl-A unless
-                // next_raw is true.
-                for i in 0..n {
-                    let c = inbuf[i];
-                    match c {
-                        // Ctrl-A means send next one raw
-                        b'\x01' => {
-                            if next_raw {
-                                // Ctrl-A Ctrl-A should be sent as Ctrl-A
-                                outbuf.push(c);
-                                next_raw = false;
-                            } else {
-                                next_raw = true;
-                            }
-                        }
-                        b'\x03' => {
-                            if !next_raw {
-                                // Exit on non-raw Ctrl-C
-                                exit = true;
-                                break;
-                            } else {
-                                // Otherwise send Ctrl-C
-                                outbuf.push(c);
-                                next_raw = false;
-                            }
-                        }
-                        _ => {
-                            outbuf.push(c);
-                            next_raw = false;
-                        }
-                    }
-                }
-
-                // start a timer to flush what we have and send a UDP packet,
-                // unless we're already waiting to flush
-                if flush_timeout.is_terminated() {
-                    flush_timeout.set(
-                        tokio::time::sleep(Duration::from_millis(500)).fuse(),
-                    );
-                }
+    match args.command {
+        Command::State { sp } => {
+            if let Some(sp) = sp {
+                let info = client.sp_get(sp.type_, sp.slot).await?.into_inner();
+                dumper.dump(&info)?;
             } else {
-                outbuf.extend_from_slice(&inbuf[..n]);
-                flush_timeout
-                    .set(tokio::time::sleep(Duration::default()).fuse());
+                let info = client.sp_list().await?.into_inner();
+                dumper.dump(&info)?;
             }
         }
-    });
+        Command::Ignition { sp } => {
+            if let Some(sp) = sp {
+                let info =
+                    client.ignition_get(sp.type_, sp.slot).await?.into_inner();
+                dumper.dump(&info)?;
+            } else {
+                let info = client.ignition_list().await?.into_inner();
+                dumper.dump(&info)?;
+            }
+        }
+        Command::IgnitionCommand { sp, command } => match command {
+            IgnitionCommand::PowerOn => {
+                client.ignition_power_on(sp.type_, sp.slot).await?;
+            }
+            IgnitionCommand::PowerOff => {
+                client.ignition_power_off(sp.type_, sp.slot).await?;
+            }
+            IgnitionCommand::PowerReset => todo!("missing MGS endpoint"),
+        },
+        Command::ComponentActiveSlot { .. }
+        | Command::StartupOptions { .. } => {
+            todo!("missing MGS endpoint");
+        }
+        Command::Inventory { sp } => {
+            let info =
+                client.sp_component_list(sp.type_, sp.slot).await?.into_inner();
+            dumper.dump(&info)?;
+        }
+        Command::ComponentDetails { .. }
+        | Command::ComponentClearStatus { .. } => {
+            todo!("missing MGS endpoint");
+        }
+        Command::UsartAttach {
+            sp,
+            raw,
+            stdin_buffer_time_millis,
+            imap,
+            omap,
+            uart_logfile,
+        } => {
+            let type_ = match sp.type_ {
+                SpType::Sled => "sled",
+                SpType::Switch => "switch",
+                SpType::Power => "power",
+            };
+            // TODO should we be able to attach through the openapi client?
+            let path = format!(
+                "ws://{}/sp/{}/{}/component/{}/serial-console/attach",
+                args.server, type_, sp.slot, SERIAL_CONSOLE_COMPONENT,
+            );
+            let (ws, _response) = tokio_tungstenite::connect_async(path)
+                .await
+                .with_context(|| "failed to create serial websocket stream")?;
+            usart::run(
+                ws,
+                raw,
+                Duration::from_millis(stdin_buffer_time_millis),
+                imap,
+                omap,
+                uart_logfile,
+            )
+            .await?;
+        }
+        Command::UsartDetach { sp } => {
+            client
+                .sp_component_serial_console_detach(
+                    sp.type_,
+                    sp.slot,
+                    SERIAL_CONSOLE_COMPONENT,
+                )
+                .await?;
+        }
+        Command::UploadRecoveryHostPhase2 { .. } => {
+            todo!("missing MGS endpoint");
+        }
+        Command::Update { sp, component, slot, image } => {
+            let image = fs::read(&image).with_context(|| {
+                format!("failed to read {}", image.display())
+            })?;
+            let update_id = Uuid::new_v4();
 
-    let mut stdout = tokio::io::stdout();
-    let mut ws = client.attach().await?;
-    loop {
-        tokio::select! {
-            c = rx.recv() => {
-                match c {
-                    None => {
-                        // channel is closed
-                        _ = ws.close(Some(CloseFrame {
-                            code: CloseCode::Normal,
-                            reason: Cow::Borrowed("client closed stdin"),
-                        })).await;
-                        break;
-                    }
-                    Some(c) => {
-                        ws.send(Message::Binary(c)).await?;
-                    },
-                }
+            let body = UpdateBody { id: update_id, image, slot };
+
+            client
+                .sp_component_update(sp.type_, sp.slot, &component, &body)
+                .await?;
+
+            // We don't get a meaningful response on success from the server,
+            // but we the CLI generated this update's ID, so print it.
+            println!("{update_id}");
+        }
+        Command::UpdateStatus { sp, component } => {
+            let info = client
+                .sp_component_update_status(sp.type_, sp.slot, &component)
+                .await?
+                .into_inner();
+            dumper.dump(&info)?;
+        }
+        Command::UpdateAbort { sp, component, update_id } => {
+            let body = UpdateAbortBody { id: update_id };
+            client
+                .sp_component_update_abort(sp.type_, sp.slot, &component, &body)
+                .await?;
+        }
+        Command::PowerState { sp, new_power_state } => {
+            if let Some(power_state) = new_power_state {
+                client
+                    .sp_power_state_set(sp.type_, sp.slot, power_state)
+                    .await?;
+            } else {
+                let info = client
+                    .sp_power_state_get(sp.type_, sp.slot)
+                    .await?
+                    .into_inner();
+                dumper.dump(&info)?;
             }
-            msg = ws.next() => {
-                match msg {
-                    Some(Ok(Message::Binary(input))) => {
-                        stdout.write_all(&input).await?;
-                        stdout.flush().await?;
-                    }
-                    Some(Ok(Message::Close(..))) | None => break,
-                    _ => continue,
-                }
-            }
+        }
+        Command::Reset { sp } => {
+            client.sp_reset(sp.type_, sp.slot).await?;
         }
     }
 
     Ok(())
-}
-
-/// Guard object that will set the terminal to raw mode and restore it
-/// to its previous state when it's dropped
-struct RawTermiosGuard(libc::c_int, libc::termios);
-
-impl RawTermiosGuard {
-    fn stdio_guard() -> Result<RawTermiosGuard, std::io::Error> {
-        use std::os::unix::prelude::AsRawFd;
-        let fd = std::io::stdout().as_raw_fd();
-        let termios = unsafe {
-            let mut curr_termios = std::mem::zeroed();
-            let r = libc::tcgetattr(fd, &mut curr_termios);
-            if r == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            curr_termios
-        };
-        let guard = RawTermiosGuard(fd, termios);
-        unsafe {
-            let mut raw_termios = termios;
-            libc::cfmakeraw(&mut raw_termios);
-            let r = libc::tcsetattr(fd, libc::TCSAFLUSH, &raw_termios);
-            if r == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-        }
-        Ok(guard)
-    }
-}
-
-impl Drop for RawTermiosGuard {
-    fn drop(&mut self) {
-        let r = unsafe { libc::tcsetattr(self.0, libc::TCSADRAIN, &self.1) };
-        if r == -1 {
-            Err::<(), _>(std::io::Error::last_os_error()).unwrap();
-        }
-    }
 }

--- a/gateway-cli/src/picocom_map.rs
+++ b/gateway-cli/src/picocom_map.rs
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! picocom-style character remapping; does not support the "... to hex" rules.
+
+use std::{collections::VecDeque, str::FromStr};
+
+use anyhow::{bail, ensure, Error, Result};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RemapRules {
+    cr: Option<&'static [u8]>,
+    lf: Option<&'static [u8]>,
+    bsdel: bool,
+    delbs: bool,
+}
+
+impl FromStr for RemapRules {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut rules = Self::default();
+
+        for rule in s.split(',') {
+            match rule {
+                "crlf" => {
+                    ensure!(rules.cr.is_none(), "multiple rules remapping cr");
+                    rules.cr = Some(&[raw::LF]);
+                }
+                "crcrlf" => {
+                    ensure!(rules.cr.is_none(), "multiple rules remapping cr");
+                    rules.cr = Some(&[raw::CR, raw::LF]);
+                }
+                "igncr" => {
+                    ensure!(rules.cr.is_none(), "multiple rules remapping cr");
+                    rules.cr = Some(&[]);
+                }
+                "lfcr" => {
+                    ensure!(rules.lf.is_none(), "multiple rules remapping lf");
+                    rules.lf = Some(&[raw::CR]);
+                }
+                "lfcrlf" => {
+                    ensure!(rules.lf.is_none(), "multiple rules remapping lf");
+                    rules.lf = Some(&[raw::CR, raw::LF]);
+                }
+                "ignlf" => {
+                    ensure!(rules.lf.is_none(), "multiple rules remapping lf");
+                    rules.lf = Some(&[]);
+                }
+                "bsdel" => {
+                    rules.bsdel = true;
+                }
+                "delbs" => {
+                    rules.delbs = true;
+                }
+                _ => bail!("unknown or unsupported remap rule: {rule:?}"),
+            }
+        }
+
+        Ok(rules)
+    }
+}
+
+impl RemapRules {
+    pub fn apply<I>(&self, bytes: I) -> RemapIter<I::IntoIter>
+    where
+        I: IntoIterator<Item = u8>,
+    {
+        RemapIter {
+            inner: bytes.into_iter(),
+            prev: VecDeque::new(),
+            rules: *self,
+        }
+    }
+}
+
+pub struct RemapIter<I> {
+    inner: I,
+    // Some rules (e.g., `crcrlf`) map one input byte to two output bytes; we
+    // can only return the first from one invocation to `next()`, so we stash
+    // any remaining output bytes from a previous input byte into this deque.
+    prev: VecDeque<u8>,
+    rules: RemapRules,
+}
+
+impl<I> Iterator for RemapIter<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Do we have any leftover bytes from a previous input byte
+            // (possibly from a previous iteration of this loop)?
+            if let Some(b) = self.prev.pop_front() {
+                return Some(b);
+            }
+
+            match self.inner.next()? {
+                raw::CR => {
+                    if let Some(repl) = self.rules.cr {
+                        // This does the right thing for all three possible
+                        // cases of replacement length:
+                        //
+                        // 0. `repl.len() == 0`: we loop back, find nothing in
+                        //    `prev`, and read the next byte from `self.inner`.
+                        // 1. `repl.len() == 1`: we loop back, pop the one and
+                        //    only byte out, and return it. On the next call to
+                        //    `self.next()`, we have no bytes left in
+                        //    `self.prev` and so read the next from
+                        //    `self.inner`.
+                        // 2. `repl.len() > 1`: we loop back, pop the first
+                        //    replacement byte out and return it, leaving the
+                        //    remaining replacement bytes in `self.prev` waiting
+                        //    for future call(s) to `self.next().
+                        self.prev.extend(repl);
+                        continue;
+                    } else {
+                        return Some(raw::CR);
+                    }
+                }
+                raw::LF => {
+                    if let Some(repl) = self.rules.lf {
+                        self.prev.extend(repl);
+                        continue;
+                    } else {
+                        return Some(raw::LF);
+                    }
+                }
+                raw::BS if self.rules.bsdel => return Some(raw::DEL),
+                raw::DEL if self.rules.delbs => return Some(raw::BS),
+                b => return Some(b),
+            }
+        }
+    }
+}
+
+mod raw {
+    pub(super) const CR: u8 = b'\r';
+    pub(super) const LF: u8 = b'\n';
+    pub(super) const BS: u8 = 0x08;
+    pub(super) const DEL: u8 = 0x7f;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_invalid_rules() {
+        // bogus rules
+        for s in ["foo", "crlf,foo"] {
+            assert!(
+                RemapRules::from_str(s)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("unsupported remap rule"),
+                "unexpected error message parsing {s:?}"
+            );
+        }
+
+        // rule strings with duplicates for CR or LF
+        for s in [
+            "crlf,crlf",
+            "crcrlf,crlf",
+            "igncr,crlf",
+            "lfcr,lfcr",
+            "lfcr,lfcrlf",
+            "lfcr,ignlf",
+        ] {
+            assert!(
+                RemapRules::from_str(s)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("multiple rules remapping"),
+                "unexpected error message parsing {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn remapping() {
+        for (rules, input, expected) in [
+            ("crlf", "foo\rbar\n", "foo\nbar\n"),
+            ("crcrlf", "foo\rbar\rbaz\n", "foo\r\nbar\r\nbaz\n"),
+            ("crlf,lfcr", "foo\rbar\n", "foo\nbar\r"),
+            ("igncr,lfcr", "foo\rbar\n", "foobar\r"),
+            ("ignlf,crcrlf", "foo\rbar\n", "foo\r\nbar"),
+            ("crlf,delbs", "foo\rbar\x7fbaz", "foo\nbar\x08baz"),
+            ("igncr,delbs,bsdel", "foo\rbar\x7fbaz\x08", "foobar\x08baz\x7f"),
+        ] {
+            let rules: RemapRules = rules.parse().unwrap();
+            let output = rules
+                .apply(input.as_bytes().iter().copied())
+                .collect::<Vec<_>>();
+            let output = std::str::from_utf8(&output).unwrap();
+            assert_eq!(expected, output, "mismatch with rules {rules:?}");
+        }
+    }
+}

--- a/gateway-cli/src/usart.rs
+++ b/gateway-cli/src/usart.rs
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+use anyhow::Context;
+use anyhow::Result;
+use gateway_messages::SpComponent;
+use gateway_sp_comms::AttachedSerialConsoleSend;
+use gateway_sp_comms::SingleSp;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::mem;
+use std::os::unix::prelude::AsRawFd;
+use std::path::PathBuf;
+use std::time::Duration;
+use termios::Termios;
+use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
+
+use crate::picocom_map::RemapRules;
+
+const CTRL_A: u8 = b'\x01';
+const CTRL_X: u8 = b'\x18';
+
+pub(crate) async fn run(
+    sp: SingleSp,
+    raw: bool,
+    stdin_buffer_time: Duration,
+    imap: Option<String>,
+    omap: Option<String>,
+    uart_logfile: Option<PathBuf>,
+) -> Result<()> {
+    // Put terminal in raw mode, if requested, with a guard to restore it.
+    let _guard =
+        if raw { Some(UnrawTermiosGuard::make_stdout_raw()?) } else { None };
+
+    // Parse imap/omap strings.
+    let imap = match imap {
+        Some(s) => s.parse().context("invalid imap rules")?,
+        None => RemapRules::default(),
+    };
+    let omap = match omap {
+        Some(s) => s.parse().context("invalid omap rules")?,
+        None => RemapRules::default(),
+    };
+
+    // Open uart logfile, if requested.
+    let mut uart_logfile = match uart_logfile {
+        Some(path) => {
+            let f = File::options()
+                .append(true)
+                .create(true)
+                .open(&path)
+                .with_context(|| {
+                    format!("failed to open {}", path.display())
+                })?;
+            Some(f)
+        }
+        None => None,
+    };
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = Vec::with_capacity(64);
+    let mut out_buf = StdinOutBuf::new(omap, raw);
+    let mut flush_delay = FlushDelay::new(stdin_buffer_time);
+    let console = sp
+        .serial_console_attach(SpComponent::SP3_HOST_CPU)
+        .await
+        .with_context(|| "failed to attach to serial console")?;
+
+    let (console_tx, mut console_rx) = console.split();
+    let (send_tx, send_rx) = mpsc::channel(8);
+    let tx_to_sp_handle = tokio::spawn(async move {
+        relay_data_to_sp(console_tx, send_rx).await.unwrap();
+    });
+
+    loop {
+        tokio::select! {
+            result = stdin.read_buf(&mut stdin_buf) => {
+                let n = result.context("failed to read from stdin")?;
+                if n == 0 {
+                    mem::drop(send_tx);
+                    tx_to_sp_handle.await.unwrap();
+                    return Ok(());
+                }
+
+                match out_buf.ingest(&mut stdin_buf) {
+                    IngestResult::Ok => (),
+                    IngestResult::Exit => {
+                        mem::drop(send_tx);
+                        tx_to_sp_handle.await.unwrap();
+                        return Ok(());
+                    }
+                }
+
+                flush_delay.start_if_unstarted().await;
+            }
+
+            chunk = console_rx.recv() => {
+                let chunk = chunk.unwrap();
+
+                if let Some(uart_logfile) = uart_logfile.as_mut() {
+                    uart_logfile
+                        .write_all(&chunk)
+                        .context("failed to write to logfile")?;
+                }
+
+                let data = imap.apply(chunk).collect::<Vec<_>>();
+
+                let mut stdout = io::stdout().lock();
+                stdout.write_all(&data).context("failed to write to stdout")?;
+                stdout.flush().context("failed to flush stdout")?;
+            }
+
+            _ = flush_delay.ready() => {
+                send_tx
+                    .send(out_buf.steal_buf())
+                    .await
+                    .with_context(|| "failed to send data (task shutdown?)")?;
+            }
+        }
+    }
+}
+
+async fn relay_data_to_sp(
+    mut console_tx: AttachedSerialConsoleSend,
+    mut data_rx: mpsc::Receiver<Vec<u8>>,
+) -> Result<()> {
+    while let Some(data) = data_rx.recv().await {
+        console_tx.write(data).await?;
+    }
+    console_tx.detach().await?;
+
+    Ok(())
+}
+
+struct UnrawTermiosGuard {
+    stdout: i32,
+    ios: Termios,
+}
+
+impl Drop for UnrawTermiosGuard {
+    fn drop(&mut self) {
+        termios::tcsetattr(self.stdout, termios::TCSAFLUSH, &self.ios).unwrap();
+    }
+}
+
+impl UnrawTermiosGuard {
+    fn make_stdout_raw() -> Result<Self> {
+        let stdout = io::stdout().as_raw_fd();
+        let mut ios = Termios::from_fd(stdout)
+            .with_context(|| "could not get termios for stdout")?;
+        let orig_ios = ios;
+        termios::cfmakeraw(&mut ios);
+        termios::tcsetattr(stdout, termios::TCSANOW, &ios)
+            .with_context(|| "failed to set TCSANOW on stdout")?;
+        termios::tcflush(stdout, termios::TCIOFLUSH)
+            .with_context(|| "failed to set TCIOFLUSH on stdout")?;
+        Ok(Self { stdout, ios: orig_ios })
+    }
+}
+
+struct FlushDelay {
+    started: bool,
+    tx: mpsc::Sender<()>,
+    rx: mpsc::Receiver<()>,
+}
+
+impl FlushDelay {
+    fn new(duration: Duration) -> Self {
+        let (tx0, mut rx0) = mpsc::channel(1);
+        let (tx1, rx1) = mpsc::channel(1);
+        tokio::spawn(async move {
+            loop {
+                match rx0.recv().await {
+                    Some(()) => (),
+                    None => return,
+                }
+
+                tokio::time::sleep(duration).await;
+
+                let _ = tx1.send(()).await;
+            }
+        });
+        Self { started: false, tx: tx0, rx: rx1 }
+    }
+
+    async fn start_if_unstarted(&mut self) {
+        if !self.started {
+            self.started = true;
+            self.tx.send(()).await.unwrap();
+        }
+    }
+
+    async fn ready(&mut self) {
+        self.rx.recv().await.unwrap();
+        self.started = false;
+    }
+}
+
+struct StdinOutBuf {
+    raw_mode: bool,
+    in_prefix: bool,
+    remap: RemapRules,
+    buf: Vec<u8>,
+}
+
+enum IngestResult {
+    Ok,
+    Exit,
+}
+
+impl StdinOutBuf {
+    fn new(remap: RemapRules, raw_mode: bool) -> Self {
+        Self { raw_mode, in_prefix: false, remap, buf: Vec::new() }
+    }
+
+    fn ingest(&mut self, buf: &mut Vec<u8>) -> IngestResult {
+        let buf = self.remap.apply(buf.drain(..));
+
+        if !self.raw_mode {
+            self.buf.extend(buf);
+            return IngestResult::Ok;
+        }
+
+        for c in buf {
+            match c {
+                CTRL_A => {
+                    if self.in_prefix {
+                        // Ctrl-A Ctrl-A should be sent as Ctrl-A
+                        self.buf.push(c);
+                        self.in_prefix = false;
+                    } else {
+                        self.in_prefix = true;
+                    }
+                }
+                CTRL_X => {
+                    if self.in_prefix {
+                        // Exit on Ctrl-A Ctrl-X
+                        return IngestResult::Exit;
+                    } else {
+                        self.buf.push(c);
+                    }
+                }
+                _ => {
+                    self.buf.push(c);
+                    self.in_prefix = false;
+                }
+            }
+        }
+
+        IngestResult::Ok
+    }
+
+    fn steal_buf(&mut self) -> Vec<u8> {
+        let mut stolen = Vec::new();
+        mem::swap(&mut stolen, &mut self.buf);
+        stolen
+    }
+}

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -2,10 +2,15 @@
 # Oxide API: example configuration file
 #
 
+[dropshot]
+# We want to allow uploads of host phase 2 recovery images, which may be
+# measured in the (small) hundreds of MiB. Set this to 512 MiB.
+request_body_max_bytes = 536870912
+
 [switch]
-# which vsc port is connected to our local sidecar SP (i.e., the SP that acts as
-# our contact to the ignition controller)
-local_ignition_controller_port = 0
+# Which interface is connected to our local sidecar SP (i.e., the SP that acts
+# as our contact to the ignition controller)?
+local_ignition_controller_interface = "fake-switch0"
 
 # when sending UDP RPC packets to an SP, how many total attempts do we make
 # before giving up?
@@ -31,12 +36,7 @@ names = ["switch0", "switch1"]
 # if there is a miscabling that results in an unsolvable system (e.g.,
 # determination 0 reports "switch0" and determination 1 reports "switch1").
 [[switch.location.determination]]
-switch_port = 1
-sp_port_1 = ["switch0"]
-sp_port_2 = ["switch1"]
-
-[[switch.location.determination]]
-switch_port = 2
+interfaces = ["fake-sled0", "fake-sled1"]
 sp_port_1 = ["switch0"]
 sp_port_2 = ["switch1"]
 
@@ -44,31 +44,26 @@ sp_port_2 = ["switch1"]
 # interface configured to use VLAN tag  assigned to the given port) and the
 # logical ID of the remote SP ("sled 7", "switch 1", etc.), which must have an
 # entry for each member of `[switch.location]` above.
-#
-# TODO This section has some concessions to local testing: ultimately we will
-# use a single multicast address, target port, and source port, but for now all
-# three are configured on a per-port basis, which allows a single system to
-# simulate a full set of ports and SPs.
-[switch.port.0]
-data_link_addr = "[::]:33200"
-multicast_addr = "[ff15:0:1de::0]:33300"
-[switch.port.0.location]
-switch0 = ["switch", 0]
-switch1 = ["switch", 1]
+[[switch.port]]
+kind = "simulated"
+fake-interface = "fake-switch0"
+addr = "[::1]:33300"
+ignition-target = 1
+location = { switch0 = ["switch", 0], switch1 = ["switch", 1] }
 
-[switch.port.1]
-data_link_addr = "[::]:33201"
-multicast_addr = "[ff15:0:1de::1]:33310"
-[switch.port.1.location]
-switch0 = ["sled", 0]
-switch1 = ["sled", 0]
+[[switch.port]]
+kind = "simulated"
+fake-interface = "fake-sled0"
+addr = "[::1]:33310"
+ignition-target = 2
+location = { switch0 = ["sled", 0], switch1 = ["sled", 0] }
 
-[switch.port.2]
-data_link_addr = "[::]:33202"
-multicast_addr = "[ff15:0:1de::2]:33320"
-[switch.port.2.location]
-switch0 = ["sled", 1]
-switch1 = ["sled", 1]
+[[switch.port]]
+kind = "simulated"
+fake-interface = "fake-sled1"
+addr = "[::1]:33320"
+ignition-target = 3
+location = { switch0 = ["sled", 1], switch1 = ["sled", 1] }
 
 [log]
 # Show log messages of this level and more severe

--- a/sp-sim/examples/config.toml
+++ b/sp-sim/examples/config.toml
@@ -5,7 +5,7 @@
 [[simulated_sps.sidecar]]
 multicast_addr = "ff15:0:1de::0"
 bind_addrs = ["[::]:33300", "[::]:33301"]
-serial_number = "00000000000000000000000000000001"
+serial_number = "SimSidecar0"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000000"
 
@@ -13,7 +13,7 @@ device_id_cert_seed = "01de00000000000000000000000000000000000000000000000000000
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::1"
 bind_addrs = ["[::]:33310", "[::]:33311"]
-serial_number = "00000000000000000000000000000002"
+serial_number = "SimGimlet0"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000001"
 
@@ -28,7 +28,7 @@ serial_console = "[::1]:33312"
 [[simulated_sps.gimlet]]
 multicast_addr = "ff15:0:1de::2"
 bind_addrs = ["[::]:33320", "[::]:33321"]
-serial_number = "00000000000000000000000000000003"
+serial_number = "SimGimlet1"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 


### PR DESCRIPTION
This PR reworks `gateway-cli` (which had languished quite a bit) to be closer to in parity with `faux-mgs`, with a few notable exceptions:

1. The SP the user wants to talk to is specified in terms of a logical / physical identifier (e.g., `sled/7` is "the gimlet in slot 7") instead of an IP address or interface. The only network connection made by gateway-cli itself is to MGS.
2. There is no `discover` subcommand. MGS uses discovery packets to find and map out online SPs, but doesn't expose those to its clients.
3. The `IgnitionLinkEvents` and `ClearIgnitionLinkEvents` commands are omitted. My current understanding is that these are for manual ignition debugging only and not events we want the control plane to care about in general. If that changes, they're in the MGS protocol already and would need endpoints added.
4. A few commands have no MGS endpoint; these are left as `todo!()`s that I will address in followup PRs that touch both MGS proper and `gateway-cli`.