### PR TITLE
[wicketd] add integration test with installinator, fix some issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,6 +8023,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "installinator",
  "installinator-artifact-client",
  "installinator-artifactd",
  "installinator-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ hyper-rustls = "0.23.2"
 hyper = "0.14"
 illumos-utils = { path = "illumos-utils" }
 indicatif = { version = "0.17.3", features = ["rayon"] }
+installinator = { path = "installinator" }
 installinator-artifactd = { path = "installinator-artifactd" }
 installinator-artifact-client = { path = "installinator-artifact-client" }
 installinator-common = { path = "installinator-common" }

--- a/installinator-artifactd/src/server.rs
+++ b/installinator-artifactd/src/server.rs
@@ -44,6 +44,16 @@ impl ArtifactServer {
 
         let dropshot_config = dropshot::ConfigDropshot {
             bind_address: std::net::SocketAddr::V6(self.address),
+            // Even though the installinator sets an upper bound on the number
+            // of items in a progress report, they can get pretty large if they
+            // haven't gone through for a bit. Ensure that hitting the max
+            // request size won't cause a failure by setting a generous upper
+            // bound for ther request size.
+            //
+            // TODO: replace with an endpoint-specific option once
+            // https://github.com/oxidecomputer/dropshot/pull/618 lands and is
+            // available in omicron.
+            request_body_max_bytes: 4 * 1024 * 1024,
             ..Default::default()
         };
 

--- a/installinator/src/lib.rs
+++ b/installinator/src/lib.rs
@@ -17,3 +17,4 @@ mod test_helpers;
 mod write;
 
 pub use dispatch::*;
+pub use write::*;

--- a/installinator/src/main.rs
+++ b/installinator/src/main.rs
@@ -10,6 +10,7 @@ use installinator::InstallinatorApp;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let app = InstallinatorApp::parse();
-    app.exec().await?;
+    let log = InstallinatorApp::setup_log("/tmp/installinator.log")?;
+    app.exec(&log).await?;
     Ok(())
 }

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -64,6 +64,16 @@ pub(crate) struct WriteDestination {
     drives: BTreeMap<M2Slot, ArtifactDestination>,
 }
 
