### PR TITLE
[wicket] Add UpdateState and poll it from wicketd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7858,6 +7858,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libsw",
+ "omicron-common",
  "proptest",
  "reqwest",
  "semver 1.0.16",

--- a/wicket/Cargo.toml
+++ b/wicket/Cargo.toml
@@ -14,6 +14,7 @@ crossterm = { version = "0.26.1", features = ["event-stream"] }
 futures.workspace = true
 hex = { workspace = true, features = ["serde"] }
 lazy_static.workspace = true
+omicron-common.workspace = true
 reqwest.workspace = true
 semver.workspace = true
 serde.workspace = true

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::state::ComponentId;
 use tokio::time::Instant;
-use wicketd_client::types::RackV1Inventory;
+use wicketd_client::types::{ArtifactId, RackV1Inventory, UpdateLogAll};
 
 use crossterm::event::Event as TermEvent;
 
@@ -17,6 +17,12 @@ pub enum Event {
 
     /// An Inventory Update Event
     Inventory(InventoryEvent),
+
+    /// Update Log Event
+    UpdateLog(UpdateLogAll),
+
+    /// TUF repo artifacts unpacked by wicketd
+    UpdateArtifacts(Vec<ArtifactId>),
 
     /// The tick of a Timer
     /// This can be used to draw a frame to the terminal

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -7,12 +7,14 @@
 mod inventory;
 mod rack;
 mod status;
+mod update;
 
 pub use inventory::{
     Component, ComponentId, Inventory, PowerState, Sp, ALL_COMPONENT_IDS,
 };
 pub use rack::{KnightRiderMode, RackState};
 pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
+pub use update::{FinalInstallArtifact, RackUpdateState, UpdateState};
 
 /// The global state of wicket
 ///
@@ -20,9 +22,12 @@ pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
 /// receipt.
 #[derive(Debug)]
 pub struct State {
+    pub screen_width: u16,
+    pub screen_height: u16,
     pub inventory: Inventory,
     pub rack_state: RackState,
     pub service_status: ServiceStatus,
+    pub update_state: RackUpdateState,
 }
 
 impl Default for State {
@@ -34,9 +39,12 @@ impl Default for State {
 impl State {
     pub fn new() -> State {
         State {
+            screen_height: 0,
+            screen_width: 0,
             inventory: Inventory::default(),
             rack_state: RackState::new(),
             service_status: ServiceStatus::new(),
+            update_state: RackUpdateState::new(),
         }
     }
 }

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -14,7 +14,7 @@ pub use inventory::{
 };
 pub use rack::{KnightRiderMode, RackState};
 pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
-pub use update::{KnownArtifactKind, RackUpdateState, UpdateState};
+pub use update::{RackUpdateState, UpdateState};
 
 /// The global state of wicket
 ///

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -14,7 +14,7 @@ pub use inventory::{
 };
 pub use rack::{KnightRiderMode, RackState};
 pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
-pub use update::{FinalInstallArtifact, RackUpdateState, UpdateState};
+pub use update::{KnownArtifactKind, RackUpdateState, UpdateState};
 
 /// The global state of wicket
 ///

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -1,0 +1,193 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use tui::style::Style;
+
+use crate::ui::defaults::style;
+
+use super::{ComponentId, ALL_COMPONENT_IDS};
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use wicketd_client::types::ArtifactId;
+
+#[derive(Debug)]
+pub struct RackUpdateState {
+    pub items:
+        BTreeMap<ComponentId, BTreeMap<FinalInstallArtifact, UpdateState>>,
+    pub artifacts: Vec<ArtifactId>,
+    pub final_artifact_versions: BTreeMap<FinalInstallArtifact, String>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum UpdateState {
+    Waiting,
+    Updated,
+    Updating,
+    Failed,
+}
+
+impl Display for UpdateState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateState::Waiting => write!(f, "WAITING"),
+            UpdateState::Updated => write!(f, "UPDATED"),
+            UpdateState::Updating => write!(f, "UPDATING"),
+            UpdateState::Failed => write!(f, "FAILED"),
+        }
+    }
+}
+
+impl UpdateState {
+    pub fn style(&self) -> Style {
+        match self {
+            UpdateState::Waiting => style::deselected(),
+            UpdateState::Updated => style::successful_update(),
+            UpdateState::Updating => style::start_update(),
+            UpdateState::Failed => style::failed_update(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FinalInstallArtifact {
+    // Sled Artifacts
+    GimletSp,
+    GimletRot,
+    Host,
+    ControlPlane,
+
+    // PSC Artifacts
+    PscSp,
+    PscRot,
+
+    // Switch Artifacts
+    SwitchSp,
+    SwitchRot,
+}
+
+impl Display for FinalInstallArtifact {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FinalInstallArtifact::Host => write!(f, "HOST"),
+            FinalInstallArtifact::ControlPlane => write!(f, "CONTROL PLANE"),
+            FinalInstallArtifact::GimletRot => write!(f, "ROOT OF TRUST"),
+            FinalInstallArtifact::GimletSp => write!(f, "SERVICE PROCESSOR"),
+            FinalInstallArtifact::PscSp => write!(f, "ROOT OF TRUST"),
+            FinalInstallArtifact::PscRot => write!(f, "SERVICE PROCESSOR"),
+            FinalInstallArtifact::SwitchSp => write!(f, "ROOT OF TRUST"),
+            FinalInstallArtifact::SwitchRot => write!(f, "SERVICE PROCESSOR"),
+        }
+    }
+}
+
+impl RackUpdateState {
+    pub fn new() -> Self {
+        RackUpdateState {
+            items: ALL_COMPONENT_IDS
+                .iter()
+                .map(|id| match id {
+                    ComponentId::Sled(_) => (
+                        *id,
+                        BTreeMap::from([
+                            (FinalInstallArtifact::Host, UpdateState::Waiting),
+                            (
+                                FinalInstallArtifact::ControlPlane,
+                                UpdateState::Waiting,
+                            ),
+                            (
+                                FinalInstallArtifact::GimletRot,
+                                UpdateState::Waiting,
+                            ),
+                            (
+                                FinalInstallArtifact::GimletSp,
+                                UpdateState::Waiting,
+                            ),
+                        ]),
+                    ),
+                    ComponentId::Switch(_) => (
+                        *id,
+                        BTreeMap::from([
+                            (
+                                FinalInstallArtifact::SwitchRot,
+                                UpdateState::Waiting,
+                            ),
+                            (
+                                FinalInstallArtifact::SwitchSp,
+                                UpdateState::Waiting,
+                            ),
+                        ]),
+                    ),
+                    ComponentId::Psc(_) => (
+                        *id,
+                        BTreeMap::from([
+                            (
+                                FinalInstallArtifact::PscRot,
+                                UpdateState::Waiting,
+                            ),
+                            (FinalInstallArtifact::PscSp, UpdateState::Waiting),
+                        ]),
+                    ),
+                })
+                .collect(),
+            artifacts: vec![],
+            final_artifact_versions: BTreeMap::default(),
+        }
+    }
+
+    pub fn update_artifacts(&mut self, artifacts: Vec<ArtifactId>) {
+        self.artifacts = artifacts;
+        self.final_artifact_versions.clear();
+        for id in &mut self.artifacts {
+            match id.kind.as_str() {
+                "gimlet_sp" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::GimletSp,
+                        id.version.clone(),
+                    );
+                }
+                "gimlet_rot" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::GimletRot,
+                        id.version.clone(),
+                    );
+                }
+                "psc_sp" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::PscSp,
+                        id.version.clone(),
+                    );
+                }
+                "psc_rot" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::PscRot,
+                        id.version.clone(),
+                    );
+                }
+                "switch_sp" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::SwitchSp,
+                        id.version.clone(),
+                    );
+                }
+                "switch_rot" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::SwitchRot,
+                        id.version.clone(),
+                    );
+                }
+                "host" => {
+                    self.final_artifact_versions
+                        .insert(FinalInstallArtifact::Host, id.version.clone());
+                }
+                "control_plane" => {
+                    self.final_artifact_versions.insert(
+                        FinalInstallArtifact::ControlPlane,
+                        id.version.clone(),
+                    );
+                }
+                _ => (),
+            }
+        }
+    }
+}

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -107,12 +107,12 @@ impl RackUpdateState {
 
 #[allow(unused)]
 pub fn artifact_title(kind: KnownArtifactKind) -> &'static str {
-    type K = KnownArtifactKind;
+    use KnownArtifactKind::*;
     match kind {
-        K::GimletSp | K::PscSp | K::SwitchSp => "SP",
-        K::GimletRot | K::PscRot | K::SwitchRot => "ROT",
-        K::Host => "HOST",
-        K::Trampoline => "TRAMPOLINE",
-        K::ControlPlane => "CONTROL PLANE",
+        GimletSp | PscSp | SwitchSp => "SP",
+        GimletRot | PscRot | SwitchRot => "ROT",
+        Host => "HOST",
+        Trampoline => "TRAMPOLINE",
+        ControlPlane => "CONTROL PLANE",
     }
 }

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -7,11 +7,10 @@ use tui::style::Style;
 use crate::ui::defaults::style;
 
 use super::{ComponentId, ALL_COMPONENT_IDS};
