### PR TITLE
Add Bootstrap vnic and address to switch zone

### DIFF
--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -8,8 +8,7 @@ use clap::Parser;
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
 use omicron_sled_agent::bootstrap::{
-    agent::bootstrap_address, config::Config as BootstrapConfig,
-    server as bootstrap_server,
+    config::Config as BootstrapConfig, server as bootstrap_server,
 };
 use omicron_sled_agent::rack_setup::config::SetupServiceConfig as RssConfig;
 use omicron_sled_agent::sp::SimSpConfig;

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -674,12 +674,12 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn test_mac_to_socket_addr() {
+    fn test_mac_to_bootstrap_ip() {
         let mac = MacAddr("a8:40:25:10:00:01".parse::<MacAddr6>().unwrap());
 
         assert_eq!(
-            mac_to_socket_addr(mac, 1, BOOTSTRAP_AGENT_PORT).ip(),
-            &"fdb0:a840:2510:1::1".parse::<Ipv6Addr>().unwrap(),
+            mac_to_bootstrap_ip(mac, 1),
+            "fdb0:a840:2510:1::1".parse::<Ipv6Addr>().unwrap(),
         );
     }
 

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -171,11 +171,12 @@ impl Agent {
 
         // The only zone with a bootstrap ip address besides the global zone,
         // is the switch zone. We allocate this address here since we have
-        // access to the  physical link. This also allows us to keep bootstrap
+        // access to the physical link. This also allows us to keep bootstrap
         // address allocation in one place.
         //
         // If other zones end up needing bootstrap addresses, we'll have to
-        // rethink this strategy.
+        // rethink this strategy, and plumb bootstrap adresses similar to
+        // underlay addresses.
         let switch_zone_bootstrap_address = bootstrap_ip(link, 2)?;
 
         // We expect this directory to exist - ensure that it does, before any

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -183,7 +183,7 @@ impl Agent {
                 err,
             })?;
 
-        let etherstub = Dladm::ensure_etherstub(
+        let bootstrap_etherstub = Dladm::ensure_etherstub(
             crate::illumos::dladm::BOOTSTRAP_ETHERSTUB_NAME,
         )
         .map_err(|e| {
@@ -193,19 +193,18 @@ impl Agent {
             ))
         })?;
 
-        // TODO: Create a vnic for the switch zone over the boostrap etherstub
-        // TODO: Create an address using bootstrap address for the switch zone,
-        // with ip ::2
-        let etherstub_vnic =
-            Dladm::ensure_etherstub_vnic(&etherstub).map_err(|e| {
-                BootstrapError::SledError(format!(
-                    "Can't access etherstub VNIC device: {}",
-                    e
-                ))
-            })?;
+        let bootstrap_etherstub_vnic = Dladm::ensure_etherstub_vnic(
+            &bootstrap_etherstub,
+        )
+        .map_err(|e| {
+            BootstrapError::SledError(format!(
+                "Can't access etherstub VNIC device: {}",
+                e
+            ))
+        })?;
 
         Zones::ensure_has_global_zone_v6_address(
-            etherstub_vnic.clone(),
+            bootstrap_etherstub_vnic.clone(),
             *address.ip(),
             "bootstrap6",
         )
@@ -247,6 +246,7 @@ impl Agent {
             &sled_config,
             underlay_etherstub,
             underlay_etherstub_vnic,
+            bootstrap_etherstub,
         )
         .await?;
 

--- a/sled-agent/src/bootstrap/config.rs
+++ b/sled-agent/src/bootstrap/config.rs
@@ -4,11 +4,11 @@
 
 //! Interfaces for working with bootstrap agent configuration
 
+use crate::illumos::dladm::PhysicalLink;
 use crate::sp::SimSpConfig;
 use dropshot::ConfigLogging;
 use serde::Deserialize;
 use serde::Serialize;
-use std::net::SocketAddrV6;
 use uuid::Uuid;
 
 pub const BOOTSTRAP_AGENT_PORT: u16 = 12346;
@@ -17,10 +17,8 @@ pub const BOOTSTRAP_AGENT_PORT: u16 = 12346;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Config {
     pub id: Uuid,
-    pub bind_address: SocketAddrV6,
+    pub link: PhysicalLink,
     pub log: ConfigLogging,
-
     pub rss_config: Option<crate::rack_setup::config::SetupServiceConfig>,
-
     pub sp_config: Option<SimSpConfig>,
 }

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -134,7 +134,6 @@ impl HardwareMonitor {
             HardwareManager::new(log.clone(), sled_config.stub_scrimlet)
                 .map_err(|e| Error::Hardware(e))?;
 
-        // TODO: Add the etherstub for the bootstrap network here
         let service_manager = ServiceManager::new(
             log.clone(),
             underlay_etherstub.clone(),

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -124,17 +124,20 @@ impl HardwareMonitor {
     pub async fn new(
         log: &Logger,
         sled_config: &SledConfig,
-        etherstub: Etherstub,
-        etherstub_vnic: EtherstubVnic,
+        underlay_etherstub: Etherstub,
+        underlay_etherstub_vnic: EtherstubVnic,
+        bootstrap_etherstub: Etherstub,
     ) -> Result<Self, Error> {
         let hardware =
             HardwareManager::new(log.clone(), sled_config.stub_scrimlet)
                 .map_err(|e| Error::Hardware(e))?;
 
+        // TODO: Add the etherstub for the bootstrap network here
         let service_manager = ServiceManager::new(
             log.clone(),
-            etherstub.clone(),
-            etherstub_vnic.clone(),
+            underlay_etherstub.clone(),
+            underlay_etherstub_vnic.clone(),
+            bootstrap_etherstub,
             sled_config.stub_scrimlet,
             sled_config.sidecar_revision.clone(),
         )

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -9,6 +9,7 @@ use crate::hardware::HardwareManager;
 use crate::illumos::dladm::{Etherstub, EtherstubVnic};
 use crate::services::ServiceManager;
 use slog::Logger;
+use std::net::Ipv6Addr;
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -127,6 +128,7 @@ impl HardwareMonitor {
         underlay_etherstub: Etherstub,
         underlay_etherstub_vnic: EtherstubVnic,
         bootstrap_etherstub: Etherstub,
+        switch_zone_bootstrap_address: Ipv6Addr,
     ) -> Result<Self, Error> {
         let hardware =
             HardwareManager::new(log.clone(), sled_config.stub_scrimlet)
@@ -140,6 +142,7 @@ impl HardwareMonitor {
             bootstrap_etherstub,
             sled_config.stub_scrimlet,
             sled_config.sidecar_revision.clone(),
+            switch_zone_bootstrap_address,
         )
         .await?;
 

--- a/sled-agent/src/illumos/dladm.rs
+++ b/sled-agent/src/illumos/dladm.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 
 pub const VNIC_PREFIX: &str = "ox";
 pub const VNIC_PREFIX_CONTROL: &str = "oxControl";
+pub const VNIC_PREFIX_BOOTSTRAP: &str = "oxBootstrap";
 
 /// Prefix used to name VNICs over xde devices / OPTE ports.
 // TODO-correctness: Remove this when `xde` devices can be directly used beneath

--- a/sled-agent/src/illumos/link.rs
+++ b/sled-agent/src/illumos/link.rs
@@ -71,6 +71,12 @@ impl<DL: VnicSource + Clone> VnicAllocator<DL> {
         }
     }
 
+    pub fn new_bootstrap(&self) -> Result<Link, CreateVnicError> {
+        let name = self.next();
+        Dladm::create_vnic(&self.data_link, &name, None, None)?;
+        Ok(Link { name, deleted: false, kind: LinkKind::OxideBootstrapVnic })
+    }
+
     /// Allocates a new VNIC name, which should be unique within the
     /// scope of this allocator.
     fn next(&self) -> String {
@@ -89,6 +95,7 @@ pub enum LinkKind {
     Physical,
     OxideControlVnic,
     GuestVnic,
+    OxideBootstrapVnic,
 }
 
 impl LinkKind {

--- a/sled-agent/src/illumos/link.rs
+++ b/sled-agent/src/illumos/link.rs
@@ -6,7 +6,7 @@
 
 use crate::illumos::dladm::{
     CreateVnicError, DeleteVnicError, VnicSource, VNIC_PREFIX,
-    VNIC_PREFIX_CONTROL, VNIC_PREFIX_GUEST,
+    VNIC_PREFIX_BOOTSTRAP, VNIC_PREFIX_CONTROL, VNIC_PREFIX_GUEST,
 };
 use omicron_common::api::external::MacAddr;
 use std::sync::{
@@ -106,6 +106,8 @@ impl LinkKind {
             Some(LinkKind::OxideControlVnic)
         } else if name.starts_with(VNIC_PREFIX_GUEST) {
             Some(LinkKind::GuestVnic)
+        } else if name.starts_with(VNIC_PREFIX_BOOTSTRAP) {
+            Some(LinkKind::OxideBootstrapVnic)
         } else {
             None
         }

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -632,12 +632,12 @@ impl Zones {
             )
             .map_err(|err| anyhow!(err))?;
 
-            // Ensure that a static IPv6 address has been allocated
-            // to the Global Zone. Without this, we don't have a way
-            // to route to IP addresses that we want to create in
-            // the non-GZ. Note that we use a `/64` prefix, as all addresses
-            // allocated for services on this sled itself are within the underlay
-            // prefix. Anything else must be routed through Sidecar.
+            // Ensure that a static IPv6 address has been allocated to the
+            // Global Zone. Without this, we don't have a way to route to IP
+            // addresses that we want to create in the non-GZ. Note that we
+            // use a `/64` prefix, as all addresses allocated for services on
+            // this sled itself are within the underlay or bootstrap prefix.
+            // Anything else must be routed through Sidecar.
             Self::ensure_address(
                 None,
                 &gz_link_local_addrobj

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -87,7 +87,7 @@ pub enum GetControlInterfaceError {
 }
 
 /// Errors from [`Zones::get_bootstrap_interface`].
-/// Error which may be returned accessing the control interface of a zone.
+/// Error which may be returned accessing the bootstrap interface of a zone.
 #[derive(thiserror::Error, Debug)]
 pub enum GetBootstrapInterfaceError {
     #[error("Failed to query zone '{zone}' for control interface: {err}")]
@@ -100,7 +100,9 @@ pub enum GetBootstrapInterfaceError {
     #[error("VNIC starting with 'oxBootstrap' not found in {zone}")]
     NotFound { zone: String },
 
-    #[error("VNIC starting with 'oxBootstrap' found non-switch zone: {zone}")]
+    #[error(
+        "VNIC starting with 'oxBootstrap' found in non-switch zone: {zone}"
+    )]
     Unexpected { zone: String },
 }
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -581,6 +581,7 @@ impl Instance {
             opte_ports,
             // physical_nic=
             None,
+            None,
             vec![],
         )
         .await?;

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1176,8 +1176,8 @@ mod test {
     use super::*;
     use crate::illumos::{
         dladm::{
-            Etherstub, MockDladm, UNDERLAY_ETHERSTUB_NAME,
-            UNDERLAY_ETHERSTUB_VNIC_NAME,
+            Etherstub, MockDladm, BOOTSTRAP_ETHERSTUB_NAME,
+            UNDERLAY_ETHERSTUB_NAME, UNDERLAY_ETHERSTUB_VNIC_NAME,
         },
         svc,
         zone::MockZones,
@@ -1186,6 +1186,9 @@ mod test {
     use std::net::Ipv6Addr;
     use std::os::unix::process::ExitStatusExt;
     use uuid::Uuid;
+
+    // Just a placeholder. Not used.
+    const SWITCH_ZONE_BOOTSTRAP_IP: Ipv6Addr = Ipv6Addr::LOCALHOST;
 
     const EXPECTED_ZONE_NAME: &str = "oxz_oximeter";
 
@@ -1336,8 +1339,10 @@ mod test {
             log,
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();
@@ -1371,8 +1376,10 @@ mod test {
             log,
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();
@@ -1408,8 +1415,10 @@ mod test {
             logctx.log.clone(),
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();
@@ -1434,8 +1443,10 @@ mod test {
             logctx.log.clone(),
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();
@@ -1468,8 +1479,10 @@ mod test {
             logctx.log.clone(),
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();
@@ -1496,8 +1509,10 @@ mod test {
             logctx.log.clone(),
             Etherstub(UNDERLAY_ETHERSTUB_NAME.to_string()),
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
+            Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             None,
             "rev-test".to_string(),
+            SWITCH_ZONE_BOOTSTRAP_IP,
         )
         .await
         .unwrap();

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -500,6 +500,7 @@ async fn ensure_running_zone(
                 &[],
                 vec![],
                 None,
+                None,
                 vec![],
             )
             .await?;


### PR DESCRIPTION
Add a bootstrap vnic (over the bootstrap etherstub in the global zone) to the switch zone, along with a bootstrap IP address that can be listened on by the wicketd artifact server. The wicketd artifact server is used for serving OS and host images, and a follow up change will be made for it to listen on the bootstrap server. 

Currently we don't expect any other zones besides the switch and global zone to have access to the bootstrap network. Therefore we keep address allocation and plumbing minimal for now.