### PR TITLE
Update OPTE for DNS domain search list & IPv6 fw filters.

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "helios / deploy"
 #: variety = "basic"
-#: target = "lab-opte-0.19"
+#: target = "lab-opte-0.20"
 #: output_rules = [
 #:	"%/var/svc/log/system-illumos-sled-agent:default.log",
 #:	"%/zone/oxz_nexus/root/var/svc/log/system-illumos-nexus:default.log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -2990,7 +2990,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 dependencies = [
  "quote",
  "syn",
@@ -4129,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 dependencies = [
  "cfg-if 0.1.10",
  "dyn-clone",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 dependencies = [
  "cfg-if 0.1.10",
  "illumos-sys-hdrs",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 dependencies = [
  "libc",
  "libnet",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=f501445f5a6c275c79f08a876fff6a861df31d46#f501445f5a6c275c79f08a876fff6a861df31d46"
+source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
 dependencies = [
  "cfg-if 0.1.10",
  "illumos-sys-hdrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ omicron-package = { path = "package" }
 omicron-sled-agent = { path = "sled-agent" }
 omicron-test-utils = { path = "test-utils" }
 omicron-zone-package = "0.5.1"
-oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "f501445f5a6c275c79f08a876fff6a861df31d46", features = [ "api", "std" ] }
+oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "6be54acd2438f0864a68bca44d7511f2ee50d761", features = [ "api", "std" ] }
 once_cell = "1.17.0"
 openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 openapiv3 = "1.0"
@@ -177,7 +177,7 @@ openapiv3 = "1.0"
 openssl = "0.10"
 openssl-sys = "0.9"
 openssl-probe = "0.1.2"
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "f501445f5a6c275c79f08a876fff6a861df31d46" }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "6be54acd2438f0864a68bca44d7511f2ee50d761" }
 oso = "0.26"
 oximeter = { path = "oximeter/oximeter" }
 oximeter-client = { path = "oximeter-client" }

--- a/sled-agent/src/opte/illumos/firewall_rules.rs
+++ b/sled-agent/src/opte/illumos/firewall_rules.rs
@@ -18,8 +18,12 @@ use oxide_vpc::api::Direction;
 use oxide_vpc::api::Filters;
 use oxide_vpc::api::FirewallAction;
 use oxide_vpc::api::FirewallRule;
+use oxide_vpc::api::IpAddr;
+use oxide_vpc::api::IpCidr;
 use oxide_vpc::api::Ipv4Cidr;
 use oxide_vpc::api::Ipv4PrefixLen;
+use oxide_vpc::api::Ipv6Cidr;
+use oxide_vpc::api::Ipv6PrefixLen;
 use oxide_vpc::api::Ports;
 use oxide_vpc::api::ProtoFilter;
 use oxide_vpc::api::Protocol;
@@ -66,16 +70,24 @@ impl FromVpcFirewallRule for VpcFirewallRule {
                         HostIdentifier::Ip(IpNet::V4(net))
                             if net.prefix() == 32 =>
                         {
-                            Address::Ip(net.ip().into())
+                            Address::Ip(IpAddr::Ip4(net.ip().into()))
                         }
                         HostIdentifier::Ip(IpNet::V4(net)) => {
-                            Address::Subnet(Ipv4Cidr::new(
+                            Address::Subnet(IpCidr::Ip4(Ipv4Cidr::new(
                                 net.ip().into(),
                                 Ipv4PrefixLen::new(net.prefix()).unwrap(),
-                            ))
+                            )))
                         }
-                        HostIdentifier::Ip(IpNet::V6(_net)) => {
-                            todo!("IPv6 host filters")
+                        HostIdentifier::Ip(IpNet::V6(net))
+                            if net.prefix() == 128 =>
+                        {
+                            Address::Ip(IpAddr::Ip6(net.ip().into()))
+                        }
+                        HostIdentifier::Ip(IpNet::V6(net)) => {
+                            Address::Subnet(IpCidr::Ip6(Ipv6Cidr::new(
+                                net.ip().into(),
+                                Ipv6PrefixLen::new(net.prefix()).unwrap(),
+                            )))
                         }
                         HostIdentifier::Vpc(vni) => {
                             Address::Vni(Vni::new(u32::from(*vni)).unwrap())

--- a/sled-agent/src/opte/illumos/port_manager.rs
+++ b/sled-agent/src/opte/illumos/port_manager.rs
@@ -293,6 +293,8 @@ impl PortManager {
             phys_gw_mac: Some(MacAddr::from(
                 self.inner.gateway_mac.into_array(),
             )),
+            // TODO-completeness (#2153): Plumb domain search list
+            domain_list: vec![],
         };
         hdl.create_xde(&port_name, vpc_cfg, /* passthru = */ false)?;
         debug!(

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -122,7 +122,7 @@ function add_publisher {
 # `helios-netdev` provides the xde kernel driver and the `opteadm` userland tool
 # for interacting with it.
 HELIOS_NETDEV_BASE_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/opte/repo"
-HELIOS_NETDEV_COMMIT="f501445f5a6c275c79f08a876fff6a861df31d46"
+HELIOS_NETDEV_COMMIT="6be54acd2438f0864a68bca44d7511f2ee50d761"
 HELIOS_NETDEV_REPO_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p"
 HELIOS_NETDEV_REPO_SHA_URL="$HELIOS_NETDEV_BASE_URL/$HELIOS_NETDEV_COMMIT/opte.p5p.sha256"
 HELIOS_NETDEV_REPO_PATH="$XDE_DIR/$(basename "$HELIOS_NETDEV_REPO_URL")"


### PR DESCRIPTION
Bump OPTE rev to https://github.com/oxidecomputer/opte/commit/6be54acd2438f0864a68bca44d7511f2ee50d761 to pull in:

1. https://github.com/oxidecomputer/opte/pull/324

    We can now start to plumb the domain search list returned via DHCP (#2153), still needs follow up work to expose in the console, nexus, etc

2. https://github.com/oxidecomputer/opte/pull/325

    IPv6 support for firewall host filters.