### PR TITLE
[wicketd] Add endpoints to drive updates (SP only, for now)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7773,6 +7773,7 @@ dependencies = [
  "expectorate",
  "futures",
  "gateway-client",
+ "gateway-messages",
  "http",
  "hyper",
  "installinator-artifactd",

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -18,7 +18,6 @@ use gateway_client::types::SpComponentFirmwareSlot;
 use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpUpdateStatus;
 use gateway_client::types::UpdateAbortBody;
-use gateway_client::types::UpdateBody;
 use gateway_client::Client;
 use serde::Serialize;
 use slog::o;
@@ -614,9 +613,10 @@ async fn update(
     let update_id = Uuid::new_v4();
     println!("generated update ID {update_id}");
 
-    let body = UpdateBody { id: update_id, image, slot };
     client
-        .sp_component_update(sp.type_, sp.slot, component, &body)
+        .sp_component_update(
+            sp.type_, sp.slot, component, slot, &update_id, image,
+        )
         .await
         .context("failed to start update")?;
 

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -2,6 +2,12 @@
 # Oxide API: example configuration file
 #
 
+# Maximum number of host phase2 trampoline images we're willing to cache. Note
+# that this value is specified in terms of _number of images_, not bytes, and
+# our cache is in-memory. We expect this value to be small in production,
+# potentially even 1 (i.e., only keep the most-recently-uploaded image).
+host_phase2_recovery_image_cache_max_images = 1
+
 [dropshot]
 # We want to allow uploads of host phase 2 recovery images, which may be
 # measured in the (small) hundreds of MiB. Set this to 512 MiB.

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -19,6 +19,7 @@ use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Path;
+use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
 use dropshot::UntypedBody;
@@ -856,20 +857,17 @@ async fn sp_component_serial_console_detach(
     Ok(HttpResponseUpdatedNoContent {})
 }
 
-// TODO: how can we make this generic enough to support any update mechanism?
 #[derive(Deserialize, JsonSchema)]
-pub struct UpdateBody {
+pub struct ComponentUpdateIdSlot {
     /// An identifier for this update.
     ///
     /// This ID applies to this single instance of the API call; it is not an
     /// ID of `image` itself. Multiple API calls with the same `image` should
     /// use different IDs.
     pub id: Uuid,
-    /// The binary blob containing the update image (component-specific).
-    pub image: Vec<u8>,
     /// The update slot to apply this image to. Supply 0 if the component only
     /// has one update slot.
-    pub slot: u16,
+    pub firmware_slot: u16,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -927,16 +925,20 @@ async fn sp_reset(
 async fn sp_component_update(
     rqctx: RequestContext<Arc<ServerContext>>,
     path: Path<PathSpComponent>,
-    body: TypedBody<UpdateBody>,
+    query_params: Query<ComponentUpdateIdSlot>,
+    body: UntypedBody,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let apictx = rqctx.context();
 
     let PathSpComponent { sp, component } = path.into_inner();
     let sp = apictx.mgmt_switch.sp(sp.into())?;
     let component = component_from_str(&component)?;
+    let ComponentUpdateIdSlot { id, firmware_slot } = query_params.into_inner();
 
-    let UpdateBody { id, image, slot } = body.into_inner();
-    sp.start_update(component, id, slot, image)
+    // TODO-performance: this makes a full copy of the uploaded data
+    let image = body.as_bytes().to_vec();
+
+    sp.start_update(component, id, firmware_slot, image)
         .await
         .map_err(SpCommsError::from)?;
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -625,13 +625,35 @@
             "schema": {
               "$ref": "#/components/schemas/SpType"
             }
+          },
+          {
+            "in": "query",
+            "name": "firmware_slot",
+            "description": "The update slot to apply this image to. Supply 0 if the component only has one update slot.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "description": "An identifier for this update.\n\nThis ID applies to this single instance of the API call; it is not an ID of `image` itself. Multiple API calls with the same `image` should use different IDs.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/octet-stream": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateBody"
+                "type": "string",
+                "format": "binary"
               }
             }
           },
@@ -2648,36 +2670,6 @@
         },
         "required": [
           "id"
-        ]
-      },
-      "UpdateBody": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "description": "An identifier for this update.\n\nThis ID applies to this single instance of the API call; it is not an ID of `image` itself. Multiple API calls with the same `image` should use different IDs.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "image": {
-            "description": "The binary blob containing the update image (component-specific).",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
-          },
-          "slot": {
-            "description": "The update slot to apply this image to. Supply 0 if the component only has one update slot.",
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "id",
-          "image",
-          "slot"
         ]
       },
       "UpdatePreparationProgress": {

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -10,6 +10,31 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/artifacts": {
+      "get": {
+        "summary": "An endpoint used to report all available artifacts.",
+        "description": "The order of the returned artifacts is unspecified, and may change between calls even if the total set of artifacts has not.",
+        "operationId": "get_artifacts",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetArtifactsResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/inventory": {
       "get": {
         "summary": "A status endpoint used to report high level information known to wicketd.",
@@ -63,6 +88,111 @@
           }
         }
       }