+/// The name of the host phase 2 image written to disk.
+///
+/// Exposed for testing.
+pub static HOST_PHASE_2_FILE_NAME: &str = "host_phase_2.bin";
+
+/// The name of the control plane image written to disk.
+///
+/// Exposed for testing.
+pub static CONTROL_PLANE_FILE_NAME: &str = "control_plane.bin";
+
 impl WriteDestination {
     pub(crate) fn in_directory(dir: &Utf8Path) -> Result<Self> {
         std::fs::create_dir_all(&dir)
@@ -76,8 +86,8 @@ impl WriteDestination {
             M2Slot::A,
             ArtifactDestination {
                 create_host_phase_2: true,
-                host_phase_2: dir.join("host_phase_2.bin"),
-                control_plane: Some(dir.join("control_plane.bin")),
+                host_phase_2: dir.join(HOST_PHASE_2_FILE_NAME),
+                control_plane: Some(dir.join(CONTROL_PLANE_FILE_NAME)),
             },
         );
 

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -48,6 +48,7 @@ expectorate.workspace = true
 fs-err.workspace = true
 gateway-test-utils.workspace = true
 http.workspace = true
+installinator.workspace = true
 installinator-artifact-client.workspace = true
 omicron-test-utils.workspace = true
 openapi-lint.workspace = true

--- a/wicketd/src/installinator_progress.rs
+++ b/wicketd/src/installinator_progress.rs
@@ -101,9 +101,9 @@ impl IprArtifactServer {
 }
 
 /// The update tracker's interface to the progress store.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[must_use]
-pub(crate) struct IprUpdateTracker {
+pub struct IprUpdateTracker {
     log: slog::Logger,
     running_updates: Arc<Mutex<HashMap<Uuid, RunningUpdate>>>,
 }
@@ -113,7 +113,10 @@ impl IprUpdateTracker {
     ///
     /// Returns a oneshot receiver that resolves when the first message from the
     /// installinator has been received.
-    pub(crate) async fn register(&self, update_id: Uuid) -> IprStartReceiver {
+    ///
+    /// Exposed for testing.
+    #[doc(hidden)]
+    pub async fn register(&self, update_id: Uuid) -> IprStartReceiver {
         slog::debug!(self.log, "registering new update id"; "update_id" => %update_id);
         let (start_sender, start_receiver) = oneshot::channel();
 

--- a/wicketd/tests/integration_tests/setup.rs
+++ b/wicketd/tests/integration_tests/setup.rs
@@ -10,10 +10,12 @@ use dropshot::test_util::ClientTestContext;
 use gateway_test_utils::setup::GatewayTestContext;
 
 pub struct WicketdTestContext {
+    pub wicketd_addr: SocketAddrV6,
     pub wicketd_client: wicketd_client::Client,
     // This is not currently used but is kept here because it's easier to debug
     // this way.
     pub wicketd_raw_client: ClientTestContext,
+    pub artifact_addr: SocketAddrV6,
     pub artifact_client: installinator_artifact_client::Client,
     pub server: wicketd::Server,
     pub gateway: GatewayTestContext,
@@ -44,8 +46,8 @@ impl WicketdTestContext {
             .await
             .expect("error starting wicketd");
 
+        let wicketd_addr = assert_ipv6(server.wicketd_server.local_addr());
         let wicketd_client = {
-            let wicketd_addr = assert_ipv6(server.wicketd_server.local_addr());
             let endpoint = format!(
                 "http://[{}]:{}",
                 wicketd_addr.ip(),
@@ -57,9 +59,8 @@ impl WicketdTestContext {
             )
         };
 
+        let artifact_addr = assert_ipv6(server.artifact_server.local_addr());
         let artifact_client = {
-            let artifact_addr =
-                assert_ipv6(server.artifact_server.local_addr());
             let endpoint = format!(
                 "http://[{}]:{}",
                 artifact_addr.ip(),
@@ -77,8 +78,10 @@ impl WicketdTestContext {
         );
 
         Self {
+            wicketd_addr,
             wicketd_client,
             wicketd_raw_client,
+            artifact_addr,
             artifact_client,
             server,
             gateway,

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -11,8 +11,13 @@ use camino::Utf8Path;
 use clap::Parser;
 use gateway_messages::SpPort;
 use gateway_test_utils::setup as gateway_setup;
-use omicron_common::api::internal::nexus::KnownArtifactKind;
+use installinator::{CONTROL_PLANE_FILE_NAME, HOST_PHASE_2_FILE_NAME};
+use omicron_common::{
+    api::internal::nexus::KnownArtifactKind,
+    update::{ArtifactHashId, ArtifactKind},
+};
 use tempfile::TempDir;
+use uuid::Uuid;
 use wicketd_client::types::{UpdateEventKind, UpdateTerminalEventKind};
 
 #[tokio::test]
@@ -107,4 +112,110 @@ async fn test_updates() {
     // commands.
 
     wicketd_testctx.teardown().await;
+}
+
+#[tokio::test]
+async fn test_installinator_fetch() {
+    let gateway = gateway_setup::test_setup("test_updates", SpPort::One).await;
+    let wicketd_testctx = WicketdTestContext::setup(gateway).await;
+    let log = wicketd_testctx.log();
+
+    let temp_dir = TempDir::new().expect("temp dir created");
+    let path: &Utf8Path =
+        temp_dir.path().try_into().expect("temp dir is valid UTF-8");
+    let archive_path = path.join("archive.zip");
+
+    let args = tufaceous::Args::try_parse_from([
+        "tufaceous",
+        "assemble",
+        "../tufaceous/manifests/fake.toml",
+        archive_path.as_str(),
+    ])
+    .expect("args parsed correctly");
+
+    args.exec(log).expect("assemble command completed successfully");
+
+    // Read the archive and upload it to the server.
+    let zip_bytes =
+        fs_err::read(&archive_path).expect("archive read correctly");
+    wicketd_testctx
+        .wicketd_client
+        .put_repository(zip_bytes)
+        .await
+        .expect("bytes read and archived");
+
+    let update_plan = wicketd_testctx
+        .server
+        .artifact_store
+        .current_plan()
+        .expect("we just uploaded a repository, so there should be a plan");
+    let host_phase_2_hash = update_plan.host_phase_2_hash.to_string();
+    let control_plane_hash = update_plan.control_plane_hash.to_string();
+
+    // Are the artifacts available when looked up by hash?
+    let host_phase_2_id = ArtifactHashId {
+        kind: ArtifactKind::HOST_PHASE_2,
+        hash: update_plan.host_phase_2_hash,
+    };
+    assert!(
+        wicketd_testctx
+            .server
+            .artifact_store
+            .get_by_hash(&host_phase_2_id)
+            .is_some(),
+        "host phase 2 ID found by hash"
+    );
+
+    let control_plane_id = ArtifactHashId {
+        kind: KnownArtifactKind::ControlPlane.into(),
+        hash: update_plan.control_plane_hash,
+    };
+    assert!(
+        wicketd_testctx
+            .server
+            .artifact_store
+            .get_by_hash(&control_plane_id)
+            .is_some(),
+        "control plane ID found by hash"
+    );
+
+    // Tell the installinator to download artifacts from that location.
+    let peers_list = format!(
+        "list:[{}]:{}",
+        wicketd_testctx.artifact_addr.ip(),
+        wicketd_testctx.artifact_addr.port()
+    );
+
+    // Create a new update ID and register it. This is required to ensure the
+    // installinator reaches completion.
+    let update_id = Uuid::new_v4();
+    wicketd_testctx.server.ipr_update_tracker.register(update_id).await;
+
+    let update_id_str = update_id.to_string();
+    let dest_path = path.join("installinator-out");
+    let args = installinator::InstallinatorApp::try_parse_from([
+        "installinator",
+        "install",
+        "--mechanism",
+        peers_list.as_str(),
+        "--update-id",
+        update_id_str.as_str(),
+        "--host-phase-2",
+        host_phase_2_hash.as_str(),
+        "--control-plane",
+        control_plane_hash.as_str(),
+        dest_path.as_str(),
+    ])
+    .expect("installinator args parsed successfully");
+
+    args.exec(&log.new(slog::o!("crate" => "installinator")))
+        .await
+        .expect("installinator succeeded");
+
+    // Check that the host and control plane artifacts were downloaded
+    // correctly.
+    for file_name in [HOST_PHASE_2_FILE_NAME, CONTROL_PLANE_FILE_NAME] {
+        let path = dest_path.join(file_name);
+        assert!(path.is_file(), "{path} was written out");
+    }
 }


### PR DESCRIPTION
* Only send the last few failure events rather than all of them, capping
  the size of progress reports on the client side.
* Set a generous upper bound on the size of progress reports on the
  server side, with the aim of ensuring that a report that's too large
  doesn't block completion.
* Add an integration test against the real installinator and wicketd
  instances.
