### PR TITLE
[trivial] remove misleading comment about string sizes in `dbinit.sql`

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -10,11 +10,6 @@
 /*
  * Important CockroachDB notes:
  *
- *    The syntax STRING(63) means a Unicode string with at most 63 code points,
- *    not 63 bytes.  In many cases, Nexus itself will validate a string's
- *    byte count or code points, so it's still reasonable to limit ourselves to
- *    powers of two (or powers-of-two-minus-one) to improve storage utilization.
- *
  *    For timestamps, CockroachDB's docs recommend TIMESTAMPTZ rather than
  *    TIMESTAMP.  This does not change what is stored with each datum, but
  *    rather how it's interpreted when clients use it.  It should make no


### PR DESCRIPTION
I believe sizing strings in powers of 2 byte count is an outdated rule of thumb. We discussed this in [chat](https://matrix.to/#/!YNYPOVxjAUeXksTcRj:oxide.computer/$j1bC36FajKGi1PxsKh6nH27aiP1heh65IcfA26vhAe4?via=oxide.computer&via=unix.house&via=timecube.club) in February and I made a note to remove the comment because it has thrown me off when picking string sizes. The only real size limit tip I see in the CRDB docs is this

> The size of a STRING value is variable, but it's recommended to keep values under 64 kilobytes to ensure performance

plus them recommending you have a limit at all. See https://www.cockroachlabs.com/docs/stable/string.html#size.