+    },
+    "/update": {
+      "get": {
+        "summary": "An endpoint to get the status of all updates being performed or recently",
+        "description": "completed on all SPs.",
+        "operationId": "get_update_all",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateLogAll"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/update/{type}/{slot}": {
+      "get": {
+        "summary": "An endpoint to get the status of any update being performed or recently",
+        "description": "completed on a single SP.",
+        "operationId": "get_update_sp",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateLog"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "post": {
+        "summary": "An endpoint to start updating a sled.",
+        "operationId": "post_start_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -79,6 +209,29 @@
       }
     },
     "schemas": {
+      "ArtifactId": {
+        "description": "An identifier for an artifact.\n\nThe kind is [`ArtifactKind`], indicating that it might represent an artifact whose kind is unknown.",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "description": "The kind of artifact this is.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The artifact's name.",
+            "type": "string"
+          },
+          "version": {
+            "description": "The artifact's version.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name",
+          "version"
+        ]
+      },
       "Duration": {
         "type": "object",
         "properties": {
@@ -117,8 +270,23 @@
           "request_id"
         ]
       },
+      "GetArtifactsResponse": {
+        "description": "The response to a `get_artifacts` call: the list of all artifacts currently held by wicketd.",
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactId"
+            }
+          }
+        },
+        "required": [
+          "artifacts"
+        ]
+      },
       "GetInventoryResponse": {
-        "description": "The response to a `get_inventory` call: the inventory of artifacts known to wicketd, or a notification that data is unavailable.",
+        "description": "The response to a `get_inventory` call: the inventory known to wicketd, or a notification that data is unavailable.",
         "oneOf": [
           {
             "type": "object",
@@ -678,6 +846,378 @@
           "sled",
           "power",
           "switch"
+        ]
+      },
+      "UpdateEvent": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/UpdateEventKind"
+          }
+        },
+        "required": [
+          "age",
+          "kind"
+        ]
+      },
+      "UpdateEventFailureKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "sp_reset_failed"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "artifact",
+                  "reason"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "artifact_update_failed"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          }
+        ]
+      },
+      "UpdateEventKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/UpdateEventSuccessKind"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "success"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/UpdateEventFailureKind"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "failure"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          }
+        ]
+      },
+      "UpdateEventSuccessKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "sp_reset_complete"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  }
+                },
+                "required": [
+                  "artifact"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "artifact_update_complete"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          }
+        ]
+      },
+      "UpdateLog": {
+        "type": "object",
+        "properties": {
+          "current": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateState"
+              }
+            ]
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UpdateEvent"
+            }
+          }
+        },
+        "required": [
+          "events"
+        ]
+      },
+      "UpdateLogAll": {
+        "description": "The response to a `get_update_all` call: the list of all updates (in-flight or completed) known by wicketd.",
+        "type": "object",
+        "properties": {
+          "sps": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/UpdateLog"
+              }
+            }
+          }
+        },
+        "required": [
+          "sps"
+        ]
+      },
+      "UpdatePreparationProgress": {
+        "description": "Progress of an SP preparing to update.\n\nThe units of `current` and `total` are unspecified and defined by the SP; e.g., if preparing for an update requires erasing a flash device, this may indicate progress of that erasure without defining units (bytes, pages, sectors, etc.).",
+        "type": "object",
+        "properties": {
+          "current": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "current",
+          "total"
+        ]
+      },
+      "UpdateState": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/UpdateStateKind"
+          }
+        },
+        "required": [
+          "age",
+          "kind"
+        ]
+      },
+      "UpdateStateKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "resetting_sp"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  }
+                },
+                "required": [
+                  "artifact"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "sending_artifact_to_mgs"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  },
+                  "progress": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/UpdatePreparationProgress"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "artifact"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "preparing_for_artifact"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "bytes_received": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "total_bytes": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "bytes_received",
+                  "total_bytes"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "artifact_update_progress"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  }
+                },
+                "required": [
+                  "artifact"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "waiting_for_status"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "state"
+            ]
+          }
         ]
       }
     }

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -15,6 +15,7 @@ debug-ignore.workspace = true
 display-error-chain.workspace = true
 dropshot.workspace = true
 futures.workspace = true
