### PR TITLE
Remove `verification_url_complete` from device auth response

### DIFF
--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -41,10 +41,6 @@ impl DeviceAuthRequest {
         let scheme = if tls { "https" } else { "http" };
         views::DeviceAuthResponse {
             verification_uri: format!("{scheme}://{host}/device/verify"),
-            verification_uri_complete: format!(
-                "{scheme}://{host}/device/verify?user_code={}",
-                &self.user_code
-            ),
             user_code: self.user_code,
             device_code: self.device_code,
             expires_in: self

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -403,10 +403,6 @@ pub struct DeviceAuthResponse {
     /// may be asked to manually type it into their user agent.
     pub verification_uri: String,
 
-    /// A verification URI that includes the `user_code`,
-    /// which is designed for non-textual transmission.
-    pub verification_uri_complete: String,
-
     /// The lifetime in seconds of the `device_code` and `user_code`.
     pub expires_in: u16,
 }


### PR DESCRIPTION
`verification_url_complete`, a URI that includes the auth code, is [optional in the spec ](https://www.rfc-editor.org/rfc/rfc8628#section-3.2)and we are no longer using it. The CLI [now](https://github.com/oxidecomputer/oxide-sdk-and-cli/pull/59) opens a console page with a form and the user has to type in the code they see printed in the terminal.

![image](https://user-images.githubusercontent.com/3612203/228924135-4ee2e0f7-483c-42a4-860b-ba273e6b8518.png)


