### PR TITLE
Add top level hardware disks list endpoint

### DIFF
--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -110,7 +110,7 @@ impl super::Nexus {
 
     // Physical disks
 
-    pub async fn physical_disks_list(
+    pub async fn sled_list_physical_disks(
         &self,
         opctx: &OpContext,
         sled_id: Uuid,
@@ -119,6 +119,14 @@ impl super::Nexus {
         self.db_datastore
             .sled_list_physical_disks(&opctx, sled_id, pagparams)
             .await
+    }
+
+    pub async fn physical_disk_list(
+        &self,
+        opctx: &OpContext,
+        pagparams: &DataPageParams<'_, Uuid>,
+    ) -> ListResultVec<db::model::PhysicalDisk> {
+        self.db_datastore.physical_disk_list(&opctx, pagparams).await
     }
 
     /// Upserts a physical disk into the database, updating it if it already exists.

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -45,6 +45,8 @@ lazy_static! {
     pub static ref HARDWARE_SLED_URL: String =
         format!("/system/hardware/sleds/{}", SLED_AGENT_UUID);
     pub static ref HARDWARE_DISK_URL: String =
+        format!("/system/hardware/disks");
+    pub static ref HARDWARE_SLED_DISK_URL: String =
         format!("/system/hardware/sleds/{}/disks", SLED_AGENT_UUID);
 
     // Global policy
@@ -1466,6 +1468,13 @@ lazy_static! {
 
         VerifyEndpoint {
             url: &HARDWARE_DISK_URL,
+            visibility: Visibility::Public,
+            unprivileged_access: UnprivilegedAccess::None,
+            allowed_methods: vec![AllowedMethod::Get],
+        },
+
+        VerifyEndpoint {
+            url: &HARDWARE_SLED_DISK_URL,
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -166,7 +166,7 @@ ip_pool_view_by_id                       /system/by-id/ip-pools/{id}
 local_idp_user_create                    /system/silos/{silo_name}/identity-providers/local/users
 local_idp_user_delete                    /system/silos/{silo_name}/identity-providers/local/users/{user_id}
 local_idp_user_set_password              /system/silos/{silo_name}/identity-providers/local/users/{user_id}/set-password
-physical_disks_list                      /system/hardware/sleds/{sled_id}/disks
+physical_disk_list                       /system/hardware/disks
 rack_list                                /system/hardware/racks
 rack_view                                /system/hardware/racks/{rack_id}
 saga_list                                /system/sagas
@@ -184,6 +184,7 @@ silo_users_list                          /system/silos/{silo_name}/users/all
 silo_view                                /system/silos/{silo_name}
 silo_view_by_id                          /system/by-id/silos/{id}
 sled_list                                /system/hardware/sleds
+sled_physical_disk_list                  /system/hardware/sleds/{sled_id}/disks
 sled_view                                /system/hardware/sleds/{sled_id}
 system_component_version_list            /v1/system/update/components
 system_image_create                      /system/images

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5610,6 +5610,63 @@
         }
       }
     },
+    "/system/hardware/disks": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List physical disks",
+        "operationId": "physical_disk_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhysicalDiskResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
     "/system/hardware/racks": {
       "get": {
         "tags": [
@@ -5808,7 +5865,7 @@
           "system"
         ],
         "summary": "List physical disks attached to sleds",
-        "operationId": "physical_disks_list",
+        "operationId": "sled_physical_disk_list",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
For the purpose of inventory we need the ability to list all disks, not just those associated to a given sled. This PR adds a new endpoint to achieve that. 

Once I get to this via V1 I may look at being flexible with the selector as a sort of filter mechanism. 