### PR TITLE
[MGS] Add endpoints to set and clear the installinator image ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "clap 4.1.4",
  "futures",
  "gateway-client",
+ "hex",
  "libc",
  "reqwest",
  "serde",
@@ -2138,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a97fa5f1d19aa3062e0dfa433a5040161c5d9113#a97fa5f1d19aa3062e0dfa433a5040161c5d9113"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2153,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a97fa5f1d19aa3062e0dfa433a5040161c5d9113#a97fa5f1d19aa3062e0dfa433a5040161c5d9113"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2849,6 +2850,14 @@ checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "ipcc-key-value"
+version = "0.1.0"
+dependencies = [
+ "ciborium",
+ "serde",
 ]
 
 [[package]]
@@ -3686,6 +3695,7 @@ name = "omicron-gateway"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "clap 4.1.4",
  "crucible-smf",
  "dropshot",
@@ -3696,6 +3706,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "ipcc-key-value",
  "omicron-common",
  "omicron-test-utils",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=482bae9bfa704282e981008abae9328344150d36#482bae9bfa704282e981008abae9328344150d36"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=installinator-id-plumbing#98af0bb6cae8f5aedb6c2180ea05f9bfc8e18a68"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=482bae9bfa704282e981008abae9328344150d36#482bae9bfa704282e981008abae9328344150d36"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,9 @@ name = "ipcc-key-value"
 version = "0.1.0"
 dependencies = [
  "ciborium",
+ "proptest",
  "serde",
+ "test-strategy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], branch = "installinator-id-plumbing" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", branch = "installinator-id-plumbing" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "482bae9bfa704282e981008abae9328344150d36" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "482bae9bfa704282e981008abae9328344150d36" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "installinator-artifactd",
     "internal-dns",
     "internal-dns-client",
+    "ipcc-key-value",
     "nexus",
     "nexus-client",
     "nexus/authz-macros",
@@ -58,6 +59,7 @@ default-members = [
     "installinator-artifactd",
     "internal-dns",
     "internal-dns-client",
+    "ipcc-key-value",
     "nexus",
     "nexus-client",
     "nexus/authz-macros",
@@ -104,6 +106,7 @@ bincode = "1.3.3"
 buf-list = "0.1.3"
 bytes = "1.3.0"
 camino = "1.1"
+ciborium = "0.2.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.1", features = ["derive"] }
@@ -126,8 +129,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a97fa5f1d19aa3062e0dfa433a5040161c5d9113", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a97fa5f1d19aa3062e0dfa433a5040161c5d9113" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], branch = "installinator-id-plumbing" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", branch = "installinator-id-plumbing" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"
@@ -140,6 +143,7 @@ installinator-artifactd = { path = "installinator-artifactd" }
 installinator-artifact-client = { path = "installinator-artifact-client" }
 internal-dns = { path = "internal-dns" }
 internal-dns-client = { path = "internal-dns-client" }
+ipcc-key-value = { path = "ipcc-key-value" }
 ipnetwork = "0.20"
 itertools = "0.10.5"
 lazy_static = "1.4.0"

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 anyhow.workspace = true
 clap.workspace = true
 futures.workspace = true
+hex.workspace = true
 libc.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use clap::Subcommand;
 use gateway_client::types::HostStartupOptions;
 use gateway_client::types::IgnitionCommand;
+use gateway_client::types::InstallinatorImageId;
 use gateway_client::types::PowerState;
 use gateway_client::types::SpComponentFirmwareSlot;
 use gateway_client::types::SpIdentifier;
