### PR TITLE
[wicket] Make escape key contextual

### DIFF
--- a/wicket/src/screens/component.rs
+++ b/wicket/src/screens/component.rs
@@ -233,7 +233,7 @@ impl ComponentScreen {
                 if self.help_menu_state.is_closed() {
                     return vec![Action::SwitchScreen(ScreenId::Rack)];
                 } else {
-                    self.help_menu_state.toggle();
+                    self.help_menu_state.close();
                 }
             }
             _ => (),

--- a/wicket/src/screens/component.rs
+++ b/wicket/src/screens/component.rs
@@ -40,7 +40,7 @@ impl ComponentScreen {
         let help_data = vec![
             ("<TAB>", "Cycle forward through components"),
             ("<SHIFT>-<TAB>", "Cycle backwards through components"),
-            ("<ESC>", "Go back to the rack screen"),
+            ("<ESC>", "Exit help menu | Go back to the rack screen"),
             ("<CTRL-r>", "Go back to the rack screen"),
             ("<CTRL-h>", "Toggle this help menu"),
             ("<CTRL-c>", "Exit the program"),
@@ -226,6 +226,13 @@ impl ComponentScreen {
             }
             KeyCode::Char('h') => {
                 if event.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.help_menu_state.toggle();
+                }
+            }
+            KeyCode::Esc => {
+                if self.help_menu_state.is_closed() {
+                    return vec![Action::SwitchScreen(ScreenId::Rack)];
+                } else {
                     self.help_menu_state.toggle();
                 }
             }

--- a/wicket/src/screens/rack.rs
+++ b/wicket/src/screens/rack.rs
@@ -172,7 +172,7 @@ impl RackScreen {
                 if self.help_menu_state.is_closed() {
                     state.rack_state.clear_tab_index();
                 } else {
-                    self.help_menu_state.toggle();
+                    self.help_menu_state.close();
                 }
             }
             KeyCode::Enter => {

--- a/wicket/src/screens/rack.rs
+++ b/wicket/src/screens/rack.rs
@@ -39,7 +39,7 @@ impl RackScreen {
             ("<TAB>", "Cycle forward through components"),
             ("<SHIFT>-<TAB>", "Cycle backwards through components"),
             ("<Enter> | left mouse click", "Select hovered object"),
-            ("<ESC>", "Reset the TabIndex of the Rack"),
+            ("<ESC>", "Exit help menu | Reset the TabIndex of the Rack"),
             ("<CTRL-h>", "Toggle this help menu"),
             ("<CTRL-c>", "Exit the program"),
         ];
@@ -169,7 +169,11 @@ impl RackScreen {
                 state.rack_state.dec_tab_index();
             }
             KeyCode::Esc => {
-                state.rack_state.clear_tab_index();
+                if self.help_menu_state.is_closed() {
+                    state.rack_state.clear_tab_index();
+                } else {
+                    self.help_menu_state.toggle();
+                }
             }
             KeyCode::Enter => {
                 if state.rack_state.tab_index.is_set() {


### PR DESCRIPTION
If the help menu is open in a screen close it when escape is pressed. When the help menu is closed, perform the screen default op.

Fixes #2336