### PR TITLE
[wicketd] fix delayed status of updates from MGS

### DIFF
--- a/gateway/tests/integration_tests/setup.rs
+++ b/gateway/tests/integration_tests/setup.rs
@@ -92,7 +92,7 @@ pub async fn test_setup_with_config(
     test_name: &str,
     sp_port: SpPort,
     mut server_config: omicron_gateway::Config,
-    sp_sim_config: &mut sp_sim::Config,
+    sp_sim_config: &sp_sim::Config,
 ) -> GatewayTestContext {
     // Can't be `const` because `SocketAddrV6::new()` isn't const yet
     let localhost_port_0 = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0);


### PR DESCRIPTION
Previously, we were only sending notifications over this channel if the
inventory had changed. This meant that we weren't getting newer instants
if the inventory was unchanged, causing wicket to say "delayed" rather
than "live".

Tested by setting up MGS and sp-sim, then ensuring that the status was
always "live".
