### PR TITLE
CI: generate a TUF repo with the control plane assets

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -13,8 +13,8 @@
 #: [dependencies.package]
 #: job = "helios / package"
 #:
-#: [dependencies.build-end-to-end-tests]
-#: job = "helios / build-end-to-end-tests"
+#: [dependencies.ci-tools]
+#: job = "helios / CI tools"
 
 set -o errexit
 set -o pipefail
@@ -118,7 +118,7 @@ cd /opt/oxide/work
 ptime -m tar xvzf /input/package/work/package.tar.gz
 cp /input/package/work/zones/* out/
 mkdir tests
-for p in /input/build-end-to-end-tests/work/*.gz; do
+for p in /input/ci-tools/work/end-to-end-tests/*.gz; do
 	ptime -m gunzip < "$p" > "tests/$(basename "${p%.gz}")"
 	chmod a+x "tests/$(basename "${p%.gz}")"
 done

--- a/.github/buildomat/jobs/trampoline-image.sh
+++ b/.github/buildomat/jobs/trampoline-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "helios / build recovery OS image"
+#: name = "helios / build trampoline OS image"
 #: variety = "basic"
 #: target = "helios-latest"
 #: rust_toolchain = "1.68.2"
@@ -29,7 +29,7 @@
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "os-recovery.tar.gz"
+#: name = "os-trampoline.tar.gz"
 #: from_output = "/work/helios/image/output/os.tar.gz"
 #:
 

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -29,6 +29,12 @@ rustc --version
 COMMIT=$(git rev-parse HEAD)
 VERSION="1.0.0-alpha+git${COMMIT:0:11}"
 
+#
+# The package job builds two switch zones. The one we need should be named "switch.tar.gz" so sled-agent can find it.
+#
+mv /input/package/work/zones/{switch-asic,switch}.tar.gz
+rm /input/package/work/zones/switch-softnpu.tar.gz
+
 cargo build --locked --release --bin tufaceous
 
 # Generate a throwaway repository key.

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -5,7 +5,7 @@
 #: target = "helios-latest"
 #: output_rules = [
 #:	"=/work/manifest.toml",
-#:	"=/work/repo.zip",
+#:	"=/work/repo.zip.part*",
 #: ]
 #:
 #: [dependencies.ci-tools]
@@ -83,3 +83,9 @@ EOF
 done
 
 /work/tufaceous assemble --no-generate-key --skip-all-present /work/manifest.toml /work/repo.zip
+
+#
+# XXX: Buildomat currently does not support uploads greater than 1 GiB. This is
+# an awful temporary hack which we need to strip out the moment it does.
+#
+split -a 1 -b 1024m /work/repo.zip /work/repo.zip.part

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#:
+#: name = "helios / tuf-repo"
+#: variety = "basic"
+#: target = "helios-latest"
+#: rust_toolchain = "1.68.2"
+#: output_rules = [
+#:	"=/work/manifest.toml",
+#:	"=/work/repo.zip",
+#: ]
+#:
+#: [dependencies.package]
+#: job = "helios / package"
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+COMMIT=$(git rev-parse HEAD)
+VERSION="1.0.0-alpha+git${COMMIT:0:11}"
+
+cargo build --locked --release --bin tufaceous
+
+# Generate a throwaway repository key.
+python3 -c 'import secrets; open("/work/key.txt", "w").write("ed25519:%s\n" % secrets.token_hex(32))'
+read -r TUFACEOUS_KEY </work/key.txt
+export TUFACEOUS_KEY
+
+cat >/work/manifest.toml <<EOF
+system_version = "$VERSION"
+
+[artifact.control_plane]
+name = "control-plane"
+version = "$VERSION"
+[artifact.control_plane.source]
+kind = "composite-control-plane"
+EOF
+
+for zone in /input/package/work/zones/*; do
+    cat >>/work/manifest.toml <<EOF
+[[artifact.control_plane.source.zones]]
+kind = "file"
+path = "$zone"
+EOF
+done
+
+target/release/tufaceous assemble --no-generate-key --skip-all-present /work/manifest.toml /work/repo.zip

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -73,12 +73,6 @@ EOF
 done
 
 for kind in host trampoline; do
-    mkdir -p /work/os/$kind
-    pushd /work/os/$kind
-    # https://github.com/oxidecomputer/helios#os-image-archives
-    tar xf /input/$kind/work/helios/image/output/os.tar.gz image/rom image/zfs.img
-    popd
-
     cat >>/work/manifest.toml <<EOF
 [artifact.$kind]
 name = "$kind"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -84,9 +84,8 @@ for kind in host trampoline; do
 name = "$kind"
 version = "$VERSION"
 [artifact.$kind.source]
-kind = "composite-host"
-phase_1 = { kind = "file", path = "/work/os/$kind/image/rom" }
-phase_2 = { kind = "file", path = "/work/os/$kind/image/zfs.img" }
+kind = "file"
+path = "/input/$kind/work/helios/image/output/os.tar.gz"
 EOF
 done
 


### PR DESCRIPTION
or: MORE JOBS FOR THE BUILDOMAT GODS

This generates a partial TUF repo (multipart for now since Buildomat has a 1 GiB file size limit) using `tufaceous assemble`. It currently contains the control plane bundle and host OS images; I'm going to go looking for how I can find the other artifacts to include, but I think this is ready enough for review.

This also renames the "build-end-to-end-tests" job to "CI tools", and adds a build for tufaceous there. This is a "how long does it take CI to run" optimization, because this allows us to build the tufaceous binary while we're waiting for the rest of the control plane to build.