### PR TITLE
Bugfix: Use OptionalVpcSelector for subnet view API

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5420,7 +5420,7 @@ async fn vpc_subnet_create(
 async fn vpc_subnet_view_v1(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<params::SubnetPath>,
-    query_params: Query<params::VpcSelector>,
+    query_params: Query<params::OptionalVpcSelector>,
 ) -> Result<HttpResponseOk<VpcSubnet>, HttpError> {
     let apictx = rqctx.context();
     let handler = async {
@@ -5429,7 +5429,7 @@ async fn vpc_subnet_view_v1(
         let query = query_params.into_inner();
         let opctx = OpContext::for_external_api(&rqctx).await?;
         let subnet_selector = params::SubnetSelector {
-            vpc_selector: Some(query),
+            vpc_selector: query.vpc_selector,
             subnet: path.subnet,
         };
         let (.., subnet) =

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -217,6 +217,17 @@ async fn test_vpc_subnets(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
     subnets_eq(&subnet, &same_subnet);
 
+    // get subnet by ID, should retrieve the same subnet
+    let subnet_by_id_url = format!("/v1/vpc-subnets/{}", &subnet.identity.id);
+    let same_subnet_again = NexusRequest::object_get(client, &subnet_by_id_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .unwrap()
+        .parsed_body()
+        .unwrap();
+    subnets_eq(&subnet, &same_subnet_again);
+
     // subnets list should now have the one in it
     let subnets =
         objects_list_page_authz::<VpcSubnet>(client, &subnets_url).await.items;

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11934,7 +11934,6 @@
           {
             "in": "query",
             "name": "vpc",
-            "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }


### PR DESCRIPTION
Fixes a bug where the `GET /v1/vpc-subnets/{subnet}` endpoint required a VPC identifier if subnet UUID was being used.

Tested locally:

```console
Feb 28 04:11:06.205 INFO request completed, response_code: 200, uri: /v1/vpc-subnets/4f668e88-88cd-44c6-9b60-89ec8e3d751e, method: GET, req_id: c821283b-380c-456d-a5a5-d4c834e0256d, remote_addr: 127.0.0.1:57238, local_addr: 127.0.0.1:12220, component: dropshot_external, name: e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c
```