@@ -127,6 +128,32 @@ enum Command {
         boot_net: bool,
         #[clap(long, requires = "set")]
         startup_verbose: bool,
+    },
+
+    /// Set the installinator image ID IPCC key/value.
+    SetInstallinatorImageId {
+        /// Target SP (e.g., 'sled/7', 'switch/1', 'power/0')
+        #[clap(value_parser = sp_identifier_from_str, action)]
+        sp: SpIdentifier,
+        /// Clear any previously-set ID.
+        #[clap(long)]
+        clear: bool,
+        /// Hash of the host OS image.
+        #[clap(
+            long,
+            value_parser = sha256_from_str,
+            conflicts_with = "clear",
+            required_unless_present = "clear",
+        )]
+        host_os: Option<[u8; 32]>,
+        /// Hash of the control plane image.
+        #[clap(
+            long,
+            value_parser = sha256_from_str,
+            conflicts_with = "clear",
+            required_unless_present = "clear",
+        )]
+        control_plane: Option<[u8; 32]>,
     },
 
     /// Ask SP for its inventory.
@@ -263,6 +290,12 @@ fn level_from_str(s: &str) -> Result<Level> {
     } else {
         bail!(format!("Invalid log level: {}", s))
     }
+}
+
+fn sha256_from_str(s: &str) -> Result<[u8; 32]> {
+    hex::FromHex::from_hex(s).map_err(|err| {
+        anyhow!("failed to parse {s:?} as a sha256 digest: {err}")
+    })
 }
 
 fn sp_identifier_from_str(s: &str) -> Result<SpIdentifier> {
@@ -421,6 +454,29 @@ async fn main() -> Result<()> {
                     .await?
                     .into_inner();
                 dumper.dump(&info)?;
+            }
+        }
+        Command::SetInstallinatorImageId {
+            sp,
+            clear,
+            host_os,
+            control_plane,
+        } => {
+            if clear {
+                client
+                    .sp_installinator_image_id_delete(sp.type_, sp.slot)
+                    .await?;
+            } else {
+                // clap guarantees these are not `None`.
+                let host_os = host_os.unwrap().to_vec();
+                let control_plane = control_plane.unwrap().to_vec();
+                client
+                    .sp_installinator_image_id_set(
+                        sp.type_,
+                        sp.slot,
+                        &InstallinatorImageId { host_os, control_plane },
+                    )
+                    .await?;
             }
         }
         Command::Inventory { sp } => {

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -145,7 +145,7 @@ enum Command {
             conflicts_with = "clear",
             required_unless_present = "clear",
         )]
-        host_os: Option<[u8; 32]>,
+        host_phase_2: Option<[u8; 32]>,
         /// Hash of the control plane image.
         #[clap(
             long,