+use omicron_common::api::internal::nexus::KnownArtifactKind;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use wicketd_client::types::ArtifactId;
-
-pub use omicron_common::api::internal::nexus::KnownArtifactKind;
 
 #[derive(Debug)]
 pub struct RackUpdateState {
@@ -103,5 +102,17 @@ impl RackUpdateState {
                 self.artifact_versions.insert(known, id.version.clone());
             }
         }
+    }
+}
+
+#[allow(unused)]
+pub fn artifact_title(kind: KnownArtifactKind) -> &'static str {
+    type K = KnownArtifactKind;
+    match kind {
+        K::GimletSp | K::PscSp | K::SwitchSp => "SP",
+        K::GimletRot | K::PscRot | K::SwitchRot => "ROT",
+        K::Host => "HOST",
+        K::Trampoline => "TRAMPOLINE",
+        K::ControlPlane => "CONTROL PLANE",
     }
 }

--- a/wicket/src/ui/defaults/style.rs
+++ b/wicket/src/ui/defaults/style.rs
@@ -47,3 +47,51 @@ pub fn service() -> Style {
 pub fn delayed() -> Style {
     Style::default().fg(OX_OFF_WHITE)
 }
+
+pub fn highlighted() -> Style {
+    Style::default().bg(TUI_PURPLE).fg(TUI_BLACK)
+}
+
+pub fn plain_text() -> Style {
+    Style::default().bg(TUI_BLACK).fg(OX_OFF_WHITE)
+}
+
+pub fn successful_update() -> Style {
+    selected()
+}
+
+pub fn failed_update() -> Style {
+    Style::default().fg(OX_RED)
+}
+
+pub fn start_update() -> Style {
+    Style::default().fg(OX_YELLOW)
+}
+
+pub fn line(active: bool) -> Style {
+    if active {
+        selected_line()
+    } else {
+        deselected()
+    }
+}
+
+pub fn warning() -> Style {
+    Style::default().fg(OX_YELLOW)
+}
+
+pub fn header(active: bool) -> Style {
+    if active {
+        selected()
+    } else {
+        deselected()
+    }
+}
+
+pub fn popup_highlight() -> Style {
+    Style::default().fg(TUI_PURPLE)
+}
+
+pub fn faded_background() -> Style {
+    Style::default().bg(TUI_BLACK).fg(TUI_GREY)
+}

--- a/wicket/src/ui/widgets/fade.rs
+++ b/wicket/src/ui/widgets/fade.rs
@@ -1,0 +1,23 @@
+use crate::ui::defaults::style;
+use tui::buffer::Buffer;
+use tui::layout::Rect;
+use tui::widgets::Widget;
+
+/// Style every character as `style::faded_background`
+#[derive(Default)]
+pub struct Fade {}
+
+impl Widget for Fade {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        for x in area.left()..area.right() {
+            for y in area.top()..area.bottom() {
+                buf.set_string(
+                    x,
+                    y,
+                    buf.get(x, y).symbol.clone(),
+                    style::faded_background(),
+                );
+            }
+        }
+    }
+}

