### PR TITLE
Update tests to have V1 references

### DIFF
--- a/docs/debugging-authz.adoc
+++ b/docs/debugging-authz.adoc
@@ -29,7 +29,7 @@ Here's the raw (JSON-formatted) log message:
   "time": "2022-07-07T20:54:08.687405857Z",
   "hostname": "ivanova",
   "pid": 12898,
-  "uri": "/system/hardware/racks",
+  "uri": "/v1/system/hardware/racks",
   "method": "GET",
   "req_id": "58bcb3a5-0381-4e41-8ee6-e34837c4becc",
   "remote_addr": "127.0.0.1:36233",

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -248,11 +248,11 @@ the exact addresses that are available depends on the environment.
     }
     EOF
 
-3. Define a global image that will be used as initial disk contents.
+3. Define a project image that will be used as initial disk contents.
 
  a. This can be the alpine.iso image that ships with propolis:
 
-    oxide api /system/images --method POST --input - <<EOF
+    oxide api /v1/images?organization=<org>&project=<proj> --method POST --input - <<EOF
     {
       "name": "alpine",
       "description": "boot from propolis zone blob!",
@@ -269,7 +269,7 @@ the exact addresses that are available depends on the environment.
 
  b. Or an ISO / raw disk image / etc hosted at a URL:
 
-    oxide api /system/images --method POST --input - <<EOF
+    oxide api /v1/images?organization=<org>&project=<proj> --method POST --input - <<EOF
     {
       "name": "crucible-tester-sparse",
       "description": "boot from a url!",
@@ -287,7 +287,7 @@ the exact addresses that are available depends on the environment.
 
 4. Create a disk from that global image (note that disk size must be greater than or equal to image size and a 1GiB multiple!). The example below creates a disk using the image made from the alpine ISO that ships with propolis, and sets the size to the next 1GiB multiple of the original alpine source:
 
-    oxide api /organizations/myorg/projects/myproj/disks/ --method POST --input - <<EOF
+    oxide api /v1/disks?organization=myorg&project=myproj --method POST --input - <<EOF
     {
       "name": "alpine",
       "description": "alpine.iso blob",
@@ -302,7 +302,7 @@ the exact addresses that are available depends on the environment.
 
 5. Create an instance, attaching the alpine disk created above:
 
-    oxide api /organizations/myorg/projects/myproj/instances --method POST --input - <<EOF
+    oxide api /v1/instances?organization=myorg&project=myproj --method POST --input - <<EOF
     {
       "name": "myinst",
       "description": "my inst",

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -2254,7 +2254,7 @@ mod test {
         .await;
 
         let instances_url = format!(
-            "/organizations/{}/projects/{}/instances",
+            "/v1/instances?organization={}&project={}",
             ORG_NAME, PROJECT_NAME,
         );
         let instance_name = "base-instance";

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -8116,7 +8116,7 @@ struct SystemMetricsPathParam {
 /// Access metrics data
 #[endpoint {
      method = GET,
-     path = "/system/metrics/{metric_name}",
+     path = "/v1/system/metrics/{metric_name}",
      tags = ["system"],
 }]
 async fn system_metric(

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -305,7 +305,7 @@ pub async fn create_disk(
     disk_name: &str,
 ) -> Disk {
     let url = format!(
-        "/organizations/{}/projects/{}/disks",
+        "/v1/disks?organization={}&project={}",
         organization_name, project_name
     );
     object_create(
@@ -332,8 +332,8 @@ pub async fn delete_disk(
     disk_name: &str,
 ) {
     let url = format!(
-        "/organizations/{}/projects/{}/disks/{}",
-        organization_name, project_name, disk_name
+        "/v1/disks/{}?organization={}&project={}",
+        disk_name, organization_name, project_name,
     );
     object_delete(client, &url).await
 }
@@ -404,7 +404,7 @@ pub async fn create_vpc(
     object_create(
         &client,
         format!(
-            "/organizations/{}/projects/{}/vpcs",
+            "/v1/vpcs?organization={}&project={}",
             &organization_name, &project_name
         )
         .as_str(),
@@ -434,7 +434,7 @@ pub async fn create_vpc_with_error(
             client,
             Method::POST,
             format!(
-                "/organizations/{}/projects/{}/vpcs",
+                "/v1/vpcs?organization={}&project={}",
                 &organization_name, &project_name
             )
             .as_str(),
@@ -467,7 +467,7 @@ pub async fn create_router(
     NexusRequest::objects_post(
         &client,
         format!(
-            "/organizations/{}/projects/{}/vpcs/{}/routers",
+            "/v1/vpc-routers?organization={}&project={}&vpc={}",
             &organization_name, &project_name, &vpc_name
         )
         .as_str(),

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -153,7 +153,7 @@ pub async fn create_certificate(
     cert: Vec<u8>,
     key: Vec<u8>,
 ) -> Certificate {
-    let url = "/system/certificates".to_string();
+    let url = "/v1/system/certificates".to_string();
     object_create(
         client,
         &url,
@@ -171,7 +171,7 @@ pub async fn create_certificate(
 }
 
 pub async fn delete_certificate(client: &ClientTestContext, cert_name: &str) {
-    let url = format!("/system/certificates/{}", cert_name);
+    let url = format!("/v1/system/certificates/{}", cert_name);
     object_delete(client, &url).await
 }
 

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -253,7 +253,8 @@ pub async fn create_local_user(
     password: params::UserPassword,
 ) -> User {
     let silo_name = &silo.identity.name;
-    let url = format!("/v1/identity-providers/local/users?silo={}", silo_name);
+    let url =
+        format!("/v1/system/identity-providers/local/users?silo={}", silo_name);
     object_create(
         client,
         &url,

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -253,8 +253,7 @@ pub async fn create_local_user(
     password: params::UserPassword,
 ) -> User {
     let silo_name = &silo.identity.name;
-    let url =
-        format!("/system/silos/{}/identity-providers/local/users", silo_name);
+    let url = format!("/v1/identity-providers/local/users?silo={}", silo_name);
     object_create(
         client,
         &url,

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -67,12 +67,9 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         // appropriate?
         TestCase {
             method: Method::GET,
-            uri: "/organizations/test-org/projects/-invalid-name",
-            // TODO
-            // uri: "/v1/projects/-invalid-name?organization=test-org",
+            uri: "/v1/projects/-invalid-name?organization=test-org",
             expected_code: StatusCode::BAD_REQUEST,
-            expected_error: "bad parameter in URL path: name must begin with \
-            an ASCII lowercase character",
+            expected_error: "bad parameter in URL path: data did not match any variant of untagged enum NameOrId",
             body: None,
         },
         TestCase {
@@ -108,13 +105,9 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         // Error case: fetch an instance with an invalid name
         TestCase {
             method: Method::GET,
-            uri: "/organizations/test-org/projects/nonexistent/instances/my_instance",
-            // TODO
-            // uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
+            uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
             expected_code: StatusCode::BAD_REQUEST,
-            expected_error: "bad parameter in URL path: name contains \
-                invalid character: \"_\" (allowed characters are lowercase \
-                ASCII, digits, and \"-\")",
+            expected_error: "bad parameter in URL path: data did not match any variant of untagged enum NameOrId",
             body: Some("".into()),
         },
         // Error case: delete an instance with an invalid name

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -113,13 +113,9 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         // Error case: delete an instance with an invalid name
         TestCase {
             method: Method::DELETE,
-            uri: "/organizations/test-org/projects/nonexistent/instances/my_instance",
-            // TODO
-            // uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
+            uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
             expected_code: StatusCode::BAD_REQUEST,
-            expected_error: "bad parameter in URL path: name contains \
-                invalid character: \"_\" (allowed characters are lowercase \
-                ASCII, digits, and \"-\")",
+            expected_error: "bad parameter in URL path: data did not match any variant of untagged enum NameOrId",
             body: Some("".into()),
         },
     ];

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -45,7 +45,7 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
     }
 
     let test_cases = vec![
-        // Error case: GET /nonexistent (a path with no route at all)(
+        // Error case: GET /nonexistent (a path with no route at all)
         TestCase {
             method: Method::GET,
             uri: "/nonexistent",
@@ -54,39 +54,37 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
             body: None,
         },
 
-        // Error case: GET /organizations/test-org/projects/nonexistent (a
-        // possible value that does not exist inside a collection that does
-        // exist) from an authorized user results in a 404.
+        // Error case: a possible value that does not exist inside a collection
+        // that does exist) from an authorized user results in a 404.
         TestCase {
             method: Method::GET,
-            uri: "/organizations/test-org/projects/nonexistent",
+            uri: "/v1/projects/nonexistent?organization=test-org",
             expected_code: StatusCode::NOT_FOUND,
             expected_error: "not found: project with name \"nonexistent\"",
             body: None,
         },
-        // Error case: GET /organizations/test-org/projects/-invalid-name
         // TODO-correctness is 400 the right error code here or is 404 more
         // appropriate?
         TestCase {
             method: Method::GET,
             uri: "/organizations/test-org/projects/-invalid-name",
+            // TODO
+            // uri: "/v1/projects/-invalid-name?organization=test-org",
             expected_code: StatusCode::BAD_REQUEST,
             expected_error: "bad parameter in URL path: name must begin with \
             an ASCII lowercase character",
             body: None,
         },
-        // Error case: PUT /organizations/test-org/projects
         TestCase {
             method: Method::PUT,
-            uri: "/organizations/test-org/projects",
+            uri: "/v1/projects?organization=test-org",
             expected_code: StatusCode::METHOD_NOT_ALLOWED,
             expected_error: "Method Not Allowed",
             body: None,
         },
-        // Error case: DELETE /organizations/test-org/projects
         TestCase {
             method: Method::DELETE,
-            uri: "/organizations/test-org/projects",
+            uri: "/v1/projects?organization=test-org",
             expected_code: StatusCode::METHOD_NOT_ALLOWED,
             expected_error: "Method Not Allowed",
             body: None,
@@ -94,7 +92,7 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         // Error case: list instances in a nonexistent project
         TestCase {
             method: Method::GET,
-            uri: "/organizations/test-org/projects/nonexistent/instances",
+            uri: "/v1/instances?organization=test-org&project=nonexistent",
             expected_code: StatusCode::NOT_FOUND,
             expected_error: "not found: project with name \"nonexistent\"",
             body: Some("".into()),
@@ -102,7 +100,7 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         // Error case: fetch an instance in a nonexistent project
         TestCase {
             method: Method::GET,
-            uri: "/organizations/test-org/projects/nonexistent/instances/my-instance",
+            uri: "/v1/instances/my-instance?organization=test-org&project=nonexistent",
             expected_code: StatusCode::NOT_FOUND,
             expected_error: "not found: project with name \"nonexistent\"",
             body: Some("".into()),
@@ -111,6 +109,8 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         TestCase {
             method: Method::GET,
             uri: "/organizations/test-org/projects/nonexistent/instances/my_instance",
+            // TODO
+            // uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
             expected_code: StatusCode::BAD_REQUEST,
             expected_error: "bad parameter in URL path: name contains \
                 invalid character: \"_\" (allowed characters are lowercase \
@@ -121,6 +121,8 @@ async fn test_basic_failures(cptestctx: &ControlPlaneTestContext) {
         TestCase {
             method: Method::DELETE,
             uri: "/organizations/test-org/projects/nonexistent/instances/my_instance",
+            // TODO
+            // uri: "/v1/instances/my_instance?organization=test-org&project=nonexistent",
             expected_code: StatusCode::BAD_REQUEST,
             expected_error: "bad parameter in URL path: name contains \
                 invalid character: \"_\" (allowed characters are lowercase \
@@ -160,7 +162,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
 
     let org_name = "test-org";
     create_organization(&client, &org_name).await;
-    let projects_url = "/organizations/test-org/projects";
+    let projects_url = "/v1/projects?organization=test-org";
 
     // Verify that there are no projects to begin with.
     let projects = projects_list(&client, &projects_url).await;
@@ -200,18 +202,18 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         project_ids
     };
 
-    // Error case: GET /organizations/test-org/projects/simproject1/nonexistent
-    // (a path that does not exist beneath a resource that does exist)
+    // Error case: GET a path that does not exist beneath a resource that does
+    // exist
     let error = client
         .make_request_error(
             Method::GET,
-            "/organizations/test-org/projects/simproject1/nonexistent",
+            "/v1/projects/nonexistent/nonexistent",
             StatusCode::NOT_FOUND,
         )
         .await;
     assert_eq!("Not Found", error.message);
 
-    // Basic GET /organizations/test-org/projects now that we've created a few.
+    // Basic GET projects list now that we've created a few.
     // TODO-coverage: pagination
     // TODO-coverage: marker even without pagination
     let initial_projects = projects_list(&client, &projects_url).await;
@@ -226,10 +228,9 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(initial_projects[2].identity.name, "simproject3");
     assert!(initial_projects[2].identity.description.len() > 0);
 
-    // Basic test of out-of-the-box GET
-    // /organizations/test-org/projects/simproject2
+    // Basic test of out-of-the-box GET project
     let project =
-        project_get(&client, "/organizations/test-org/projects/simproject2")
+        project_get(&client, "/v1/projects/simproject2?organization=test-org")
             .await;
     let expected = &initial_projects[1];
     assert_eq!(project.identity.id, expected.identity.id);
@@ -242,7 +243,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     // - The default VPC
     NexusRequest::object_delete(
         client,
-        "/organizations/test-org/projects/simproject2/vpcs/default/subnets/default",
+        "/v1/vpc-subnets/default?organization=test-org&project=simproject2&vpc=default",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -250,7 +251,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
     NexusRequest::object_delete(
         client,
-        "/organizations/test-org/projects/simproject2/vpcs/default",
+        "/v1/vpcs/default?organization=test-org&project=simproject2",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -258,7 +259,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
     NexusRequest::object_delete(
         client,
-        "/organizations/test-org/projects/simproject2",
+        "/v1/projects/simproject2?organization=test-org",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -266,13 +267,13 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
 
     // Having deleted "simproject2", verify "GET", "PUT", and "DELETE" on
-    // "/organizations/test-org/projects/simproject2".
+    // it all 404
     for method in [Method::GET, Method::DELETE] {
         NexusRequest::expect_failure(
             client,
             StatusCode::NOT_FOUND,
             method,
-            "/organizations/test-org/projects/simproject2",
+            "/v1/projects/simproject2?organization=test-org",
         )
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
@@ -283,7 +284,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::PUT,
-            "/organizations/test-org/projects/simproject2",
+            "/v1/projects/simproject2?organization=test-org",
         )
         .body(Some(&params::ProjectUpdate {
             identity: IdentityMetadataUpdateParams {
@@ -298,13 +299,13 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     .await
     .expect("failed to make request");
 
-    // Similarly, verify "GET /organizations/test-org/projects"
+    // Similarly, verify GET projects list
     let expected_projects: Vec<&Project> = initial_projects
         .iter()
         .filter(|p| p.identity.name != "simproject2")
         .collect();
     let new_projects =
-        projects_list(&client, "/organizations/test-org/projects").await;
+        projects_list(&client, "/v1/projects?organization=test-org").await;
     assert_eq!(new_projects.len(), expected_projects.len());
     assert_eq!(new_projects[0].identity.id, expected_projects[0].identity.id);
     assert_eq!(
@@ -335,7 +336,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     };
     let project = NexusRequest::object_put(
         client,
-        "/organizations/test-org/projects/simproject3",
+        "/v1/projects/simproject3?organization=test-org",
         Some(&project_update),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -350,7 +351,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
 
     let expected = project;
     let project =
-        project_get(&client, "/organizations/test-org/projects/simproject3")
+        project_get(&client, "/v1/projects/simproject3?organization=test-org")
             .await;
     assert_eq!(project.identity.name, expected.identity.name);
     assert_eq!(project.identity.description, expected.identity.description);
@@ -367,7 +368,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     };
     let project = NexusRequest::object_put(
         client,
-        "/organizations/test-org/projects/simproject3",
+        "/v1/projects/simproject3?organization=test-org",
         Some(&project_update),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -384,7 +385,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         client,
         StatusCode::NOT_FOUND,
         Method::GET,
-        "/organizations/test-org/projects/simproject3",
+        "/v1/projects/simproject3?organization=test-org",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -480,7 +481,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
     create_organization(&client, &org_name).await;
 
     // Verify that there are no projects to begin with.
-    let projects_url = "/organizations/test-org/projects";
+    let projects_url = "/v1/projects?organization=test-org";
     assert_eq!(projects_list(&client, &projects_url).await.len(), 0);
 
     // Create a large number of projects that we can page through.

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -158,7 +158,7 @@ fn tls_cert_to_pem(certs: &Vec<rustls::Certificate>) -> Vec<u8> {
     serialized_certs
 }
 
-const CERTS_URL: &str = "/system/certificates";
+const CERTS_URL: &str = "/v1/system/certificates";
 const CERT_NAME: &str = "my-certificate";
 const CERT_NAME2: &str = "my-other-certificate";
 

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -116,7 +116,7 @@ fn test_nexus_openapi() {
 
     // Spot check a couple of items.
     assert!(!spec.paths.paths.is_empty());
-    assert!(spec.paths.paths.get("/organizations").is_some());
+    assert!(spec.paths.paths.get("/v1/organizations").is_some());
 
     // Check for lint errors.
     let errors = openapi_lint::validate(&spec);

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -70,7 +70,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
     // without other privileges.  However, they _do_ need the privilege to
     // create Organizations because we'll be testing that as a smoke test.
     // We'll remove that privilege afterwards.
-    let silo_url = format!("/system/silos/{}", DEFAULT_SILO.identity().name);
+    let silo_url = format!("/v1/system/silos/{}", DEFAULT_SILO.identity().name);
     let policy_url = format!("{}/policy", silo_url);
     let initial_policy: shared::Policy<SiloRole> =
         NexusRequest::object_get(testctx, &policy_url)

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -52,7 +52,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
     };
 
     // hitting auth-gated API endpoint without session cookie 401s
-    RequestBuilder::new(&testctx, Method::POST, "/organizations")
+    RequestBuilder::new(&testctx, Method::POST, "/v1/organizations")
         .body(Some(&org_params))
         .expect_status(Some(StatusCode::UNAUTHORIZED))
         .execute()
@@ -90,7 +90,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
     .await;
 
     // now make same requests with cookie
-    RequestBuilder::new(&testctx, Method::POST, "/organizations")
+    RequestBuilder::new(&testctx, Method::POST, "/v1/organizations")
         .header(header::COOKIE, &session_token)
         .body(Some(&org_params))
         // TODO: explicit expect_status not needed. decide whether to keep it anyway
@@ -127,7 +127,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
 
     // now the same requests with the same session cookie should 401/302 because
     // logout also deletes the session server-side
-    RequestBuilder::new(&testctx, Method::POST, "/organizations")
+    RequestBuilder::new(&testctx, Method::POST, "/v1/organizations")
         .header(header::COOKIE, &session_token)
         .body(Some(&org_params))
         .expect_status(Some(StatusCode::UNAUTHORIZED))

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -1414,7 +1414,7 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
     // Check the utilization info for the whole project too.
     let utilization_url = |id: Uuid| {
         format!(
-            "/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={:?}",
+            "/v1/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={:?}",
             Utc::now() - chrono::Duration::seconds(10),
             Utc::now() + chrono::Duration::seconds(10),
             id,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -593,7 +593,7 @@ impl AllowedMethod {
 
 lazy_static! {
     pub static ref URL_USERS_DB_INIT: String =
-        format!("/v1/system/user/{}", authn::USER_DB_INIT.name);
+        format!("/system/user/{}", authn::USER_DB_INIT.name);
 
     /// List of endpoints to be verified
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
@@ -1385,7 +1385,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: "/v1/system/user",
+            url: "/system/user",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -442,7 +442,7 @@ lazy_static! {
 
     pub static ref DEMO_SYSTEM_METRICS_URL: String =
         format!(
-            "/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={}",
+            "/v1/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={}",
             Utc::now(),
             Utc::now(),
             "3aaf22ae-5691-4f6d-b62c-aa532512fa78",
@@ -593,7 +593,7 @@ impl AllowedMethod {
 
 lazy_static! {
     pub static ref URL_USERS_DB_INIT: String =
-        format!("/system/user/{}", authn::USER_DB_INIT.name);
+        format!("/v1/system/user/{}", authn::USER_DB_INIT.name);
 
     /// List of endpoints to be verified
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
@@ -1385,7 +1385,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: "/system/user",
+            url: "/v1/system/user",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -473,7 +473,7 @@ pub struct VerifyEndpoint {
     /// Specifies whether an HTTP resource handled by this endpoint is visible
     /// to unauthenticated or unauthorized users
     ///
-    /// If it's [`Visibility::Public`] (like "/organizations"), unauthorized
+    /// If it's [`Visibility::Public`] (like "/v1/organizations"), unauthorized
     /// users can expect to get back a 401 or 403 when they attempt to access
     /// it.  If it's [`Visibility::Protected`] (like a specific Organization),
     /// unauthorized users will get a 404.
@@ -513,7 +513,7 @@ pub enum Visibility {
     /// All users can see the resource (including unauthenticated or
     /// unauthorized users)
     ///
-    /// "/organizations" is Public, for example.
+    /// "/v1/organizations" is Public, for example.
     Public,
 
     /// Only users with certain privileges can see this endpoint

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3087,7 +3087,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
     // Create test organization and projects.
     NexusRequest::objects_post(
         client,
-        "/organizations",
+        "/v1/organizations",
         &params::OrganizationCreate {
             identity: IdentityMetadataCreateParams {
                 name: ORGANIZATION_NAME.parse().unwrap(),

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3074,7 +3074,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
     .id;
     grant_iam(
         client,
-        "/system/silos/authz",
+        "/v1/system/silos/authz",
         SiloRole::Collaborator,
         user_id,
         AuthnMode::PrivilegedUser,

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1266,7 +1266,7 @@ async fn test_instance_create_delete_network_interface(
 
     // Verify there are no interfaces
     let url_interfaces = format!(
-        "/organizations/{}/projects/{}/instances/{}/network-interfaces",
+        "/v1/network-interfaces?organization={}&project={}&instance={}",
         ORGANIZATION_NAME, PROJECT_NAME, instance.identity.name,
     );
     let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
@@ -1506,7 +1506,7 @@ async fn test_instance_update_network_interfaces(
             .expect("Failed to create instance with two network interfaces");
     let instance = response.parsed_body::<Instance>().unwrap();
     let url_interfaces = format!(
-        "/organizations/{}/projects/{}/instances/{}/network-interfaces",
+        "/v1/network-interfaces?organization={}&project={}&instance={}",
         ORGANIZATION_NAME, PROJECT_NAME, instance.identity.name,
     );
 

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -534,7 +534,7 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     let organization_id =
         create_organization(&client, ORGANIZATION_NAME).await.identity.id;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     let project_id = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME)
@@ -709,7 +709,7 @@ async fn test_instances_create_stopped_start(
 
     create_org_and_project(&client).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -819,7 +819,7 @@ async fn test_instances_invalid_creation_returns_bad_request(
 
     let client = &cptestctx.external_client;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -878,7 +878,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
     // Create test IP pool, organization and project
     create_org_and_project(&client).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -988,7 +988,7 @@ async fn test_instance_with_single_explicit_ip_address(
 
     create_org_and_project(&client).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -1061,7 +1061,7 @@ async fn test_instance_with_new_custom_network_interfaces(
 
     create_org_and_project(&client).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -1217,7 +1217,7 @@ async fn test_instance_create_delete_network_interface(
 
     create_org_and_project(&client).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -1851,7 +1851,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
     // Create a project that we'll use for testing.
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
@@ -2068,7 +2068,7 @@ async fn test_instance_fails_to_boot_with_disk(
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2153,7 +2153,7 @@ async fn test_instance_create_attach_disks(
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2274,7 +2274,7 @@ async fn test_instance_create_attach_disks_undo(
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2372,7 +2372,7 @@ async fn test_attach_eight_disks_to_instance(
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2478,7 +2478,7 @@ async fn test_cannot_attach_nine_disks_to_instance(
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2600,7 +2600,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
     };
 
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
 
@@ -2981,7 +2981,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     // Create test organization and projects.
     create_organization(&client, ORGANIZATION_NAME).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     let _ = create_project(&client, ORGANIZATION_NAME, PROJECT_NAME).await;
@@ -3137,7 +3137,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         start: true,
     };
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         ORGANIZATION_NAME, PROJECT_NAME
     );
     NexusRequest::objects_post(client, &url_instances, &instance_params)

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -555,7 +555,7 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     // Query the view of these metrics stored within Clickhouse
     let metric_url = |metric_type: &str, id: Uuid| {
         format!(
-            "/system/metrics/{metric_type}?start_time={:?}&end_time={:?}&id={id}",
+            "/v1/system/metrics/{metric_type}?start_time={:?}&end_time={:?}&id={id}",
             Utc::now() - chrono::Duration::seconds(30),
             Utc::now() + chrono::Duration::seconds(30),
         )

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -619,8 +619,8 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
 
     // Stop the instance, wait until it is in fact stopped.
     let instance_url = format!(
-        "/organizations/{}/projects/{}/instances/{}",
-        ORG_NAME, PROJECT_NAME, INSTANCE_NAME,
+        "/v1/instances/{}?organization={}&project={}",
+        INSTANCE_NAME, ORG_NAME, PROJECT_NAME,
     );
     let instance_stop_url = format!("{}/stop", instance_url);
     NexusRequest::new(

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -622,7 +622,10 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
         "/v1/instances/{}?organization={}&project={}",
         INSTANCE_NAME, ORG_NAME, PROJECT_NAME,
     );
-    let instance_stop_url = format!("{}/stop", instance_url);
+    let instance_stop_url = format!(
+        "/v1/instances/{}/stop?organization={}&project={}",
+        INSTANCE_NAME, ORG_NAME, PROJECT_NAME,
+    );
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &instance_stop_url)
             .body(None as Option<&serde_json::Value>)

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -45,7 +45,7 @@ async fn test_local_users(cptestctx: &ControlPlaneTestContext) {
     test_local_user_with_no_initial_password(client, &silo).await;
     NexusRequest::object_delete(
         client,
-        &format!("/system/silos/{}", silo_name),
+        &format!("/v1/system/silos/{}", silo_name),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -105,7 +105,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     let test_password2 =
         params::Password::from_str("as was the style at the time").unwrap();
     let user_password_url = format!(
-        "/system/silos/{}/identity-providers/local/users/{}/set-password",
+        "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
         silo_name, created_user.id
     );
     NexusRequest::new(
@@ -170,11 +170,11 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     )
     .await;
     let admin_password_url = format!(
-        "/system/silos/{}/identity-providers/local/users/{}/set-password",
+        "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
         silo_name, admin_user_obj.id
     );
 
-    let silo_url = format!("/system/silos/{}", silo_name);
+    let silo_url = format!("/v1/system/silos/{}", silo_name);
     grant_iam(
         client,
         &silo_url,
@@ -328,7 +328,7 @@ async fn test_local_user_with_no_initial_password(
     // Now, set a password.
     let test_password2 = params::Password::from_str("joshua").unwrap();
     let user_password_url = format!(
-        "/system/silos/{}/identity-providers/local/users/{}/set-password",
+        "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
         silo_name, created_user.id
     );
     NexusRequest::new(

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -329,7 +329,7 @@ async fn test_local_user_with_no_initial_password(
     let test_password2 = params::Password::from_str("joshua").unwrap();
     let user_password_url = format!(
         "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
-        silo_name, created_user.id
+        created_user.id, silo_name,
     );
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -106,7 +106,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         params::Password::from_str("as was the style at the time").unwrap();
     let user_password_url = format!(
         "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
-        silo_name, created_user.id
+        created_user.id, silo_name
     );
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -171,7 +171,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     .await;
     let admin_password_url = format!(
         "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
-        silo_name, admin_user_obj.id
+        admin_user_obj.id, silo_name
     );
 
     let silo_url = format!("/v1/system/silos/{}", silo_name);

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -49,10 +49,9 @@ async fn test_projects(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(project.identity.name, p2_name);
 
     // Verify the list of Projects.
-    let projects_url = format!("/organizations/{}/projects", org_name);
     let projects = NexusRequest::iter_collection_authn::<Project>(
         &client,
-        &projects_url,
+        &format!("/v1/projects?organization={}", org_name),
         "",
         None,
     )
@@ -86,19 +85,30 @@ async fn test_projects(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(projects[0].identity.name, p1_name);
 }
 
-async fn delete_project_default_subnet(url: &str, client: &ClientTestContext) {
-    NexusRequest::object_delete(
-        &client,
-        &format!("{url}/vpcs/default/subnets/default"),
-    )
-    .authn_as(AuthnMode::PrivilegedUser)
-    .execute()
-    .await
-    .expect("failed to make request");
+async fn delete_project_default_subnet(
+    org: &str,
+    project: &str,
+    client: &ClientTestContext,
+) {
+    let subnet_url = format!(
+        "/v1/vpc-subnets/default?organization={}&project={}&vpc=default",
+        org, project
+    );
+    NexusRequest::object_delete(&client, &subnet_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to make request");
 }
 
-async fn delete_project_default_vpc(url: &str, client: &ClientTestContext) {
-    NexusRequest::object_delete(&client, &format!("{url}/vpcs/default"))
+async fn delete_project_default_vpc(
+    org: &str,
+    project: &str,
+    client: &ClientTestContext,
+) {
+    let vpc_url =
+        format!("/v1/vpcs/default?organization={}&project={}", org, project);
+    NexusRequest::object_delete(&client, &vpc_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -141,7 +151,7 @@ async fn test_project_deletion(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let url = format!("/v1/projects/{}?organization={}", name, org_name);
 
     // Project deletion will fail while the subnet & VPC remain.
     create_project(&client, &org_name, &name).await;
@@ -149,12 +159,12 @@ async fn test_project_deletion(cptestctx: &ControlPlaneTestContext) {
         "project to be deleted contains a vpc: default",
         delete_project_expect_fail(&url, &client).await,
     );
-    delete_project_default_subnet(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
     assert_eq!(
         "project to be deleted contains a vpc: default",
         delete_project_expect_fail(&url, &client).await,
     );
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
     delete_project(&url, &client).await;
 }
 
@@ -170,15 +180,15 @@ async fn test_project_deletion_with_instance(
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let url = format!("/v1/projects/{}?organization={}", name, org_name);
 
     create_project(&client, &org_name, &name).await;
-    delete_project_default_subnet(&url, &client).await;
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
 
     let _: Instance = object_create(
         client,
-        &format!("{url}/instances"),
+        &format!("/v1/instances?organization={}&project={}", org_name, name),
         &params::InstanceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "my-instance".parse().unwrap(),
@@ -204,7 +214,10 @@ async fn test_project_deletion_with_instance(
 
     NexusRequest::object_delete(
         client,
-        &format!("{url}/instances/my-instance"),
+        &format!(
+            "/v1/instances/my-instance?organization={}&project={}",
+            org_name, name
+        ),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -224,17 +237,19 @@ async fn test_project_deletion_with_disk(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let url = format!("/v1/projects/{}?organization={}", name, org_name);
 
     create_project(&client, &org_name, &name).await;
-    delete_project_default_subnet(&url, &client).await;
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
     create_disk(&client, &org_name, &name, "my-disk").await;
     assert_eq!(
         "project to be deleted contains a disk: my-disk",
         delete_project_expect_fail(&url, &client).await,
     );
-    NexusRequest::object_delete(&client, &format!("{url}/disks/my-disk"))
+    let disk_url =
+        format!("/v1/disks/my-disk?organization={}&project={}", org_name, name);
+    NexusRequest::object_delete(&client, &disk_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -252,11 +267,11 @@ async fn test_project_deletion_with_image(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let url = format!("/v1/projects/{}?organization={}", name, org_name);
 
     create_project(&client, &org_name, &name).await;
-    delete_project_default_subnet(&url, &client).await;
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
 
     let image_create_params = params::ImageCreate {
         identity: IdentityMetadataCreateParams {
@@ -325,16 +340,17 @@ async fn test_project_deletion_with_snapshot(
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let project_url =
+        format!("/v1/projects/{}?organization={}", name, org_name);
 
     create_project(&client, &org_name, &name).await;
-    delete_project_default_subnet(&url, &client).await;
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
     create_disk(&client, &org_name, &name, "my-disk").await;
 
     let _: views::Snapshot = object_create(
         client,
-        &format!("{url}/snapshots"),
+        &format!("/v1/snapshots?organization={}&project={}", org_name, name),
         &params::SnapshotCreate {
             identity: IdentityMetadataCreateParams {
                 name: "my-snapshot".parse().unwrap(),
@@ -345,7 +361,9 @@ async fn test_project_deletion_with_snapshot(
     )
     .await;
 
-    NexusRequest::object_delete(&client, &format!("{url}/disks/my-disk"))
+    let disk_url =
+        format!("/v1/disks/my-disk?organization={}&project={}", org_name, name);
+    NexusRequest::object_delete(&client, &disk_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -353,23 +371,23 @@ async fn test_project_deletion_with_snapshot(
 
     assert_eq!(
         "project to be deleted contains a snapshot: my-snapshot",
-        delete_project_expect_fail(&url, &client).await,
+        delete_project_expect_fail(&project_url, &client).await,
     );
 
+    let snapshot_url = format!(
+        "/v1/snapshots/my-snapshot?organization={}&project={}",
+        org_name, name
+    );
     NexusRequest::new(
-        RequestBuilder::new(
-            client,
-            Method::DELETE,
-            &format!("{url}/snapshots/my-snapshot"),
-        )
-        .expect_status(Some(StatusCode::NO_CONTENT)),
+        RequestBuilder::new(client, Method::DELETE, &snapshot_url)
+            .expect_status(Some(StatusCode::NO_CONTENT)),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
     .await
     .unwrap();
 
-    delete_project(&url, &client).await;
+    delete_project(&project_url, &client).await;
 }
 
 #[nexus_test]
@@ -381,22 +399,29 @@ async fn test_project_deletion_with_vpc(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let name = "springfield-squidport";
-    let url = format!("/organizations/{}/projects/{}", org_name, name);
+    let project_url =
+        format!("/v1/projects/{}?organization={}", name, org_name);
 
     create_project(&client, &org_name, &name).await;
-    delete_project_default_subnet(&url, &client).await;
-    delete_project_default_vpc(&url, &client).await;
+    delete_project_default_subnet(&org_name, &name, &client).await;
+    delete_project_default_vpc(&org_name, &name, &client).await;
 
     let vpc_name = "just-rainsticks";
     create_vpc(&client, org_name, name, vpc_name).await;
 
     assert_eq!(
         "project to be deleted contains a vpc: just-rainsticks",
-        delete_project_expect_fail(&url, &client).await,
+        delete_project_expect_fail(&project_url, &client).await,
     );
 
-    let vpc_url = format!("{url}/vpcs/{vpc_name}");
-    let default_subnet_url = format!("{vpc_url}/subnets/default");
+    let vpc_url = format!(
+        "/v1/vpcs/{vpc_name}?organization={}&project={}",
+        org_name, name
+    );
+    let default_subnet_url = format!(
+        "/v1/vpc-subnets/default?organization={}&project={}&vpc={}",
+        org_name, name, vpc_name
+    );
     NexusRequest::object_delete(client, &default_subnet_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
@@ -407,5 +432,5 @@ async fn test_project_deletion_with_vpc(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .unwrap();
-    delete_project(&url, &client).await;
+    delete_project(&project_url, &client).await;
 }

--- a/nexus/tests/integration_tests/rack.rs
+++ b/nexus/tests/integration_tests/rack.rs
@@ -15,7 +15,7 @@ type ControlPlaneTestContext =
 async fn test_list_own_rack(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    let racks_url = "/system/hardware/racks";
+    let racks_url = "/v1/system/hardware/racks";
     let racks: Vec<Rack> =
         NexusRequest::iter_collection_authn(client, racks_url, "", None)
             .await
@@ -31,7 +31,7 @@ async fn test_get_own_rack(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     let expected_id = cptestctx.server.apictx().nexus.rack_id();
-    let rack_url = format!("/system/hardware/racks/{}", expected_id);
+    let rack_url = format!("/v1/system/hardware/racks/{}", expected_id);
     let rack = NexusRequest::object_get(client, &rack_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -110,7 +110,7 @@ async fn test_role_assignments_fleet(cptestctx: &ControlPlaneTestContext) {
         const ROLE: Self::RoleType = authz::FleetRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
-            String::from("/system/policy")
+            String::from("/v1/system/policy")
         }
 
         fn verify_initial<'a, 'b, 'c, 'd>(

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -231,7 +231,7 @@ async fn test_role_assignments_silo_implicit(
         const ROLE: Self::RoleType = authz::SiloRole::Admin;
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
-            "/policy".to_string()
+            "/v1/policy".to_string()
         }
 
         fn verify_initial<'a, 'b, 'c, 'd>(

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -280,7 +280,7 @@ async fn test_role_assignments_organization(
     let client = &cptestctx.external_client;
     let org_name = "test-org";
     create_organization(client, org_name).await;
-    let org_url = format!("/organizations/{}", org_name);
+    let org_url = format!("/v1/organizations/{}", org_name);
 
     struct OrganizationRoleAssignmentTest {
         org_name: String,

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -342,7 +342,7 @@ async fn test_role_assignments_project(cptestctx: &ControlPlaneTestContext) {
     create_organization(client, org_name).await;
     create_project(client, org_name, project_name).await;
     let project_url =
-        format!("/organizations/{}/projects/{}", org_name, project_name);
+        format!("/v1/projects/{}?organization={}", project_name, org_name);
 
     struct ProjectRoleAssignmentTest {
         project_name: String,
@@ -352,7 +352,10 @@ async fn test_role_assignments_project(cptestctx: &ControlPlaneTestContext) {
     let test_case = ProjectRoleAssignmentTest {
         project_name: String::from(project_name),
         project_url: project_url.clone(),
-        policy_url: format!("{}/policy", project_url),
+        policy_url: format!(
+            "/v1/projects/{}/policy?organization={}",
+            project_name, org_name
+        ),
     };
     impl RoleAssignmentTest for ProjectRoleAssignmentTest {
         type RoleType = authz::ProjectRole;

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -176,7 +176,7 @@ async fn test_role_assignments_silo(cptestctx: &ControlPlaneTestContext) {
         const VISIBLE_TO_UNPRIVILEGED: bool = true;
         fn policy_url(&self) -> String {
             format!(
-                "/system/silos/{}/policy",
+                "/v1/system/silos/{}/policy",
                 fixed_data::silo::DEFAULT_SILO.identity().name
             )
         }

--- a/nexus/tests/integration_tests/router_routes.rs
+++ b/nexus/tests/integration_tests/router_routes.rs
@@ -35,15 +35,15 @@ async fn test_router_routes(cptestctx: &ControlPlaneTestContext) {
 
     let get_routes_url = |router_name: &str| -> String {
         format!(
-            "/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+            "/v1/vpc-router-routes?organization={}&project={}&vpc={}&router={}",
             organization_name, project_name, vpc_name, router_name
         )
     };
 
     let get_route_url = |router_name: &str, route_name: &str| -> String {
         format!(
-            "/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-            organization_name, project_name, vpc_name, router_name, route_name
+            "/v1/vpc-router-routes/{}?organization={}&project={}&vpc={}&router={}",
+            route_name, organization_name, project_name, vpc_name, router_name
         )
     };
 

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -175,7 +175,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_truncated(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+            &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -246,7 +246,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_no_redirect_binding(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+            &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -368,7 +368,7 @@ async fn test_saml_idp_metadata_url_404(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+            &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -416,7 +416,7 @@ async fn test_saml_idp_metadata_url_invalid(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+            &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -517,7 +517,10 @@ async fn test_saml_idp_reject_keypair(cptestctx: &ControlPlaneTestContext) {
             RequestBuilder::new(
                 client,
                 Method::POST,
-                &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+                &format!(
+                    "/v1/system/identity-providers/saml?silo={}",
+                    SILO_NAME
+                ),
             )
             .body(Some(&params::SamlIdentityProviderCreate {
                 identity: IdentityMetadataCreateParams {
@@ -574,7 +577,7 @@ async fn test_saml_idp_rsa_keypair_ok(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+            &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -951,7 +954,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+        &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -1085,7 +1088,7 @@ async fn test_post_saml_response_with_relay_state(
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+        &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -197,7 +197,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     .expect("failed to make request");
 
     // Delete organization
-    NexusRequest::object_delete(&client, &"/organizations/someorg")
+    NexusRequest::object_delete(&client, &"/v1/organizations/someorg")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -1559,10 +1559,6 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     let mut output = String::new();
     for test_silo in [test_silo1, test_silo2] {
         let silo_name = &test_silo.silo.identity().name;
-        let silo_users_url = &format!(
-            "/v1/system/users?silo={}",
-            test_silo.silo.identity().name
-        );
 
         write!(&mut output, "SILO: {}\n", silo_name).unwrap();
 
@@ -1582,7 +1578,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
             let test_response = NexusRequest::new(RequestBuilder::new(
                 client,
                 Method::GET,
-                &format!("{}/all", silo_users_url),
+                &format!("/v1/system/users?silo={}", silo_name),
             ))
             .authn_as(calling_user.clone())
             .execute()
@@ -1616,7 +1612,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
                 let test_response = NexusRequest::new(RequestBuilder::new(
                     client,
                     Method::GET,
-                    &format!("{}/id/{}", silo_users_url, user_id),
+                    &format!("/v1/system/users/{}?silo={}", user_id, silo_name),
                 ))
                 .authn_as(calling_user.clone())
                 .execute()
@@ -1964,10 +1960,9 @@ async fn run_user_tests(
     authn_mode: &AuthnMode,
     existing_users: &[views::User],
 ) {
-    let url_all_users =
-        format!("/v1/system/users/all?silo={}", silo.identity.name);
+    let url_all_users = format!("/v1/system/users?silo={}", silo.identity.name);
     let url_local_idp_users = format!(
-        "/system/identity-providers/local/users?silo={}",
+        "/v1/system/identity-providers/local/users?silo={}",
         silo.identity.name
     );
     let url_user_create = url_local_idp_users.to_string();
@@ -2005,7 +2000,7 @@ async fn run_user_tests(
 
     // Fetch the user we just created.
     let user_url_get = format!(
-        "/v1/system/users/id/{}?silo={}",
+        "/v1/system/users/{}?silo={}",
         user_created.id, silo.identity.name,
     );
     let user_found = NexusRequest::object_get(client, &user_url_get)
@@ -2035,7 +2030,7 @@ async fn run_user_tests(
 
     // Delete the user that we created.
     let user_url_delete = format!(
-        "/system/identity-providers/local/users/{}?silo={}",
+        "/v1/system/identity-providers/local/users/{}?silo={}",
         user_created.id, silo.identity.name,
     );
     NexusRequest::object_delete(client, &user_url_delete)

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -130,7 +130,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     // that's possible.
     let new_org_in_our_silo = NexusRequest::objects_post(
         client,
-        "/organizations",
+        "/v1/organizations",
         &params::OrganizationCreate {
             identity: IdentityMetadataCreateParams {
                 name: org_name.clone(),
@@ -155,7 +155,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     // Delete it so that we can delete the Silo later.
     NexusRequest::object_delete(
         client,
-        &format!("/organizations/{}", org_name),
+        &format!("/v1/organizations/{}", org_name),
     )
     .authn_as(AuthnMode::SiloUser(new_silo_user_id))
     .execute()
@@ -164,7 +164,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
 
     // Verify GET /organizations works with built-in user auth
     let organizations =
-        objects_list_page_authz::<Organization>(client, "/organizations")
+        objects_list_page_authz::<Organization>(client, "/v1/organizations")
             .await
             .items;
     assert_eq!(organizations.len(), 1);
@@ -176,7 +176,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     // different silo.
     let organizations =
         objects_list_page_authz_with_session::<Organization>(
-            client, "/organizations", &session,
+            client, "/v1/organizations", &session,
         )
         .await
         .items;
@@ -289,7 +289,7 @@ async fn test_silo_admin_group(cptestctx: &ControlPlaneTestContext) {
     // Create an organization
     let _org = NexusRequest::objects_post(
         client,
-        "/organizations",
+        "/v1/organizations",
         &params::OrganizationCreate {
             identity: IdentityMetadataCreateParams {
                 name: "myorg".parse().unwrap(),

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -55,9 +55,9 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     create_silo(&client, "hidden", false, shared::SiloIdentityMode::LocalOnly)
         .await;
 
-    // Verify GET /system/silos/{silo} works for both discoverable and not
-    let discoverable_url = "/system/silos/discoverable";
-    let hidden_url = "/system/silos/hidden";
+    // Verify GET /v1/system/silos/{silo} works for both discoverable and not
+    let discoverable_url = "/v1/system/silos/discoverable";
+    let hidden_url = "/v1/system/silos/hidden";
 
     let silo: Silo = NexusRequest::object_get(&client, &discoverable_url)
         .authn_as(AuthnMode::PrivilegedUser)
@@ -82,16 +82,16 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         &client,
         StatusCode::NOT_FOUND,
         Method::GET,
-        &"/system/silos/testpost",
+        &"/v1/system/silos/testpost",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
     .await
     .expect("failed to make request");
 
-    // Verify GET /system/silos only returns discoverable silos
+    // Verify GET /v1/system/silos only returns discoverable silos
     let silos =
-        objects_list_page_authz::<Silo>(client, "/system/silos").await.items;
+        objects_list_page_authz::<Silo>(client, "/v1/system/silos").await.items;
     assert_eq!(silos.len(), 1);
     assert_eq!(silos[0].identity.name, "discoverable");
 
@@ -108,7 +108,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     // Grant the user "admin" privileges on that Silo.
     grant_iam(
         client,
-        "/system/silos/discoverable",
+        "/v1/system/silos/discoverable",
         SiloRole::Admin,
         new_silo_user_id,
         AuthnMode::PrivilegedUser,
@@ -189,7 +189,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         &client,
         StatusCode::BAD_REQUEST,
         Method::DELETE,
-        &"/system/silos/default-silo",
+        &"/v1/system/silos/default-silo",
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -204,7 +204,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         .expect("failed to make request");
 
     // Verify silo DELETE works
-    NexusRequest::object_delete(&client, &"/system/silos/discoverable")
+    NexusRequest::object_delete(&client, &"/v1/system/silos/discoverable")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -226,7 +226,7 @@ async fn test_silo_admin_group(cptestctx: &ControlPlaneTestContext) {
 
     let silo: Silo = object_create(
         client,
-        "/system/silos",
+        "/v1/system/silos",
         &params::SiloCreate {
             identity: IdentityMetadataCreateParams {
                 name: "silo-name".parse().unwrap(),
@@ -315,7 +315,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
     // List providers - should be none
     let providers = objects_list_page_authz::<IdentityProvider>(
         client,
-        "/system/silos/test-silo/identity-providers",
+        "/v1/system/identity-providers?silo=test-silo",
     )
     .await
     .items;
@@ -334,7 +334,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
 
     let silo_saml_idp_1: SamlIdentityProvider = object_create(
         client,
-        &"/system/silos/test-silo/identity-providers/saml",
+        &"/v1/system/identity-providers/saml?silo=test-silo",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -363,7 +363,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
 
     let silo_saml_idp_2: SamlIdentityProvider = object_create(
         client,
-        &"/system/silos/test-silo/identity-providers/saml",
+        &"/v1/system/identity-providers/saml?silo=test-silo",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "another-totally-real-saml-provider"
@@ -393,7 +393,7 @@ async fn test_listing_identity_providers(cptestctx: &ControlPlaneTestContext) {
     // List providers again - expect 2
     let providers = objects_list_page_authz::<IdentityProvider>(
         client,
-        "/system/silos/test-silo/identity-providers",
+        "/v1/system/identity-providers?silo=test-silo",
     )
     .await
     .items;
@@ -427,7 +427,7 @@ async fn test_deleting_a_silo_deletes_the_idp(
 
     let silo_saml_idp: SamlIdentityProvider = object_create(
         client,
-        &format!("/system/silos/{}/identity-providers/saml", SILO_NAME),
+        &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -457,7 +457,7 @@ async fn test_deleting_a_silo_deletes_the_idp(
     // Delete the silo
     NexusRequest::object_delete(
         &client,
-        &format!("/system/silos/{}", SILO_NAME),
+        &format!("/v1/system/silos/{}", SILO_NAME),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -527,7 +527,7 @@ async fn test_saml_idp_metadata_data_valid(
 
     let silo_saml_idp: SamlIdentityProvider = object_create(
         client,
-        "/system/silos/blahblah/identity-providers/saml",
+        "/v1/system/identity-providers/saml?silo=blahblah",
         &params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
                 name: "some-totally-real-saml-provider"
@@ -591,7 +591,7 @@ async fn test_saml_idp_metadata_data_truncated(
         RequestBuilder::new(
             client,
             Method::POST,
-            "/system/silos/blahblah/identity-providers/saml",
+            "/v1/system/identity-providers/saml?silo=blahblah",
         )
         .body(Some(&params::SamlIdentityProviderCreate {
             identity: IdentityMetadataCreateParams {
@@ -770,7 +770,7 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
             assert!(existing_silo_user.is_none());
         }
 
-        NexusRequest::object_delete(&client, &"/system/silos/test-silo")
+        NexusRequest::object_delete(&client, &"/v1/system/silos/test-silo")
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await
@@ -924,7 +924,7 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
     .id;
     grant_iam(
         client,
-        "/system/silos/silo2",
+        "/v1/system/silos/silo2",
         SiloRole::Admin,
         new_silo_user_id,
         AuthnMode::PrivilegedUser,
@@ -1359,7 +1359,7 @@ async fn test_silo_delete_clean_up_groups(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     // Delete the silo
-    NexusRequest::object_delete(&client, &"/system/silos/test-silo")
+    NexusRequest::object_delete(&client, &"/v1/system/silos/test-silo")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -1534,7 +1534,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     // - on failure, the "list" and "view" endpoints always return the right
     //   status code and message for the failure mode
     // - that users can always list and fetch all users in their own Silo via
-    //   /system/silos (/users is tested elsewhere)
+    //   /v1/system/silos (/users is tested elsewhere)
     // - that users without privileges cannot list or fetch users in other Silos
     // - that users with privileges on another Silo can list and fetch users in
     //   that Silo
@@ -1559,8 +1559,10 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
     let mut output = String::new();
     for test_silo in [test_silo1, test_silo2] {
         let silo_name = &test_silo.silo.identity().name;
-        let silo_users_url =
-            &format!("/system/silos/{}/users", test_silo.silo.identity().name);
+        let silo_users_url = &format!(
+            "/v1/system/users?silo={}",
+            test_silo.silo.identity().name
+        );
 
         write!(&mut output, "SILO: {}\n", silo_name).unwrap();
 
@@ -1696,7 +1698,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     // Grant this user "admin" privileges on that Silo.
     grant_iam(
         client,
-        "/system/silos/jit",
+        "/v1/system/silos/jit",
         SiloRole::Admin,
         admin_user.id,
         AuthnMode::PrivilegedUser,
@@ -1714,7 +1716,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
                 client,
                 StatusCode::NOT_FOUND,
                 Method::POST,
-                "/system/silos/jit/identity-providers/local/users",
+                "/v1/system/identity-providers/local/users?silo=jit",
                 &params::UserCreate {
                     external_id: params::UserId::from_str("dummy").unwrap(),
                     password: params::UserPassword::InvalidPassword,
@@ -1729,11 +1731,11 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     let other_user_id =
         create_jit_user(datastore, &silo, "other-user").await.id;
     let user_url_delete = format!(
-        "/system/silos/jit/identity-providers/local/users/{}",
+        "/v1/system/identity-providers/local/users/{}?silo=jit",
         other_user_id
     );
     let user_url_set_password = format!(
-        "/system/silos/jit/identity-providers/local/users/{}/set-password",
+        "/v1/system/identity-providers/local/users/{}/set-password?silo=jit",
         other_user_id
     );
 
@@ -1940,7 +1942,7 @@ async fn test_local_silo_users(cptestctx: &ControlPlaneTestContext) {
     .await;
     grant_iam(
         client,
-        "/system/silos/silo1",
+        "/v1/system/silos/silo1",
         SiloRole::Admin,
         admin_user.id,
         AuthnMode::PrivilegedUser,
@@ -1963,9 +1965,9 @@ async fn run_user_tests(
     existing_users: &[views::User],
 ) {
     let url_all_users =
-        format!("/system/silos/{}/users/all", silo.identity.name);
+        format!("/v1/system/users/all?silo={}", silo.identity.name);
     let url_local_idp_users = format!(
-        "/system/silos/{}/identity-providers/local/users",
+        "/system/identity-providers/local/users?silo={}",
         silo.identity.name
     );
     let url_user_create = url_local_idp_users.to_string();
@@ -2003,8 +2005,8 @@ async fn run_user_tests(
 
     // Fetch the user we just created.
     let user_url_get = format!(
-        "/system/silos/{}/users/id/{}",
-        silo.identity.name, user_created.id
+        "/v1/system/users/id/{}?silo={}",
+        user_created.id, silo.identity.name,
     );
     let user_found = NexusRequest::object_get(client, &user_url_get)
         .authn_as(authn_mode.clone())
@@ -2033,8 +2035,8 @@ async fn run_user_tests(
 
     // Delete the user that we created.
     let user_url_delete = format!(
-        "/system/silos/{}/identity-providers/local/users/{}",
-        silo.identity.name, user_created.id
+        "/system/identity-providers/local/users/{}?silo={}",
+        user_created.id, silo.identity.name,
     );
     NexusRequest::object_delete(client, &user_url_delete)
         .authn_as(authn_mode.clone())

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -38,7 +38,7 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Verify that there is one sled to begin with.
-    let sleds_url = "/system/hardware/sleds";
+    let sleds_url = "/v1/system/hardware/sleds";
     assert_eq!(sleds_list(&client, &sleds_url).await.len(), 1);
 
     // Now start a few more sled agents.
@@ -81,11 +81,12 @@ async fn test_physical_disk_create_list_delete(
     let internal_client = &cptestctx.internal_client;
 
     // Verify that there is one sled to begin with.
-    let sleds_url = "/system/hardware/sleds";
+    let sleds_url = "/v1/system/hardware/sleds";
     assert_eq!(sleds_list(&external_client, &sleds_url).await.len(), 1);
 
     // Verify that there are no disks.
-    let disks_url = format!("/system/hardware/sleds/{SLED_AGENT_UUID}/disks");
+    let disks_url =
+        format!("/v1/system/hardware/sleds/{SLED_AGENT_UUID}/disks");
     assert!(physical_disks_list(&external_client, &disks_url).await.is_empty());
 
     // Insert a new disk using the internal API, observe it in the external API

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -89,7 +89,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     create_organization(&client, organization_name).await;
     create_project(&client, organization_name, project_name).await;
     let url_instances = format!(
-        "/organizations/{}/projects/{}/instances",
+        "/v1/instances?organization={}&project={}",
         organization_name, project_name
     );
 

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -97,10 +97,11 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     // to test address exhaustion.
     let subnet_size =
         cptestctx.server.apictx().nexus.tunables().max_vpc_ipv4_subnet_prefix;
-    let url_subnets = format!(
-        "/organizations/{}/projects/{}/vpcs/default/subnets",
+    let vpc_selector = format!(
+        "organization={}&project={}&vpc=default",
         organization_name, project_name
     );
+    let subnets_url = format!("/v1/vpc-subnets?{}", vpc_selector);
     let subnet_name = "small";
     let network_address = Ipv4Addr::new(192, 168, 42, 0);
     let subnet = Ipv4Network::new(network_address, subnet_size)
@@ -114,7 +115,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
         ipv4_block: Ipv4Net(subnet),
         ipv6_block: None,
     };
-    NexusRequest::objects_post(client, &url_subnets, &Some(&subnet_create))
+    NexusRequest::objects_post(client, &subnets_url, &Some(&subnet_create))
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -164,7 +165,10 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(error.message, "No available IP addresses for interface");
 
     // Verify the subnet lists the two addresses as in use
-    let url_ips = format!("{}/{}/network-interfaces", url_subnets, subnet_name);
+    let url_ips = format!(
+        "/v1/vpc-subnets/{}/network-interfaces?{}",
+        subnet_name, vpc_selector
+    );
     let mut network_interfaces =
         objects_list_page_authz::<NetworkInterface>(client, &url_ips)
             .await

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -190,7 +190,7 @@ lazy_static! {
         SetupReq::Post {
             url: "/v1/system/silos",
             body: serde_json::to_value(&*DEMO_SILO_CREATE).unwrap(),
-            id_routes: vec!["/system/by-id/silos/{id}"],
+            id_routes: vec![],
         },
         // Create a local User
         SetupReq::Post {
@@ -205,7 +205,7 @@ lazy_static! {
         // Get the default IP pool
         SetupReq::Get {
             url: &DEMO_IP_POOL_URL,
-            id_routes: vec!["/system/by-id/ip-pools/{id}"],
+            id_routes: vec![],
         },
         // Create an IP pool range
         SetupReq::Post {

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -188,7 +188,7 @@ lazy_static! {
     static ref SETUP_REQUESTS: Vec<SetupReq> = vec![
         // Create a separate Silo
         SetupReq::Post {
-            url: "/system/silos",
+            url: "/v1/system/silos",
             body: serde_json::to_value(&*DEMO_SILO_CREATE).unwrap(),
             id_routes: vec!["/system/by-id/silos/{id}"],
         },

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -311,7 +311,7 @@ struct IdMetadata {
 /// Verifies a single API endpoint, described with `endpoint`
 ///
 /// (Technically, a single `VerifyEndpoint` struct describes an HTTP resource,
-/// like "/organizations".  There are several API endpoints there, like "GET
+/// like "/v1/organizations".  There are several API endpoints there, like "GET
 /// /organizations" and "POST /organizations".  We're a little loose with the
 /// terminology here.)
 ///
@@ -337,7 +337,7 @@ struct IdMetadata {
 /// - If the resource is publicly visible (based on `endpoint.visibility`), then
 ///   we expect a 401 for unauthenticated users and a 403 for unauthenticated,
 ///   unauthorized users.  Note that "visible" here doesn't mean "accessible".
-///   We assume that everybody is allowed to know that "/organizations" exists.
+///   We assume that everybody is allowed to know that "/v1/organizations" exists.
 ///   But they're not necessarily allowed to _use_ it.  That's why it's correct
 ///   to get 401/403 on "GET /organizations", even though it's a GET and you
 ///   might think all GETs to things you can't access should be 404s.

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -15,7 +15,7 @@ type ControlPlaneTestContext =
 async fn test_users_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
-    let mut users = NexusRequest::object_get(testctx, "/v1/system/user")
+    let mut users = NexusRequest::object_get(testctx, "/system/user")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -15,7 +15,7 @@ type ControlPlaneTestContext =
 async fn test_users_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
-    let mut users = NexusRequest::object_get(testctx, "/system/user")
+    let mut users = NexusRequest::object_get(testctx, "/v1/system/user")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -258,7 +258,7 @@ system_image_delete                      /system/images/{image_name}
 system_image_list                        /system/images
 system_image_view                        /system/images/{image_name}
 system_image_view_by_id                  /system/by-id/images/{id}
-system_metric                            /system/metrics/{metric_name}
+system_metric                            /v1/system/metrics/{metric_name}
 system_update_components_list            /v1/system/update/updates/{version}/components
 system_update_list                       /v1/system/update/updates
 system_update_refresh                    /v1/system/update/refresh

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6722,92 +6722,6 @@
         "deprecated": true
       }
     },
-    "/system/metrics/{metric_name}": {
-      "get": {
-        "tags": [
-          "system"
-        ],
-        "summary": "Access metrics data",
-        "operationId": "system_metric",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "metric_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SystemMetricName"
-            }
-          },
-          {
-            "in": "query",
-            "name": "end_time",
-            "description": "An exclusive end time of metrics.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "in": "query",
-            "name": "id",
-            "description": "The UUID of the container being queried",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "start_time",
-            "description": "An inclusive start time of metrics.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeasurementResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": true
-      }
-    },
     "/system/policy": {
       "get": {
         "tags": [
@@ -12020,6 +11934,92 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      }
+    },
+    "/v1/system/metrics/{metric_name}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Access metrics data",
+        "operationId": "system_metric",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "metric_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SystemMetricName"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "description": "An exclusive end time of metrics.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "description": "The UUID of the container being queried",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "description": "An inclusive start time of metrics.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
       }
     },
     "/v1/system/policy": {


### PR DESCRIPTION
This PR pulls test updates out of several of the deprecation PRs as it's pre-mergable and will reduce overall conflicts. 