### PR TITLE
omicron#2431 refresh dendrite rather than restarting

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -253,7 +253,7 @@ only_for_targets.image_type = "standard"
 source.type = "prebuilt"
 source.repo = "dendrite"
 source.commit = "8ba0f2cde2577219f58eb768850705e9ef7249a0"
-source.sha256 = "5ca05573a21612a8f92af428200342b63b6fb6e1b6cce89a8008341cf08a4dbe"
+source.sha256 = "05a47e1a069a376b29c9171abd8b558b4498bd2b1d623c889c6b712334d23815"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -272,7 +272,7 @@ only_for_targets.image_type = "standard"
 source.type = "prebuilt"
 source.repo = "dendrite"
 source.commit = "8ba0f2cde2577219f58eb768850705e9ef7249a0"
-source.sha256 = "52772b64689a590663716bcd79d10e9013f31a05f2315472495c09241069eb47"
+source.sha256 = "b1efb112820a682a4fd651825a835d35c5a55cc15fc7898266bbd77c2f48c18a"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -252,8 +252,8 @@ only_for_targets.image_type = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "67a45ff847989e8b8be37c099f70a7451b277c0d"
-source.sha256 = "a2d7bda00d53e1fc2f569ef9afbef4a56a82636e2d613b7668fba7b767805474"
+source.commit = "8ba0f2cde2577219f58eb768850705e9ef7249a0"
+source.sha256 = "5ca05573a21612a8f92af428200342b63b6fb6e1b6cce89a8008341cf08a4dbe"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -271,8 +271,8 @@ only_for_targets.image_type = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
-source.commit = "67a45ff847989e8b8be37c099f70a7451b277c0d"
-source.sha256 = "633e71a764fe02adf2c62dff31923ca4f8863818d0e4d68983c8a360bf23eb3a"
+source.commit = "8ba0f2cde2577219f58eb768850705e9ef7249a0"
+source.sha256 = "52772b64689a590663716bcd79d10e9013f31a05f2315472495c09241069eb47"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1111,9 +1111,6 @@ impl ServiceManager {
                                 )?;
                             }
                             smfh.refresh()?;
-                            // TODO: For this restart to be optional, Dendrite must
-                            // implement a non-default "refresh" method.
-                            smfh.restart()?;
                         }
                         ServiceType::Tfport { .. } => {
                             // Since tfport and dpd communicate using localhost,

--- a/sled-agent/src/smf_helper.rs
+++ b/sled-agent/src/smf_helper.rs
@@ -128,20 +128,6 @@ impl<'t> SmfHelper<'t> {
         Ok(())
     }
 
-    pub fn restart(&self) -> Result<(), Error> {
-        self.running_zone
-            .run_cmd(&[
-                illumos_utils::zone::SVCADM,
-                "restart",
-                &self.default_smf_name,
-            ])
-            .map_err(|err| Error::ZoneCommand {
-                intent: format!("Restart {} service", self.default_smf_name),
-                err,
-            })?;
-        Ok(())
-    }
-
     pub fn enable(&self) -> Result<(), Error> {
         self.running_zone
             .run_cmd(&[


### PR DESCRIPTION
With the updated dendrite commit hash, dpd handles an "smf refresh" by pulling updated api_server addresses from the SMF config and setting up / tearing down Dropshot servers as necessary to listen on exactly the set of addresses specified.  This removes the need for the `smf restart`.