--- a/wicket/src/ui/widgets/mod.rs
+++ b/wicket/src/ui/widgets/mod.rs
@@ -6,8 +6,12 @@
 
 mod animated_logo;
 mod box_connector;
+mod fade;
+mod popup;
 mod rack;
 
 pub use animated_logo::{Logo, LogoState, LOGO_HEIGHT, LOGO_WIDTH};
 pub use box_connector::{BoxConnector, BoxConnectorKind};
+pub use fade::Fade;
+pub use popup::{ButtonText, Popup};
 pub use rack::Rack;

--- a/wicket/src/ui/widgets/popup.rs
+++ b/wicket/src/ui/widgets/popup.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A popup dialog box widget
+
+use tui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::Style,
+    text::{Span, Spans, Text},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
+};
+
+use crate::ui::defaults::dimensions::RectExt;
+use crate::ui::defaults::{colors::*, style};
+use crate::ui::widgets::{BoxConnector, BoxConnectorKind, Fade};
+use std::iter;
+
+pub struct ButtonText<'a> {
+    pub instruction: &'a str,
+    pub key: &'a str,
+}
+
+#[derive(Default)]
+pub struct Popup<'a> {
+    pub header: Text<'a>,
+    pub body: Text<'a>,
+    pub buttons: Vec<ButtonText<'a>>,
+}
+
+impl Popup<'_> {
+    pub fn height(&self) -> u16 {
+        let button_height: u16 = if self.buttons.is_empty() { 0 } else { 3 };
+        let bottom_margin: u16 = 1;
+        let borders: u16 = 3;
+        u16::try_from(self.header.height()).unwrap()
+            + u16::try_from(self.body.height()).unwrap()
+            + button_height
+            + bottom_margin
+            + borders
+    }
+
+    pub fn width(&self) -> u16 {
+        let borders: u16 = 2;
+        let right_margin: u16 = 3;
+        u16::try_from(self.body.width()).unwrap() + borders + right_margin
+    }
+}
+
+impl Widget for Popup<'_> {
+    fn render(self, full_screen: Rect, buf: &mut Buffer) {
+        let fade = Fade {};
+        fade.render(full_screen, buf);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .style(style::selected_line());
+
+        let rect = full_screen
+            .center_horizontally(self.width())
+            .center_vertically(self.height());
+
+        // Clear the popup
+        Clear.render(rect, buf);
+        Block::default()
+            .style(Style::default().bg(TUI_BLACK).fg(TUI_BLACK))
+            .render(rect, buf);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
+            .split(rect);
+
+        let header = Paragraph::new(self.header).block(block.clone());
+        header.render(chunks[0], buf);
+
+        let body = Paragraph::new(self.body).block(
+            block.borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT),
+        );
+        body.render(chunks[1], buf);
+
+        let connector = BoxConnector::new(BoxConnectorKind::Top);
+        connector.render(chunks[1], buf);
+
+        draw_buttons(self.buttons, chunks[1], buf);
+    }
+}
+pub fn draw_buttons(
+    buttons: Vec<ButtonText<'_>>,
+    body_rect: Rect,
+    buf: &mut Buffer,
+) {
+    // Enough space at the bottom for buttons and margin
+    let button_and_margin_height = 4;
+    let mut rect = body_rect;
+    rect.y = (body_rect.y + body_rect.height)
+        .saturating_sub(button_and_margin_height);
+    rect.height = 3;
+
+    let brackets = 2;
+    let margin = 2;
+    let borders = 2;
+
+    // The first constraint right aligns the buttons
+    // The buttons themselves are sized according to their contents
+    let constraints: Vec<_> = iter::once(Constraint::Min(0))
+        .chain(buttons.iter().map(|b| {
+            Constraint::Length(
+                u16::try_from(
+                    b.instruction.len()
+                        + b.key.len()
+                        + brackets
+                        + margin
+                        + borders
+                        + 1,
+                )
+                .unwrap(),
+            )
+        }))
+        .collect();
+
+    let button_rects = Layout::default()
+        .direction(Direction::Horizontal)
+        .horizontal_margin(2)
+        .constraints(constraints.as_ref())
+        .split(rect);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(style::selected_line());
+
+    for (i, button) in buttons.into_iter().enumerate() {
+        let b = Paragraph::new(Spans::from(vec![
+            Span::raw(" "),
+            Span::styled(button.instruction, style::selected()),
+            Span::styled(format!(" <{}> ", button.key), style::selected_line()),
+        ]))
+        .block(block.clone());
+        b.render(button_rects[i + 1], buf);
+    }
+}

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -5,14 +5,31 @@
 //! Code for talking to wicketd
 
 use slog::{o, warn, Logger};
