### PR TITLE
[installinator] Add `debug-hardware-scan` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "proptest",
  "reqwest",
  "serde",
+ "sled-hardware",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -6,6 +6,7 @@
 
 use crate::{execute, PFEXEC};
 use serde::{Deserialize, Deserializer};
+use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -236,7 +237,7 @@ impl<'de> Deserialize<'de> for ZpoolName {
                 "Bad zpool prefix - must start with 'oxp_'",
             )
         })?;
-        let id = Uuid::from_str(&s).map_err(serde::de::Error::custom)?;
+        let id = Uuid::from_str(s).map_err(serde::de::Error::custom)?;
         Ok(ZpoolName(id))
     }
 }
@@ -248,14 +249,14 @@ impl FromStr for ZpoolName {
         let s = s.strip_prefix(ZPOOL_PREFIX).ok_or_else(|| {
             format!("Bad zpool name {}; must start with {}", s, ZPOOL_PREFIX)
         })?;
-        let id = Uuid::from_str(&s).map_err(|e| e.to_string())?;
+        let id = Uuid::from_str(s).map_err(|e| e.to_string())?;
         Ok(ZpoolName(id))
     }
 }
 
-impl ToString for ZpoolName {
-    fn to_string(&self) -> String {
-        format!("{}{}", ZPOOL_PREFIX, self.0)
+impl fmt::Display for ZpoolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", ZPOOL_PREFIX, self.0)
     }
 }
 
