### PR TITLE
[mgs] Send keepalives while attached to SP serial console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a15a3f8f58bb7b2fadc94f42a4747022ae6d401d#a15a3f8f58bb7b2fadc94f42a4747022ae6d401d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2dcc63c645005a7184ba754b5c42c341a0777c66#2dcc63c645005a7184ba754b5c42c341a0777c66"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack 0.1.1",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a15a3f8f58bb7b2fadc94f42a4747022ae6d401d#a15a3f8f58bb7b2fadc94f42a4747022ae6d401d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2dcc63c645005a7184ba754b5c42c341a0777c66#2dcc63c645005a7184ba754b5c42c341a0777c66"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,8 +156,8 @@ flate2 = "1.0.25"
 fs-err = "2.9.0"
 futures = "0.3.27"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "a15a3f8f58bb7b2fadc94f42a4747022ae6d401d" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a15a3f8f58bb7b2fadc94f42a4747022ae6d401d" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "2dcc63c645005a7184ba754b5c42c341a0777c66" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2dcc63c645005a7184ba754b5c42c341a0777c66" }
 gateway-test-utils = { path = "gateway-test-utils" }
 headers = "0.3.8"
 heck = "0.4"

--- a/sled-agent/src/sp/mod.rs
+++ b/sled-agent/src/sp/mod.rs
@@ -59,7 +59,7 @@ pub enum SpError {
     CreateEtherstubVnic(CreateVnicError),
     #[error("Could not ensure IP address {addr} in global zone for simulated SP: {err}")]
     EnsureGlobalZoneAddressError { addr: Ipv6Addr, err: EnsureGzAddressError },
-    #[error("Could not start simualted SP: {0}")]
+    #[error("Could not start simulated SP: {0}")]
     StartSimSpError(String),
     #[error("Communication with RoT failed: {0}")]
     RotCommunicationError(String),

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -112,7 +112,7 @@ impl SimulatedSp for Gimlet {
 
 impl Gimlet {
     pub async fn spawn(gimlet: &GimletConfig, log: Logger) -> Result<Self> {
-        info!(log, "setting up simualted gimlet");
+        info!(log, "setting up simulated gimlet");
 
         let attached_mgs = Arc::new(Mutex::new(None));
 
@@ -752,6 +752,33 @@ impl SpHandler for Handler {
         let _ = incoming_serial_console.send(data.to_vec());
 
         Ok(offset + data.len() as u64)
+    }
+
+    fn serial_console_keepalive(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> std::result::Result<(), SpError> {
+        debug!(
+            &self.log,
+            "received serial console keepalive";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+
+        let component = self
+            .attached_mgs
+            .lock()
+            .unwrap()
+            .map(|(component, _port, _addr)| component)
+            .ok_or(SpError::SerialConsoleNotAttached)?;
+
+        let _incoming_serial_console = self
+            .incoming_serial_console
+            .get(&component)
+            .ok_or(SpError::RequestUnsupportedForComponent)?;
+
+        Ok(())
     }
 
     fn serial_console_detach(

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -124,7 +124,7 @@ impl Sidecar {
         sidecar: &SidecarConfig,
         log: Logger,
     ) -> Result<Self> {
-        info!(log, "setting up simualted sidecar");
+        info!(log, "setting up simulated sidecar");
 
         let (commands, commands_rx) = mpsc::unbounded_channel();
 
@@ -554,6 +554,20 @@ impl SpHandler for Handler {
     ) -> Result<u64, SpError> {
         warn!(
             &self.log, "received serial console write; unsupported by sidecar";
+            "sender" => %sender,
+            "port" => ?port,
+        );
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn serial_console_keepalive(
+        &mut self,
+        sender: SocketAddrV6,
+        port: SpPort,
+    ) -> Result<(), SpError> {
+        warn!(
+            &self.log,
+            "received serial console keepalive; unsupported by sidecar";
             "sender" => %sender,
             "port" => ?port,
         );


### PR DESCRIPTION
As of https://github.com/oxidecomputer/hubris/pull/1214, the SP expects periodic keepalive packets if an MGS instance is attached to its host's serial console but not actively sending data. `faux-mgs` (which is what is used today in the lab to do serial console things) already has this change; this catches MGS proper up.