### PR TITLE
[wicketd] Add installinator completion events to update event log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8010,6 +8010,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
+ "serde_json",
  "slog",
  "uuid",
 ]

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -11,7 +11,7 @@ use schemars::{
     schema::{Schema, SchemaObject},
     JsonSchema,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A report, consisting of a list of events and some more metadata.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, JsonSchema)]
@@ -51,7 +51,7 @@ pub struct CompletionEvent {
 /// An individual kind of completion event.
 ///
 /// Forms part of [`CompletionEvent`].
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "reason")]
 pub enum CompletionEventKind {
     /// The download of an artifact failed.

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -232,6 +232,366 @@
           "version"
         ]
       },
+      "CompletionEventKind": {
+        "description": "An individual kind of completion event.\n\nForms part of [`CompletionEvent`].",
+        "oneOf": [
+          {
+            "description": "The download of an artifact failed.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The download attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "downloaded_bytes": {
+                "description": "The number of bytes downloaded before failure.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the download took before failing.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "kind": {
+                "description": "The kind of artifact being downloaded.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message indicating the reason for failure.",
+                "type": "string"
+              },
+              "peer": {
+                "description": "The peer the artifact was being downloaded from, if any.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "download_failed"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "downloaded_bytes",
+              "elapsed",
+              "kind",
+              "message",
+              "peer",
+              "reason"
+            ]
+          },
+          {
+            "description": "An artifact download was completed.",
+            "type": "object",
+            "properties": {
+              "artifact_size": {
+                "description": "The number of bytes downloaded.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "attempt": {
+                "description": "The download attempt that completed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the download took.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "kind": {
+                "description": "The artifact downloaded.",
+                "type": "string"
+              },
+              "peer": {
+                "description": "The peer the artifact was downloaded from.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "download_completed"
+                ]
+              }
+            },
+            "required": [
+              "artifact_size",
+              "attempt",
+              "elapsed",
+              "kind",
+              "peer",
+              "reason"
+            ]
+          },
+          {
+            "description": "Failed to format a disk.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The format attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the format attempt took.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "message": {
+                "description": "A message indicating the reason for failure.",
+                "type": "string"
+              },
+              "path": {
+                "description": "The path to the disk.",
+                "type": "string",
+                "format": "Utf8PathBuf"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "format_failed"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "elapsed",
+              "message",
+              "path",
+              "reason"
+            ]
+          },
+          {
+            "description": "Completed formatting a disk.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The format attempt.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "elapsed": {
+                "description": "How long the format attempt took.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "path": {
+                "description": "The path to the disk.",
+                "type": "string",
+                "format": "Utf8PathBuf"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "format_completed"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "elapsed",
+              "path",
+              "reason"
+            ]
+          },
+          {
+            "description": "Failed to write an artifact.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The write attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "destination": {
+                "description": "The destination the artifact is being written out to.",
+                "type": "string",
+                "format": "Utf8PathBuf"
+              },
+              "elapsed": {
+                "description": "How long the write took before it failed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "kind": {
+                "description": "The kind of artifact being written out.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message indicating why the write failed.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "write_failed"
+                ]
+              },
+              "total_bytes": {
+                "description": "The total number of bytes that should have been written out.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "written_bytes": {
+                "description": "The number of bytes written out before failure.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "attempt",
+              "destination",
+              "elapsed",
+              "kind",
+              "message",
+              "reason",
+              "total_bytes",
+              "written_bytes"
+            ]
+          },
+          {
+            "description": "Completed writing an artifact.",
+            "type": "object",
+            "properties": {
+              "artifact_size": {
+                "description": "The number of bytes written out.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "attempt": {
+                "description": "The write attempt that completed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "destination": {
+                "description": "The destination for the artifact.",
+                "type": "string",
+                "format": "Utf8PathBuf"
+              },
+              "elapsed": {
+                "description": "How long the write took to complete.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "kind": {
+                "description": "The kind of artifact that was written out.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "write_completed"
+                ]
+              }
+            },
+            "required": [
+              "artifact_size",
+              "attempt",
+              "destination",
+              "elapsed",
+              "kind",
+              "reason"
+            ]
+          },
+          {
+            "description": "A miscellaneous error occurred.\n\nThis is a catch-all for errors that aren't described by any of the variants.",
+            "type": "object",
+            "properties": {
+              "attempt": {
+                "description": "The attempt that failed.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "data": {
+                "description": "Data about the operation, serialized as JSON."
+              },
+              "elapsed": {
+                "description": "How long the operation took before it failed.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Duration"
+                  }
+                ]
+              },
+              "is_fatal": {
+                "description": "Whether this operation is fatal, i.e. will not be retried.",
+                "type": "boolean"
+              },
+              "message": {
+                "description": "A message indicating why the operation failed.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "The name of the operation that failed.",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "misc_error"
+                ]
+              }
+            },
+            "required": [
+              "attempt",
+              "data",
+              "elapsed",
+              "is_fatal",
+              "message",
+              "operation",
+              "reason"
+            ]
+          },
+          {
+            "description": "Completed the entire operation.",
+            "type": "object",
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "completed"
+                ]
+              }
+            },
+            "required": [
+              "reason"
+            ]
+          }
+        ]
+      },
       "Duration": {
         "type": "object",
         "properties": {
@@ -927,7 +1287,47 @@
           "kind"
         ]
       },
