### PR TITLE
NTP zones and time synchronisation

### DIFF
--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -109,6 +109,7 @@ zones=(
 	out/propolis-server.tar.gz
 	out/switch-asic.tar.gz
 	out/switch-softnpu.tar.gz
+	out/ntp.tar.gz
 )
 cp "${zones[@]}" /work/zones/
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ smf/nexus/root.json
 core
 *.vdev
 debug.out
+rusty-tags.vi

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -45,6 +45,8 @@ pub const CRUCIBLE_PANTRY_PORT: u16 = 17000;
 
 pub const NEXUS_INTERNAL_PORT: u16 = 12221;
 
+pub const NTP_PORT: u16 = 123;
+
 // Anycast is a mechanism in which a single IP address is shared by multiple
 // devices, and the destination is located based on routing distance.
 //

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -113,7 +113,9 @@ CREATE TYPE omicron.public.service_kind AS ENUM (
   'oximeter',
   'dendrite',
   'tfport',
-  'crucible_pantry'
+  'crucible_pantry',
+  'ntp',
+  'dns_client'
 );
 
 CREATE TABLE omicron.public.service (

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -9,6 +9,7 @@ use crate::dladm::Etherstub;
 use crate::link::{Link, VnicAllocator};
 use crate::opte::Port;
 use crate::svc::wait_for_service;
+use crate::zfs::ZONE_ZFS_DATASET_MOUNTPOINT;
 use crate::zone::{AddressRequest, ZONE_PREFIX};
 use ipnetwork::IpNetwork;
 use slog::info;
@@ -121,6 +122,11 @@ pub struct RunningZone {
 impl RunningZone {
     pub fn name(&self) -> &str {
         &self.inner.name
+    }
+
+    /// Returns the filesystem path to the zone's root
+    pub fn root(&self) -> String {
+        format!("{}/{}/root", ZONE_ZFS_DATASET_MOUNTPOINT, self.name())
     }
 
     /// Runs a command within the Zone, return the output.

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -62,7 +62,7 @@ pub enum EnsureAddressError {
     MissingBootstrapVnic { address: String, zone: String },
 }
 
-/// Erros returned from [`RunningZone::get`].
+/// Errors returned from [`RunningZone::get`].
 #[derive(thiserror::Error, Debug)]
 pub enum GetZoneError {
     #[error("While looking up zones with prefix '{prefix}', could not get zones: {err}")]

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -24,6 +24,8 @@ pub enum ServiceName {
     CruciblePantry,
     SledAgent(Uuid),
     Crucible(Uuid),
+    BoundaryNTP,
+    InternalNTP,
 }
 
 impl ServiceName {
@@ -41,6 +43,8 @@ impl ServiceName {
             ServiceName::CruciblePantry => "crucible-pantry",
             ServiceName::SledAgent(_) => "sledagent",
             ServiceName::Crucible(_) => "crucible",
+            ServiceName::BoundaryNTP => "boundary-ntp",
+            ServiceName::InternalNTP => "internal-ntp",
         }
     }
 
@@ -57,7 +61,9 @@ impl ServiceName {
             | ServiceName::Wicketd
             | ServiceName::Dendrite
             | ServiceName::Tfport
-            | ServiceName::CruciblePantry => {
+            | ServiceName::CruciblePantry
+            | ServiceName::BoundaryNTP
+            | ServiceName::InternalNTP => {
                 format!("_{}._tcp", self.service_kind())
             }
             ServiceName::SledAgent(id) => {

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -23,6 +23,8 @@ impl_enum_type!(
     Dendrite => b"dendrite"
     Tfport => b"tfport"
     CruciblePantry => b"crucible_pantry"
+    NTP => b"ntp"
+    DNSClient => b"dns_client"
 );
 
 impl TryFrom<ServiceKind> for ServiceUsingCertificate {
@@ -61,6 +63,10 @@ impl From<internal_api::params::ServiceKind> for ServiceKind {
             internal_api::params::ServiceKind::Tfport => ServiceKind::Tfport,
             internal_api::params::ServiceKind::CruciblePantry => {
                 ServiceKind::CruciblePantry
+            }
+            internal_api::params::ServiceKind::NTP => ServiceKind::NTP,
+            internal_api::params::ServiceKind::DNSClient => {
+                ServiceKind::DNSClient
             }
         }
     }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -169,6 +169,8 @@ pub enum ServiceKind {
     Dendrite,
     Tfport,
     CruciblePantry,
+    NTP,
+    DNSClient,
 }
 
 impl fmt::Display for ServiceKind {
@@ -181,6 +183,8 @@ impl fmt::Display for ServiceKind {
             Dendrite => "dendrite",
             Tfport => "tfport",
             CruciblePantry => "crucible_pantry",
+            NTP => "ntp",
+            DNSClient => "dns_client",
         };
         write!(f, "{}", s)
     }

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -183,6 +183,13 @@
         "description": "Configuration for the \"rack setup service\".\n\nThe Rack Setup Service should be responsible for one-time setup actions, such as CockroachDB placement and initialization.  Without operator intervention, however, these actions need a way to be automated in our deployment.",
         "type": "object",
         "properties": {
+          "dns_servers": {
+            "description": "The external DNS server addresses.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "gateway": {
             "description": "Internet gateway information.",
             "allOf": [
@@ -196,6 +203,13 @@
             "type": "string",
             "format": "ip"
           },
+          "ntp_servers": {
+            "description": "The external NTP server addresses.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "rack_secret_threshold": {
             "description": "The minimum number of sleds required to unlock the rack secret.\n\nIf this value is less than 2, no rack secret will be created on startup; this is the typical case for single-server test/development.",
             "type": "integer",
@@ -208,8 +222,10 @@
           }
         },
         "required": [
+          "dns_servers",
           "gateway",
           "nexus_external_address",
+          "ntp_servers",
           "rack_secret_threshold",
           "rack_subnet"
         ]

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2345,6 +2345,34 @@
             "required": [
               "type"
             ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "n_t_p"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "d_n_s_client"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -204,6 +204,29 @@
         }
       }
     },
+    "/timesync": {
+      "get": {
+        "operationId": "timesync_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeSync"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/update": {
       "post": {
         "operationId": "update_artifact",
@@ -1647,6 +1670,27 @@
           "first_port",
           "ip",
           "last_port"
+        ]
+      },
+      "TimeSync": {
+        "type": "object",
+        "properties": {
+          "correction": {
+            "type": "number",
+            "format": "float"
+          },
+          "skew": {
+            "type": "number",
+            "format": "float"
+          },
+          "sync": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "correction",
+          "skew",
+          "sync"
         ]
       },
       "UpdateArtifactId": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1677,11 +1677,11 @@
         "properties": {
           "correction": {
             "type": "number",
-            "format": "float"
+            "format": "double"
           },
           "skew": {
             "type": "number",
-            "format": "float"
+            "format": "double"
           },
           "sync": {
             "type": "boolean"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1522,6 +1522,56 @@
             "required": [
               "type"
             ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "boundary": {
+                "type": "boolean"
+              },
+              "servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ntp"
+                ]
+              }
+            },
+            "required": [
+              "boundary",
+              "servers",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "domain": {
+                "nullable": true,
+                "type": "string"
+              },
+              "servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dns_client"
+                ]
+              }
+            },
+            "required": [
+              "servers",
+              "type"
+            ]
           }
         ]
       },
@@ -1887,7 +1937,8 @@
           "nexus",
           "oximeter",
           "switch",
-          "crucible_pantry"
+          "crucible_pantry",
+          "ntp"
         ]
       },
       "Zpool": {

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -152,6 +152,17 @@ source.paths = [ { from = "smf/external-dns", to = "/var/svc/manifest/site/exter
 output.intermediate_only = true
 output.type = "zone"
 
+[package.ntp]
+service_name = "ntp"
+only_for_targets.image = "standard"
+source.type = "local"
+source.paths = [
+	{ from = "smf/ntp/manifest", to = "/var/svc/manifest/site/ntp" },
+	{ from = "smf/ntp/method", to = "/var/svc/method" },
+	{ from = "smf/ntp/etc", to = "/etc/inet" },
+]
+output.type = "zone"
+
 [package.omicron-gateway]
 service_name = "mgs"
 only_for_targets.image = "standard"

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -1000,6 +1000,8 @@ mod tests {
                     address: None,
                     mac: MacAddr6::nil().into(),
                 },
+                ntp_servers: vec![String::from("test.pool.example.com")],
+                dns_servers: vec![String::from("1.1.1.1")],
                 subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
             }),
             trust_quorum_share: Some(

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -170,6 +170,7 @@ impl HardwareMonitor {
             underlay_etherstub_vnic.clone(),
             bootstrap_etherstub,
             sled_mode,
+            sled_config.skip_timesync,
             sled_config.sidecar_revision.clone(),
             switch_zone_bootstrap_address,
         )

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -33,6 +33,12 @@ pub struct RackInitializeRequest {
     /// Internet gateway information.
     pub gateway: Gateway,
 
+    /// The external NTP server addresses.
+    pub ntp_servers: Vec<String>,
+
+    /// The external DNS server addresses.
+    pub dns_servers: Vec<String>,
+
     /// The address on which Nexus should serve an external interface.
     // TODO(https://github.com/oxidecomputer/omicron/issues/1530): Eventually,
     // this should be pulled from a pool of addresses.
@@ -70,6 +76,12 @@ pub struct SledAgentRequest {
     // Longer-term, it probably makes sense to store this in CRDB and transfer
     // it to Sled Agent as part of the request to launch Nexus.
     pub gateway: Gateway,
+
+    /// The external NTP servers to use
+    pub ntp_servers: Vec<String>,
+    //
+    /// The external DNS servers to use
+    pub dns_servers: Vec<String>,
 
     // Note: The order of these fields is load bearing, because we serialize
     // `SledAgentRequest`s as toml. `subnet` serializes as a TOML table, so it
@@ -205,6 +217,8 @@ mod tests {
                         address: None,
                         mac: MacAddr6::nil().into(),
                     },
+                    ntp_servers: vec![String::from("test.pool.example.com")],
+                    dns_servers: vec![String::from("1.1.1.1")],
                     subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
                 }),
                 Some(

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     pub vlan: Option<VlanID>,
     /// Optional list of zpools to be used as "discovered disks".
     pub zpools: Option<Vec<ZpoolName>>,
+    /// Optionally skip waiting for time synchronization
+    pub skip_timesync: Option<bool>,
 
     /// The data link on which we infer the bootstrap address.
     ///

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -7,7 +7,7 @@
 use crate::params::VpcFirewallRulesEnsureBody;
 use crate::params::{
     DatasetEnsureBody, DiskEnsureBody, InstanceEnsureBody, ServiceEnsureBody,
-    Zpool,
+    TimeSync, Zpool,
 };
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk,
@@ -36,6 +36,7 @@ pub fn api() -> SledApiDescription {
         api.register(update_artifact)?;
         api.register(instance_issue_disk_snapshot_request)?;
         api.register(vpc_firewall_rules_put)?;
+        api.register(timesync_get)?;
 
         Ok(())
     }
@@ -231,4 +232,15 @@ async fn vpc_firewall_rules_put(
         .map_err(Error::from)?;
 
     Ok(HttpResponseUpdatedNoContent())
+}
+
+#[endpoint {
+    method = GET,
+    path = "/timesync",
+}]
+async fn timesync_get(
+    rqctx: RequestContext<SledAgent>,
+) -> Result<HttpResponseOk<TimeSync>, HttpError> {
+    let sa = rqctx.context();
+    Ok(HttpResponseOk(sa.timesync_get().await.map_err(|e| Error::from(e))?))
 }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -431,6 +431,10 @@ pub struct ServiceEnsureBody {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct TimeSync {
     pub sync: bool,
+    // These could both be f32, but there is a problem with progenitor/typify
+    // where, although the f32 correctly becomes "float" (and not "double") in
+    // the API spec, that "float" gets converted back to f64 when generating
+    // the client.
     pub skew: f64,
     pub correction: f64,
 }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -427,3 +427,10 @@ impl From<ServiceZoneRequest> for sled_agent_client::types::ServiceZoneRequest {
 pub struct ServiceEnsureBody {
     pub services: Vec<ServiceZoneRequest>,
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct TimeSync {
+    pub sync: bool,
+    pub skew: f64,
+    pub correction: f64,
+}

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -272,6 +272,8 @@ pub enum ServiceType {
     Dendrite { asic: DendriteAsic },
     Tfport { pkt_source: String },
     CruciblePantry,
+    Ntp { servers: Vec<String>, boundary: bool },
+    DnsClient { servers: Vec<String>, domain: Option<String> },
 }
 
 impl std::fmt::Display for ServiceType {
@@ -285,6 +287,8 @@ impl std::fmt::Display for ServiceType {
             ServiceType::Dendrite { .. } => write!(f, "dendrite"),
             ServiceType::Tfport { .. } => write!(f, "tfport"),
             ServiceType::CruciblePantry => write!(f, "crucible_pantry"),
+            ServiceType::Ntp { .. } => write!(f, "ntp"),
+            ServiceType::DnsClient { .. } => write!(f, "dns_client"),
         }
     }
 }
@@ -318,6 +322,10 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
             }
             St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
             St::CruciblePantry => AutoSt::CruciblePantry,
+            St::Ntp { servers, boundary } => AutoSt::Ntp { servers, boundary },
+            St::DnsClient { servers, domain } => {
+                AutoSt::DnsClient { servers, domain }
+            }
         }
     }
 }
