### PR TITLE
Require `summary` on non-hidden Nexus endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
@@ -1598,7 +1598,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#89f45ecd9bd997cab2a3cc86f622fb658191c6d8"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#9a02dd007ac38cc19823527aae9ca54bdfa759c0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#89f45ecd9bd997cab2a3cc86f622fb658191c6d8"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#9a02dd007ac38cc19823527aae9ca54bdfa759c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2105,7 +2105,7 @@ name = "gateway-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.1",
  "futures",
  "gateway-client",
  "libc",
@@ -2724,7 +2724,7 @@ dependencies = [
  "buf-list",
  "bytes",
  "camino",
- "clap 4.1.4",
+ "clap 4.1.1",
  "ddm-admin-client",
  "display-error-chain",
  "futures",
@@ -2762,7 +2762,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "expectorate",
  "hyper",
@@ -2792,7 +2792,7 @@ name = "internal-dns"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "expectorate",
  "internal-dns-client",
@@ -3652,7 +3652,7 @@ name = "omicron-deploy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.1",
  "crossbeam",
  "omicron-package",
  "omicron-sled-agent",
@@ -3669,7 +3669,7 @@ name = "omicron-gateway"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 4.1.4",
+ "clap 4.1.1",
  "crucible-smf",
  "dropshot",
  "expectorate",
@@ -3713,7 +3713,7 @@ dependencies = [
  "base64 0.21.0",
  "bb8",
  "chrono",
- "clap 4.1.4",
+ "clap 4.1.1",
  "cookie",
  "criterion",
  "crucible-agent-client",
@@ -3803,7 +3803,7 @@ name = "omicron-package"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.1",
  "futures",
  "hex",
  "indicatif",
@@ -3841,7 +3841,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "chrono",
- "clap 4.1.4",
+ "clap 4.1.1",
  "crucible-agent-client",
  "crucible-client-types",
  "ddm-admin-client",
@@ -3901,7 +3901,7 @@ name = "omicron-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "expectorate",
  "futures",
@@ -4161,7 +4161,7 @@ dependencies = [
 name = "oximeter-collector"
 version = "0.1.0"
 dependencies = [
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "expectorate",
  "futures",
@@ -4193,7 +4193,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "itertools",
  "omicron-test-utils",
@@ -4783,7 +4783,7 @@ source = "git+https://github.com/oxidecomputer/progenitor?branch=main#b04c54d792
 dependencies = [
  "anyhow",
  "built",
- "clap 4.1.4",
+ "clap 4.1.1",
  "openapiv3",
  "progenitor-client",
  "progenitor-impl",
@@ -6074,9 +6074,9 @@ dependencies = [
 
 [[package]]
 name = "slog-dtrace"
-version = "0.2.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb79013d51afb48c5159d62068658fa672772be3aeeadee0d2710fb3903f637"
+checksum = "190194b8b00b629b1003daf2a4e40167b7b6b35b00598a131b6b0481205e96a4"
 dependencies = [
  "chrono",
  "serde",
@@ -6212,7 +6212,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.1.4",
+ "clap 4.1.1",
  "dropshot",
  "futures",
  "gateway-messages",
@@ -7007,7 +7007,7 @@ dependencies = [
  "assert_cmd",
  "camino",
  "chrono",
- "clap 4.1.4",
+ "clap 4.1.1",
  "console",
  "fs-err",
  "humantime",
@@ -7514,7 +7514,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "camino",
- "clap 4.1.4",
+ "clap 4.1.1",
  "crossterm 0.26.0",
  "futures",
  "hex",
@@ -7545,7 +7545,7 @@ dependencies = [
  "async-trait",
  "buf-list",
  "bytes",
- "clap 4.1.4",
+ "clap 4.1.1",
  "debug-ignore",
  "dropshot",
  "expectorate",

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -3270,6 +3270,7 @@ async fn instance_serial_console_stream(
     Ok(())
 }
 
+/// List an instance's disks
 #[endpoint {
     method = GET,
     path = "/v1/instances/{instance}/disks",
@@ -3356,6 +3357,7 @@ async fn instance_disk_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Attach a disk to an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances/{instance}/disks/attach",
@@ -3421,6 +3423,7 @@ async fn instance_disk_attach(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// Detach a disk from an instance
 #[endpoint {
     method = POST,
     path = "/v1/instances/{instance}/disks/detach",

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -137,6 +137,15 @@ fn test_nexus_openapi() {
             op.tags.len()
         );
 
+        // Every non-hidden endpoint must have a summary
+        if !op.tags.contains(&"hidden".to_string()) {
+            assert!(
+                op.summary.is_some(),
+                "operation '{}' is missing a summary doc comment",
+                op.operation_id.as_ref().unwrap()
+            );
+        }
+
         ops_by_tag
             .entry(op.tags.first().unwrap().to_string())
             .or_default()

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8001,6 +8001,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "List an instance's disks",
         "operationId": "instance_disk_list_v1",
         "parameters": [
           {
@@ -8079,6 +8080,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Attach a disk to an instance",
         "operationId": "instance_disk_attach_v1",
         "parameters": [
           {
@@ -8139,6 +8141,7 @@
         "tags": [
           "instances"
         ],
+        "summary": "Detach a disk from an instance",
         "operationId": "instance_disk_detach_v1",
         "parameters": [
           {


### PR DESCRIPTION
- add missing summaries to instance disks v1 endpoints
- add test to require non-hidden endpoints to have summaries

It's entirely possible this is easy to do in openapi-lint https://github.com/oxidecomputer/openapi-lint/issues/13 but it's _very_ easy to do here and has a smaller blast radius since we're only requiring it for the external API, so it may actually be preferable.