### PR TITLE
[wicket] More style tweaks

### DIFF
--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -126,9 +126,9 @@ impl ComponentId {
 impl Display for ComponentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ComponentId::Sled(i) => write!(f, "sled {}", i),
-            ComponentId::Switch(i) => write!(f, "switch {}", i),
-            ComponentId::Psc(i) => write!(f, "psc {}", i),
+            ComponentId::Sled(i) => write!(f, "SLED {}", i),
+            ComponentId::Switch(i) => write!(f, "SWITCH {}", i),
+            ComponentId::Psc(i) => write!(f, "PSC {}", i),
         }
     }
 }

--- a/wicket/src/ui/defaults/colors.rs
+++ b/wicket/src/ui/defaults/colors.rs
@@ -26,3 +26,4 @@ pub const TUI_GREEN: Color = Color::Rgb(0x8F, 0xEF, 0xBF);
 pub const TUI_GREEN_DARK: Color = Color::Rgb(0x2E, 0x81, 0x60);
 pub const TUI_GREY: Color = Color::Rgb(0x78, 0x78, 0x7A);
 pub const TUI_PURPLE: Color = Color::Rgb(0xBE, 0x95, 0xEB);
+pub const TUI_PURPLE_DIM: Color = Color::Rgb(0x6C, 0x55, 0x84);

--- a/wicket/src/ui/panes/overview_pane.rs
+++ b/wicket/src/ui/panes/overview_pane.rs
@@ -14,7 +14,7 @@ use crate::{Action, Event, Frame, State};
 use crossterm::event::Event as TermEvent;
 use crossterm::event::KeyCode;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use tui::style::{Color, Style};
+use tui::style::Style;
 use tui::text::Text;
 use tui::widgets::{Block, BorderType, Borders, Paragraph};
 
@@ -138,18 +138,22 @@ impl Control for RackTab {
             state: &state.rack_state,
             switch_style: Style::default().bg(OX_GRAY_DARK).fg(OX_WHITE),
             power_shelf_style: Style::default().bg(OX_GRAY).fg(OX_OFF_WHITE),
-            sled_style: Style::default().bg(OX_GREEN_LIGHT).fg(Color::Black),
+            sled_style: Style::default().bg(OX_GREEN_LIGHT).fg(TUI_BLACK),
             sled_selected_style: Style::default()
-                .fg(Color::Black)
-                .bg(OX_GRAY_DARK),
+                .fg(TUI_BLACK)
+                .bg(TUI_PURPLE_DIM),
 
-            border_style: Style::default().fg(OX_GRAY).bg(Color::Black),
+            border_style: Style::default().fg(OX_GRAY).bg(TUI_BLACK),
             border_selected_style: Style::default()
-                .fg(OX_YELLOW)
-                .bg(OX_GRAY_DARK),
+                .fg(TUI_BLACK)
+                .bg(TUI_PURPLE),
 
-            switch_selected_style: Style::default().bg(OX_GRAY_DARK),
-            power_shelf_selected_style: Style::default().bg(OX_GRAY),
+            switch_selected_style: Style::default()
+                .bg(TUI_PURPLE_DIM)
+                .fg(TUI_PURPLE),
+            power_shelf_selected_style: Style::default()
+                .bg(TUI_PURPLE_DIM)
+                .fg(TUI_PURPLE),
         };
 
         frame.render_widget(rack, inner);


### PR DESCRIPTION
Nothing substantial, just some colour changes and capitalisation.

Using the purple as a item selection colour on the rack since that's what we will use eventually for row selection when we implement update.

One thing I wanted to discuss (can do here or in the main PR) is the UX of what is currently overview and 
inventory. I think we could have what is currently inventory be a child view of the rack view.

You'd have something like this: 
![image](https://user-images.githubusercontent.com/4020798/221559531-4cb77f3c-03a1-403d-9a3e-57f74cc40e5b.png)

Oxide Rack -> Sub component

I know it's an added layer of complexity but it's a really useful pattern that we we'd reuse for software update (and other future panes) too — so you can start an update or view an update in progress — which is a child view of the main update view.