+use std::convert::From;
 use std::net::SocketAddrV6;
-use std::sync::mpsc::Sender;
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, Sender, UnboundedSender};
 use tokio::time::{interval, Duration, Instant, MissedTickBehavior};
-use wicketd_client::types::RackV1Inventory;
+use wicketd_client::types::{RackV1Inventory, SpIdentifier, SpType};
 use wicketd_client::GetInventoryResponse;
 
+use crate::state::ComponentId;
 use crate::{Event, InventoryEvent};
+
+impl From<ComponentId> for SpIdentifier {
+    fn from(id: ComponentId) -> Self {
+        match id {
+            ComponentId::Sled(i) => {
+                SpIdentifier { type_: SpType::Sled, slot: i as u32 }
+            }
+            ComponentId::Psc(i) => {
+                SpIdentifier { type_: SpType::Power, slot: i as u32 }
+            }
+            ComponentId::Switch(i) => {
+                SpIdentifier { type_: SpType::Switch, slot: i as u32 }
+            }
+        }
+    }
+}
 
 const WICKETD_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const WICKETD_TIMEOUT: Duration = Duration::from_millis(1000);
@@ -22,38 +39,36 @@ const WICKETD_TIMEOUT: Duration = Duration::from_millis(1000);
 // large.
 const CHANNEL_CAPACITY: usize = 1000;
 
