### PR TITLE
[wicket] Consistent key management

### DIFF
--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A mapping of keys to behaviors interpreted by the UI
+//!
+//! The purpose of the keymap is allow making the operation of wicket consistent
+//! while decoupling keys from actions on [`crate::Control`]s
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// All commands handled by [`crate::Control::on`].
+///
+/// These are mostly user input commands from the keyboard,
+/// but also include certain events like `Tick`.,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cmd {
+    /// Select the only available action for a current control
+    /// This can trigger an operation, popup, etc...
+    Enter,
+
+    /// Exit the current context
+    Exit,
+
+    /// Expand the current tree context
+    Expand,
+
+    /// Collapse the current tree context
+    Collapse,
+
+    /// Raw mode directly passes key presses through to the underlying
+    /// [`crate::Control`]s where the user needs to directly input text.
+    ///
+    /// When a user `Select`s  a user input an [`crate::Action`]  will be
+    /// returned that establishes Raw mode. When the context is exited, `Raw`
+    /// mode will be disabled.
+    Raw(KeyEvent),
+
+    /// Display details for the given selection
+    /// This can be used to do things like open a scollable popup for a given
+    /// `Control`.
+    Details,
+
+    /// Move up or scroll up
+    Up,
+
+    /// Move down or scroll down
+    Down,
+
+    /// Move right
+    Right,
+
+    /// Move left
+    Left,
+
+    /// Accept
+    Yes,
+
+    /// Goto top of list/screen/etc...
+    GotoTop,
+
+    /// Goto bottom of list/screen/etc...
+    GotoBottom,
+
+    /// Decline
+    No,
+
+    /// Easter Egg in Rack View
+    KnightRiderMode,
+
+    /// Trigger any operation that must be executed periodically, like
+    /// animations.
+    Tick,
+
+    /// Swap between the sidebar and primary pane
+    SwapPane,
+}
+
+/// We allow certain multi-key sequences, and explicitly enumerate the starting
+/// key(s) here.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_camel_case_types)]
+enum MultiKeySeqStart {
+    g,
+}
+
+/// A Key Handler maintains any state that is needed across key presses,
+/// such as whether the user is in `insert` mode, or a key sequence is
+/// being processed.
+///
+/// Return the [`Cmd`] that gets interpreted or `None` if the key press is part
+/// of a sequence or not a valid key press.
+///
+/// Note: We don't handle raw events or key sequences yet, although this is
+/// possible.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KeyHandler {
+    seq: Option<MultiKeySeqStart>,
+}
+
+impl KeyHandler {
+    pub fn on(&mut self, event: KeyEvent) -> Option<Cmd> {
+        if let Some(seq) = self.seq {
+            match seq {
+                MultiKeySeqStart::g => match event.code {
+                    KeyCode::Char('g') => {
+                        self.seq = None;
+                        return Some(Cmd::GotoTop);
+                    }
+                    KeyCode::Char('e') => {
+                        self.seq = None;
+                        return Some(Cmd::GotoBottom);
+                    }
+                    _ => (),
+                },
+            }
+        }
+
+        // We didn't match any multi-sequence starting characters. Treat this
+        // key-press as a new key-press and reset the sequence.
+        self.seq = None;
+
+        let cmd = match event.code {
+            KeyCode::Enter => Cmd::Enter,
+            KeyCode::Esc => Cmd::Exit,
+            KeyCode::Char('e') => Cmd::Expand,
+            KeyCode::Char('c') => Cmd::Collapse,
+            KeyCode::Char('d') => Cmd::Details,
+            KeyCode::Up => Cmd::Up,
+            KeyCode::Down => Cmd::Down,
+            KeyCode::Right => Cmd::Right,
+            KeyCode::Left => Cmd::Left,
+            KeyCode::Char('y') => Cmd::Yes,
+            KeyCode::Char('n') => Cmd::No,
+            KeyCode::Char('k') if event.modifiers == KeyModifiers::CONTROL => {
+                Cmd::KnightRiderMode
+            }
+            KeyCode::Char('s') => Cmd::SwapPane,
+
+            // Vim navigation
+            KeyCode::Char('k') => Cmd::Up,
+            KeyCode::Char('j') => Cmd::Down,
+            KeyCode::Char('h') => Cmd::Left,
+            KeyCode::Char('l') => Cmd::Right,
+            KeyCode::Char('g') => {
+                self.seq = Some(MultiKeySeqStart::g);
+                return None;
+            }
+            _ => return None,
+        };
+        Some(cmd)
+    }
+}

