### PR TITLE
RFD-322: v1 subnet nics endpoint

### DIFF
--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -17,7 +17,6 @@ use crate::external_api::params;
 use omicron_common::api::external;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
-use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
@@ -256,19 +255,11 @@ impl super::Nexus {
     pub async fn subnet_list_network_interfaces(
         &self,
         opctx: &OpContext,
-        organization_name: &Name,
-        project_name: &Name,
-        vpc_name: &Name,
-        subnet_name: &Name,
-        pagparams: &DataPageParams<'_, Name>,
+        subnet_lookup: &lookup::VpcSubnet<'_>,
+        pagparams: &PaginatedBy<'_>,
     ) -> ListResultVec<db::model::NetworkInterface> {
-        let (.., authz_subnet) = LookupPath::new(opctx, &self.db_datastore)
-            .organization_name(organization_name)
-            .project_name(project_name)
-            .vpc_name(vpc_name)
-            .vpc_subnet_name(subnet_name)
-            .lookup_for(authz::Action::ListChildren)
-            .await?;
+        let (.., authz_subnet) =
+            subnet_lookup.lookup_for(authz::Action::ListChildren).await?;
         self.db_datastore
             .subnet_list_network_interfaces(opctx, &authz_subnet, pagparams)
             .await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5689,6 +5689,10 @@ async fn vpc_subnet_list_network_interfaces(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+// This endpoint is likely temporary. We would rather list all IPs allocated in
+// a subnet whether they come from NICs or something else. See
+// https://github.com/oxidecomputer/omicron/issues/2476
+
 /// List network interfaces
 #[endpoint {
     method = GET,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -131,13 +131,16 @@ lazy_static! {
     // VPC used for testing
     pub static ref DEMO_VPC_NAME: Name = "demo-vpc".parse().unwrap();
     pub static ref DEMO_VPC_URL: String =
-        format!("/v1/vpcs/{}?organization={}&project={}", *DEMO_VPC_NAME, *DEMO_ORG_NAME, *DEMO_PROJECT_NAME);
+        format!("/v1/vpcs/{}?{}", *DEMO_VPC_NAME, *DEMO_PROJECT_SELECTOR);
+
+    pub static ref DEMO_VPC_SELECTOR: String =
+        format!("organization={}&project={}&vpc={}", *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME);
     pub static ref DEMO_VPC_URL_FIREWALL_RULES: String =
-        format!("/v1/vpc-firewall-rules?organization={}&project={}&vpc={}", *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME);
+        format!("/v1/vpc-firewall-rules?{}", *DEMO_VPC_SELECTOR);
     pub static ref DEMO_VPC_URL_ROUTERS: String =
-        format!("/v1/vpc-routers?organization={}&project={}&vpc={}", *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME);
+        format!("/v1/vpc-routers?{}", *DEMO_VPC_SELECTOR);
     pub static ref DEMO_VPC_URL_SUBNETS: String =
-        format!("/v1/vpc-subnets?organization={}&project={}&vpc={}", *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME);
+        format!("/v1/vpc-subnets?{}", *DEMO_VPC_SELECTOR);
     pub static ref DEMO_VPC_CREATE: params::VpcCreate =
         params::VpcCreate {
             identity: IdentityMetadataCreateParams {
@@ -152,9 +155,9 @@ lazy_static! {
     pub static ref DEMO_VPC_SUBNET_NAME: Name =
         "demo-vpc-subnet".parse().unwrap();
     pub static ref DEMO_VPC_SUBNET_URL: String =
-        format!("/v1/vpc-subnets/{}?organization={}&project={}&vpc={}", *DEMO_VPC_SUBNET_NAME, *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME);
+        format!("/v1/vpc-subnets/{}?{}", *DEMO_VPC_SUBNET_NAME, *DEMO_VPC_SELECTOR);
     pub static ref DEMO_VPC_SUBNET_INTERFACES_URL: String =
-        format!("/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces", *DEMO_ORG_NAME, *DEMO_PROJECT_NAME, *DEMO_VPC_NAME, *DEMO_VPC_SUBNET_NAME);
+        format!("/v1/vpc-subnets/{}/network-interfaces?{}", *DEMO_VPC_SUBNET_NAME, *DEMO_VPC_SELECTOR);
     pub static ref DEMO_VPC_SUBNET_CREATE: params::VpcSubnetCreate =
         params::VpcSubnetCreate {
             identity: IdentityMetadataCreateParams {

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -268,12 +268,12 @@ async fn test_instances_create_reboot_halt(
     assert_eq!(instance.runtime.run_state, InstanceState::Starting);
 
     // Check that the instance got a network interface
-    let ips_url = format!(
-        "/organizations/{}/projects/{}/vpcs/default/subnets/default/network-interfaces",
+    let nics_url = format!(
+        "/v1/vpc-subnets/default/network-interfaces?organization={}&project={}&vpc=default",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     let network_interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &ips_url)
+        objects_list_page_authz::<NetworkInterface>(client, &nics_url)
             .await
             .items;
     assert_eq!(network_interfaces.len(), 1);
@@ -465,7 +465,7 @@ async fn test_instances_create_reboot_halt(
     // Check that the network interfaces for that instance are gone, peeking
     // at the subnet-scoped URL so we don't 404 at the instance-scoped route.
     let url_interfaces = format!(
-        "/organizations/{}/projects/{}/vpcs/default/subnets/default/network-interfaces",
+        "/v1/vpc-subnets/default/network-interfaces?organization={}&project={}&vpc=default",
         ORGANIZATION_NAME, PROJECT_NAME,
     );
     let interfaces =
@@ -1150,17 +1150,17 @@ async fn test_instance_with_new_custom_network_interfaces(
     let instance = response.parsed_body::<Instance>().unwrap();
 
     // Check that both interfaces actually appear correct.
-    let ip_url = |subnet_name: &Name| {
+    let nics_url = |subnet_name: &Name| {
         format!(
-            "/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-            ORGANIZATION_NAME, PROJECT_NAME, "default", subnet_name
+            "/v1/vpc-subnets/{}/network-interfaces?organization={}&project={}&vpc=default",
+            subnet_name, ORGANIZATION_NAME, PROJECT_NAME
         )
     };
 
     // The first interface is in the default VPC Subnet
     let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
         client,
-        ip_url(&default_name).as_str(),
+        nics_url(&default_name).as_str(),
         "",
         Some(100),
     )
@@ -1179,7 +1179,7 @@ async fn test_instance_with_new_custom_network_interfaces(
 
     let interfaces1 = NexusRequest::iter_collection_authn::<NetworkInterface>(
         client,
-        ip_url(&non_default_subnet_name).as_str(),
+        nics_url(&non_default_subnet_name).as_str(),
         "",
         Some(100),
     )
@@ -1912,8 +1912,8 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
 
     // Verify that there are no NICs at all in the subnet.
     let url_nics = format!(
-        "/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-        ORGANIZATION_NAME, PROJECT_NAME, "default", "default"
+        "/v1/vpc-subnets/default/network-interfaces?organization={}&project={}&vpc=default",
+        ORGANIZATION_NAME, PROJECT_NAME,
     );
     let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
         client, &url_nics, "", None,

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -273,6 +273,7 @@ vpc_subnet_delete                        /organizations/{organization_name}/proj
 vpc_subnet_delete_v1                     /v1/vpc-subnets/{subnet}
 vpc_subnet_list                          /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets
 vpc_subnet_list_network_interfaces       /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/network-interfaces
+vpc_subnet_list_network_interfaces_v1    /v1/vpc-subnets/{subnet}/network-interfaces
 vpc_subnet_list_v1                       /v1/vpc-subnets
 vpc_subnet_update                        /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}
 vpc_subnet_update_v1                     /v1/vpc-subnets/{subnet}

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -44,6 +44,7 @@ vpc_router_route_list                    (get    "/organizations/{organization_n
 vpc_router_route_view                    (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}")
 vpc_subnet_list                          (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets")
 vpc_subnet_view                          (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}")
+vpc_subnet_list_network_interfaces       (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/network-interfaces")
 policy_view                              (get    "/policy")
 certificate_list                         (get    "/system/certificates")
 certificate_view                         (get    "/system/certificates/{certificate}")

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -222,7 +222,7 @@ pub struct VpcSelector {
     pub vpc: NameOrId,
 }
 
-#[derive(Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct OptionalVpcSelector {
     #[serde(flatten)]
     pub vpc_selector: Option<VpcSelector>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4932,7 +4932,8 @@
         "tags": [
           "vpcs"
         ],
-        "summary": "List network interfaces",
+        "summary": "List network interfaces for a VPC subnet",
+        "description": "Use `/v1/vpc-subnets/{subnet}/network-interfaces` instead",
         "operationId": "vpc_subnet_list_network_interfaces",
         "parameters": [
           {
@@ -4959,7 +4960,7 @@
             "in": "query",
             "name": "sort_by",
             "schema": {
-              "$ref": "#/components/schemas/NameSortMode"
+              "$ref": "#/components/schemas/NameOrIdSortMode"
             }
           },
           {
@@ -5013,6 +5014,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -12237,6 +12239,92 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      }
+    },
+    "/v1/vpc-subnets/{subnet}/network-interfaces": {
+      "get": {
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "List network interfaces",
+        "operationId": "vpc_subnet_list_network_interfaces_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subnet",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrIdSortMode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vpc",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkInterfaceResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/v1/vpcs": {


### PR DESCRIPTION
I considered also changing `/v1/network-interfaces` to `/v1/instances/{instance}/network-interfaces` for consistency. I'm not sure yet what's best. 

You could imagine a single `/v1/network-interfaces` that lets you select by instance or by subnet. That might be confusing to users, since as far as I know it would be the only endpoint that allows filtering by two totally different parents. Perhaps even more importantly, it would be pretty complicated to implement.

I think for now I'll leave things as-is because the actual parent of a network interface is an instance:

https://github.com/oxidecomputer/omicron/blob/b61a56555bdd86865ba79e187ae3ff3d66f1ab3b/nexus/src/db/lookup.rs#L593-L600

so, given that fact, it makes sense for the top-level `/v1/network-interfaces` to use instance as its selector. That's what we do for every other kind of resource: the top-level endpoint always uses that resource's intrinsic parent as the selector. For example `/v1/vpcs` takes a project selector in the query params because VPC's parent is Project.

It may be slightly misleading to have `/v1/vpc-subnets/{subnet}/network-interfaces` because that makes you think NICs hang off a subnet; they don't, and one major indication of that is that you can have two NICs with the same name from different instances come back in the response to the subnet-filtered list (I think). So we probably do have to think more about this.