+gateway-messages.workspace = true
 http.workspace = true
 hyper.workspace = true
 reqwest.workspace = true

--- a/wicketd/src/context.rs
+++ b/wicketd/src/context.rs
@@ -5,7 +5,7 @@
 //! User provided dropshot server context
 
 use crate::artifacts::WicketdArtifactStore;
-use crate::update_planner::UpdatePlanner;
+use crate::update_tracker::UpdateTracker;
 use crate::MgsHandle;
 
 /// Shared state used by API handlers
@@ -13,5 +13,5 @@ pub struct ServerContext {
     pub mgs_handle: MgsHandle,
     pub mgs_client: gateway_client::Client,
     pub(crate) artifact_store: WicketdArtifactStore,
-    pub(crate) update_planner: UpdatePlanner,
+    pub(crate) update_tracker: UpdateTracker,
 }

--- a/wicketd/src/context.rs
+++ b/wicketd/src/context.rs
@@ -4,10 +4,14 @@
 
 //! User provided dropshot server context
 
-use crate::{artifacts::WicketdArtifactStore, MgsHandle};
+use crate::artifacts::WicketdArtifactStore;
+use crate::update_planner::UpdatePlanner;
+use crate::MgsHandle;
 
 /// Shared state used by API handlers
 pub struct ServerContext {
     pub mgs_handle: MgsHandle,
+    pub mgs_client: gateway_client::Client,
     pub(crate) artifact_store: WicketdArtifactStore,
+    pub(crate) update_planner: UpdatePlanner,
 }

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -5,6 +5,9 @@
 //! HTTP entrypoint functions for wicketd
 
 use crate::mgs::GetInventoryResponse;
+use crate::update_events::UpdateLog;
+use crate::update_planner::UpdatePlanError;
+use dropshot::Path;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
@@ -12,6 +15,12 @@ use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::RequestContext;
 use dropshot::UntypedBody;
+use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpType;
+use omicron_common::update::ArtifactId;
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::collections::BTreeMap;
 
 use crate::ServerContext;
 
@@ -24,6 +33,10 @@ pub fn api() -> WicketdApiDescription {
     ) -> Result<(), String> {
         api.register(get_inventory)?;
         api.register(put_repository)?;
+        api.register(get_artifacts)?;
+        api.register(post_start_update)?;
+        api.register(get_update_all)?;
+        api.register(get_update_sp)?;
         Ok(())
     }
 
