### PR TITLE
[wicket] Start recording event history

### DIFF
--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -1,24 +1,23 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-use crate::state::ComponentId;
-use tokio::time::Instant;
+use crate::{keymap::Cmd, state::ComponentId, State};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use wicketd_client::types::{
     ArtifactId, RackV1Inventory, SemverVersion, UpdateLogAll,
 };
 
-use crossterm::event::Event as TermEvent;
-
 /// An event that will update state
 ///
 /// This can be a keypress, mouse event, or response from a downstream service.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
-    /// An input event from the terminal
-    Term(TermEvent),
+    /// An input event from the terminal translated to a Cmd
+    Term(Cmd),
 
     /// An Inventory Update Event
-    Inventory(InventoryEvent),
+    Inventory { inventory: RackV1Inventory, mgs_last_seen: Duration },
 
     /// Update Log Event
     UpdateLog(UpdateLogAll),
@@ -32,7 +31,15 @@ pub enum Event {
     /// The tick of a Timer
     /// This can be used to draw a frame to the terminal
     Tick,
+
+    /// A terminal resize event
+    Resize { width: u16, height: u16 },
+
+    /// ctrl-c was pressed
+    Shutdown,
 }
+
+/// An event that can be recorded.
 
 /// Instructions for the [`crate::Runner`]
 ///
@@ -57,23 +64,66 @@ impl Action {
     }
 }
 