@@ -459,7 +459,7 @@ async fn main() -> Result<()> {
         Command::SetInstallinatorImageId {
             sp,
             clear,
-            host_os,
+            host_phase_2,
             control_plane,
         } => {
             if clear {
@@ -468,13 +468,13 @@ async fn main() -> Result<()> {
                     .await?;
             } else {
                 // clap guarantees these are not `None`.
-                let host_os = host_os.unwrap().to_vec();
+                let host_phase_2 = host_phase_2.unwrap().to_vec();
                 let control_plane = control_plane.unwrap().to_vec();
                 client
                     .sp_installinator_image_id_set(
                         sp.type_,
                         sp.slot,
-                        &InstallinatorImageId { host_os, control_plane },
+                        &InstallinatorImageId { host_phase_2, control_plane },
                     )
                     .await?;
             }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 async-trait.workspace = true
+ciborium.workspace = true
 clap.workspace = true
 crucible-smf.workspace = true
 dropshot.workspace = true
@@ -15,6 +16,7 @@ gateway-sp-comms.workspace = true
 hex.workspace = true
 http.workspace = true
 hyper.workspace = true
+ipcc-key-value.workspace = true
 omicron-common.workspace = true
 once_cell.workspace = true
 schemars.workspace = true

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -397,12 +397,18 @@ pub struct ImageVersion {
     pub version: u32,
 }
 
+// This type is a duplicate of the type in `ipcc-key-value`, and we provide a
+// `From<_>` impl to convert to it. We keep these types distinct to allow us to
+// choose different representations for MGS's HTTP API (this type) and the wire
+// format passed through the SP to installinator
+// (`ipcc_key_value::InstallinatorImageId`), although _currently_ they happen to
+// be defined identically.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
 pub struct InstallinatorImageId {
-    pub host_os: [u8; 32],
+    pub host_phase_2: [u8; 32],
     pub control_plane: [u8; 32],
 }
 

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -397,6 +397,15 @@ pub struct ImageVersion {
     pub version: u32,
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub struct InstallinatorImageId {
+    pub host_os: [u8; 32],
+    pub control_plane: [u8; 32],
+}
+
 /// Identifier for an SP's component's firmware slot; e.g., slots 0 and 1 for
 /// the host boot flash.
 #[derive(
@@ -1094,6 +1103,58 @@ async fn sp_power_state_set(
     Ok(HttpResponseUpdatedNoContent {})
 }
 
+/// Set the installinator image ID the sled should use for recovery.
+///
+/// This value can be read by the host via IPCC; see the `ipcc-key-value` crate.
+#[endpoint {
+    method = PUT,
+    path = "/sp/{type}/{slot}/ipcc/installinator-image-id",
+}]
+async fn sp_installinator_image_id_set(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    path: Path<PathSp>,
+    body: TypedBody<InstallinatorImageId>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    use ipcc_key_value::Key;
+
+    let apictx = rqctx.context();
+    let sp = apictx.mgmt_switch.sp(path.into_inner().sp.into())?;
+
+    let image_id =
+        ipcc_key_value::InstallinatorImageId::from(body.into_inner());
+
+    sp.set_ipcc_key_lookup_value(
+        Key::InstallinatorImageId as u8,
+        image_id.serialize(),
+    )
+    .await
+    .map_err(SpCommsError::from)?;
+
+    Ok(HttpResponseUpdatedNoContent {})
+}
+
+/// Clear any previously-set installinator image ID on the target sled.
+#[endpoint {
+    method = DELETE,
+    path = "/sp/{type}/{slot}/ipcc/installinator-image-id",
+}]
+async fn sp_installinator_image_id_delete(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    path: Path<PathSp>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    use ipcc_key_value::Key;
+
+    let apictx = rqctx.context();
+    let sp = apictx.mgmt_switch.sp(path.into_inner().sp.into())?;
+
+    // We clear the image ID by setting it to a 0-length vec.
+    sp.set_ipcc_key_lookup_value(Key::InstallinatorImageId as u8, Vec::new())
+        .await
+        .map_err(SpCommsError::from)?;
+
+    Ok(HttpResponseUpdatedNoContent {})
+}
+
 /// Upload a host phase2 image that can be served to recovering hosts via the
 /// host/SP control uart.
 ///
