### PR TITLE
update everything in the docker-image action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,19 +8,18 @@ jobs:
   docker-image:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v2
-      - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -33,7 +32,7 @@ jobs:
         # This pushes a docker image to github's container registry.
         # It is not a public image by default.
         # The docs are here: https://github.com/docker/build-push-action
-        uses: docker/build-push-action@9379083e426e2e84abb80c8c091f5cdeb7d3fd7a
+        uses: docker/build-push-action@v4
         with:
           push: ${{ ! startsWith(github.ref, 'refs/heads/dependabot') }}
           file: ./Dockerfile


### PR DESCRIPTION
I don't know if this will fix the spurious timeouts but it definitely reduces [the long list of deprecation warnings on our current workflow](https://github.com/oxidecomputer/omicron/actions/runs/4047899801).