### PR TITLE
[MGS] Replace ignition/power-{on,off} with one ignition-command endpoint

### DIFF
--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -10,6 +10,7 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
+use gateway_client::types::IgnitionCommand;
 use gateway_client::types::PowerState;
 use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpType;
@@ -263,13 +264,6 @@ fn sp_identifier_from_str(s: &str) -> Result<SpIdentifier> {
     })
 }
 
-#[derive(Debug, Clone, Copy)]
-enum IgnitionCommand {
-    PowerOn,
-    PowerOff,
-    PowerReset,
-}
-
 fn ignition_command_from_str(s: &str) -> Result<IgnitionCommand> {
     match s {
         "power-on" => Ok(IgnitionCommand::PowerOn),
@@ -339,15 +333,9 @@ async fn main() -> Result<()> {
                 dumper.dump(&info)?;
             }
         }
-        Command::IgnitionCommand { sp, command } => match command {
-            IgnitionCommand::PowerOn => {
-                client.ignition_power_on(sp.type_, sp.slot).await?;
-            }
-            IgnitionCommand::PowerOff => {
-                client.ignition_power_off(sp.type_, sp.slot).await?;
-            }
-            IgnitionCommand::PowerReset => todo!("missing MGS endpoint"),
-        },
+        Command::IgnitionCommand { sp, command } => {
+            client.ignition_command(sp.type_, sp.slot, command).await?;
+        }
         Command::ComponentActiveSlot { .. }
         | Command::StartupOptions { .. } => {
             todo!("missing MGS endpoint");

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -23,7 +23,6 @@ use dropshot::TypedBody;
 use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use futures::TryFutureExt;
-use gateway_messages::IgnitionCommand;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -119,6 +118,17 @@ pub enum SpIgnition {
     },
     #[serde(rename = "error")]
     CommunicationFailed { message: String },
+}
+
+/// Ignition command.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum IgnitionCommand {
+    PowerOn,
+    PowerOff,
+    PowerReset,
 }
 
 /// TODO: Do we want to bake in specific board names, or use raw u16 ID numbers?
@@ -336,6 +346,16 @@ struct PathSpComponent {
     /// ID for the component of the SP; this is the internal identifier used by
     /// the SP itself to identify its components.
     component: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct PathSpIgnitionCommand {
+    /// ID for the SP that the gateway service translates into the appropriate
+    /// port for communicating with the given SP.
+    #[serde(flatten)]
+    sp: SpIdentifier,
+    /// Ignition command to perform on the targeted SP.
+    command: IgnitionCommand,
 }
 
 /// List SPs
@@ -703,36 +723,6 @@ async fn sp_component_update_abort(
     Ok(HttpResponseUpdatedNoContent {})
 }
 
-/// Power on an SP component
-///
-/// Components whose power state cannot be changed will always return an error.
-#[endpoint {
-    method = POST,
-    path = "/sp/{type}/{slot}/component/{component}/power-on",
-}]
-async fn sp_component_power_on(
-    _rqctx: RequestContext<Arc<ServerContext>>,
-    _path: Path<PathSpComponent>,
-    // TODO do we need a timeout?
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    todo!()
-}
-
-/// Power off an SP component
-///
-/// Components whose power state cannot be changed will always return an error.
-#[endpoint {
-    method = POST,
-    path = "/sp/{type}/{slot}/component/{component}/power-off",
-}]
-async fn sp_component_power_off(
-    _rqctx: RequestContext<Arc<ServerContext>>,
-    _path: Path<PathSpComponent>,
-    // TODO do we need a timeout?
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    todo!()
-}
-
 /// List SPs via Ignition
 ///
 /// Retreive information for all SPs via the Ignition controller. This is lower
@@ -789,50 +779,30 @@ async fn ignition_get(
     Ok(HttpResponseOk(info))
 }
 
-/// Power on a sled via a request to its SP.
+/// Send an ignition command targeting a specific SP.
 ///
-/// This corresponds to moving the sled into A2.
+/// This endpoint can be used to transition a target between A2 and A3 (via
+/// power-on / power-off) or reset it.
+///
+/// The management network traffic caused by requests to this endpoint is
+/// between this MGS instance and its local ignition controller, _not_ the SP
+/// targeted by the command.
 #[endpoint {
     method = POST,
-    path = "/ignition/{type}/{slot}/power-on",
+    path = "/ignition/{type}/{slot}/{command}",
 }]