--- a/wicket/src/lib.rs
+++ b/wicket/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod dispatch;
 mod events;
+mod keymap;
 mod runner;
 mod state;
 mod ui;
@@ -16,5 +17,6 @@ mod wicketd;
 pub use crate::dispatch::*;
 pub use crate::runner::*;
 pub use events::{Action, Event, InventoryEvent};
+pub use keymap::{Cmd, KeyHandler};
 pub use state::State;
 pub use ui::Control;

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -22,9 +22,8 @@ use tui::backend::CrosstermBackend;
 use tui::Terminal;
 
 use crate::ui::Screen;
-use crate::wicketd;
-use crate::wicketd::{WicketdHandle, WicketdManager};
-use crate::{Action, Event, InventoryEvent, State};
+use crate::wicketd::{self, WicketdHandle, WicketdManager};
+use crate::{Action, Cmd, Event, InventoryEvent, KeyHandler, State};
 
 // We can avoid a bunch of unnecessary type parameters by picking them ahead of time.
 pub type Term = Terminal<CrosstermBackend<Stdout>>;
@@ -107,6 +106,8 @@ impl Runner {
     fn main_loop(&mut self) -> anyhow::Result<()> {
         info!(self.log, "Starting main loop");
 
+        let mut key_handler = KeyHandler::default();
+
         // Size the initial screen
         let rect = self.terminal.get_frame().size();
         self.screen.resize(&mut self.state, rect.width, rect.height);
@@ -119,7 +120,7 @@ impl Runner {
             let event = self.events_rx.blocking_recv().unwrap();
             match event {
                 Event::Tick => {
-                    let action = self.screen.on(&mut self.state, Event::Tick);
+                    let action = self.screen.on(&mut self.state, Cmd::Tick);
                     self.handle_action(action)?;
                 }
                 Event::Term(TermEvent::Key(key_event)) => {
@@ -127,11 +128,10 @@ impl Runner {
                         info!(self.log, "CTRL-C Pressed. Exiting.");
                         break;
                     }
-                    let action = self.screen.on(
-                        &mut self.state,
-                        Event::Term(TermEvent::Key(key_event)),
-                    );
-                    self.handle_action(action)?;
+                    if let Some(cmd) = key_handler.on(key_event) {
+                        let action = self.screen.on(&mut self.state, cmd);
+                        self.handle_action(action)?;
+                    }
                 }
                 Event::Term(TermEvent::Resize(width, height)) => {
                     self.screen.resize(&mut self.state, width, height);
@@ -144,10 +144,7 @@ impl Runner {
                     self.state.update_state.update_artifacts(artifacts);
                     self.screen.draw(&self.state, &mut self.terminal)?;
                 }
-                _ => {
-                    let action = self.screen.on(&mut self.state, event);
-                    self.handle_action(action)?;
-                }
+                _ => (),
             }
         }
         Ok(())

--- a/wicket/src/ui/controls/mod.rs
+++ b/wicket/src/ui/controls/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::{Action, Event, Frame, State};
+use crate::{Action, Cmd, Frame, State};
 use tui::layout::Rect;
 
 /// A [`Control`] is the an item on a screen that can be selected and interacted with.
@@ -17,7 +17,7 @@ use tui::layout::Rect;
 /// To allow for distinctive styling on active/selected widgets we allow the
 /// caller to indicate this via the `active` parameter.
 pub trait Control {
-    fn on(&mut self, state: &mut State, event: Event) -> Option<Action>;
+    fn on(&mut self, state: &mut State, cmd: Cmd) -> Option<Action>;
     fn draw(
         &mut self,
         state: &State,

--- a/wicket/src/ui/main.rs
+++ b/wicket/src/ui/main.rs
@@ -8,9 +8,7 @@ use super::{Control, OverviewPane, StatefulList, UpdatePane};
 use crate::ui::defaults::colors::*;
 use crate::ui::defaults::style;
 use crate::ui::widgets::Fade;
-use crate::{Action, Event, Frame, State, Term};
-use crossterm::event::Event as TermEvent;
-use crossterm::event::KeyCode;
+use crate::{Action, Cmd, Frame, State, Term};
 use slog::{o, Logger};
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use tui::style::{Modifier, Style};
@@ -120,49 +118,39 @@ impl MainScreen {
         self.current_pane().resize(state, pane_rect);
     }
 
-    /// Handle an [`Event`] to update state and output any necessary actions for the
+    /// Handle a [`Cmd`] to update state and output any necessary actions for the
     /// system to take.
-    pub fn on(&mut self, state: &mut State, event: Event) -> Option<Action> {
-        match event {
-            Event::Term(TermEvent::Key(e)) => match e.code {
-                KeyCode::Esc => {
-                    if self.sidebar.active {
-                        None
+    pub fn on(&mut self, state: &mut State, cmd: Cmd) -> Option<Action> {
+        match cmd {
+            Cmd::SwapPane => {
+                if self.sidebar.active {
+                    self.sidebar.active = false;
+                    Some(Action::Redraw)
+                } else {
+                    if self.current_pane().is_modal_active() {
+                        self.current_pane().on(state, cmd)
                     } else {
-                        if self.current_pane().is_modal_active() {
-                            self.current_pane().on(state, event)
-                        } else {
-                            self.sidebar.active = true;
-                            Some(Action::Redraw)
-                        }
-                    }
-                }
-                KeyCode::Tab | KeyCode::Enter => {
-                    if self.sidebar.active {
-                        self.sidebar.active = false;
+                        self.sidebar.active = true;
                         Some(Action::Redraw)
-                    } else {
-                        self.current_pane()
-                            .on(state, Event::Term(TermEvent::Key(e)))
                     }
                 }
-                _ => {
-                    let event = Event::Term(TermEvent::Key(e));
-                    self.dispatch_event(state, event)
+            }
+            Cmd::Enter => {
+                if self.sidebar.active {
+                    self.sidebar.active = false;
+                    Some(Action::Redraw)
+                } else {
+                    self.current_pane().on(state, cmd)
                 }
-            },
-            e => self.dispatch_event(state, e),
+            }
+            _ => self.dispatch_cmd(state, cmd),
         }
     }
 
-    fn dispatch_event(
-        &mut self,
-        state: &mut State,
-        event: Event,
-    ) -> Option<Action> {
+    fn dispatch_cmd(&mut self, state: &mut State, cmd: Cmd) -> Option<Action> {
         let current_pane = self.sidebar.selected_pane();
         if self.sidebar.active {
-            let _ = self.sidebar.on(state, event);
+            let _ = self.sidebar.on(state, cmd);
             if self.sidebar.selected_pane() != current_pane {
                 // We need to inform the new pane, which may not have
                 // ever been drawn what its Rect is.
@@ -172,7 +160,7 @@ impl MainScreen {
                 None
             }
         } else {
-            self.current_pane().on(state, event)
+            self.current_pane().on(state, cmd)
         }
     }
 
@@ -250,19 +238,16 @@ impl Sidebar {
 }
 
 impl Control for Sidebar {
-    fn on(&mut self, _: &mut State, event: Event) -> Option<Action> {
-        match event {
-            Event::Term(TermEvent::Key(e)) => match e.code {
-                KeyCode::Up => {
-                    self.panes.previous();
-                    Some(Action::Redraw)
-                }
-                KeyCode::Down => {
-                    self.panes.next();
-                    Some(Action::Redraw)
-                }
-                _ => None,
-            },
+    fn on(&mut self, _: &mut State, cmd: Cmd) -> Option<Action> {
+        match cmd {
+            Cmd::Up => {
+                self.panes.previous();
+                Some(Action::Redraw)
+            }
+            Cmd::Down => {
+                self.panes.next();
+                Some(Action::Redraw)
+            }
             _ => None,
         }
     }

--- a/wicket/src/ui/mod.rs
+++ b/wicket/src/ui/mod.rs
@@ -9,7 +9,7 @@ mod panes;
 mod splash;
 mod widgets;
 
-use crate::{Action, Event, State, Term};
+use crate::{Action, Cmd, State, Term};
 use slog::{o, Logger};
 use tui::widgets::ListState;
 
@@ -20,8 +20,8 @@ pub use controls::Control;
 pub use panes::OverviewPane;
 pub use panes::UpdatePane;
 
-/// The primary display representation. It's sole purpose is to dispatch events
-/// to the underlying splash and main screens.
+/// The primary display representation. It's sole purpose is to dispatch
+/// [`Cmd`]s to the underlying splash and main screens.
 ///
 // Note: It would be nice to use an enum here, but swapping between enum
 // variants requires taking the screen by value or having a wrapper struct with
@@ -55,14 +55,14 @@ impl Screen {
         self.main.resize(state, width, height);
     }
 
-    pub fn on(&mut self, state: &mut State, event: Event) -> Option<Action> {
+    pub fn on(&mut self, state: &mut State, cmd: Cmd) -> Option<Action> {
         if let Some(splash) = &mut self.splash {
-            if splash.on(event) {
+            if splash.on(cmd) {
                 self.splash = None;
             }
             Some(Action::Redraw)
         } else {
-            self.main.on(state, event)
+            self.main.on(state, cmd)
         }
     }
 

--- a/wicket/src/ui/panes/mod.rs
+++ b/wicket/src/ui/panes/mod.rs
@@ -55,3 +55,47 @@ pub fn align_by(
     }
     Text::from(Spans::from(text))
 }
+
+/// Compute the scroll offset for a `Paragraph` widget
+///
+/// This takes the text size and number of visible lines of the terminal `Rect`
+/// account such that it will render the whole paragraph and not scroll if
+/// there is enough room. Otherwise it will scroll as expected with the top of
+/// the terminal `Rect` set to current_offset. We don't allow scrolling beyond
+/// the bottom of the text content.
+///
+///
+/// XXX: This whole paragraph scroll only allows length of less than
+/// 64k rows even though it shouldn't be limited. We can do our own
+/// scrolling instead to obviate this limit. we may want to anyway, as
+/// it's less data to be formatted for the Paragraph.
+///
+/// XXX: This algorithm doesn't work properly with line wraps, so we should
+/// ensure that the data we populate doesn't wrap or we have truncation turned
+/// on.
+pub fn compute_scroll_offset(
+    current_offset: usize,
+    text_height: usize,
+    num_lines: usize,
+) -> u16 {
+    let mut offset: usize = current_offset;
+
+    if offset > text_height {
+        offset = text_height;
+    }
+
+    if text_height <= num_lines {
+        offset = 0;
+    } else {
+        if text_height - offset < num_lines {
+            // Don't allow scrolling past bottom of content
+            //
+            // Reset the scroll_offset, so that an up arrow
+            // will scroll up on the next try.
+            offset = text_height - num_lines;
+        }
+    }
+    // This doesn't allow data more than 64k rows. We shouldn't need
+    // more than that for wicket, but who knows!
+    u16::try_from(offset).unwrap()
+}

--- a/wicket/src/ui/splash.rs
+++ b/wicket/src/ui/splash.rs
@@ -10,8 +10,7 @@ use super::defaults::colors::*;
 use super::defaults::dimensions::RectExt;
 use super::defaults::style;
 use super::widgets::{Logo, LogoState, LOGO_HEIGHT, LOGO_WIDTH};
-use crate::{Event, Frame, Term};
-use crossterm::event::Event as TermEvent;
+use crate::{Cmd, Frame, Term};
 use tui::style::Style;
 use tui::widgets::Block;
 
@@ -68,17 +67,14 @@ impl SplashScreen {
 
     /// Return true if the splash screen should transition to the main screen, false
     /// if it should keep animating.
-    pub fn on(&mut self, event: Event) -> bool {
-        match event {
-            Event::Tick => {
+    pub fn on(&mut self, cmd: Cmd) -> bool {
+        match cmd {
+            Cmd::Tick => {
                 self.state.frame += 1;
                 self.state.frame >= TOTAL_FRAMES
             }
-            Event::Term(TermEvent::Key(_)) => {
-                // Allow the user to skip the splash screen with any key press
-                true
-            }
-            _ => false,
+            // Allow the user to skip the splash screen with any key press
+            _ => true,
         }
     }
 }


### PR DESCRIPTION
In order to be more consistent with keys across panes, a `KeyHandler` was added that processes all key presses and returns `Cmd`s. Raw key events are no longer sent to `Control`s directly. Instead `Cmd`s are handled in `Control::on`. This results in a more consistent experience, and also puts all key-handlign in one place. There is one exception to this, which is when the user needs to enter raw data in a text box. For this we allow a `Cmd::Raw` variant, using the vim command `i` to trigger it. We don't currently do this as we don't have any need for it. We are preparing for the future though.

Additionally, this change moves out scroll functionality into its own function in preparation for scrollable popups.