### PR TITLE
[MGS] Implement component details endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2220180907345c4a0430503a30955aa38ce19a4a#2220180907345c4a0430503a30955aa38ce19a4a"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a97fa5f1d19aa3062e0dfa433a5040161c5d9113#a97fa5f1d19aa3062e0dfa433a5040161c5d9113"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2220180907345c4a0430503a30955aa38ce19a4a#2220180907345c4a0430503a30955aa38ce19a4a"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a97fa5f1d19aa3062e0dfa433a5040161c5d9113#a97fa5f1d19aa3062e0dfa433a5040161c5d9113"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2220180907345c4a0430503a30955aa38ce19a4a", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2220180907345c4a0430503a30955aa38ce19a4a" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a97fa5f1d19aa3062e0dfa433a5040161c5d9113", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a97fa5f1d19aa3062e0dfa433a5040161c5d9113" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -428,8 +428,14 @@ async fn main() -> Result<()> {
                 client.sp_component_list(sp.type_, sp.slot).await?.into_inner();
             dumper.dump(&info)?;
         }
-        Command::ComponentDetails { .. }
-        | Command::ComponentClearStatus { .. } => {
+        Command::ComponentDetails { sp, component } => {
+            let info = client
+                .sp_component_get(sp.type_, sp.slot, &component)
+                .await?
+                .into_inner();
+            dumper.dump(&info)?;
+        }
+        Command::ComponentClearStatus { .. } => {
             todo!("missing MGS endpoint");
         }
         Command::UsartAttach {

--- a/gateway/src/http_entrypoints/component_details.rs
+++ b/gateway/src/http_entrypoints/component_details.rs
@@ -1,0 +1,411 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+// --------------------------------------
+// Monorail port status-related types
+// --------------------------------------
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SpComponentDetails {
+    PortStatus(PortStatus),
+    PortStatusError(PortStatusError),
+    Measurement(Measurement),
+    MeasurementError(MeasurementError),
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub struct PortStatusError {
+    pub port: u32,
+    pub code: PortStatusErrorCode,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum PortStatusErrorCode {
+    Unconfigured,
+    Other { raw: u32 },
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+pub struct PortStatus {
+    pub port: u32,
+    pub cfg: PortConfig,
+    pub link_status: LinkStatus,
+    pub phy_status: Option<PhyStatus>,
+    pub counters: PortCounters,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+pub struct PortConfig {
+    pub mode: PortMode,
+    pub dev_type: PortDev,
+    pub dev_num: u8,
+    pub serdes_type: PortSerdes,
+    pub serdes_num: u8,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PortDev {
+    Dev1g,
+    Dev2g5,
+    Dev10g,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PortSerdes {
+    Serdes1g,
+    Serdes6g,
+    Serdes10g,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "speed", rename_all = "snake_case")]
+pub enum Speed {
+    Speed100M,
+    Speed1G,
+    Speed10G,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum PortMode {
+    Sfi,
+    BaseKr,
+    Sgmii { speed: Speed },
+    Qsgmii { speed: Speed },
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+pub struct PacketCount {
+    pub multicast: u32,
+    pub unicast: u32,
+    pub broadcast: u32,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+pub struct PortCounters {
+    pub rx: PacketCount,
+    pub tx: PacketCount,
+    pub link_down_sticky: bool,
+    pub phy_link_down_sticky: bool,
+}
+
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq,
+)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum LinkStatus {
+    Error,
+    Down,
+    Up,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+pub struct PhyStatus {
+    pub ty: PhyType,
+    pub mac_link_up: LinkStatus,
+    pub media_link_up: LinkStatus,
+}
+
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PhyType {
+    Vsc8504,
+    Vsc8522,
+    Vsc8552,
+    Vsc8562,
+}
+
+impl From<gateway_messages::ComponentDetails> for SpComponentDetails {
+    fn from(details: gateway_messages::ComponentDetails) -> Self {
+        use gateway_messages::ComponentDetails;
+        match details {
+            ComponentDetails::PortStatus(Ok(status)) => {
+                Self::PortStatus(status.into())
+            }
+            ComponentDetails::PortStatus(Err(err)) => {
+                Self::PortStatusError(err.into())
+            }
+            ComponentDetails::Measurement(m) => match m.value {
+                Ok(value) => Self::Measurement(Measurement {
+                    name: m.name,
+                    kind: m.kind.into(),
+                    value,
+                }),
+                Err(err) => Self::MeasurementError(MeasurementError {
+                    name: m.name,
+                    kind: m.kind.into(),
+                    error: err.into(),
+                }),
+            },
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortStatus> for PortStatus {
+    fn from(
+        status: gateway_messages::monorail_port_status::PortStatus,
+    ) -> Self {
+        Self {
+            port: status.port,
+            cfg: status.cfg.into(),
+            link_status: status.link_status.into(),
+            phy_status: status.phy_status.map(Into::into),
+            counters: status.counters.into(),
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortConfig> for PortConfig {
+    fn from(cfg: gateway_messages::monorail_port_status::PortConfig) -> Self {
+        Self {
+            mode: cfg.mode.into(),
+            dev_type: cfg.dev.0.into(),
+            dev_num: cfg.dev.1,
+            serdes_type: cfg.serdes.0.into(),
+            serdes_num: cfg.serdes.1,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortMode> for PortMode {
+    fn from(mode: gateway_messages::monorail_port_status::PortMode) -> Self {
+        use gateway_messages::monorail_port_status::PortMode;
+        match mode {
+            PortMode::Sfi => Self::Sfi,
+            PortMode::BaseKr => Self::BaseKr,
+            PortMode::Sgmii(s) => Self::Sgmii { speed: s.into() },
+            PortMode::Qsgmii(s) => Self::Qsgmii { speed: s.into() },
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::Speed> for Speed {
+    fn from(speed: gateway_messages::monorail_port_status::Speed) -> Self {
+        use gateway_messages::monorail_port_status::Speed;
+        match speed {
+            Speed::Speed100M => Self::Speed100M,
+            Speed::Speed1G => Self::Speed1G,
+            Speed::Speed10G => Self::Speed10G,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortDev> for PortDev {
+    fn from(dev: gateway_messages::monorail_port_status::PortDev) -> Self {
+        use gateway_messages::monorail_port_status::PortDev;
+        match dev {
+            PortDev::Dev1g => Self::Dev1g,
+            PortDev::Dev2g5 => Self::Dev2g5,
+            PortDev::Dev10g => Self::Dev10g,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortSerdes> for PortSerdes {
+    fn from(
+        serdes: gateway_messages::monorail_port_status::PortSerdes,
+    ) -> Self {
+        use gateway_messages::monorail_port_status::PortSerdes;
+        match serdes {
+            PortSerdes::Serdes1g => Self::Serdes1g,
+            PortSerdes::Serdes6g => Self::Serdes6g,
+            PortSerdes::Serdes10g => Self::Serdes10g,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::LinkStatus> for LinkStatus {
+    fn from(
+        status: gateway_messages::monorail_port_status::LinkStatus,
+    ) -> Self {
+        use gateway_messages::monorail_port_status::LinkStatus;
+        match status {
+            LinkStatus::Error => Self::Error,
+            LinkStatus::Down => Self::Down,
+            LinkStatus::Up => Self::Up,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PhyStatus> for PhyStatus {
+    fn from(status: gateway_messages::monorail_port_status::PhyStatus) -> Self {
+        Self {
+            ty: status.ty.into(),
+            mac_link_up: status.mac_link_up.into(),
+            media_link_up: status.media_link_up.into(),
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PhyType> for PhyType {
+    fn from(ty: gateway_messages::monorail_port_status::PhyType) -> Self {
+        use gateway_messages::monorail_port_status::PhyType;
+        match ty {
+            PhyType::Vsc8504 => Self::Vsc8504,
+            PhyType::Vsc8522 => Self::Vsc8522,
+            PhyType::Vsc8552 => Self::Vsc8552,
+            PhyType::Vsc8562 => Self::Vsc8562,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortCounters>
+    for PortCounters
+{
+    fn from(c: gateway_messages::monorail_port_status::PortCounters) -> Self {
+        Self {
+            rx: c.rx.into(),
+            tx: c.tx.into(),
+            link_down_sticky: c.link_down_sticky,
+            phy_link_down_sticky: c.phy_link_down_sticky,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PacketCount> for PacketCount {
+    fn from(c: gateway_messages::monorail_port_status::PacketCount) -> Self {
+        Self {
+            multicast: c.multicast,
+            unicast: c.unicast,
+            broadcast: c.broadcast,
+        }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortStatusError>
+    for PortStatusError
+{
+    fn from(
+        err: gateway_messages::monorail_port_status::PortStatusError,
+    ) -> Self {
+        Self { port: err.port, code: err.code.into() }
+    }
+}
+
+impl From<gateway_messages::monorail_port_status::PortStatusErrorCode>
+    for PortStatusErrorCode
+{
+    fn from(
+        err: gateway_messages::monorail_port_status::PortStatusErrorCode,
+    ) -> Self {
+        use gateway_messages::monorail_port_status::PortStatusErrorCode;
+        match err {
+            PortStatusErrorCode::Unconfigured => Self::Unconfigured,
+            PortStatusErrorCode::Other(raw) => Self::Other { raw },
+        }
+    }
+}
+
+// --------------------------------------
+// Measurement-related types
+// --------------------------------------
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct Measurement {
+    pub name: String,
+    pub kind: MeasurementKind,
+    pub value: f32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct MeasurementError {
+    pub name: String,
+    pub kind: MeasurementKind,
+    pub error: MeasurementErrorCode,
+}
+
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum MeasurementErrorCode {
+    InvalidSensor,
+    NoReading,
+    NotPresent,
+    DeviceError,
+    DeviceUnavailable,
+    DeviceTimeout,
+    DeviceOff,
+}
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MeasurementKind {
+    Temperature,
+    Power,
+    Current,
+    Voltage,
+    InputCurrent,
+    InputVoltage,
+    Speed,
+}
+
+impl From<gateway_messages::measurement::MeasurementKind> for MeasurementKind {
+    fn from(kind: gateway_messages::measurement::MeasurementKind) -> Self {
+        use gateway_messages::measurement::MeasurementKind;
+        match kind {
+            MeasurementKind::Temperature => Self::Temperature,
+            MeasurementKind::Power => Self::Power,
+            MeasurementKind::Current => Self::Current,
+            MeasurementKind::Voltage => Self::Voltage,
+            MeasurementKind::InputCurrent => Self::InputCurrent,
+            MeasurementKind::InputVoltage => Self::InputVoltage,
+            MeasurementKind::Speed => Self::Speed,
+        }
+    }
+}
+
+impl From<gateway_messages::measurement::MeasurementError>
+    for MeasurementErrorCode
+{
+    fn from(err: gateway_messages::measurement::MeasurementError) -> Self {
+        use gateway_messages::measurement::MeasurementError;
+        match err {
+            MeasurementError::InvalidSensor => Self::InvalidSensor,
+            MeasurementError::NoReading => Self::NoReading,
+            MeasurementError::NotPresent => Self::NotPresent,
+            MeasurementError::DeviceError => Self::DeviceError,
+            MeasurementError::DeviceUnavailable => Self::DeviceUnavailable,
+            MeasurementError::DeviceTimeout => Self::DeviceTimeout,
+            MeasurementError::DeviceOff => Self::DeviceOff,
+        }
+    }
+}

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -325,7 +325,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SpComponentInfo"
+                  "title": "Array_of_SpComponentDetails",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SpComponentDetails"
+                  }
                 }
               }
             }
@@ -1017,6 +1021,612 @@
           "verbose"
         ]
       },
+      "LinkStatus": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "error"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "down"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "up"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        ]
+      },
+      "MeasurementErrorCode": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "invalid_sensor"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "no_reading"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "not_present"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "device_error"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "device_unavailable"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "device_timeout"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "device_off"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          }
+        ]
+      },
+      "MeasurementKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "temperature"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "power"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "current"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "voltage"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "input_current"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "input_voltage"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "speed"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          }
+        ]
+      },
+      "PacketCount": {
+        "type": "object",
+        "properties": {
+          "broadcast": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "multicast": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "unicast": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "broadcast",
+          "multicast",
+          "unicast"
+        ]
+      },
+      "PhyStatus": {
+        "type": "object",
+        "properties": {
+          "mac_link_up": {
+            "$ref": "#/components/schemas/LinkStatus"
+          },
+          "media_link_up": {
+            "$ref": "#/components/schemas/LinkStatus"
+          },
+          "ty": {
+            "$ref": "#/components/schemas/PhyType"
+          }
+        },
+        "required": [
+          "mac_link_up",
+          "media_link_up",
+          "ty"
+        ]
+      },
+      "PhyType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsc8504"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsc8522"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsc8552"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsc8562"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "PortConfig": {
+        "type": "object",
+        "properties": {
+          "dev_num": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "dev_type": {
+            "$ref": "#/components/schemas/PortDev"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PortMode"
+          },
+          "serdes_num": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "serdes_type": {
+            "$ref": "#/components/schemas/PortSerdes"
+          }
+        },
+        "required": [
+          "dev_num",
+          "dev_type",
+          "mode",
+          "serdes_num",
+          "serdes_type"
+        ]
+      },
+      "PortCounters": {
+        "type": "object",
+        "properties": {
+          "link_down_sticky": {
+            "type": "boolean"
+          },
+          "phy_link_down_sticky": {
+            "type": "boolean"
+          },
+          "rx": {
+            "$ref": "#/components/schemas/PacketCount"
+          },
+          "tx": {
+            "$ref": "#/components/schemas/PacketCount"
+          }
+        },
+        "required": [
+          "link_down_sticky",
+          "phy_link_down_sticky",
+          "rx",
+          "tx"
+        ]
+      },
+      "PortDev": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dev1g"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dev2g5"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dev10g"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "PortMode": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "sfi"
+                ]
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "base_kr"
+                ]
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "sgmii"
+                ]
+              },
+              "speed": {
+                "$ref": "#/components/schemas/Speed"
+              }
+            },
+            "required": [
+              "mode",
+              "speed"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "qsgmii"
+                ]
+              },
+              "speed": {
+                "$ref": "#/components/schemas/Speed"
+              }
+            },
+            "required": [
+              "mode",
+              "speed"
+            ]
+          }
+        ]
+      },
+      "PortSerdes": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "serdes1g"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "serdes6g"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "serdes10g"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "PortStatusErrorCode": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "unconfigured"
+                ]
+              }
+            },
+            "required": [
+              "code"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "other"
+                ]
+              },
+              "raw": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "code",
+              "raw"
+            ]
+          }
+        ]
+      },
       "PowerState": {
         "description": "See RFD 81.\n\nThis enum only lists power states the SP is able to control; higher power states are controlled by ignition.",
         "type": "string",
@@ -1024,6 +1634,127 @@
           "A0",
           "A1",
           "A2"
+        ]
+      },
+      "SpComponentDetails": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "cfg": {
+                "$ref": "#/components/schemas/PortConfig"
+              },
+              "counters": {
+                "$ref": "#/components/schemas/PortCounters"
+              },
+              "link_status": {
+                "$ref": "#/components/schemas/LinkStatus"
+              },
+              "phy_status": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PhyStatus"
+                  }
+                ]
+              },
+              "port": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "port_status"
+                ]
+              }
+            },
+            "required": [
+              "cfg",
+              "counters",
+              "link_status",
+              "port",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "code": {
+                "$ref": "#/components/schemas/PortStatusErrorCode"
+              },
+              "port": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "port_status_error"
+                ]
+              }
+            },
+            "required": [
+              "code",
+              "port",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "$ref": "#/components/schemas/MeasurementKind"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "measurement"
+                ]
+              },
+              "value": {
+                "type": "number",
+                "format": "float"
+              }
+            },
+            "required": [
+              "kind",
+              "name",
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "$ref": "#/components/schemas/MeasurementErrorCode"
+              },
+              "kind": {
+                "$ref": "#/components/schemas/MeasurementKind"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "measurement_error"
+                ]
+              }
+            },
+            "required": [
+              "error",
+              "kind",
+              "name",
+              "type"
+            ]
+          }
         ]
       },
       "SpComponentFirmwareSlot": {
@@ -1532,6 +2263,52 @@
               "code",
               "id",
               "state"
+            ]
+          }
+        ]
+      },
+      "Speed": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "speed": {
+                "type": "string",
+                "enum": [
+                  "speed100_m"
+                ]
+              }
+            },
+            "required": [
+              "speed"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "speed": {
+                "type": "string",
+                "enum": [
+                  "speed1_g"
+                ]
+              }
+            },
+            "required": [
+              "speed"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "speed": {
+                "type": "string",
+                "enum": [
+                  "speed10_g"
+                ]
+              }
+            },
+            "required": [
+              "speed"
             ]
           }
         ]

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -535,6 +535,34 @@ impl SpHandler for Handler {
         Err(SpError::RequestUnsupportedForSp)
     }
 
