### PR TITLE
[mgs] Return detailed error messages with HTTP 503 codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=f896b7cf0fe7e72641b33060185b71e5d3562b12#f896b7cf0fe7e72641b33060185b71e5d3562b12"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a15a3f8f58bb7b2fadc94f42a4747022ae6d401d#a15a3f8f58bb7b2fadc94f42a4747022ae6d401d"
 dependencies = [
  "bitflags",
  "hubpack 0.1.1",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=f896b7cf0fe7e72641b33060185b71e5d3562b12#f896b7cf0fe7e72641b33060185b71e5d3562b12"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a15a3f8f58bb7b2fadc94f42a4747022ae6d401d#a15a3f8f58bb7b2fadc94f42a4747022ae6d401d"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2215,7 +2215,7 @@ dependencies = [
  "serde",
  "serde-big-array 0.5.1",
  "slog",
- "socket2",
+ "socket2 0.5.1",
  "string_cache",
  "thiserror",
  "tlvc",
@@ -2616,7 +2616,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2933,7 +2933,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
 dependencies = [
- "socket2",
+ "socket2 0.4.9",
  "widestring",
  "winapi",
  "winreg",
@@ -3126,7 +3126,7 @@ dependencies = [
  "nvpair",
  "nvpair-sys",
  "rusty-doors",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tracing",
 ]
@@ -6460,6 +6460,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "sp-sim"
 version = "0.1.0"
 dependencies = [
@@ -7014,7 +7024,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.45.0",
 ]
@@ -7059,7 +7069,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,8 +144,8 @@ fatfs = "0.3.6"
 fs-err = "2.9.0"
 futures = "0.3.25"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "f896b7cf0fe7e72641b33060185b71e5d3562b12" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "f896b7cf0fe7e72641b33060185b71e5d3562b12" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "a15a3f8f58bb7b2fadc94f42a4747022ae6d401d" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a15a3f8f58bb7b2fadc94f42a4747022ae6d401d" }
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -1,7 +1,6 @@
 #
 # Oxide API: example configuration file
 #
-host_phase2_recovery_image_cache_max_images=1
 
 # Maximum number of host phase2 trampoline images we're willing to cache. Note
 # that this value is specified in terms of _number of images_, not bytes, and

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -297,7 +297,7 @@ impl SerialConsoleTcpTask {
         while !remaining.is_empty() {
             let message = Message {
                 header: Header {
-                    version: version::V2,
+                    version: version::CURRENT,
                     message_id: self.next_request_message_id(),
                 },
                 kind: MessageKind::SpRequest(SpRequest::SerialConsole {
@@ -1137,6 +1137,18 @@ impl SpHandler for Handler {
             "port" => ?port,
             "key" => key,
             "value" => ?value,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn get_caboose_value(
+        &mut self,
+        key: [u8; 4],
+    ) -> std::result::Result<&'static [u8], SpError> {
+        warn!(
+            &self.log,
+            "received request for caboose key; not supported by simulated gimlet";
+            "key" => ?key,
         );
         Err(SpError::RequestUnsupportedForSp)
     }

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -930,6 +930,18 @@ impl SpHandler for Handler {
         );
         Err(SpError::RequestUnsupportedForSp)
     }
+
+    fn get_caboose_value(
+        &mut self,
+        key: [u8; 4],
+    ) -> std::result::Result<&'static [u8], SpError> {
+        warn!(
+            &self.log,
+            "received request for caboose key; not supported by simulated sidecar";
+            "key" => ?key,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
 }
 
 struct FakeIgnition {


### PR DESCRIPTION
This is primarily for plumbing through to wicketd -> wicket, but will probably be useful to nexus in the future. MGS returns HTTP 500-level codes (mostly 503 unavailable) when it has issues communicating with an SP; previously, these errors did not include any details in the response body. We now include an error message string.

A trivial example from wicketd's logs when trying to update an SP with an empty file:

```
Mar 13 19:51:29.975 ERRO update failed, err: ArtifactUpdateFailed { artifact: ArtifactId { name: "fake-switch-sp", version: SemverVersion(Version { major: 1, minor: 0, patch: 0 }), kind: ArtifactKind("switch_sp") }, reason: "failed to start update: Error Response: status: 503 Service Unavailable; headers: {\"content-type\": \"application/json\", \"x-request-id\": \"f538b319-8116-4eb7-91ed-a4299ecc6a6b\", \"content-length\": \"155\", \"date\": \"Mon, 13 Mar 2023 19:51:29 GMT\"}; value: Error { error_code: Some(\"UpdateFailed\"), message: \"updating SP failed: update image cannot be empty\", request_id: \"f538b319-8116-4eb7-91ed-a4299ecc6a6b\" }" }, update_id: d24c5a04-d1c8-4b46-a257-9c102379b727, sp: SpIdentifier { slot: 0, type_: Switch }, component: wicketd update planner
```

The relevent bit is

```
message: \"updating SP failed: update image cannot be empty\"
```

which prior to this PR was just

```
message: \"Service Unavailable\"
```