@@ -68,10 +81,108 @@ async fn put_repository(
     rqctx: RequestContext<ServerContext>,
     body: UntypedBody,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let rqctx = rqctx.context();
+
     // TODO: do we need to return more information with the response?
 
     // TODO: `UntypedBody` is currently inefficient for large request bodies -- it does many copies
     // and allocations. Replace this with a better solution once it's available in dropshot.
-    rqctx.context().artifact_store.put_repository(body.as_bytes())?;
+    rqctx.artifact_store.put_repository(body.as_bytes())?;
+
+    // Ensure we can actually apply updates from this repository.
+    //
+    // TODO-correctness If this fails, we've left `artifact_store` in a bad
+    // state. Maybe we should try to plan before replacing the existing
+    // artifact_store contents?
+    rqctx
+        .update_planner
+        .regenerate_plan()
+        .map_err(|err| HttpError::for_bad_request(None, err.to_string()))?;
+
     Ok(HttpResponseUpdatedNoContent())
+}
+
+/// The response to a `get_artifacts` call: the list of all artifacts currently
+/// held by wicketd.
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct GetArtifactsResponse {
+    pub artifacts: Vec<ArtifactId>,
+}
+
+/// An endpoint used to report all available artifacts.
+///
+/// The order of the returned artifacts is unspecified, and may change between
+/// calls even if the total set of artifacts has not.
+#[endpoint {
+    method = GET,
+    path = "/artifacts",
+}]
+async fn get_artifacts(
+    rqctx: RequestContext<ServerContext>,
+) -> Result<HttpResponseOk<GetArtifactsResponse>, HttpError> {
+    let artifacts = rqctx.context().artifact_store.artifact_ids();
+    Ok(HttpResponseOk(GetArtifactsResponse { artifacts }))
+}
+
+/// An endpoint to start updating a sled.
+#[endpoint {
+    method = POST,
+    path = "/update/{type}/{slot}",
+}]
+async fn post_start_update(
+    rqctx: RequestContext<ServerContext>,
+    target: Path<SpIdentifier>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    match rqctx.context().update_planner.start(target.into_inner()).await {
+        Ok(()) => Ok(HttpResponseUpdatedNoContent {}),
+        Err(err) => match err {
+            UpdatePlanError::DuplicateArtifacts(_)
+            | UpdatePlanError::MissingArtifact(_) => {
+                // TODO-correctness for_bad_request may not be right - both of
+                // these errors are issues with the TUF repository, not this
+                // request itself.
+                Err(HttpError::for_bad_request(None, err.to_string()))
+            }
+            UpdatePlanError::UpdateInProgress(_) => {
+                Err(HttpError::for_unavail(None, err.to_string()))
+            }
+        },
+    }
+}
+
+/// The response to a `get_update_all` call: the list of all updates (in-flight
+/// or completed) known by wicketd.
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateLogAll {
+    pub sps: BTreeMap<SpType, BTreeMap<u32, UpdateLog>>,
+}
+
+/// An endpoint to get the status of all updates being performed or recently
+/// completed on all SPs.
+#[endpoint {
+    method = GET,
+    path = "/update",
+}]
+async fn get_update_all(
+    rqctx: RequestContext<ServerContext>,
+) -> Result<HttpResponseOk<UpdateLogAll>, HttpError> {
+    let sps = rqctx.context().update_planner.update_log_all().await;
+    Ok(HttpResponseOk(UpdateLogAll { sps }))
+}
+
+/// An endpoint to get the status of any update being performed or recently
+/// completed on a single SP.
+#[endpoint {
+    method = GET,
+    path = "/update/{type}/{slot}",
+}]
+async fn get_update_sp(
+    rqctx: RequestContext<ServerContext>,
+    target: Path<SpIdentifier>,
+) -> Result<HttpResponseOk<UpdateLog>, HttpError> {
+    let update_log =
+        rqctx.context().update_planner.update_log(target.into_inner()).await;
+    Ok(HttpResponseOk(update_log))
 }

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -9,7 +9,7 @@ mod http_entrypoints;
 mod inventory;
 mod mgs;
 mod update_events;
-mod update_planner;
+mod update_tracker;
 
 use artifacts::WicketdArtifactStore;
 pub use config::Config;
@@ -21,7 +21,7 @@ pub(crate) use mgs::{MgsHandle, MgsManager};
 use dropshot::ConfigDropshot;
 use slog::{debug, error, o, Drain};
 use std::net::{SocketAddr, SocketAddrV6};
-use update_planner::UpdatePlanner;
+use update_tracker::UpdateTracker;
 
 /// Run the OpenAPI generator for the API; which emits the OpenAPI spec
 /// to stdout.
@@ -75,8 +75,7 @@ pub async fn run_server(config: Config, args: Args) -> Result<(), String> {
     });
 
     let store = WicketdArtifactStore::new(&log);
-    let update_planner =
-        UpdatePlanner::new(store.clone(), args.mgs_address, &log);
+    let update_tracker = UpdateTracker::new(args.mgs_address, &log);
 
     let wicketd_server_fut = {
         let log = log.new(o!("component" => "dropshot (wicketd)"));
@@ -88,7 +87,7 @@ pub async fn run_server(config: Config, args: Args) -> Result<(), String> {
                 mgs_handle,
                 mgs_client,
                 artifact_store: store.clone(),
-                update_planner,
+                update_tracker,
             },
             &log,
         )

--- a/wicketd/src/mgs.rs
+++ b/wicketd/src/mgs.rs
@@ -34,6 +34,7 @@ pub struct ShutdownInProgress;
 #[derive(Debug)]
 enum MgsRequest {
     GetInventory {
+        #[allow(dead_code)]
         etag: Option<String>,
         reply_tx: oneshot::Sender<GetInventoryResponse>,
     },

--- a/wicketd/src/update_events.rs
+++ b/wicketd/src/update_events.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+use gateway_client::types::UpdatePreparationProgress;
+use omicron_common::update::ArtifactId;
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateState {
+    pub age: Duration,
+    pub kind: UpdateStateKind,
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case", tag = "state", content = "data")]
+pub enum UpdateStateKind {
+    ResettingSp,
+    SendingArtifactToMgs {
+        artifact: ArtifactId,
+    },
+    PreparingForArtifact {
+        artifact: ArtifactId,
+        progress: Option<UpdatePreparationProgress>,
+    },
+    ArtifactUpdateProgress {
+        bytes_received: u64,
+        total_bytes: u64,
+    },
+    WaitingForStatus {
+        artifact: ArtifactId,
+    },
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateEvent {
+    pub age: Duration,
+    pub kind: UpdateEventKind,
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "data")]
+pub enum UpdateEventKind {
+    Success(UpdateEventSuccessKind),
+    Failure(UpdateEventFailureKind),
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "data")]
+pub enum UpdateEventSuccessKind {
+    SpResetComplete,
+    ArtifactUpdateComplete { artifact: ArtifactId },
+}
+
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "data")]
+pub enum UpdateEventFailureKind {
+    SpResetFailed { reason: String },
+    ArtifactUpdateFailed { artifact: ArtifactId, reason: String },
+}
+
+#[derive(Clone, Debug, Default, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateLog {
+    pub current: Option<UpdateState>,
+    pub events: Vec<UpdateEvent>,
+}

