### PR TITLE
support multiple api addresses for dendrite

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -220,8 +220,8 @@ only_for_targets.switch_variant = "stub"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "cd0793ca40f3b7542d82e586ceb1dc7279d3afee"
-source.sha256 = "1d824a8eee30c8e187a7a5cbdc931872b5a6a3096cdd52a5e0b1a5bec872a39f"
+source.commit = "67a45ff847989e8b8be37c099f70a7451b277c0d"
+source.sha256 = "a2d7bda00d53e1fc2f569ef9afbef4a56a82636e2d613b7668fba7b767805474"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -238,8 +238,8 @@ only_for_targets.switch_variant = "asic"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "cd0793ca40f3b7542d82e586ceb1dc7279d3afee"
-source.sha256 = "00b615894d146fb04749cd91254e715ed5ec43c5057a5309e314dadcee9d3626"
+source.commit = "67a45ff847989e8b8be37c099f70a7451b277c0d"
+source.sha256 = "633e71a764fe02adf2c62dff31923ca4f8863818d0e4d68983c8a360bf23eb3a"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -540,6 +540,9 @@ impl ServiceManager {
         }
 
         for addr in &request.addresses {
+            if *addr == Ipv6Addr::LOCALHOST {
+                continue;
+            }
             info!(
                 self.inner.log,
                 "Ensuring address {} exists",
@@ -793,8 +796,9 @@ impl ServiceManager {
                 ServiceType::Dendrite { asic } => {
                     info!(self.inner.log, "Setting up dendrite service");
 
-                    if let Some(address) = request.addresses.get(0) {
-                        smfh.setprop(
+                    smfh.delpropvalue("config/address", "*")?;
+                    for address in &request.addresses {
+                        smfh.addpropvalue(
                             "config/address",
                             &format!("[{}]:{}", address, DENDRITE_PORT),
                         )?;
@@ -826,6 +830,10 @@ impl ServiceManager {
                                 "config/board_rev",
                                 &self.inner.sidecar_revision,
                             )?;
+                            smfh.setprop(
+                                "config/transceiver_interface",
+                                "tfportCPU0",
+                            )?;
                         }
                         DendriteAsic::TofinoStub => smfh.setprop(
                             "config/port_config",
@@ -839,9 +847,10 @@ impl ServiceManager {
                     info!(self.inner.log, "Setting up tfport service");
 
                     smfh.setprop("config/pkt_source", pkt_source)?;
-                    if let Some(address) = request.addresses.get(0) {
-                        smfh.setprop("config/host", &format!("[{}]", address))?;
-                    }
+                    smfh.setprop(
+                        "config/host",
+                        &format!("[{}]", Ipv6Addr::LOCALHOST),
+                    )?;
                     smfh.setprop("config/port", &format!("{}", DENDRITE_PORT))?;
                     smfh.refresh()?;
                 }
@@ -998,8 +1007,9 @@ impl ServiceManager {
             }
         };
 
-        let addresses =
+        let mut addresses =
             if let Some(ip) = switch_zone_ip { vec![ip] } else { vec![] };
+        addresses.push(Ipv6Addr::LOCALHOST);
 
         let request = ServiceZoneRequest {
             id: Uuid::new_v4(),
@@ -1093,24 +1103,21 @@ impl ServiceManager {
                             smfh.refresh()?;
                         }
                         ServiceType::Dendrite { .. } => {
-                            smfh.setprop(
-                                "config/address",
-                                &format!("[{}]:{}", address, DENDRITE_PORT),
-                            )?;
+                            smfh.delpropvalue("config/address", "*")?;
+                            for address in &request.addresses {
+                                smfh.addpropvalue(
+                                    "config/address",
+                                    &format!("[{}]:{}", address, DENDRITE_PORT),
+                                )?;
+                            }
                             smfh.refresh()?;
                             // TODO: For this restart to be optional, Dendrite must
                             // implement a non-default "refresh" method.
                             smfh.restart()?;
                         }
                         ServiceType::Tfport { .. } => {
-                            smfh.setprop(
-                                "config/host",
-                                &format!("[{}]", address),
-                            )?;
-                            smfh.refresh()?;
-                            // TODO: For this restart to be optional, Tfport must
-                            // implement a non-default "refresh" method.
-                            smfh.restart()?;
+                            // Since tfport and dpd communicate using localhost,
+                            // the tfport service shouldn't need to be restarted.
                         }
                         _ => (),
                     }


### PR DESCRIPTION
- Let dendrite listen on multiple addresses: i.e., underlay (for nexus) and localhost (or tfportd)
- tfportd no longer needs to be restarted when dendrite is