### PR TITLE
Add some missing endpoint deprecations

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2788,10 +2788,12 @@ async fn instance_list_v1(
 }
 
 /// List instances
+/// Use `GET /v1/instances` instead
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}/projects/{project_name}/instances",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_list(
     rqctx: RequestContext<Arc<ServerContext>>,
@@ -2967,10 +2969,12 @@ async fn instance_view(
 }
 
 /// Fetch an instance by id
+/// Use `GET /v1/instances/{instance}` instead
 #[endpoint {
     method = GET,
     path = "/by-id/instances/{id}",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_view_by_id(
     rqctx: RequestContext<Arc<ServerContext>>,
@@ -4239,10 +4243,12 @@ async fn instance_network_interface_list_v1(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 /// List network interfaces
+/// Use `GET /v1/network-interfaces` instead
 #[endpoint {
     method = GET,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_network_interface_list(
     rqctx: RequestContext<Arc<ServerContext>>,
@@ -4395,10 +4401,13 @@ async fn instance_network_interface_delete_v1(
 /// are any secondary interfaces. A new primary interface must be designated
 /// first. The primary interface can be deleted if there are no secondary
 /// interfaces.
+///
+/// Use `DELETE /v1/network-interfaces/{interface}` instead
 #[endpoint {
     method = DELETE,
     path = "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/network-interfaces/{interface_name}",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_network_interface_delete(
     rqctx: RequestContext<Arc<ServerContext>>,
@@ -4486,10 +4495,13 @@ async fn instance_network_interface_view(
 }
 
 /// Fetch a network interface by id
+///
+/// Use `GET /v1/network-interfaces/{interface}` instead
 #[endpoint {
     method = GET,
     path = "/by-id/network-interfaces/{id}",
     tags = ["instances"],
+    deprecated = true,
 }]
 async fn instance_network_interface_view_by_id(
     rqctx: RequestContext<Arc<ServerContext>>,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5894,10 +5894,12 @@ async fn vpc_router_view(
 }
 
 /// Get a router by id
+/// Use `GET /v1/vpc-routers/{router}` instead
 #[endpoint {
     method = GET,
     path = "/by-id/vpc-routers/{id}",
     tags = ["vpcs"],
+    deprecated = true,
 }]
 async fn vpc_router_view_by_id(
     rqctx: RequestContext<Arc<ServerContext>>,
@@ -6118,7 +6120,7 @@ async fn vpc_router_update(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-// List routes
+/// List routes
 ///
 /// List the routes associated with a router in a particular VPC.
 #[endpoint {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -334,6 +334,7 @@
           "vpcs"
         ],
         "summary": "Get a router by id",
+        "description": "Use `GET /v1/vpc-routers/{router}` instead",
         "operationId": "vpc_router_view_by_id",
         "parameters": [
           {
@@ -363,7 +364,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/by-id/vpc-subnets/{id}": {
@@ -10995,7 +10997,8 @@
         "tags": [
           "vpcs"
         ],
-        "summary": "List the routes associated with a router in a particular VPC.",
+        "summary": "List routes",
+        "description": "List the routes associated with a router in a particular VPC.",
         "operationId": "vpc_router_route_list_v1",
         "parameters": [
           {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -94,6 +94,7 @@
           "instances"
         ],
         "summary": "Fetch an instance by id",
+        "description": "Use `GET /v1/instances/{instance}` instead",
         "operationId": "instance_view_by_id",
         "parameters": [
           {
@@ -123,7 +124,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/by-id/network-interfaces/{id}": {
@@ -132,6 +134,7 @@
           "instances"
         ],
         "summary": "Fetch a network interface by id",
+        "description": "Use `GET /v1/network-interfaces/{interface}` instead",
         "operationId": "instance_network_interface_view_by_id",
         "parameters": [
           {
@@ -161,7 +164,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/by-id/organizations/{id}": {
@@ -1929,6 +1933,7 @@
           "instances"
         ],
         "summary": "List instances",
+        "description": "Use `GET /v1/instances` instead",
         "operationId": "instance_list",
         "parameters": [
           {
@@ -1995,6 +2000,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       },
       "post": {
@@ -2492,6 +2498,7 @@
           "instances"
         ],
         "summary": "List network interfaces",
+        "description": "Use `GET /v1/network-interfaces` instead",
         "operationId": "instance_network_interface_list",
         "parameters": [
           {
@@ -2564,6 +2571,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       },
       "post": {
@@ -2768,7 +2776,7 @@
           "instances"
         ],
         "summary": "Delete a network interface",
-        "description": "Note that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.",
+        "description": "Note that the primary interface for an instance cannot be deleted if there are any secondary interfaces. A new primary interface must be designated first. The primary interface can be deleted if there are no secondary interfaces.\nUse `DELETE /v1/network-interfaces/{interface}` instead",
         "operationId": "instance_network_interface_delete",
         "parameters": [
           {
@@ -2814,7 +2822,8 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot": {


### PR DESCRIPTION
Followup to #2057. Noticed these while upgrading the docs site — deprecated endpoints are filtered out to give priority to the v1 ones, but these were not being filtered out.