### PR TITLE
[tufaceous] add global = true to global arguments

### DIFF
--- a/tufaceous/src/main.rs
+++ b/tufaceous/src/main.rs
@@ -24,14 +24,20 @@ struct Args {
     #[clap(subcommand)]
     command: Command,
 
-    #[clap(short = 'k', long = "key", env = "TUFACEOUS_KEY", required = false)]
+    #[clap(
+        short = 'k',
+        long = "key",
+        env = "TUFACEOUS_KEY",
+        required = false,
+        global = true
+    )]
     keys: Vec<Key>,
 
-    #[clap(long, value_parser = crate::date::parse_duration_or_datetime, default_value = "7d")]
+    #[clap(long, value_parser = crate::date::parse_duration_or_datetime, default_value = "7d", global = true)]
     expiry: DateTime<Utc>,
 
     /// TUF repository path (default: current working directory)
-    #[clap(short = 'r', long)]
+    #[clap(short = 'r', long, global = true)]
     repo: Option<PathBuf>,
 }
 


### PR DESCRIPTION
This lets users specify these arguments as both:

```
tufaceous --repo foo init
```

(this previously worked)

and as:

```
tufaceous init --repo foo
```

(this didn't work previously)
