### PR TITLE
[ipcc-key-value] Add an `update_id` to InstallinatorImageId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "proptest",
  "serde",
  "test-strategy",
+ "uuid",
 ]
 
 [[package]]

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -409,6 +409,7 @@ pub struct ImageVersion {
 )]
 #[serde(rename_all = "snake_case")]
 pub struct InstallinatorImageId {
+    pub update_id: Uuid,
     pub host_phase_2: [u8; 32],
     pub control_plane: [u8; 32],
 }

--- a/gateway/src/http_entrypoints/conversions.rs
+++ b/gateway/src/http_entrypoints/conversions.rs
@@ -366,6 +366,10 @@ impl From<StartupOptions> for HostStartupOptions {
 
 impl From<InstallinatorImageId> for ipcc_key_value::InstallinatorImageId {
     fn from(id: InstallinatorImageId) -> Self {
-        Self { host_phase_2: id.host_phase_2, control_plane: id.control_plane }
+        Self {
+            update_id: id.update_id,
+            host_phase_2: id.host_phase_2,
+            control_plane: id.control_plane,
+        }
     }
 }

--- a/ipcc-key-value/Cargo.toml
+++ b/ipcc-key-value/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 ciborium.workspace = true
 serde.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/ipcc-key-value/src/lib.rs
+++ b/ipcc-key-value/src/lib.rs
@@ -9,6 +9,12 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use uuid::Uuid;
+
+#[cfg(test)]
+use proptest::arbitrary::any;
+#[cfg(test)]
+use proptest::strategy::Strategy;
 
 /// Supported keys.
 ///
@@ -30,10 +36,74 @@ pub enum Key {
 )]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct InstallinatorImageId {
+    /// UUID identifying this update.
+    ///
+    /// Installinator can send progress and completion messages to all peers it
+    /// finds, and any peer that cares about progress can use this ID to match
+    /// the progress message with a running recovery.
+    #[cfg_attr(test, strategy(any::<[u8; 16]>().prop_map(Uuid::from_bytes)))]
+    pub update_id: Uuid,
     /// SHA-256 hash of the host phase 2 image to fetch.
+    #[serde(with = "serde_bytes_array")]
     pub host_phase_2: [u8; 32],
     /// SHA-256 hash of the control plane image to fetch.
+    #[serde(with = "serde_bytes_array")]
     pub control_plane: [u8; 32],
+}
+
+// Adapted from https://github.com/serde-rs/bytes/issues/26: this is a
+// workaround to serialize our `[u8; 32]` arrays above as bytes instead of
+// arbitrary sequences, which results in a shorter CBOR encoding.
+//
+// Uuid's serde implementation already does the equivalent of this, so it is
+// already serialized as a 16-long byte sequence.
+mod serde_bytes_array {
+    use serde::de::{self, Error};
+    use serde::{Deserializer, Serializer};
+
+    // Call `serialize_bytes` instead of the derived `serialized_seq`.
+    pub(crate) fn serialize<S>(
+        bytes: &[u8],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(bytes)
+    }
+
+    struct BytesVisitor<const N: usize>;
+
+    impl<'vi, const N: usize> de::Visitor<'vi> for BytesVisitor<N> {
+        type Value = [u8; N];
+
+        fn expecting(
+            &self,
+            formatter: &mut std::fmt::Formatter,
+        ) -> std::fmt::Result {
+            write!(formatter, "[u8; {N}]")
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Self::Value::try_from(v).map_err(|_| {
+                let expected = format!("[u8; {}]", N);
+                E::invalid_length(v.len(), &expected.as_str())
+            })
+        }
+    }
+
+    // Deserialize a byte sequence into a `[u8; N]`.
+    pub(crate) fn deserialize<'de, D, const N: usize>(
+        deserializer: D,
+    ) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(BytesVisitor)
+    }
 }
 
 // The existence of these methods is a _little_ dubious: `InstallinatorImageId`
