### PR TITLE
[wicket] show PWR1 as empty, skip over it while tabbing over

### DIFF
--- a/wicket/src/state/rack.rs
+++ b/wicket/src/state/rack.rs
@@ -71,8 +71,9 @@ impl RackState {
                     ComponentId::Sled(17)
                 }
             }
-            ComponentId::Psc(0) => ComponentId::Psc(1),
-            ComponentId::Psc(1) => ComponentId::Switch(1),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
+            ComponentId::Psc(0) => ComponentId::Switch(1),
             _ => unreachable!(),
         };
     }
@@ -81,7 +82,9 @@ impl RackState {
         self.selected = match self.selected {
             ComponentId::Sled(16 | 17) => ComponentId::Switch(1),
             ComponentId::Sled(i) => ComponentId::Sled((30 + i) % 32),
-            ComponentId::Switch(1) => ComponentId::Psc(1),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
+            ComponentId::Switch(1) => ComponentId::Psc(0),
             ComponentId::Switch(0) => {
                 if self.left_column {
                     ComponentId::Sled(14)
@@ -90,7 +93,6 @@ impl RackState {
                 }
             }
             ComponentId::Psc(0) => ComponentId::Switch(0),
-            ComponentId::Psc(1) => ComponentId::Psc(0),
             _ => unreachable!(),
         };
     }
@@ -115,8 +117,9 @@ impl RackState {
             ComponentId::Sled(15) => ComponentId::Switch(0),
             ComponentId::Sled(i) => ComponentId::Sled((i + 1) % 32),
             ComponentId::Switch(0) => ComponentId::Psc(0),
-            ComponentId::Psc(0) => ComponentId::Psc(1),
-            ComponentId::Psc(1) => ComponentId::Switch(1),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
+            ComponentId::Psc(0) => ComponentId::Switch(1),
             ComponentId::Switch(1) => ComponentId::Sled(16),
             _ => unreachable!(),
         };
@@ -128,8 +131,9 @@ impl RackState {
             ComponentId::Sled(16) => ComponentId::Switch(1),
             ComponentId::Sled(0) => ComponentId::Sled(31),
             ComponentId::Sled(i) => ComponentId::Sled(i - 1),
-            ComponentId::Switch(1) => ComponentId::Psc(1),
-            ComponentId::Psc(1) => ComponentId::Psc(0),
+            // Skip over Psc(1) because it is always empty in currently shipping
+            // racks.
+            ComponentId::Switch(1) => ComponentId::Psc(0),
             ComponentId::Psc(0) => ComponentId::Switch(0),
             ComponentId::Switch(0) => ComponentId::Sled(15),
             _ => unreachable!(),


### PR DESCRIPTION
Our current shipping racks just have one power shelf, so show PWR1 as empty.

![image](https://user-images.githubusercontent.com/180618/227033223-bd511b29-0b7c-4ce8-a6a4-ef648c35cad3.png)

(This was originally reviewed in #2637 but I screwed up the land so putting this up again. Will land without reviewing since there are no changes compared to 2637.)
