### PR TITLE
[wicket] show PWR1 as empty, skip over it while tabbing over

### DIFF
--- a/wicket/src/state/rack.rs
+++ b/wicket/src/state/rack.rs
@@ -71,6 +71,8 @@ impl RackState {
                     ComponentId::Sled(17)
                 }
             }
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
             ComponentId::Psc(0) => ComponentId::Switch(1),
             _ => unreachable!(),
         };
@@ -80,6 +82,8 @@ impl RackState {
         self.selected = match self.selected {
             ComponentId::Sled(16 | 17) => ComponentId::Switch(1),
             ComponentId::Sled(i) => ComponentId::Sled((30 + i) % 32),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
             ComponentId::Switch(1) => ComponentId::Psc(0),
             ComponentId::Switch(0) => {
                 if self.left_column {
@@ -113,6 +117,8 @@ impl RackState {
             ComponentId::Sled(15) => ComponentId::Switch(0),
             ComponentId::Sled(i) => ComponentId::Sled((i + 1) % 32),
             ComponentId::Switch(0) => ComponentId::Psc(0),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
             ComponentId::Psc(0) => ComponentId::Switch(1),
             ComponentId::Switch(1) => ComponentId::Sled(16),
             _ => unreachable!(),
@@ -125,6 +131,8 @@ impl RackState {
             ComponentId::Sled(16) => ComponentId::Switch(1),
             ComponentId::Sled(0) => ComponentId::Sled(31),
             ComponentId::Sled(i) => ComponentId::Sled(i - 1),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
             ComponentId::Switch(1) => ComponentId::Psc(0),
             ComponentId::Psc(0) => ComponentId::Switch(0),
             ComponentId::Switch(0) => ComponentId::Sled(15),


### PR DESCRIPTION
Our current shipping racks just have one power shelf, so show PWR1 as empty.

![image](https://user-images.githubusercontent.com/180618/227033223-bd511b29-0b7c-4ce8-a6a4-ef648c35cad3.png)

Closes #2559.