### PR TITLE
[wicket] Start of Update Pane UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,6 +7451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-tree-widget"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd64e2088f26dd5f7e5239cdd7ee234098d3bda4dc214e4bb58c2049ce5af3"
+dependencies = [
+ "tui",
+ "unicode-width",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7952,6 +7962,7 @@ dependencies = [
  "tokio",
  "toml 0.7.2",
  "tui",
+ "tui-tree-widget",
  "wicketd-client",
 ]
 

--- a/wicket/Cargo.toml
+++ b/wicket/Cargo.toml
@@ -31,6 +31,7 @@ tar.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tui = "0.19.0"
+tui-tree-widget = "0.11.0"
 
 wicketd-client.workspace = true
 

--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::iter::Iterator;
+use tui::text::Text;
 use wicketd_client::types::{
     RackV1Inventory, SpComponentInfo, SpIgnition, SpState, SpType,
 };
@@ -130,6 +131,12 @@ impl Display for ComponentId {
             ComponentId::Switch(i) => write!(f, "SWITCH {}", i),
             ComponentId::Psc(i) => write!(f, "PSC {}", i),
         }
+    }
+}
+
+impl From<ComponentId> for Text<'_> {
+    fn from(value: ComponentId) -> Self {
+        value.to_string().into()
     }
 }
 

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -14,7 +14,7 @@ pub use inventory::{
 };
 pub use rack::{KnightRiderMode, RackState};
 pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
-pub use update::{RackUpdateState, UpdateState};
+pub use update::{artifact_title, RackUpdateState, UpdateState};
 
 /// The global state of wicket
 ///

--- a/wicket/src/ui/controls/mod.rs
+++ b/wicket/src/ui/controls/mod.rs
@@ -44,4 +44,15 @@ pub trait Control {
     /// of the child. The parent computes its own layout during resize and
     /// passes the appropriate `Rect` to the child.
     fn resize(&mut self, _: &mut State, _: Rect) {}
+
+    /// Some [`Control`]s can launch modal popups.
+    ///
+    /// Return false by default so parent behavior does not change.
+    ///
+    /// If a control has a modal active, its parent should not switch away from
+    /// it. For example, in [`MainScreen`], the escape key should not allow
+    /// transferring control from a pane's modal to the side bar.
+    fn is_modal_active(&self) -> bool {
+        false
+    }
 }

