### PR TITLE
Flatten selectors; allow owned names to be looked up

### DIFF
--- a/nexus/db-queries/src/db/lookup.rs
+++ b/nexus/db-queries/src/db/lookup.rs
@@ -136,6 +136,30 @@ impl<'a> LookupPath<'a> {
         }
     }
 
+    /// Select a resource of type Project, identified by its owned name
+    pub fn project_name_owned<'b, 'c>(self, name: Name) -> Project<'c>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        match self
+            .opctx
+            .authn
+            .silo_required()
+            .internal_context("looking up Organization by name")
+        {
+            Ok(authz_silo) => {
+                let root = Root { lookup_root: self };
+                let silo_key = Silo::PrimaryKey(root, authz_silo.id());
+                Project::OwnedName(silo_key, name)
+            }
+            Err(error) => {
+                let root = Root { lookup_root: self };
+                Project::Error(root, error)
+            }
+        }
+    }
+
     /// Select a resource of type Project, identified by its id
     pub fn project_id(self, id: Uuid) -> Project<'a> {
         Project::PrimaryKey(Root { lookup_root: self }, id)

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -24,7 +24,6 @@ use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::ResourceType;
-use ref_cast::RefCast;
 use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -33,28 +32,28 @@ impl super::Nexus {
     pub fn image_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        image_selector: &'a params::ImageSelector,
+        image_selector: params::ImageSelector,
     ) -> LookupResult<lookup::Image<'a>> {
         match image_selector {
             params::ImageSelector {
                 image: NameOrId::Id(id),
-                project_selector: None,
+                project: None,
             } => {
                 let image = LookupPath::new(opctx, &self.db_datastore)
-                    .image_id(*id);
+                    .image_id(id);
                 Ok(image)
             }
             params::ImageSelector {
                 image: NameOrId::Name(name),
-                project_selector: Some(project_selector),
+                project: Some(project),
             } => {
                 let image =
-                    self.project_lookup(opctx, project_selector)?.image_name(Name::ref_cast(name));
+                    self.project_lookup(opctx, params::ProjectSelector { project })?.image_name_owned(name.into());
                 Ok(image)
             }
             params::ImageSelector {
                 image: NameOrId::Id(_),
-                project_selector: Some(_),
+                ..
             } => Err(Error::invalid_request(
                 "when providing image as an ID, project should not be specified",
             )),

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -19,7 +19,6 @@ use crate::external_api::params;
 use futures::future::Fuse;
 use futures::{FutureExt, SinkExt, StreamExt};
 use nexus_db_model::IpKind;
-use nexus_db_model::Name;
 use nexus_db_queries::context::OpContext;
 use omicron_common::address::PROPOLIS_PORT;
 use omicron_common::api::external::http_pagination::PaginatedBy;
@@ -36,7 +35,6 @@ use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::nexus;
-use ref_cast::RefCast;
 use sled_agent_client::types::InstanceRuntimeStateMigrateParams;
 use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
@@ -58,32 +56,32 @@ impl super::Nexus {
     pub fn instance_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        instance_selector: &'a params::InstanceSelector,
+        instance_selector: params::InstanceSelector,
     ) -> LookupResult<lookup::Instance<'a>> {
         match instance_selector {
             params::InstanceSelector {
-                project_selector: None,
                 instance: NameOrId::Id(id),
+                project: None
             } => {
                 let instance =
-                    LookupPath::new(opctx, &self.db_datastore).instance_id(*id);
+                    LookupPath::new(opctx, &self.db_datastore).instance_id(id);
                 Ok(instance)
             }
             params::InstanceSelector {
-                project_selector: Some(project_selector),
                 instance: NameOrId::Name(name),
+                project: Some(project)
             } => {
                 let instance = self
-                    .project_lookup(opctx, project_selector)?
-                    .instance_name(Name::ref_cast(name));
+                    .project_lookup(opctx, params::ProjectSelector { project })?
+                    .instance_name_owned(name.into());
                 Ok(instance)
             }
             params::InstanceSelector {
-                project_selector: Some(_),
                 instance: NameOrId::Id(_),
+                ..
             } => {
                 Err(Error::invalid_request(
-                    "when providing instance as an ID, project should not be specified",
+                    "when providing instance as an ID project should not be specified",
                 ))
             }
             _ => {
@@ -711,10 +709,8 @@ impl super::Nexus {
         let (.., authz_project_disk, authz_disk) = self
             .disk_lookup(
                 opctx,
-                &params::DiskSelector {
-                    project_selector: Some(params::ProjectSelector {
-                        project: authz_project.id().into(),
-                    }),
+                params::DiskSelector {
+                    project: Some(authz_project.id().into()),
                     disk,
                 },
             )?
@@ -770,10 +766,8 @@ impl super::Nexus {
         let (.., authz_disk) = self
             .disk_lookup(
                 opctx,
-                &params::DiskSelector {
-                    project_selector: Some(params::ProjectSelector {
-                        project: authz_project.id().into(),
-                    }),
+                params::DiskSelector {
+                    project: Some(authz_project.id().into()),
                     disk,
                 },
             )?

--- a/nexus/src/app/network_interface.rs
+++ b/nexus/src/app/network_interface.rs
@@ -1,6 +1,5 @@
 use crate::authz::ApiResource;
 use crate::db::queries::network_interface;
-use nexus_db_model::Name;
 use nexus_db_queries::context::OpContext;
 use nexus_types::external_api::params;
 use omicron_common::api::external::CreateResult;
@@ -12,7 +11,6 @@ use omicron_common::api::external::NameOrId;
 
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::UpdateResult;
-use ref_cast::RefCast;
 use uuid::Uuid;
 
 use crate::authz;
@@ -23,33 +21,35 @@ impl super::Nexus {
     pub fn network_interface_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        network_interface_selector: &'a params::NetworkInterfaceSelector,
+        network_interface_selector: params::NetworkInterfaceSelector,
     ) -> LookupResult<lookup::NetworkInterface<'a>> {
         match network_interface_selector {
             params::NetworkInterfaceSelector {
-                instance_selector: None,
                 network_interface: NameOrId::Id(id),
+                instance: None,
+                project: None
             } => {
                 let network_interface =
                     LookupPath::new(opctx, &self.db_datastore)
-                        .network_interface_id(*id);
+                        .network_interface_id(id);
                 Ok(network_interface)
             }
             params::NetworkInterfaceSelector {
-                instance_selector: Some(instance_selector),
                 network_interface: NameOrId::Name(name),
+                instance: Some(instance),
+                project
             } => {
                 let network_interface = self
-                    .instance_lookup(opctx, instance_selector)?
-                    .network_interface_name(Name::ref_cast(name));
+                    .instance_lookup(opctx, params::InstanceSelector { project, instance })?
+                    .network_interface_name_owned(name.into());
                 Ok(network_interface)
             }
             params::NetworkInterfaceSelector {
-              instance_selector: Some(_),
               network_interface: NameOrId::Id(_),
+              ..
             } => {
               Err(Error::invalid_request(
-                "when providing network_interface as an id, instance_selector should not be specified"
+                "when providing network_interface as an id instance and project should not be specified"
               ))
             }
             _ => {

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -10,7 +10,6 @@ use crate::authz;
 use crate::db;
 use crate::db::lookup;
 use crate::db::lookup::LookupPath;
-use crate::db::model::Name;
 use crate::external_api::params;
 use crate::external_api::shared;
 use anyhow::Context;
@@ -24,22 +23,21 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
-use ref_cast::RefCast;
 use std::sync::Arc;
 
 impl super::Nexus {
     pub fn project_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        project_selector: &'a params::ProjectSelector,
+        project_selector: params::ProjectSelector,
     ) -> LookupResult<lookup::Project<'a>> {
         let lookup_path = LookupPath::new(opctx, &self.db_datastore);
         Ok(match project_selector {
             params::ProjectSelector { project: NameOrId::Id(id) } => {
-                lookup_path.project_id(*id)
+                lookup_path.project_id(id)
             }
             params::ProjectSelector { project: NameOrId::Name(name) } => {
-                lookup_path.project_name(Name::ref_cast(name))
+                lookup_path.project_name_owned(name.into())
             }
         })
     }

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -1155,14 +1155,12 @@ pub(crate) mod test {
         let nexus = &cptestctx.server.apictx.nexus;
         let opctx = test_opctx(&cptestctx);
         let disk_selector = params::DiskSelector {
-            project_selector: Some(params::ProjectSelector {
-                project: Name::try_from(PROJECT_NAME.to_string())
-                    .unwrap()
-                    .into(),
-            }),
+            project: Some(
+                Name::try_from(PROJECT_NAME.to_string()).unwrap().into(),
+            ),
             disk: Name::try_from(DISK_NAME.to_string()).unwrap().into(),
         };
-        let disk_lookup = nexus.disk_lookup(&opctx, &disk_selector).unwrap();
+        let disk_lookup = nexus.disk_lookup(&opctx, disk_selector).unwrap();
 
         nexus
             .project_delete_disk(&opctx, &disk_lookup)

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -190,7 +190,7 @@ pub(crate) mod test {
             project: Name::try_from(PROJECT_NAME.to_string()).unwrap().into(),
         };
         let project_lookup =
-            nexus.project_lookup(&opctx, &project_selector).unwrap();
+            nexus.project_lookup(&opctx, project_selector).unwrap();
 
         nexus
             .project_create_disk(

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1677,15 +1677,12 @@ pub mod test {
         let nexus = &cptestctx.server.apictx().nexus;
         let opctx = test_opctx(&cptestctx);
 
-        let project_selector = params::ProjectSelector {
-            project: PROJECT_NAME.to_string().try_into().unwrap(),
-        };
         let instance_selector = params::InstanceSelector {
-            project_selector: Some(project_selector),
+            project: Some(PROJECT_NAME.to_string().try_into().unwrap()),
             instance: INSTANCE_NAME.to_string().try_into().unwrap(),
         };
         let instance_lookup =
-            nexus.instance_lookup(&opctx, &instance_selector).unwrap();
+            nexus.instance_lookup(&opctx, instance_selector).unwrap();
         nexus.project_destroy_instance(&opctx, &instance_lookup).await.unwrap();
     }
 

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -364,7 +364,7 @@ mod test {
             project: PROJECT_NAME.to_string().try_into().unwrap(),
         };
         let project_lookup =
-            nexus.project_lookup(&opctx, &project_selector).unwrap();
+            nexus.project_lookup(&opctx, project_selector).unwrap();
         nexus
             .project_create_instance(&opctx, &project_lookup, &params)
             .await

--- a/nexus/src/app/sagas/vpc_create.rs
+++ b/nexus/src/app/sagas/vpc_create.rs
@@ -505,7 +505,7 @@ pub(crate) mod test {
             params::ProjectSelector { project: NameOrId::Id(project_id) };
         let opctx = test_opctx(&cptestctx);
         let (.., authz_project) = nexus
-            .project_lookup(&opctx, &project_selector)
+            .project_lookup(&opctx, project_selector)
             .expect("Invalid parameters constructing project lookup")
             .lookup_for(action)
             .await

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -31,7 +31,6 @@ use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::Vni;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::internal::nexus::HostIdentifier;
-use ref_cast::RefCast;
 use sled_agent_client::types::NetworkInterface;
 
 use futures::future::join_all;
@@ -47,29 +46,25 @@ impl super::Nexus {
     pub fn vpc_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        vpc_selector: &'a params::VpcSelector,
+        vpc_selector: params::VpcSelector,
     ) -> LookupResult<lookup::Vpc<'a>> {
         match vpc_selector {
-            params::VpcSelector {
-                vpc: NameOrId::Id(id),
-                project_selector: None,
-            } => {
-                let vpc =
-                    LookupPath::new(opctx, &self.db_datastore).vpc_id(*id);
+            params::VpcSelector { vpc: NameOrId::Id(id), project: None } => {
+                let vpc = LookupPath::new(opctx, &self.db_datastore).vpc_id(id);
                 Ok(vpc)
             }
             params::VpcSelector {
                 vpc: NameOrId::Name(name),
-                project_selector: Some(selector),
+                project: Some(project),
             } => {
                 let vpc = self
-                    .project_lookup(opctx, selector)?
-                    .vpc_name(Name::ref_cast(name));
+                    .project_lookup(opctx, params::ProjectSelector { project })?
+                    .vpc_name_owned(name.into());
                 Ok(vpc)
             }
             params::VpcSelector {
                 vpc: NameOrId::Id(_),
-                project_selector: Some(_),
+                project: Some(_),
             } => Err(Error::invalid_request(
                 "when providing vpc as an ID, project should not be specified",
             )),

--- a/nexus/src/app/vpc_router.rs
+++ b/nexus/src/app/vpc_router.rs
@@ -8,7 +8,6 @@ use crate::authz;
 use crate::db;
 use crate::db::lookup;
 use crate::db::lookup::LookupPath;
-use crate::db::model::Name;
 use crate::db::model::RouterRoute;
 use crate::db::model::VpcRouter;
 use crate::db::model::VpcRouterKind;
@@ -23,7 +22,6 @@ use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::UpdateResult;
-use ref_cast::RefCast;
 use uuid::Uuid;
 
 impl super::Nexus {
@@ -31,34 +29,36 @@ impl super::Nexus {
     pub fn vpc_router_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        router_selector: &'a params::RouterSelector,
+        router_selector: params::RouterSelector,
     ) -> LookupResult<lookup::VpcRouter<'a>> {
         match router_selector {
             params::RouterSelector {
                 router: NameOrId::Id(id),
-                vpc_selector: None,
+                vpc: None,
+                project: None
             } => {
                 let router = LookupPath::new(opctx, &self.db_datastore)
-                    .vpc_router_id(*id);
+                    .vpc_router_id(id);
                 Ok(router)
             }
             params::RouterSelector {
                 router: NameOrId::Name(name),
-                vpc_selector: Some(vpc_selector),
+                vpc: Some(vpc),
+                project
             } => {
                 let router = self
-                    .vpc_lookup(opctx, vpc_selector)?
-                    .vpc_router_name(Name::ref_cast(name));
+                    .vpc_lookup(opctx, params::VpcSelector { project, vpc })?
+                    .vpc_router_name_owned(name.into());
                 Ok(router)
             }
             params::RouterSelector {
                 router: NameOrId::Id(_),
-                vpc_selector: Some(_),
+                ..
             } => Err(Error::invalid_request(
-                "when providing vpc_router as an ID, vpc should not be specified",
+                "when providing router as an ID vpc and project should not be specified",
             )),
             _ => Err(Error::invalid_request(
-                "vpc_router should either be an ID or vpc should be specified",
+                "router should either be an ID or vpc should be specified",
             )),
         }
     }
@@ -141,34 +141,41 @@ impl super::Nexus {
     pub fn vpc_router_route_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        route_selector: &'a params::RouteSelector,
+        route_selector: params::RouteSelector,
     ) -> LookupResult<lookup::RouterRoute<'a>> {
         match route_selector {
             params::RouteSelector {
                 route: NameOrId::Id(id),
-                router_selector: None,
+                router: None,
+                vpc: None,
+                project: None,
             } => {
                 let route = LookupPath::new(opctx, &self.db_datastore)
-                    .router_route_id(*id);
+                    .router_route_id(id);
                 Ok(route)
             }
             params::RouteSelector {
                 route: NameOrId::Name(name),
-                router_selector: Some(selector),
+                router: Some(router),
+                vpc,
+                project,
             } => {
                 let route = self
-                    .vpc_router_lookup(opctx, selector)?
-                    .router_route_name(Name::ref_cast(name));
+                    .vpc_router_lookup(
+                        opctx,
+                        params::RouterSelector { project, vpc, router },
+                    )?
+                    .router_route_name_owned(name.into());
                 Ok(route)
             }
             params::RouteSelector {
                 route: NameOrId::Id(_),
-                router_selector: Some(_),
+                ..
             } => Err(Error::invalid_request(
-                "when providing subnet as an ID, vpc should not be specified",
+                "when providing route as an ID router, subnet, vpc, and project should not be specified",
             )),
             _ => Err(Error::invalid_request(
-                "router should either be an ID or vpc should be specified",
+                "route should either be an ID or router should be specified",
             )),
         }
     }

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -9,7 +9,6 @@ use crate::db;
 use crate::db::identity::Resource;
 use crate::db::lookup;
 use crate::db::lookup::LookupPath;
-use crate::db::model::Name;
 use crate::db::model::VpcSubnet;
 use crate::db::queries::vpc_subnet::SubnetError;
 use crate::external_api::params;
@@ -24,38 +23,40 @@ use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::nexus_config::MIN_VPC_IPV4_SUBNET_PREFIX;
-use ref_cast::RefCast;
 use uuid::Uuid;
 
 impl super::Nexus {
     pub fn vpc_subnet_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,
-        subnet_selector: &'a params::SubnetSelector,
+        subnet_selector: params::SubnetSelector,
     ) -> LookupResult<lookup::VpcSubnet<'a>> {
         match subnet_selector {
             params::SubnetSelector {
                 subnet: NameOrId::Id(id),
-                vpc_selector: None,
+                vpc: None,
+                project: None,
             } => {
                 let subnet = LookupPath::new(opctx, &self.db_datastore)
-                    .vpc_subnet_id(*id);
+                    .vpc_subnet_id(id);
                 Ok(subnet)
             }
             params::SubnetSelector {
                 subnet: NameOrId::Name(name),
-                vpc_selector: Some(selector),
+                vpc: Some(vpc),
+                project,
             } => {
                 let subnet = self
-                    .vpc_lookup(opctx, selector)?
-                    .vpc_subnet_name(Name::ref_cast(name));
+                    .vpc_lookup(opctx, params::VpcSelector { project, vpc })?
+                    .vpc_subnet_name_owned(name.into());
                 Ok(subnet)
             }
             params::SubnetSelector {
                 subnet: NameOrId::Id(_),
-                vpc_selector: Some(_),
+                vpc: _,
+                project: _,
             } => Err(Error::invalid_request(
-                "when providing subnet as an ID, vpc should not be specified",
+                "when providing subnet as an ID, vpc and project should not be specified",
             )),
             _ => Err(Error::invalid_request(
                 "subnet should either be an ID or vpc should be specified",

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -95,100 +95,114 @@ pub struct ProjectSelector {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct OptionalProjectSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    // Name or ID of the project
+    pub project: Option<NameOrId>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct DiskSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `disk` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the disk
     pub disk: NameOrId,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct SnapshotSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `snapshot` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the snapshot
     pub snapshot: NameOrId,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct ImageSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `image` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the image
     pub image: NameOrId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct InstanceSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `instance` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the instance
     pub instance: NameOrId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct OptionalInstanceSelector {
-    #[serde(flatten)]
+    /// Name or ID of the project, only required if `instance` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the instance
-    pub instance_selector: Option<InstanceSelector>,
+    pub instance: Option<NameOrId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct NetworkInterfaceSelector {
-    #[serde(flatten)]
-    pub instance_selector: Option<InstanceSelector>,
+    /// Name or ID of the project, only required if `instance` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Name or ID of the instance, only required if `network_interface` is provided as a `Name`
+    pub instance: Option<NameOrId>,
     /// Name or ID of the network interface
     pub network_interface: NameOrId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct VpcSelector {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the VPC
     pub vpc: NameOrId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct OptionalVpcSelector {
-    #[serde(flatten)]
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Name or ID of the VPC
-    pub vpc_selector: Option<VpcSelector>,
+    pub vpc: Option<NameOrId>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct SubnetSelector {
-    #[serde(flatten)]
-    pub vpc_selector: Option<VpcSelector>,
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    pub vpc: Option<NameOrId>,
     /// Name or ID of the subnet
     pub subnet: NameOrId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct RouterSelector {
-    #[serde(flatten)]
-    pub vpc_selector: Option<VpcSelector>,
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    pub vpc: Option<NameOrId>,
     /// Name or ID of the router
     pub router: NameOrId,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct OptionalRouterSelector {
-    #[serde(flatten)]
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    pub vpc: Option<NameOrId>,
     /// Name or ID of the router
-    pub router_selector: Option<RouterSelector>,
+    pub router: Option<NameOrId>,
 }
 
 #[derive(Deserialize, JsonSchema)]
 pub struct RouteSelector {
-    #[serde(flatten)]
-    /// Name or ID of the router
-    pub router_selector: Option<RouterSelector>,
+    /// Name or ID of the project, only required if `vpc` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    pub vpc: Option<NameOrId>,
+    /// Name or ID of the router, only required if `route` is provided as a `Name`
+    pub router: Option<NameOrId>,
     /// Name or ID of the route
     pub route: NameOrId,
 }
@@ -883,8 +897,8 @@ pub struct InstanceMigrate {
 /// Forwarded to a propolis server to request the contents of an Instance's serial console.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct InstanceSerialConsoleRequest {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    /// Name or ID of the project, only required if `instance` is provided as a `Name`
+    pub project: Option<NameOrId>,
     /// Character index in the serial buffer from which to read, counting the bytes output since
     /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
     /// provided, `most_recent` must *not* be provided.
@@ -1117,8 +1131,7 @@ pub struct ImportBlocksBulkWrite {
 /// Parameters for finalizing a disk
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct FinalizeDisk {
-    #[serde(flatten)]
-    pub project_selector: Option<ProjectSelector>,
+    pub project: Option<NameOrId>,
 
     /// an optional snapshot name
     pub snapshot_name: Option<String>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -639,7 +639,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -683,7 +682,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -722,7 +720,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -771,7 +768,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -810,7 +806,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -849,7 +844,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -897,7 +891,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -991,7 +984,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1248,7 +1240,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1293,7 +1284,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1434,7 +1424,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1478,7 +1467,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1537,7 +1525,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1600,7 +1587,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1656,7 +1642,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1703,7 +1688,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1749,7 +1733,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1805,7 +1788,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1893,7 +1875,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -1972,7 +1954,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2002,7 +1984,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2048,7 +2029,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2369,7 +2349,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2421,7 +2401,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2485,7 +2465,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2537,7 +2517,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -2600,7 +2580,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `instance` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -3102,7 +3082,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -3146,7 +3125,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5692,7 +5670,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5736,7 +5714,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5813,7 +5791,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5836,7 +5814,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC",
+            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5872,7 +5850,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5889,7 +5867,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC",
+            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5945,7 +5923,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -5962,7 +5940,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC",
+            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6006,7 +5984,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6022,7 +6000,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC",
+            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6076,7 +6054,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6092,7 +6070,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC",
+            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6142,7 +6120,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6193,7 +6171,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6258,7 +6236,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6310,7 +6288,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6372,7 +6350,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6430,7 +6408,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6481,7 +6459,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6546,7 +6524,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6598,7 +6576,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6660,7 +6638,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6727,7 +6705,7 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
+            "description": "Name or ID of the project, only required if `vpc` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6900,7 +6878,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6944,7 +6921,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -6998,7 +6974,6 @@
           {
             "in": "query",
             "name": "project",
-            "description": "Name or ID of the project",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }


### PR DESCRIPTION
This is a resurrection of #2647 with a simplified approach as originally suggested by @sunshowers. Instead of the approach I took last time, this introduces `OwnedName` in the lookup macro such that you can lookup resources via `_name` or `_name_owned`. This added flexibility enables the simplified selector approach (which I'll discuss more below) and allows us to pass owned names in a given scope when it may otherwise be impossible.

I've endeavored to change as little as possible and reduce the overall noise. 

---

The selector approach that I implemented in the V1 work is nice in that it's compositional. The niceness of it soft of ends there though. It has an over-reliance on serde's flatten. It's not the easiest to see all the properties that a selector contains. On top of that it's not possible to individually document parameters that are inherited from a parent selector. This point is important because our hierarchy is only explicit through error handling. I think it's important to be able to communicate through our docs that a certain parameter depends on another. Given that each parameter is _contextual_ to the selector in which it lives it's not possible to give unique docs to each given their implementations. 

@davepacheco noted in the last PR
> ...with the nested "Russian doll" approach, the hierarchy wasn't duplicated in each struct, which seems better? (It seems like lots of opportunities for error to duplicate these fields in a lot of places.) The previous approach presumably makes it easier to write functions that operate on the selector for some middle node in the hierarchy (like Vpc), whereas it seems like you can't do that today because things further in the hierarchy don't use a VpcSelector any more?

That feedback is still relevant but I think it's important to keep in mind the role that selectors play in our system. A selector is constructed at the API layer and _should not_ be passed to the app layer (beyond performing lookups). We specifically want lookups to be the primitives that we're passing around at the app layer. Given their intentional limited exposure I feel like the flattened selectors don't pose any outsized risk in producing error prone code. The makeup of the selector itself is enforced by its lookup (which every selector has) and the lookups themselves are recursive (such that any selector only cares about its principle parameter and delegates the remaining parameters to the next lookup handler in the chain). 