### PR TITLE
[ipcc-key-value] Add `Ipcc` ioctl wrapper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,9 +2905,11 @@ name = "ipcc-key-value"
 version = "0.1.0"
 dependencies = [
  "ciborium",
+ "libc",
  "proptest",
  "serde",
  "test-strategy",
+ "thiserror",
  "uuid",
 ]
 

--- a/ipcc-key-value/Cargo.toml
+++ b/ipcc-key-value/Cargo.toml
@@ -6,7 +6,9 @@ license = "MPL-2.0"
 
 [dependencies]
 ciborium.workspace = true
+libc.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/ipcc-key-value/src/ioctl.rs
+++ b/ipcc-key-value/src/ioctl.rs
@@ -111,9 +111,8 @@ enum IpccKey {
 
 const IPCC_DEV: &str = "/dev/ipcc";
 
-const IPCC_IOC: c_int = ((b'i' as c_int) << 24)
-    | ((b'c' as c_int) << 16)
-    | ((b'c' as c_int) << 8);
+const IPCC_IOC: c_int =
+    ((b'i' as c_int) << 24) | ((b'c' as c_int) << 16) | ((b'c' as c_int) << 8);
 
 const IPCC_KEYLOOKUP: c_int = IPCC_IOC | 4;
 

--- a/ipcc-key-value/src/ioctl.rs
+++ b/ipcc-key-value/src/ioctl.rs
@@ -111,9 +111,9 @@ enum IpccKey {
 
 const IPCC_DEV: &str = "/dev/ipcc";
 
-const IPCC_IOC: c_int = (c_int::from(b'i') << 24)
-    | (c_int::from(b'c') << 16)
-    | (c_int::from(b'c') << 8);
+const IPCC_IOC: c_int = ((b'i' as c_int) << 24)
+    | ((b'c' as c_int) << 16)
+    | ((b'c' as c_int) << 8);
 
 const IPCC_KEYLOOKUP: c_int = IPCC_IOC | 4;
 

--- a/ipcc-key-value/src/ioctl.rs
+++ b/ipcc-key-value/src/ioctl.rs
@@ -75,8 +75,8 @@ impl Ipcc {
         };
 
         if result != 0 {
-            let errno = unsafe { *libc::___errno() };
-            return Err(IpccKeyLookupError::IoctlFailed { errno });
+            let error = io::Error::last_os_error();
+            return Err(IpccKeyLookupError::IoctlFailed { error });
         }
 
         match kl.result {

--- a/ipcc-key-value/src/ioctl.rs
+++ b/ipcc-key-value/src/ioctl.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! IPCC `ioctl` interface.
+//!
+//! This module is tightly-coupled to the host OS image, and should only be used
+//! by services bundled with it (e.g., sled-agent and installinator).
+
+use crate::InstallinatorImageId;
+use crate::InstallinatorImageIdError;
+use crate::IpccKeyLookupError;
+use crate::PingError;
+use crate::Pong;
+use libc::c_int;
+use std::fs::File;
+use std::io;
+use std::os::unix::prelude::AsRawFd;
+
+pub struct Ipcc {
+    file: File,
+}
+
+impl Ipcc {
+    pub fn open() -> io::Result<Self> {
+        let file = File::options().read(true).write(true).open(IPCC_DEV)?;
+        Ok(Self { file })
+    }
+
+    pub fn ping(&self) -> Result<Pong, PingError> {
+        const EXPECTED_REPLY: &[u8] = b"pong";
+
+        let mut buf = [0; EXPECTED_REPLY.len()];
+        let n = self.key_lookup(IpccKey::Ping, &mut buf)?;
+        let buf = &buf[..n];
+
+        if buf == EXPECTED_REPLY {
+            Ok(Pong)
+        } else {
+            Err(PingError::UnexpectedReply(buf.to_vec()))
+        }
+    }
+
+    pub fn installinator_image_id(
+        &self,
+    ) -> Result<InstallinatorImageId, InstallinatorImageIdError> {
+        let mut buf = [0; InstallinatorImageId::CBOR_SERIALIZED_SIZE];
+        let n = self.key_lookup(IpccKey::InstallinatorImageId, &mut buf)?;
+        let id = InstallinatorImageId::deserialize(&buf[..n])
+            .map_err(InstallinatorImageIdError::DeserializationFailed)?;
+        Ok(id)
+    }
+
+    fn key_lookup(
+        &self,
+        key: IpccKey,
+        buf: &mut [u8],
+    ) -> Result<usize, IpccKeyLookupError> {
+        let mut kl = IpccKeyLookup {
+            key: key as u8,
+            buflen: u16::try_from(buf.len()).unwrap_or(u16::MAX),
+            result: 0,
+            datalen: 0,
+            buf: buf.as_mut_ptr(),
+        };
+
+        let result = unsafe {
+            libc::ioctl(
+                self.file.as_raw_fd(),
+                IPCC_KEYLOOKUP,
+                &mut kl as *mut IpccKeyLookup,
+            )
+        };
+
+        if result != 0 {
+            let errno = unsafe { *libc::___errno() };
+            return Err(IpccKeyLookupError::IoctlFailed { errno });
+        }
+
+        match kl.result {
+            IPCC_KEYLOOKUP_SUCCESS => Ok(usize::from(kl.datalen)),
+            IPCC_KEYLOOKUP_UNKNOWN_KEY => {
+                Err(IpccKeyLookupError::UnknownKey { key: format!("{key:?}") })
+            }
+            IPCC_KEYLOOKUP_NO_VALUE => Err(IpccKeyLookupError::NoValueForKey),
+            IPCC_KEYLOOKUP_BUFFER_TOO_SMALL => {
+                Err(IpccKeyLookupError::BufferTooSmallForValue)
+            }
+            _ => Err(IpccKeyLookupError::UnknownResultValue(kl.result)),
+        }
+    }
+}
+
+// --------------------------------------------------------------------
+// IPCC keys; the source of truth for these is RFD 316 + the
+// `host-sp-messages` crate in hubris.
+// --------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+enum IpccKey {
+    Ping = 0,
+    InstallinatorImageId = 1,
+}
+
+// --------------------------------------------------------------------
+// Constants and structures from stlouis `usr/src/uts/oxide/sys/ipcc.h`
+// --------------------------------------------------------------------
+
+const IPCC_DEV: &str = "/dev/ipcc";
+
+const IPCC_IOC: c_int = (c_int::from(b'i') << 24)
+    | (c_int::from(b'c') << 16)
+    | (c_int::from(b'c') << 8);
+
+const IPCC_KEYLOOKUP: c_int = IPCC_IOC | 4;
+
+const IPCC_KEYLOOKUP_SUCCESS: u8 = 0;
+const IPCC_KEYLOOKUP_UNKNOWN_KEY: u8 = 1;
+const IPCC_KEYLOOKUP_NO_VALUE: u8 = 2;
+const IPCC_KEYLOOKUP_BUFFER_TOO_SMALL: u8 = 3;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct IpccKeyLookup {
+    key: u8,
+    buflen: u16,
+    result: u8,
+    datalen: u16,
+    buf: *mut u8,
+}

--- a/ipcc-key-value/src/ioctl_common.rs
+++ b/ipcc-key-value/src/ioctl_common.rs
@@ -4,8 +4,8 @@
 
 // Copyright 2023 Oxide Computer Company
 
-//! This module is logically part of the [`crate::ioctl`] module, but is split
-//! out to be shared with the non-illumos stub module.
+//! This module contains types shared between the real (illumos-only)
+//! `crate::ioctl` module and the generic `crate::ioctl_stub` module.
 
 use thiserror::Error;
 

--- a/ipcc-key-value/src/ioctl_common.rs
+++ b/ipcc-key-value/src/ioctl_common.rs
@@ -7,12 +7,13 @@
 //! This module contains types shared between the real (illumos-only)
 //! `crate::ioctl` module and the generic `crate::ioctl_stub` module.
 
+use std::io;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum IpccKeyLookupError {
-    #[error("IPCC key lookup ioctl failed: errno {errno}")]
-    IoctlFailed { errno: i32 },
+    #[error("IPCC key lookup ioctl failed: {error}")]
+    IoctlFailed { error: io::Error },
     #[error("IPCC key lookup failed: unknown key {key}")]
     UnknownKey { key: String },
     #[error("IPCC key lookup failed: no value for key")]

--- a/ipcc-key-value/src/ioctl_common.rs
+++ b/ipcc-key-value/src/ioctl_common.rs
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! This module is logically part of the [`crate::ioctl`] module, but is split
+//! out to be shared with the non-illumos stub module.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IpccKeyLookupError {
+    #[error("IPCC key lookup ioctl failed: errno {errno}")]
+    IoctlFailed { errno: i32 },
+    #[error("IPCC key lookup failed: unknown key {key}")]
+    UnknownKey { key: String },
+    #[error("IPCC key lookup failed: no value for key")]
+    NoValueForKey,
+    #[error("IPCC key lookup failed: buffer too small for value")]
+    BufferTooSmallForValue,
+    #[error("IPCC key lookup failed: unknown result value {0}")]
+    UnknownResultValue(u8),
+}
+
+#[derive(Debug, Error)]
+pub enum InstallinatorImageIdError {
+    #[error(transparent)]
+    IpccKeyLookupError(#[from] IpccKeyLookupError),
+    #[error("deserializing installinator image ID failed: {0}")]
+    DeserializationFailed(String),
+}
+
+#[derive(Debug, Error)]
+pub enum PingError {
+    #[error(transparent)]
+    IpccKeyLookupError(#[from] IpccKeyLookupError),
+    #[error("unexpected reply from SP (expected `pong`: {0:?})")]
+    UnexpectedReply(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Pong;

--- a/ipcc-key-value/src/ioctl_common.rs
+++ b/ipcc-key-value/src/ioctl_common.rs
@@ -10,18 +10,31 @@
 use std::io;
 use thiserror::Error;
 
+/// IPCC keys; the source of truth for these is RFD 316 + the
+/// `host-sp-messages` crate in hubris.
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum IpccKey {
+    Ping = 0,
+    InstallinatorImageId = 1,
+}
+
 #[derive(Debug, Error)]
 pub enum IpccKeyLookupError {
-    #[error("IPCC key lookup ioctl failed: {error}")]
-    IoctlFailed { error: io::Error },
-    #[error("IPCC key lookup failed: unknown key {key}")]
-    UnknownKey { key: String },
-    #[error("IPCC key lookup failed: no value for key")]
-    NoValueForKey,
-    #[error("IPCC key lookup failed: buffer too small for value")]
-    BufferTooSmallForValue,
-    #[error("IPCC key lookup failed: unknown result value {0}")]
-    UnknownResultValue(u8),
+    #[error("IPCC key lookup ioctl failed for key {key:?}: {error}")]
+    IoctlFailed { key: IpccKey, error: io::Error },
+    #[error("IPCC key lookup failed for key {key:?}: unknown key")]
+    UnknownKey { key: IpccKey },
+    #[error("IPCC key lookup failed for key {key:?}: no value for key")]
+    NoValueForKey { key: IpccKey },
+    #[error(
+        "IPCC key lookup failed for key {key:?}: buffer too small for value"
+    )]
+    BufferTooSmallForValue { key: IpccKey },
+    #[error(
+        "IPCC key lookup failed for key {key:?}: unknown result value {result}"
+    )]
+    UnknownResultValue { key: IpccKey, result: u8 },
 }
 
 #[derive(Debug, Error)]

--- a/ipcc-key-value/src/ioctl_stub.rs
+++ b/ipcc-key-value/src/ioctl_stub.rs
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Stub definition of the `Ipcc` type for compiling (but not running) on
+//! non-Oxide systems.
+
+use crate::InstallinatorImageId;
+use crate::InstallinatorImageIdError;
+use crate::PingError;
+use crate::Pong;
+use std::io;
+
+pub struct Ipcc {}
+
+impl Ipcc {
+    pub fn open() -> io::Result<Self> {
+        panic!("ipcc unavailable on this platform")
+    }
+
+    pub fn ping(&self) -> Result<Pong, PingError> {
+        panic!("ipcc unavailable on this platform")
+    }
+
+    pub fn installinator_image_id(
+        &self,
+    ) -> Result<InstallinatorImageId, InstallinatorImageIdError> {
+        panic!("ipcc unavailable on this platform")
+    }
+}


### PR DESCRIPTION
This extends the `ipcc-key-value` crate, adding a wrapper for the `/dev/ipcc` device:

```rust
// open /dev/ipcc
let ipcc = Ipcc::open()?;

// uninteresting except for debugging
let _pong = ipcc.ping()?;

// get the most-recently-set-by-MGS installinator image ID
let installinator_image_id = ipcc.installinator_image_id()?;
```

~~I still need to finish testing this on a physical gimlet, but it's close enough for review.~~

Confirmed this works on a real gimlet:

```
igor% faux-mgs --interface axf0 --discovery-addr '[fe80::aa40:25ff:fe01:0103]:11111' set-ipcc-key-value 1 dummy-installinator-image-id
Feb 21 20:46:02.519 INFO creating SP handle on interface axf0, component: faux-mgs
Feb 21 20:46:02.520 INFO initial discovery complete, addr: [fe80::aa40:25ff:fe01:103%3]:11111, interface: axf0, component: faux-mgs
done
```

```
gimlet-sn06 # ./dummy-ipcc
ping result = Ok(Pong)
installinator image id result = Ok(InstallinatorImageId { update_id: 41424344-4546-4748-494a-4b4c4d4e4f50, host_phase_2: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32], control_plane: [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64] })
```