-async fn ignition_power_on(
+async fn ignition_command(
     rqctx: RequestContext<Arc<ServerContext>>,
-    path: Path<PathSp>,
+    path: Path<PathSpIgnitionCommand>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let apictx = rqctx.context();
     let mgmt_switch = &apictx.mgmt_switch;
-    let ignition_target =
-        mgmt_switch.ignition_target(path.into_inner().sp.into())?;
+    let PathSpIgnitionCommand { sp, command } = path.into_inner();
+    let ignition_target = mgmt_switch.ignition_target(sp.into())?;
 
     mgmt_switch
         .ignition_controller()
-        .ignition_command(ignition_target, IgnitionCommand::PowerOn)
-        .await
-        .map_err(SpCommsError::from)?;
-
-    Ok(HttpResponseUpdatedNoContent {})
-}
-
-/// Power off a sled via Ignition
-///
-/// This corresponds to moving the sled into A3.
-#[endpoint {
-    method = POST,
-    path = "/ignition/{type}/{slot}/power-off",
-}]
-async fn ignition_power_off(
-    rqctx: RequestContext<Arc<ServerContext>>,
-    path: Path<PathSp>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let apictx = rqctx.context();
-    let mgmt_switch = &apictx.mgmt_switch;
-    let ignition_target =
-        mgmt_switch.ignition_target(path.into_inner().sp.into())?;
-
-    mgmt_switch
-        .ignition_controller()
-        .ignition_command(ignition_target, IgnitionCommand::PowerOff)
+        .ignition_command(ignition_target, command.into())
         .await
         .map_err(SpCommsError::from)?;
 
@@ -911,12 +881,9 @@ pub fn api() -> GatewayApiDescription {
         api.register(sp_component_update)?;
         api.register(sp_component_update_status)?;
         api.register(sp_component_update_abort)?;
-        api.register(sp_component_power_on)?;
-        api.register(sp_component_power_off)?;
         api.register(ignition_list)?;
         api.register(ignition_get)?;
-        api.register(ignition_power_on)?;
-        api.register(ignition_power_off)?;
+        api.register(ignition_command)?;
         Ok(())
     }
 

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -6,6 +6,7 @@
 
 //! Conversions between externally-defined types and HTTP / JsonSchema types.
 
+use super::IgnitionCommand;
 use super::PowerState;
 use super::SpComponentInfo;
 use super::SpComponentList;
@@ -176,6 +177,22 @@ impl From<gateway_messages::ignition::SystemType> for SpIgnitionSystemType {
             SystemType::Sidecar => Self::Sidecar,
             SystemType::Psc => Self::Psc,
             SystemType::Unknown(id) => Self::Unknown { id },
+        }
+    }
+}
+
+impl From<IgnitionCommand> for gateway_messages::IgnitionCommand {
+    fn from(cmd: IgnitionCommand) -> Self {
+        match cmd {
+            IgnitionCommand::PowerOn => {
+                gateway_messages::IgnitionCommand::PowerOn
+            }
+            IgnitionCommand::PowerOff => {
+                gateway_messages::IgnitionCommand::PowerOff
+            }
+            IgnitionCommand::PowerReset => {
+                gateway_messages::IgnitionCommand::PowerReset
+            }
         }
     }
 }

--- a/gateway/tests/integration_tests/bulk_state_get.rs
+++ b/gateway/tests/integration_tests/bulk_state_get.rs
@@ -72,7 +72,7 @@ async fn bulk_sp_get_one_sp_powered_off() {
     assert!(expected.iter().all(|sp| sp.details.is_enabled()));
 
     // power off sled 0 (guaranteed to exist via the assertion above)
-    let url = format!("{}", client.url("/ignition/sled/0/power-off"));
+    let url = format!("{}", client.url("/ignition/sled/0/power_off"));
     client
         .make_request_no_body(Method::POST, &url, StatusCode::NO_CONTENT)
         .await

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -84,50 +84,21 @@
         }
       }
     },
-    "/ignition/{type}/{slot}/power-off": {
+    "/ignition/{type}/{slot}/{command}": {
       "post": {
-        "summary": "Power off a sled via Ignition",
-        "description": "This corresponds to moving the sled into A3.",
-        "operationId": "ignition_power_off",
+        "summary": "Send an ignition command targeting a specific SP.",
+        "description": "This endpoint can be used to transition a target between A2 and A3 (via power-on / power-off) or reset it.\nThe management network traffic caused by requests to this endpoint is between this MGS instance and its local ignition controller, _not_ the SP targeted by the command.",
+        "operationId": "ignition_command",
         "parameters": [
           {
             "in": "path",
-            "name": "slot",
+            "name": "command",
+            "description": "Ignition command to perform on the targeted SP.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
+              "$ref": "#/components/schemas/IgnitionCommand"
             }
           },
-          {
-            "in": "path",
-            "name": "type",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SpType"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/ignition/{type}/{slot}/power-on": {
-      "post": {
-        "summary": "Power on a sled via a request to its SP.",
-        "description": "This corresponds to moving the sled into A2.",
-        "operationId": "ignition_power_on",
-        "parameters": [
           {
             "in": "path",
             "name": "slot",
@@ -322,100 +293,6 @@
                 }
               }
             }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/sp/{type}/{slot}/component/{component}/power-off": {
-      "post": {
-        "summary": "Power off an SP component",
-        "description": "Components whose power state cannot be changed will always return an error.",
-        "operationId": "sp_component_power_off",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "component",
-            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "slot",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            }
-          },
-          {
-            "in": "path",
-            "name": "type",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SpType"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/sp/{type}/{slot}/component/{component}/power-on": {
-      "post": {
-        "summary": "Power on an SP component",
-        "description": "Components whose power state cannot be changed will always return an error.",
-        "operationId": "sp_component_power_on",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "component",
-            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "slot",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            }
-          },
-          {
-            "in": "path",
-            "name": "type",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SpType"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -1415,6 +1292,15 @@
         "required": [
           "current",
           "total"
+        ]
+      },
+      "IgnitionCommand": {
+        "description": "Ignition command.",
+        "type": "string",
+        "enum": [
+          "power_on",
+          "power_off",
+          "power_reset"
         ]
       }
     }


### PR DESCRIPTION
This addresses one "todo missing MGS endpoint" (sending ignition power-reset to an SP) in gateway-cli.

While we're here, remove the unimplemented and currently-unplanned endpoints to power on/off individual components.