### PR TITLE
Work around flaky apt repo in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-11 ]
     steps:
+    # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
+    - name: Disable packages.microsoft.com repo
+      run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
     - uses: Swatinem/rust-cache@v1
@@ -41,6 +44,9 @@ jobs:
   clippy-lint:
     runs-on: ubuntu-20.04
     steps:
+    # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
+    - name: Disable packages.microsoft.com repo
+      run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
     - uses: Swatinem/rust-cache@v1
@@ -66,6 +72,9 @@ jobs:
   build-docs:
     runs-on: ubuntu-20.04
     steps:
+    # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
+    - name: Disable packages.microsoft.com repo
+      run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
     - uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
[Something is wrong with the packages.microsoft.com repository](https://github.com/microsoft/linux-package-repositories/issues/34) and it is causing CI flakes whenever they update the repository. We don't need it so we'll remove it.

https://github.com/iliana/there-are-too-many-things-in-the-computer-box/actions/runs/4147694155/jobs/7174875470 is a briefer demonstration of this being run.