### PR TITLE
[wicket] upgrade libsw to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,9 +3164,12 @@ dependencies = [
 
 [[package]]
 name = "libsw"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d81b373cd988b6e2b6e32ded4ea80c15085028efcdd5f83e37f9cbfb9c517ca"
+checksum = "9021b9cc0f078fba93f59d6e6f1fce89682171107a21fc421eb130efd2048189"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "libxml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,7 @@ sprockets-rot = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df
 steno = "0.3.1"
 strum = { version = "0.24", features = [ "derive" ] }
 subprocess = "0.2.9"
-libsw = "2.2.0"
+libsw = { version = "3.1.0", features = ["tokio"] }
 syn = { version = "1.0" }
 tar = "0.4"
 tempdir = "0.3"

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -58,7 +58,7 @@ pub enum InventoryEvent {
         wicketd_received: Instant,
 
         /// The time at which information was received from MGS.
-        mgs_received: libsw::Stopwatch,
+        mgs_received: libsw::TokioSw,
     },
     /// The inventory is unavailable.
     Unavailable {

--- a/wicket/src/state/status.rs
+++ b/wicket/src/state/status.rs
@@ -69,7 +69,7 @@ impl ServiceStatus {
 #[derive(Debug)]
 pub struct LivenessState {
     // None means that the stopwatch hasn't yet been initialized.
-    stopwatch: Option<libsw::Stopwatch>,
+    stopwatch: Option<libsw::TokioSw>,
 
     #[allow(unused)]
     live_threshold: Duration,
@@ -82,7 +82,7 @@ impl LivenessState {
 
     /// Resets or initializes the stopwatch state.
     pub fn reset(&mut self, elapsed: Duration) {
-        self.stopwatch = Some(libsw::Stopwatch::with_elapsed_started(elapsed));
+        self.stopwatch = Some(libsw::TokioSw::with_elapsed_started(elapsed));
     }
 
     /// Compute the liveness for this state.

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -159,7 +159,7 @@ impl InventoryState {
                     .send(InventoryEvent::Inventory {
                         changed_inventory,
                         wicketd_received: Instant::now(),
-                        mgs_received: libsw::Stopwatch::with_elapsed_started(
+                        mgs_received: libsw::TokioSw::with_elapsed_started(
                             mgs_received_ago,
                         ),
                     })


### PR DESCRIPTION
libsw 3.x includes explicit support for tokio instants, via the `TokioSw`
alias. We should generally be using tokio instants since they're
the same as `std::time::Instant` in normal use, and allow pausing and
resuming time when the `test-util` feature is enabled.
