### PR TITLE
[MGS] [wicketd] Report progress from MGS to wicketd of trampoline image delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=e35df234f9db57b1b7fc0a8ca279fb2774ff1046#e35df234f9db57b1b7fc0a8ca279fb2774ff1046"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=host-phase2-progress#e775162f8594d306292b8f0634f5cd40a9ced616"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=e35df234f9db57b1b7fc0a8ca279fb2774ff1046#e35df234f9db57b1b7fc0a8ca279fb2774ff1046"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=host-phase2-progress#e775162f8594d306292b8f0634f5cd40a9ced616"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2214,7 +2214,6 @@ dependencies = [
  "tokio",
  "usdt",
  "uuid",
- "version_check",
  "zip",
 ]
 
@@ -3801,6 +3800,7 @@ dependencies = [
  "openapiv3",
  "schemars",
  "serde",
+ "serde_human_bytes",
  "serde_json",
  "signal-hook",
  "signal-hook-tokio",
@@ -6863,8 +6863,8 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tlvc"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tlvc.git#2643765eb7775d1f5e8ec56910f1ab15e9c75170"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/tlvc.git#533f0bf26b0a8f32d287af4f2ea09320bc05c2cd"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=host-phase2-progress#e775162f8594d306292b8f0634f5cd40a9ced616"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=f896b7cf0fe7e72641b33060185b71e5d3562b12#f896b7cf0fe7e72641b33060185b71e5d3562b12"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?branch=host-phase2-progress#e775162f8594d306292b8f0634f5cd40a9ced616"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=f896b7cf0fe7e72641b33060185b71e5d3562b12#f896b7cf0fe7e72641b33060185b71e5d3562b12"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2205,7 +2205,7 @@ dependencies = [
  "nix",
  "once_cell",
  "serde",
- "serde-big-array 0.4.1",
+ "serde-big-array 0.5.0",
  "slog",
  "socket2",
  "string_cache",
@@ -2214,6 +2214,7 @@ dependencies = [
  "tokio",
  "usdt",
  "uuid",
+ "version_check",
  "zip",
 ]
 
@@ -5847,6 +5848,15 @@ name = "serde-big-array"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bb66e1af4481c21cbc943cabb68b98aabb4d7f935e47d1b4de722ca09da0b4"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,9 +130,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-# TODO convert back to a revision on `main` before merging
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], branch = "host-phase2-progress" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", branch = "host-phase2-progress" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "f896b7cf0fe7e72641b33060185b71e5d3562b12" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "f896b7cf0fe7e72641b33060185b71e5d3562b12" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,9 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "e35df234f9db57b1b7fc0a8ca279fb2774ff1046" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "e35df234f9db57b1b7fc0a8ca279fb2774ff1046" }
+# TODO convert back to a revision on `main` before merging
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], branch = "host-phase2-progress" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", branch = "host-phase2-progress" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/gateway-client/src/lib.rs
+++ b/gateway-client/src/lib.rs
@@ -54,5 +54,6 @@ progenitor::generate_api!(
         RotImageDetails = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
         RotSlot = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
         ImageVersion = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        HostPhase2RecoveryImageId = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
     },
 );

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -21,6 +21,7 @@ omicron-common.workspace = true
 once_cell.workspace = true
 schemars.workspace = true
 serde.workspace = true
+serde_human_bytes.workspace = true
 signal-hook.workspace = true
 signal-hook-tokio.workspace = true
 slog.workspace = true

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -783,6 +783,86 @@
         }
       }
     },
+    "/sp/{type}/{slot}/host-phase2-progress": {
+      "get": {
+        "summary": "Get the most recent host phase2 request we've seen from the target SP.",
+        "description": "This method can be used as an indirect progress report for how far along a host is when it is booting via the MGS -> SP -> UART recovery path. This path is used to install the trampoline image containing installinator to recover a sled.",
+        "operationId": "sp_host_phase2_progress_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostPhase2Progress"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Clear the most recent host phase2 request we've seen from the target SP.",
+        "operationId": "sp_host_phase2_progress_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/ipcc/installinator-image-id": {
       "put": {
         "summary": "Set the installinator image ID the sled should use for recovery.",
@@ -1100,6 +1180,25 @@
       }
     },
     "schemas": {
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "nanos": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "secs": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "nanos",
+          "secs"
+        ]
+      },
       "Error": {
         "description": "Error information from a response.",
         "type": "object",
@@ -1119,12 +1218,65 @@
           "request_id"
         ]
       },
+      "HostPhase2Progress": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "image_id": {
+                "$ref": "#/components/schemas/HostPhase2RecoveryImageId"
+              },
+              "offset": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "progress": {
+                "type": "string",
+                "enum": [
+                  "available"
+                ]
+              },
+              "total_size": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "age",
+              "image_id",
+              "offset",
+              "progress",
+              "total_size"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "progress": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "progress"
+            ]
+          }
+        ]
+      },
       "HostPhase2RecoveryImageId": {
         "description": "Identity of a host phase2 recovery image.",
         "type": "object",
         "properties": {
           "sha256_hash": {
-            "type": "string"
+            "type": "string",
+            "format": "hex string (32 bytes)"
           }
         },
         "required": [

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -334,6 +334,70 @@
           }
         ]
       },
+      "HostPhase2Progress": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "image_id": {
+                "$ref": "#/components/schemas/HostPhase2RecoveryImageId"
+              },
+              "offset": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "progress": {
+                "type": "string",
+                "enum": [
+                  "available"
+                ]
+              },
+              "total_size": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "age",
+              "image_id",
+              "offset",
+              "progress",
+              "total_size"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "progress": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "progress"
+            ]
+          }
+        ]
+      },
+      "HostPhase2RecoveryImageId": {
+        "description": "Identity of a host phase2 recovery image.",
+        "type": "object",
+        "properties": {
+          "sha256_hash": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sha256_hash"
+        ]
+      },
       "ImageVersion": {
         "type": "object",
         "properties": {
@@ -1269,6 +1333,36 @@
               }
             },
             "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  },
+                  "progress": {
+                    "$ref": "#/components/schemas/HostPhase2Progress"
+                  }
+                },
+                "required": [
+                  "artifact",
+                  "progress"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "waiting_for_trampoline_image_delivery"
+                ]
+              }
+            },
+            "required": [
+              "data",
               "state"
             ]
           }

--- a/wicketd/src/update_events.rs
+++ b/wicketd/src/update_events.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use gateway_client::types::HostPhase2Progress;
 use gateway_client::types::PowerState;
 use gateway_client::types::UpdatePreparationProgress;
 use omicron_common::update::ArtifactId;
@@ -41,6 +42,10 @@ pub enum UpdateStateKind {
     },
     SettingInstallinatorOptions,
     SettingHostStartupOptions,
+    WaitingForTrampolineImageDelivery {
+        artifact: ArtifactId,
+        progress: HostPhase2Progress,
+    },
 }
 
 #[derive(Clone, Debug, JsonSchema, Serialize)]


### PR DESCRIPTION
During gimlet recovery, booting OS is the ultimate source of truth for how far along the boot process is, but we can't communicate (directly) with it while it's booting. We can get progress indirectly: this PR adds endpoints to MGS that get and clear the most-recently-requested host image message from the gimlet's SP. Assuming the host fetches the trampoline image sequentially, this gives us progress-by-proxy.

We start to flesh out one of the TODOs in wicketd where we need to wait for installinator completion: we now first wait for the first installinator progress message (which is still a placeholder for now, and will come in after #2413), and while we're waiting for that first message, we poll MGS periodically to attempt to record the trampoline boot progress.