### PR TITLE
[MGS] Add "component clear status" endpoint

### DIFF
--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -435,8 +435,10 @@ async fn main() -> Result<()> {
                 .into_inner();
             dumper.dump(&info)?;
         }
-        Command::ComponentClearStatus { .. } => {
-            todo!("missing MGS endpoint");
+        Command::ComponentClearStatus { sp, component } => {
+            client
+                .sp_component_clear_status(sp.type_, sp.slot, &component)
+                .await?;
         }
         Command::UsartAttach {
             sp,

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -452,6 +452,53 @@
         }
       }
     },
+    "/sp/{type}/{slot}/component/{component}/clear-status": {
+      "post": {
+        "summary": "Clear status of a component",
+        "description": "For components that maintain event counters (e.g., the sidecar `monorail`), this will reset the event counters to zero.",
+        "operationId": "sp_component_clear_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/component/{component}/serial-console/attach": {
       "get": {
         "summary": "Upgrade into a websocket connection attached to the given SP component's",


### PR DESCRIPTION
This is currently only useful with the `monorail` component of a sidecar's SP, for which it resets the packet counters for each port.

Builds on #2285 and should be merged after it.