-/// An inventory event occurred.
-#[derive(Clone, Debug)]
-pub enum InventoryEvent {
-    /// Inventory was received.
-    Inventory {
-        /// This is Some if the inventory changed.
-        changed_inventory: Option<RackV1Inventory>,
+/// A recorder for [`Event`]s to allow playback and debugging later.
+///
+/// The recorder maintains a copy of state, and a log of events called the
+/// `history`. The number of events can be restricted to limit memory usage. A
+/// user can only `play` as many `frames` of a recording  of history as there
+/// are events.
+///
+/// Once the log is full of events, the recorder automatically takes an in-
+/// memory "snapshot" by saving the current state, clearing the log, and
+/// appending the event that did not fit before.
+pub struct Recorder {
+    snapshot: Snapshot,
+}
 
-        /// The time at which at which information was received from wicketd.
-        wicketd_received: Instant,
+impl Recorder {
+    pub fn new(max_events: usize) -> Self {
+        Recorder { snapshot: Snapshot::new(max_events) }
+    }
 
-        /// The time at which information was received from MGS.
-        mgs_received: libsw::TokioSw,
-    },
-    /// The inventory is unavailable.
-    Unavailable {
-        /// The time at which at which information was received from wicketd.
-        wicketd_received: Instant,
-    },
+    /// Append an event to the recorder.
+    ///
+    /// Return true if the in-memory snapshot was taken, false if not.
+    pub fn push(&mut self, state: &State, event: Event) -> bool {
+        if self.snapshot.history_full() {
+            self.snapshot.take(state, event);
+            return false;
+        }
+        self.snapshot.history.push(event);
+        true
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub version: usize,
+    pub start: usize,
+    pub state: State,
+    pub history: Vec<Event>,
+    pub max_events: usize,
+}
+
+impl Snapshot {
+    fn new(max_events: usize) -> Self {
+        Snapshot {
+            version: 1,
+            start: 0,
+            state: State::new(&slog::Logger::root(slog::Discard, slog::o!())),
+            history: Vec::with_capacity(max_events),
+            max_events,
+        }
+    }
+
+    fn history_full(&self) -> bool {
+        self.max_events == self.history.len()
+    }
+
+    fn take(&mut self, state: &State, event: Event) {
+        self.start += self.history.len();
+        self.state = state.clone();
+        self.history.clear();
+        self.history.push(event);
+    }
 }

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -110,7 +110,7 @@ impl Snapshot {
         Snapshot {
             version: 1,
             start: 0,
-            state: State::new(&slog::Logger::root(slog::Discard, slog::o!())),
+            state: State::new(),
             history: Vec::with_capacity(max_events),
             max_events,
         }

--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -8,12 +8,13 @@
 //! while decoupling keys from actions on [`crate::Control`]s
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::{Deserialize, Serialize};
 
 /// All commands handled by [`crate::Control::on`].
 ///
 /// These are mostly user input commands from the keyboard,
 /// but also include certain events like `Tick`.,
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Cmd {
     /// Select the only available action for a current control
     /// This can trigger an operation, popup, etc...
@@ -34,7 +35,11 @@ pub enum Cmd {
     /// When a user `Select`s  a user input an [`crate::Action`]  will be
     /// returned that establishes Raw mode. When the context is exited, `Raw`
     /// mode will be disabled.
-    Raw(KeyEvent),
+    ///
+    /// TODO: This is currently commented out because we need to translate key
+    /// presses to something we can serialize/deserialize once we decide to use
+    /// it.
+    /// Raw(KeyEvent),
 
     /// Display details for the given selection
     /// This can be used to do things like open a scollable popup for a given

--- a/wicket/src/lib.rs
+++ b/wicket/src/lib.rs
@@ -16,7 +16,7 @@ mod wicketd;
 
 pub use crate::dispatch::*;
 pub use crate::runner::*;
-pub use events::{Action, Event, InventoryEvent};
+pub use events::{Action, Event, Recorder};
 pub use keymap::{Cmd, KeyHandler};
 pub use state::State;
 pub use ui::Control;

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -77,7 +77,7 @@ pub struct Runner {
 impl Runner {
     pub fn new(log: slog::Logger, wicketd_addr: SocketAddrV6) -> Runner {
         let (events_tx, events_rx) = unbounded_channel();
-        let state = State::new(&log);
+        let state = State::new();
         let backend = CrosstermBackend::new(stdout());
         let terminal = Terminal::new(backend).unwrap();
         let tokio_rt = tokio::runtime::Builder::new_multi_thread()
@@ -162,7 +162,7 @@ impl Runner {
                 Event::UpdateLog(logs) => {
                     self.state.service_status.reset_wicketd(Duration::ZERO);
                     debug!(self.log, "{:#?}", logs);
-                    self.state.update_state.update_logs(logs);
+                    self.state.update_state.update_logs(&self.log, logs);
                     self.screen.draw(&self.state, &mut self.terminal)?;
                 }
                 Event::Shutdown => break,

--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -7,6 +7,7 @@
 use anyhow::anyhow;
 use lazy_static::lazy_static;
 use omicron_common::api::internal::nexus::KnownArtifactKind;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::iter::Iterator;
@@ -27,7 +28,7 @@ lazy_static! {
 
 /// Inventory is the most recent information about rack composition as
 /// received from MGS.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Inventory {
     power: BTreeMap<ComponentId, PowerState>,
     inventory: BTreeMap<ComponentId, Component>,
@@ -97,7 +98,7 @@ impl Inventory {
 
 // We just print the debug info on the screen for now
 #[allow(unused)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Sp {
     ignition: SpIgnition,
     state: SpState,
@@ -105,7 +106,7 @@ pub struct Sp {
 }
 
 // XXX: Eventually a Sled will have a host component.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Component {
     Sled(Sp),
     Switch(Sp),
@@ -149,7 +150,9 @@ impl Component {
 }
 
 // The component type and its slot.
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize,
+)]
 pub enum ComponentId {
     Sled(u8),
     Switch(u8),
@@ -212,7 +215,7 @@ impl<'a> TryFrom<ParsableComponentId<'a>> for ComponentId {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum PowerState {
     /// Working
     A0,

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -14,16 +14,17 @@ pub use inventory::{
     ALL_COMPONENT_IDS,
 };
 pub use rack::{KnightRiderMode, RackState};
-pub use status::{ComputedLiveness, LivenessState, ServiceStatus};
+pub use status::{Liveness, ServiceStatus};
 pub use update::{artifact_title, RackUpdateState, UpdateState};
 
+use serde::{Deserialize, Serialize};
 use slog::Logger;
 
 /// The global state of wicket
 ///
 /// [`State`] is not tied to any specific screen and is updated upon event
 /// receipt.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct State {
     pub screen_width: u16,
     pub screen_height: u16,

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -18,7 +18,6 @@ pub use status::{Liveness, ServiceStatus};
 pub use update::{artifact_title, RackUpdateState, UpdateState};
 
 use serde::{Deserialize, Serialize};
-use slog::Logger;
 
 /// The global state of wicket
 ///
@@ -35,14 +34,14 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(log: &Logger) -> State {
+    pub fn new() -> State {
         State {
             screen_height: 0,
             screen_width: 0,
             inventory: Inventory::default(),
             rack_state: RackState::new(),
             service_status: ServiceStatus::new(),
-            update_state: RackUpdateState::new(log),
+            update_state: RackUpdateState::new(),
         }
     }
 }

--- a/wicket/src/state/rack.rs
+++ b/wicket/src/state/rack.rs
@@ -7,10 +7,11 @@
 //! This is mostly visual selection state right now.
 
 use super::inventory::ComponentId;
+use serde::{Deserialize, Serialize};
 use slog::Logger;
 
 // Easter egg alert: Support for Knight Rider mode
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct KnightRiderMode {
     pub count: usize,
 }
@@ -22,8 +23,9 @@ impl KnightRiderMode {
 }
 
 // The visual state of the rack
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RackState {
+    #[serde(skip)]
     pub log: Option<Logger>,
     pub selected: ComponentId,
     pub knight_rider_mode: Option<KnightRiderMode>,

--- a/wicket/src/ui/main.rs
+++ b/wicket/src/ui/main.rs
@@ -189,9 +189,8 @@ impl MainScreen {
         frame: &mut Frame<'_>,
         rect: Rect,
     ) {
-        let wicketd_spans =
-            state.service_status.wicketd_liveness.compute().to_spans();
-        let mgs_spans = state.service_status.mgs_liveness.compute().to_spans();
+        let wicketd_spans = state.service_status.wicketd_liveness().to_spans();
+        let mgs_spans = state.service_status.mgs_liveness().to_spans();
         let mut spans = vec![Span::styled("WICKETD: ", style::service())];
         spans.extend_from_slice(&wicketd_spans);
         spans.push(Span::styled(" | ", style::divider()));

--- a/wicketd-client/src/lib.rs
+++ b/wicketd-client/src/lib.rs
@@ -24,17 +24,17 @@ progenitor::generate_api!(
     derives = [schemars::JsonSchema],
     patch =
         {
-        SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord] },
-        SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        SpComponentInfo= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        SpIgnition= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        SpIgnitionSystemType= { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        SpInventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        RackV1Inventory = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        RotState = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        RotImageDetails = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        RotSlot = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
-        ImageVersion = { derives = [ PartialEq, Eq, PartialOrd, Ord] },
+        SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
+        SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
+        SpComponentInfo= { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        SpIgnition= { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        SpIgnitionSystemType= { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        SpInventory = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        RackV1Inventory = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        RotState = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        RotImageDetails = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        RotSlot = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
+        ImageVersion = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize]},
     }
 );
 


### PR DESCRIPTION
We are starting to record events in memory so that we can dump a snapshot and replay it for visual debugging.

The events must replay determinisitically, and so events that contained `Instants` were changed to use `Durations` resulting in some corresponding change elsewhere. This actually fixed a bug I noticed periodically in display of the countdown when MGS was offline for a while, and countdown would move at a weird rate.

Right now the recording isn't 100% deterministic because there is some state stored within the UI panes. We should move this state into the global `State` to make it deterministic. This actually doesn't  matter for short recordings, as we always start from newly initialized data. But if we ever have enough data to exceed our event storage, we snapshot `State`, which doesn't capture what's in the panes and may trigger anomalies.