### PR TITLE
Add an SMF manifest for installinator, and add an `image_type` target to package-manifest

### DIFF
--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -111,6 +111,9 @@ $ cargo run --release --bin omicron-package -- package
 NOTE: Running in `release` mode isn't strictly required, but improves
 the performance of the packaging tools significantly.
 
+NOTE: To build packages for the trampoline recovery image, pass omicron-package
+`--target image_type=trampoline`.
+
 The aforementioned package command fills a target directory of choice
 (by default, `out/` within the omicron repository) with tarballs ready
 to be unpacked as services.

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -126,13 +126,19 @@ struct InstallOpts {
     #[command(flatten)]
     artifact_ids: ArtifactIdOpts,
 
-    // TODO: checksum?
+    /// If true, do not exit after successful completion (e.g., to continue
+    /// running as an smf service).
+    #[clap(long)]
+    stay_alive: bool,
+
     /// Install on a gimlet's M.2 drives, found via scanning for hardware.
     ///
     /// WARNING: This will overwrite the boot image slice of both M.2 drives, if
     /// present!
     #[clap(long)]
     install_on_gimlet: bool,
+
+    // TODO: checksum?
 
     // The destination to write to.
     #[clap(
@@ -220,6 +226,13 @@ impl InstallOpts {
 
         // Wait for all progress reports to be sent.
         progress_handle.await.context("progress reporter to complete")?;
+
+        if self.stay_alive {
+            loop {
+                slog::info!(log, "installation complete; sleeping");
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }
+        }
 
         Ok(())
     }

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -43,11 +43,10 @@ source.rust.release = true
 source.paths = [ { from = "smf/sled-agent", to = "pkg" } ]
 output.type = "tarball"
 
-# Installinator is a special package: we do not want it bundled into the normal
-# omicron install; it duplicates some of sled-agent's work and would conflict
-# with it if run side-by-side, and it's completely useless! We only want to
-# build it for inclusion in the trampoline ("recovery") image, which we indicate
-# here via `only_for_target.image_type`.
+# Installinator is a service which should run in the Global Zone for the
+# explicit purpose of recovery and OS re-installation. It should not be
+# installed concurrently with the sled-agent, and is built separately using the
+# target only_for_target.image_type = "trampoline".
 [package.installinator]
 service_name = "installinator"
 only_for_targets.image_type = "trampoline"
@@ -56,7 +55,6 @@ source.rust.binary_names = ["installinator"]
 source.rust.release = true
 source.paths = [ { from = "smf/installinator", to = "pkg" } ]
 output.type = "tarball"
-output.intermediate_only = true
 
 [package.omicron-nexus]
 service_name = "nexus"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -36,14 +36,21 @@
 
 [package.omicron-sled-agent]
 service_name = "sled-agent"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["sled-agent"]
 source.rust.release = true
 source.paths = [ { from = "smf/sled-agent", to = "pkg" } ]
 output.type = "tarball"
 
+# Installinator is a special package: we do not want it bundled into the normal
+# omicron install; it duplicates some of sled-agent's work and would conflict
+# with it if run side-by-side, and it's completely useless! We only want to
+# build it for inclusion in the trampoline ("recovery") image, which we indicate
+# here via `only_for_target.image_type`.
 [package.installinator]
 service_name = "installinator"
+only_for_targets.image_type = "trampoline"
 source.type = "local"
 source.rust.binary_names = ["installinator"]
 source.rust.release = true
@@ -53,6 +60,7 @@ output.intermediate_only = true
 
 [package.omicron-nexus]
 service_name = "nexus"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["nexus"]
 source.rust.release = true
@@ -69,6 +77,7 @@ setup_hint = """
 
 [package.oximeter-collector]
 service_name = "oximeter"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["oximeter"]
 source.rust.release = true
@@ -77,6 +86,7 @@ output.type = "zone"
 
 [package.clickhouse]
 service_name = "clickhouse"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.paths = [
   { from = "out/clickhouse", to = "/opt/oxide/clickhouse" },
@@ -87,6 +97,7 @@ setup_hint = "Run `./tools/ci_download_clickhouse` to download the necessary bin
 
 [package.cockroachdb]
 service_name = "cockroachdb"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.paths = [
   { from = "out/cockroachdb", to = "/opt/oxide/cockroachdb" },
@@ -98,18 +109,21 @@ setup_hint = "Run `./tools/ci_download_cockroachdb` to download the necessary bi
 
 [package.internal-dns]
 service_name = "internal_dns"
+only_for_targets.image_type = "standard"
 source.type = "composite"
 source.packages = [ "dns-server.tar.gz", "internal-dns-customizations.tar.gz" ]
 output.type = "zone"
 
 [package.external-dns]
 service_name = "external_dns"
+only_for_targets.image_type = "standard"
 source.type = "composite"
 source.packages = [ "dns-server.tar.gz", "external-dns-customizations.tar.gz" ]
 output.type = "zone"
 
 [package.dns-server]
 service_name = "dns-server"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["dnsadm", "dns-server"]
 source.rust.release = true
@@ -119,6 +133,7 @@ output.intermediate_only = true
 
 [package.internal-dns-customizations]
 service_name = "internal-dns-customizations"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.paths = [ { from = "smf/internal-dns", to = "/var/svc/manifest/site/internal_dns" } ]
 output.intermediate_only = true
@@ -126,6 +141,7 @@ output.type = "zone"
 
 [package.external-dns-customizations]
 service_name = "external-dns-customizations"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.paths = [ { from = "smf/external-dns", to = "/var/svc/manifest/site/external_dns" } ]
 output.intermediate_only = true
@@ -133,6 +149,7 @@ output.type = "zone"
 
 [package.omicron-gateway]
 service_name = "mgs"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["mgs"]
 source.rust.release = true
@@ -142,6 +159,7 @@ output.intermediate_only = true
 
 [package.wicketd]
 service_name = "wicketd"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["wicketd"]
 source.rust.release = true
@@ -151,6 +169,7 @@ output.intermediate_only = true
 
 [package.wicket]
 service_name = "wicket"
+only_for_targets.image_type = "standard"
 source.type = "local"
 source.rust.binary_names = ["wicket"]
 source.rust.release = true
@@ -165,6 +184,7 @@ output.intermediate_only = true
 # for instructions on building this manually.
 [package.crucible]
 service_name = "crucible"
+only_for_targets.image_type = "standard"
 # To manually override the package source (for example, to test a change in
 # both Crucible and Omicron simultaneously):
 #
@@ -181,6 +201,7 @@ output.type = "zone"
 
 [package.crucible-pantry]
 service_name = "crucible_pantry"
+only_for_targets.image_type = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
 source.commit = "fb671895e8adb3cab5e801bbbe8728997178aba4"
@@ -194,6 +215,7 @@ output.type = "zone"
 # for instructions on building this manually.
 [package.propolis-server]
 service_name = "propolis-server"
+only_for_targets.image_type = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
 source.commit = "880a031fbdd7417cd3a4643f8bf419d8d5ea8224"
@@ -204,6 +226,8 @@ output.type = "zone"
 
 [package.maghemite]
 service_name = "mg-ddm"
+# Note: unlike every other package, `maghemite` is not restricted to either the
+# "standard" or "trampoline" image_type; it is included in both.
 source.type = "prebuilt"
 source.repo = "maghemite"
 # Updating the commit hash here currently requires also updating
@@ -219,6 +243,7 @@ output.type = "tarball"
 [package.dendrite-stub]
 service_name = "dendrite"
 only_for_targets.switch_variant = "stub"
+only_for_targets.image_type = "standard"
 # To manually override the package source:
 #
 # 1. Build the zone image manually
@@ -237,6 +262,7 @@ output.intermediate_only = true
 [package.dendrite-asic]
 service_name = "dendrite"
 only_for_targets.switch_variant = "asic"
+only_for_targets.image_type = "standard"
 # To manually override the package source:
 #
 # 1. Build the zone image manually
@@ -259,6 +285,7 @@ output.intermediate_only = true
 [package.switch-asic]
 service_name = "switch"
 only_for_targets.switch_variant = "asic"
+only_for_targets.image_type = "standard"
 source.type = "composite"
 source.packages = [ "omicron-gateway.tar.gz", "dendrite-asic.tar.gz", "wicketd.tar.gz", "wicket.tar.gz" ]
 output.type = "zone"
@@ -272,6 +299,7 @@ output.type = "zone"
 [package.switch-stub]
 service_name = "switch"
 only_for_targets.switch_variant = "stub"
+only_for_targets.image_type = "standard"
 source.type = "composite"
 source.packages = [ "omicron-gateway.tar.gz", "dendrite-stub.tar.gz", "wicketd.tar.gz", "wicket.tar.gz" ]
 output.type = "zone"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -42,6 +42,15 @@ source.rust.release = true
 source.paths = [ { from = "smf/sled-agent", to = "pkg" } ]
 output.type = "tarball"
 
+[package.installinator]
+service_name = "installinator"
+source.type = "local"
+source.rust.binary_names = ["installinator"]
+source.rust.release = true
+source.paths = [ { from = "smf/installinator", to = "pkg" } ]
+output.type = "tarball"
+output.intermediate_only = true
+
 [package.omicron-nexus]
 service_name = "nexus"
 source.type = "local"

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -47,7 +47,7 @@ enum SubCommand {
 // involvement. If we choose to remove it, having users pick one of a few
 // "build profiles" (in other words, a curated list of target strings)
 // seems like a promising alternative.
-const DEFAULT_TARGET: &str = "switch_variant=stub";
+const DEFAULT_TARGET: &str = "image_type=standard switch_variant=stub";
 
 #[derive(Debug, Parser)]
 #[clap(name = "packaging tool")]

--- a/smf/installinator/manifest.xml
+++ b/smf/installinator/manifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='installinator'>
+
+<service name='system/illumos/installinator' type='service' version='1'>
+  <create_default_instance enabled='false' />
+  <single_instance />
+
+  <dependency name='multi_user' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/milestone/multi-user:default' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/installinator/bin/installinator install --from-ipcc --install-on-gimlet --stay-alive &amp;'
+    timeout_seconds='0' />
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='contract' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Installinator</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Server for returning a sled to factory condition</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>


### PR DESCRIPTION
The main intent for this PR was to add an SMF manifest to run `installinator` as a service and to build an `installinator` package we could include in host OS images, but it grew a bit when I went to add `installinator` to `package-manifest.toml`. In particular, we do _not_ want installinator to be installed alongside `sled-agent` in a standard omicron install. It should only be included in the `trampoline` image. Therefore, this PR adds a new target key `image_type` that takes the possible options `standard` and `trampoline`. I marked the majority of the pre-existing packages in `package-manifest` as `only_for_targets.image_type = standard` with the exception of maghemite, which should be included in both standard and trampoline images.

The end result of this is that a normal `omicron-package package` looks almost the same, except for the additional logged key/value for the image_type (which defaults to `standard`); note that `installinator` is not present:

```
$ ./target/release/omicron-package package
Mar 03 21:40:40.251 DEBG target: Target({"image_type": "standard", "switch_variant": "stub"})
[00:00:04] ########################################       6/6       clickhouse: done
[00:00:08] ########################################      12/12      cockroachdb: done
[00:00:14] ########################################       1/1       crucible: done
[00:00:05] ########################################       1/1       crucible-pantry: done
[00:00:29] ######################################## 28471030/28471030 dendrite-stub: done
[00:00:00] ########################################       1/1       dns-server: done
[00:00:00] ########################################       3/3       external-dns-customizations: done
[00:00:00] ########################################       3/3       internal-dns-customizations: done
[00:00:06] ########################################       1/1       maghemite: done
[00:00:00] ########################################       4/4       omicron-gateway: done
[00:00:02] ########################################      65/65      omicron-nexus: done
[00:00:00] ########################################       5/5       omicron-sled-agent: done
[00:00:01] ########################################       4/4       oximeter-collector: done
[00:00:04] ########################################       1/1       propolis-server: done
[00:00:02] ########################################       1/1       wicket: done
[00:00:01] ########################################       4/4       wicketd: done
[00:00:01] ########################################       1/1       external-dns: done
[00:00:02] ########################################       1/1       internal-dns: done
[00:00:03] ########################################       1/1       switch-stub: done
```

Passing `--target image_type=trampoline` builds only maghemite and installinator:

```
$ ./target/release/omicron-package --target image_type=trampoline package
[00:00:00] ########################################       3/3       installinator: done
[00:00:01] ########################################       1/1       maghemite: done
```