### PR TITLE
use the tofino crate to probe for tofino devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +239,7 @@ dependencies = [
 name = "authz-macros"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "serde",
@@ -776,6 +785,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -786,9 +810,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -802,7 +826,7 @@ dependencies = [
  "clap_lex 0.3.0",
  "is-terminal",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
 ]
 
@@ -812,7 +836,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -825,7 +849,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1327,7 +1351,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -1364,7 +1388,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 name = "db-macros"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustfmt-wrapper",
@@ -1795,7 +1819,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2369,6 +2393,15 @@ dependencies = [
  "serde",
  "spin 0.9.4",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3952,6 +3985,7 @@ dependencies = [
  "subprocess",
  "tempfile",
  "thiserror",
+ "tofino",
  "tokio",
  "tokio-tungstenite",
  "toml 0.5.11",
@@ -4028,7 +4062,7 @@ name = "openapi-lint"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#91f0af87bdaed0e41c8b43f4b0d85cc706d6a961"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "indexmap",
  "openapiv3",
 ]
@@ -4878,7 +4912,7 @@ version = "0.2.1-dev"
 source = "git+https://github.com/oxidecomputer/progenitor?branch=main#680150559a55f6ff7fc8d783c9a72461a233c3b5"
 dependencies = [
  "getopts",
- "heck",
+ "heck 0.4.1",
  "indexmap",
  "openapiv3",
  "proc-macro2",
@@ -6264,7 +6298,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -6453,6 +6487,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -6481,6 +6521,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,7 +6559,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6637,6 +6701,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
@@ -6763,6 +6836,18 @@ dependencies = [
  "byteorder",
  "crc",
  "zerocopy 0.6.1",
+]
+
+[[package]]
+name = "tofino"
+version = "0.1.0"
+source = "git+http://github.com/oxidecomputer/tofino?branch=main#2249eaa53c3d3bad512ac7f47d59b888b09d4145"
+dependencies = [
+ "anyhow",
+ "cc",
+ "chrono",
+ "illumos-devinfo",
+ "structopt",
 ]
 
 [[package]]
@@ -7196,7 +7281,7 @@ name = "typify-impl"
 version = "0.0.11-dev"
 source = "git+https://github.com/oxidecomputer/typify#f1945ac6f451a25a671429a9812158e9b79464a0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "log",
  "proc-macro2",
  "quote",
@@ -7415,6 +7500,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -7945,7 +8036,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef224b009d070d3b1adb9e375fcf8ec2f1948a412c3bbf8755c0ef4e3f91ef94"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ term = "0.7"
 termios = "0.3"
 test-strategy = "0.2.1"
 thiserror = "1.0"
+tofino = { git = "http://github.com/oxidecomputer/tofino", branch = "main" }
 tokio = "1.25"
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }
 tokio-stream = "0.1.11"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -161,8 +161,8 @@ only_for_targets.switch_variant = "stub"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "1614d9997443da2a8dea103628c1490b266ee115"
-source.sha256 = "75c3436ba987791c31469fda57b75027c9e41463872556df7a6c5378b856702f"
+source.commit = "cd0793ca40f3b7542d82e586ceb1dc7279d3afee"
+source.sha256 = "1d824a8eee30c8e187a7a5cbdc931872b5a6a3096cdd52a5e0b1a5bec872a39f"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -179,8 +179,8 @@ only_for_targets.switch_variant = "asic"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "1614d9997443da2a8dea103628c1490b266ee115"
-source.sha256 = "ea4e77472523ccbf412f81a05d5f327fa0fcdf505553701e47e9b1317b767238"
+source.commit = "cd0793ca40f3b7542d82e586ceb1dc7279d3afee"
+source.sha256 = "00b615894d146fb04749cd91254e715ed5ec43c5057a5309e314dadcee9d3626"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -161,8 +161,8 @@ only_for_targets.switch_variant = "stub"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "10e305a52c45bee91ffb16f6d3ad7a5cc3100e73"
-source.sha256 = "3142e71f7eb61e258dab3f6bf02e37ccfc2a0b2eeb134aadfe62603092175430"
+source.commit = "1614d9997443da2a8dea103628c1490b266ee115"
+source.sha256 = "75c3436ba987791c31469fda57b75027c9e41463872556df7a6c5378b856702f"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -179,8 +179,8 @@ only_for_targets.switch_variant = "asic"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "10e305a52c45bee91ffb16f6d3ad7a5cc3100e73"
-source.sha256 = "5bf81b8678fde53508d50cda973e2c8eacbe8b29a2e76e3809cdb1156c632702"
+source.commit = "1614d9997443da2a8dea103628c1490b266ee115"
+source.sha256 = "ea4e77472523ccbf412f81a05d5f327fa0fcdf505553701e47e9b1317b767238"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -50,6 +50,7 @@ sprockets-common.workspace = true
 sprockets-host.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+tofino.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
 tokio-tungstenite.workspace = true
 toml.workspace = true

--- a/sled-agent/src/hardware/illumos/mod.rs
+++ b/sled-agent/src/hardware/illumos/mod.rs
@@ -217,24 +217,21 @@ fn slot_to_disk_variant(slot: i64) -> Option<DiskVariant> {
 }
 
 fn get_tofino_snapshot(log: &Logger, devinfo: &mut DevInfo) -> TofinoSnapshot {
-    let mut exists = false;
-    let mut driver_loaded = false;
-
-    match tofino::get_tofino_from_devinfo(devinfo) {
-        Ok(node) => {
-            if let Some(node) = node {
-                exists = node.has_asic();
-                driver_loaded = node.has_driver();
-                debug!(
-                    log,
-                    "Found tofino node, with driver {}loaded",
-                    if driver_loaded { "" } else { "not " }
-                );
-            }
-        }
+    let (exists, driver_loaded) = match tofino::get_tofino_from_devinfo(devinfo)
+    {
+        Ok(None) => (false, false),
+        Ok(Some(node)) => (node.has_asic(), node.has_driver()),
         Err(e) => {
             error!(log, "failed to get tofino state: {e:?}");
+            (false, false)
         }
+    };
+    if exists {
+        debug!(
+            log,
+            "Found tofino node, with driver {}loaded",
+            if driver_loaded { "" } else { "not " }
+        );
     }
     TofinoSnapshot { exists, driver_loaded }
 }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -801,6 +801,23 @@ impl ServiceManager {
                     }
                     match *asic {
                         DendriteAsic::TofinoAsic => {
+                            // There should be exactly one device_name
+                            // associated with this zone: the /dev path for
+                            // the tofino ASIC.
+                            let dev_cnt = device_names.len();
+                            if dev_cnt == 1 {
+                                smfh.setprop(
+                                    "config/dev_path",
+                                    device_names[0].clone(),
+                                )?;
+                            } else {
+                                return Err(Error::SwitchZone(
+                                    anyhow::anyhow!(
+                                    "{dev_cnt} devices needed for tofino asic"
+                                ),
+                                ));
+                            }
+
                             smfh.setprop(
                                 "config/port_config",
                                 "/opt/oxide/dendrite/misc/sidecar_config.toml",

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -252,36 +252,6 @@ struct SledAgentInfo {
     rack_id: Uuid,
 }
 
-fn is_char_device(name: impl Into<PathBuf>) -> bool {
-    use std::os::unix::fs::FileTypeExt;
-
-    match std::fs::metadata(name.into()) {
-        Ok(metadata) => metadata.file_type().is_char_device(),
-        Err(_) => false,
-    }
-}
-
-// Depending on the kernel version, a tofino device can be found at either
-// /dev/tofino or /dev/tofino/<instance#>.  This method examines each in
-// turn, returning the first character device it finds in either of those
-// locations.
-fn find_tofino(root: &str) -> Result<String, Error> {
-    if is_char_device(root) {
-        return Ok(root.to_string());
-    }
-
-    for entry in std::fs::read_dir(root)
-        .map_err(|e| Error::Io { path: root.into(), err: e })?
-    {
-        let entry =
-            entry.map_err(|e| Error::Io { path: root.into(), err: e })?;
-        if is_char_device(&entry.path()) {
-            return Ok(entry.path().into_os_string().into_string().unwrap());
-        }
-    }
-    Err(Error::MissingDevice { device: "tofino".to_string() })
-}
-
 #[derive(Clone)]
 pub struct ServiceManager {
     inner: Arc<ServiceManagerInner>,
@@ -418,9 +388,15 @@ impl ServiceManager {
         for svc in &req.services {
             match svc {
                 ServiceType::Dendrite { asic: DendriteAsic::TofinoAsic } => {
-                    // When running on a real sidecar, we need the /dev/tofino
-                    // device to talk to the tofino ASIC.
-                    devices.push(find_tofino("/dev/tofino")?);
+                    if let Ok(Some(n)) = tofino::get_tofino() {
+                        if let Ok(device_path) = n.device_path() {
+                            devices.push(device_path);
+                            continue;
+                        }
+                    }
+                    return Err(Error::MissingDevice {
+                        device: "tofino".to_string(),
+                    });
                 }
                 _ => (),
             }


### PR DESCRIPTION
The `tofino` create provides the functionality to probe the device tree for tofino ASICs and drivers.  Use that crate rather than doing the search internally.

When configuring a switch zone, set an `smf` property that tells the `dpd` daemon which tofino device it is expected to use.