+    fn serial_console_break(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError> {
+        warn!(
+            &self.log,
+            "received serial console break; not supported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn send_host_nmi(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError> {
+        warn!(
+            &self.log,
+            "received host NMI request; not supported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
     fn sp_state(
         &mut self,
         sender: SocketAddrV6,


### PR DESCRIPTION
This allows us to fetch things like monorail port status information:

```
bash% curl -s http://[::1]:12345/sp/switch/0/component/monorail | jq
[
  {
    "type": "port_status",
    "port": 0,
    "cfg": {
      "mode": {
        "mode": "sgmii",
        "speed": {
          "speed": "speed100_m"
        }
      },
      "dev_type": {
        "type": "dev1g"
      },
      "dev_num": 0,
      "serdes_type": {
        "type": "serdes1g"
      },
      "serdes_num": 1
    },
    "link_status": {
      "status": "down"
    },
    "phy_status": null,
    "counters": {
      "rx": {
        "multicast": 0,
        "unicast": 0,
        "broadcast": 0
      },
      "tx": {
        "multicast": 4636081,
        "unicast": 2,
        "broadcast": 0
      },
      "link_down_sticky": true,
      "phy_link_down_sticky": false
    }
  },
  ... repeated for the rest of the ports ...
```

and current sensor readings for any devices that have them:

```
# use JQ to find the first couple devices with capabilities == 2; this really ought to be `capabilities & 2 == 2` but bitwise ops in jq don't exist, I think?
bash% curl -s http://[::1]:12345/sp/sled/19/component | jq 'limit(2; .components | .[] | select(.capabilities == 2))'
{
  "component": "dev-0",
  "device": "tmp117",
  "serial_number": null,
  "description": "Southwest temperature sensor",
  "capabilities": 2,
  "presence": "present"
}
{
  "component": "dev-1",
  "device": "tmp117",
  "serial_number": null,
  "description": "South temperature sensor",
  "capabilities": 2,
  "presence": "present"
}

# fetch the details of those two components
bash% curl -s http://[::1]:12345/sp/sled/19/component/dev-0
[{"type":"measurement","name":"Southwest","kind":{"kind":"temperature"},"value":30.5}]
bash% curl -s http://[::1]:12345/sp/sled/19/component/dev-1
[{"type":"measurement","name":"South","kind":{"kind":"temperature"},"value":30.679688}]
```

This builds on #2284 and should be merged after it. It's not nearly as large as the diff implies: the vast majority of that is changes to the OpenAPI spec, and the majority of what's left after that is `From` impls.