### PR TITLE
[sled-agent] Test that all SMF configs can be parsed

### DIFF
--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -92,3 +92,32 @@ impl Config {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_smf_configs() {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR")
+            .expect("Cannot access manifest directory");
+        let smf = PathBuf::from(manifest).join("../smf/sled-agent");
+
+        for variant in std::fs::read_dir(smf).unwrap() {
+            let variant = variant.unwrap();
+            if variant.file_type().unwrap().is_dir() {
+                for entry in std::fs::read_dir(variant.path()).unwrap() {
+                    let entry = entry.unwrap();
+                    if entry.file_name() == "config.toml" {
+                        Config::from_file(entry.path()).unwrap_or_else(|_| {
+                            panic!(
+                                "Failed to parse config {}",
+                                entry.path().display()
+                            )
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -103,6 +103,7 @@ mod test {
             .expect("Cannot access manifest directory");
         let smf = PathBuf::from(manifest).join("../smf/sled-agent");
 
+        let mut configs_seen = 0;
         for variant in std::fs::read_dir(smf).unwrap() {
             let variant = variant.unwrap();
             if variant.file_type().unwrap().is_dir() {
@@ -115,9 +116,11 @@ mod test {
                                 entry.path().display()
                             )
                         });
+                        configs_seen += 1;
                     }
                 }
             }
         }
+        assert!(configs_seen > 0, "No sled-agent configs found");
     }
 }


### PR DESCRIPTION
Now that there are a few different configs, add a test that validates they don't bit-rot.