### PR TITLE
clarify DNS-related type names

### DIFF
--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -67,15 +67,13 @@ use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use uuid::Uuid;
 
-/// Describes the DNS name used for a control plane host
-///
-/// This does not describe the AAA record itself.
+/// Used to construct the DNS name for a control plane host
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 enum Host {
-    /// Identifies an AAAA record for a sled.
+    /// Used to construct an AAAA record for a sled.
     Sled(Uuid),
 
-    /// Identifies an AAAA record for a zone within a sled.
+    /// Used to construct an AAAA record for a zone on a sled.
     Zone(Uuid),
 }
 

--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -60,46 +60,18 @@
 //!
 //! This module provides types used to assemble that configuration.
 
-use crate::names::{BackendName, ServiceName, DNS_ZONE};
+use crate::names::{ServiceName, DNS_ZONE};
 use anyhow::{anyhow, ensure};
 use dns_service_client::types::{DnsConfigParams, DnsConfigZone, DnsRecord};
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use uuid::Uuid;
 
-/// Describes the DNS name that will be used for a control plane service
-///
-/// This does not describe the SRV record itself.
-#[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
-pub enum SRV {
-    /// A service identified and accessed by name, such as "nexus", "CRDB", etc.
-    ///
-    /// This is used in cases where services are interchangeable.
-    Service(ServiceName),
-
-    /// A service identified by name and a unique identifier.
-    ///
-    /// This is used in cases where services are not interchangeable, such as
-    /// for the Sled agent.
-    Backend(BackendName, Uuid),
-}
-
-impl SRV {
-    /// Returns the DNS name for this service, ignoring the zone part of the DNS
-    /// name
-    pub(crate) fn dns_name(&self) -> String {
-        match &self {
-            SRV::Service(name) => format!("_{}._tcp", name),
-            SRV::Backend(name, id) => format!("_{}._tcp.{}", name, id),
-        }
-    }
-}
-
 /// Describes the DNS name used for a control plane host
 ///
 /// This does not describe the AAA record itself.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
