### PR TITLE
[wicketd] fix test_inventory on illumos

### DIFF
--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -11,7 +11,7 @@ use gateway_messages::SpPort;
 use gateway_test_utils::setup as gateway_setup;
 use wicketd_client::GetInventoryResponse;
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn test_inventory() {
     let gateway =
         gateway_setup::test_setup("test_inventory", SpPort::One).await;


### PR DESCRIPTION
For some reason, tokio's paused time functionality works fine on Linux
but not so much on illumos (at least for this test). It's not really
relevant to the test (I think I added it by mistake!) so remove it.

Fixes #2651.