@@ -337,6 +345,8 @@ pub enum ZoneType {
     Switch,
     #[serde(rename = "crucible_pantry")]
     CruciblePantry,
+    #[serde(rename = "ntp")]
+    NTP,
 }
 
 impl From<ZoneType> for sled_agent_client::types::ZoneType {
@@ -347,6 +357,7 @@ impl From<ZoneType> for sled_agent_client::types::ZoneType {
             ZoneType::Oximeter => Self::Oximeter,
             ZoneType::Switch => Self::Switch,
             ZoneType::CruciblePantry => Self::CruciblePantry,
+            ZoneType::NTP => Self::Ntp,
         }
     }
 }
@@ -360,6 +371,7 @@ impl std::fmt::Display for ZoneType {
             Oximeter => "oximeter",
             Switch => "switch",
             CruciblePantry => "crucible_pantry",
+            NTP => "ntp",
         };
         write!(f, "{name}")
     }

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -51,6 +51,8 @@ mod test {
                 address: None,
                 mac: macaddr::MacAddr6::nil().into(),
             },
+            ntp_servers: vec![String::from("test.pool.example.com")],
+            dns_servers: vec![String::from("1.1.1.1")],
             nexus_external_address: "192.168.1.20".parse().unwrap(),
         };
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -9,10 +9,10 @@ use crate::params::{
 };
 use crate::rack_setup::config::SetupServiceConfig as Config;
 use dns_service_client::types::DnsConfigParams;
