### PR TITLE
simplify DNS data types

### DIFF
--- a/dns-server/src/dns_types.rs
+++ b/dns-server/src/dns_types.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// types describing DNS records and configuration
+//! types describing DNS records and configuration
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::net::Ipv6Addr;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -25,19 +27,7 @@ pub struct DnsConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct DnsConfigZone {
     pub zone_name: String,
-    pub records: Vec<DnsKV>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "DnsKv")]
-pub struct DnsKV {
-    pub key: DnsRecordKey,
-    pub records: Vec<DnsRecord>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct DnsRecordKey {
-    pub name: String,
+    pub records: HashMap<String, Vec<DnsRecord>>,
 }
 
 #[allow(clippy::upper_case_acronyms)]

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -176,6 +176,7 @@ mod test {
     use dns_service_client::types::DnsConfigParams;
     use omicron_test_utils::dev::test_setup_log;
     use slog::{o, Logger};
+    use std::collections::HashMap;
     use std::net::Ipv6Addr;
     use std::net::SocketAddr;
     use std::net::SocketAddrV6;
@@ -440,7 +441,7 @@ mod test {
         // If we deploy a new generation that removes all records, then we don't
         // find anything any more.
         dns_config.generation += 1;
-        dns_config.zones[0].records = Vec::new();
+        dns_config.zones[0].records = HashMap::new();
         dns_server.update(&dns_config).await.unwrap();
 
         // If we remove the records for all services, we won't find them any

--- a/internal-dns/tests/output/internal-dns-zone.txt
+++ b/internal-dns/tests/output/internal-dns-zone.txt
@@ -1,187 +1,122 @@
 builder: "empty"
-[]
+{}
 builder: "hosts_only"
-[
-  {
-    "key": {
-      "name": "001de000-51ed-4000-8000-000000000001.sled"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::1"
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-51ed-4000-8000-000000000002.sled"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.0.0.2"
-      }
-    ]
-  }
-]
+{
+  "001de000-51ed-4000-8000-000000000001.sled": [
+    {
+      "type": "AAAA",
+      "data": "::1"
+    }
+  ],
+  "001de000-51ed-4000-8000-000000000002.sled": [
+    {
+      "type": "AAAA",
+      "data": "::0.0.0.2"
+    }
+  ]
+}
 builder: "zones_only"
-[
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000001.host"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.1"
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000002.host"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.2"
-      }
-    ]
-  }
-]
+{
+  "001de000-c04e-4000-8000-000000000001.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.1"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000002.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.2"
+    }
+  ]
+}
 builder: "non_trivial"
-[
-  {
-    "key": {
-      "name": "001de000-51ed-4000-8000-000000000001.sled"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::1"
+{
+  "001de000-51ed-4000-8000-000000000001.sled": [
+    {
+      "type": "AAAA",
+      "data": "::1"
+    }
+  ],
+  "001de000-51ed-4000-8000-000000000002.sled": [
+    {
+      "type": "AAAA",
+      "data": "::0.0.0.2"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000001.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.1"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000002.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.2"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000003.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.3"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000004.host": [
+    {
+      "type": "AAAA",
+      "data": "::0.1.0.4"
+    }
+  ],
+  "_nexus._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "port": 123,
+        "prio": 0,
+        "target": "001de000-c04e-4000-8000-000000000001.host.control-plane.oxide.internal",
+        "weight": 0
       }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-51ed-4000-8000-000000000002.sled"
     },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.0.0.2"
+    {
+      "type": "SRV",
+      "data": {
+        "port": 124,
+        "prio": 0,
+        "target": "001de000-c04e-4000-8000-000000000002.host.control-plane.oxide.internal",
+        "weight": 0
       }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000001.host"
+    }
+  ],
+  "_oximeter._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "port": 125,
+        "prio": 0,
+        "target": "001de000-c04e-4000-8000-000000000002.host.control-plane.oxide.internal",
+        "weight": 0
+      }
     },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.1"
+    {
+      "type": "SRV",
+      "data": {
+        "port": 126,
+        "prio": 0,
+        "target": "001de000-c04e-4000-8000-000000000003.host.control-plane.oxide.internal",
+        "weight": 0
       }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000002.host"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.2"
+    }
+  ],
+  "_sledagent._tcp.001de000-51ed-4000-8000-000000000001": [
+    {
+      "type": "SRV",
+      "data": {
+        "port": 123,
+        "prio": 0,
+        "target": "001de000-51ed-4000-8000-000000000001.sled.control-plane.oxide.internal",
+        "weight": 0
       }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000003.host"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.3"
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "001de000-c04e-4000-8000-000000000004.host"
-    },
-    "records": [
-      {
-        "type": "AAAA",
-        "data": "::0.1.0.4"
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "_sledagent._tcp.001de000-51ed-4000-8000-000000000001"
-    },
-    "records": [
-      {
-        "type": "SRV",
-        "data": {
-          "port": 123,
-          "prio": 0,
-          "target": "001de000-51ed-4000-8000-000000000001.sled.control-plane.oxide.internal",
-          "weight": 0
-        }
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "_nexus._tcp"
-    },
-    "records": [
-      {
-        "type": "SRV",
-        "data": {
-          "port": 123,
-          "prio": 0,
-          "target": "001de000-c04e-4000-8000-000000000001.host.control-plane.oxide.internal",
-          "weight": 0
-        }
-      },
-      {
-        "type": "SRV",
-        "data": {
-          "port": 124,
-          "prio": 0,
-          "target": "001de000-c04e-4000-8000-000000000002.host.control-plane.oxide.internal",
-          "weight": 0
-        }
-      }
-    ]
-  },
-  {
-    "key": {
-      "name": "_oximeter._tcp"
-    },
-    "records": [
-      {
-        "type": "SRV",
-        "data": {
-          "port": 125,
-          "prio": 0,
-          "target": "001de000-c04e-4000-8000-000000000002.host.control-plane.oxide.internal",
-          "weight": 0
-        }
-      },
-      {
-        "type": "SRV",
-        "data": {
-          "port": 126,
-          "prio": 0,
-          "target": "001de000-c04e-4000-8000-000000000003.host.control-plane.oxide.internal",
-          "weight": 0
-        }
-      }
-    ]
-  }
-]
+    }
+  ]
+}

