### PR TITLE
actions: bump everything

### DIFF
--- a/.github/workflows/check-opte-ver.yml
+++ b/.github/workflows/check-opte-ver.yml
@@ -6,7 +6,7 @@ on:
       - 'tools/opte_version'
 jobs:
   check-opte-ver:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install jq

--- a/.github/workflows/check-opte-ver.yml
+++ b/.github/workflows/check-opte-ver.yml
@@ -2,6 +2,7 @@ name: check-opte-ver
 on:
   pull_request:
     paths:
+      - '.github/workflows/check-opte-ver.yml'
       - 'Cargo.toml'
       - 'tools/opte_version'
 jobs:

--- a/.github/workflows/check-opte-ver.yml
+++ b/.github/workflows/check-opte-ver.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
       - name: Install toml-cli
-        run: cargo install toml-cli
+        run: cargo install toml-cli@0.2.3
       - name: Check OPTE version and rev match
         run: ./tools/ci_check_opte_ver.sh

--- a/.github/workflows/check-opte-ver.yml
+++ b/.github/workflows/check-opte-ver.yml
@@ -8,7 +8,7 @@ jobs:
   check-opte-ver:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
       - name: Install jq
         run: sudo apt-get install -y jq
       - name: Install toml-cli

--- a/.github/workflows/check-workspace-deps.yml
+++ b/.github/workflows/check-workspace-deps.yml
@@ -9,7 +9,7 @@ jobs:
   check-workspace-deps:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
       - name: Install jq
         run: sudo apt-get install -y jq
       - name: Install toml-cli

--- a/.github/workflows/check-workspace-deps.yml
+++ b/.github/workflows/check-workspace-deps.yml
@@ -7,7 +7,7 @@ on:
     inputs:
 jobs:
   check-workspace-deps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install jq

--- a/.github/workflows/check-workspace-deps.yml
+++ b/.github/workflows/check-workspace-deps.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
       - name: Install toml-cli
-        run: cargo install toml-cli
+        run: cargo install toml-cli@0.2.3
       - name: Check Workspace Dependencies
         run: ./tools/ci_check_workspace_deps.sh

--- a/.github/workflows/check-workspace-deps.yml
+++ b/.github/workflows/check-workspace-deps.yml
@@ -2,6 +2,7 @@ name: check-workspace-deps
 on:
   pull_request:
     paths:
+      - '.github/workflows/check-workspace-deps.yml'
       - '**/Cargo.toml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on: [ push, pull_request ]
 
 jobs:
   check-style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11 ]
+        os: [ ubuntu-22.04, macos-12 ]
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
@@ -44,7 +44,7 @@ jobs:
       run: cargo run --bin omicron-package -- -t default check
 
   clippy-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
@@ -72,7 +72,7 @@ jobs:
   # This is just a test build of docs.  Publicly available docs are built via
   # the separate "rustdocs" repo.
   build-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,7 @@ jobs:
   check-style:
     runs-on: ubuntu-22.04
     steps:
-    # actions/checkout@v2
-    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+    - uses: actions/checkout@v3.5.0
     - name: Report cargo version
       run: cargo --version
     - name: Report rustfmt version
@@ -28,9 +27,8 @@ jobs:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
       run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-    # actions/checkout@v2
-    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v3.5.0
+    - uses: Swatinem/rust-cache@v2.2.1
       if: ${{ github.ref != 'refs/heads/main' }}
     - name: Report cargo version
       run: cargo --version
@@ -49,9 +47,8 @@ jobs:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
       run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-    # actions/checkout@v2
-    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v3.5.0
+    - uses: Swatinem/rust-cache@v2.2.1
       if: ${{ github.ref != 'refs/heads/main' }}
     - name: Report cargo version
       run: cargo --version
@@ -77,9 +74,8 @@ jobs:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
       run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-    # actions/checkout@v2
-    - uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v3.5.0
+    - uses: Swatinem/rust-cache@v2.2.1
       if: ${{ github.ref != 'refs/heads/main' }}
     - name: Report cargo version
       run: cargo --version

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -10,8 +10,8 @@ jobs:
   format:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3.5.0
+      - uses: actions/setup-node@v2.5.2
         with:
           node-version: '14'
       - name: Install our tools

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -8,7 +8,7 @@ on:
     inputs:
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.5.0
-      - uses: actions/setup-node@v2.5.2
+      - uses: actions/setup-node@v3.6.0
         with:
-          node-version: '14'
+          node-version: '18'
       - name: Install our tools
         shell: bash
         run: |


### PR DESCRIPTION
There are [a few dozen deprecation warnings](https://github.com/oxidecomputer/omicron/actions/runs/4556020859) on any given Actions run, so I re-pinned everything to latest versions (and also pinned toml-cli).

(PR in draft mode while I see if any of this works.)