### PR TITLE
Create separate underlay and bootstrap etherstubs

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1125,7 +1125,10 @@ impl ServiceManager {
 mod test {
     use super::*;
     use crate::illumos::{
-        dladm::{Etherstub, MockDladm, ETHERSTUB_NAME, ETHERSTUB_VNIC_NAME},
+        dladm::{
+            Etherstub, MockDladm, UNDERLAY_ETHERSTUB_NAME,
+            UNDERLAY_ETHERSTUB_VNIC_NAME,
+        },
         svc,
         zone::MockZones,
     };
@@ -1142,7 +1145,7 @@ mod test {
         let create_vnic_ctx = MockDladm::create_vnic_context();
         create_vnic_ctx.expect().return_once(
             |physical_link: &Etherstub, _, _, _| {
-                assert_eq!(&physical_link.0, &ETHERSTUB_NAME);
+                assert_eq!(&physical_link.0, &UNDERLAY_ETHERSTUB_NAME);
                 Ok(())
             },
         );
@@ -1281,8 +1284,8 @@ mod test {
 
         let mgr = ServiceManager::new(
             log,
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )
@@ -1316,8 +1319,8 @@ mod test {
 
         let mgr = ServiceManager::new(
             log,
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )
@@ -1353,8 +1356,8 @@ mod test {
         // down.
         let mgr = ServiceManager::new(
             logctx.log.clone(),
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )
@@ -1379,8 +1382,8 @@ mod test {
         let _expectations = expect_new_service();
         let mgr = ServiceManager::new(
             logctx.log.clone(),
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )
@@ -1413,8 +1416,8 @@ mod test {
         // down.
         let mgr = ServiceManager::new(
             logctx.log.clone(),
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )
@@ -1441,8 +1444,8 @@ mod test {
         // Observe that the old service is not re-initialized.
         let mgr = ServiceManager::new(
             logctx.log.clone(),
-            Etherstub(ETHERSTUB_NAME.to_string()),
-            EtherstubVnic(ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
+            EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             None,
             "rev-test".to_string(),
         )

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -214,8 +214,10 @@ impl SledAgent {
         ));
         info!(&log, "created sled agent");
 
-        let etherstub =
-            Dladm::ensure_etherstub().map_err(|e| Error::Etherstub(e))?;
+        let etherstub = Dladm::ensure_etherstub(
+            crate::illumos::dladm::UNDERLAY_ETHERSTUB_NAME,
+        )
+        .map_err(|e| Error::Etherstub(e))?;
         let etherstub_vnic = Dladm::ensure_etherstub_vnic(&etherstub)
             .map_err(|e| Error::EtherstubVnic(e))?;
 
@@ -670,11 +672,15 @@ impl SledAgent {
     }
 }
 
-// Delete all underlay addresses created directly over the etherstub VNIC used
+// Delete all underlay addresses created directly over the etherstub VNICs used
 // for inter-zone communications.
 fn delete_etherstub_addresses(log: &Logger) -> Result<(), Error> {
-    let prefix = format!("{}/", crate::illumos::dladm::ETHERSTUB_VNIC_NAME);
-    delete_addresses_matching_prefixes(log, &[prefix])
+    let underlay_prefix =
+        format!("{}/", crate::illumos::dladm::UNDERLAY_ETHERSTUB_VNIC_NAME);
+    let bootstrap_prefix =
+        format!("{}/", crate::illumos::dladm::BOOTSTRAP_ETHERSTUB_VNIC_NAME);
+    delete_addresses_matching_prefixes(log, &[underlay_prefix])?;
+    delete_addresses_matching_prefixes(log, &[bootstrap_prefix])
 }
 
 fn delete_underlay_addresses(log: &Logger) -> Result<(), Error> {
@@ -746,12 +752,18 @@ async fn delete_omicron_vnics(log: &Logger) -> Result<(), Error> {
 
 // Delete the etherstub and underlay VNIC used for interzone communication
 fn delete_etherstub(log: &Logger) -> Result<(), Error> {
-    use crate::illumos::dladm::ETHERSTUB_NAME;
-    use crate::illumos::dladm::ETHERSTUB_VNIC_NAME;
-    warn!(log, "Deleting Omicron underlay VNIC"; "vnic_name" => ETHERSTUB_VNIC_NAME);
-    Dladm::delete_etherstub_vnic()?;
-    warn!(log, "Deleting Omicron etherstub"; "stub_name" => ETHERSTUB_NAME);
-    Dladm::delete_etherstub()?;
+    use crate::illumos::dladm::BOOTSTRAP_ETHERSTUB_NAME;
+    use crate::illumos::dladm::BOOTSTRAP_ETHERSTUB_VNIC_NAME;
+    use crate::illumos::dladm::UNDERLAY_ETHERSTUB_NAME;
+    use crate::illumos::dladm::UNDERLAY_ETHERSTUB_VNIC_NAME;
+    warn!(log, "Deleting Omicron underlay VNIC"; "vnic_name" => UNDERLAY_ETHERSTUB_VNIC_NAME);
+    Dladm::delete_etherstub_vnic(UNDERLAY_ETHERSTUB_VNIC_NAME)?;
+    warn!(log, "Deleting Omicron underlay etherstub"; "stub_name" => UNDERLAY_ETHERSTUB_NAME);
+    Dladm::delete_etherstub(UNDERLAY_ETHERSTUB_NAME)?;
+    warn!(log, "Deleting Omicron bootstrap VNIC"; "vnic_name" => BOOTSTRAP_ETHERSTUB_VNIC_NAME);
+    Dladm::delete_etherstub_vnic(BOOTSTRAP_ETHERSTUB_VNIC_NAME)?;
+    warn!(log, "Deleting Omicron bootstrap etherstub"; "stub_name" => BOOTSTRAP_ETHERSTUB_NAME);
+    Dladm::delete_etherstub(BOOTSTRAP_ETHERSTUB_NAME)?;
     Ok(())
 }
 

--- a/sled-agent/src/sp/simulated.rs
+++ b/sled-agent/src/sp/simulated.rs
@@ -5,7 +5,7 @@
 //! Implementation of a simulated SP / RoT.
 
 use super::SpError;
-use crate::illumos::dladm::Dladm;
+use crate::illumos::dladm::{Dladm, UNDERLAY_ETHERSTUB_NAME};
 use crate::zone::Zones;
 use slog::Logger;
 use sp_sim::config::GimletConfig;
@@ -60,8 +60,8 @@ impl SimulatedSp {
             }
 
             // Ensure we have the global zone IP address we need for the SP.
-            let etherstub =
-                Dladm::ensure_etherstub().map_err(SpError::CreateEtherstub)?;
+            let etherstub = Dladm::ensure_etherstub(UNDERLAY_ETHERSTUB_NAME)
+                .map_err(SpError::CreateEtherstub)?;
             let etherstub_vnic = Dladm::ensure_etherstub_vnic(&etherstub)
                 .map_err(SpError::CreateEtherstubVnic)?;
             Zones::ensure_has_global_zone_v6_address(


### PR DESCRIPTION
VNICs used across zones shared a single etherstub. This commit changes
it so that the bootstrap and underlay networks no longer share an
etherstub, and therefore are no longer on the same L2 network.

All service zones have VNICs on the underlay network. A new VNIC for the
bootstrap network will be added to the switch network in a follow up.

Fixes https://github.com/oxidecomputer/omicron/issues/2297