-use internal_dns::ServiceName;
+use internal_dns::{ServiceName, DNS_ZONE};
 use omicron_common::address::{
     get_switch_zone_address, Ipv6Subnet, ReservedRackSubnet, DNS_PORT,
-    DNS_SERVER_PORT, RSS_RESERVED_ADDRESSES, SLED_PREFIX,
+    DNS_SERVER_PORT, NTP_PORT, RSS_RESERVED_ADDRESSES, SLED_PREFIX,
 };
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
@@ -27,6 +27,9 @@ use std::net::{Ipv6Addr, SocketAddrV6};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use uuid::Uuid;
+
+// The number of boundary NTP servers to create from RSS.
+const BOUNDARY_NTP_COUNT: usize = 2;
 
 // The number of Nexus instances to create from RSS.
 const NEXUS_COUNT: usize = 1;
@@ -187,6 +190,14 @@ impl Plan {
 
         let mut allocations = vec![];
         let mut dns_builder = internal_dns::DnsConfigBuilder::new();
+
+        let rack_dns_servers = dns_subnets
+            .clone()
+            .into_iter()
+            .map(|dns_subnet| dns_subnet.dns_address().ip().to_string())
+            .collect::<Vec<String>>();
+
+        let mut boundary_ntp_servers = vec![];
 
         for idx in 0..sled_addrs.len() {
             let sled_address = sled_addrs[idx];
@@ -360,6 +371,65 @@ impl Plan {
                     gz_addresses: vec![],
                     services: vec![ServiceType::CruciblePantry],
                 })
+            }
+
+            // All sleds get an NTP server, but the first few are nominated as
+            // boundary servers, responsible for communicating with the external
+            // network.
+            {
+                let id = Uuid::new_v4();
+                let address = addr_alloc.next().expect("Not enough addrs");
+                let zone = dns_builder.host_zone(id, address).unwrap();
+
+                let (services, svcname) = if idx < BOUNDARY_NTP_COUNT {
+                    boundary_ntp_servers
+                        .push(format!("{}.host.{}", id, DNS_ZONE));
+                    (
+                        // XXXNTP - these boundary servers need a path to the
+                        // external network via OPTE.
+                        vec![
+                            ServiceType::Ntp {
+                                servers: config.ntp_servers.clone(),
+                                boundary: true,
+                            },
+                            ServiceType::DnsClient {
+                                servers: config.dns_servers.clone(),
+                                domain: None,
+                            },
+                        ],
+                        ServiceName::BoundaryNTP,
+                    )
+                } else {
+                    (
+                        vec![
+                            ServiceType::Ntp {
+                                servers: boundary_ntp_servers.clone(),
+                                boundary: false,
+                            },
+                            ServiceType::DnsClient {
+                                servers: rack_dns_servers.clone(),
+                                domain: None,
+                            },
+                        ],
+                        ServiceName::InternalNTP,
+                    )
+                };
+
+                dns_builder
+                    .service_backend_zone(
+                        SRV::Service(svcname),
+                        &zone,
+                        NTP_PORT,
+                    )
+                    .unwrap();
+
+                request.services.push(ServiceZoneRequest {
+                    id,
+                    zone_type: ZoneType::NTP,
+                    addresses: vec![address],
+                    gz_addresses: vec![],
+                    services: services,
+                });
             }
 
             allocations.push((sled_address, request));

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -416,11 +416,7 @@ impl Plan {
                 };
 
                 dns_builder
