### PR TITLE
RFD-322: `/v1/sagas`

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5999,10 +5999,12 @@ async fn saga_view_v1(
 }
 
 /// Fetch a saga
+/// /// Use `GET v1/system/sagas/{saga_id}` instead
 #[endpoint {
     method = GET,
     path = "/system/sagas/{saga_id}",
     tags = ["system"],
+    deprecated = true,
 }]
 async fn saga_view(
     rqctx: RequestContext<Arc<ServerContext>>,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1474,14 +1474,14 @@ lazy_static! {
         /* Sagas */
 
         VerifyEndpoint {
-            url: "/system/sagas",
+            url: "v1/system/sagas",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
         },
 
         VerifyEndpoint {
-            url: "/system/sagas/48a1b8c8-fc1c-6fea-9de9-fdeb8dda7823",
+            url: "v1/system/sagas/48a1b8c8-fc1c-6fea-9de9-fdeb8dda7823",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::GetNonexistent],

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -174,7 +174,9 @@ physical_disk_list                       /system/hardware/disks
 rack_list                                /system/hardware/racks
 rack_view                                /system/hardware/racks/{rack_id}
 saga_list                                /system/sagas
+saga_list_v1                             /v1/system/sagas
 saga_view                                /system/sagas/{saga_id}
+saga_view_v1                             /v1/system/sagas/{saga_id}
 saml_identity_provider_create            /system/silos/{silo_name}/identity-providers/saml
 saml_identity_provider_view              /system/silos/{silo_name}/identity-providers/saml/{provider_name}
 silo_create                              /system/silos

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6743,6 +6743,7 @@
           "system"
         ],
         "summary": "List sagas",
+        "description": "Use `GET v1/system/sagas` instead",
         "operationId": "saga_list",
         "parameters": [
           {
@@ -6791,6 +6792,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -9499,6 +9501,101 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/sagas": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List sagas",
+        "operationId": "saga_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SagaResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/sagas/{saga_id}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a saga",
+        "operationId": "saga_view_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "saga_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Saga"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6802,6 +6802,7 @@
           "system"
         ],
         "summary": "Fetch a saga",
+        "description": "/// Use `GET v1/system/sagas/{saga_id}` instead",
         "operationId": "saga_view",
         "parameters": [
           {
@@ -6831,7 +6832,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/system/silos": {


### PR DESCRIPTION
Adds `/v1/` sagas APIs

```
GET /v1/system/sagas/          # List sagas
GET /v1/system/sagas/{saga_id} # View sagas
```
 
Related https://github.com/oxidecomputer/omicron/issues/2028