### PR TITLE
Better detection of underlay devices based on system ID

### DIFF
--- a/sled-agent/src/common/underlay.rs
+++ b/sled-agent/src/common/underlay.rs
@@ -31,7 +31,7 @@ pub enum Error {
     BadAddrObj(#[from] addrobj::ParseError),
 
     #[error("Could not determine if host is a Gimlet: {0}")]
-    SystemDetection(#[from] anyhow::Error),
+    SystemDetection(#[source] anyhow::Error),
 
     #[error("Could not enumerate physical links")]
     FindLinks(#[from] FindPhysicalLinkError),
@@ -56,7 +56,7 @@ pub fn find_nics() -> Result<Vec<AddrObject>, Error> {
 /// developer machine, or generally a non-Gimlet, this will return the
 /// VNICs we use to emulate those Chelsio links.
 pub(crate) fn find_chelsio_links() -> Result<Vec<PhysicalLink>, Error> {
-    if is_gimlet()? {
+    if is_gimlet().map_err(Error::SystemDetection)? {
         Dladm::list_physical().map_err(Error::FindLinks).map(|links| {
             links
                 .into_iter()

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -57,7 +57,7 @@ pub enum ConfigError {
         err: toml::de::Error,
     },
     #[error("Could not determine if host is a Gimlet: {0}")]
-    SystemDetection(#[from] anyhow::Error),
+    SystemDetection(#[source] anyhow::Error),
     #[error("Could not enumerate physical links")]
     FindLinks(#[from] FindPhysicalLinkError),
 }
@@ -76,7 +76,7 @@ impl Config {
         if let Some(link) = self.data_link.as_ref() {
             Ok(link.clone())
         } else {
-            if is_gimlet()? {
+            if is_gimlet().map_err(ConfigError::SystemDetection)? {
                 Dladm::list_physical()
                     .map_err(ConfigError::FindLinks)?
                     .into_iter()

--- a/sled-agent/src/hardware/illumos/mod.rs
+++ b/sled-agent/src/hardware/illumos/mod.rs
@@ -48,18 +48,28 @@ pub fn is_gimlet() -> anyhow::Result<bool> {
     let mut device_info = DevInfo::new_force_load()?;
     let mut node_walker = device_info.walk_node();
     let Some(root) = node_walker.next().transpose()? else {
-        return Err(anyhow::anyhow!("No nodes in device tree"));
+        anyhow::bail!("No nodes in device tree");
     };
     Ok(root.node_name() == GIMLET_ROOT_NODE_NAME)
 }
 
 /// Return true if the host system is an Oxide Gimlet.
 //
-// TODO-testing: This assumes we never test on real Gimlets. That seems like a
-// very bad assumption.
+// TODO-testing: This assumes we never test on real Gimlets. That's likely to be
+// a bad assumption in the long-term. For now, however, we catch permissions
+// errors and return `Ok(false)`, on the assumption that (1) either you're not a
+// Gimlet, so that's the correct answer or (2) if you are on a Gimlet, you are
+// root or have configured the right permissions anyway.
 #[cfg(test)]
 pub fn is_gimlet() -> anyhow::Result<bool> {
-    Ok(false)
+    let Ok(mut device_info) = DevInfo::new_force_load() else {
+        return Ok(false);
+    };
+    let mut node_walker = device_info.walk_node();
+    let Ok(Some(root)) = node_walker.next().transpose() else {
+        return Ok(false);
+    };
+    Ok(root.node_name() == GIMLET_ROOT_NODE_NAME)
 }
 
 // A snapshot of information about the underlying Tofino device

--- a/sled-agent/src/hardware/illumos/mod.rs
+++ b/sled-agent/src/hardware/illumos/mod.rs
@@ -40,6 +40,28 @@ enum Error {
     NoDevLinks(PathBuf),
 }
 
+const GIMLET_ROOT_NODE_NAME: &str = "Oxide,Gimlet";
+
+/// Return true if the host system is an Oxide Gimlet.
+#[cfg(not(test))]
+pub fn is_gimlet() -> anyhow::Result<bool> {
+    let mut device_info = DevInfo::new_force_load()?;
+    let mut node_walker = device_info.walk_node();
+    let Some(root) = node_walker.next().transpose()? else {
+        return Err(anyhow::anyhow!("No nodes in device tree"));
+    };
+    Ok(root.node_name() == GIMLET_ROOT_NODE_NAME)
+}
+
+/// Return true if the host system is an Oxide Gimlet.
+//
+// TODO-testing: This assumes we never test on real Gimlets. That seems like a
+// very bad assumption.
+#[cfg(test)]
+pub fn is_gimlet() -> anyhow::Result<bool> {
+    Ok(false)
+}
+
 // A snapshot of information about the underlying Tofino device
 #[derive(Copy, Clone)]
 struct TofinoSnapshot {
@@ -73,7 +95,7 @@ impl HardwareSnapshot {
             return Err(Error::DevInfo(anyhow::anyhow!("No nodes in device tree")));
         };
         let root_node = root.node_name();
-        if root_node != "Oxide,Gimlet" {
+        if root_node != GIMLET_ROOT_NODE_NAME {
             return Err(Error::NotAGimlet(root_node));
         }
 

--- a/sled-agent/src/hardware/non_illumos/mod.rs
+++ b/sled-agent/src/hardware/non_illumos/mod.rs
@@ -55,3 +55,8 @@ pub fn ensure_partition_layout(
 ) -> Result<Vec<Partition>, DiskError> {
     unimplemented!("Accessing hardware unsupported on non-illumos");
 }
+
+/// Return true if the host system is an Oxide Gimlet.
+pub fn is_gimlet() -> anyhow::Result<bool> {
+    Ok(false)
+}

--- a/sled-agent/src/illumos/addrobj.rs
+++ b/sled-agent/src/illumos/addrobj.rs
@@ -4,6 +4,9 @@
 
 //! API for operating on addrobj objects.
 
+/// The name provided to all link-local IPv6 addresses.
+pub const IPV6_LINK_LOCAL_NAME: &str = "ll";
+
 /// Describes an "addrobj", which is the combination of an interface
 /// with an associated name.
 ///
@@ -53,6 +56,12 @@ impl AddrObject {
         Self::new(&self.interface, name)
     }
 
+    /// Create a new addrobj on the same interface with the IPv6 link-local
+    /// name.
+    pub fn link_local_on_same_interface(&self) -> Result<Self, ParseError> {
+        self.on_same_interface(IPV6_LINK_LOCAL_NAME)
+    }
+
     pub fn new(interface: &str, name: &str) -> Result<Self, ParseError> {
         if interface.contains('/') {
             return Err(ParseError {
@@ -63,6 +72,11 @@ impl AddrObject {
             return Err(ParseError { name: BadName::Object(name.to_string()) });
         }
         Ok(Self { interface: interface.to_string(), name: name.to_string() })
+    }
+
+    /// A link-local IPv6 addrobj over the provided interface.
+    pub fn link_local(interface: &str) -> Result<Self, ParseError> {
+        Self::new(interface, IPV6_LINK_LOCAL_NAME)
     }
 
     pub fn interface(&self) -> &str {

--- a/sled-agent/src/illumos/zone.rs
+++ b/sled-agent/src/illumos/zone.rs
@@ -629,7 +629,7 @@ impl Zones {
         // Call the guts of this function within a closure to make it easier
         // to wrap the error with appropriate context.
         |link: EtherstubVnic, address, name| -> Result<(), anyhow::Error> {
-            let gz_link_local_addrobj = AddrObject::new(&link.0, "linklocal")
+            let gz_link_local_addrobj = AddrObject::link_local(&link.0)
                 .map_err(|err| anyhow!(err))?;
             Self::ensure_has_link_local_v6_address(
                 None,
@@ -701,7 +701,7 @@ impl Zones {
                         // Finally, actually ensure that the v6 address we want
                         // exists within the zone.
                         let link_local_addrobj =
-                            addrobj.on_same_interface("linklocal")?;
+                            addrobj.link_local_on_same_interface()?;
                         Self::ensure_has_link_local_v6_address(
                             Some(zone),
                             &link_local_addrobj,

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -43,8 +43,8 @@ use crate::serial::ByteOffset;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Physical link not in config, nor found automatically: {0}")]
-    FindPhysicalLink(#[from] crate::illumos::dladm::FindPhysicalLinkError),
+    #[error("Configuration error: {0}")]
+    Config(#[from] crate::config::ConfigError),
 
     #[error("Failed to enable routing: {0}")]
     EnablingRouting(crate::illumos::ExecutionError),


### PR DESCRIPTION
- Adds a `is_gimlet()` function that returns true on, well, Gimlets.
- Use the `is_gimlet()` to detect whether we're on a developer maching, and thus which NICs to use in two places. The first is `find_chelsio_links`, which has thus far been returning the emulated Chelsios, net0 and net1. On non-Gimlets, that's still the case. On Gimlets it returns the list of devices named `cxgbeN`, all actual Chelsio NICs. The second is the physical link that is currently used to determine the bootstrap address. That's net0 or cxgbe0, for non-Gimlets and Gimlets, respecively.
- Adds a few helper functions for creating IPv6 link-locals in a well-defined way, and factors out the name for all of them, which is now `iface/ll`, rather than `iface/linklocal`.