### PR TITLE
Refactor host OS CI scripts to allow running them locally

### DIFF
--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -74,4 +74,4 @@ git checkout "$COMMIT"
 popd
 
 # TODO: Consider importing zones here too?
-./tools/build-recovery-image.sh -B helios /input/package/work/global-zone-packages.tar.gz
+./tools/build-host-image.sh -B helios /input/package/work/global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -74,4 +74,4 @@ git checkout "$COMMIT"
 popd
 
 # TODO: Consider importing zones here too?
-./tools/build-host-image.sh -B helios /input/package/work/global-zone-packages.tar.gz
+./tools/build-host-image.sh -B /work/helios /input/package/work/global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -63,32 +63,15 @@ done
 #
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-pfexec mkdir -p /work
-cd /work
-
-# /work/gz: Global Zone artifacts to be placed in the Helios image.
-mkdir gz && cd gz
-ptime -m tar xvzf /input/package/work/global-zone-packages.tar.gz
-cd -
-
 # TODO: Consider importing zones here too?
 
-# Checkout helios at a pinned commit
+# Checkout helios at a pinned commit into /work/helios
+pfexec mkdir -p /work
+pushd /work
 git clone https://github.com/oxidecomputer/helios.git
 cd helios
-
 git checkout "$COMMIT"
+popd
 
-# Create the "./helios-build" command, which lets us build images
-gmake setup
-
-# Commands that "./helios-build" would ask us to run (either explicitly
-# or implicitly, to avoid an error).
-pfexec pkg install /system/zones/brand/omicron1/tools
-pfexec zfs create -p rpool/images/build
-
-./helios-build experiment-image \
-	-p helios-netdev=https://pkg.oxide.computer/helios-netdev \
-	-F optever=0.21 \
-	-P /work/gz/root \
-	-B
+# TODO: Consider importing zones here too?
+./tools/build-recovery-image.sh -B helios /input/package/work/global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -50,6 +50,7 @@ files=(
 	tools/create_virtual_hardware.sh
 )
 
+pfexec mkdir -p /work && pfexec chown $USER /work
 ptime -m tar cvzf /work/package.tar.gz "${files[@]}"
 
 # Build necessary for the global zone
@@ -86,7 +87,6 @@ cd "$pkg_dir"
 tar -xvfz "$tarball_src_dir/maghemite.tar"
 cd -
 
-mkdir -p /work
 cd "$tmp_gz" && tar cvfz /work/global-zone-packages.tar.gz oxide.json root
 cd -
 

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -71,4 +71,4 @@ cd helios
 git checkout "$COMMIT"
 popd
 
-./tools/build-host-image.sh -R helios /input/package/work/trampoline-global-zone-packages.tar.gz
+./tools/build-host-image.sh -R /work/helios /input/package/work/trampoline-global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -71,4 +71,4 @@ cd helios
 git checkout "$COMMIT"
 popd
 
-./tools/build-recovery-image.sh helios /input/package/work/trampoline-global-zone-packages.tar.gz
+./tools/build-recovery-image.sh -R helios /input/package/work/trampoline-global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -63,30 +63,10 @@ done
 #
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-pfexec mkdir -p /work
-cd /work
-
-# /work/gz: Global Zone artifacts to be placed in the Helios image.
-mkdir gz && cd gz
-ptime -m tar xvzf /input/package/work/trampoline-global-zone-packages.tar.gz
-cd -
-
 # Checkout helios at a pinned commit
 git clone https://github.com/oxidecomputer/helios.git
 cd helios
-
 git checkout "$COMMIT"
+cd ..
 
-# Create the "./helios-build" command, which lets us build images
-gmake setup
-
-# Commands that "./helios-build" would ask us to run (either explicitly
-# or implicitly, to avoid an error).
-pfexec pkg install /system/zones/brand/omicron1/tools
-pfexec zfs create -p rpool/images/build
-
-./helios-build experiment-image \
-	-p helios-netdev=https://pkg.oxide.computer/helios-netdev \
-	-F optever=0.21 \
-	-P /work/gz/root \
-	-R
+./tools/build-recovery-image.sh helios /input/package/work/trampoline-global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -63,10 +63,12 @@ done
 #
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-# Checkout helios at a pinned commit
+# Checkout helios at a pinned commit into /work/helios
+pfexec mkdir -p /work
+pushd /work
 git clone https://github.com/oxidecomputer/helios.git
 cd helios
 git checkout "$COMMIT"
-cd ..
+popd
 
 ./tools/build-recovery-image.sh helios /input/package/work/trampoline-global-zone-packages.tar.gz

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -71,4 +71,4 @@ cd helios
 git checkout "$COMMIT"
 popd
 