-enum AAAA {
+enum Host {
     /// Identifies an AAAA record for a sled.
     Sled(Uuid),
 
@@ -107,13 +79,13 @@ enum AAAA {
     Zone(Uuid),
 }
 
-impl AAAA {
+impl Host {
     /// Returns the DNS name for this host, ignoring the zone part of the DNS
     /// name
     pub(crate) fn dns_name(&self) -> String {
         match &self {
-            AAAA::Sled(id) => format!("{}.sled", id),
-            AAAA::Zone(id) => format!("{}.host", id),
+            Host::Sled(id) => format!("{}.sled", id),
+            Host::Zone(id) => format!("{}.host", id),
         }
     }
 }
@@ -153,14 +125,14 @@ pub struct DnsConfigBuilder {
     zones: BTreeMap<Uuid, Ipv6Addr>,
 
     /// set of services (see module-level comment) that have been configured so
-    /// far, mapping the name of the service (encapsulated in an [`SRV`]) to the
-    /// backends configured for that service.  The set of backends is
+    /// far, mapping the name of the service (encapsulated in a [`ServiceName`])
+    /// to the backends configured for that service.  The set of backends is
     /// represented as a mapping from the zone's uuid to the port on which it's
     /// running the service.
-    service_instances_zones: BTreeMap<SRV, BTreeMap<Uuid, u16>>,
+    service_instances_zones: BTreeMap<ServiceName, BTreeMap<Uuid, u16>>,
 
     /// similar to service_instances_zones, but for services that run on sleds
-    service_instances_sleds: BTreeMap<SRV, BTreeMap<Uuid, u16>>,
+    service_instances_sleds: BTreeMap<ServiceName, BTreeMap<Uuid, u16>>,
 }
 
 /// Describes a host of type "sled" in the control plane DNS zone
@@ -241,7 +213,7 @@ impl DnsConfigBuilder {
     /// backend for this service.
     pub fn service_backend_zone(
         &mut self,
-        service: SRV,
+        service: ServiceName,
         zone: &Zone,
         port: u16,
     ) -> anyhow::Result<()> {
@@ -281,7 +253,7 @@ impl DnsConfigBuilder {
     /// backend for this service.
     pub fn service_backend_sled(
         &mut self,
-        service: SRV,
+        service: ServiceName,
         sled: &Sled,
         port: u16,
     ) -> anyhow::Result<()> {
@@ -318,13 +290,13 @@ impl DnsConfigBuilder {
     pub fn build(self) -> DnsConfigParams {
         // Assemble the set of "AAAA" records for sleds.
         let sled_records = self.sleds.into_iter().map(|(sled_id, sled_ip)| {
-            let name = AAAA::Sled(sled_id).dns_name();
+            let name = Host::Sled(sled_id).dns_name();
             (name, vec![DnsRecord::Aaaa(sled_ip)])
         });
 
         // Assemble the set of AAAA records for zones.
         let zone_records = self.zones.into_iter().map(|(zone_id, zone_ip)| {
-            let name = AAAA::Zone(zone_id).dns_name();
+            let name = Host::Zone(zone_id).dns_name();
             (name, vec![DnsRecord::Aaaa(zone_ip)])
         });
 
@@ -342,7 +314,7 @@ impl DnsConfigBuilder {
                             port,
                             target: format!(
                                 "{}.{}",
-                                AAAA::Zone(zone_id).dns_name(),
+                                Host::Zone(zone_id).dns_name(),
                                 DNS_ZONE
                             ),
                         })
@@ -365,7 +337,7 @@ impl DnsConfigBuilder {
                             port,
                             target: format!(
                                 "{}.{}",
-                                AAAA::Sled(sled_id).dns_name(),
+                                Host::Sled(sled_id).dns_name(),
                                 DNS_ZONE
                             ),
                         })
@@ -395,62 +367,43 @@ impl DnsConfigBuilder {
 
 #[cfg(test)]
 mod test {
-    use super::{BackendName, DnsConfigBuilder, ServiceName, AAAA, SRV};
+    use super::{DnsConfigBuilder, Host, ServiceName};
     use crate::DNS_ZONE;
     use std::{collections::BTreeMap, io::Write, net::Ipv6Addr};
     use uuid::Uuid;
 
     #[test]
     fn display_srv_service() {
+        assert_eq!(ServiceName::Clickhouse.dns_name(), "_clickhouse._tcp",);
+        assert_eq!(ServiceName::Cockroach.dns_name(), "_cockroach._tcp",);
+        assert_eq!(ServiceName::InternalDNS.dns_name(), "_nameservice._tcp",);
+        assert_eq!(ServiceName::Nexus.dns_name(), "_nexus._tcp",);
+        assert_eq!(ServiceName::Oximeter.dns_name(), "_oximeter._tcp",);
+        assert_eq!(ServiceName::Dendrite.dns_name(), "_dendrite._tcp",);
         assert_eq!(
-            SRV::Service(ServiceName::Clickhouse).dns_name(),
-            "_clickhouse._tcp",
-        );
-        assert_eq!(
-            SRV::Service(ServiceName::Cockroach).dns_name(),
-            "_cockroach._tcp",
-        );
-        assert_eq!(
-            SRV::Service(ServiceName::InternalDNS).dns_name(),
-            "_internalDNS._tcp",
-        );
-        assert_eq!(SRV::Service(ServiceName::Nexus).dns_name(), "_nexus._tcp",);
-        assert_eq!(
-            SRV::Service(ServiceName::Oximeter).dns_name(),
-            "_oximeter._tcp",
-        );
-        assert_eq!(
-            SRV::Service(ServiceName::Dendrite).dns_name(),
-            "_dendrite._tcp",
-        );
-        assert_eq!(
-            SRV::Service(ServiceName::CruciblePantry).dns_name(),
+            ServiceName::CruciblePantry.dns_name(),
             "_crucible-pantry._tcp",
         );
-    }
-
-    #[test]
-    fn display_srv_backend() {
         let uuid = Uuid::nil();
         assert_eq!(
-            SRV::Backend(BackendName::Crucible, uuid).dns_name(),
+            ServiceName::Crucible(uuid).dns_name(),
             "_crucible._tcp.00000000-0000-0000-0000-000000000000",
         );
         assert_eq!(
-            SRV::Backend(BackendName::SledAgent, uuid).dns_name(),
+            ServiceName::SledAgent(uuid).dns_name(),
             "_sledagent._tcp.00000000-0000-0000-0000-000000000000",
         );
     }
 
     #[test]
-    fn display_aaaa() {
+    fn display_hosts() {
         let uuid = Uuid::nil();
         assert_eq!(
-            AAAA::Sled(uuid).dns_name(),
+            Host::Sled(uuid).dns_name(),
             "00000000-0000-0000-0000-000000000000.sled",
         );
         assert_eq!(
-            AAAA::Zone(uuid).dns_name(),
+            Host::Zone(uuid).dns_name(),
             "00000000-0000-0000-0000-000000000000.host",
         );
     }
@@ -512,37 +465,17 @@ mod test {
 
             // A service with two backends on two zones using two different
             // ports
-            b.service_backend_zone(
-                SRV::Service(ServiceName::Nexus),
-                &zone1,
-                123,
-            )
-            .unwrap();
-            b.service_backend_zone(
-                SRV::Service(ServiceName::Nexus),
-                &zone2,
-                124,
-            )
-            .unwrap();
+            b.service_backend_zone(ServiceName::Nexus, &zone1, 123).unwrap();
+            b.service_backend_zone(ServiceName::Nexus, &zone2, 124).unwrap();
 
             // Another service, using one of the same zones (so the same zone is
             // used in two services)
-            b.service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone2,
-                125,
-            )
-            .unwrap();
-            b.service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone3,
-                126,
-            )
-            .unwrap();
+            b.service_backend_zone(ServiceName::Oximeter, &zone2, 125).unwrap();
+            b.service_backend_zone(ServiceName::Oximeter, &zone3, 126).unwrap();
 
             // A sharded service
             b.service_backend_sled(
-                SRV::Backend(BackendName::SledAgent, sled1_uuid),
+                ServiceName::SledAgent(sled1_uuid),
                 &sled1,
                 123,
             )
@@ -621,22 +554,14 @@ mod test {
         let sled = builder1.host_sled(sled1_uuid, SLED1_IP).unwrap();
         let mut builder2 = DnsConfigBuilder::new();
         let error = builder2
-            .service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone,
-                123,
-            )
+            .service_backend_zone(ServiceName::Oximeter, &zone, 123)
             .unwrap_err();
         assert_eq!(
             error.to_string(),
             "zone 001de000-c04e-4000-8000-000000000001 has not been defined"
         );
         let error = builder2
-            .service_backend_sled(
-                SRV::Service(ServiceName::Oximeter),
-                &sled,
-                123,
-            )
+            .service_backend_sled(ServiceName::Oximeter, &sled, 123)
             .unwrap_err();
         assert_eq!(
             error.to_string(),
@@ -648,18 +573,10 @@ mod test {
         let mut builder = DnsConfigBuilder::new();
         let zone = builder.host_zone(zone1_uuid, ZONE1_IP).unwrap();
         builder
-            .service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone,
-                123,
-            )
+            .service_backend_zone(ServiceName::Oximeter, &zone, 123)
             .unwrap();
         let error = builder
-            .service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone,
-                123,
-            )
+            .service_backend_zone(ServiceName::Oximeter, &zone, 123)
             .unwrap_err();
         assert_eq!(
             error.to_string(),
@@ -668,11 +585,7 @@ mod test {
             (previously port 123, now 123)"
         );
         let error = builder
-            .service_backend_zone(
-                SRV::Service(ServiceName::Oximeter),
-                &zone,
-                456,
-            )
+            .service_backend_zone(ServiceName::Oximeter, &zone, 456)
             .unwrap_err();
         assert_eq!(
             error.to_string(),

--- a/internal-dns/src/lib.rs
+++ b/internal-dns/src/lib.rs
@@ -10,7 +10,5 @@ pub mod resolver;
 
 // We export these names out to the root for compatibility.
 pub use config::DnsConfigBuilder;
-pub use config::SRV;
-pub use names::BackendName;
 pub use names::ServiceName;
 pub use names::DNS_ZONE;

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -22,7 +22,7 @@ pub enum ResolveError {
     Resolve(#[from] trust_dns_resolver::error::ResolveError),
 
     #[error("Record not found for SRV key: {}", .0.dns_name())]
-    NotFound(crate::SRV),
+    NotFound(crate::ServiceName),
 
     #[error("Record not found for {0}")]
     NotFoundByString(String),
@@ -103,7 +103,7 @@ impl Resolver {
     // API that can be improved upon later.
     pub async fn lookup_ipv6(
         &self,
-        srv: crate::SRV,
+        srv: crate::ServiceName,
     ) -> Result<Ipv6Addr, ResolveError> {
         let name = format!("{}.{}", srv.dns_name(), DNS_ZONE);
         debug!(self.log, "lookup_ipv6 srv"; "dns_name" => &name);
@@ -119,7 +119,7 @@ impl Resolver {
     /// Returns an error if the record does not exist.
     pub async fn lookup_socket_v6(
         &self,
-        srv: crate::SRV,
+        srv: crate::ServiceName,
     ) -> Result<SocketAddrV6, ResolveError> {
         let name = format!("{}.{}", srv.dns_name(), DNS_ZONE);
         debug!(self.log, "lookup_socket_v6 srv"; "dns_name" => &name);
@@ -153,7 +153,7 @@ impl Resolver {
 
     pub async fn lookup_ip(
         &self,
-        srv: crate::SRV,
+        srv: crate::ServiceName,
     ) -> Result<IpAddr, ResolveError> {
         let name = format!("{}.{}", srv.dns_name(), DNS_ZONE);
         debug!(self.log, "lookup srv"; "dns_name" => &name);
@@ -170,7 +170,7 @@ impl Resolver {
 mod test {
     use super::ResolveError;
     use super::Resolver;
-    use crate::{BackendName, DnsConfigBuilder, ServiceName, SRV};
+    use crate::{DnsConfigBuilder, ServiceName};
     use anyhow::Context;
     use assert_matches::assert_matches;
     use dns_service_client::types::DnsConfigParams;
@@ -292,7 +292,7 @@ mod test {
         let resolver = dns_server.resolver().unwrap();
 
         let err = resolver
-            .lookup_ip(SRV::Service(ServiceName::Cockroach))
+            .lookup_ip(ServiceName::Cockroach)
             .await
             .expect_err("Looking up non-existent service should fail");
 
@@ -321,18 +321,14 @@ mod test {
         let ip = Ipv6Addr::from_str("ff::01").unwrap();
         let zone = dns_config.host_zone(Uuid::new_v4(), ip).unwrap();
         dns_config
-            .service_backend_zone(
-                SRV::Service(ServiceName::Cockroach),
-                &zone,
-                12345,
-            )
+            .service_backend_zone(ServiceName::Cockroach, &zone, 12345)
             .unwrap();
         let dns_config = dns_config.build();
         dns_server.update(&dns_config).await.unwrap();
 
         let resolver = dns_server.resolver().unwrap();
         let found_ip = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+            .lookup_ipv6(ServiceName::Cockroach)
             .await
             .expect("Should have been able to look up IP address");
         assert_eq!(found_ip, ip,);
@@ -379,9 +375,9 @@ mod test {
             0,
         );
 
-        let srv_crdb = SRV::Service(ServiceName::Cockroach);
-        let srv_clickhouse = SRV::Service(ServiceName::Clickhouse);
-        let srv_backend = SRV::Backend(BackendName::Crucible, Uuid::new_v4());
+        let srv_crdb = ServiceName::Cockroach;
+        let srv_clickhouse = ServiceName::Clickhouse;
+        let srv_backend = ServiceName::Crucible(Uuid::new_v4());
 
         let mut dns_builder = DnsConfigBuilder::new();
         for db_ip in &cockroach_addrs {
@@ -419,14 +415,14 @@ mod test {
         // Look up Cockroach
         let resolver = dns_server.resolver().unwrap();
         let ip = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+            .lookup_ipv6(ServiceName::Cockroach)
             .await
             .expect("Should have been able to look up IP address");
         assert!(cockroach_addrs.iter().any(|addr| addr.ip() == &ip));
 
         // Look up Clickhouse
         let ip = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Clickhouse))
+            .lookup_ipv6(ServiceName::Clickhouse)
             .await
             .expect("Should have been able to look up IP address");
         assert_eq!(&ip, clickhouse_addr.ip());
@@ -447,7 +443,7 @@ mod test {
         // If we remove the records for all services, we won't find them any
         // more.  (e.g., there's no hidden caching going on)
         let error = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+            .lookup_ipv6(ServiceName::Cockroach)
             .await
             .expect_err("unexpectedly found records");
         assert_matches!(
@@ -479,14 +475,14 @@ mod test {
         let mut dns_builder = DnsConfigBuilder::new();
         let ip1 = Ipv6Addr::from_str("ff::01").unwrap();
         let zone = dns_builder.host_zone(Uuid::new_v4(), ip1).unwrap();
-        let srv_crdb = SRV::Service(ServiceName::Cockroach);
+        let srv_crdb = ServiceName::Cockroach;
         dns_builder
             .service_backend_zone(srv_crdb.clone(), &zone, 12345)
             .unwrap();
         let dns_config = dns_builder.build();
         dns_server.update(&dns_config).await.unwrap();
         let found_ip = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+            .lookup_ipv6(ServiceName::Cockroach)
             .await
             .expect("Should have been able to look up IP address");
         assert_eq!(found_ip, ip1);
@@ -496,7 +492,7 @@ mod test {
         let mut dns_builder = DnsConfigBuilder::new();
         let ip2 = Ipv6Addr::from_str("ee::02").unwrap();
         let zone = dns_builder.host_zone(Uuid::new_v4(), ip2).unwrap();
-        let srv_crdb = SRV::Service(ServiceName::Cockroach);
+        let srv_crdb = ServiceName::Cockroach;
         dns_builder
             .service_backend_zone(srv_crdb.clone(), &zone, 54321)
             .unwrap();
@@ -504,7 +500,7 @@ mod test {
         dns_config.generation += 1;
         dns_server.update(&dns_config).await.unwrap();
         let found_ip = resolver
-            .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+            .lookup_ipv6(ServiceName::Cockroach)
             .await
             .expect("Should have been able to look up IP address");
         assert_eq!(found_ip, ip2);

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -10,7 +10,7 @@ use crate::external_api::params::ResourceMetrics;
 use crate::internal_api::params::OximeterInfo;
 use dropshot::PaginationParams;
 use internal_dns::resolver::{ResolveError, Resolver};
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use omicron_common::address::CLICKHOUSE_PORT;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
@@ -64,7 +64,7 @@ impl LazyTimeseriesClient {
                 resolver
                     .lock()
                     .await
-                    .lookup_ip(SRV::Service(ServiceName::Clickhouse))
+                    .lookup_ip(ServiceName::Clickhouse)
                     .await?,
                 CLICKHOUSE_PORT,
             ),

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -18,7 +18,6 @@ use crucible_agent_client::{
 };
 use futures::StreamExt;
 use internal_dns::ServiceName;
-use internal_dns::SRV;
 use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::Error;
 use omicron_common::backoff::{self, BackoffError};
@@ -274,7 +273,7 @@ pub async fn get_pantry_address(
     nexus
         .resolver()
         .await
-        .lookup_socket_v6(SRV::Service(ServiceName::CruciblePantry))
+        .lookup_socket_v6(ServiceName::CruciblePantry)
         .await
         .map_err(|e| e.to_string())
         .map_err(ActionError::action_failed)

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -16,7 +16,7 @@ use authn::external::spoof::HttpAuthnSpoof;
 use authn::external::token::HttpAuthnToken;
 use authn::external::HttpAuthnScheme;
 use chrono::Duration;
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use nexus_db_queries::context::{OpContext, OpKind};
 use omicron_common::address::{Ipv6Subnet, AZ_PREFIX, COCKROACH_PORT};
 use omicron_common::nexus_config;
@@ -151,7 +151,7 @@ impl ServerContext {
             nexus_config::Database::FromDns => {
                 info!(log, "Accessing DB url from DNS");
                 let address = resolver
-                    .lookup_ipv6(SRV::Service(ServiceName::Cockroach))
+                    .lookup_ipv6(ServiceName::Cockroach)
                     .await
                     .map_err(|e| format!("Failed to lookup IP: {}", e))?;
                 info!(log, "DB address: {}", address);

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -713,6 +713,7 @@
           {
             "in": "path",
             "name": "disk",
+            "description": "Name or ID of the disk",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -721,6 +722,7 @@
           {
             "in": "query",
             "name": "project",
+            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -760,6 +762,7 @@
           {
             "in": "path",
             "name": "disk",
+            "description": "Name or ID of the disk",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -768,6 +771,7 @@
           {
             "in": "query",
             "name": "project",
+            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -797,6 +801,7 @@
           {
             "in": "path",
             "name": "disk",
+            "description": "Name or ID of the disk",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -805,6 +810,7 @@
           {
             "in": "query",
             "name": "project",
+            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -834,6 +840,7 @@
           {
             "in": "path",
             "name": "disk",
+            "description": "Name or ID of the disk",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -842,6 +849,7 @@
           {
             "in": "query",
             "name": "project",
+            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -880,6 +888,7 @@
           {
             "in": "path",
             "name": "disk",
+            "description": "Name or ID of the disk",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -888,6 +897,7 @@
           {
             "in": "query",
             "name": "project",
+            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -12,7 +12,7 @@ use dropshot::{
     RequestContext, TypedBody,
 };
 use internal_dns::resolver::{ResolveError, Resolver};
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use omicron_common::address::{CLICKHOUSE_PORT, NEXUS_INTERNAL_PORT};
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::backoff;
@@ -316,9 +316,7 @@ impl OximeterAgent {
             address
         } else {
             SocketAddr::new(
-                resolver
-                    .lookup_ip(SRV::Service(ServiceName::Clickhouse))
-                    .await?,
+                resolver.lookup_ip(ServiceName::Clickhouse).await?,
                 CLICKHOUSE_PORT,
             )
         };
@@ -532,12 +530,9 @@ impl Oximeter {
                 address
             } else {
                 SocketAddr::V6(SocketAddrV6::new(
-                    resolver
-                        .lookup_ipv6(SRV::Service(ServiceName::Nexus))
-                        .await
-                        .map_err(|e| {
-                            backoff::BackoffError::transient(e.to_string())
-                        })?,
+                    resolver.lookup_ipv6(ServiceName::Nexus).await.map_err(
+                        |e| backoff::BackoffError::transient(e.to_string()),
+                    )?,
                     NEXUS_INTERNAL_PORT,
                     0,
                     0,

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -8,7 +8,7 @@ pub use crate::mocks::MockNexusClient as NexusClient;
 pub use nexus_client::Client as NexusClient;
 
 use internal_dns::resolver::{ResolveError, Resolver};
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use omicron_common::address::NEXUS_INTERNAL_PORT;
 use slog::Logger;
 use std::future::Future;
@@ -52,7 +52,7 @@ impl LazyNexusClient {
     }
 
     pub async fn get_ip(&self) -> Result<Ipv6Addr, ResolveError> {
-        self.inner.resolver.lookup_ipv6(SRV::Service(ServiceName::Nexus)).await
+        self.inner.resolver.lookup_ipv6(ServiceName::Nexus).await
     }
 
     pub async fn get(&self) -> Result<NexusClient, ResolveError> {

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -9,7 +9,7 @@ use crate::params::{
 };
 use crate::rack_setup::config::SetupServiceConfig as Config;
 use dns_service_client::types::DnsConfigParams;
-use internal_dns::{BackendName, ServiceName, SRV};
+use internal_dns::ServiceName;
 use omicron_common::address::{
     get_switch_zone_address, Ipv6Subnet, ReservedRackSubnet, DNS_PORT,
     DNS_SERVER_PORT, RSS_RESERVED_ADDRESSES, SLED_PREFIX,
@@ -206,7 +206,7 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, address).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        SRV::Service(ServiceName::Nexus),
+                        ServiceName::Nexus,
                         &zone,
                         omicron_common::address::NEXUS_INTERNAL_PORT,
                     )
@@ -230,7 +230,7 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, address).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        SRV::Service(ServiceName::Oximeter),
+                        ServiceName::Oximeter,
                         &zone,
                         omicron_common::address::OXIMETER_PORT,
                     )
@@ -252,11 +252,7 @@ impl Plan {
                 let port = omicron_common::address::COCKROACH_PORT;
                 let zone = dns_builder.host_zone(id, address).unwrap();
                 dns_builder
-                    .service_backend_zone(
-                        SRV::Service(ServiceName::Cockroach),
-                        &zone,
-                        port,
-                    )
+                    .service_backend_zone(ServiceName::Cockroach, &zone, port)
                     .unwrap();
                 let address = SocketAddrV6::new(address, port, 0, 0);
                 request.datasets.push(DatasetEnsureBody {
@@ -276,11 +272,7 @@ impl Plan {
                 let port = omicron_common::address::CLICKHOUSE_PORT;
                 let zone = dns_builder.host_zone(id, address).unwrap();
                 dns_builder
-                    .service_backend_zone(
-                        SRV::Service(ServiceName::Clickhouse),
-                        &zone,
-                        port,
-                    )
+                    .service_backend_zone(ServiceName::Clickhouse, &zone, port)
                     .unwrap();
                 let address = SocketAddrV6::new(address, port, 0, 0);
                 request.datasets.push(DatasetEnsureBody {
@@ -305,7 +297,7 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, *address.ip()).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        SRV::Backend(BackendName::Crucible, id),
+                        ServiceName::Crucible(id),
                         &zone,
                         address.port(),
                     )
@@ -328,7 +320,7 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, dns_addr).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        SRV::Service(ServiceName::InternalDNS),
+                        ServiceName::InternalDNS,
                         &zone,
                         DNS_SERVER_PORT,
                     )
@@ -359,11 +351,7 @@ impl Plan {
                 let id = Uuid::new_v4();
                 let zone = dns_builder.host_zone(id, address).unwrap();
                 dns_builder
-                    .service_backend_zone(
-                        SRV::Service(ServiceName::InternalDNS),
-                        &zone,
-                        port,
-                    )
+                    .service_backend_zone(ServiceName::InternalDNS, &zone, port)
                     .unwrap();
                 request.services.push(ServiceZoneRequest {
                     id,

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -70,7 +70,7 @@ use crate::rack_setup::plan::sled::{
     generate_rack_secret, Plan as SledPlan, PlanError as SledPlanError,
 };
 use internal_dns::resolver::{DnsError, Resolver as DnsResolver};
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use nexus_client::{
     types as NexusTypes, Client as NexusClient, Error as NexusError,
 };
@@ -509,7 +509,7 @@ impl ServiceInner {
         )
         .expect("Failed to create DNS resolver");
         let ip = resolver
-            .lookup_ip(SRV::Service(ServiceName::Nexus))
+            .lookup_ip(ServiceName::Nexus)
             .await
             .expect("Failed to lookup IP");
         let nexus_address = SocketAddr::new(ip, NEXUS_INTERNAL_PORT);

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -12,7 +12,7 @@ use crate::nexus::d2n_params;
 use crate::nexus::NexusClient;
 use anyhow::Context;
 use crucible_agent_client::types::State as RegionState;
-use internal_dns::{ServiceName, SRV};
+use internal_dns::ServiceName;
 use nexus_client::types as NexusTypes;
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
@@ -199,7 +199,7 @@ impl Server {
             .host_zone(pantry_zone_id, *pantry_addr.ip())
             .expect("failed to set up DNS");
         dns.service_backend_zone(
-            SRV::Service(ServiceName::CruciblePantry),
+            ServiceName::CruciblePantry,
             &pantry_zone,
             pantry_addr.port(),
         )


### PR DESCRIPTION
This change brings the type names used for describing internal DNS into better alignment with RFD 248 (and specifically [section 4.1](https://github.com/oxidecomputer/rfd/tree/master/rfd/0248#terminology)).  Quoting it here since it's not public:

> Consider the case where Nexus depends on CockroachDB. We say that Nexus is a **service**. It may have one or more **instances**, each being a different Unix process, typically running on a different host.
> 
> CockroachDB is also a service. It too may have many instances.
> 
> In the context of a service, we refer to instances of a dependent service as **backends**. Different backends of a service are interchangeable. So for Nexus, there’s only one service containing all the backends.
> 
> In the end, we might have:
> 
>     Service Nexus instance N1 at 192.168.0.10 port 12220
> 
>     Service Nexus instance N2 at 192.168.0.11 port 12220
> 
>     Service CockroachDB instance D1 at 192.168.0.6 port 26257
> 
>     Service CockroachDB instance D2 at 192.168.0.7 port 26257
> 
>     Service CockroachDB instance D3 at 192.168.0.8 port 26257
> 
> Nexus thus has two backends. CockroachDB has three backends.
> 
> For something like Sled Agent, each Sled Agent would be its own service with exactly one backend, since the Sled Agents cannot be treated as interchangeable with each other.

It's that last sentence where I found the code confusing.  _Each_ Sled Agent is its own service, but it's not part of ServiceName.  (Ditto each Crucible.)  And all the _other_ services have backends, but they're not in BackendName.

After this PR, there's only `ServiceName`.  This is the name of a service (as in the "n" part of DNS): it's the identifier you use to look up a single logical service, no matter how many backends it might have.  That means for stuff like CockroachDB, the variant has no data (it's just `ServiceName::Cockroach`).  For sled agents, the variant has a datum which is the id of the specific Sled Agent _service_ you want (`ServiceName::SledAgent(Uuid)`).

I also got rid of `SRV` -- this layer of indirection is no longer necessary (and it was confusing because it doesn't actually describe an SRV record -- it has no port information or anything like that.  It was just a wrapper that you'd use in a context where you were doing a DNS lookup of a service, but that's what `ServiceName` now is.)