### PR TITLE
[wicket] Move some shared screen code to common

### DIFF
--- a/wicket/src/screens/common.rs
+++ b/wicket/src/screens/common.rs
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Code that is shared among screens, although not necessarily all screens.
+//! In particular, the splash and rack screens don't use much of this.
+
+use super::ScreenId;
+use crate::defaults::colors::*;
+use crate::defaults::dimensions::MENUBAR_HEIGHT;
+use crate::defaults::style;
+use crate::widgets::{
+    Control, ControlId, HelpButton, HelpButtonState, HelpMenu, HelpMenuState,
+    ScreenButton, ScreenButtonState,
+};
+use crate::wizard::{Action, Frame, State};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui::style::{Color, Style};
+use tui::widgets::Block;
+
+// State shared between all screens except the splash and rack screens
+//
+// Each screen will maintain its own instance of this state.
+pub struct CommonScreenState {
+    pub help_menu_state: HelpMenuState,
+    pub help_button_state: HelpButtonState,
+    pub rack_screen_button_state: ScreenButtonState,
+    pub hovered: Option<ControlId>,
+}
+
+impl CommonScreenState {
+    pub fn resize(&mut self, width: u16, _height: u16) {
+        self.rack_screen_button_state.rect.x =
+            width - ScreenButtonState::width();
+    }
+
+    pub fn handle_mouse_click(&mut self) -> Vec<Action> {
+        match self.hovered {
+            Some(control_id) if control_id == self.help_button_state.id() => {
+                self.help_menu_state.open();
+                vec![]
+            }
+            Some(control_id)
+                if control_id == self.rack_screen_button_state.id() =>
+            {
+                vec![Action::SwitchScreen(ScreenId::Rack)]
+            }
+            _ => vec![],
+        }
+    }
+
+    pub fn handle_key_event(&mut self, event: KeyEvent) -> Vec<Action> {
+        match event.code {
+            KeyCode::Char('r') => {
+                if event.modifiers.contains(KeyModifiers::CONTROL) {
+                    return vec![Action::SwitchScreen(ScreenId::Rack)];
+                }
+            }
+            KeyCode::Char('h') => {
+                if event.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.help_menu_state.toggle();
+                }
+            }
+            _ => (),
+        }
+        vec![Action::Redraw]
+    }
+
+    // Handle a tick event. Return true if a redraw is required, false
+    // otherwise.
+    pub fn tick(&mut self) -> bool {
+        if !self.help_menu_state.is_closed() {
+            self.help_menu_state.step();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return if the coordinates interesct a given control.
+    /// This assumes disjoint control rectangles.
+    pub fn find_intersection(&self, x: u16, y: u16) -> Option<ControlId> {
+        if self.help_button_state.intersects_point(x, y) {
+            Some(self.help_button_state.id())
+        } else if self.rack_screen_button_state.intersects_point(x, y) {
+            Some(self.rack_screen_button_state.id())
+        } else {
+            None
+        }
+    }
+
+    pub fn draw_background(&self, f: &mut Frame) {
+        let style = Style::default().fg(OX_GREEN_DARK).bg(Color::Black);
+        let block = Block::default().style(style);
+        f.render_widget(block, f.size());
+    }
+
+    pub fn draw_menubar(&self, f: &mut Frame, _state: &State) {
+        let mut rect = f.size();
+        rect.height = MENUBAR_HEIGHT;
+
+        let bar_block = Block::default().style(style::menu_bar());
+        f.render_widget(bar_block, rect);
+    }
+
+    pub fn draw_help_menu(&self, f: &mut Frame) {
+        // Draw the help button if the help menu is closed, otherwise draw the
+        // help menu
+        if !self.help_menu_state.is_closed() {
+            let menu = HelpMenu {
+                help: self.help_menu_state.help_text(),
+                style: style::help_menu(),
+                command_style: style::help_menu_command(),
+                // Unwrap is safe because we check that the menu is open (and
+                // thus has an AnimationState).
+                state: self.help_menu_state.get_animation_state().unwrap(),
+            };
+            f.render_widget(menu, f.size());
+        } else {
+            let border_style =
+                if self.hovered == Some(self.help_button_state.id()) {
+                    style::button_hovered()
+                } else {
+                    style::button()
+                };
+            let button = HelpButton::new(
+                &self.help_button_state,
+                style::button(),
+                border_style,
+            );
+
+            f.render_widget(button, f.size());
+        }
+    }
+
+    pub fn draw_screen_selection_buttons(&self, f: &mut Frame) {
+        // Draw the RackSreenButton
+        let border_style =
+            if self.hovered == Some(self.rack_screen_button_state.id()) {
+                style::button_hovered()
+            } else {
+                style::button()
+            };
+        let button = ScreenButton::new(
+            &self.rack_screen_button_state,
+            style::button(),
+            border_style,
+        );
+        f.render_widget(button, f.size());
+    }
+}

--- a/wicket/src/screens/component.rs
+++ b/wicket/src/screens/component.rs
@@ -4,40 +4,34 @@
 
 //! Inventory and control of individual rack components: sled,switch,psc
 
+use super::common::CommonScreenState;
 use super::Screen;
 use crate::defaults::colors::*;
 use crate::defaults::dimensions::RectExt;
 use crate::defaults::dimensions::MENUBAR_HEIGHT;
 use crate::defaults::style;
 use crate::screens::ScreenId;
-use crate::widgets::Control;
-use crate::widgets::ControlId;
+use crate::widgets::HelpButtonState;
 use crate::widgets::HelpMenuState;
-use crate::widgets::{HelpButton, HelpButtonState, HelpMenu};
-use crate::widgets::{ScreenButton, ScreenButtonState};
+use crate::widgets::ScreenButtonState;
 use crate::wizard::{Action, Frame, ScreenEvent, State, Term};
 use crossterm::event::Event as TermEvent;
 use crossterm::event::{
-    KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind,
 };
 use tui::layout::Alignment;
 use tui::style::Modifier;
-use tui::style::{Color, Style};
+use tui::style::Style;
 use tui::text::{Span, Spans, Text};
-use tui::widgets::Block;
-use tui::widgets::Paragraph;
+use tui::widgets::{Block, Paragraph};
 
 pub struct ComponentScreen {
-    hovered: Option<ControlId>,
-    help_data: Vec<(&'static str, &'static str)>,
-    help_button_state: HelpButtonState,
-    help_menu_state: HelpMenuState,
-    rack_screen_button_state: ScreenButtonState,
+    common: CommonScreenState,
 }
 
 impl ComponentScreen {
     pub fn new() -> ComponentScreen {
-        let help_data = vec![
+        let help_text = vec![
             ("<TAB>", "Cycle forward through components"),
             ("<SHIFT>-<TAB>", "Cycle backwards through components"),
             ("<ESC>", "Exit help menu | Go back to the rack screen"),
@@ -46,53 +40,15 @@ impl ComponentScreen {
             ("<CTRL-c>", "Exit the program"),
         ];
         ComponentScreen {
-            hovered: None,
-            help_data,
-            help_button_state: HelpButtonState::new(1, 0),
-            help_menu_state: HelpMenuState::default(),
-            rack_screen_button_state: ScreenButtonState::new(ScreenId::Rack),
+            common: CommonScreenState {
+                hovered: None,
+                help_button_state: HelpButtonState::new(1, 0),
+                help_menu_state: HelpMenuState::new(help_text),
+                rack_screen_button_state: ScreenButtonState::new(
+                    ScreenId::Rack,
+                ),
+            },
         }
-    }
-
-    fn draw_background(&self, f: &mut Frame) {
-        let style = Style::default().fg(OX_GREEN_DARK).bg(Color::Black);
-        let block = Block::default().style(style);
-        f.render_widget(block, f.size());
-    }
-
-    fn draw_menubar(&self, f: &mut Frame, state: &State) {
-        let mut rect = f.size();
-        rect.height = MENUBAR_HEIGHT;
-
-        let bar_block = Block::default().style(style::menu_bar());
-        f.render_widget(bar_block, rect);
-
-        self.draw_component_list(f, state);
-        self.draw_power_state(f, state);
-        self.draw_help_menu(f, state);
-        self.draw_screen_selection_buttons(f, state);
-    }
-
-    fn draw_power_state(&self, f: &mut Frame, state: &State) {
-        let current = state.rack_state.get_current_component_id();
-        let title = match state.inventory.get_power_state(&current) {
-            Some(s) => {
-                format!(
-                    "⌁ Power State: {}",
-                    s.description().to_ascii_uppercase()
-                )
-            }
-            None => "⌁ Power State: UNKNOWN".to_string(),
-        };
-
-        let mut rect = f.size();
-        rect.height = 1;
-        rect.y = 3;
-        let power_state_block = Block::default()
-            .style(style::menu_bar_selected())
-            .title(title)
-            .title_alignment(Alignment::Center);
-        f.render_widget(power_state_block, rect);
     }
 
     fn draw_component_list(&self, f: &mut Frame, state: &State) {
@@ -125,50 +81,26 @@ impl ComponentScreen {
         f.render_widget(title_block, rect);
     }
 
-    fn draw_help_menu(&self, f: &mut Frame, _: &State) {
-        // Draw the help button if the help menu is closed, otherwise draw the
-        // help menu
-        if !self.help_menu_state.is_closed() {
-            let menu = HelpMenu {
-                help: &self.help_data,
-                style: style::help_menu(),
-                command_style: style::help_menu_command(),
-                // Unwrap is safe because we check that the menu is open (and
-                // thus has an AnimationState).
-                state: self.help_menu_state.get_animation_state().unwrap(),
-            };
-            f.render_widget(menu, f.size());
-        } else {
-            let border_style =
-                if self.hovered == Some(self.help_button_state.id()) {
-                    style::button_hovered()
-                } else {
-                    style::button()
-                };
-            let button = HelpButton::new(
-                &self.help_button_state,
-                style::button(),
-                border_style,
-            );
+    fn draw_power_state(&self, f: &mut Frame, state: &State) {
+        let current = state.rack_state.get_current_component_id();
+        let title = match state.inventory.get_power_state(&current) {
+            Some(s) => {
+                format!(
+                    "⌁ Power State: {}",
+                    s.description().to_ascii_uppercase()
+                )
+            }
+            None => "⌁ Power State: UNKNOWN".to_string(),
+        };
 
-            f.render_widget(button, f.size());
-        }
-    }
-
-    fn draw_screen_selection_buttons(&self, f: &mut Frame, _: &State) {
-        // Draw the RackSreenButton
-        let border_style =
-            if self.hovered == Some(self.rack_screen_button_state.id()) {
-                style::button_hovered()
-            } else {
-                style::button()
-            };
-        let button = ScreenButton::new(
-            &self.rack_screen_button_state,
-            style::button(),
-            border_style,
-        );
-        f.render_widget(button, f.size());
+        let mut rect = f.size();
+        rect.height = 1;
+        rect.y = 3;
+        let power_state_block = Block::default()
+            .style(style::menu_bar_selected())
+            .title(title)
+            .title_alignment(Alignment::Center);
+        f.render_widget(power_state_block, rect);
     }
 
     fn draw_inventory(&self, f: &mut Frame, state: &State) {
@@ -219,31 +151,17 @@ impl ComponentScreen {
             KeyCode::BackTab => {
                 state.rack_state.dec_tab_index();
             }
-            KeyCode::Char('r') => {
-                if event.modifiers.contains(KeyModifiers::CONTROL) {
-                    return vec![Action::SwitchScreen(ScreenId::Rack)];
-                }
-            }
-            KeyCode::Char('h') => {
-                if event.modifiers.contains(KeyModifiers::CONTROL) {
-                    self.help_menu_state.toggle();
-                }
-            }
             KeyCode::Esc => {
-                if self.help_menu_state.is_closed() {
+                if self.common.help_menu_state.is_closed() {
                     return vec![Action::SwitchScreen(ScreenId::Rack)];
                 } else {
-                    self.help_menu_state.close();
+                    self.common.help_menu_state.close();
                 }
             }
-            _ => (),
+            // Delegate to common handler
+            _ => return self.common.handle_key_event(event),
         }
         vec![Action::Redraw]
-    }
-
-    fn resize(&mut self, width: u16, _height: u16) {
-        self.rack_screen_button_state.rect.x =
-            width - ScreenButtonState::width();
     }
 
     fn handle_mouse_event(
@@ -256,22 +174,7 @@ impl ComponentScreen {
                 self.set_hover_state(state, event.column, event.row)
             }
             MouseEventKind::Down(MouseButton::Left) => {
-                self.handle_mouse_click(state)
-            }
-            _ => vec![],
-        }
-    }
-
-    fn handle_mouse_click(&mut self, _: &mut State) -> Vec<Action> {
-        match self.hovered {
-            Some(control_id) if control_id == self.help_button_state.id() => {
-                self.help_menu_state.open();
-                vec![]
-            }
-            Some(control_id)
-                if control_id == self.rack_screen_button_state.id() =>
-            {
-                vec![Action::SwitchScreen(ScreenId::Rack)]
+                self.common.handle_mouse_click()
             }
             _ => vec![],
         }
@@ -283,25 +186,13 @@ impl ComponentScreen {
         x: u16,
         y: u16,
     ) -> Vec<Action> {
-        let current_id = self.find_intersection(x, y);
-        if current_id == self.hovered {
+        let current_id = self.common.find_intersection(x, y);
+        if current_id == self.common.hovered {
             // No change
             vec![]
         } else {
-            self.hovered = current_id;
+            self.common.hovered = current_id;
             vec![Action::Redraw]
-        }
-    }
-
-    // Return if the coordinates interesct a given control.
-    // This assumes disjoint control rectangles.
-    fn find_intersection(&self, x: u16, y: u16) -> Option<ControlId> {
-        if self.help_button_state.intersects_point(x, y) {
-            Some(self.help_button_state.id())
-        } else if self.rack_screen_button_state.intersects_point(x, y) {
-            Some(self.rack_screen_button_state.id())
-        } else {
-            None
         }
     }
 }
@@ -309,8 +200,12 @@ impl ComponentScreen {
 impl Screen for ComponentScreen {
     fn draw(&self, state: &State, terminal: &mut Term) -> anyhow::Result<()> {
         terminal.draw(|f| {
-            self.draw_background(f);
-            self.draw_menubar(f, state);
+            self.common.draw_background(f);
+            self.common.draw_menubar(f, state);
+            self.draw_component_list(f, state);
+            self.draw_power_state(f, state);
+            self.common.draw_help_menu(f);
+            self.common.draw_screen_selection_buttons(f);
             self.draw_inventory(f, state);
             state.status_bar.draw(f);
         })?;
@@ -326,18 +221,12 @@ impl Screen for ComponentScreen {
                 self.handle_mouse_event(state, mouse_event)
             }
             ScreenEvent::Term(TermEvent::Resize(width, height)) => {
-                self.resize(width, height);
+                self.common.resize(width, height);
                 // A redraw always occurs in the wizard
                 vec![]
             }
             ScreenEvent::Tick => {
-                let mut redraw = false;
-
-                if !self.help_menu_state.is_closed() {
-                    self.help_menu_state.step();
-                    redraw = true;
-                }
-
+                let mut redraw = self.common.tick();
                 redraw |= state.status_bar.should_redraw();
 
                 if redraw {

--- a/wicket/src/screens/mod.rs
+++ b/wicket/src/screens/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod common;
 mod component;
 mod rack;
 mod splash;

--- a/wicket/src/screens/rack.rs
+++ b/wicket/src/screens/rack.rs
@@ -13,6 +13,7 @@ use crate::widgets::ControlId;
 use crate::widgets::HelpMenuState;
 use crate::widgets::{Banner, HelpButton, HelpButtonState, HelpMenu, Rack};
 use crate::wizard::{Action, Frame, ScreenEvent, State, Term};
+use crate::{BOTTOM_MARGIN, TOP_MARGIN};
 use crossterm::event::Event as TermEvent;
 use crossterm::event::{
     KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -28,7 +29,6 @@ pub struct RackScreen {
     log: Logger,
     watermark: &'static str,
     hovered: Option<ControlId>,
-    help_data: Vec<(&'static str, &'static str)>,
     help_button_state: HelpButtonState,
     help_menu_state: HelpMenuState,
 }
@@ -49,9 +49,8 @@ impl RackScreen {
             log: log.clone(),
             watermark: include_str!("../../banners/oxide.txt"),
             hovered: None,
-            help_data,
             help_button_state: HelpButtonState::new(1, 0),
-            help_menu_state: HelpMenuState::default(),
+            help_menu_state: HelpMenuState::new(help_data),
         }
     }
 
@@ -85,7 +84,7 @@ impl RackScreen {
         // help menu
         if !self.help_menu_state.is_closed() {
             let menu = HelpMenu {
-                help: &self.help_data,
+                help: self.help_menu_state.help_text(),
                 style: help_menu_style,
                 command_style: help_menu_command_style,
                 state: self.help_menu_state.get_animation_state().unwrap(),
@@ -325,6 +324,15 @@ impl Screen for RackScreen {
                 } else {
                     vec![]
                 }
+            }
+            ScreenEvent::Term(TermEvent::Resize(width, height)) => {
+                state.rack_state.resize(
+                    width,
+                    height,
+                    TOP_MARGIN,
+                    BOTTOM_MARGIN,
+                );
+                vec![Action::Redraw]
             }
             _ => vec![],
         }

--- a/wicket/src/widgets/help_menu.rs
+++ b/wicket/src/widgets/help_menu.rs
@@ -14,17 +14,29 @@ use tui::widgets::Paragraph;
 use tui::widgets::Widget;
 use tui::widgets::{Block, Borders};
 
-#[derive(Default)]
-pub struct HelpMenuState(Option<AnimationState>);
+pub type HelpText = Vec<(&'static str, &'static str)>;
+
+pub struct HelpMenuState {
+    animation_state: Option<AnimationState>,
+    help: HelpText,
+}
 
 impl HelpMenuState {
+    pub fn new(help: HelpText) -> HelpMenuState {
+        HelpMenuState { animation_state: None, help }
+    }
+
+    pub fn help_text(&self) -> &HelpText {
+        &self.help
+    }
+
     pub fn get_animation_state(&self) -> Option<AnimationState> {
-        self.0
+        self.animation_state
     }
 
     // Return true if there is no [`AnimationState`]
     pub fn is_closed(&self) -> bool {
-        self.0.is_none()
+        self.animation_state.is_none()
     }
 
     // Toggle the display of the help menu
@@ -38,30 +50,31 @@ impl HelpMenuState {
 
     // Perform an animation step
     pub fn step(&mut self) {
-        let state = self.0.as_mut().unwrap();
+        let state = self.animation_state.as_mut().unwrap();
         let done = state.step();
         let is_closed = state.is_closing() && done;
         if is_closed {
-            self.0 = None;
+            self.animation_state = None;
         }
     }
 
     pub fn open(&mut self) {
-        self.0
+        self.animation_state
             .get_or_insert(AnimationState::Opening { frame: 0, frame_max: 8 });
     }
 
     pub fn close(&mut self) {
-        let state = self.0.take();
+        let state = self.animation_state.take();
         match state {
             None => (), // Already closed
             Some(AnimationState::Opening { frame, frame_max }) => {
                 // Transition to closing at the same position in the animation
-                self.0 = Some(AnimationState::Closing { frame, frame_max });
+                self.animation_state =
+                    Some(AnimationState::Closing { frame, frame_max });
             }
             Some(s) => {
                 // Already closing. Maintain same state
-                self.0 = Some(s);
+                self.animation_state = Some(s);
             }
         }
     }

--- a/wicket/src/wizard.rs
+++ b/wicket/src/wizard.rs
@@ -141,13 +141,6 @@ impl Wizard {
     fn mainloop(&mut self) -> anyhow::Result<()> {
         info!(self.log, "Starting main loop");
         let rect = self.terminal.get_frame().size();
-        // Size the rack for the initial draw
-        self.state.rack_state.resize(
-            rect.width,
-            rect.height,
-            TOP_MARGIN,
-            BOTTOM_MARGIN,
-        );
 
         // Draw the initial screen
         let screen = self.screens.get_mut(self.active_screen);
@@ -175,12 +168,6 @@ impl Wizard {
                     self.handle_actions(actions)?;
                 }
                 Event::Term(TermEvent::Resize(width, height)) => {
-                    self.state.rack_state.resize(
-                        width,
-                        height,
-                        TOP_MARGIN,
-                        BOTTOM_MARGIN,
-                    );
                     screen.resize(&mut self.state, width, height);
                     screen.draw(&self.state, &mut self.terminal)?;
                 }


### PR DESCRIPTION
In preparation for the update screen, common code has been moved. Additionally rack resize has been moved out of the wizard and into the rack screen, similar to how it will be done in the update screen.