### PR TITLE
[installinator] add some more variants to wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,6 +2868,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
+ "serde_json",
  "slog",
  "uuid",
 ]
@@ -2905,6 +2906,7 @@ dependencies = [
  "omicron-common",
  "schemars",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/installinator-artifact-client/Cargo.toml
+++ b/installinator-artifact-client/Cargo.toml
@@ -10,5 +10,6 @@ progenitor.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
 schemars.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 slog.workspace = true
 uuid.workspace = true

--- a/installinator-artifact-client/src/lib.rs
+++ b/installinator-artifact-client/src/lib.rs
@@ -83,6 +83,26 @@ impl From<installinator_common::CompletionEventKind>
                 artifact_size,
                 elapsed: elapsed.into(),
             },
+            installinator_common::CompletionEventKind::FormatFailed {
+                attempt,
+                path,
+                elapsed,
+                message,
+            } => Self::FormatFailed {
+                attempt: attempt as u32,
+                path: path.into_string(),
+                elapsed: elapsed.into(),
+                message,
+            },
+            installinator_common::CompletionEventKind::FormatCompleted {
+                attempt,
+                path,
+                elapsed,
+            } => Self::FormatCompleted {
+                attempt: attempt as u32,
+                path: path.into_string(),
+                elapsed: elapsed.into(),
+            },
             installinator_common::CompletionEventKind::WriteFailed {
                 attempt,
                 kind,
@@ -112,6 +132,21 @@ impl From<installinator_common::CompletionEventKind>
                 destination: destination.into_string(),
                 artifact_size,
                 elapsed: elapsed.into(),
+            },
+            installinator_common::CompletionEventKind::MiscError {
+                operation,
+                attempt,
+                data,
+                elapsed,
+                message,
+                is_fatal,
+            } => Self::MiscError {
+                operation,
+                attempt: attempt as u32,
+                data,
+                elapsed: elapsed.into(),
+                message,
+                is_fatal,
             },
             installinator_common::CompletionEventKind::Completed => {
                 Self::Completed

--- a/installinator-common/Cargo.toml
+++ b/installinator-common/Cargo.toml
@@ -9,3 +9,4 @@ camino.workspace = true
 omicron-common.workspace = true
 schemars.workspace = true
 serde.workspace = true
+serde_json.workspace = true

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -93,6 +93,35 @@ pub enum CompletionEventKind {
         elapsed: Duration,
     },
 
+    /// Failed to format a disk.
+    FormatFailed {
+        /// The format attempt that failed.
+        attempt: usize,
+
+        /// The path to the disk.
+        #[schemars(schema_with = "path_schema")]
+        path: Utf8PathBuf,
+
+        /// How long the format attempt took.
+        elapsed: Duration,
+
+        /// A message indicating the reason for failure.
+        message: String,
+    },
+
+    /// Completed formatting a disk.
+    FormatCompleted {
+        /// The format attempt.
+        attempt: usize,
+
+        /// The path to the disk.
+        #[schemars(schema_with = "path_schema")]
+        path: Utf8PathBuf,
+
+        /// How long the format attempt took.
+        elapsed: Duration,
+    },
+
     /// Failed to write an artifact.
     WriteFailed {
         /// The write attempt that failed.
@@ -137,6 +166,29 @@ pub enum CompletionEventKind {
         elapsed: Duration,
     },
 
+    /// A miscellaneous error occurred.
+    ///
+    /// This is a catch-all for errors that aren't described by any of the variants.
+    MiscError {
+        /// The name of the operation that failed.
+        operation: String,
+
+        /// The attempt that failed.
+        attempt: usize,
+
+        /// Data about the operation, serialized as JSON.
+        data: serde_json::Value,
+
+        /// How long the operation took before it failed.
+        elapsed: Duration,
+
+        /// A message indicating why the operation failed.
+        message: String,
+
+        /// Whether this operation is fatal, i.e. will not be retried.
+        is_fatal: bool,
+    },
+
     /// Completed the entire operation.
     Completed,
 }
@@ -147,8 +199,11 @@ impl CompletionEventKind {
         match self {
             Self::DownloadCompleted { attempt, .. }
             | Self::DownloadFailed { attempt, .. }
+            | Self::FormatFailed { attempt, .. }
+            | Self::FormatCompleted { attempt, .. }
             | Self::WriteCompleted { attempt, .. }
-            | Self::WriteFailed { attempt, .. } => Some(*attempt),
+            | Self::WriteFailed { attempt, .. }
+            | Self::MiscError { attempt, .. } => Some(*attempt),
             Self::Completed => None,
         }
     }
@@ -157,9 +212,13 @@ impl CompletionEventKind {
     pub fn is_success(&self) -> bool {
         match self {
             Self::DownloadCompleted { .. }
+            | Self::FormatCompleted { .. }
             | Self::WriteCompleted { .. }
             | Self::Completed => true,
-            Self::DownloadFailed { .. } | Self::WriteFailed { .. } => false,
+            Self::DownloadFailed { .. }
+            | Self::FormatFailed { .. }
+            | Self::WriteFailed { .. }
+            | Self::MiscError { .. } => false,
         }
     }
 
@@ -170,8 +229,11 @@ impl CompletionEventKind {
         match self {
             Self::DownloadCompleted { peer, .. }
             | Self::DownloadFailed { peer, .. } => Some(*peer),
-            Self::WriteCompleted { .. }
+            Self::FormatCompleted { .. }
+            | Self::FormatFailed { .. }
+            | Self::WriteCompleted { .. }
             | Self::WriteFailed { .. }
+            | Self::MiscError { .. }
             | Self::Completed => None,
         }
     }

--- a/openapi/installinator-artifactd.json
+++ b/openapi/installinator-artifactd.json
@@ -290,6 +290,85 @@
             ]
           },
           {
+            "description": "Failed to format a disk.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The format attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the format attempt took.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "message": {
+                "description": "A message indicating the reason for failure.",
+                "type": "string"
+              },
+              "path": {
+                "description": "The path to the disk.",
+                "type": "string",
+                "format": "UTF-8 path"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "format_failed"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "elapsed",
+              "message",
+              "path",
+              "reason"
+            ]
+          },
+          {
+            "description": "Completed formatting a disk.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The format attempt.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the format attempt took.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "path": {
+                "description": "The path to the disk.",
+                "type": "string",
+                "format": "UTF-8 path"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "format_completed"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "elapsed",
+              "path",
+              "reason"
+            ]
+          },
+          {
             "description": "Failed to write an artifact.",
             "type": "object",
             "properties": {
@@ -396,6 +475,56 @@
               "destination",
               "elapsed",
               "kind",
+              "reason"
+            ]
+          },
+          {
+            "description": "A miscellaneous error occurred.\n\nThis is a catch-all for errors that aren't described by any of the variants.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "data": {
+                "description": "Data about the operation, serialized as JSON."
+              },
+              "elapsed": {
+                "description": "How long the operation took before it failed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "is_fatal": {
+                "description": "Whether this operation is fatal, i.e. will not be retried.",
+                "type": "boolean"
+              },
+              "message": {
+                "description": "A message indicating why the operation failed.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "The name of the operation that failed.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "misc_error"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "data",
+              "elapsed",
+              "is_fatal",
+              "message",
+              "operation",
               "reason"
             ]
           },


### PR DESCRIPTION
Add variants for:

* formatting the disk failed/succeeded/progress
* some sort of miscellaneous error occurred that isn't described by one
  of the other variants

Even though the installinator isn't formatting disks yet, we need
wicketd to at least try and understand these events.