--- a/wicket/src/ui/controls/mod.rs
+++ b/wicket/src/ui/controls/mod.rs
@@ -50,7 +50,7 @@ pub trait Control {
     /// Return false by default so parent behavior does not change.
     ///
     /// If a control has a modal active, its parent should not switch away from
-    /// it. For example, in [`MainScreen`], the escape key should not allow
+    /// it. For example, in `crate::ui::MainScreen`, the escape key should not allow
     /// transferring control from a pane's modal to the side bar.
     fn is_modal_active(&self) -> bool {
         false

--- a/wicket/src/ui/defaults/colors.rs
+++ b/wicket/src/ui/defaults/colors.rs
@@ -27,3 +27,4 @@ pub const TUI_GREEN_DARK: Color = Color::Rgb(0x2E, 0x81, 0x60);
 pub const TUI_GREY: Color = Color::Rgb(0x78, 0x78, 0x7A);
 pub const TUI_PURPLE: Color = Color::Rgb(0xBE, 0x95, 0xEB);
 pub const TUI_PURPLE_DIM: Color = Color::Rgb(0x6C, 0x55, 0x84);
+pub const TUI_GREY_DARK: Color = Color::Rgb(66, 66, 69);

--- a/wicket/src/ui/defaults/dimensions.rs
+++ b/wicket/src/ui/defaults/dimensions.rs
@@ -30,7 +30,7 @@ pub trait RectExt {
 
 impl RectExt for Rect {
     fn center_horizontally(mut self, width: u16) -> Self {
-        let center = (self.width - width) / 2;
+        let center = (self.width.saturating_sub(width)) / 2;
         self.x += center;
         self.width = width;
         self

--- a/wicket/src/ui/main.rs
+++ b/wicket/src/ui/main.rs
@@ -4,9 +4,10 @@
 
 use std::collections::BTreeMap;
 
-use super::{Control, OverviewPane, StatefulList};
+use super::{Control, OverviewPane, StatefulList, UpdatePane};
 use crate::ui::defaults::colors::*;
 use crate::ui::defaults::style;
+use crate::ui::widgets::Fade;
 use crate::{Action, Event, Frame, State, Term};
 use crossterm::event::Event as TermEvent;
 use crossterm::event::KeyCode;
@@ -35,10 +36,10 @@ pub struct MainScreen {
 impl MainScreen {
     pub fn new() -> MainScreen {
         // We want the sidebar ordered in this specific manner
-        let sidebar_ordered_panes = vec![(
-            "overview",
-            Box::new(OverviewPane::new()) as Box<dyn Control>,
-        )];
+        let sidebar_ordered_panes = vec![
+            ("overview", Box::new(OverviewPane::new()) as Box<dyn Control>),
+            ("update", Box::new(UpdatePane::new()) as Box<dyn Control>),
+        ];
         let sidebar_keys: Vec<_> =
             sidebar_ordered_panes.iter().map(|&(title, _)| title).collect();
         MainScreen {
@@ -79,7 +80,7 @@ impl MainScreen {
             // Draw all the components, starting with the background
             let background = Block::default().style(style::background());
             frame.render_widget(background, frame.size());
-            self.sidebar.draw(state, frame, chunks[0], self.sidebar.selected);
+            self.sidebar.draw(state, frame, chunks[0], self.sidebar.active);
             self.draw_pane(state, frame, chunks[1]);
             self.draw_statusbar(state, frame, statusbar_rect);
         })?;
@@ -120,16 +121,20 @@ impl MainScreen {
         match event {
             Event::Term(TermEvent::Key(e)) => match e.code {
                 KeyCode::Esc => {
-                    if self.sidebar.selected {
+                    if self.sidebar.active {
                         None
                     } else {
-                        self.sidebar.selected = true;
-                        Some(Action::Redraw)
+                        if self.current_pane().is_modal_active() {
+                            self.current_pane().on(state, event)
+                        } else {
+                            self.sidebar.active = true;
+                            Some(Action::Redraw)
+                        }
                     }
                 }
-                KeyCode::Enter => {
-                    if self.sidebar.selected {
-                        self.sidebar.selected = false;
+                KeyCode::Tab | KeyCode::Enter => {
+                    if self.sidebar.active {
+                        self.sidebar.active = false;
                         Some(Action::Redraw)
                     } else {
                         self.current_pane()
@@ -138,35 +143,36 @@ impl MainScreen {
                 }
                 _ => {
                     let event = Event::Term(TermEvent::Key(e));
-                    if self.sidebar.selected {
-                        self.sidebar.on(state, event)
-                    } else {
-                        self.current_pane()
-                            .on(state, Event::Term(TermEvent::Key(e)))
-                    }
+                    self.dispatch_event(state, event)
                 }
             },
-            e => {
-                let current_pane = self.sidebar.selected();
-                if self.sidebar.selected {
-                    let _ = self.sidebar.on(state, e);
-                    if self.sidebar.selected() != current_pane {
-                        // We need to inform the new pane, which may not have
-                        // ever been drawn what its Rect is.
-                        self.resize(state, self.rect.width, self.rect.height);
-                        Some(Action::Redraw)
-                    } else {
-                        None
-                    }
-                } else {
-                    self.current_pane().on(state, e)
-                }
+            e => self.dispatch_event(state, e),
+        }
+    }
+
+    fn dispatch_event(
+        &mut self,
+        state: &mut State,
+        event: Event,
+    ) -> Option<Action> {
+        let current_pane = self.sidebar.selected_pane();
+        if self.sidebar.active {
+            let _ = self.sidebar.on(state, event);
+            if self.sidebar.selected_pane() != current_pane {
+                // We need to inform the new pane, which may not have
+                // ever been drawn what its Rect is.
+                self.resize(state, self.rect.width, self.rect.height);
+                Some(Action::Redraw)
+            } else {
+                None
             }
+        } else {
+            self.current_pane().on(state, event)
         }
     }
 
     fn current_pane(&mut self) -> &mut Box<dyn Control> {
-        self.panes.get_mut(self.sidebar.selected()).unwrap()
+        self.panes.get_mut(self.sidebar.selected_pane()).unwrap()
     }
 
     fn draw_pane(
@@ -175,9 +181,13 @@ impl MainScreen {
         frame: &mut Frame<'_>,
         pane_rect: Rect,
     ) {
-        let active = !self.sidebar.selected;
+        let active = !self.sidebar.active;
         let pane = self.current_pane();
-        pane.draw(state, frame, pane_rect, active)
+        pane.draw(state, frame, pane_rect, active);
+        if !active {
+            let fade = Fade::default();
+            frame.render_widget(fade, pane_rect);
+        }
     }
 
     fn draw_statusbar(
@@ -198,8 +208,11 @@ impl MainScreen {
         frame.render_widget(main, rect);
 
         let test = Paragraph::new(Spans::from(vec![
-            Span::styled("VERSION: ", Style::default().fg(TUI_GREEN_DARK)),
-            Span::styled("v0.0.1", Style::default().fg(TUI_GREEN)),
+            Span::styled(
+                "UPDATE VERSION: ",
+                Style::default().fg(TUI_GREEN_DARK),
+            ),
+            Span::styled("UNKNOWN", style::plain_text()),
         ]))
         .alignment(Alignment::Right);
         frame.render_widget(test, rect);
@@ -210,13 +223,13 @@ impl MainScreen {
 pub struct Sidebar {
     panes: StatefulList<&'static str>,
     // Whether the sidebar is selected currently.
-    selected: bool,
+    active: bool,
 }
 
 impl Sidebar {
     pub fn new(panes: Vec<&'static str>) -> Sidebar {
         let mut sidebar =
-            Sidebar { panes: StatefulList::new(panes), selected: true };
+            Sidebar { panes: StatefulList::new(panes), active: true };
 
         // Select the first pane
         sidebar.panes.next();
@@ -226,7 +239,7 @@ impl Sidebar {
     /// Return the name of the selected Pane
     ///
     /// TODO: Is an `&'static str` good enough? Should we define a `PaneId`?
-    pub fn selected(&self) -> &'static str {
+    pub fn selected_pane(&self) -> &'static str {
         self.panes.items[self.panes.state.selected().unwrap()]
     }
 }
@@ -254,7 +267,7 @@ impl Control for Sidebar {
         _state: &State,
         frame: &mut Frame<'_>,
         area: Rect,
-        _active: bool,
+        active: bool,
     ) {
         let items: Vec<ListItem> = self
             .panes
@@ -267,11 +280,7 @@ impl Control for Sidebar {
             })
             .collect();
 
-        let border_style = if self.selected {
-            style::selected_line()
-        } else {
-            style::deselected()
-        };
+        let border_style = style::selected_line();
 
         let panes = List::new(items)
             .block(
@@ -284,5 +293,10 @@ impl Control for Sidebar {
             .highlight_style(style::selected().add_modifier(Modifier::BOLD));
 
         frame.render_stateful_widget(panes, area, &mut self.panes.state);
+
+        if !active {
+            let fade = Fade::default();
+            frame.render_widget(fade, area);
+        }
     }
 }

--- a/wicket/src/ui/mod.rs
+++ b/wicket/src/ui/mod.rs
@@ -17,6 +17,7 @@ use splash::SplashScreen;
 
 pub use controls::Control;
 pub use panes::OverviewPane;
+pub use panes::UpdatePane;
 
 /// The primary display representation. It's sole purpose is to dispatch events
 /// to the underlying splash and main screens.
@@ -28,26 +29,19 @@ pub use panes::OverviewPane;
 pub struct Screen {
     splash: Option<SplashScreen>,
     main: MainScreen,
-    width: u16,
-    height: u16,
 }
 
 impl Screen {
     pub fn new() -> Screen {
-        Screen {
-            splash: Some(SplashScreen::new()),
-            main: MainScreen::new(),
-            width: 0,
-            height: 0,
-        }
+        Screen { splash: Some(SplashScreen::new()), main: MainScreen::new() }
     }
 
     /// Compute the layout of the [`MainScreen`]
     ///
     // A draw is issued after every resize, so no need to return an Action
     pub fn resize(&mut self, state: &mut State, width: u16, height: u16) {
-        self.width = width;
-        self.height = height;
+        state.screen_width = width;
+        state.screen_height = height;
 
         // Size the main screen
         self.main.resize(state, width, height);

--- a/wicket/src/ui/panes/mod.rs
+++ b/wicket/src/ui/panes/mod.rs
@@ -3,12 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod overview;
+mod update;
 
 pub use super::Control;
 use crate::ui::defaults::style;
 pub use overview::OverviewPane;
-use tui::text::{Span, Spans};
+use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::text::{Span, Spans, Text};
 use tui::widgets::Paragraph;
+pub use update::UpdatePane;
 
 /// Generate one line of text for the help bar in panes
 pub fn help_text<'a>(data: &'a [(&'a str, &'a str)]) -> Paragraph<'a> {
@@ -21,4 +24,34 @@ pub fn help_text<'a>(data: &'a [(&'a str, &'a str)]) -> Paragraph<'a> {
     }
     text.pop();
     Paragraph::new(Spans::from(text))
+}
+
+/// Align a bunch of spans on a single line with with at most `column_width`
+/// length, and being left-aligned by `left_margin`
+pub fn align_by<'a>(
+    left_margin: u16,
+    column_width: u16,
+    mut rect: Rect,
+    spans: Vec<Span<'a>>,
+) -> Text<'a> {
+    rect.x += left_margin;
+    rect.width -= left_margin;
+    let constraints: Vec<_> = (0..spans.len())
+        .into_iter()
+        .map(|_| Constraint::Max(column_width))
+        .collect();
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .split(rect);
+
+    let mut text =
+        vec![Span::raw(format!("{:width$}", "", width = left_margin as usize))];
+    for (rect, span) in chunks.iter().zip(spans).into_iter() {
+        let spaces = rect.width.saturating_sub(span.width().try_into().unwrap())
+            as usize;
+        text.push(span);
+        text.push(Span::raw(format!("{:spaces$}", "")));
+    }
+    Text::from(Spans::from(text))
 }

--- a/wicket/src/ui/panes/mod.rs
+++ b/wicket/src/ui/panes/mod.rs
@@ -28,12 +28,12 @@ pub fn help_text<'a>(data: &'a [(&'a str, &'a str)]) -> Paragraph<'a> {
 
 /// Align a bunch of spans on a single line with with at most `column_width`
 /// length, and being left-aligned by `left_margin`
-pub fn align_by<'a>(
+pub fn align_by(
     left_margin: u16,
     column_width: u16,
     mut rect: Rect,
-    spans: Vec<Span<'a>>,
-) -> Text<'a> {
+    spans: Vec<Span>,
+) -> Text {
     rect.x += left_margin;
     rect.width -= left_margin;
     let constraints: Vec<_> = (0..spans.len())
@@ -47,7 +47,7 @@ pub fn align_by<'a>(
 
     let mut text =
         vec![Span::raw(format!("{:width$}", "", width = left_margin as usize))];
-    for (rect, span) in chunks.iter().zip(spans).into_iter() {
+    for (rect, span) in chunks.iter().zip(spans) {
         let spaces = rect.width.saturating_sub(span.width().try_into().unwrap())
             as usize;
         text.push(span);

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -1,0 +1,286 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+use super::{align_by, help_text, Control};
+use crate::state::{artifact_title, ALL_COMPONENT_IDS};
+use crate::ui::defaults::style;
+use crate::ui::widgets::{BoxConnector, BoxConnectorKind, ButtonText, Popup};
+use crate::{Action, Event, Frame, State};
+use crossterm::event::Event as TermEvent;
+use crossterm::event::KeyCode;
+use omicron_common::api::internal::nexus::KnownArtifactKind;
+use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::text::{Span, Spans, Text};
+use tui::widgets::{Block, BorderType, Borders, Paragraph};
+use tui_tree_widget::{Tree, TreeItem, TreeState};
+
+/// Overview of update status and ability to install updates
+/// from a single TUF repo uploaded to wicketd via wicket.
+pub struct UpdatePane {
+    tree_state: TreeState,
+    items: Vec<TreeItem<'static>>,
+    help: Vec<(&'static str, &'static str)>,
+    rect: Rect,
+    // TODO: These will likely move into a status view, because there will be
+    // other update views/tabs
+    title_rect: Rect,
+    table_headers_rect: Rect,
+    contents_rect: Rect,
+    help_rect: Rect,
+    popup_open: bool,
+}
+
+impl UpdatePane {
+    pub fn new() -> UpdatePane {
+        UpdatePane {
+            tree_state: Default::default(),
+            items: ALL_COMPONENT_IDS
+                .iter()
+                .map(|id| TreeItem::new(*id, vec![]))
+                .collect(),
+            help: vec![
+                ("OPEN", "<RIGHT>"),
+                ("CLOSE", "<LEFT>"),
+                ("SELECT", "<UP/DOWN>"),
+            ],
+            rect: Rect::default(),
+            title_rect: Rect::default(),
+            table_headers_rect: Rect::default(),
+            contents_rect: Rect::default(),
+            help_rect: Rect::default(),
+            popup_open: false,
+        }
+    }
+
+    pub fn draw_update_missing_popup(
+        &mut self,
+        state: &State,
+        frame: &mut Frame<'_>,
+    ) {
+        let popup = Popup {
+            header: Text::from(vec![Spans::from(vec![Span::styled(
+                " MISSING UPDATE BUNDLE",
+                style::header(true),
+            )])]),
+            body: Text::from(vec![
+                Spans::from(vec![Span::styled(
+                    " Use the following command to transfer an update: ",
+                    style::plain_text(),
+                )]),
+                "".into(),
+                Spans::from(vec![
+                    Span::styled(" cat", style::plain_text()),
+                    Span::styled(" $UPDATE", style::popup_highlight()),
+                    Span::styled(".zip | ssh", style::plain_text()),
+                    Span::styled(" $IPV6_ADDRESS", style::popup_highlight()),
+                    Span::styled(" upload", style::plain_text()),
+                ]),
+            ]),
+            buttons: vec![ButtonText { instruction: "CLOSE", key: "ESC" }],
+        };
+        let full_screen = Rect {
+            width: state.screen_width,
+            height: state.screen_height,
+            x: 0,
+            y: 0,
+        };
+        frame.render_widget(popup, full_screen);
+    }
+
+    fn update_items(&mut self, state: &State) {
+        let versions = state.update_state.artifact_versions.clone();
+
+        self.items = state
+            .update_state
+            .items
+            .iter()
+            .map(|(id, states)| {
+                let children: Vec<_> = states
+                    .iter()
+                    .map(|(artifact, s)| {
+                        let version = artifact_version(artifact, &versions);
+                        let spans = vec![
+                            Span::styled(
+                                artifact_title(*artifact),
+                                style::selected(),
+                            ),
+                            Span::styled("UNKNOWN", style::selected_line()),
+                            Span::styled(version, style::selected()),
+                            Span::styled(s.to_string(), s.style()),
+                        ];
+                        TreeItem::new_leaf(align_by(
+                            0,
+                            25,
+                            self.contents_rect,
+                            spans,
+                        ))
+                    })
+                    .collect();
+                TreeItem::new(*id, children)
+            })
+            .collect();
+    }
+}
+
+fn artifact_version(
+    artifact: &KnownArtifactKind,
+    versions: &BTreeMap<KnownArtifactKind, String>,
+) -> String {
+    versions.get(artifact).cloned().unwrap_or_else(|| "UNKNOWN".to_string())
+}
+
+impl Control for UpdatePane {
+    fn is_modal_active(&self) -> bool {
+        self.popup_open
+    }
+
+    fn resize(&mut self, state: &mut State, rect: Rect) {
+        self.rect = rect;
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                    Constraint::Length(3),
+                ]
+                .as_ref(),
+            )
+            .split(rect);
+        self.title_rect = chunks[0];
+        self.table_headers_rect = chunks[1];
+        self.contents_rect = chunks[2];
+        self.help_rect = chunks[3];
+
+        self.update_items(state);
+    }
+
+    fn on(&mut self, state: &mut State, event: Event) -> Option<Action> {
+        match event {
+            Event::Term(TermEvent::Key(e)) => match e.code {
+                KeyCode::Up => {
+                    // Keep the rack selection in sync across panes
+                    state.rack_state.prev();
+                    self.tree_state.key_up(&self.items);
+                    Some(Action::Redraw)
+                }
+                KeyCode::Down => {
+                    // Keep the rack selection in sync across panes
+                    state.rack_state.next();
+                    self.tree_state.key_down(&self.items);
+                    Some(Action::Redraw)
+                }
+                KeyCode::Left => {
+                    self.tree_state.key_left();
+                    Some(Action::Redraw)
+                }
+                KeyCode::Right => {
+                    self.tree_state.key_right();
+                    Some(Action::Redraw)
+                }
+                KeyCode::Enter => {
+                    // Only open the warning popup if an upload is required
+                    if state.update_state.artifacts.is_empty() {
+                        if !self.popup_open {
+                            self.popup_open = true;
+                            Some(Action::Redraw)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+                KeyCode::Esc => {
+                    if self.popup_open {
+                        self.popup_open = false;
+                        Some(Action::Redraw)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn draw(
+        &mut self,
+        state: &State,
+        frame: &mut Frame<'_>,
+        _: Rect,
+        active: bool,
+    ) {
+        let border_style = style::line(active);
+        let header_style = style::header(active);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .style(border_style);
+
+        // Draw the title/tab bar
+        let title_bar = Paragraph::new(Spans::from(vec![Span::styled(
+            "UPDATE STATUS",
+            header_style,
+        )]))
+        .block(block.clone().title("<ENTER>"));
+        frame.render_widget(title_bar, self.title_rect);
+
+        // Draw the table headers
+        let mut line_rect = self.table_headers_rect;
+        line_rect.x += 2;
+        line_rect.width -= 2;
+        let headers = Paragraph::new(align_by(
+            4,
+            25,
+            line_rect,
+            vec![
+                Span::styled("COMPONENT", header_style),
+                Span::styled("VERSION", header_style),
+                Span::styled("TARGET", header_style),
+                Span::styled("STATUS", header_style),
+            ],
+        ))
+        .block(block.clone());
+        frame.render_widget(headers, self.table_headers_rect);
+
+        // Need to refresh the items, as their versions/state may have changed
+        self.update_items(state);
+
+        // Draw the contents
+        let tree = Tree::new(self.items.clone())
+            .block(block.clone().borders(Borders::LEFT | Borders::RIGHT))
+            .style(style::plain_text())
+            .highlight_style(style::highlighted());
+        frame.render_stateful_widget(
+            tree,
+            self.contents_rect,
+            &mut self.tree_state,
+        );
+
+        // Draw the help bar
+        let help = help_text(&self.help).block(block.clone());
+        frame.render_widget(help, self.help_rect);
+
+        // Ensure the contents is connected to the table headers and help bar
+        frame.render_widget(
+            BoxConnector::new(BoxConnectorKind::Both),
+            self.contents_rect,
+        );
+
+        // TODO: Check to see which popup is open
+        if self.popup_open {
+            // TODO: Only open if an update has not been uploaded to wicketd
+            // Otherwise, prompt whether to update or not.
+            // We can also open the update logs inline once the update has been started
+            // or has completed.
+            self.draw_update_missing_popup(state, frame);
+        }
+    }
+}

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -17,6 +17,8 @@ use tui::text::{Span, Spans, Text};
 use tui::widgets::{Block, BorderType, Borders, Paragraph};
 use tui_tree_widget::{Tree, TreeItem, TreeState};
 
+const MAX_COLUMN_WIDTH: u16 = 25;
+
 /// Overview of update status and ability to install updates
 /// from a single TUF repo uploaded to wicketd via wicket.
 pub struct UpdatePane {
@@ -115,7 +117,7 @@ impl UpdatePane {
                         ];
                         TreeItem::new_leaf(align_by(
                             0,
-                            25,
+                            MAX_COLUMN_WIDTH,
                             self.contents_rect,
                             spans,
                         ))
@@ -245,7 +247,7 @@ impl Control for UpdatePane {
         line_rect.width -= 2;
         let headers = Paragraph::new(align_by(
             4,
-            25,
+            MAX_COLUMN_WIDTH,
             line_rect,
             vec![
                 Span::styled("COMPONENT", header_style),

--- a/wicket/src/ui/widgets/popup.rs
+++ b/wicket/src/ui/widgets/popup.rs
@@ -92,19 +92,15 @@ pub fn draw_buttons(
     body_rect: Rect,
     buf: &mut Buffer,
 ) {
-    // Enough space at the bottom for buttons and margin
-    let button_and_margin_height = 4;
     let mut rect = body_rect;
-    rect.y = (body_rect.y + body_rect.height)
-        .saturating_sub(button_and_margin_height);
+    // Enough space at the bottom for buttons and margin
+    rect.y = body_rect.y + body_rect.height - 4;
     rect.height = 3;
 
     let brackets = 2;
     let margin = 2;
     let borders = 2;
 
-    // The first constraint right aligns the buttons
-    // The buttons themselves are sized according to their contents
     let constraints: Vec<_> = iter::once(Constraint::Min(0))
         .chain(buttons.iter().map(|b| {
             Constraint::Length(


### PR DESCRIPTION
This builds upon #2503 and #2504. It adds the visual components to the relevant state and wicketd interaction changes.

A tree view for update components has been added. It currently only live updates target versions for components when a TUF repo has been uploaded. If a TUF repo has not been added, and the user presses `Enter`, a popup instructing the user how to upload the repo is provided.

Currently initiating updates, and live updating progress is not implemented in the UI, although many of the underlying mechanisms exist already. It's expected for a follow up commit , that if `Enter` is hit in the tree view, and the component requires updating a warning popup will  be launched. If the user selects ok, and the update starts, then further presses of `Enter` will toggle  log views of the ongoing update. If the update has failed, we may also want a way to show this. I need to think a bit about these interactions and likely play with them once implemented.

Actual known versions of running software from inventory also needs to be put into this view. This information for SP and RoT is currently known from MGS, but we will soon have additional info available from sled-agents. It's unknown if we will actually plumb this through immediately.

The system version for an update is currently listed as "UNKNOWN" in the lower right of the screen (in the status bar). This is because we don't currently have that info inside the TUF repo. This will be fixed in a follow up as well.

Additional styling to fade either the sidebar for selecting panes, or the panes themselves was added to make it more apparent the context the user is operating in. It also makes the rack rendering look cool :)