### PR TITLE
RFD 322: v1 built-in users

### DIFF
--- a/nexus/db-queries/src/db/lookup.rs
+++ b/nexus/db-queries/src/db/lookup.rs
@@ -410,6 +410,14 @@ impl<'a> LookupPath<'a> {
     }
 
     /// Select a resource of type UserBuiltin, identified by its `name`
+    pub fn user_builtin_id<'b>(self, id: Uuid) -> UserBuiltin<'b>
+    where
+        'a: 'b,
+    {
+        UserBuiltin::PrimaryKey(Root { lookup_root: self }, id)
+    }
+
+    /// Select a resource of type UserBuiltin, identified by its `name`
     pub fn user_builtin_name<'b, 'c>(self, name: &'b Name) -> UserBuiltin<'c>
     where
         'a: 'c,

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -6,17 +6,20 @@
 
 use crate::authz;
 use crate::db;
-use crate::db::lookup::LookupPath;
+use crate::db::lookup::{self, LookupPath};
 use crate::db::model::Name;
 use crate::external_api::shared;
 use anyhow::Context;
 use nexus_db_queries::context::OpContext;
+use nexus_types::external_api::params;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
+use ref_cast::RefCast;
 use uuid::Uuid;
 
 impl super::Nexus {
@@ -154,16 +157,21 @@ impl super::Nexus {
         self.db_datastore.users_builtin_list_by_name(opctx, pagparams).await
     }
 
-    pub async fn user_builtin_fetch(
-        &self,
-        opctx: &OpContext,
-        name: &Name,
-    ) -> LookupResult<db::model::UserBuiltin> {
-        let (.., db_user_builtin) = LookupPath::new(opctx, &self.db_datastore)
-            .user_builtin_name(name)
-            .fetch()
-            .await?;
-        Ok(db_user_builtin)
+    pub fn user_builtin_lookup<'a>(
+        &'a self,
+        opctx: &'a OpContext,
+        user_selector: &'a params::UserBuiltinSelector,
+    ) -> LookupResult<lookup::UserBuiltin<'a>> {
+        let lookup_path = LookupPath::new(opctx, &self.db_datastore);
+        let user = match user_selector {
+            params::UserBuiltinSelector { user: NameOrId::Id(id) } => {
+                lookup_path.user_builtin_id(*id)
+            }
+            params::UserBuiltinSelector { user: NameOrId::Name(name) } => {
+                lookup_path.user_builtin_name(Name::ref_cast(name))
+            }
+        };
+        Ok(user)
     }
 
     // Built-in roles

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -331,6 +331,9 @@ pub fn external_api() -> NexusApiDescription {
         api.register(role_list)?;
         api.register(role_view)?;
 
+        api.register(role_list_v1)?;
+        api.register(role_view_v1)?;
+
         api.register(session_sshkey_list)?;
         api.register(session_sshkey_view)?;
         api.register(session_sshkey_create)?;
@@ -8875,6 +8878,75 @@ struct RolePathParam {
     tags = ["roles"],
 }]
 async fn role_view(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    path_params: Path<RolePathParam>,
+) -> Result<HttpResponseOk<Role>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let path = path_params.into_inner();
+    let role_name = &path.role_name;
+    let handler = async {
+        let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
+        let role = nexus.role_builtin_fetch(&opctx, &role_name).await?;
+        Ok(HttpResponseOk(role.into()))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// List built-in roles
+#[endpoint {
+    method = GET,
+    path = "/v1/roles",
+    tags = ["roles"],
+}]
+async fn role_list_v1(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    query_params: Query<PaginationParams<EmptyScanParams, RolePage>>,
+) -> Result<HttpResponseOk<ResultsPage<Role>>, HttpError> {
+    let apictx = rqctx.context();
+    let nexus = &apictx.nexus;
+    let query = query_params.into_inner();
+    let handler = async {
+        let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
+        let marker = match &query.page {
+            WhichPage::First(..) => None,
+            WhichPage::Next(RolePage { last_seen }) => {
+                Some(last_seen.split_once('.').ok_or_else(|| {
+                    Error::InvalidValue {
+                        label: last_seen.clone(),
+                        message: String::from("bad page token"),
+                    }
+                })?)
+                .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
+            }
+        };
+        let pagparams = DataPageParams {
+            limit: rqctx.page_limit(&query)?,
+            direction: PaginationOrder::Ascending,
+            marker: marker.as_ref(),
+        };
+        let roles = nexus
+            .roles_builtin_list(&opctx, &pagparams)
+            .await?
+            .into_iter()
+            .map(|i| i.into())
+            .collect();
+        Ok(HttpResponseOk(dropshot::ResultsPage::new(
+            roles,
+            &EmptyScanParams {},
+            |role: &Role, _| RolePage { last_seen: role.name.to_string() },
+        )?))
+    };
+    apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Fetch a built-in role
+#[endpoint {
+    method = GET,
+    path = "/v1/roles/{role_name}",
+    tags = ["roles"],
+}]
+async fn role_view_v1(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<RolePathParam>,
 ) -> Result<HttpResponseOk<Role>, HttpError> {

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -8956,7 +8956,7 @@ async fn role_view(
 /// List built-in roles
 #[endpoint {
     method = GET,
-    path = "/v1/roles",
+    path = "/v1/system/roles",
     tags = ["roles"],
 }]
 async fn role_list_v1(
@@ -9003,7 +9003,7 @@ async fn role_list_v1(
 /// Fetch a built-in role
 #[endpoint {
     method = GET,
-    path = "/v1/roles/{role_name}",
+    path = "/v1/system/roles/{role_name}",
     tags = ["roles"],
 }]
 async fn role_view_v1(

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1372,13 +1372,13 @@ lazy_static! {
         /* IAM */
 
         VerifyEndpoint {
-            url: "/roles",
+            url: "/v1/roles",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
         },
         VerifyEndpoint {
-            url: "/roles/fleet.admin",
+            url: "/v1/roles/fleet.admin",
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1372,13 +1372,13 @@ lazy_static! {
         /* IAM */
 
         VerifyEndpoint {
-            url: "/v1/roles",
+            url: "/v1/system/roles",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],
         },
         VerifyEndpoint {
-            url: "/v1/roles/fleet.admin",
+            url: "/v1/system/roles/fleet.admin",
             visibility: Visibility::Protected,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -593,7 +593,7 @@ impl AllowedMethod {
 
 lazy_static! {
     pub static ref URL_USERS_DB_INIT: String =
-        format!("/system/user/{}", authn::USER_DB_INIT.name);
+        format!("/v1/system/users-builtin/{}", authn::USER_DB_INIT.name);
 
     /// List of endpoints to be verified
     pub static ref VERIFY_ENDPOINTS: Vec<VerifyEndpoint> = vec![
@@ -1385,7 +1385,7 @@ lazy_static! {
         },
 
         VerifyEndpoint {
-            url: "/system/user",
+            url: "/v1/system/users-builtin",
             visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![AllowedMethod::Get],

--- a/nexus/tests/integration_tests/roles_builtin.rs
+++ b/nexus/tests/integration_tests/roles_builtin.rs
@@ -20,7 +20,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
     // Success cases
-    let roles = NexusRequest::object_get(&testctx, "/roles")
+    let roles = NexusRequest::object_get(&testctx, "/v1/roles")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -54,32 +54,33 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     // This endpoint uses a custom pagination scheme that is easy to get wrong.
     // Let's test that all markers do work.
     let roles_paginated =
-        NexusRequest::iter_collection_authn(&testctx, "/roles", "", Some(1))
+        NexusRequest::iter_collection_authn(&testctx, "/v1/roles", "", Some(1))
             .await
             .expect("failed to iterate all roles");
     assert_eq!(roles, roles_paginated.all_items);
     // There's an empty page at the end of each dropshot scan.
     assert_eq!(roles.len() + 1, roles_paginated.npages);
 
-    // Test GET /roles/$role_name
-    //
+    // Test GET /v1/roles/$role_name
 
     // Success cases
     for r in &roles {
-        let one_role =
-            NexusRequest::object_get(&testctx, &format!("/roles/{}", r.name))
-                .authn_as(AuthnMode::PrivilegedUser)
-                .execute()
-                .await
-                .unwrap()
-                .parsed_body::<Role>()
-                .unwrap();
+        let one_role = NexusRequest::object_get(
+            &testctx,
+            &format!("/v1/roles/{}", r.name),
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .unwrap()
+        .parsed_body::<Role>()
+        .unwrap();
         assert_eq!(one_role, *r);
     }
 
     // Invalid name: missing "."
     NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/roles/fleet_admin")
+        RequestBuilder::new(testctx, Method::GET, "/v1/roles/fleet_admin")
             .expect_status(Some(StatusCode::NOT_FOUND)),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -89,7 +90,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
 
     // Invalid name: not found
     NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/roles/fleet.admiral")
+        RequestBuilder::new(testctx, Method::GET, "/v1/roles/fleet.admiral")
             .expect_status(Some(StatusCode::NOT_FOUND)),
     )
     .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/roles_builtin.rs
+++ b/nexus/tests/integration_tests/roles_builtin.rs
@@ -20,7 +20,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
     // Success cases
-    let roles = NexusRequest::object_get(&testctx, "/v1/roles")
+    let roles = NexusRequest::object_get(&testctx, "/v1/system/roles")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -53,21 +53,25 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
 
     // This endpoint uses a custom pagination scheme that is easy to get wrong.
     // Let's test that all markers do work.
-    let roles_paginated =
-        NexusRequest::iter_collection_authn(&testctx, "/v1/roles", "", Some(1))
-            .await
-            .expect("failed to iterate all roles");
+    let roles_paginated = NexusRequest::iter_collection_authn(
+        &testctx,
+        "/v1/system/roles",
+        "",
+        Some(1),
+    )
+    .await
+    .expect("failed to iterate all roles");
     assert_eq!(roles, roles_paginated.all_items);
     // There's an empty page at the end of each dropshot scan.
     assert_eq!(roles.len() + 1, roles_paginated.npages);
 
-    // Test GET /v1/roles/$role_name
+    // Test GET /v1/system/roles/$role_name
 
     // Success cases
     for r in &roles {
         let one_role = NexusRequest::object_get(
             &testctx,
-            &format!("/v1/roles/{}", r.name),
+            &format!("/v1/system/roles/{}", r.name),
         )
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
@@ -80,8 +84,12 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
 
     // Invalid name: missing "."
     NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/v1/roles/fleet_admin")
-            .expect_status(Some(StatusCode::NOT_FOUND)),
+        RequestBuilder::new(
+            testctx,
+            Method::GET,
+            "/v1/system/roles/fleet_admin",
+        )
+        .expect_status(Some(StatusCode::NOT_FOUND)),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -90,8 +98,12 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
 
     // Invalid name: not found
     NexusRequest::new(
-        RequestBuilder::new(testctx, Method::GET, "/v1/roles/fleet.admiral")
-            .expect_status(Some(StatusCode::NOT_FOUND)),
+        RequestBuilder::new(
+            testctx,
+            Method::GET,
+            "/v1/system/roles/fleet.admiral",
+        )
+        .expect_status(Some(StatusCode::NOT_FOUND)),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -15,17 +15,18 @@ type ControlPlaneTestContext =
 async fn test_users_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
-    let mut users = NexusRequest::object_get(testctx, "/system/user")
-        .authn_as(AuthnMode::PrivilegedUser)
-        .execute()
-        .await
-        .unwrap()
-        .parsed_body::<ResultsPage<UserBuiltin>>()
-        .unwrap()
-        .items
-        .into_iter()
-        .map(|u| (u.identity.name.to_string(), u))
-        .collect::<BTreeMap<String, UserBuiltin>>();
+    let mut users =
+        NexusRequest::object_get(testctx, "/v1/system/users-builtin")
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .unwrap()
+            .parsed_body::<ResultsPage<UserBuiltin>>()
+            .unwrap()
+            .items
+            .into_iter()
+            .map(|u| (u.identity.name.to_string(), u))
+            .collect::<BTreeMap<String, UserBuiltin>>();
 
     let u = users.remove(&authn::USER_DB_INIT.name.to_string()).unwrap();
     assert_eq!(u.identity.id, authn::USER_DB_INIT.id);

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -273,7 +273,7 @@ system_version                           /v1/system/update/version
 update_deployment_view                   /v1/system/update/deployments/{id}
 update_deployments_list                  /v1/system/update/deployments
 user_builtin_list                        /v1/system/users-builtin
-user_builtin_view                        /v1/system/users-builtin/{user_name}
+user_builtin_view                        /v1/system/users-builtin/{user}
 
 API operations found with tag "vpcs"
 OPERATION ID                             URL PATH

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -133,7 +133,9 @@ project_view_v1                          /v1/projects/{project}
 API operations found with tag "roles"
 OPERATION ID                             URL PATH
 role_list                                /roles
+role_list_v1                             /v1/roles
 role_view                                /roles/{role_name}
+role_view_v1                             /v1/roles/{role_name}
 
 API operations found with tag "session"
 OPERATION ID                             URL PATH

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -133,9 +133,9 @@ project_view_v1                          /v1/projects/{project}
 API operations found with tag "roles"
 OPERATION ID                             URL PATH
 role_list                                /roles
-role_list_v1                             /v1/roles
+role_list_v1                             /v1/system/roles
 role_view                                /roles/{role_name}
-role_view_v1                             /v1/roles/{role_name}
+role_view_v1                             /v1/system/roles/{role_name}
 
 API operations found with tag "session"
 OPERATION ID                             URL PATH

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -272,6 +272,8 @@ system_user_view                         /system/user/{user_name}
 system_version                           /v1/system/update/version
 update_deployment_view                   /v1/system/update/deployments/{id}
 update_deployments_list                  /v1/system/update/deployments
+user_builtin_list                        /v1/system/users-builtin
+user_builtin_view                        /v1/system/users-builtin/{user_name}
 
 API operations found with tag "vpcs"
 OPERATION ID                             URL PATH

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -57,6 +57,8 @@ vpc_subnet_list                          (get    "/organizations/{organization_n
 vpc_subnet_view                          (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}")
 vpc_subnet_list_network_interfaces       (get    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/network-interfaces")
 policy_view                              (get    "/policy")
+role_list                                (get    "/roles")
+role_view                                (get    "/roles/{role_name}")
 session_me                               (get    "/session/me")
 session_me_groups                        (get    "/session/me/groups")
 session_sshkey_list                      (get    "/session/me/sshkeys")

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -91,6 +91,8 @@ saml_identity_provider_view              (get    "/system/silos/{silo_name}/iden
 silo_policy_view                         (get    "/system/silos/{silo_name}/policy")
 silo_users_list                          (get    "/system/silos/{silo_name}/users/all")
 silo_user_view                           (get    "/system/silos/{silo_name}/users/id/{user_id}")
+system_user_list                         (get    "/system/user")
+system_user_view                         (get    "/system/user/{user_name}")
 user_list                                (get    "/users")
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1431,6 +1431,11 @@ pub struct UserBuiltinCreate {
     pub identity: IdentityMetadataCreateParams,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct UserBuiltinSelector {
+    pub user: NameOrId,
+}
+
 // SSH PUBLIC KEYS
 //
 // The SSH key mangement endpoints are currently under `/v1/me`,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -13065,7 +13065,7 @@
         "x-dropshot-pagination": true
       }
     },
-    "/v1/system/users-builtin/{user_name}": {
+    "/v1/system/users-builtin/{user}": {
       "get": {
         "tags": [
           "system"
@@ -13075,11 +13075,10 @@
         "parameters": [
           {
             "in": "path",
-            "name": "user_name",
-            "description": "The built-in user's unique name.",
+            "name": "user",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/Name"
+              "$ref": "#/components/schemas/NameOrId"
             }
           }
         ],

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10453,94 +10453,6 @@
         }
       }
     },
-    "/v1/roles": {
-      "get": {
-        "tags": [
-          "roles"
-        ],
-        "summary": "List built-in roles",
-        "operationId": "role_list_v1",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RoleResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": true
-      }
-    },
-    "/v1/roles/{role_name}": {
-      "get": {
-        "tags": [
-          "roles"
-        ],
-        "summary": "Fetch a built-in role",
-        "operationId": "role_view_v1",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "role_name",
-            "description": "The built-in role's unique name.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Role"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/v1/snapshots": {
       "get": {
         "tags": [
@@ -12159,6 +12071,94 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FleetRolePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/roles": {
+      "get": {
+        "tags": [
+          "roles"
+        ],
+        "summary": "List built-in roles",
+        "operationId": "role_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/roles/{role_name}": {
+      "get": {
+        "tags": [
+          "roles"
+        ],
+        "summary": "Fetch a built-in role",
+        "operationId": "role_view_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "role_name",
+            "description": "The built-in role's unique name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Role"
                 }
               }
             }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -13008,6 +13008,101 @@
         }
       }
     },
+    "/v1/system/users-builtin": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "List built-in users",
+        "operationId": "user_builtin_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserBuiltinResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/system/users-builtin/{user_name}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch a built-in user",
+        "operationId": "user_builtin_view",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_name",
+            "description": "The built-in user's unique name.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserBuiltin"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/users": {
       "get": {
         "tags": [

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10453,6 +10453,94 @@
         }
       }
     },
+    "/v1/roles": {
+      "get": {
+        "tags": [
+          "roles"
+        ],
+        "summary": "List built-in roles",
+        "operationId": "role_list_v1",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/v1/roles/{role_name}": {
+      "get": {
+        "tags": [
+          "roles"
+        ],
+        "summary": "Fetch a built-in role",
+        "operationId": "role_view_v1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "role_name",
+            "description": "The built-in role's unique name.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Role"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/snapshots": {
       "get": {
         "tags": [


### PR DESCRIPTION
Roles don't have IDs exposed in the responses so it doesn't make sense to make them fetchable by ID.