@@ -78,7 +148,7 @@ impl InstallinatorImageId {
         match ciborium::de::from_reader(data) {
             Ok(value) => Ok(value),
             Err(Error::Io(err)) => {
-                unreachable!("i/o error reading from slice: {err}")
+                Err(format!("i/o error reading from slice: {err}"))
             }
             Err(Error::Syntax(offset)) => {
                 Err(format!("syntax error at offset {offset}"))
@@ -116,27 +186,24 @@ mod tests {
     }
 
     #[proptest]
-    fn serialized_max_size(image_id: InstallinatorImageId) {
+    fn serialized_size(image_id: InstallinatorImageId) {
         // Double-check that ciborium is encoding this how we expect. Our
         // serialized size should be:
         //
         // 1. 1 byte to identify a map
         // 2. 1 byte + strlen for each key
+        // 3. 1 byte for the 16-long array (Uuid)
         // 3. 2 bytes for each 32-long array
-        // 4. 1 or 2 bytes per `u8` in each array, where the number depends on
-        //    the value of the byte
-        //
-        // The absolute cap assuming 2 bytes per `u8` in step 4 is therefore:
-        const MAX_SIZE: usize = 1 // map
+        // 4. 1 byte per u8 in each of the arrays
+        const EXPECTED_SIZE: usize = 1 // map
+            + 1 + "update_id".len() // key
             + 1 + "host_phase_2".len() // key
             + 1 + "control_plane".len() // key
-            + 2 * ( // 2 arrays
-                2 + // "32-long array"
-                32 * 2 // 32 bytes, 1-2 bytes each
-            );
+            + 1 + 16 // UUID byte array
+            + 2*(2 + 32); // 2 32-long byte arrays
 
         let serialized = image_id.serialize();
-        assert!(serialized.len() <= MAX_SIZE);
+        assert!(serialized.len() == EXPECTED_SIZE);
     }
 
     #[test]
@@ -145,11 +212,31 @@ mod tests {
         // host_phase_2 hash [1, 2, ..., 32] and the control_plane hash [33, 34,
         // ..., 64]:
         const SERIALIZED: &[u8] = &[
-            0xA2, // map(2)
+            0xA3, // map(3)
+            0x69, // text(9)
+            0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x5f, 0x69,
+            0x64, // "update_id"
+            0x50, // bytes(16),
+            0x41, // byte(65)
+            0x42, // byte(66)
+            0x43, // byte(67)
+            0x44, // byte(68)
+            0x45, // byte(69)
+            0x46, // byte(70)
+            0x47, // byte(71)
+            0x48, // byte(72)
+            0x49, // byte(73)
+            0x4a, // byte(74)
+            0x4b, // byte(75)
+            0x4c, // byte(76)
+            0x4d, // byte(77)
+            0x4e, // byte(78)
+            0x4f, // byte(79)
+            0x50, // byte(80)
             0x6C, // text(12)
             0x68, 0x6F, 0x73, 0x74, 0x5F, 0x70, 0x68, 0x61, 0x73, 0x65, 0x5F,
             0x32, // "host_phase_2"
-            0x98, 0x20, // array(32)
+            0x58, 0x20, // bytes(32)
             0x01, // unsigned(1)
             0x02, // unsigned(2)
             0x03, // unsigned(3)
@@ -173,54 +260,57 @@ mod tests {
             0x15, // unsigned(21)
             0x16, // unsigned(22)
             0x17, // unsigned(23)
-            0x18, 0x18, // unsigned(24)
-            0x18, 0x19, // unsigned(25)
-            0x18, 0x1A, // unsigned(26)
-            0x18, 0x1B, // unsigned(27)
-            0x18, 0x1C, // unsigned(28)
-            0x18, 0x1D, // unsigned(29)
-            0x18, 0x1E, // unsigned(30)
-            0x18, 0x1F, // unsigned(31)
-            0x18, 0x20, // unsigned(32)
+            0x18, // unsigned(24)
+            0x19, // unsigned(25)
+            0x1A, // unsigned(26)
+            0x1B, // unsigned(27)
+            0x1C, // unsigned(28)
+            0x1D, // unsigned(29)
+            0x1E, // unsigned(30)
+            0x1F, // unsigned(31)
+            0x20, // unsigned(32)
             0x6D, // text(13)
             0x63, 0x6F, 0x6E, 0x74, 0x72, 0x6F, 0x6C, 0x5F, 0x70, 0x6C, 0x61,
             0x6E, 0x65, // "control_plane"
-            0x98, 0x20, // array(32)
-            0x18, 0x21, // unsigned(33)
-            0x18, 0x22, // unsigned(34)
-            0x18, 0x23, // unsigned(35)
-            0x18, 0x24, // unsigned(36)
-            0x18, 0x25, // unsigned(37)
-            0x18, 0x26, // unsigned(38)
-            0x18, 0x27, // unsigned(39)
-            0x18, 0x28, // unsigned(40)
-            0x18, 0x29, // unsigned(41)
-            0x18, 0x2A, // unsigned(42)
-            0x18, 0x2B, // unsigned(43)
-            0x18, 0x2C, // unsigned(44)
-            0x18, 0x2D, // unsigned(45)
-            0x18, 0x2E, // unsigned(46)
-            0x18, 0x2F, // unsigned(47)
-            0x18, 0x30, // unsigned(48)
-            0x18, 0x31, // unsigned(49)
-            0x18, 0x32, // unsigned(50)
-            0x18, 0x33, // unsigned(51)
-            0x18, 0x34, // unsigned(52)
-            0x18, 0x35, // unsigned(53)
-            0x18, 0x36, // unsigned(54)
-            0x18, 0x37, // unsigned(55)
-            0x18, 0x38, // unsigned(56)
-            0x18, 0x39, // unsigned(57)
-            0x18, 0x3A, // unsigned(58)
-            0x18, 0x3B, // unsigned(59)
-            0x18, 0x3C, // unsigned(60)
-            0x18, 0x3D, // unsigned(61)
-            0x18, 0x3E, // unsigned(62)
-            0x18, 0x3F, // unsigned(63)
-            0x18, 0x40, // unsigned(64)
+            0x58, 0x20, // bytes(32)
+            0x21, // unsigned(33)
+            0x22, // unsigned(34)
+            0x23, // unsigned(35)
+            0x24, // unsigned(36)
+            0x25, // unsigned(37)
+            0x26, // unsigned(38)
+            0x27, // unsigned(39)
+            0x28, // unsigned(40)
+            0x29, // unsigned(41)
+            0x2A, // unsigned(42)
+            0x2B, // unsigned(43)
+            0x2C, // unsigned(44)
+            0x2D, // unsigned(45)
+            0x2E, // unsigned(46)
+            0x2F, // unsigned(47)
+            0x30, // unsigned(48)
+            0x31, // unsigned(49)
+            0x32, // unsigned(50)
+            0x33, // unsigned(51)
+            0x34, // unsigned(52)
+            0x35, // unsigned(53)
+            0x36, // unsigned(54)
+            0x37, // unsigned(55)
+            0x38, // unsigned(56)
+            0x39, // unsigned(57)
+            0x3A, // unsigned(58)
+            0x3B, // unsigned(59)
+            0x3C, // unsigned(60)
+            0x3D, // unsigned(61)
+            0x3E, // unsigned(62)
+            0x3F, // unsigned(63)
+            0x40, // unsigned(64)
         ];
 
         let expected = InstallinatorImageId {
+            update_id: Uuid::from_bytes([
+                65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+            ]),
             host_phase_2: [
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
                 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -1193,11 +1193,16 @@
             },
             "minItems": 32,
             "maxItems": 32
+          },
+          "update_id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
           "control_plane",
-          "host_phase_2"
+          "host_phase_2",
+          "update_id"
         ]
       },
       "LinkStatus": {


### PR DESCRIPTION
The primary motivation for this PR is to add an `update_id: Uuid` to the data passed down to installiator via MGS and the SP, which will allow us to track progress / completion over the bootstrap network.

While making this change, I realized `Uuid`s were be serialized by ciborium more efficiently than our `[u8; 32]` arrays, so this PR also optimizes the serialization of the hash fields: they now always serialize as exactly 34 bytes, instead of varying between 34 and 66.

Specifically, serde has an optimized path for [serializing byte sequences](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_bytes), which ciborium uses (encoding them as a `bytes` CBOR object). However, serde's derived `Serialize` implementation for `[T; N]` cannot be specialized for `[u8; N]`, so it serializes them as arbitrary sequences (which ciborium then encodes as an `array` CBOR object, within which bytes may take 1 or 2 bytes on the wire, depending on the value). [serde_bytes](https://docs.rs/serde_bytes/latest/serde_bytes/) exists to give an easy way to opt into optimizing byte sequences, but it's only defined for byte slices and `Vec<u8>`, not `[u8; N]`, so I adapted [this workaround](https://github.com/serde-rs/bytes/issues/26#issuecomment-902550669), which didn't quite work with ciborium. The overall effect is most visible in the tests: the explicit example is obviously shorter, and the test that previously checked for a `MAX_SIZE` (because the actual on-the-wire size was variable) now checks for an exact `EXPECTED_SIZE` (by using `bytes` instead of `array` we now always serialize to exactly the size we expect).