### PR TITLE
[installinator] set and read Content-Length header for artifact fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
+ "http",
  "installinator-artifact-client",
  "installinator-common",
  "ipcc-key-value",

--- a/installinator-artifact-client/src/lib.rs
+++ b/installinator-artifact-client/src/lib.rs
@@ -174,12 +174,14 @@ impl From<installinator_common::ProgressEventKind>
                 kind,
                 peer,
                 downloaded_bytes,
+                total_bytes,
                 elapsed,
             } => Self::DownloadProgress {
                 attempt: attempt as u32,
                 kind: kind.to_string(),
                 peer: peer.to_string(),
                 downloaded_bytes,
+                total_bytes,
                 elapsed: elapsed.into(),
             },
             installinator_common::ProgressEventKind::FormatProgress {

--- a/installinator-artifactd/src/http_entrypoints.rs
+++ b/installinator-artifactd/src/http_entrypoints.rs
@@ -52,7 +52,7 @@ async fn get_artifact_by_id(
 ) -> Result<HttpResponseHeaders<HttpResponseOk<FreeformBody>>, HttpError> {
     match rqctx.context().artifact_store.get_artifact(&path.into_inner()).await
     {
-        Some((body, size)) => Ok(body_to_artifact_response(body, size)),
+        Some((size, body)) => Ok(body_to_artifact_response(size, body)),
         None => {
             Err(HttpError::for_not_found(None, "Artifact not found".into()))
         }
@@ -74,7 +74,7 @@ async fn get_artifact_by_hash(
         .get_artifact_by_hash(&path.into_inner())
         .await
     {
-        Some((body, size)) => Ok(body_to_artifact_response(body, size)),
+        Some((size, body)) => Ok(body_to_artifact_response(size, body)),
         None => {
             Err(HttpError::for_not_found(None, "Artifact not found".into()))
         }
@@ -121,8 +121,8 @@ async fn report_progress(
 }
 
 fn body_to_artifact_response(
+    size: u64,
     body: Body,
-    size: usize,
 ) -> HttpResponseHeaders<HttpResponseOk<FreeformBody>> {
     let mut response =
         HttpResponseHeaders::new_unnamed(HttpResponseOk(body.into()));

--- a/installinator-artifactd/src/http_entrypoints.rs
+++ b/installinator-artifactd/src/http_entrypoints.rs
@@ -5,10 +5,11 @@
 // Copyright 2022 Oxide Computer Company
 
 use dropshot::{
-    endpoint, ApiDescription, FreeformBody, HttpError, HttpResponseOk,
-    HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
+    endpoint, ApiDescription, FreeformBody, HttpError, HttpResponseHeaders,
+    HttpResponseOk, HttpResponseUpdatedNoContent, Path, RequestContext,
+    TypedBody,
 };
-use hyper::StatusCode;
+use hyper::{header, Body, StatusCode};
 use installinator_common::ProgressReport;
 use omicron_common::update::{ArtifactHashId, ArtifactId};
 use schemars::JsonSchema;
@@ -48,10 +49,10 @@ async fn get_artifact_by_id(
     // code might be dealing with an unknown artifact kind. This can happen
     // if a new artifact kind is introduced across version changes.
     path: Path<ArtifactId>,
-) -> Result<HttpResponseOk<FreeformBody>, HttpError> {
+) -> Result<HttpResponseHeaders<HttpResponseOk<FreeformBody>>, HttpError> {
     match rqctx.context().artifact_store.get_artifact(&path.into_inner()).await
     {
-        Some(body) => Ok(HttpResponseOk(body.into())),
+        Some((body, size)) => Ok(body_to_artifact_response(body, size)),
         None => {
             Err(HttpError::for_not_found(None, "Artifact not found".into()))
         }
@@ -66,14 +67,14 @@ async fn get_artifact_by_id(
 async fn get_artifact_by_hash(
     rqctx: RequestContext<ServerContext>,
     path: Path<ArtifactHashId>,
-) -> Result<HttpResponseOk<FreeformBody>, HttpError> {
+) -> Result<HttpResponseHeaders<HttpResponseOk<FreeformBody>>, HttpError> {
     match rqctx
         .context()
         .artifact_store
         .get_artifact_by_hash(&path.into_inner())
         .await
     {
-        Some(body) => Ok(HttpResponseOk(body.into())),
+        Some((body, size)) => Ok(body_to_artifact_response(body, size)),
         None => {
             Err(HttpError::for_not_found(None, "Artifact not found".into()))
         }
@@ -117,4 +118,15 @@ async fn report_progress(
             ))
         }
     }
+}
+
+fn body_to_artifact_response(
+    body: Body,
+    size: usize,
+) -> HttpResponseHeaders<HttpResponseOk<FreeformBody>> {
+    let mut response =
+        HttpResponseHeaders::new_unnamed(HttpResponseOk(body.into()));
+    let headers = response.headers_mut();
+    headers.append(header::CONTENT_LENGTH, size.into());
+    response
 }

--- a/installinator-artifactd/src/store.rs
+++ b/installinator-artifactd/src/store.rs
@@ -18,10 +18,10 @@ use uuid::Uuid;
 #[async_trait]
 pub trait ArtifactGetter: fmt::Debug + Send + Sync + 'static {
     /// Gets an artifact, returning it as a [`Body`] along with its length.
-    async fn get(&self, id: &ArtifactId) -> Option<(Body, usize)>;
+    async fn get(&self, id: &ArtifactId) -> Option<(u64, Body)>;
 
     /// Gets an artifact by hash, returning it as a [`Body`].
-    async fn get_by_hash(&self, id: &ArtifactHashId) -> Option<(Body, usize)>;
+    async fn get_by_hash(&self, id: &ArtifactHashId) -> Option<(u64, Body)>;
 
     /// Reports update progress events from the installinator.
     async fn report_progress(
@@ -63,7 +63,7 @@ impl ArtifactStore {
     pub(crate) async fn get_artifact(
         &self,
         id: &ArtifactId,
-    ) -> Option<(Body, usize)> {
+    ) -> Option<(u64, Body)> {
         slog::debug!(self.log, "Artifact requested: {:?}", id);
         self.getter.get(id).await
     }
@@ -71,7 +71,7 @@ impl ArtifactStore {
     pub(crate) async fn get_artifact_by_hash(
         &self,
         id: &ArtifactHashId,
-    ) -> Option<(Body, usize)> {
+    ) -> Option<(u64, Body)> {
         slog::debug!(self.log, "Artifact requested by hash: {:?}", id);
         self.getter.get_by_hash(id).await
     }

--- a/installinator-artifactd/src/store.rs
+++ b/installinator-artifactd/src/store.rs
@@ -17,11 +17,11 @@ use uuid::Uuid;
 /// Represents a way to fetch artifacts.
 #[async_trait]
 pub trait ArtifactGetter: fmt::Debug + Send + Sync + 'static {
-    /// Gets an artifact, returning it as a [`Body`].
-    async fn get(&self, id: &ArtifactId) -> Option<Body>;
+    /// Gets an artifact, returning it as a [`Body`] along with its length.
+    async fn get(&self, id: &ArtifactId) -> Option<(Body, usize)>;
 
     /// Gets an artifact by hash, returning it as a [`Body`].
-    async fn get_by_hash(&self, id: &ArtifactHashId) -> Option<Body>;
+    async fn get_by_hash(&self, id: &ArtifactHashId) -> Option<(Body, usize)>;
 
     /// Reports update progress events from the installinator.
     async fn report_progress(
@@ -60,7 +60,10 @@ impl ArtifactStore {
         Self { log, getter: Box::new(getter) }
     }
 
-    pub(crate) async fn get_artifact(&self, id: &ArtifactId) -> Option<Body> {
+    pub(crate) async fn get_artifact(
+        &self,
+        id: &ArtifactId,
+    ) -> Option<(Body, usize)> {
         slog::debug!(self.log, "Artifact requested: {:?}", id);
         self.getter.get(id).await
     }
@@ -68,7 +71,7 @@ impl ArtifactStore {
     pub(crate) async fn get_artifact_by_hash(
         &self,
         id: &ArtifactHashId,
-    ) -> Option<Body> {
+    ) -> Option<(Body, usize)> {
         slog::debug!(self.log, "Artifact requested by hash: {:?}", id);
         self.getter.get_by_hash(id).await
     }

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -275,6 +275,9 @@ pub enum ProgressEventKind {
         /// The number of bytes downloaded so far.
         downloaded_bytes: u64,
 
+        /// The size of the artifact, as provided in the Content-Length header.
+        total_bytes: u64,
+
         /// How long it's been since the download started.
         elapsed: Duration,
     },

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -15,6 +15,7 @@ ddm-admin-client.workspace = true
 display-error-chain.workspace = true
 futures.workspace = true
 hex.workspace = true
+http.workspace = true
 installinator-artifact-client.workspace = true
 installinator-common.workspace = true
 ipcc-key-value.workspace = true

--- a/installinator/src/errors.rs
+++ b/installinator/src/errors.rs
@@ -13,11 +13,14 @@ pub(crate) enum ArtifactFetchError {
     HttpError {
         peer: SocketAddrV6,
         #[source]
-        error: ClientError,
+        error: HttpError,
     },
 
     #[error("peer {peer} timed out ({timeout:?}) after returning {bytes_fetched} bytes")]
     Timeout { peer: SocketAddrV6, timeout: Duration, bytes_fetched: usize },
+
+    #[error("artifact size in Content-Length header ({artifact_size}) did not match downloaded size ({downloaded_bytes})")]
+    SizeMismatch { artifact_size: u64, downloaded_bytes: u64 },
 }
 
 #[derive(Debug, Error)]
@@ -29,4 +32,16 @@ pub(crate) enum DiscoverPeersError {
     #[error("failed to discover peers (no more retries left, will abort)")]
     #[allow(unused)]
     Abort(#[source] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum HttpError {
+    #[error("HTTP client error")]
+    Client(#[from] ClientError),
+
+    #[error("missing Content-Length header")]
+    MissingContentLength,
+
+    #[error("Content-Length header could not be parsed into an integer")]
+    InvalidContentLength,
 }

--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -6,7 +6,6 @@ use std::{
     collections::BTreeMap,
     fmt,
     net::{Ipv6Addr, SocketAddrV6},
-    pin::Pin,
     time::Duration,
 };
 
@@ -23,7 +22,10 @@ use test_strategy::Arbitrary;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::peers::{FetchSender, PeersImpl};
+use crate::{
+    errors::HttpError,
+    peers::{FetchReceiver, PeersImpl},
+};
 
 struct MockPeersUniverse {
     artifact: Bytes,
@@ -228,18 +230,22 @@ impl PeersImpl for MockPeers {
         self.selected_peers.len()
     }
 
-    fn fetch_from_peer_impl(
+    async fn fetch_from_peer_impl(
         &self,
         peer: SocketAddrV6,
         // We don't (yet) use the artifact ID in MockPeers
         _artifact_hash_id: ArtifactHashId,
-        sender: FetchSender,
-    ) -> Pin<Box<dyn futures::Future<Output = ()> + Send>> {
+    ) -> Result<(u64, FetchReceiver), HttpError> {
         let peer_data = self
             .get(peer)
             .unwrap_or_else(|| panic!("peer {peer} not found in selection"))
             .clone();
-        Box::pin(async move { peer_data.send_response(sender).await })
+        let artifact_size = peer_data.artifact.len() as u64;
+
+        let (sender, receiver) = mpsc::channel(8);
+        tokio::spawn(async move { peer_data.send_response(sender).await });
+        // TODO: add tests to ensure an invalid artifact size is correctly detected
+        Ok((artifact_size, receiver))
     }
 
     async fn report_progress_impl(
@@ -271,7 +277,10 @@ impl fmt::Debug for MockPeer {
 }
 
 impl MockPeer {
-    async fn send_response(self, sender: FetchSender) {
+    async fn send_response(
+        self,
+        sender: mpsc::Sender<Result<Bytes, ClientError>>,
+    ) {
         let mut artifact = self.artifact;
         match self.response {
             MockResponse::Response(actions) => {
@@ -486,12 +495,11 @@ impl PeersImpl for MockReportPeers {
         3
     }
 
-    fn fetch_from_peer_impl(
+    async fn fetch_from_peer_impl(
         &self,
         _peer: SocketAddrV6,
         _artifact_hash_id: ArtifactHashId,
-        _sender: FetchSender,
-    ) -> Pin<Box<dyn futures::Future<Output = ()> + Send>> {
+    ) -> Result<(u64, FetchReceiver), HttpError> {
         unimplemented!(
             "this should never be called -- \
             eventually we'll want to unify this with MockPeers",

--- a/openapi/installinator-artifactd.json
+++ b/openapi/installinator-artifactd.json
@@ -649,6 +649,12 @@
                 "enum": [
                   "download_progress"
                 ]
+              },
+              "total_bytes": {
+                "description": "The size of the artifact, as provided in the Content-Length header.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
               }
             },
             "required": [
@@ -657,7 +663,8 @@
               "elapsed",
               "kind",
               "peer",
-              "reason"
+              "reason",
+              "total_bytes"
             ]
           },
           {


### PR DESCRIPTION
The main advantage is that the installinator can check, and report, how
far along the download is.

Also do a small rework of how channels work in the installinator:
overall this cleans some of this code up.

This is still a bit hard to test end-to-end until we have a host image
to test against, but I think it's pretty straightforward.

(thanks to @andrewjstone for showing me how to add a Content-Length header!)