### PR TITLE
Wicket packaging

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -40,7 +40,7 @@ pub const OXIMETER_PORT: u16 = 12223;
 pub const DENDRITE_PORT: u16 = 12224;
 pub const MGS_PORT: u16 = 12225;
 pub const WICKETD_PORT: u16 = 12226;
-pub const WICKETD_ARTIFACT_PORT: u16 = 12227;
+pub const BOOTSTRAP_ARTIFACT_PORT: u16 = 12227;
 
 pub const NEXUS_INTERNAL_PORT: u16 = 12221;
 

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -39,6 +39,8 @@ pub const CLICKHOUSE_PORT: u16 = 8123;
 pub const OXIMETER_PORT: u16 = 12223;
 pub const DENDRITE_PORT: u16 = 12224;
 pub const MGS_PORT: u16 = 12225;
+pub const WICKETD_PORT: u16 = 12226;
+pub const WICKETD_ARTIFACT_PORT: u16 = 12227;
 
 pub const NEXUS_INTERNAL_PORT: u16 = 12221;
 

--- a/internal-dns-client/src/names.rs
+++ b/internal-dns-client/src/names.rs
@@ -18,6 +18,7 @@ pub enum ServiceName {
     Nexus,
     Oximeter,
     ManagementGatewayService,
+    Wicketd,
     Dendrite,
     Tfport,
 }
@@ -31,6 +32,7 @@ impl fmt::Display for ServiceName {
             ServiceName::Nexus => write!(f, "nexus"),
             ServiceName::Oximeter => write!(f, "oximeter"),
             ServiceName::ManagementGatewayService => write!(f, "mgs"),
+            ServiceName::Wicketd => write!(f, "wicketd"),
             ServiceName::Dendrite => write!(f, "dendrite"),
             ServiceName::Tfport => write!(f, "tfport"),
         }

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1486,6 +1486,20 @@
           {
             "type": "object",
             "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "wicketd"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
               "asic": {
                 "$ref": "#/components/schemas/DendriteAsic"
               },

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -77,7 +77,7 @@ service_name = "wicketd"
 source.type = "local"
 source.rust.binary_names = ["wicketd"]
 source.rust.release = true
-#source.paths = [ { from = "smf/mgs", to = "/var/svc/manifest/site/mgs" } ]
+source.paths = [ { from = "smf/mgs", to = "/var/svc/manifest/site/mgs" } ]
 output.type = "zone"
 output.intermediate_only = true
 

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -72,6 +72,24 @@ source.paths = [ { from = "smf/mgs", to = "/var/svc/manifest/site/mgs" } ]
 output.type = "zone"
 output.intermediate_only = true
 
+[package.wicketd]
+service_name = "wicketd"
+source.type = "local"
+source.rust.binary_names = ["wicketd"]
+source.rust.release = true
+#source.paths = [ { from = "smf/mgs", to = "/var/svc/manifest/site/mgs" } ]
+output.type = "zone"
+output.intermediate_only = true
+
+[package.wicket]
+service_name = "wicket"
+source.type = "local"
+source.rust.binary_names = ["wicket"]
+source.rust.release = true
+output.type = "zone"
+output.intermediate_only = true
+
+
 # Packages not built within Omicron, but which must be imported.
 
 # Refer to
@@ -164,7 +182,7 @@ output.intermediate_only = true
 service_name = "switch"
 only_for_targets.switch_variant = "asic"
 source.type = "composite"
-source.packages = [ "omicron-gateway.tar.gz", "dendrite-asic.tar.gz" ]
+source.packages = [ "omicron-gateway.tar.gz", "dendrite-asic.tar.gz", "wicketd.tar.gz", "wicket.tar.gz" ]
 output.type = "zone"
 
 # To package and install the stub variant of the switch, do the following:
@@ -177,5 +195,5 @@ output.type = "zone"
 service_name = "switch"
 only_for_targets.switch_variant = "stub"
 source.type = "composite"
-source.packages = [ "omicron-gateway.tar.gz", "dendrite-stub.tar.gz" ]
+source.packages = [ "omicron-gateway.tar.gz", "dendrite-stub.tar.gz", "wicketd.tar.gz", "wicket.tar.gz" ]
 output.type = "zone"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -77,7 +77,7 @@ service_name = "wicketd"
 source.type = "local"
 source.rust.binary_names = ["wicketd"]
 source.rust.release = true
-source.paths = [ { from = "smf/mgs", to = "/var/svc/manifest/site/mgs" } ]
+source.paths = [ { from = "smf/wicketd", to = "/var/svc/manifest/site/wicketd" } ]
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -378,6 +378,7 @@ pub enum ServiceType {
     InternalDns { server_address: SocketAddrV6, dns_address: SocketAddrV6 },
     Oximeter,
     ManagementGatewayService,
+    Wicketd,
     Dendrite { asic: DendriteAsic },
     Tfport { pkt_source: String },
 }
@@ -389,6 +390,7 @@ impl std::fmt::Display for ServiceType {
             ServiceType::InternalDns { .. } => write!(f, "internal_dns"),
             ServiceType::Oximeter => write!(f, "oximeter"),
             ServiceType::ManagementGatewayService => write!(f, "mgs"),
+            ServiceType::Wicketd => write!(f, "wicketd"),
             ServiceType::Dendrite { .. } => write!(f, "dendrite"),
             ServiceType::Tfport { .. } => write!(f, "tfport"),
         }
@@ -412,6 +414,7 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
             }
             St::Oximeter => AutoSt::Oximeter,
             St::ManagementGatewayService => AutoSt::ManagementGatewayService,