@@ -268,7 +269,7 @@ mod test {
     }
 
     fn parse_name(s: &str) -> Result<ZpoolName, toml::de::Error> {
-        toml_string(&s)
+        toml_string(s)
             .parse::<toml::Value>()
             .expect("Cannot parse as TOML value")
             .get("zpool_name")

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -24,6 +24,7 @@ omicron-common.workspace = true
 progenitor-client.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+sled-hardware.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-envlogger.workspace = true

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -12,11 +12,12 @@ use omicron_common::{
     api::internal::nexus::KnownArtifactKind,
     update::{ArtifactHashId, ArtifactKind},
 };
-use slog::Drain;
+use slog::{info, warn, Drain};
 use tokio::sync::mpsc;
 
 use crate::{
     artifact::ArtifactIdOpts,
+    hardware::Hardware,
     peers::{DiscoveryMechanism, FetchedArtifact, Peers},
     reporter::{ProgressReporter, ReportEvent},
     write::{write_artifact, WriteDestination},
@@ -37,6 +38,9 @@ impl InstallinatorApp {
 
         match self.subcommand {
             InstallinatorCommand::DebugDiscover(opts) => opts.exec(log).await,
+            InstallinatorCommand::DebugHardwareScan(opts) => {
+                opts.exec(log).await
+            }
             InstallinatorCommand::Install(opts) => opts.exec(log).await,
         }
     }
@@ -64,6 +68,8 @@ impl InstallinatorApp {
 enum InstallinatorCommand {
     /// Discover peers on the bootstrap network.
     DebugDiscover(DebugDiscoverOpts),
+    /// Scan hardware to find the target M.2 device.
+    DebugHardwareScan(DebugHardwareScan),
     /// Perform the installation.
     Install(InstallOpts),
 }
@@ -94,6 +100,44 @@ struct DiscoverOpts {
     /// The mechanism by which to discover peers: bootstrap or list:[::1]:8000
     #[clap(long, default_value_t = DiscoveryMechanism::Bootstrap)]
     mechanism: DiscoveryMechanism,
+}
+
+/// Perform a scan of the device hardware looking for the target M.2.
+#[derive(Debug, Args)]
+#[command(version)]
+struct DebugHardwareScan {}
+
+impl DebugHardwareScan {
+    async fn exec(self, log: slog::Logger) -> Result<()> {
+        let hardware = Hardware::scan(&log)?;
+
+        for disk in hardware.m2_disks() {
+            match disk.boot_image_devfs_path() {
+                Ok(boot_image_path) => {
+                    info!(
+                        log, "found M.2 disk";
+                        "identity" => ?disk.identity(),
+                        "path" => disk.devfs_path().display(),
+                        "slot" => disk.slot(),
+                        "boot_image_path" => boot_image_path.display(),
+                        "zpool" => %disk.zpool_name(),
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        log, "found M.2 disk but failed to find boot image path";
+                        "identity" => ?disk.identity(),
+                        "path" => disk.devfs_path().display(),
+                        "slot" => disk.slot(),
+                        "boot_image_path_err" => %err,
+                        "zpool" => %disk.zpool_name(),
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Args)]

--- a/installinator/src/hardware.rs
+++ b/installinator/src/hardware.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::anyhow;
+use anyhow::ensure;
+use anyhow::Context;
+use anyhow::Result;
+use sled_hardware::Disk;
+use sled_hardware::DiskVariant;
+use sled_hardware::HardwareManager;
+use slog::info;
+use slog::Logger;
+
+pub struct Hardware {
+    m2_disks: Vec<Disk>,
+}
+
+impl Hardware {
+    pub fn scan(log: &Logger) -> Result<Self> {
+        let is_gimlet = sled_hardware::is_gimlet()
+            .context("failed to detect whether host is a gimlet")?;
+        ensure!(is_gimlet, "hardware scan only supported on gimlets");
+
+        let hardware = HardwareManager::new(log, None).map_err(|err| {
+            anyhow!("failed to create HardwareManager: {err}")
+        })?;
+
+        let disks = hardware.disks();
+
+        info!(
+            log, "found gimlet hardware";
+            "baseboard" => ?hardware.baseboard(),
+            "is_scrimlet" => hardware.is_scrimlet(),
+            "num_disks" => disks.len(),
+        );
+
+        let m2_disks = disks
+            .into_iter()
+            .filter_map(|disk| {
+                // Skip U.2 disks
+                match disk.variant() {
+                    DiskVariant::U2 => {
+                        info!(
+                            log, "ignoring U.2 disk";
+                            "path" => disk.devfs_path().display(),
+                        );
+                        return None;
+                    }
+                    DiskVariant::M2 => (),
+                }
+
+                Some(
+                    Disk::new(log, disk)
+                        .context("failed to instantiate Disk handle for M.2"),
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { m2_disks })
+    }
+
+    pub fn m2_disks(&self) -> &[Disk] {
+        &self.m2_disks
+    }
+}

--- a/installinator/src/lib.rs
+++ b/installinator/src/lib.rs
@@ -6,6 +6,7 @@ mod artifact;
 mod ddm_admin_client;
 mod dispatch;
 mod errors;
+mod hardware;
 #[cfg(test)]
 mod mock_peers;
 mod peers;

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -130,9 +130,8 @@ impl HardwareMonitor {
         bootstrap_etherstub: Etherstub,
         switch_zone_bootstrap_address: Ipv6Addr,
     ) -> Result<Self, Error> {
-        let hardware =
-            HardwareManager::new(log.clone(), sled_config.stub_scrimlet)
-                .map_err(|e| Error::Hardware(e))?;
+        let hardware = HardwareManager::new(log, sled_config.stub_scrimlet)
+            .map_err(|e| Error::Hardware(e))?;
 
         let service_manager = ServiceManager::new(
             log.clone(),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -271,9 +271,8 @@ impl SledAgent {
             request.gateway.address,
         );
 
-        let hardware =
-            HardwareManager::new(parent_log.clone(), config.stub_scrimlet)
-                .map_err(|e| Error::Hardware(e))?;
+        let hardware = HardwareManager::new(&parent_log, config.stub_scrimlet)
+            .map_err(|e| Error::Hardware(e))?;
 
         let update_config =
             ConfigUpdates { zone_artifact_path: PathBuf::from("/opt/oxide") };

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -513,7 +513,7 @@ impl HardwareManager {
     /// If this argument is not supplied, we assume the device is a gimlet until
     /// device scanning informs us otherwise.
     pub fn new(
-        log: Logger,
+        log: &Logger,
         stub_scrimlet: Option<bool>,
     ) -> Result<Self, String> {
         let log = log.new(o!("component" => "HardwareManager"));

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -213,6 +213,10 @@ impl UnparsedDisk {
     pub fn devfs_path(&self) -> &PathBuf {
         &self.paths.devfs_path
     }
+
+    pub fn variant(&self) -> DiskVariant {
+        self.variant
+    }
 }
 
 /// A physical disk conforming to the expected partition layout.
@@ -298,6 +302,14 @@ impl Disk {
 
     pub fn zpool_name(&self) -> &ZpoolName {
         &self.zpool_name
+    }
+
+    pub fn boot_image_devfs_path(&self) -> Result<PathBuf, DiskError> {
+        self.paths.partition_device_path(&self.partitions, Partition::BootImage)
+    }
+
+    pub fn slot(&self) -> i64 {
+        self.slot
     }
 }
 

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -21,7 +21,7 @@ pub struct HardwareManager {}
 
 impl HardwareManager {
     pub fn new(
-        _log: Logger,
+        _log: &Logger,
         _stub_scrimlet: Option<bool>,
     ) -> Result<Self, String> {
         unimplemented!("Accessing hardware unsupported on non-illumos");


### PR DESCRIPTION
The next step from this will be to set destination paths based on the hardware scan; that will come in a later PR.

Builds on the changes in #2451 that pull a bunch of hardware-scanning logic out of sled-agent so we can use it too.