### PR TITLE
Update addresses reserved for RSS to 32

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -58,7 +58,7 @@ const DNS_ADDRESS_INDEX: usize = 1;
 const GZ_ADDRESS_INDEX: usize = 2;
 
 /// The maximum number of addresses per sled reserved for RSS.
-pub const RSS_RESERVED_ADDRESSES: u16 = 16;
+pub const RSS_RESERVED_ADDRESSES: u16 = 32;
 
 /// Wraps an [`Ipv6Network`] with a compile-time prefix length.
 #[derive(


### PR DESCRIPTION
The dogfood rack needs more addresses for RSS.
The 16 it had was not enough. This system has 10 disks, so those crucible zones may have pushed it over the limit.

With more zones coming, this should give us some time before we hit the limit again.