@@ -1154,6 +1215,8 @@ pub fn api() -> GatewayApiDescription {
         api.register(sp_reset)?;
         api.register(sp_power_state_get)?;
         api.register(sp_power_state_set)?;
+        api.register(sp_installinator_image_id_set)?;
+        api.register(sp_installinator_image_id_delete)?;
         api.register(sp_component_list)?;
         api.register(sp_component_get)?;
         api.register(sp_component_clear_status)?;

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -9,6 +9,7 @@
 use super::HostStartupOptions;
 use super::IgnitionCommand;
 use super::ImageVersion;
+use super::InstallinatorImageId;
 use super::PowerState;
 use super::RotImageDetails;
 use super::RotSlot;
@@ -360,5 +361,11 @@ impl From<StartupOptions> for HostStartupOptions {
             boot_net: opt.contains(StartupOptions::STARTUP_BOOT_NET),
             verbose: opt.contains(StartupOptions::STARTUP_VERBOSE),
         }
+    }
+}
+
+impl From<InstallinatorImageId> for ipcc_key_value::InstallinatorImageId {
+    fn from(id: InstallinatorImageId) -> Self {
+        Self { host_os: id.host_os, control_plane: id.control_plane }
     }
 }

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -366,6 +366,6 @@ impl From<StartupOptions> for HostStartupOptions {
 
 impl From<InstallinatorImageId> for ipcc_key_value::InstallinatorImageId {
     fn from(id: InstallinatorImageId) -> Self {
-        Self { host_os: id.host_os, control_plane: id.control_plane }
+        Self { host_phase_2: id.host_phase_2, control_plane: id.control_plane }
     }
 }

--- a/ipcc-key-value/Cargo.toml
+++ b/ipcc-key-value/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ipcc-key-value"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+ciborium.workspace = true
+serde.workspace = true

--- a/ipcc-key-value/Cargo.toml
+++ b/ipcc-key-value/Cargo.toml
@@ -7,3 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 ciborium.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+test-strategy.workspace = true

--- a/ipcc-key-value/src/lib.rs
+++ b/ipcc-key-value/src/lib.rs
@@ -30,8 +30,8 @@ pub enum Key {
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
 pub struct InstallinatorImageId {
-    /// SHA-256 hash of the host OS image to fetch.
-    pub host_os: [u8; 32],
+    /// SHA-256 hash of the host phase 2 image to fetch.
+    pub host_phase_2: [u8; 32],
     /// SHA-256 hash of the control plane image to fetch.
     pub control_plane: [u8; 32],
 }

--- a/ipcc-key-value/src/lib.rs
+++ b/ipcc-key-value/src/lib.rs
@@ -29,6 +29,7 @@ pub enum Key {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct InstallinatorImageId {
     /// SHA-256 hash of the host phase 2 image to fetch.
     pub host_phase_2: [u8; 32],
@@ -101,3 +102,137 @@ impl InstallinatorImageId {
 // `Key::InstallinatorImageId`, but we might grow other keys for other clients,
 // at which point we probably want all the ioctl wrapping to happen in one
 // place.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn installinator_image_id_round_trip(image_id: InstallinatorImageId) {
+        let serialized = image_id.serialize();
+        assert_eq!(
+            InstallinatorImageId::deserialize(&serialized),
+            Ok(image_id)
+        );
+    }
+
+    #[proptest]
+    fn serialized_max_size(image_id: InstallinatorImageId) {
+        // Double-check that ciborium is encoding this how we expect. Our
+        // serialized size should be:
+        //
+        // 1. 1 byte to identify a map
+        // 2. 1 byte + strlen for each key
+        // 3. 2 bytes for each 32-long array
+        // 4. 1 or 2 bytes per `u8` in each array, where the number depends on
+        //    the value of the byte
+        //
+        // The absolute cap assuming 2 bytes per `u8` in step 4 is therefore:
+        const MAX_SIZE: usize = 1 // map
+            + 1 + "host_phase_2".len() // key
+            + 1 + "control_plane".len() // key
+            + 2 * ( // 2 arrays
+                2 + // "32-long array"
+                32 * 2 // 32 bytes, 1-2 bytes each
+            );
+
+        let serialized = image_id.serialize();
+        assert!(serialized.len() <= MAX_SIZE);
+    }
+
+    #[test]
+    fn deserialize_fixed_value() {
+        // Encoding an `InstallinatorImageId` at https://cbor.me with the
+        // host_phase_2 hash [1, 2, ..., 32] and the control_plane hash [33, 34,
+        // ..., 64]:
+        const SERIALIZED: &[u8] = &[
+            0xA2, // map(2)
+            0x6C, // text(12)
+            0x68, 0x6F, 0x73, 0x74, 0x5F, 0x70, 0x68, 0x61, 0x73, 0x65, 0x5F,
+            0x32, // "host_phase_2"
+            0x98, 0x20, // array(32)
+            0x01, // unsigned(1)
+            0x02, // unsigned(2)
+            0x03, // unsigned(3)
+            0x04, // unsigned(4)
+            0x05, // unsigned(5)
+            0x06, // unsigned(6)
+            0x07, // unsigned(7)
+            0x08, // unsigned(8)
+            0x09, // unsigned(9)
+            0x0A, // unsigned(10)
+            0x0B, // unsigned(11)
+            0x0C, // unsigned(12)
+            0x0D, // unsigned(13)
+            0x0E, // unsigned(14)
+            0x0F, // unsigned(15)
+            0x10, // unsigned(16)
+            0x11, // unsigned(17)
+            0x12, // unsigned(18)
+            0x13, // unsigned(19)
+            0x14, // unsigned(20)
+            0x15, // unsigned(21)
+            0x16, // unsigned(22)
+            0x17, // unsigned(23)
+            0x18, 0x18, // unsigned(24)
+            0x18, 0x19, // unsigned(25)
+            0x18, 0x1A, // unsigned(26)
+            0x18, 0x1B, // unsigned(27)
+            0x18, 0x1C, // unsigned(28)
+            0x18, 0x1D, // unsigned(29)
+            0x18, 0x1E, // unsigned(30)
+            0x18, 0x1F, // unsigned(31)
+            0x18, 0x20, // unsigned(32)
+            0x6D, // text(13)
+            0x63, 0x6F, 0x6E, 0x74, 0x72, 0x6F, 0x6C, 0x5F, 0x70, 0x6C, 0x61,
+            0x6E, 0x65, // "control_plane"
+            0x98, 0x20, // array(32)
+            0x18, 0x21, // unsigned(33)
+            0x18, 0x22, // unsigned(34)
+            0x18, 0x23, // unsigned(35)
+            0x18, 0x24, // unsigned(36)
+            0x18, 0x25, // unsigned(37)
+            0x18, 0x26, // unsigned(38)
+            0x18, 0x27, // unsigned(39)
+            0x18, 0x28, // unsigned(40)
+            0x18, 0x29, // unsigned(41)
+            0x18, 0x2A, // unsigned(42)
+            0x18, 0x2B, // unsigned(43)
+            0x18, 0x2C, // unsigned(44)
+            0x18, 0x2D, // unsigned(45)
+            0x18, 0x2E, // unsigned(46)
+            0x18, 0x2F, // unsigned(47)
+            0x18, 0x30, // unsigned(48)
+            0x18, 0x31, // unsigned(49)
+            0x18, 0x32, // unsigned(50)
+            0x18, 0x33, // unsigned(51)
+            0x18, 0x34, // unsigned(52)
+            0x18, 0x35, // unsigned(53)
+            0x18, 0x36, // unsigned(54)
+            0x18, 0x37, // unsigned(55)
+            0x18, 0x38, // unsigned(56)
+            0x18, 0x39, // unsigned(57)
+            0x18, 0x3A, // unsigned(58)
+            0x18, 0x3B, // unsigned(59)
+            0x18, 0x3C, // unsigned(60)
+            0x18, 0x3D, // unsigned(61)
+            0x18, 0x3E, // unsigned(62)
+            0x18, 0x3F, // unsigned(63)
+            0x18, 0x40, // unsigned(64)
+        ];
+
+        let expected = InstallinatorImageId {
+            host_phase_2: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+            control_plane: [
+                33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+            ],
+        };
+
+        assert_eq!(InstallinatorImageId::deserialize(SERIALIZED), Ok(expected));
+    }
+}

--- a/ipcc-key-value/src/lib.rs
+++ b/ipcc-key-value/src/lib.rs
@@ -25,7 +25,6 @@ pub enum Key {
 
 /// Description of the images `installinator` needs to fetch from a peer on the
 /// bootstrap network during sled recovery.
-// TODO this may need more or different fields
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
@@ -37,13 +36,12 @@ pub struct InstallinatorImageId {
     pub control_plane: [u8; 32],
 }
 
-// TODO the existence of these methods is a _little_ dubious:
-// `InstallinatorImageId` is `pub` and implements `Serialize + Deserialize`, so
-// any caller could choose to serialize/deserialize an instance with any
-// serde serializer/deserializer already. However, in our case MGS will be
-// serializing and installinator will be deserializing, so I think it makes
-// sense that both of those can call these functions to keep the choice of
-// encoding in one place.
+// The existence of these methods is a _little_ dubious: `InstallinatorImageId`
+// is `pub` and implements `Serialize + Deserialize`, so any caller could choose
+// to serialize/deserialize an instance with any serde serializer/deserializer
+// already. However, in our case MGS will be serializing and installinator will
+// be deserializing, so I think it makes sense that both of those can call these
+// functions to keep the choice of encoding in one place.
 impl InstallinatorImageId {
     pub fn serialize(&self) -> Vec<u8> {
         use ciborium::ser::Error;

--- a/ipcc-key-value/src/lib.rs
+++ b/ipcc-key-value/src/lib.rs
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Utilities for key/value pairs passed from the control plane to the SP
+//! (through MGS) to the host (through the host/SP uart) via IPCC.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Supported keys.
+///
+/// The numeric values of these keys should match the definitions in the SP
+/// `host-sp-comms` task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum Key {
+    /// Always responds `"pong"`.
+    Ping = 0,
+    /// The value should be an encoded [`InstallinatorImageId`].
+    InstallinatorImageId = 1,
+}
+
+/// Description of the images `installinator` needs to fetch from a peer on the
+/// bootstrap network during sled recovery.
+// TODO this may need more or different fields
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct InstallinatorImageId {
+    /// SHA-256 hash of the host OS image to fetch.
+    pub host_os: [u8; 32],
+    /// SHA-256 hash of the control plane image to fetch.
+    pub control_plane: [u8; 32],
+}
+
+// TODO the existence of these methods is a _little_ dubious:
+// `InstallinatorImageId` is `pub` and implements `Serialize + Deserialize`, so
+// any caller could choose to serialize/deserialize an instance with any
+// serde serializer/deserializer already. However, in our case MGS will be
+// serializing and installinator will be deserializing, so I think it makes
+// sense that both of those can call these functions to keep the choice of
+// encoding in one place.
+impl InstallinatorImageId {
+    pub fn serialize(&self) -> Vec<u8> {
+        use ciborium::ser::Error;
+
+        let mut out = Vec::new();
+
+        // Serializing is infallible:
+        //
+        // a) `Vec`'s `io::Write` implementation is infallible, so we can't get
+        //    `Error::Io(_)`
+        // b) We know `InstallinatorImageId` can be represented and serialized
+        //    by ciborium, so we can't get `Error::Value(_)`.
+        //
+        // so we mark both of those cases as `unreachable!()`.
+        match ciborium::ser::into_writer(self, &mut out) {
+            Ok(()) => out,
+            Err(Error::Io(err)) => {
+                unreachable!("i/o error appending to Vec: {err}");
+            }
+            Err(Error::Value(err)) => {
+                unreachable!("failed to serialize an image ID: {err}");
+            }
+        }
+    }
+
+    pub fn deserialize(data: &[u8]) -> Result<Self, String> {
+        use ciborium::de::Error;
+
+        // ciborium deserialization errors aren't super useful; their
+        // `Display` impl just forwards to `Debug` formatting, and we don't
+        // expect callers to be able to meaningfully handle the distinction
+        // between these cases. We'll squish all of these cases down to just an
+        // error string.
+        match ciborium::de::from_reader(data) {
+            Ok(value) => Ok(value),
+            Err(Error::Io(err)) => {
+                unreachable!("i/o error reading from slice: {err}")
+            }
+            Err(Error::Syntax(offset)) => {
+                Err(format!("syntax error at offset {offset}"))
+            }
+            Err(Error::Semantic(Some(offset), description)) => {
+                Err(format!("semantic error: {description} (offset {offset})"))
+            }
+            Err(Error::Semantic(None, description)) => {
+                Err(format!("semantic error: {description} (offset unknown)"))
+            }
+            Err(Error::RecursionLimitExceeded) => {
+                Err("recursion limit exceeded".to_string())
+            }
+        }
+    }
+}
+
+// TODO Add ioctl wrappers? `installinator` is the only client for
+// `Key::InstallinatorImageId`, but we might grow other keys for other clients,
+// at which point we probably want all the ioctl wrapping to happen in one
+// place.

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -1183,7 +1183,7 @@
             "minItems": 32,
             "maxItems": 32
           },
-          "host_os": {
+          "host_phase_2": {
             "type": "array",
             "items": {
               "type": "integer",
@@ -1196,7 +1196,7 @@
         },
         "required": [
           "control_plane",
-          "host_os"
+          "host_phase_2"
         ]
       },
       "LinkStatus": {

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -760,6 +760,89 @@
         }
       }
     },
+    "/sp/{type}/{slot}/ipcc/installinator-image-id": {
+      "put": {
+        "summary": "Set the installinator image ID the sled should use for recovery.",
+        "description": "This value can be read by the host via IPCC; see the `ipcc-key-value` crate.",
+        "operationId": "sp_installinator_image_id_set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallinatorImageId"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Clear any previously-set installinator image ID on the target sled.",
+        "operationId": "sp_installinator_image_id_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/power-state": {
       "get": {
         "summary": "Get the current power state of a sled via its SP.",
@@ -1085,6 +1168,35 @@
         "required": [
           "epoch",
           "version"
+        ]
+      },
+      "InstallinatorImageId": {
+        "type": "object",
+        "properties": {
+          "control_plane": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 32,
+            "maxItems": 32
+          },
+          "host_os": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 32,
+            "maxItems": 32
+          }
+        },
+        "required": [
+          "control_plane",
+          "host_os"
         ]
       },
       "LinkStatus": {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1120,4 +1120,22 @@ impl SpHandler for Handler {
             "data_len" => data.len(),
         );
     }
+
+    fn set_ipcc_key_lookup_value(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        key: u8,
+        value: &[u8],
+    ) -> Result<(), SpError> {
+        warn!(
+            &self.log,
+            "received IPCC key/value; not supported by simulated gimlet";
+            "sender" => %sender,
+            "port" => ?port,
+            "key" => key,
+            "value" => ?value,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
 }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -910,6 +910,24 @@ impl SpHandler for Handler {
             "data_len" => data.len(),
         );
     }
+
+    fn set_ipcc_key_lookup_value(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+        key: u8,
+        value: &[u8],
+    ) -> Result<(), SpError> {
+        warn!(
+            &self.log,
+            "received IPCC key/value; not supported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+            "key" => key,
+            "value" => ?value,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
 }
 
 struct FakeIgnition {


### PR DESCRIPTION
This ID is stored in memory on the SP, and can be retrieved by userland programs (installinator) via `ioctl`.

This depends on https://github.com/oxidecomputer/management-gateway-service/pull/58 (and currently points to that branch), but I wanted to get this open to get any feedback that might affect that work before merging it.

One thing I really hemmed and hawed over what: how far up the stack do we take an opaque blob? Neither MGS nor the SP really care about the contents of the installinator image ID; they're both just acting as a conduit. Where I landed was:

1. The SP just stores an opaque blob. This has to have a maximum length; I set it to 512 bytes for now, but we can revisit if that seems wrong (in either direction).
2. The MGS/SP protocol also traffics in opaque blobs, along with the integer key (shared with the IPCC ioctl) identifying it. This shows up in this PR as the calls to `sp.set_ipcc_key_lookup_value(key, bytes)`.
3. MGS exposes a typed endpoint specifically for the installinator image ID; this is where we convert from strongly-typed to "CBOR-encoded blob".

MGS could itself accept "integer key and binary blob", or "enum key and binary blob", but that's messier on the client side, I think - nexus/wicketd would then be responsible for encoding the image ID. I tried this first and didn't like it, but am open to revisiting.

Because this split expects MGS to encode and installinator to decode, I put those together in a new crate (`ipcc-key-value`, happy to bikeshed the name) that both can depend on. I did not make any changes to installinator to use this.