### PR TITLE
Merge `version` and `version_sort`

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1573,18 +1573,13 @@ CREATE TABLE omicron.public.system_update (
     -- this resource different from every other resource for little benefit.
 
     -- Unique semver version
-    version STRING(64) NOT NULL, -- TODO: length
-    -- version string with maj/min/patch 0-padded to be string sortable
-    version_sort STRING(64) NOT NULL -- TODO: length
+    version STRING(64) NOT NULL -- TODO: length
 );
 
 CREATE UNIQUE INDEX ON omicron.public.system_update (
     version
 );
 
-CREATE UNIQUE INDEX ON omicron.public.system_update (
-    version_sort
-);
  
 CREATE TYPE omicron.public.updateable_component_type AS ENUM (
     'bootloader_for_rot',
@@ -1668,8 +1663,6 @@ CREATE TABLE omicron.public.updateable_component (
     -- This may need to be nullable if we are registering components before we
     -- know about system versions at all
     system_version STRING(64) NOT NULL, -- TODO: length
-    -- version string with maj/min/patch 0-padded to be string sortable
-    system_version_sort STRING(64) NOT NULL, -- TODO: length
 
     status omicron.public.update_status NOT NULL
     -- TODO: status reason for updateable_component
@@ -1681,7 +1674,7 @@ CREATE UNIQUE INDEX ON omicron.public.updateable_component (
 );
 
 CREATE INDEX ON omicron.public.updateable_component (
-    system_version_sort
+    system_version
 );
 
 /*

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -706,7 +706,6 @@ table! {
         time_modified -> Timestamptz,
 
         version -> Text,
-        version_sort -> Text,
     }
 }
 
@@ -742,7 +741,6 @@ table! {
         device_id -> Text,
         version -> Text,
         system_version -> Text,
-        system_version_sort -> Text,
         component_type -> crate::UpdateableComponentTypeEnum,
         status -> crate::UpdateStatusEnum,
         // TODO: status reason for updateable_component

--- a/nexus/db-model/src/semver_version.rs
+++ b/nexus/db-model/src/semver_version.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 // We wrap semver::Version in external to impl JsonSchema, and we wrap it again
 // here to impl ToSql/FromSql
 
+/// Semver version with zero-padded numbers in `ToSql`/`FromSql` to allow
+/// lexicographic DB sorting
 #[derive(
     Clone,
     Debug,
@@ -31,56 +33,92 @@ pub struct SemverVersion(pub external::SemverVersion);
 NewtypeFrom! { () pub struct SemverVersion(external::SemverVersion); }
 NewtypeDeref! { () pub struct SemverVersion(external::SemverVersion); }
 
-const MAX_VERSION_NUM: u64 = 99999999;
+/// Width of version numbers after zero-padding. `u8` because you can always
+/// convert to both `u32` and `usize`. Everything having to do with ser/de on
+/// the version strings below is derived from this value, so in order to
+/// increase or decrease the padding amount, you only have to change this (and
+/// the tests).
+const PADDED_WIDTH: u8 = 8;
 
 impl SemverVersion {
     pub fn new(major: u64, minor: u64, patch: u64) -> Self {
         Self(external::SemverVersion(semver::Version::new(major, minor, patch)))
     }
+}
 
-    /// Generate a string with 0s padding the numbers so the result is
-    /// lexicographically sortable. 0.1.2 -> 00000000.00000001.00000002.
-    ///
-    /// This requires that we impose a maximum size on each of the numbers so as
-    /// not to exceed the available number of digits. See TODO for this
-    /// validation logic.
-    ///
-    /// An important caveat is that while lexicographic sort with padding does
-    /// work for the maj/min/patch part of the version string, it does not
-    /// technically satisfy the semver spec's rules for sorting pre-release and
-    /// build metadata. Build metadata is supposed to be ignored. Pre-release
-    /// has more complicated rules, most notably that a version *with* a
-    /// pre-lease string on it has lower precedence than one *without*. See:
-    /// <https://semver.org/#spec-item-11>. We have decided this is tolerable for
-    /// now. We can revisit later if necessary.
-    ///
-    /// Compare to the `Display` implementation on Semver::Version
-    /// <https://github.com/dtolnay/semver/blob/7fd09f7/src/display.rs>
-    pub fn to_sortable_string(self) -> Result<String, external::Error> {
-        let v = &self.0 .0;
+/// Pad the version numbers with zeros so the result is lexicographically
+/// sortable, e.g., `0.1.2` becomes `00000000.00000001.00000002`.
+///
+/// This requires that we impose a maximum size on each of the numbers so as not
+/// to exceed the available number of digits.
+///
+/// An important caveat is that while lexicographic sort with padding does work
+/// for the numeric part of the version string, it does not technically satisfy
+/// the semver spec's rules for sorting pre-release and build metadata. Build
+/// metadata is supposed to be ignored. Pre-release has more complicated rules,
+/// most notably that a version *with* a pre-release string on it has lower
+/// precedence than one *without*. See: <https://semver.org/#spec-item-11>. We
+/// have decided sorting these wrong is tolerable for now. We can revisit later
+/// if necessary.
+///
+/// Compare to the `Display` implementation on `Semver::Version`
+/// <https://github.com/dtolnay/semver/blob/7fd09f7/src/display.rs>
+fn to_sortable_string(v: semver::Version) -> Result<String, external::Error> {
+    // the largest N-digit number is 10^N - 1
+    let max = u64::pow(10, u32::from(PADDED_WIDTH)) - 1;
 
-        if v.major > MAX_VERSION_NUM
-            || v.minor > MAX_VERSION_NUM
-            || v.patch > MAX_VERSION_NUM
-        {
-            return Err(external::Error::InvalidValue {
-                label: "version".to_string(),
-                message: format!("Major, minor, and patch version must be less than {MAX_VERSION_NUM}"),
-            });
-        }
-
-        let mut result =
-            format!("{:0>8}.{:0>8}.{:0>8}", v.major, v.minor, v.patch);
-
-        if !v.pre.is_empty() {
-            result.push_str(&format!("-{}", v.pre));
-        }
-        if !v.build.is_empty() {
-            result.push_str(&format!("+{}", v.build));
-        }
-
-        Ok(result)
+    if v.major > max || v.minor > max || v.patch > max {
+        return Err(external::Error::InvalidValue {
+            label: "version".to_string(),
+            message: format!(
+                "Major, minor, and patch version must be less than {max}"
+            ),
+        });
     }
+
+    let mut result = format!(
+        "{:0>0width$}.{:0>0width$}.{:0>0width$}",
+        v.major,
+        v.minor,
+        v.patch,
+        width = usize::from(PADDED_WIDTH)
+    );
+
+    if !v.pre.is_empty() {
+        result.push_str(&format!("-{}", v.pre));
+    }
+    if !v.build.is_empty() {
+        result.push_str(&format!("+{}", v.build));
+    }
+
+    Ok(result)
+}
+
+/// Take the zero padding back out of the semver string. Assume that it's a
+/// valid semver string aside from the padding, because we wrote it ourselves.
+/// If it's not, the resulting string will fail `semver::Version`'s rather
+/// strict parser.
+fn from_sortable_string(s: String) -> String {
+    // if there's no - or +, we use length as the split idx so rest = ""
+    let delim_idx = s.find(&['-', '+']).unwrap_or_else(|| s.len());
+    let (nums, rest) = s.split_at(delim_idx);
+
+    // we split `rest` off first because otherwise the "" => "0" trick below
+    // would not work
+
+    let nums = nums
+        .split('.')
+        // Turn `"0010"` into `"10"` and `"0000"` into `"0"`
+        .map(|s| match s.trim_start_matches('0') {
+            // assuming, as we are, that the string is non-empty, the only way
+            // we end up with an empty string is if it was all zeros
+            "" => "0",
+            x => x,
+        })
+        .collect::<Vec<_>>()
+        .join(".");
+
+    format!("{}{}", nums, rest)
 }
 
 impl<DB> ToSql<sql_types::Text, DB> for SemverVersion
@@ -92,7 +130,8 @@ where
         &'a self,
         out: &mut serialize::Output<'a, '_, DB>,
     ) -> serialize::Result {
-        (self.0).0.to_string().to_sql(&mut out.reborrow())
+        let v = (self.0).0.to_owned();
+        to_sortable_string(v)?.to_sql(&mut out.reborrow())
     }
 }
 
@@ -101,10 +140,37 @@ where
     DB: Backend,
     String: FromSql<sql_types::Text, DB>,
 {
+    /// Remove the zero-padding before running it through
+    /// `semver::Version::parse` because the extra zeros are not allowed.
     fn from_sql(raw: RawValue<DB>) -> deserialize::Result<Self> {
-        String::from_sql(raw)?
+        from_sortable_string(String::from_sql(raw)?)
             .parse()
             .map(|s| SemverVersion(external::SemverVersion(s)))
             .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use semver;
+
+    #[test]
+    fn test_to_from_sortable_string() {
+        let pairs = [
+            ("1.0.2", "00000001.00000000.00000002"),
+            ("1.0.2-0.3.7", "00000001.00000000.00000002-0.3.7"),
+            ("0.0.0-abc", "00000000.00000000.00000000-abc"),
+            ("1.0.2-abc", "00000001.00000000.00000002-abc"),
+            ("1.0.2+abc", "00000001.00000000.00000002+abc"),
+            // don't strip zeros after a period in build meta
+            ("1.2.0+a.000d--32", "00000001.00000002.00000000+a.000d--32"),
+            ("1.0.2-abc+def", "00000001.00000000.00000002-abc+def"),
+        ];
+        for (orig, padded) in pairs {
+            let v = orig.parse::<semver::Version>().unwrap();
+            assert_eq!(&to_sortable_string(v).unwrap(), padded);
+            assert_eq!(&from_sortable_string(padded.to_string()), orig);
+        }
     }
 }

--- a/nexus/db-model/src/system_update.rs
+++ b/nexus/db-model/src/system_update.rs
@@ -34,9 +34,6 @@ pub struct SystemUpdate {
     #[diesel(embed)]
     pub identity: SystemUpdateIdentity,
     pub version: SemverVersion,
-    /// Semver version string with 0-padding on the numeric parts to make it
-    /// DB-sortable. See `to_sortable_string` on `SemverVersion`
-    pub version_sort: String,
 }
 
 impl SystemUpdate {
@@ -44,11 +41,9 @@ impl SystemUpdate {
     pub fn new(
         version: external::SemverVersion,
     ) -> Result<Self, external::Error> {
-        let db_version = SemverVersion(version);
         Ok(Self {
             identity: SystemUpdateIdentity::new(Uuid::new_v4()),
-            version: db_version.clone(),
-            version_sort: db_version.to_sortable_string()?,
+            version: SemverVersion(version),
         })
     }
 }
@@ -248,9 +243,6 @@ pub struct UpdateableComponent {
     pub component_type: UpdateableComponentType,
     pub version: SemverVersion,
     pub system_version: SemverVersion,
-    /// Semver version string with 0-padding on the numeric parts to make it
-    /// DB-sortable. See `to_sortable_string` on `SemverVersion`
-    pub system_version_sort: String,
     pub status: UpdateStatus,
     // TODO: point to the actual update artifact
 }
@@ -261,12 +253,10 @@ impl TryFrom<params::UpdateableComponentCreate> for UpdateableComponent {
     fn try_from(
         create: params::UpdateableComponentCreate,
     ) -> Result<Self, Self::Error> {
-        let system_version = SemverVersion(create.system_version);
         Ok(Self {
             identity: UpdateableComponentIdentity::new(Uuid::new_v4()),
             version: SemverVersion(create.version),
-            system_version: system_version.clone(),
-            system_version_sort: system_version.to_sortable_string()?,
+            system_version: SemverVersion(create.system_version),
             component_type: create.component_type.into(),
             device_id: create.device_id,
             status: UpdateStatus::Steady,

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -713,12 +713,7 @@ mod tests {
         let nexus = &cptestctx.server.apictx.nexus;
         let opctx = test_opctx(&cptestctx);
 
-        let expected = external::Error::InvalidValue {
-            label: "version".to_string(),
-            message:
-                "Major, minor, and patch version must be less than 99999999"
-                    .to_string(),
-        };
+        let expected = "Invalid Value: version, Major, minor, and patch version must be less than 99999999";
 
         // major, minor, and patch are all capped
 
@@ -727,21 +722,21 @@ mod tests {
         };
         let error =
             nexus.create_system_update(&opctx, su_create).await.unwrap_err();
-        assert_eq!(error, expected);
+        assert!(error.to_string().contains(expected));
 
         let su_create = SystemUpdateCreate {
             version: external::SemverVersion::new(0, 100000000, 0),
         };
         let error =
             nexus.create_system_update(&opctx, su_create).await.unwrap_err();
-        assert_eq!(error, expected);
+        assert!(error.to_string().contains(expected));
 
         let su_create = SystemUpdateCreate {
             version: external::SemverVersion::new(0, 0, 100000000),
         };
         let error =
             nexus.create_system_update(&opctx, su_create).await.unwrap_err();
-        assert_eq!(error, expected);
+        assert!(error.to_string().contains(expected));
     }
 
     #[nexus_test(server = crate::Server)]

--- a/nexus/src/db/datastore/update.rs
+++ b/nexus/src/db/datastore/update.rs
@@ -179,7 +179,7 @@ impl DataStore {
 
         paginated(system_update, id, pagparams)
             .select(SystemUpdate::as_select())
-            .order(version_sort.desc())
+            .order(version.desc())
             .load_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
@@ -259,7 +259,7 @@ impl DataStore {
 
         updateable_component
             .select(system_version)
-            .order(system_version_sort.asc())
+            .order(system_version.asc())
             .first_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
@@ -275,7 +275,7 @@ impl DataStore {
 
         updateable_component
             .select(system_version)
-            .order(system_version_sort.desc())
+            .order(system_version.desc())
             .first_async(self.pool_authorized(opctx).await?)
             .await
             .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))


### PR DESCRIPTION
Closes #2344. Followup to #2100. Rather than manually adding a sortable `version_sort` column alongside the `version` column, make `SemverVersion` itself automatically sortable by serializing it to the DB in sortable form (with zero padding on the numbers). On deserialization, we remove the padding before trying to parse it.