### PR TITLE
[nexus] Add silo name to /v1/me response

### DIFF
--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -131,7 +131,7 @@ impl super::Nexus {
         let authz_silo = opctx
             .authn
             .silo_required()
-            .internal_context("loading current silo")?;
+            .internal_context("loading current user's silo")?;
         let silo_id = authz_silo.id().into();
         let (.., db_silo) = self.silo_lookup(&opctx, &silo_id)?.fetch().await?;
         Ok(db_silo)

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -123,6 +123,20 @@ impl super::Nexus {
         Ok(db_silo_user)
     }
 
+    /// Fetch the currently-authenticated Silo user's Silo
+    pub async fn silo_user_fetch_silo(
+        &self,
+        opctx: &OpContext,
+    ) -> LookupResult<db::model::Silo> {
+        let authz_silo = opctx
+            .authn
+            .silo_required()
+            .internal_context("loading current silo")?;
+        let silo_id = authz_silo.id().into();
+        let (.., db_silo) = self.silo_lookup(&opctx, &silo_id)?.fetch().await?;
+        Ok(db_silo)
+    }
+
     pub async fn silo_user_fetch_groups_for_self(
         &self,
         opctx: &OpContext,

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -327,14 +327,11 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     .await
     .id;
 
-    let _session_user: views::User =
-        NexusRequest::object_get(client, &"/v1/me")
-            .authn_as(AuthnMode::SiloUser(new_silo_user_id))
-            .execute()
-            .await
-            .expect("failed to make GET request")
-            .parsed_body()
-            .unwrap();
+    let _session_user = NexusRequest::object_get(client, &"/v1/me")
+        .authn_as(AuthnMode::SiloUser(new_silo_user_id))
+        .execute()
+        .await
+        .expect("failed to make GET request");
 }
 
 // Test that an authenticated, unprivileged user can access their own silo

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -341,32 +341,35 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to get current user")
-        .parsed_body::<views::User>()
+        .parsed_body::<views::CurrentUser>()
         .unwrap();
 
     assert_eq!(
         priv_user,
-        views::User {
-            id: USER_TEST_PRIVILEGED.id(),
-            display_name: USER_TEST_PRIVILEGED.external_id.clone(),
-            silo_id: DEFAULT_SILO.id(),
+        views::CurrentUser {
+            user: views::User {
+                id: USER_TEST_PRIVILEGED.id(),
+                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                silo_id: DEFAULT_SILO.id(),
+            },
+            silo_name: DEFAULT_SILO.name().clone()
         }
     );
 
     let unpriv_user = NexusRequest::object_get(testctx, "/v1/me")
         .authn_as(AuthnMode::UnprivilegedUser)
-        .execute()
-        .await
-        .expect("failed to get current user")
-        .parsed_body::<views::User>()
-        .unwrap();
+        .execute_and_parse_unwrap::<views::CurrentUser>()
+        .await;
 
     assert_eq!(
         unpriv_user,
-        views::User {
-            id: USER_TEST_UNPRIVILEGED.id(),
-            display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
-            silo_id: DEFAULT_SILO.id(),
+        views::CurrentUser {
+            user: views::User {
+                id: USER_TEST_UNPRIVILEGED.id(),
+                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                silo_id: DEFAULT_SILO.id(),
+            },
+            silo_name: DEFAULT_SILO.name().clone()
         }
     );
 }

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -99,7 +99,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     )
     .await;
     let found_user = expect_session_valid(client, &session_token).await;
-    assert_eq!(created_user, found_user);
+    assert_eq!(created_user, found_user.user);
 
     // While we're still logged in, change the password.
     let test_password2 =
@@ -352,20 +352,17 @@ async fn test_local_user_with_no_initial_password(
     )
     .await;
     let found_user = expect_session_valid(client, &session_token).await;
-    assert_eq!(created_user, found_user);
+    assert_eq!(created_user, found_user.user);
 }
 
 async fn expect_session_valid(
     client: &ClientTestContext,
     session_token: &str,
-) -> views::User {
+) -> views::CurrentUser {
     NexusRequest::object_get(client, "/v1/me")
         .authn_as(AuthnMode::Session(session_token.to_string()))
-        .execute()
+        .execute_and_parse_unwrap::<views::CurrentUser>()
         .await
-        .expect("expected successful request, but it failed")
-        .parsed_body()
-        .expect("failed to parse /v1/me response body")
 }
 
 async fn expect_session_invalid(

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -337,6 +337,19 @@ pub struct User {
     pub silo_id: Uuid,
 }
 
+// SESSION
+
+// Add silo name to User because the console needs to display it
+/// Info about the current user
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+pub struct CurrentUser {
+    #[serde(flatten)]
+    pub user: User,
+
+    /** Name of the silo to which this user belongs. */
+    pub silo_name: Name,
+}
+
 // SILO GROUPS
 
 /// Client view of a [`Group`]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2096,7 +2096,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/CurrentUser"
                 }
               }
             }
@@ -7455,6 +7455,39 @@
         "required": [
           "start_time",
           "value"
+        ]
+      },
+      "CurrentUser": {
+        "description": "Info about the current user",
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "description": "Human-readable name that can identify the user",
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "description": "Uuid of the silo to which this user belongs",
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_name": {
+            "description": "Name of the silo to which this user belongs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        },
+        "required": [
+          "display_name",
+          "id",
+          "silo_id",
+          "silo_name"
         ]
       },
       "Datum": {


### PR DESCRIPTION
There are places in the web console where we will want to use the silo name as a kind of root org name. We know from [RFD 357](https://rfd.shared.oxide.computer/rfd/0357#_external_dns_names) that in production we will have the silo name in the domain, but if we can instead pull that from the API we get a solution that works regardless of how the API and console are being served.

The one real Design Choice I'm making here is to have `views::CurrentUser` include `views::User` with `#[serde(flatten)]` rather than inlining the same fields. Initially I thought this was a neat way to make it clear that `CurrentUser`'s fields are a superset of `User`'s, but if you look at the tests you can see there are a couple of spots where we actually want to check a `User` against a `CurrentUser`, and having the `user` field makes that easy. If we wanted to inline the fields instead, we could of course compare the fields one by one.

I think I had attempted this change before and run into issues with permissions. I vaguely remember something about not being able to access the silo. But every authenticated user can read their silo:

https://github.com/oxidecomputer/omicron/blob/18177ba83b0c80e933b004c1263b11ca76fca7d6/nexus/db-queries/src/authz/omicron.polar#L152-L154

So I'm thinking I must have messed up by trying to do the silo fetch lower down with an authz context that had already been narrowed too far, if that makes sense.