### PR TITLE
Set disk's target state based on instance's target

### DIFF
--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -2522,11 +2522,15 @@ async fn test_disks_detached_when_instance_destroyed(
 
     // Stop and delete instance
     let instance_url = format!("/v1/instances/nfs?project={}", PROJECT_NAME);
-
     let instance =
         instance_post(&client, instance_name, InstanceOp::Stop).await;
+
     let apictx = &cptestctx.server.apictx();
     let nexus = &apictx.nexus;
+
+    // Store the sled agent for this instance for later disk simulation
+    let sa = nexus.instance_sled_by_id(&instance.identity.id).await.unwrap();
+
     instance_simulate(nexus, &instance.identity.id).await;
     let instance = instance_get(&client, &instance_url).await;
     assert_eq!(instance.runtime.run_state, InstanceState::Stopped);
@@ -2547,6 +2551,57 @@ async fn test_disks_detached_when_instance_destroyed(
     assert_eq!(disks.len(), 8);
     for disk in &disks {
         assert_eq!(disk.state, DiskState::Detached);
+
+        // Simulate each one of the disks to move from "Detaching" to "Detached"
+        sa.disk_finish_transition(disk.identity.id).await;
+    }
+
+    // Ensure that the disks can be attached to another instance
+    let instance_params = params::InstanceCreate {
+        identity: IdentityMetadataCreateParams {
+            name: "nfsv2".parse().unwrap(),
+            description: String::from("probably serving data too!"),
+        },
+        ncpus: InstanceCpuCount::try_from(2).unwrap(),
+        memory: ByteCount::from_gibibytes_u32(4),
+        hostname: String::from("nfsv2"),
+        user_data: vec![],
+        network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
+        external_ips: vec![],
+        disks: (0..8)
+            .map(|i| {
+                params::InstanceDiskAttachment::Attach(
+                    params::InstanceDiskAttach {
+                        name: Name::try_from(format!("probablydata{}", i))
+                            .unwrap(),
+                    },
+                )
+            })
+            .collect(),
+        start: true,
+    };
+
+    let builder =
+        RequestBuilder::new(client, http::Method::POST, &get_instances_url())
+            .body(Some(&instance_params))
+            .expect_status(Some(http::StatusCode::CREATED));
+
+    let _response = NexusRequest::new(builder)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("expected instance creation!");
+
+    // Assert disks are attached to this new instance
+    let disks: Vec<Disk> =
+        NexusRequest::iter_collection_authn(client, &get_disks_url(), "", None)
+            .await
+            .expect("failed to list disks")
+            .all_items;
+
+    assert_eq!(disks.len(), 8);
+    for disk in &disks {
+        assert!(matches!(disk.state, DiskState::Attached(_)));
     }
 }
 

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -229,7 +229,18 @@ impl SledAgent {
                 gen: omicron_common::api::external::Generation::new(),
                 time_updated: chrono::Utc::now(),
             };
-            let target = DiskStateRequested::Attached(instance_id);
+
+            let target = match target.run_state {
+                InstanceStateRequested::Running
+                | InstanceStateRequested::Reboot => {
+                    DiskStateRequested::Attached(instance_id)
+                }
+                InstanceStateRequested::Stopped
+                | InstanceStateRequested::Destroyed => {
+                    DiskStateRequested::Detached
+                }
+                _ => panic!("state {} not covered!", target.run_state),
+            };
 
             let id = match disk.volume_construction_request {
                 propolis_client::instance_spec::VolumeConstructionRequest::Volume { id, .. } => id,


### PR DESCRIPTION
When simulating a disk, set the target state based on the instance's target state.

Add a test to ensure that detached disks can be attached to another instance.

Fixes #2675