### PR TITLE
RFD322: `/v1/system/hardware` APIs

### DIFF
--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -41,13 +41,13 @@ use std::str::FromStr;
 
 lazy_static! {
     pub static ref HARDWARE_RACK_URL: String =
-        format!("/system/hardware/racks/{}", RACK_UUID);
+        format!("/v1/system/hardware/racks/{}", RACK_UUID);
     pub static ref HARDWARE_SLED_URL: String =
-        format!("/system/hardware/sleds/{}", SLED_AGENT_UUID);
+        format!("/v1/system/hardware/sleds/{}", SLED_AGENT_UUID);
     pub static ref HARDWARE_DISK_URL: String =
-        format!("/system/hardware/disks");
+        format!("/v1/system/hardware/disks");
     pub static ref HARDWARE_SLED_DISK_URL: String =
-        format!("/system/hardware/sleds/{}/disks", SLED_AGENT_UUID);
+        format!("/v1/system/hardware/sleds/{}/disks", SLED_AGENT_UUID);
 
     // Global policy
     pub static ref SYSTEM_POLICY_URL: &'static str = "/system/policy";
@@ -1430,7 +1430,7 @@ lazy_static! {
         /* Hardware */
 
         VerifyEndpoint {
-            url: "/system/hardware/racks",
+            url: "/v1/system/hardware/racks",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
@@ -1444,7 +1444,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: "/system/hardware/sleds",
+            url: "/v1/system/hardware/sleds",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -171,8 +171,11 @@ local_idp_user_create                    /system/silos/{silo_name}/identity-prov
 local_idp_user_delete                    /system/silos/{silo_name}/identity-providers/local/users/{user_id}
 local_idp_user_set_password              /system/silos/{silo_name}/identity-providers/local/users/{user_id}/set-password
 physical_disk_list                       /system/hardware/disks
+physical_disk_list_v1                    /v1/system/hardware/disks
 rack_list                                /system/hardware/racks
+rack_list_v1                             /v1/system/hardware/racks
 rack_view                                /system/hardware/racks/{rack_id}
+rack_view_v1                             /v1/system/hardware/racks/{rack_id}
 saga_list                                /system/sagas
 saga_view                                /system/sagas/{saga_id}
 saml_identity_provider_create            /system/silos/{silo_name}/identity-providers/saml
@@ -188,8 +191,11 @@ silo_users_list                          /system/silos/{silo_name}/users/all
 silo_view                                /system/silos/{silo_name}
 silo_view_by_id                          /system/by-id/silos/{id}
 sled_list                                /system/hardware/sleds
+sled_list_v1                             /v1/system/hardware/sleds
 sled_physical_disk_list                  /system/hardware/sleds/{sled_id}/disks
+sled_physical_disk_list_v1               /v1/system/hardware/sleds/{sled_id}/disks
 sled_view                                /system/hardware/sleds/{sled_id}
+sled_view_v1                             /v1/system/hardware/sleds/{sled_id}
 system_component_version_list            /v1/system/update/components
 system_image_create                      /system/images
 system_image_delete                      /system/images/{image_name}

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5625,6 +5625,7 @@
           "system"
         ],
         "summary": "List physical disks",
+        "description": "Use `GET /v1/system/hardware/disks` instead",
         "operationId": "physical_disk_list",
         "parameters": [
           {
@@ -5673,6 +5674,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -5682,6 +5684,7 @@
           "system"
         ],
         "summary": "List racks",
+        "description": "Use `GET /v1/system/hardware/racks` instead",
         "operationId": "rack_list",
         "parameters": [
           {
@@ -5730,6 +5733,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -5739,6 +5743,7 @@
           "system"
         ],
         "summary": "Fetch a rack",
+        "description": "Use `GET /v1/system/hardware/racks/{rack_id}` instead",
         "operationId": "rack_view",
         "parameters": [
           {
@@ -5769,7 +5774,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/system/hardware/sleds": {
@@ -5778,6 +5784,7 @@
           "system"
         ],
         "summary": "List sleds",
+        "description": "Use `GET /v1/system/hardware/sleds instead`",
         "operationId": "sled_list",
         "parameters": [
           {
@@ -5826,6 +5833,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -5835,6 +5843,7 @@
           "system"
         ],
         "summary": "Fetch a sled",
+        "description": "Use `GET /v1/system/hardware/sleds/{sled_id}` instead",
         "operationId": "sled_view",
         "parameters": [
           {
@@ -5865,7 +5874,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/system/hardware/sleds/{sled_id}/disks": {
@@ -5874,6 +5884,7 @@
           "system"
         ],
         "summary": "List physical disks attached to sleds",
+        "description": "Use `GET /v1/system/hardware/sleds/{sled_id}/disks` instead",
         "operationId": "sled_physical_disk_list",
         "parameters": [
           {
@@ -5932,6 +5943,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -9507,6 +9519,322 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      }
+    },
+    "/v1/system/hardware/disks": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List physical disks",
+        "operationId": "physical_disk_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhysicalDiskResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/hardware/racks": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List racks",
+        "operationId": "rack_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RackResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/hardware/racks/{rack_id}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a rack",
+        "operationId": "rack_view_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rack_id",
+            "description": "The rack's unique ID.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Rack"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/hardware/sleds": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List sleds",
+        "operationId": "sled_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/hardware/sleds/{sled_id}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a sled",
+        "operationId": "sled_view_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sled_id",
+            "description": "The sled's unique ID.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sled"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/hardware/sleds/{sled_id}/disks": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List physical disks attached to sleds",
+        "operationId": "sled_physical_disk_list_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sled_id",
+            "description": "The sled's unique ID.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhysicalDiskResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/v1/system/update/components": {


### PR DESCRIPTION
Adds `/v1/` system hardware APIs

```
GET /v1/system/hardware/disks                 # List physical disks
GET /v1/system/hardware/racks                 # List racks
GET /v1/system/hardware/racks/{rack_id}       # View a rack
GET /v1/system/hardware/sleds                 # List sleds
GET /v1/system/hardware/sleds/{sled_id}/disks # List physical disks attached to a sled
GET /v1/system/hardware/sleds/{sled_id}       # View a sled
```
 
Related https://github.com/oxidecomputer/omicron/issues/2028