### PR TITLE
Bump russh to 0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,9 +5303,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.35.0-beta.9"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd075593e0e0880877d9d9c67abf6dbb8bea6cbecc13d2d444d3ca5b20dceea"
+checksum = "cf49b8ecfac8cb6c7798584418beefa051ab0c96a98baf044be3f5a77d8e219d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5338,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.7.0-beta.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89fd30a2ef98dfa621409d5bc56a2479d5810bf13a5eea3de89d859437b7e2e"
+checksum = "c3fdf036c2216b554053d19d4af45c1722d13b00ac494ea19825daf4beac034e"
 dependencies = [
  "libc",
  "winapi",
@@ -5348,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "russh-keys"
-version = "0.23.0-beta.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583adc8a2d6a70b86abb6fb9b0564b85df58198586a7665920d46ffaf7ac383d"
+checksum = "599475db29aa4edb88ed552be752d642f6d78e3a58da0eb9d8953fdc24b028e1"
 dependencies = [
  "aes",
  "bcrypt-pbkdf",

--- a/end-to-end-tests/Cargo.toml
+++ b/end-to-end-tests/Cargo.toml
@@ -13,6 +13,6 @@ omicron-test-utils.workspace = true
 oxide-client = { path = "../oxide-client" }
 rand.workspace = true
 reqwest.workspace = true
-russh = "0.35.0-beta.9"
-russh-keys = "0.23.0-beta.1"
+russh = "0.36.0"
+russh-keys = "0.24.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
#2251 and #2252 need to be applied simultaneously to work.

(I idly wonder if this class of problem will ever work under Dependabot.)