--- a/nexus/db-model/src/dns.rs
+++ b/nexus/db-model/src/dns.rs
@@ -9,6 +9,7 @@ use nexus_types::internal_api::params;
 use omicron_common::api::external::Error;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::{fmt, net::Ipv6Addr};
 use uuid::Uuid;
 
@@ -198,7 +199,7 @@ impl From<SRV> for params::Srv {
 pub struct InitialDnsGroup {
     dns_group: DnsGroup,
     zone_name: String,
-    records: Vec<params::DnsKv>,
+    records: HashMap<String, Vec<params::DnsRecord>>,
     version: Generation,
     dns_zone_id: Uuid,
     time_created: DateTime<Utc>,
@@ -212,7 +213,7 @@ impl InitialDnsGroup {
         zone_name: &str,
         creator: &str,
         comment: &str,
-        records: Vec<params::DnsKv>,
+        records: HashMap<String, Vec<params::DnsRecord>>,
     ) -> InitialDnsGroup {
         InitialDnsGroup {
             dns_group,
@@ -248,13 +249,13 @@ impl InitialDnsGroup {
     pub fn rows_for_names(&self) -> Result<Vec<DnsName>, Error> {
         self.records
             .iter()
-            .map(|r| {
+            .map(|(name, records)| {
                 DnsName::new(
                     self.dns_zone_id,
-                    r.key.name.clone(),
+                    name.clone(),
                     self.version,
                     None,
-                    r.records.clone(),
+                    records.clone(),
                 )
             })
             .collect::<Result<Vec<_>, _>>()

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -289,6 +289,7 @@ mod test {
         self, ByteCount, Error, IdentityMetadataCreateParams, LookupType, Name,
     };
     use omicron_test_utils::dev;
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
     use std::sync::Arc;
@@ -1076,7 +1077,7 @@ mod test {
             internal_dns::DNS_ZONE,
             "test suite",
             "test suite",
-            vec![],
+            HashMap::new(),
         );
 
         let external_dns = InitialDnsGroup::new(
@@ -1084,7 +1085,7 @@ mod test {
             "testing.oxide.example",
             "test suite",
             "test suite",
-            vec![],
+            HashMap::new(),
         );
 
         // Initialize the Rack.

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -415,7 +415,7 @@ mod test {
     use crate::db::model::IpPoolRange;
     use crate::db::model::ServiceKind;
     use async_bb8_diesel::AsyncSimpleConnection;
-    use internal_params::{DnsKv, DnsRecord, DnsRecordKey};
+    use internal_params::DnsRecord;
     use nexus_db_model::{DnsGroup, InitialDnsGroup};
     use nexus_test_utils::db::test_setup_database;
     use nexus_types::identity::Asset;
@@ -433,7 +433,7 @@ mod test {
             internal_dns::DNS_ZONE,
             "test suite",
             "test suite",
-            vec![],
+            HashMap::new(),
         )
     }
 
@@ -443,7 +443,7 @@ mod test {
             "testing.oxide.example",
             "test suite",
             "test suite",
-            vec![],
+            HashMap::new(),
         )
     }
 
@@ -714,10 +714,7 @@ mod test {
             internal_dns::DNS_ZONE,
             "test suite",
             "initial test suite internal rev",
-            vec![DnsKv {
-                key: DnsRecordKey { name: "nexus".to_string() },
-                records: internal_records.clone(),
-            }],
+            HashMap::from([("nexus".to_string(), internal_records.clone())]),
         );
 
         let external_records =
@@ -727,10 +724,7 @@ mod test {
             "test-suite.oxide.test",
             "test suite",
             "initial test suite external rev",
-            vec![DnsKv {
-                key: DnsRecordKey { name: "api.sys".to_string() },
-                records: external_records.clone(),
-            }],
+            HashMap::from([("api.sys".to_string(), external_records.clone())]),
         );
 
         let rack = datastore
@@ -831,11 +825,9 @@ mod test {
             dns_config_internal.zones[0].zone_name,
             internal_dns::DNS_ZONE
         );
-        assert_eq!(dns_config_internal.zones[0].records.len(), 1);
-        assert_eq!(dns_config_internal.zones[0].records[0].key.name, "nexus");
         assert_eq!(
-            dns_config_internal.zones[0].records[0].records,
-            internal_records
+            dns_config_internal.zones[0].records,
+            HashMap::from([("nexus".to_string(), internal_records)]),
         );
 
         let dns_config_external = datastore
@@ -848,11 +840,9 @@ mod test {
             dns_config_external.zones[0].zone_name,
             "test-suite.oxide.test",
         );
-        assert_eq!(dns_config_external.zones[0].records.len(), 1);
-        assert_eq!(dns_config_external.zones[0].records[0].key.name, "api.sys");
         assert_eq!(
-            dns_config_external.zones[0].records[0].records,
-            external_records
+            dns_config_external.zones[0].records,
+            HashMap::from([("api.sys".to_string(), external_records)]),
         );
 
         db.cleanup().await.unwrap();

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -20,6 +20,7 @@ use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::Name;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl super::Nexus {
@@ -136,7 +137,7 @@ impl super::Nexus {
             "oxide-dev.test",
             &self.id.to_string(),
             "rack setup",
-            vec![],
+            HashMap::new(),
         );
 
         self.db_datastore

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -238,8 +238,6 @@ pub struct RackInitializationRequest {
 
 pub type DnsConfigParams = dns_service_client::types::DnsConfigParams;
 pub type DnsConfigZone = dns_service_client::types::DnsConfigZone;
-pub type DnsKv = dns_service_client::types::DnsKv;
-pub type DnsRecordKey = dns_service_client::types::DnsRecordKey;
 pub type DnsRecord = dns_service_client::types::DnsRecord;
 pub type Srv = dns_service_client::types::Srv;
 

--- a/openapi/dns-server.json
+++ b/openapi/dns-server.json
@@ -126,9 +126,12 @@
         "type": "object",
         "properties": {
           "records": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DnsKv"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DnsRecord"
+              }
             }
           },
           "zone_name": {
@@ -138,24 +141,6 @@
         "required": [
           "records",
           "zone_name"
-        ]
-      },
-      "DnsKv": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "$ref": "#/components/schemas/DnsRecordKey"
-          },
-          "records": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DnsRecord"
-            }
-          }
-        },
-        "required": [
-          "key",
-          "records"
         ]
       },
       "DnsRecord": {
@@ -197,17 +182,6 @@
               "type"
             ]
           }
-        ]
-      },
-      "DnsRecordKey": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
         ]
       },
       "Error": {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1196,9 +1196,12 @@
         "type": "object",
         "properties": {
           "records": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DnsKv"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DnsRecord"
+              }
             }
           },
           "zone_name": {
@@ -1208,24 +1211,6 @@
         "required": [
           "records",
           "zone_name"
-        ]
-      },
-      "DnsKv": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "$ref": "#/components/schemas/DnsRecordKey"
-          },
-          "records": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DnsRecord"
-            }
-          }
-        },
-        "required": [
-          "key",
-          "records"
         ]
       },
       "DnsRecord": {
@@ -1267,17 +1252,6 @@
               "type"
             ]
           }
