### PR TITLE
Bump rust toolchain to 1.68.2

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (ubuntu-20.04)"
 #: variety = "basic"
 #: target = "ubuntu-20.04"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",

--- a/.github/buildomat/jobs/build-end-to-end-tests.sh
+++ b/.github/buildomat/jobs/build-end-to-end-tests.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build-end-to-end-tests"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"=/work/*.gz",
 #: ]

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -3,7 +3,7 @@
 #: name = "clippy (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = []
 
 # Run clippy on illumos (not just other systems) because a bunch of our code

--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build OS image"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"=/work/helios/image/output/os.tar.gz",
 #: ]

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -3,7 +3,7 @@
 #: name = "helios / package"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"=/work/package.tar.gz",
 #:	"=/work/global-zone-packages.tar.gz",

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -3,7 +3,7 @@
 #: name = "helios / build recovery OS image"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66.1"
+#: rust_toolchain = "1.68.2"
 #: output_rules = [
 #:	"=/work/helios/image/output/os.tar.gz",
 #: ]

--- a/oximeter/oximeter/src/histogram.rs
+++ b/oximeter/oximeter/src/histogram.rs
@@ -511,10 +511,7 @@ where
     {
         let edges = [
             vec![<T as num_traits::Zero>::zero()],
-            (start_decade..end_decade)
-                .into_iter()
-                .flat_map(|x| x.span_decade())
-                .collect(),
+            (start_decade..end_decade).flat_map(|x| x.span_decade()).collect(),
         ]
         .concat();
         Histogram::new(&edges)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,8 +4,5 @@
 #
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-#
-# Right now, we skip 1.67 due to rust-lang/cargo#11629.  There are workarounds
-# for that but it's simpler to just skip this release.
-channel = "1.66.1"
+channel = "1.68.2"
 profile = "default"

--- a/wicket/src/ui/panes/mod.rs
+++ b/wicket/src/ui/panes/mod.rs
@@ -36,10 +36,8 @@ pub fn align_by(
 ) -> Text {
     rect.x += left_margin;
     rect.width -= left_margin;
-    let constraints: Vec<_> = (0..spans.len())
-        .into_iter()
-        .map(|_| Constraint::Max(column_width))
-        .collect();
+    let constraints: Vec<_> =
+        (0..spans.len()).map(|_| Constraint::Max(column_width)).collect();
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(constraints)

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -244,7 +244,7 @@ impl ArtifactsWithPlan {
             let target_name = TargetName::try_from(artifact.target.as_str())
                 .map_err(|error| RepositoryError::LocateTarget {
                     target: artifact.target.clone(),
-                    error,
+                    error: Box::new(error),
                 })?;
 
             let target_hash = repository
@@ -277,7 +277,7 @@ impl ArtifactsWithPlan {
                 .read_target(&target_name)
                 .map_err(|error| RepositoryError::LocateTarget {
                     target: artifact.target.clone(),
-                    error,
+                    error: Box::new(error),
                 })?
                 .ok_or_else(|| {
                     RepositoryError::MissingTarget(artifact.target.clone())
@@ -382,7 +382,7 @@ enum RepositoryError {
     LocateTarget {
         target: String,
         #[source]
-        error: tough::error::Error,
+        error: Box<tough::error::Error>,
     },
 
     #[error(


### PR DESCRIPTION
This is a somewhat selfish PR, as [configuring `registries.crates-io.protocol = sparse` globally](https://github.com/iliana/dotfiles/blob/7ed7d4f33bccc7ee63d74b6312cc6caa27844b63/.cargo/config) doesn't work for the window of compilers where `protocol = sparse` existed as a nightly-only option prior to stabilization.

A follow-up to this PR might shave a couple of minutes off of CI by opting into the sparse registry protocol.