-      "UpdateEventFailureKind": {
+      "UpdateEventKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/UpdateNormalEventKind"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "normal_event"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/UpdateEventTerminalFailureKind"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "terminal_failure"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          }
+        ]
+      },
+      "UpdateEventTerminalFailureKind": {
         "oneOf": [
           {
             "type": "object",
@@ -987,47 +1387,47 @@
           }
         ]
       },
-      "UpdateEventKind": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "data": {
-                "$ref": "#/components/schemas/UpdateEventSuccessKind"
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "success"
-                ]
+      "UpdateLog": {
+        "type": "object",
+        "properties": {
+          "current": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateState"
               }
-            },
-            "required": [
-              "data",
-              "kind"
             ]
           },
-          {
-            "type": "object",
-            "properties": {
-              "data": {
-                "$ref": "#/components/schemas/UpdateEventFailureKind"
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "failure"
-                ]
-              }
-            },
-            "required": [
-              "data",
-              "kind"
-            ]
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UpdateEvent"
+            }
           }
+        },
+        "required": [
+          "events"
         ]
       },
-      "UpdateEventSuccessKind": {
+      "UpdateLogAll": {
+        "description": "The response to a `get_update_all` call: the list of all updates (in-flight or completed) known by wicketd.",
+        "type": "object",
+        "properties": {
+          "sps": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/UpdateLog"
+              }
+            }
+          }
+        },
+        "required": [
+          "sps"
+        ]
+      },
+      "UpdateNormalEventKind": {
         "oneOf": [
           {
             "type": "object",
@@ -1068,47 +1468,25 @@
               "data",
               "kind"
             ]
-          }
-        ]
-      },
-      "UpdateLog": {
-        "type": "object",
-        "properties": {
-          "current": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UpdateState"
-              }
-            ]
           },
-          "events": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UpdateEvent"
-            }
-          }
-        },
-        "required": [
-          "events"
-        ]
-      },
-      "UpdateLogAll": {
-        "description": "The response to a `get_update_all` call: the list of all updates (in-flight or completed) known by wicketd.",
-        "type": "object",
-        "properties": {
-          "sps": {
+          {
             "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/UpdateLog"
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/CompletionEventKind"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "installinator_event"
+                ]
               }
-            }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
           }
-        },
-        "required": [
-          "sps"
         ]
       },
       "UpdatePreparationProgress": {

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1298,7 +1298,7 @@
               "kind": {
                 "type": "string",
                 "enum": [
-                  "normal_event"
+                  "normal"
                 ]
               }
             },
@@ -1311,72 +1311,12 @@
             "type": "object",
             "properties": {
               "data": {
-                "$ref": "#/components/schemas/UpdateEventTerminalFailureKind"
+                "$ref": "#/components/schemas/UpdateTerminalEventKind"
               },
               "kind": {
                 "type": "string",
                 "enum": [
-                  "terminal_failure"
-                ]
-              }
-            },
-            "required": [
-              "data",
-              "kind"
-            ]
-          }
-        ]
-      },
-      "UpdateEventTerminalFailureKind": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "data": {
-                "type": "object",
-                "properties": {
-                  "reason": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "reason"
-                ]
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "sp_reset_failed"
-                ]
-              }
-            },
-            "required": [
-              "data",
-              "kind"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "data": {
-                "type": "object",
-                "properties": {
-                  "artifact": {
-                    "$ref": "#/components/schemas/ArtifactId"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "artifact",
-                  "reason"
-                ]
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "artifact_update_failed"
+                  "terminal"
                 ]
               }
             },