-        ]
-      },
-      "DnsRecordKey": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
         ]
       },
       "Duration": {

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -122,12 +122,7 @@ fn d2n_zone(
         records: zone
             .records
             .iter()
-            .map(|r| nexus_client::types::DnsKv {
-                key: nexus_client::types::DnsRecordKey {
-                    name: r.key.name.clone(),
-                },
-                records: r.records.iter().map(d2n_record).collect(),
-            })
+            .map(|(n, r)| (n.clone(), r.iter().map(d2n_record).collect()))
             .collect(),
     }
 }


### PR DESCRIPTION
Following up on https://github.com/oxidecomputer/omicron/pull/2570#discussion_r1143903324, here's my attempt at simplifying the DNS-related types.  On the plus side, it's a considerable net reduction in code!

In terms of review, the essence of the change is just the change to `dns-server/src/dns_types.rs`:
https://github.com/oxidecomputer/omicron/pull/2700/files#diff-d3365fde6300987efb3dc8dd45ff52e22a8e55e33d4c6e5df1e8dfbfc5e4e721

Everything else just follows from that.  For the most part, instead of:

```rust
DnsKv {
    key: DnsRecordKey { name: name },
    records: records,
}
```

we have:

```rust
(name, records): (String, Vec<DnsRecord>)
```

And where we had a `Vec<DnsKv>`, we now have a `HashMap<String, Vec<DnsRecord>>`.