### PR TITLE
RFD-322: `/v1/disks/{disk}/metrics/{metric}`

### DIFF
--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -979,8 +979,7 @@ async fn test_disk_virtual_provisioning_collection(
     // This disk should appear in the accounting information for the project
     // in which it was allocated
     let disk_size = ByteCount::from_gibibytes_u32(1);
-    let disks_url =
-        format!("/organizations/{}/projects/{}/disks", ORG_NAME, PROJECT_NAME);
+    let disks_url = get_disks_url();
     let disk_one = params::DiskCreate {
         identity: IdentityMetadataCreateParams {
             name: "disk-one".parse().unwrap(),
@@ -1048,7 +1047,7 @@ async fn test_disk_virtual_provisioning_collection(
     // Each project should be using "one disk" of real storage, but the org
     // should be using both.
     let disks_url = format!(
-        "/organizations/{}/projects/{}/disks",
+        "/v1/disks?organization={}&project={}",
         ORG_NAME, PROJECT_NAME_2
     );
     let disk_one = params::DiskCreate {
@@ -1099,7 +1098,10 @@ async fn test_disk_virtual_provisioning_collection(
 
     // Delete the disk we just created, observe the utilization drop
     // accordingly.
-    let disk_url = format!("{}/{}", disks_url, "disk-two");
+    let disk_url = format!(
+        "/v1/disks/{}?organization={}&project={}",
+        "disk-two", ORG_NAME, PROJECT_NAME_2
+    );
     NexusRequest::object_delete(client, &disk_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
@@ -1397,12 +1399,15 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
     oximeter.force_collect().await;
 
     // Whenever we grab this URL, get the surrounding few seconds of metrics.
-    let metric_url = |metric_type: &str| {
-        let disk_url = format!("/organizations/{ORG_NAME}/projects/{PROJECT_NAME}/disks/{DISK_NAME}");
+    let metric_url = |metric: &str| {
         format!(
-            "{disk_url}/metrics/{metric_type}?start_time={:?}&end_time={:?}",
+            "/v1/disks/{}/metrics/{}?start_time={:?}&end_time={:?}&organization={}&project={}",
+            DISK_NAME,
+            metric,
             Utc::now() - chrono::Duration::seconds(10),
             Utc::now() + chrono::Duration::seconds(10),
+            ORG_NAME,
+            PROJECT_NAME,
         )
     };
     // Check the utilization info for the whole project too.
@@ -1466,14 +1471,14 @@ async fn test_disk_metrics_paginated(cptestctx: &ControlPlaneTestContext) {
     create_org_and_project(client).await;
     create_disk(&client, ORG_NAME, PROJECT_NAME, DISK_NAME).await;
     create_instance_with_disk(client).await;
-    let disk_url = format!(
-        "/organizations/{ORG_NAME}/projects/{PROJECT_NAME}/disks/{DISK_NAME}"
-    );
 
     let oximeter = &cptestctx.oximeter;
     oximeter.force_collect().await;
     for metric in &ALL_METRICS {
-        let collection_url = format!("{}/metrics/{metric}", disk_url);
+        let collection_url = format!(
+            "/v1/disks/{}/metrics/{}?organization={}&project={}",
+            DISK_NAME, metric, ORG_NAME, PROJECT_NAME
+        );
         let initial_params = format!(
             "start_time={:?}&end_time={:?}",
             Utc::now() - chrono::Duration::seconds(2),
@@ -1482,7 +1487,7 @@ async fn test_disk_metrics_paginated(cptestctx: &ControlPlaneTestContext) {
 
         objects_list_page_authz::<Measurement>(
             client,
-            &format!("{collection_url}?{initial_params}"),
+            &format!("{collection_url}&{initial_params}"),
         )
         .await;
 

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -221,12 +221,11 @@ lazy_static! {
         };
     pub static ref DEMO_DISK_METRICS_URL: String =
         format!(
-            "/organizations/{}/projects/{}/disks/{}/metrics/activated?start_time={:?}&end_time={:?}",
-            *DEMO_ORG_NAME,
-            *DEMO_PROJECT_NAME,
+            "/v1/disks/{}/metrics/activated?start_time={:?}&end_time={:?}&{}",
             *DEMO_DISK_NAME,
             Utc::now(),
             Utc::now(),
+            *DEMO_PROJECT_SELECTOR,
         );
 }
 

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -7,6 +7,7 @@ disk_delete_v1                           /v1/disks/{disk}
 disk_list                                /organizations/{organization_name}/projects/{project_name}/disks
 disk_list_v1                             /v1/disks
 disk_metrics_list                        /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}/metrics/{metric_name}
+disk_metrics_list_v1                     /v1/disks/{disk}/metrics/{metric}
 disk_view                                /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}
 disk_view_by_id                          /by-id/disks/{id}
 disk_view_v1                             /v1/disks/{disk}

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -25,6 +25,7 @@ project_list                             (get    "/organizations/{organization_n
 project_view                             (get    "/organizations/{organization_name}/projects/{project_name}")
 disk_list                                (get    "/organizations/{organization_name}/projects/{project_name}/disks")
 disk_view                                (get    "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}")
+disk_metrics_list                        (get    "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}/metrics/{metric_name}")
 instance_list                            (get    "/organizations/{organization_name}/projects/{project_name}/instances")
 instance_view                            (get    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}")
 instance_disk_list                       (get    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks")

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1606,6 +1606,7 @@
           "disks"
         ],
         "summary": "Fetch disk metrics",
+        "description": "Use `/v1/disks/{disk}/{metric}` instead",
         "operationId": "disk_metrics_list",
         "parameters": [
           {
@@ -1697,6 +1698,7 @@
             "$ref": "#/components/responses/Error"
           }
         },
+        "deprecated": true,
         "x-dropshot-pagination": true
       }
     },
@@ -8011,6 +8013,104 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      }
+    },
+    "/v1/disks/{disk}/metrics/{metric}": {
+      "get": {
+        "tags": [
+          "disks"
+        ],
+        "summary": "Fetch disk metrics",
+        "operationId": "disk_metrics_list_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "metric",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DiskMetricName"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "description": "An exclusive end time of metrics.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "description": "An inclusive start time of metrics.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "organization",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/v1/groups": {


### PR DESCRIPTION
@zephraph and I talked about `/v1/disk-metrics/{metric}?{disk_selector}` and `/v1/disks/{disk}/metrics?metric={metric}&{disk_selector}`, but decided against them. In general we are avoiding nesting selectors with names or IDs, but the set of disk metric types is a finite enum.