@@ -1878,6 +1818,66 @@
             "required": [
               "data",
               "state"
+            ]
+          }
+        ]
+      },
+      "UpdateTerminalEventKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "sp_reset_failed"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "artifact": {
+                    "$ref": "#/components/schemas/ArtifactId"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "artifact",
+                  "reason"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "artifact_update_failed"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "kind"
             ]
           }
         ]

--- a/wicketd-client/Cargo.toml
+++ b/wicketd-client/Cargo.toml
@@ -10,5 +10,6 @@ progenitor.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
 schemars.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 slog.workspace = true
 uuid.workspace = true

--- a/wicketd/src/update_events.rs
+++ b/wicketd/src/update_events.rs
@@ -90,8 +90,8 @@ pub struct UpdateEvent {
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "data")]
 pub enum UpdateEventKind {
-    NormalEvent(UpdateNormalEventKind),
-    TerminalFailure(UpdateEventTerminalFailureKind),
+    Normal(UpdateNormalEventKind),
+    Terminal(UpdateTerminalEventKind),
 }
 
 #[derive(Clone, Debug, JsonSchema, Serialize)]
@@ -104,7 +104,7 @@ pub enum UpdateNormalEventKind {
 
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "data")]
-pub enum UpdateEventTerminalFailureKind {
+pub enum UpdateTerminalEventKind {
     SpResetFailed { reason: String },
     ArtifactUpdateFailed { artifact: ArtifactId, reason: String },
 }

--- a/wicketd/src/update_events.rs
+++ b/wicketd/src/update_events.rs
@@ -8,6 +8,7 @@ use camino::Utf8PathBuf;
 use gateway_client::types::HostPhase2Progress;
 use gateway_client::types::PowerState;
 use gateway_client::types::UpdatePreparationProgress;
+use installinator_common::CompletionEventKind;
 use omicron_common::update::ArtifactId;
 use omicron_common::update::ArtifactKind;
 use schemars::gen::SchemaGenerator;
@@ -89,20 +90,21 @@ pub struct UpdateEvent {
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "data")]
 pub enum UpdateEventKind {
-    Success(UpdateEventSuccessKind),
-    Failure(UpdateEventFailureKind),
+    NormalEvent(UpdateNormalEventKind),
+    TerminalFailure(UpdateEventTerminalFailureKind),
 }
 
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "data")]
-pub enum UpdateEventSuccessKind {
+pub enum UpdateNormalEventKind {
     SpResetComplete,
     ArtifactUpdateComplete { artifact: ArtifactId },
+    InstallinatorEvent(CompletionEventKind),
 }
 
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "data")]
-pub enum UpdateEventFailureKind {
+pub enum UpdateEventTerminalFailureKind {
     SpResetFailed { reason: String },
     ArtifactUpdateFailed { artifact: ArtifactId, reason: String },
 }

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -10,9 +10,9 @@ use crate::installinator_progress::IprStartReceiver;
 use crate::installinator_progress::IprUpdateTracker;
 use crate::mgs::make_mgs_client;
 use crate::update_events::UpdateEventKind;
-use crate::update_events::UpdateTerminalEventKind;
 use crate::update_events::UpdateNormalEventKind;
 use crate::update_events::UpdateStateKind;
+use crate::update_events::UpdateTerminalEventKind;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::ensure;
@@ -375,20 +375,11 @@ impl UpdateDriver {
         kind: UpdateNormalEventKind,
         new_current: Option<UpdateStateKind>,
     ) {
-        self.push_update_event_now(
-            UpdateEventKind::Normal(kind),
-            new_current,
-        );
+        self.push_update_event_now(UpdateEventKind::Normal(kind), new_current);
     }
 
-    fn push_update_terminal_failure(
-        &self,
-        kind: UpdateTerminalEventKind,
-    ) {
-        self.push_update_event_now(
-            UpdateEventKind::Terminal(kind),
-            None,
-        );
+    fn push_update_terminal_failure(&self, kind: UpdateTerminalEventKind) {
+        self.push_update_event_now(UpdateEventKind::Terminal(kind), None);
     }
 
     async fn run_impl(

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -9,9 +9,9 @@ use crate::artifacts::UpdatePlan;
 use crate::installinator_progress::IprStartReceiver;
 use crate::installinator_progress::IprUpdateTracker;
 use crate::mgs::make_mgs_client;
-use crate::update_events::UpdateEventFailureKind;
 use crate::update_events::UpdateEventKind;
-use crate::update_events::UpdateEventSuccessKind;
+use crate::update_events::UpdateEventTerminalFailureKind;
+use crate::update_events::UpdateNormalEventKind;
 use crate::update_events::UpdateStateKind;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -338,7 +338,7 @@ impl UpdateDriver {
     ) {
         if let Err(err) = self.run_impl(plan, ipr_start_receiver).await {
             error!(self.log, "update failed"; "err" => ?err);
-            self.push_update_failure(err);
+            self.push_update_terminal_failure(err);
         }
     }
 
@@ -347,33 +347,55 @@ impl UpdateDriver {
         self.update_log.lock().unwrap().current = Some(state);
     }
 
-    fn push_update_success(
+    fn push_update_event_at(
         &self,
-        kind: UpdateEventSuccessKind,
+        kind: UpdateEventKind,
         new_current: Option<UpdateStateKind>,
+        timestamp: Instant,
     ) {
-        let timestamp = Instant::now();
-        let kind = UpdateEventKind::Success(kind);
         let event = UpdateEvent { timestamp, kind };
+        let new_current =
+            new_current.map(|kind| UpdateState { timestamp, kind });
+
         let mut update_log = self.update_log.lock().unwrap();
         update_log.events.push(event);
-        update_log.current =
-            new_current.map(|kind| UpdateState { timestamp, kind });
+        update_log.current = new_current;
     }
 
-    fn push_update_failure(&self, kind: UpdateEventFailureKind) {
-        let kind = UpdateEventKind::Failure(kind);
-        let event = UpdateEvent { timestamp: Instant::now(), kind };
-        let mut update_log = self.update_log.lock().unwrap();
-        update_log.events.push(event);
-        update_log.current = None;
+    fn push_update_event_now(
+        &self,
+        kind: UpdateEventKind,
+        new_current: Option<UpdateStateKind>,
+    ) {
+        self.push_update_event_at(kind, new_current, Instant::now());
+    }
+
+    fn push_update_normal_event_now(
+        &self,
+        kind: UpdateNormalEventKind,
+        new_current: Option<UpdateStateKind>,
+    ) {
+        self.push_update_event_now(
+            UpdateEventKind::NormalEvent(kind),
+            new_current,
+        );
+    }
+
+    fn push_update_terminal_failure(
+        &self,
+        kind: UpdateEventTerminalFailureKind,
+    ) {
+        self.push_update_event_now(
+            UpdateEventKind::TerminalFailure(kind),
+            None,
+        );
     }
 
     async fn run_impl(
         &mut self,
         plan: UpdatePlan,
         ipr_start_receiver: IprStartReceiver,
-    ) -> Result<(), UpdateEventFailureKind> {
+    ) -> Result<(), UpdateEventTerminalFailureKind> {
         // TODO-correctness Is the general order here correct? Host then SP then
         // RoT, then reboot the SP/RoT?
         if self.sp.type_ == SpType::Sled {
@@ -388,13 +410,13 @@ impl UpdateDriver {
 
         info!(self.log, "starting SP update"; "artifact" => ?sp_artifact.id);
         self.update_sp(sp_artifact).await.map_err(|err| {
-            UpdateEventFailureKind::ArtifactUpdateFailed {
+            UpdateEventTerminalFailureKind::ArtifactUpdateFailed {
                 artifact: sp_artifact.id.clone(),
                 reason: format!("{err:#}"),
             }
         })?;
-        self.push_update_success(
-            UpdateEventSuccessKind::ArtifactUpdateComplete {
+        self.push_update_normal_event_now(
+            UpdateNormalEventKind::ArtifactUpdateComplete {
                 artifact: sp_artifact.id.clone(),
             },
             Some(UpdateStateKind::ResettingSp),
@@ -402,9 +424,14 @@ impl UpdateDriver {
 
         info!(self.log, "all updates complete; resetting SP");
         self.reset_sp().await.map_err(|err| {
-            UpdateEventFailureKind::SpResetFailed { reason: format!("{err:#}") }
+            UpdateEventTerminalFailureKind::SpResetFailed {
+                reason: format!("{err:#}"),
+            }
         })?;
-        self.push_update_success(UpdateEventSuccessKind::SpResetComplete, None);
+        self.push_update_normal_event_now(
+            UpdateNormalEventKind::SpResetComplete,
+            None,
+        );
 
         Ok(())
     }
@@ -413,12 +440,12 @@ impl UpdateDriver {
         &mut self,
         plan: &UpdatePlan,
         ipr_start_receiver: IprStartReceiver,
-    ) -> Result<(), UpdateEventFailureKind> {
+    ) -> Result<(), UpdateEventTerminalFailureKind> {
         info!(self.log, "starting host recovery via trampoline image");
 
         let uploaded_trampoline_phase2_id =
             self.install_trampoline_image(plan).await.map_err(|err| {
-                UpdateEventFailureKind::ArtifactUpdateFailed {
+                UpdateEventTerminalFailureKind::ArtifactUpdateFailed {
                     // `trampoline_phase_1` and `trampoline_phase_2` have the same
                     // artifact ID, so the choice here is arbitrary.
                     artifact: plan.trampoline_phase_1.id.clone(),
@@ -434,7 +461,7 @@ impl UpdateDriver {
             )
             .await
             .map_err(|err| {
-                UpdateEventFailureKind::ArtifactUpdateFailed {
+                UpdateEventTerminalFailureKind::ArtifactUpdateFailed {
                     // `trampoline_phase_1` and `trampoline_phase_2` have the
                     // same artifact ID, so the choice here is arbitrary.
                     artifact: plan.trampoline_phase_1.id.clone(),
@@ -451,7 +478,7 @@ impl UpdateDriver {
         // Installinator is done: install the host phase 1 that matches the host
         // phase 2 it installed, and boot our newly-recovered sled.
         self.install_host_phase_1_and_boot(plan).await.map_err(|err| {
-            UpdateEventFailureKind::ArtifactUpdateFailed {
+            UpdateEventTerminalFailureKind::ArtifactUpdateFailed {
                 artifact: plan.host_phase_1.id.clone(),
                 reason: format!("{err:#}"),
             }
@@ -591,57 +618,80 @@ impl UpdateDriver {
         // Currently, progress reports have zero or one progress events. Don't
         // assert that here, in case this version of wicketd is updating a
         // future installinator which reports multiple progress events.
-        let kind = if let Some(event) = report.progress_events.drain(..).next()
-        {
-            match event.kind {
-                ProgressEventKind::DownloadProgress {
-                    attempt,
-                    kind,
-                    peer: _peer,
-                    downloaded_bytes,
-                    total_bytes,
-                    elapsed,
-                } => UpdateStateKind::ArtifactDownloadProgress {
-                    attempt,
-                    kind,
-                    downloaded_bytes,
-                    total_bytes,
-                    elapsed,
-                },
-                ProgressEventKind::FormatProgress {
-                    attempt,
-                    path,
-                    percentage,
-                    elapsed,
-                } => UpdateStateKind::InstallinatorFormatProgress {
-                    attempt,
-                    path,
-                    percentage,
-                    elapsed,
-                },
-                ProgressEventKind::WriteProgress {
-                    attempt,
-                    kind,
-                    destination,
-                    written_bytes,
-                    total_bytes,
-                    elapsed,
-                } => UpdateStateKind::ArtifactWriteProgress {
-                    attempt,
-                    kind,
-                    destination: Some(destination),
-                    written_bytes,
-                    total_bytes,
-                    elapsed,
-                },
-            }
-        } else {
-            UpdateStateKind::WaitingForProgress {
-                component: "installinator".to_owned(),
-            }
-        };
+        let progress_kind =
+            if let Some(event) = report.progress_events.drain(..).next() {
+                match event.kind {
+                    ProgressEventKind::DownloadProgress {
+                        attempt,
+                        kind,
+                        peer: _peer,
+                        downloaded_bytes,
+                        total_bytes,
+                        elapsed,
+                    } => UpdateStateKind::ArtifactDownloadProgress {
+                        attempt,
+                        kind,
+                        downloaded_bytes,
+                        total_bytes,
+                        elapsed,
+                    },
+                    ProgressEventKind::FormatProgress {
+                        attempt,
+                        path,
+                        percentage,
+                        elapsed,
+                    } => UpdateStateKind::InstallinatorFormatProgress {
+                        attempt,
+                        path,
+                        percentage,
+                        elapsed,
+                    },
+                    ProgressEventKind::WriteProgress {
+                        attempt,
+                        kind,
+                        destination,
+                        written_bytes,
+                        total_bytes,
+                        elapsed,
+                    } => UpdateStateKind::ArtifactWriteProgress {
+                        attempt,
+                        kind,
+                        destination: Some(destination),
+                        written_bytes,
+                        total_bytes,
+                        elapsed,
+                    },
+                }
+            } else {
+                UpdateStateKind::WaitingForProgress {
+                    component: "installinator".to_owned(),
+                }
+            };
 
-        self.set_current_update_state(kind);
+        if report.completion_events.is_empty() {
+            self.set_current_update_state(progress_kind);
+        } else {
+            for event in report.completion_events {
+                let event_kind =
+                    UpdateNormalEventKind::InstallinatorEvent(event.kind);
+
+                // Convert the agent of this event from installinator into an
+                // `Instant`; if we can't, log it and lie that the event
+                // occurred "now".
+                let now = Instant::now();
+                let timestamp = report
+                    .total_elapsed
+                    .checked_sub(event.total_elapsed)
+                    .and_then(|age| now.checked_sub(age))
+                    .unwrap_or(now);
+
+                self.push_update_event_at(
+                    UpdateEventKind::NormalEvent(event_kind),
+                    Some(progress_kind.clone()),
+                    timestamp,
+                );
+            }
+        }
     }
 
     // Installs the installinator phase 1 and configures the host to fetch phase

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -354,7 +354,7 @@ impl UpdateDriver {
     //   update is complete).
     fn push_update_events(
         &self,
-        events: &mut impl Iterator<Item = (Instant, UpdateEventKind)>,
+        events: impl Iterator<Item = (Instant, UpdateEventKind)>,
         new_current: Option<UpdateState>,
     ) {
         let mut update_log = self.update_log.lock().unwrap();
@@ -374,7 +374,7 @@ impl UpdateDriver {
         let new_current =
             new_current.map(|kind| UpdateState { timestamp, kind });
         let events = [(timestamp, kind)];
-        self.push_update_events(&mut events.into_iter(), new_current);
+        self.push_update_events(events.into_iter(), new_current);
     }
 
     fn push_update_normal_event_now(
@@ -678,7 +678,7 @@ impl UpdateDriver {
                 }
             };
 
-        let mut events = report.completion_events.into_iter().map(|event| {
+        let events = report.completion_events.into_iter().map(|event| {
             let event_kind =
                 UpdateNormalEventKind::InstallinatorEvent(event.kind);
 
@@ -694,7 +694,7 @@ impl UpdateDriver {
             (timestamp, UpdateEventKind::Normal(event_kind))
         });
 
-        self.push_update_events(&mut events, Some(new_state));
+        self.push_update_events(events, Some(new_state));
     }
 
     // Installs the installinator phase 1 and configures the host to fetch phase


### PR DESCRIPTION
The update event log types are getting a little hard to follow and are probably ripe for a rework. This PR renames a few types and enum variants:

* `UpdateEventSuccessKind` -> `UpdateNormalEventKind`, which also gained an `::InstallinatorEvent` variant. This rename is because installinator events can represent transient failures that will be retried, which didn't seem to fit under either `Success` or `Failure`
* `UpdateEventKind::Success` -> `UpdateEventKind::NormalEvent` to go with the previous rename
* `UpdateEventKind::Failure` -> `UpdateEventKind::TerminalFailure` to clarify that these result in the update process stopping until manual intervention is applied to restart it / debug it

A couple of minor bumps in the road:

* Reporting age of events from installinator through wicketd is a little weird (see the bit in the diff where we convert to an `Instant`)
* Installinator's `CompletionEventKind` has variants that cover both success and failure cases - maybe the wicketd update log should use a flatter representation like this too?
* wicketd's openapi is now effectively "re-exporting" `CompletionEventKind` from installinator. That seems... okay? but a little weird.

Recommend viewing the diff ignoring whitespace; it counts down the changes fairly substantially.