-// Eventually this will be filled in with things like triggering updates from the UI
-pub enum Request {}
-
+/// Requests driven by the UI and sent from [`crate::Runner`] to [`WicketdManager`]
 #[allow(unused)]
+#[derive(Debug)]
+pub enum Request {
+    StartUpdate(ComponentId),
+}
+
 pub struct WicketdHandle {
-    tx: mpsc::Sender<Request>,
+    pub tx: Sender<Request>,
 }
 
 /// Wrapper around Wicketd clients used to poll inventory
 /// and perform updates.
 pub struct WicketdManager {
     log: Logger,
-
-    //TODO: We'll use this onece we start implementing updates
-    #[allow(unused)]
     rx: mpsc::Receiver<Request>,
-    wizard_tx: Sender<Event>,
-    inventory_client: wicketd_client::Client,
+    events_tx: UnboundedSender<Event>,
+    wicketd_addr: SocketAddrV6,
 }
 
 impl WicketdManager {
     pub fn new(
         log: &Logger,
-        wizard_tx: Sender<Event>,
+        events_tx: UnboundedSender<Event>,
         wicketd_addr: SocketAddrV6,
     ) -> (WicketdHandle, WicketdManager) {
         let log = log.new(o!("component" => "WicketdManager"));
         let (tx, rx) = tokio::sync::mpsc::channel(CHANNEL_CAPACITY);
-        let inventory_client =
-            create_wicketd_client(&log, wicketd_addr, WICKETD_TIMEOUT);
         let handle = WicketdHandle { tx };
-        let manager = WicketdManager { log, rx, wizard_tx, inventory_client };
+        let manager = WicketdManager { log, rx, events_tx, wicketd_addr };
 
         (handle, manager)
     }
@@ -64,17 +79,119 @@ impl WicketdManager {
     /// * Receive responses / errors
     /// * Translate any responses/errors into [`Event`]s
     ///   that can be utilized by the UI.
-    pub async fn run(self) {
-        let mut inventory_rx =
-            poll_inventory(&self.log, self.inventory_client).await;
+    pub async fn run(mut self) {
+        self.poll_inventory().await;
+        self.poll_update_log().await;
+        self.poll_artifacts().await;
 
-        // TODO: Eventually there will be a tokio::select! here that also
-        // allows issuing updates.
-        while let Some(event) = inventory_rx.recv().await {
-            // XXX: Should we log an error and exit here? This means the wizard
-            // died and the process is exiting.
-            let _ = self.wizard_tx.send(Event::Inventory(event));
+        loop {
+            tokio::select! {
+                Some(request) = self.rx.recv() => {
+                    slog::info!(self.log, "Got wicketd req: {:?}", request);
+                    let Request::StartUpdate(component_id) = request;
+                    self.start_update(component_id).await;
+                }
+                else => {
+                    slog::info!(self.log, "Request receiver closed. Process must be exiting.");
+                    break;
+                }
+            }
         }
+    }
+
+    async fn start_update(&self, component_id: ComponentId) {
+        let log = self.log.clone();
+        let addr = self.wicketd_addr;
+        tokio::spawn(async move {
+            let update_client =
+                create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
+            let sp: SpIdentifier = component_id.into();
+            let res = update_client.post_start_update(sp.type_, sp.slot).await;
+            // We don't return errors or success values, as there's nobody to
+            // return them to. Instead, all updates are periodically polled
+            // and global state mutated. This allows the update pane to
+            // report current status to users in a more detailed and holistic
+            // fashion.
+            slog::info!(log, "Update response for {}: {:?}", component_id, res);
+        });
+    }
+
+    async fn poll_artifacts(&self) {
+        let log = self.log.clone();
+        let tx = self.events_tx.clone();
+        let addr = self.wicketd_addr;
+        tokio::spawn(async move {
+            let client = create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
+            let mut ticker = interval(WICKETD_POLL_INTERVAL * 2);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                // TODO: We should really be using ETAGs here
+                match client.get_artifacts().await {
+                    Ok(val) => {
+                        // TODO: Only send on changes
+                        let artifacts = val.into_inner().artifacts;
+                        let _ = tx.send(Event::UpdateArtifacts(artifacts));
+                    }
+                    Err(e) => {
+                        warn!(log, "{e}");
+                    }
+                }
+            }
+        });
+    }
+
+    async fn poll_update_log(&self) {
+        let log = self.log.clone();
+        let tx = self.events_tx.clone();
+        let addr = self.wicketd_addr;
+
+        tokio::spawn(async move {
+            let client = create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
+            let mut ticker = interval(WICKETD_POLL_INTERVAL * 2);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                // TODO: We should really be using ETAGs here
+                match client.get_update_all().await {
+                    Ok(val) => {
+                        // TODO: Only send on changes
+                        let logs = val.into_inner();
+                        let _ = tx.send(Event::UpdateLog(logs));
+                    }
+                    Err(e) => {
+                        warn!(log, "{e}");
+                    }
+                }
+            }
+        });
+    }
+
+    async fn poll_inventory(&self) {
+        let log = self.log.clone();
+        let tx = self.events_tx.clone();
+        let addr = self.wicketd_addr;
+
+        let mut state = InventoryState::new(&log, tx);
+
+        tokio::spawn(async move {
+            let client = create_wicketd_client(&log, addr, WICKETD_TIMEOUT);
+            let mut ticker = interval(WICKETD_POLL_INTERVAL);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                // TODO: We should really be using ETAGs here
+                match client.get_inventory().await {
+                    Ok(val) => {
+                        let new_inventory = val.into_inner();
+                        state.send_if_changed(new_inventory.into()).await;
+                    }
+                    Err(e) => {
+                        warn!(log, "{e}");
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -94,46 +211,15 @@ pub(crate) fn create_wicketd_client(
     wicketd_client::Client::new_with_client(&endpoint, client, log.clone())
 }
 
-async fn poll_inventory(
-    log: &Logger,
-    client: wicketd_client::Client,
-) -> mpsc::Receiver<InventoryEvent> {
-    let log = log.clone();
-
-    // We only want one oustanding request at a time
-    let (tx, rx) = mpsc::channel(1);
-    let mut state = InventoryState::new(&log, tx);
-
-    tokio::spawn(async move {
-        let mut ticker = interval(WICKETD_POLL_INTERVAL);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        loop {
-            ticker.tick().await;
-            // TODO: We should really be using ETAGs here
-            match client.get_inventory().await {
-                Ok(val) => {
-                    let new_inventory = val.into_inner();
-                    state.send_if_changed(new_inventory.into()).await;
-                }
-                Err(e) => {
-                    warn!(log, "{e}");
-                }
-            }
-        }
-    });
-
-    rx
-}
-
 #[derive(Debug)]
 struct InventoryState {
     log: Logger,
     current_inventory: Option<RackV1Inventory>,
-    tx: mpsc::Sender<InventoryEvent>,
+    tx: UnboundedSender<Event>,
 }
 
 impl InventoryState {
-    fn new(log: &Logger, tx: mpsc::Sender<InventoryEvent>) -> Self {
+    fn new(log: &Logger, tx: UnboundedSender<Event>) -> Self {
         let log = log.new(o!("component" => "InventoryState"));
         Self { log, current_inventory: None, tx }
     }
@@ -154,16 +240,14 @@ impl InventoryState {
                     new_inventory
                 });
 
-                let _ = self
-                    .tx
-                    .send(InventoryEvent::Inventory {
+                let _ =
+                    self.tx.send(Event::Inventory(InventoryEvent::Inventory {
                         changed_inventory,
                         wicketd_received: Instant::now(),
                         mgs_received: libsw::TokioSw::with_elapsed_started(
                             mgs_received_ago,
                         ),
-                    })
-                    .await;
+                    }));
             }
             (Some(_), GetInventoryResponse::Unavailable) => {
                 // This is an illegal state transition -- wicketd can never return Unavailable after
@@ -175,12 +259,11 @@ impl InventoryState {
             }
             (None, GetInventoryResponse::Unavailable) => {
                 // No response received by wicketd from MGS yet.
-                let _ = self
-                    .tx
-                    .send(InventoryEvent::Unavailable {
+                let _ = self.tx.send(Event::Inventory(
+                    InventoryEvent::Unavailable {
                         wicketd_received: Instant::now(),
-                    })
-                    .await;
+                    },
+                ));
             }
         };
     }


### PR DESCRIPTION
This commit builds off #2503, so that it can get access to new styles.

Update logs and artifacts are retrieved from wicketd and stored inside the global `State` as type `RackUpdateState`.

This change also makes it so that the main event channel between `WicketdManager` and `Runner` is a tokio unbounded channel rather than a std library unbounded channel. This allows us to get rid of translation channels for each request inside wicketd and simplifies the code a bit.