### PR TITLE
Update OPTE and use new dedicated dev node.

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "helios / deploy"
 #: variety = "basic"
-#: target = "lab-opte-0.20"
+#: target = "lab-opte-0.21"
 #: output_rules = [
 #:	"%/var/svc/log/system-illumos-sled-agent:default.log",
 #:	"%/zone/oxz_nexus/root/var/svc/log/system-illumos-nexus:default.log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,10 +1597,11 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 
 [[package]]
 name = "dlpi"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dlpi-sys#ca2366edd3d19fa0deefd800b3d356b901ef7cb0"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0b960559c76d475d2"
 dependencies = [
  "libc",
+ "libdlpi-sys",
  "num_enum",
  "pretty-hex 0.2.1",
  "thiserror",
@@ -2710,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -2992,7 +2993,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 dependencies = [
  "quote",
  "syn",
@@ -3045,6 +3046,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libdlpi-sys"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0b960559c76d475d2"
+
+[[package]]
 name = "libefi-illumos"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/libefi-illumos?branch=master#54c398c139f0e65252c2c0f9565d2eec7116bf02"
@@ -3092,7 +3098,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys#bf0fcd1b5d8b224e0821d14942cddfe1808f3996"
+source = "git+https://github.com/oxidecomputer/netadm-sys#e632591ab052ec1ddd6898822706c95a5098638e"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4133,11 +4139,10 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 dependencies = [
  "cfg-if 0.1.10",
  "dyn-clone",
- "heapless",
  "illumos-sys-hdrs",
  "kstat-macro",
  "opte-api",
@@ -4151,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 dependencies = [
  "cfg-if 0.1.10",
  "illumos-sys-hdrs",
@@ -4163,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 dependencies = [
  "libc",
  "libnet",
@@ -4225,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=6be54acd2438f0864a68bca44d7511f2ee50d761#6be54acd2438f0864a68bca44d7511f2ee50d761"
+source = "git+https://github.com/oxidecomputer/opte?rev=41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37#41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37"
 dependencies = [
  "cfg-if 0.1.10",
  "illumos-sys-hdrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ omicron-package = { path = "package" }
 omicron-sled-agent = { path = "sled-agent" }
 omicron-test-utils = { path = "test-utils" }
 omicron-zone-package = "0.5.1"
-oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "6be54acd2438f0864a68bca44d7511f2ee50d761", features = [ "api", "std" ] }
+oxide-vpc = { git = "https://github.com/oxidecomputer/opte", rev = "41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37", features = [ "api", "std" ] }
 once_cell = "1.17.1"
 openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 openapiv3 = "1.0"
@@ -177,7 +177,7 @@ openapiv3 = "1.0"
 openssl = "0.10"
 openssl-sys = "0.9"
 openssl-probe = "0.1.2"
-opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "6be54acd2438f0864a68bca44d7511f2ee50d761" }
+opte-ioctl = { git = "https://github.com/oxidecomputer/opte", rev = "41ba1d3fa476284c9cbc5d7eab7539cfad3eeb37" }
 oso = "0.26"
 oximeter = { path = "oximeter/oximeter" }
 oximeter-client = { path = "oximeter-client" }

--- a/sled-agent/src/opte/illumos/mod.rs
+++ b/sled-agent/src/opte/illumos/mod.rs
@@ -55,7 +55,7 @@ pub enum Error {
 
 /// Delete all xde devices on the system.
 pub fn delete_all_xde_devices(log: &Logger) -> Result<(), Error> {
-    let hdl = OpteHdl::open(OpteHdl::DLD_CTL)?;
+    let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
     for port_info in hdl.list_ports()?.ports.into_iter() {
         let name = &port_info.name;
         info!(
@@ -104,7 +104,7 @@ pub fn initialize_xde_driver(log: &Logger) -> Result<(), Error> {
             String::from(MESSAGE),
         )));
     }
-    match OpteHdl::open(OpteHdl::DLD_CTL)?.set_xde_underlay(
+    match OpteHdl::open(OpteHdl::XDE_CTL)?.set_xde_underlay(
         underlay_nics[0].interface(),
         underlay_nics[1].interface(),
     ) {

--- a/sled-agent/src/opte/illumos/port.rs
+++ b/sled-agent/src/opte/illumos/port.rs
@@ -68,7 +68,7 @@ impl Drop for PortInner {
             );
             return;
         }
-        let err = match opte_ioctl::OpteHdl::open(opte_ioctl::OpteHdl::DLD_CTL)
+        let err = match opte_ioctl::OpteHdl::open(opte_ioctl::OpteHdl::XDE_CTL)
         {
             Ok(hdl) => {
                 if let Err(e) = hdl.delete_xde(&self.name) {

--- a/sled-agent/src/opte/illumos/port_manager.rs
+++ b/sled-agent/src/opte/illumos/port_manager.rs
@@ -267,7 +267,7 @@ impl PortManager {
         // The Port object's drop implementation will clean up both of those, if
         // any of the remaining fallible operations fail.
         let port_name = self.inner.next_port_name();
-        let hdl = OpteHdl::open(OpteHdl::DLD_CTL)?;
+        let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
 
         // TODO-completeness: Add support for IPv6.
         let vpc_cfg = VpcCfg {
@@ -480,7 +480,7 @@ impl PortManager {
         &self,
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
-        let hdl = OpteHdl::open(OpteHdl::DLD_CTL)?;
+        let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
         for ((_, port_name), port) in self.inner.ports.lock().unwrap().iter() {
             let rules = opte_firewall_rules(rules, port.vni(), port.mac());
             let port_name = port_name.clone();


### PR DESCRIPTION
The kernel driver portion of OPTE (xde) no longer requires non-upstreamed kernel bits and can run on an updated stock helios. Thus we can remove the os-incorporation shuffling from the install script. The uninstall script remains mostly the same to still allow people with modified kernel bits to get back to stock.