-                    .service_backend_zone(
-                        SRV::Service(svcname),
-                        &zone,
-                        NTP_PORT,
-                    )
+                    .service_backend_zone(svcname, &zone, NTP_PORT)
                     .unwrap();
 
                 request.services.push(ServiceZoneRequest {

--- a/sled-agent/src/rack_setup/plan/sled.rs
+++ b/sled-agent/src/rack_setup/plan/sled.rs
@@ -142,6 +142,8 @@ impl Plan {
                     id: Uuid::new_v4(),
                     subnet,
                     gateway: config.gateway.clone(),
+                    ntp_servers: config.ntp_servers.clone(),
+                    dns_servers: config.dns_servers.clone(),
                     rack_id,
                 },
             )

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -480,7 +480,8 @@ impl ServiceManager {
     ) -> Result<Option<Link>, Error> {
         for svc in &req.services {
             match svc {
-                ServiceType::Nexus { .. } | ServiceType::Ntp { .. } => {
+                ServiceType::Nexus { .. }
+                | ServiceType::Ntp { boundary: true, .. } => {
                     // TODO: Remove once Nexus traffic is transmitted over OPTE.
                     match self
                         .inner
@@ -1157,8 +1158,7 @@ impl ServiceManager {
                         .map_err(|_| Error::NtpZoneNotReady)?;
 
                     Ok(TimeSync {
-                        sync: skew != 0.0
-                            && correction != 0.0
+                        sync: (skew != 0.0 || correction != 0.0)
                             && correction.abs() <= 0.05,
                         skew,
                         correction,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1185,7 +1185,7 @@ impl ServiceManager {
         let services = match self.inner.sled_mode {
             // A pure gimlet sled should not be trying to activate a switch zone.
             SledMode::Gimlet => {
-                return Err(Error::SwitchZone(anyhow::anyhow!(
+                return Err(Error::SledLocalZone(anyhow::anyhow!(
                     "attempted to activate switch zone on non-scrimlet sled"
                 )))
             }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -585,8 +585,5 @@ impl SledAgent {
     /// Gets the sled's current time synchronization state
     pub async fn timesync_get(&self) -> Result<TimeSync, Error> {
         self.inner.services.timesync_get().await.map_err(Error::from)
-
-        //let timesync = TimeSync { sync: true, skew: 0.05, correction: 0.01 };
-        //Ok(timesync)
     }
 }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -321,7 +321,9 @@ impl SledAgent {
         info!(log, "Performing full hardware scan");
         self.notify_nexus_about_self(log);
 
-        if self.inner.hardware.is_scrimlet_driver_loaded() {
+        let scrimlet = self.inner.hardware.is_scrimlet_driver_loaded();
+
+        if scrimlet {
             let switch_zone_ip = Some(self.inner.switch_zone_ip());
             if let Err(e) =
                 self.inner.services.activate_switch(switch_zone_ip).await
@@ -419,8 +421,8 @@ impl SledAgent {
         let log = log.clone();
         let fut = async move {
             // Notify the control plane that we're up, and continue trying this
-            // until it succeeds. We retry with an randomized, capped exponential
-            // backoff.
+            // until it succeeds. We retry with an randomized, capped
+            // exponential backoff.
             //
             // TODO-robustness if this returns a 400 error, we probably want to
             // return a permanent error from the `notify_nexus` closure.

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -11,7 +11,7 @@ use crate::nexus::{LazyNexusClient, NexusRequestQueue};
 use crate::params::VpcFirewallRule;
 use crate::params::{
     DatasetKind, DiskStateRequested, InstanceHardware, InstanceMigrateParams,
-    InstanceRuntimeStateRequested, ServiceEnsureBody, Zpool,
+    InstanceRuntimeStateRequested, ServiceEnsureBody, TimeSync, Zpool,
 };
 use crate::services::{self, ServiceManager};
 use crate::storage_manager::StorageManager;
@@ -580,5 +580,13 @@ impl SledAgent {
             .firewall_rules_ensure(rules)
             .await
             .map_err(Error::from)
+    }
+    //
+    /// Gets the sled's current time synchronization state
+    pub async fn timesync_get(&self) -> Result<TimeSync, Error> {
+        self.inner.services.timesync_get().await.map_err(Error::from)
+
+        //let timesync = TimeSync { sync: true, skew: 0.05, correction: 0.01 };
+        //Ok(timesync)
     }
 }

--- a/smf/ntp/etc/chrony.conf.boundary
+++ b/smf/ntp/etc/chrony.conf.boundary
@@ -1,0 +1,18 @@
+#
+# Template configuration file for a boundary NTP server - one which runs on
+# servers that are connected to a rack switch, and which communicates with NTP
+# servers outside of the rack.
+#
+
+server @SERVER@ iburst maxdelay 0.1 maxsources 16
+
+local stratum 10
+allow fe80::/10
+allow @ALLOW@
+
+driftfile /var/lib/chrony/drift
+ntsdumpdir /var/lib/chrony
+dumpdir /var/lib/chrony
+pidfile /var/run/chrony/chronyd.pid
+makestep 1.0 3
+

--- a/smf/ntp/etc/chrony.conf.boundary
+++ b/smf/ntp/etc/chrony.conf.boundary
@@ -4,7 +4,7 @@
 # servers outside of the rack.
 #
 
-server @SERVER@ iburst maxdelay 0.1 maxsources 16
+pool @SERVER@ iburst maxdelay 0.1 maxsources 16
 
 local stratum 10
 allow fe80::/10

--- a/smf/ntp/etc/chrony.conf.internal
+++ b/smf/ntp/etc/chrony.conf.internal
@@ -1,0 +1,13 @@
+#
+# Template configuration file for an internal NTP server - one which
+# communicates with boundary NTP servers running on servers which are connected
+# to a rack switch.
+
+server @SERVER@ iburst minpoll 0 maxpoll 4
+
+driftfile /var/lib/chrony/drift
+ntsdumpdir /var/lib/chrony
+dumpdir /var/lib/chrony
+pidfile /var/run/chrony/chronyd.pid
+makestep 1.0 3
+

--- a/smf/ntp/manifest/manifest.xml
+++ b/smf/ntp/manifest/manifest.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+ Copyright 2023 Oxide Computer Company
+-->
+<service_bundle type="manifest"
+                name="ntp:default">
+
+<service name="system/illumos/ntp"
+             type="service"
+             version="1">
+
+        <create_default_instance enabled="false" />
+
+        <dependency name="network"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/service" />
+        </dependency>
+
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/minimal" />
+        </dependency>
+
+        <dependency name="name-services"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/name-services" />
+        </dependency>
+
+        <dependency name="routing-setup"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/routing-setup" />
+        </dependency>
+
+	<!--
+        The service is started as root, but with only the privileges it
+	    requires. The chrony daemon forks a privileged helper and then the
+	    main daemon drops everything it does not need, leaving it with
+	    completely minimal privileges (it even divests the privilege to
+        fork/exec).
+
+        The service also always starts the binary with ASLR enabled,
+	    regardless of whether it was linked with -zaslr
+	-->
+        <exec_method type="method"
+                     name="start"
+		     exec="/var/svc/method/svc-site-ntp %m"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr">
+                <method_credential user="root"
+                                   group="root"
+                                   privileges="basic,!file_link_any,!proc_info,!proc_session,file_chown_self,file_dac_search,file_dac_write,net_privaddr,proc_lock_memory,proc_priocntl,proc_setid,sys_time" />
+            </method_context>
+        </exec_method>
+
+        <exec_method type="method"
+                     name="refresh"
+		     exec="/var/svc/method/svc-site-ntp %m %{restarter/contract}"
+                     timeout_seconds="60">
+        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+		     exec="/var/svc/method/svc-site-ntp %m %{restarter/contract}"
+                     timeout_seconds="60" />
+
+        <property_group name="config"
+                        type="application">
+            <propval name="file"
+                     type="astring"
+                     value="/etc/inet/chrony.conf" />
+	    <propval name="boundary"
+                     type="boolean"
+		    value="false" />
+            <propval name="server"
+                     type="astring"
+                     value="" />
+            <propval name="allow"
+                     type="astring"
+                     value="" />
+        </property_group>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Network Time Protocol (NTP)</loctext>
+            </common_name>
+        </template>
+
+    </service>
+
+</service_bundle>

--- a/smf/ntp/method/svc-site-ntp
+++ b/smf/ntp/method/svc-site-ntp
@@ -1,0 +1,109 @@
+#!/usr/bin/ksh
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Copyright 2023 Oxide Computer Company
+
+. /lib/svc/share/smf_include.sh
+
+function die {
+	typeset rc=$1; shift
+	echo "$@" >&2
+	exit $rc
+}
+
+function fatal { die $SMF_EXIT_ERR_FATAL "$@"; }
+function config { die $SMF_EXIT_ERR_CONFIG "$@"; }
+
+[[ -n "$SMF_FMRI" ]] || fatal "SMF framework variables are not initialized."
+
+typeset -r action=${1:?action parameter not specified}
+typeset -r contract=$2	# For the refresh and stop methods
+
+for var in file boundary server allow; do
+	nameref _var=$var
+
+	typeset _var=`svcprop -p config/$var $SMF_FMRI`
+	(($? == 0)) || config "Could not retrieve config/$var property"
+	[[ $_var == '""' ]] && _var=
+
+	# config/allow is optional - not used for non-boundary configurations.
+	if [[ $var != allow ]]; then
+		[[ -n "$_var" ]] || config "config/$var is empty."
+	fi
+done
+
+typeset template=/etc/inet/chrony.conf.internal
+[[ "$boundary" = true ]] && template=/etc/inet/chrony.conf.boundary
+
+cat <<-EOM
+	NTP Service Configuration
+	-------------------------
+	 Servers: $server
+	   Allow: $allow
+	Boundary: $boundary
+	Template: $template
+	  Config: $file
+EOM
+
+function generate_config_file {
+	typeset oldsum=
+	[[ -r "$file" ]] && oldsum=$(digest -a sha256 $file)
+
+	serverline=$(grep '@SERVER@' $template | head -1)
+	[[ -n "$serverline" ]] || fatal "No @SERVER@ line found in $template"
+
+	{
+		sed < $template "
+			/@SERVER@/d
+			s^@ALLOW@^$allow^g
+		" || fatal "Could not generate configuration file"
+		for s in $server; do
+			echo "$serverline" | sed "s^@SERVER@^$s^"
+		done
+		echo
+	} > $file
+
+	typeset newsum=$(digest -a sha256 $file)
+
+	# This function's exit status indicates if the configuration file has
+	# changed.
+	[[ -z "$oldsum" || "$oldsum" != "$newsum" ]]
+}
+
+function start_daemon {
+	echo "* Starting daemon"
+	/usr/sbin/chronyd -f "$file"
+}
+
+function stop_daemon {
+	echo "* Stopping daemon"
+	smf_kill_contract $contract TERM 1 30
+	rc=$?
+	((rc == 1)) && fatal "Invalid contract in $action"
+	# It's possible that the contract did not empty with SIGTERM; move on
+	# to KILL.
+	((rc == 2)) && smf_kill_contract $contract KILL 1
+}
+
+case $action in
+	start)
+		generate_config_file
+		start_daemon
+		;;
+	refresh)
+		generate_config_file && stop_daemon
+		# SMF will restart the service since the contract is now empty.
+		;;
+	stop)
+		stop_daemon
+		;;
+	*)
+		fatal "Unknown action '$action'"
+		;;
+esac
+
+exit $SMF_EXIT_OK
+

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -14,7 +14,7 @@ rack_secret_threshold = 1
 # NOTE: In the lab, use "172.20.15.226"
 nexus_external_address = "192.168.1.20"
 
-ntp_servers = [ "0.pool.ntp.org" ]
+ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 
 [gateway]

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -14,6 +14,9 @@ rack_secret_threshold = 1
 # NOTE: In the lab, use "172.20.15.226"
 nexus_external_address = "192.168.1.20"
 
+ntp_servers = [ "0.pool.ntp.org" ]
+dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
 [gateway]
 
 # IP address of Internet gateway

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -14,6 +14,10 @@ sled_mode = "scrimlet"
 # this information.
 sidecar_revision = "b"
 
+# Setting this to true causes sled-agent to always report that its time is
+# in-sync, rather than querying its NTP zone.
+skip_timesync = true
+
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -14,6 +14,10 @@ sled_mode = "auto"
 # this information.
 sidecar_revision = "b"
 
+# Setting this to true causes sled-agent to always report that its time is
+# in-sync, rather than querying its NTP zone.
+skip_timesync = true
+
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -14,7 +14,7 @@ rack_secret_threshold = 1
 # NOTE: In the lab, use "172.20.15.226"
 nexus_external_address = "192.168.1.20"
 
-ntp_servers = [ "0.pool.ntp.org" ]
+ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 
 [gateway]

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -14,6 +14,9 @@ rack_secret_threshold = 1
 # NOTE: In the lab, use "172.20.15.226"
 nexus_external_address = "192.168.1.20"
 
+ntp_servers = [ "0.pool.ntp.org" ]
+dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
 [gateway]
 
 # IP address of Internet gateway

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -14,6 +14,10 @@ sled_mode = "scrimlet"
 # this information.
 sidecar_revision = "b"
 
+# Setting this to true causes sled-agent to always report that its time is
+# in-sync, rather than querying its NTP zone.
+skip_timesync = true
+
 # A file-backed zpool can be manually created with the following:
 # # truncate -s 10GB testpool.vdev
 # # zpool create oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b "$PWD/testpool.vdev"


### PR DESCRIPTION
Every sled runs an NTP zone which is started once the underlay
network is available. An NTP zone runs in one of two roles - either as
a boundary server or non-boundary. A boundary server is responsible
for synchronising time with the external network, whereas a
non-boundary server synchronises with the boundary servers.

The basic flow of time synchronisation is, per RFD34,

```
                       +----------+
                       | External |
                       |  Source  |
                       +----------+
                         /      \
                       /          \
                     v              v
               +----------+    +----------+
               | Boundary |    | Boundary |
               |   NTP    |    |   NTP    |
               |  Zone    |    |  Zone    |
               +----------+    +----------+
                   |||             |||
                   vvv             vvv
     +--------+ +--------+    +--------+ +--------+
     | Gimlet | | Gimlet |    | Gimlet | | Gimlet |
     |   NTP  | |   NTP  |....|   NTP  | |   NTP  |
     |  Zone  | |  Zone  |    |  Zone  | |  Zone  |
     +--------+ +--------+    +--------+ +--------+
```

Several services on a sled should be held back until time is
synchronised "enough".

#### Boundary NTP zone

A boundary NTP zone needs a way to communicate with the external
source. It also needs to be able to perform DNS resolution as it is
likely that the external source will be a DNS name resolving to
multiple time servers. This traffic is all outbound, so could be
behind NAT.

#### Non-Boundary NTP zone

A non-boundary NTP zone synchronises time with the boundary NTP zones. It
discovers these via the internal DNS.
