### PR TITLE
[tufaceous] add the ability to add unknown artifact kinds behind a flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4797,9 +4797,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "2.1.1"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -7213,6 +7213,7 @@ dependencies = [
  "fs-err",
  "humantime",
  "omicron-common",
+ "predicates",
  "tempfile",
  "tufaceous-lib",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ percent-encoding = "2.2.0"
 pem = "1.1"
 petgraph = "0.6.3"
 postgres-protocol = "0.6.4"
+predicates = "2.1.5"
 pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }

--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{convert::Infallible, fmt, str::FromStr};
 
 use crate::api::internal::nexus::KnownArtifactKind;
 use schemars::JsonSchema;
@@ -117,6 +117,14 @@ impl From<KnownArtifactKind> for ArtifactKind {
 impl fmt::Display for ArtifactKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+impl FromStr for ArtifactKind {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
     }
 }
 

--- a/tufaceous-lib/src/artifact.rs
+++ b/tufaceous-lib/src/artifact.rs
@@ -4,11 +4,11 @@
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use omicron_common::api::internal::nexus::KnownArtifactKind;
+use omicron_common::update::ArtifactKind;
 
 /// Describes a new artifact to be added.
 pub struct AddArtifact {
-    kind: KnownArtifactKind,
+    kind: ArtifactKind,
     path: Utf8PathBuf,
     name: String,
     version: String,
@@ -20,7 +20,7 @@ impl AddArtifact {
     /// If the name is `None`, it is derived from the filename of the path
     /// without matching extensions.
     pub fn new(
-        kind: KnownArtifactKind,
+        kind: ArtifactKind,
         path: Utf8PathBuf,
         name: Option<String>,
         version: String,
@@ -40,8 +40,8 @@ impl AddArtifact {
     }
 
     /// Returns the kind of artifact this is.
-    pub fn kind(&self) -> KnownArtifactKind {
-        self.kind
+    pub fn kind(&self) -> &ArtifactKind {
+        &self.kind
     }
 
     /// Returns the path to the new artifact.

--- a/tufaceous-lib/src/repository.rs
+++ b/tufaceous-lib/src/repository.rs
@@ -250,7 +250,7 @@ impl OmicronRepoEditor {
             self.artifacts.artifacts.iter_mut().find(|artifact| {
                 artifact.name == new_artifact.name()
                     && artifact.version == new_artifact.version()
-                    && artifact.kind == new_artifact.kind().into()
+                    && artifact.kind == new_artifact.kind().clone()
             })
         {
             self.editor.remove_target(&artifact.target.as_str().try_into()?)?;
@@ -269,7 +269,7 @@ impl OmicronRepoEditor {
             self.artifacts.artifacts.push(Artifact {
                 name: new_artifact.name().to_owned(),
                 version: new_artifact.version().to_owned(),
-                kind: new_artifact.kind().into(),
+                kind: new_artifact.kind().clone(),
                 target: filename.clone(),
             })
         }

--- a/tufaceous/Cargo.toml
+++ b/tufaceous/Cargo.toml
@@ -18,4 +18,5 @@ tufaceous-lib.workspace = true
 assert_cmd.workspace = true
 fs-err.workspace = true
 omicron-common.workspace = true
+predicates.workspace = true
 tempfile.workspace = true


### PR DESCRIPTION
Currently, tufaceous only supports adding known artifact kinds. However,
in some situations (e.g. testing) it is helpful to add unknown artifact
kinds. Add support for that to tufaceous.
