### PR TITLE
[Wicket] Add resize handlers to controls

### DIFF
--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -104,6 +104,10 @@ impl Runner {
     fn main_loop(&mut self) -> anyhow::Result<()> {
         info!(self.log, "Starting main loop");
 
+        // Size the initial screen
+        let rect = self.terminal.get_frame().size();
+        self.screen.resize(&mut self.state, rect.width, rect.height);
+
         // Draw the initial screen
         self.screen.draw(&self.state, &mut self.terminal)?;
 
@@ -126,7 +130,8 @@ impl Runner {
                     );
                     self.handle_action(action)?;
                 }
-                Event::Term(TermEvent::Resize(_, _)) => {
+                Event::Term(TermEvent::Resize(width, height)) => {
+                    self.screen.resize(&mut self.state, width, height);
                     self.screen.draw(&self.state, &mut self.terminal)?;
                 }
                 Event::Inventory(event) => {

--- a/wicket/src/ui/controls/mod.rs
+++ b/wicket/src/ui/controls/mod.rs
@@ -25,4 +25,23 @@ pub trait Control {
         rect: Rect,
         active: bool,
     );
+
+    /// Optional callback for [`Control`]s that must know the size and position
+    /// of their area in order to compute visuals dynamically outside the
+    /// render process. This is useful for situations when you want to size
+    /// a widget to the the screen where the content of the widget may differ
+    /// depending upon the size available, and you want to minimize the amount
+    /// of times this computation is performed by memoizing the contents of the
+    /// widget in the `Control`. It is also useful to allow mouse input event
+    /// handling via rectangle intersection.
+    ///
+    /// This is a separate callback because not all [`Control`]s need the
+    /// functionality provided.
+    ///
+    /// Additionally, the resize events from the terminal are insufficient, as
+    /// they only give the total size of the screen, not the specific area of a
+    /// `Control`. Only the parent of a [`Control`] knows the precise [`Rect`]
+    /// of the child. The parent computes its own layout during resize and
+    /// passes the appropriate `Rect` to the child.
+    fn resize(&mut self, _: &mut State, _: Rect) {}
 }

--- a/wicket/src/ui/mod.rs
+++ b/wicket/src/ui/mod.rs
@@ -28,11 +28,29 @@ pub use panes::OverviewPane;
 pub struct Screen {
     splash: Option<SplashScreen>,
     main: MainScreen,
+    width: u16,
+    height: u16,
 }
 
 impl Screen {
     pub fn new() -> Screen {
-        Screen { splash: Some(SplashScreen::new()), main: MainScreen::new() }
+        Screen {
+            splash: Some(SplashScreen::new()),
+            main: MainScreen::new(),
+            width: 0,
+            height: 0,
+        }
+    }
+
+    /// Compute the layout of the [`MainScreen`]
+    ///
+    // A draw is issued after every resize, so no need to return an Action
+    pub fn resize(&mut self, state: &mut State, width: u16, height: u16) {
+        self.width = width;
+        self.height = height;
+
+        // Size the main screen
+        self.main.resize(state, width, height);
     }
 
     pub fn on(&mut self, state: &mut State, event: Event) -> Option<Action> {


### PR DESCRIPTION
This re-adds the capability for individual `Control`s to optionally
receive resize events. Such resize events allow a `Control` to compute
its layout outside of being rendered. This in turn allows the ability
to dynamically size contents based on the current state without having
to do it on every draw. Each `Control` is responsible for ensuring its
children receive resize events with their proper `Rect` computed if
their children require this functionality.

The current code on main does not require this functionality, but it is
needed for Update. Specifically it's needed for dynamic construction  of
[`TreeItem`s](https://docs.rs/tui-tree-widget/0.11.0/tui_tree_widget/struct.TreeItem.html)
based on changing status, since we must know the width of the pane in
order to construct the tree faithfully. We could work around this by
building a fake tree structure of the same shape and then recomputing
the real tree structure on every draw, but this is likely more code
than proper resize events, and is confusing. It also costs us CPU
unnecessarily.

As a side-effect of this change, we will now be able to re-introduce
mouse events if we desire in the future.