+            St::Wicketd => AutoSt::Wicketd,
             St::Dendrite { asic } => AutoSt::Dendrite { asic: asic.into() },
             St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
         }
@@ -497,6 +500,7 @@ impl ServiceZoneRequest {
             ServiceType::ManagementGatewayService => {
                 SRV::Service(ServiceName::ManagementGatewayService)
             }
+            ServiceType::Wicketd => SRV::Service(ServiceName::Wicketd),
             ServiceType::Dendrite { .. } => SRV::Service(ServiceName::Dendrite),
             ServiceType::Tfport { .. } => SRV::Service(ServiceName::Tfport),
         }
@@ -516,6 +520,8 @@ impl ServiceZoneRequest {
             ServiceType::ManagementGatewayService => {
                 Some(SocketAddrV6::new(self.addresses[0], MGS_PORT, 0, 0))
             }
+            // TODO: Is this correct?
+            ServiceType::Wicketd => None,
             ServiceType::Dendrite { .. } => {
                 Some(SocketAddrV6::new(self.addresses[0], DENDRITE_PORT, 0, 0))
             }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -38,13 +38,13 @@ use crate::params::{
 use crate::smf_helper::SmfHelper;
 use crate::zone::Zones;
 use omicron_common::address::Ipv6Subnet;
+use omicron_common::address::BOOTSTRAP_ARTIFACT_PORT;
 use omicron_common::address::DENDRITE_PORT;
 use omicron_common::address::MGS_PORT;
 use omicron_common::address::NEXUS_INTERNAL_PORT;
 use omicron_common::address::OXIMETER_PORT;
 use omicron_common::address::RACK_PREFIX;
 use omicron_common::address::SLED_PREFIX;
-use omicron_common::address::WICKETD_ARTIFACT_PORT;
 use omicron_common::address::WICKETD_PORT;
 use omicron_common::nexus_config::{
     self, DeploymentConfig as NexusDeploymentConfig,
@@ -754,7 +754,7 @@ impl ServiceManager {
                     // TODO: Use bootstrap address
                     smfh.setprop(
                         "config/artifact-address",
-                        &format!("[::1]:{WICKETD_ARTIFACT_PORT}"),
+                        &format!("[::1]:{BOOTSTRAP_ARTIFACT_PORT}"),
                     )?;
 
                     smfh.setprop(
@@ -928,7 +928,11 @@ impl ServiceManager {
 
         let services = match self.inner.stub_scrimlet {
             Some(_) => {
-                vec![ServiceType::Dendrite { asic: DendriteAsic::TofinoStub }]
+                vec![
+                    ServiceType::Dendrite { asic: DendriteAsic::TofinoStub },
+                    ServiceType::ManagementGatewayService,
+                    ServiceType::Wicketd,
+                ]
             }
             None => {
                 vec![

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -44,6 +44,8 @@ use omicron_common::address::NEXUS_INTERNAL_PORT;
 use omicron_common::address::OXIMETER_PORT;
 use omicron_common::address::RACK_PREFIX;
 use omicron_common::address::SLED_PREFIX;
+use omicron_common::address::WICKETD_ARTIFACT_PORT;
+use omicron_common::address::WICKETD_PORT;
 use omicron_common::nexus_config::{
     self, DeploymentConfig as NexusDeploymentConfig,
 };
@@ -739,6 +741,26 @@ impl ServiceManager {
                         )?;
                     }
 
+                    smfh.refresh()?;
+                }
+                ServiceType::Wicketd => {
+                    info!(self.inner.log, "Setting up wicketd service");
+
+                    smfh.setprop(
+                        "config/address",
+                        &format!("[::1]:{WICKETD_PORT}"),
+                    )?;
+
+                    // TODO: Use bootstrap address
+                    smfh.setprop(
+                        "config/artifact-address",
+                        &format!("[::1]:{WICKETD_ARTIFACT_PORT}"),
+                    )?;
+
+                    smfh.setprop(
+                        "config/mgs-address",
+                        &format!("[::1]:{MGS_PORT}"),
+                    )?;
                     smfh.refresh()?;
                 }
                 ServiceType::Dendrite { asic } => {

--- a/smf/wicketd/config.toml
+++ b/smf/wicketd/config.toml
@@ -1,0 +1,11 @@
+#
+# Example wicketd config file
+#
+
+[log]
+# Show log messages of this level and more severe
+level = "debug"
+# Example output to a terminal (with colors)
+mode = "stderr-terminal"
+
+

--- a/smf/wicketd/manifest.xml
+++ b/smf/wicketd/manifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='wicketd'>
+
+<service name='system/illumos/wicketd' type='service' version='1'>
+  <create_default_instance enabled='false' />
+  <single_instance />
+
+  <dependency name='multi_user' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/milestone/multi-user:default' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/wicketd/bin/wicketd run /var/svc/manifest/site/oximeter/config.toml --address %{config/address} --artifact-address %{config/artifact-address} --mgs-port %{config/mgs-port}  &amp;'
+    timeout_seconds='0' />
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='contract' />
+  </property_group>
+
+  <property_group name='config' type='application'>
+    <propval name='address' type='astring' value='unknown' />
+    <propval name='artifact-address" type='astring' value='unknown'
+    <propval name='mgs-address' type='astring' value='unknown' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Wicketd</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Technician Port Management Service</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>

--- a/smf/wicketd/manifest.xml
+++ b/smf/wicketd/manifest.xml
@@ -13,7 +13,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/wicketd/bin/wicketd run /var/svc/manifest/site/oximeter/config.toml --address %{config/address} --artifact-address %{config/artifact-address} --mgs-port %{config/mgs-port}  &amp;'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/wicketd/bin/wicketd run /var/svc/manifest/site/wicketd/config.toml --address %{config/address} --artifact-address %{config/artifact-address} --mgs-address %{config/mgs-address}  &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 

--- a/smf/wicketd/manifest.xml
+++ b/smf/wicketd/manifest.xml
@@ -23,7 +23,7 @@
 
   <property_group name='config' type='application'>
     <propval name='address' type='astring' value='unknown' />
-    <propval name='artifact-address" type='astring' value='unknown'
+    <propval name='artifact-address' type='astring' value='unknown' />
     <propval name='mgs-address' type='astring' value='unknown' />
   </property_group>
 

--- a/wicket/src/dispatch.rs
+++ b/wicket/src/dispatch.rs
@@ -38,7 +38,12 @@ impl WicketApp {
     /// Executes the command.
     pub fn exec(self) -> Result<()> {
         // TODO: make this configurable?
-        let wicketd_addr: SocketAddrV6 = "[::1]:8000".parse().unwrap();
+        // To launch within the switch zone, and as part of a login shell,
+        // we likely have to store this in a config file, which may have to be written
+        // by sled-agent.
+        //
+        // We can't just use a command line-arg because we want to act as a login shells
+        let wicketd_addr: SocketAddrV6 = "[::1]:12226".parse().unwrap();
 
         match self.shell_args {
             Some(shell_args) => {

--- a/wicketd/examples/config.toml
+++ b/wicketd/examples/config.toml
@@ -2,8 +2,6 @@
 # Example wicketd config file
 #
 
-mgs_addr = "[::1]:9999"
-
 [log]
 # Show log messages of this level and more severe
 level = "debug"

--- a/wicketd/src/bin/wicketd.rs
+++ b/wicketd/src/bin/wicketd.rs
@@ -28,6 +28,10 @@ enum Args {
         /// The address on the bootstrap network to serve artifacts at
         #[clap(long, action)]
         artifact_address: SocketAddrV6,
+
+        /// The port on localhost for MGS
+        #[clap(long, action)]
+        mgs_address: SocketAddrV6,
     },
 }
 
@@ -43,7 +47,12 @@ async fn do_run() -> Result<(), CmdError> {
 
     match args {
         Args::Openapi => run_openapi().map_err(CmdError::Failure),
-        Args::Run { config_file_path, address, artifact_address } => {
+        Args::Run {
+            config_file_path,
+            address,
+            artifact_address,
+            mgs_address,
+        } => {
             let config = Config::from_file(&config_file_path).map_err(|e| {
                 CmdError::Failure(format!(
                     "failed to parse {}: {}",
@@ -52,7 +61,7 @@ async fn do_run() -> Result<(), CmdError> {
                 ))
             })?;
 
-            let args = wicketd::Args { address, artifact_address };
+            let args = wicketd::Args { address, artifact_address, mgs_address };
             run_server(config, args).await.map_err(CmdError::Failure)
         }
     }

--- a/wicketd/src/config.rs
+++ b/wicketd/src/config.rs
@@ -7,13 +7,11 @@
 use dropshot::ConfigLogging;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
-use std::net::SocketAddrV6;
 use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
-    pub mgs_addr: SocketAddrV6,
     pub log: ConfigLogging,
 }
 

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -35,6 +35,7 @@ pub fn run_openapi() -> Result<(), String> {
 pub struct Args {
     pub address: SocketAddrV6,
     pub artifact_address: SocketAddrV6,
+    pub mgs_address: SocketAddrV6,
 }
 
 /// Run an instance of the wicketd server
@@ -63,7 +64,7 @@ pub async fn run_server(config: Config, args: Args) -> Result<(), String> {
         ..Default::default()
     };
 
-    let mgs_manager = MgsManager::new(&log, config.mgs_addr);
+    let mgs_manager = MgsManager::new(&log, args.mgs_address);
     let mgs_handle = mgs_manager.get_handle();
     tokio::spawn(async move {
         mgs_manager.run().await;


### PR DESCRIPTION
Package up `wicketd` and `wicket` with omicron-package. I tested this out locally, and it seemed to work.

There are a couple things remaining to do:
 * We need to be able to have the `BOOTSTRAP_ARTIFACT_PORT` listen on a bootstrap address. It's currently hardcoded to use localhost which is wrong. 
 * Should sled-agent construct a config file for wicket so it knows how to contact wicketd? Currently the wicketd port is just hardcoded inside wicket.

The first should probably be done in this PR. The second can likely wait until we figure out how we are going to launch wicket.