-./tools/build-recovery-image.sh -R helios /input/package/work/trampoline-global-zone-packages.tar.gz
+./tools/build-host-image.sh -R helios /input/package/work/trampoline-global-zone-packages.tar.gz

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -301,3 +301,36 @@ the exact addresses that are available depends on the environment.
 6. Optionally, attach to the proxied propolis server serial console (this requires https://github.com/oxidecomputer/cli/commit/adab246142270778db7208126fb03724f5d35858[this commit] or newer of the CLI.)
 
     oxide instance serial --interactive -p myproj -o myorg myinst
+
+== Building host images
+
+Host images for both the standard omicron install and the trampoline/recovery
+install are built as a part of CI. To build them locally, first run the CI
+script:
+
+[source,text]
+----
+$ ./.github/buildomat/jobs/package.sh
+----
+
+This will create a `/work` directory with a few tarballs in it. Building a host
+image requires a checkout of
+https://github.com/oxidecomputer/helios-engvm[helios]; the instructions below
+use `$HELIOS_PATH` for the path to this repository. To match CI builds, you
+should check out the commit specified in `./tools/helios_version`. (The script
+will check your current commit hash and will refuse to run if it doesn't match
+unless you pass `-f`.)
+
+To build a standard host image:
+
+[source,text]
+----
+$ ./tools/build-host-image.sh -B $HELIOS_PATH /work/global-zone-packages.tar.gz
+----
+
+To build a recovery host image:
+
+[source,text]
+----
+$ ./tools/build-host-image.sh -R $HELIOS_PATH /work/trampoline-global-zone-packages.tar.gz
+----

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -110,8 +110,6 @@ function main
 
     pfexec zfs create -p rpool/images/$USER
 
-    find $tmp_gz
-
     ./helios-build experiment-image \
         -p helios-netdev=https://pkg.oxide.computer/helios-netdev \
         -F optever=0.21 \

--- a/tools/build-recovery-image.sh
+++ b/tools/build-recovery-image.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+function usage
+{
+    echo "usage: $0 PATH_TO_HELIOS PATH_TO_TRAMPOLINE_TARBALL"
+    exit 1
+}
+
+function main
+{
+    while getopts ":hf" opt; do
+        case $opt in
+            f)
+                FORCE=1
+                shift
+                ;;
+            h | \?)
+                usage
+                ;;
+        esac
+    done
+
+    echo "x$FORCE"
+
+    if [ "$#" != "2" ]; then
+        usage
+    fi
+
+    # Read expected helios commit into $COMMIT
+    TOOLS_DIR="$(pwd)/$(dirname $0)"
+    source "$TOOLS_DIR/helios_version"
+
+    # Convert args to absolute paths
+    case $1 in
+        /*) HELIOS_PATH=$1 ;;
+        *) HELIOS_PATH=$(pwd)/$1 ;;
+    esac
+    case $2 in
+        /*) TRAMPOLINE_PATH=$2 ;;
+        *) TRAMPOLINE_PATH=$(pwd)/$2 ;;
+    esac
+
+    # Extract the trampoline global zone tarball into a tmp_gz directory
+    if ! tmp_gz=$(mktemp -d); then
+        exit 1
+    fi
+    trap 'cd /; rm -rf "$tmp_gz"' EXIT
+
+    echo "Extracting trampoline gz packages into $tmp_gz"
+    ptime -m tar xvzf $TRAMPOLINE_PATH -C $tmp_gz
+
+    # Move to the helios checkout
+    cd $HELIOS_PATH
+
+    # Unless the user passed -f, check that the helios commit matches the one we
+    # have specified in `tools/helios_version`
+    if [ "x$FORCE" == "x" ]; then
+        CURRENT_COMMIT=$(git rev-parse HEAD)
+        if [ "x$COMMIT" != "x$CURRENT_COMMIT" ]; then
+            echo "WARNING: omicron/tools/helios_version specifies helios commit"
+            echo "  $COMMIT"
+            echo "but you have"
+            echo "  $CURRENT_COMMIT"
+            echo "Either check out the expected commit or pass -f to this"
+            echo "script to disable this check."
+        fi
+    fi
+
+    # Create the "./helios-build" command, which lets us build images
+    gmake setup
+
+    # Commands that "./helios-build" would ask us to run (either explicitly
+    # or implicitly, to avoid an error).
+    rc=0
+    pfexec pkg install -q /system/zones/brand/omicron1/tools || rc=$?
+    case $rc in
+        # `man pkg` notes that exit code 4 means no changes were made because
+        # there is nothing to do; that's fine. Any other exit code is an error.
+        0 | 4) ;;
+        *) exit $rc ;;
+    esac
+
+    pfexec zfs create -p rpool/images/$USER
+
+    find $tmp_gz
+
+    ./helios-build experiment-image \
+        -p helios-netdev=https://pkg.oxide.computer/helios-netdev \
+        -F optever=0.21 \
+        -P $tmp_gz/root \
+        -R
+}
+
+main "$@"


### PR DESCRIPTION
This creates a new `./tools/build-host-image.sh` script which is extracted from the existing CI jobs to build host and trampoline images; those CI jobs now call this script (after doing some buildomat-specific setup).

Marking this as a draft until it passes in CI to make sure I didn't break anything there.