--- a/wicketd/src/update_planner.rs
+++ b/wicketd/src/update_planner.rs
@@ -1,0 +1,489 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+use crate::artifacts::WicketdArtifactStore;
+use crate::mgs::make_mgs_client;
+use crate::update_events::UpdateEventFailureKind;
+use crate::update_events::UpdateEventKind;
+use crate::update_events::UpdateEventSuccessKind;
+use crate::update_events::UpdateStateKind;
+use anyhow::bail;
+use anyhow::ensure;
+use anyhow::Context;
+use buf_list::BufList;
+use debug_ignore::DebugIgnore;
+use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpType;
+use gateway_client::types::SpUpdateStatus;
+use gateway_client::types::UpdateBody;
+use gateway_messages::SpComponent;
+use omicron_common::api::internal::nexus::KnownArtifactKind;
+use omicron_common::update::ArtifactId;
+use slog::error;
+use slog::info;
+use slog::o;
+use slog::Logger;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::net::SocketAddrV6;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+use std::time::Instant;
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+// These three types are mirrors of the HTTP
+// `UpdateState`/`UpdateEvent`/`UpdateLog`, but with the timestamps stored as
+// `Instant`s. This allows us to convert them to `Duration`s (i.e., ages) when
+// returning them to a caller.
+#[derive(Clone, Debug)]
+struct UpdateState {
+    timestamp: Instant,
+    kind: UpdateStateKind,
+}
+
+impl From<UpdateState> for crate::update_events::UpdateState {
+    fn from(state: UpdateState) -> Self {
+        Self { age: state.timestamp.elapsed(), kind: state.kind }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct UpdateEvent {
+    timestamp: Instant,
+    kind: UpdateEventKind,
+}
+
+impl From<UpdateEvent> for crate::update_events::UpdateEvent {
+    fn from(event: UpdateEvent) -> Self {
+        Self { age: event.timestamp.elapsed(), kind: event.kind }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct UpdateLog {
+    current: Option<UpdateState>,
+    events: Vec<UpdateEvent>,
+}
+
+impl From<UpdateLog> for crate::update_events::UpdateLog {
+    fn from(log: UpdateLog) -> Self {
+        Self {
+            current: log.current.map(Into::into),
+            events: log.events.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UpdatePlanner {
+    mgs_client: gateway_client::Client,
+    artifact_store: WicketdArtifactStore,
+    update_plan: StdMutex<Result<UpdatePlan, UpdatePlanError>>,
+    running_updates: Mutex<BTreeMap<SpIdentifier, JoinHandle<()>>>,
+    // Note: Our inner mutex here is a standard mutex, not a tokio mutex. We
+    // generally hold it only log enough to update its state or push a new
+    // update event into its running log; occasionally we hold it long enough to
+    // clone it.
+    update_logs: Mutex<BTreeMap<SpIdentifier, Arc<StdMutex<UpdateLog>>>>,
+    log: Logger,
+}
+
+impl UpdatePlanner {
+    pub(crate) fn new(
+        artifact_store: WicketdArtifactStore,
+        mgs_addr: SocketAddrV6,
+        log: &Logger,
+    ) -> Self {
+        let log = log.new(o!("component" => "wicketd update planner"));
+        let running_updates = Mutex::default();
+        let update_logs = Mutex::default();
+        let mgs_client = make_mgs_client(log.clone(), mgs_addr);
+
+        // We don't expect to be able to create an update plan before a TUF
+        // repository has been uploaded, and presumably we're being created
+        // before such a thing could happen. Therefore, we store the `Result` of
+        // creating the update plan; if someone tries to call `start()` before
+        // we've been able to successfully generate a plan, we have an error
+        // ready to hand them.
+        let update_plan = StdMutex::new(UpdatePlan::new(&artifact_store));
+
+        Self {
+            mgs_client,
+            artifact_store,
+            update_plan,
+            log,
+            running_updates,
+            update_logs,
+        }
+    }
+
+    pub(crate) fn regenerate_plan(&self) -> Result<(), UpdatePlanError> {
+        match UpdatePlan::new(&self.artifact_store) {
+            Ok(plan) => {
+                *self.update_plan.lock().unwrap() = Ok(plan);
+                Ok(())
+            }
+            Err(err) => {
+                *self.update_plan.lock().unwrap() = Err(err.clone());
+                Err(err)
+            }
+        }
+    }
+
+    pub(crate) async fn start(
+        &self,
+        sp: SpIdentifier,
+    ) -> Result<(), UpdatePlanError> {
+        let plan = self.update_plan.lock().unwrap().clone()?;
+
+        let spawn_update_driver = || async {
+            // Get a reference to the update log for this SP...
+            let update_log = Arc::clone(
+                self.update_logs.lock().await.entry(sp).or_default(),
+            );
+
+            // ...and then reset it to the empty state, removing any events or
+            // state from a previous update attempt.
+            *update_log.lock().unwrap() = UpdateLog::default();
+
+            let update_driver = UpdateDriver {
+                sp,
+                mgs_client: self.mgs_client.clone(),
+                update_log,
+                log: self.log.new(o!("sp" => format!("{sp:?}"))),
+            };
+            tokio::spawn(update_driver.run(plan))
+        };
+
+        let mut running_updates = self.running_updates.lock().await;
+        match running_updates.entry(sp) {
+            // Vacant: this is the first time we've started an update to this
+            // sp.
+            Entry::Vacant(slot) => {
+                slot.insert(spawn_update_driver().await);
+                Ok(())
+            }
+            // Occupied: we've previously started an update to this sp; only
+            // allow this one if that update is no longer running.
+            Entry::Occupied(mut slot) => {
+                if slot.get().is_finished() {
+                    slot.insert(spawn_update_driver().await);
+                    Ok(())
+                } else {
+                    Err(UpdatePlanError::UpdateInProgress(sp))
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn update_log(
+        &self,
+        sp: SpIdentifier,
+    ) -> crate::update_events::UpdateLog {
+        let mut update_logs = self.update_logs.lock().await;
+        match update_logs.entry(sp) {
+            Entry::Vacant(_) => crate::update_events::UpdateLog::default(),
+            Entry::Occupied(slot) => slot.get().lock().unwrap().clone().into(),
+        }
+    }
+
+    /// Clone the current state of the update log for every SP, returning a map
+    /// suitable for conversion to JSON.
+    pub(crate) async fn update_log_all(
+        &self,
+    ) -> BTreeMap<SpType, BTreeMap<u32, crate::update_events::UpdateLog>> {
+        let update_logs = self.update_logs.lock().await;
+        let mut converted_logs = BTreeMap::new();
+        for (sp, update_log) in &*update_logs {
+            let update_log = update_log.lock().unwrap().clone();
+            let inner: &mut BTreeMap<_, _> =
+                converted_logs.entry(sp.type_).or_default();
+            inner.insert(sp.slot, update_log.into());
+        }
+        converted_logs
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+pub(crate) enum UpdatePlanError {
+    #[error(
+        "invalid TUF repository: more than one artifact present of kind {0:?}"
+    )]
+    DuplicateArtifacts(KnownArtifactKind),
+    #[error("invalid TUF repository: no artifact present of kind {0:?}")]
+    MissingArtifact(KnownArtifactKind),
+    #[error("target is already being updated: {0:?}")]
+    UpdateInProgress(SpIdentifier),
+}
+
+#[derive(Debug, Clone)]
+struct ArtifactIdData {
+    id: ArtifactId,
+    data: DebugIgnore<BufList>,
+}
+
+#[derive(Debug, Clone)]
+struct UpdatePlan {
+    gimlet_sp: ArtifactIdData,
+    psc_sp: ArtifactIdData,
+    sidecar_sp: ArtifactIdData,
+}
+
+impl UpdatePlan {
+    fn new(
+        artifact_store: &WicketdArtifactStore,
+    ) -> Result<Self, UpdatePlanError> {
+        let snapshot = artifact_store.snapshot();
+
+        // We expect exactly one of each of these kinds to be present in the
+        // snapshot. Scan the snapshot and record the first of each we find,
+        // failing if we find a second.
+        let mut gimlet_sp = None;
+        let mut psc_sp = None;
+        let mut sidecar_sp = None;
+
+        let artifact_found = |out: &mut Option<ArtifactIdData>, id, data| {
+            let data = DebugIgnore(data);
+            match out.replace(ArtifactIdData { id, data }) {
+                None => Ok(()),
+                Some(prev) => {
+                    // This closure is only called with well-known kinds.
+                    let kind = prev.id.kind.to_known().unwrap();
+                    Err(UpdatePlanError::DuplicateArtifacts(kind))
+                }
+            }
+        };
+
+        for (id, data) in snapshot {
+            let Some(kind) = id.kind.to_known() else { continue };
+            match kind {
+                KnownArtifactKind::GimletSp => {
+                    artifact_found(&mut gimlet_sp, id, data)?
+                }
+                KnownArtifactKind::PscSp => {
+                    artifact_found(&mut psc_sp, id, data)?
+                }
+                KnownArtifactKind::SwitchSp => {
+                    artifact_found(&mut sidecar_sp, id, data)?
+                }
+                _ => {
+                    // ignore other known kinds for now
+                }
+            }
+        }
+
+        Ok(Self {
+            gimlet_sp: gimlet_sp.ok_or(UpdatePlanError::MissingArtifact(
+                KnownArtifactKind::GimletSp,
+            ))?,
+            psc_sp: psc_sp.ok_or(UpdatePlanError::MissingArtifact(
+                KnownArtifactKind::PscSp,
+            ))?,
+            sidecar_sp: sidecar_sp.ok_or(UpdatePlanError::MissingArtifact(
+                KnownArtifactKind::SwitchSp,
+            ))?,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct UpdateDriver {
+    sp: SpIdentifier,
+    mgs_client: gateway_client::Client,
+    update_log: Arc<StdMutex<UpdateLog>>,
+    log: Logger,
+}
+
+impl UpdateDriver {
+    async fn run(self, plan: UpdatePlan) {
+        if let Err(err) = self.run_impl(plan).await {
+            error!(self.log, "update failed"; "err" => ?err);
+            self.push_update_failure(err);
+        }
+    }
+
+    fn set_current_update_state(&self, kind: UpdateStateKind) {
+        let state = UpdateState { timestamp: Instant::now(), kind };
+        self.update_log.lock().unwrap().current = Some(state);
+    }
+
+    fn push_update_success(
+        &self,
+        kind: UpdateEventSuccessKind,
+        new_current: Option<UpdateStateKind>,
+    ) {
+        let timestamp = Instant::now();
+        let kind = UpdateEventKind::Success(kind);
+        let event = UpdateEvent { timestamp, kind };
+        let mut update_log = self.update_log.lock().unwrap();
+        update_log.events.push(event);
+        update_log.current =
+            new_current.map(|kind| UpdateState { timestamp, kind });
+    }
+
+    fn push_update_failure(&self, kind: UpdateEventFailureKind) {
+        let kind = UpdateEventKind::Failure(kind);
+        let event = UpdateEvent { timestamp: Instant::now(), kind };
+        let mut update_log = self.update_log.lock().unwrap();
+        update_log.events.push(event);
+        update_log.current = None;
+    }
+
+    async fn run_impl(
+        &self,
+        plan: UpdatePlan,
+    ) -> Result<(), UpdateEventFailureKind> {
+        let sp_artifact = match self.sp.type_ {
+            SpType::Sled => &plan.gimlet_sp,
+            SpType::Power => &plan.psc_sp,
+            SpType::Switch => &plan.sidecar_sp,
+        };
+
+        info!(self.log, "starting SP update"; "artifact" => ?sp_artifact.id);
+        self.update_sp(sp_artifact).await.map_err(|err| {
+            UpdateEventFailureKind::ArtifactUpdateFailed {
+                artifact: sp_artifact.id.clone(),
+                reason: format!("{err:#}"),
+            }
+        })?;
+        self.push_update_success(
+            UpdateEventSuccessKind::ArtifactUpdateComplete {
+                artifact: sp_artifact.id.clone(),
+            },
+            Some(UpdateStateKind::ResettingSp),
+        );
+
+        info!(self.log, "all updates complete; resetting SP");
+        self.reset_sp().await.map_err(|err| {
+            UpdateEventFailureKind::SpResetFailed { reason: format!("{err:#}") }
+        })?;
+        self.push_update_success(UpdateEventSuccessKind::SpResetComplete, None);
+
+        Ok(())
+    }
+
+    async fn update_sp(&self, artifact: &ArtifactIdData) -> anyhow::Result<()> {
+        const SP_COMPONENT: &str = SpComponent::SP_ITSELF.const_as_str();
+
+        let image = buf_list_to_vec(&artifact.data);
+        let update_id = Uuid::new_v4();
+        let body = UpdateBody { id: update_id, image, slot: 0 };
+        self.set_current_update_state(UpdateStateKind::SendingArtifactToMgs {
+            artifact: artifact.id.clone(),
+        });
+        self.mgs_client
+            .sp_component_update(
+                self.sp.type_,
+                self.sp.slot,
+                SP_COMPONENT,
+                &body,
+            )
+            .await
+            .context("failed to start update")?;
+
+        info!(self.log, "waiting for SP update to complete");
+        self.set_current_update_state(UpdateStateKind::WaitingForStatus {
+            artifact: artifact.id.clone(),
+        });
+        self.poll_for_component_update_completion(
+            &artifact.id,
+            update_id,
+            SP_COMPONENT,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn reset_sp(&self) -> anyhow::Result<()> {
+        self.mgs_client
+            .sp_reset(self.sp.type_, self.sp.slot)
+            .await
+            .context("failed to reset SP")
+            .map(|res| res.into_inner())
+    }
+
+    async fn poll_for_component_update_completion(
+        &self,
+        artifact: &ArtifactId,
+        update_id: Uuid,
+        component: &str,
+    ) -> anyhow::Result<()> {
+        // How often we poll MGS for the progress of an update once it starts.
+        const STATUS_POLL_FREQ: Duration = Duration::from_millis(300);
+
+        loop {
+            let status = self
+                .mgs_client
+                .sp_component_update_status(
+                    self.sp.type_,
+                    self.sp.slot,
+                    component,
+                )
+                .await?
+                .into_inner();
+
+            match status {
+                SpUpdateStatus::None => {
+                    bail!("SP no longer processing update (did it reset?")
+                }
+                SpUpdateStatus::Preparing { id, progress } => {
+                    ensure!(id == update_id, "SP processing different update");
+                    self.set_current_update_state(
+                        UpdateStateKind::PreparingForArtifact {
+                            artifact: artifact.clone(),
+                            progress,
+                        },
+                    );
+                }
+                SpUpdateStatus::InProgress {
+                    bytes_received,
+                    id,
+                    total_bytes,
+                } => {
+                    ensure!(id == update_id, "SP processing different update");
+                    self.set_current_update_state(
+                        UpdateStateKind::ArtifactUpdateProgress {
+                            bytes_received: bytes_received.into(),
+                            total_bytes: total_bytes.into(),
+                        },
+                    );
+                }
+                SpUpdateStatus::Complete { id } => {
+                    ensure!(id == update_id, "SP processing different update");
+                    return Ok(());
+                }
+                SpUpdateStatus::Aborted { id } => {
+                    ensure!(id == update_id, "SP processing different update");
+                    bail!("update aborted");
+                }
+                SpUpdateStatus::Failed { code, id } => {
+                    ensure!(id == update_id, "SP processing different update");
+                    bail!("update failed (error code {code})");
+                }
+            }
+
+            tokio::time::sleep(STATUS_POLL_FREQ).await;
+        }
+    }
+}
+
+// Helper function to convert a `BufList` into a `Vec<u8>` for use with
+// `gateway_client::Client`.
+//
+// TODO-performance Can we pass `BufList`s directly (or wrapped) to
+// `gateway_client::Client` endpoints without copying the data?
+fn buf_list_to_vec(data: &BufList) -> Vec<u8> {
+    let mut image = Vec::with_capacity(data.num_bytes());
+    for chunk in data {
+        image.extend_from_slice(&*chunk);
+    }
+    image
+}

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -372,7 +372,7 @@ impl UpdateDriver {
 fn buf_list_to_vec(data: &BufList) -> Vec<u8> {
     let mut image = Vec::with_capacity(data.num_bytes());
     for chunk in data {
-        image.extend_from_slice(&*chunk);
+        image.extend_from_slice(chunk);
     }
     image
 }


### PR DESCRIPTION
Currently this only supports updates to SPs. Adds endpoints to:

1. Get the list of available artifacts
2. Start updating a target SP
3. Get the progress of updates to a target SP
4. Get the progress of updates to all SPs (which have had at least one update started at some point in wicketd's lifetime)

It also adds a check to the repository upload endpoint that the uploaded repository contains all the artifacts we need to perform updates.

Builds on #2293 and should be merged after it.