### PR TITLE
sled agent: defer to Propolis's instance state machine

### DIFF
--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -298,15 +298,6 @@ async fn test_instances_create_reboot_halt(
     let instance = instance_next;
     instance_simulate(nexus, &instance.identity.id).await;
     let instance_next = instance_get(&client, &instance_url).await;
-    assert_eq!(instance_next.runtime.run_state, InstanceState::Starting);
-    assert!(
-        instance_next.runtime.time_run_state_updated
-            > instance.runtime.time_run_state_updated
-    );
-
-    let instance = instance_next;
-    instance_simulate(nexus, &instance.identity.id).await;
-    let instance_next = instance_get(&client, &instance_url).await;
     assert_eq!(instance_next.runtime.run_state, InstanceState::Running);
     assert!(
         instance_next.runtime.time_run_state_updated
@@ -379,15 +370,6 @@ async fn test_instances_create_reboot_halt(
     let instance_next =
         instance_post(&client, instance_name, InstanceOp::Reboot).await;
     assert_eq!(instance_next.runtime.run_state, InstanceState::Rebooting);
-    assert!(
-        instance_next.runtime.time_run_state_updated
-            > instance.runtime.time_run_state_updated
-    );
-
-    let instance = instance_next;
-    instance_simulate(nexus, &instance.identity.id).await;
-    let instance_next = instance_get(&client, &instance_url).await;
-    assert_eq!(instance_next.runtime.run_state, InstanceState::Starting);
     assert!(
         instance_next.runtime.time_run_state_updated
             > instance.runtime.time_run_state_updated

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -4,15 +4,44 @@
 
 //! Describes the states of VM instances.
 
-use crate::params::{
-    InstanceRuntimeStateMigrateParams, InstanceRuntimeStateRequested,
-    InstanceStateRequested,
-};
 use chrono::Utc;
-use omicron_common::api::external::Error;
-use omicron_common::api::external::InstanceState;
+use omicron_common::api::external::InstanceState as ApiInstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use propolis_client::api::InstanceState as PropolisInstanceState;
+
+/// Newtype to facilitate conversions from Propolis states to external API
+/// states.
+pub struct InstanceState(pub ApiInstanceState);
+
+impl From<PropolisInstanceState> for InstanceState {
+    fn from(value: PropolisInstanceState) -> Self {
+        InstanceState(match value {
+            // From an external perspective, the instance has already been
+            // created. Creating the propolis instance is an internal detail and
+            // happens every time we start the instance, so we map it to
+            // "Starting" here.
+            PropolisInstanceState::Creating
+            | PropolisInstanceState::Starting => ApiInstanceState::Starting,
+            PropolisInstanceState::Running => ApiInstanceState::Running,
+            PropolisInstanceState::Stopping => ApiInstanceState::Stopping,
+            PropolisInstanceState::Stopped => ApiInstanceState::Stopped,
+            PropolisInstanceState::Rebooting => ApiInstanceState::Rebooting,
+            PropolisInstanceState::Migrating => ApiInstanceState::Migrating,
+            PropolisInstanceState::Repairing => ApiInstanceState::Repairing,
+            PropolisInstanceState::Failed => ApiInstanceState::Failed,
+            // NOTE: This is a bit of an odd one - we intentionally do *not*
+            // translate the "destroyed" propolis state to the destroyed instance
+            // API state.
+            //
+            // When a propolis instance reports that it has been destroyed,
+            // this does not necessarily mean the customer-visible instance
+            // should be torn down. Instead, it implies that the Propolis service
+            // should be stopped, but the VM could be allocated to a different
+            // machine.
+            PropolisInstanceState::Destroyed => ApiInstanceState::Stopped,
+        })
+    }
+}
 
 /// Action to be taken on behalf of state transition.
 #[derive(Clone, Debug, PartialEq)]
@@ -27,44 +56,17 @@ pub enum Action {
     Destroy,
 }
 
-fn get_next_desired_state(
-    observed: &PropolisInstanceState,
-    requested: InstanceStateRequested,
-) -> Option<InstanceStateRequested> {
-    use InstanceStateRequested as Requested;
-    use PropolisInstanceState as Observed;
-
-    match (requested, observed) {
-        (Requested::Running, Observed::Running) => None,
-        (Requested::Stopped, Observed::Stopped) => None,
-        (Requested::Destroyed, Observed::Destroyed) => None,
-
-        // Reboot requests.
-        // - "Stopping" is an expected state on the way to rebooting.
-        // - "Starting" expects "Running" to occur next.
-        // - Other observed states stop the expected transitions.
-        (Requested::Reboot, Observed::Stopping) => Some(Requested::Reboot),
-        (Requested::Reboot, Observed::Starting) => Some(Requested::Running),
-        (Requested::Reboot, _) => None,
-
-        (_, _) => Some(requested),
-    }
-}
-
-/// The instance state is a combination of the last-known state, as well as an
-/// "objective" state which the sled agent will work towards achieving.
+/// A wrapper around an instance's current state, represented as a Nexus
+/// `InstanceRuntimeState`. The externally-visible instance state in this
+/// structure is mostly changed when the instance's Propolis state changes.
 #[derive(Clone, Debug)]
 pub struct InstanceStates {
-    // Last known state reported from Propolis.
     current: InstanceRuntimeState,
-
-    // Desired state, which we will attempt to poke the VM towards.
-    desired: Option<InstanceRuntimeStateRequested>,
 }
 
 impl InstanceStates {
     pub fn new(current: InstanceRuntimeState) -> Self {
-        InstanceStates { current, desired: None }
+        InstanceStates { current }
     }
 
     /// Returns the current instance state.
@@ -77,275 +79,31 @@ impl InstanceStates {
         &mut self.current
     }
 
-    /// Returns the desired instance state, if any exists.
-    pub fn desired(&self) -> &Option<InstanceRuntimeStateRequested> {
-        &self.desired
-    }
-
     /// Update the known state of an instance based on an observed state from
     /// Propolis.
     pub fn observe_transition(
         &mut self,
         observed: &PropolisInstanceState,
     ) -> Option<Action> {
-        use InstanceState as State;
-        use PropolisInstanceState as Observed;
-
-        let current = match observed {
-            // From an external perspective, the instance has already been created.
-            // Creating the propolis instance is an internal detail and happens
-            // every time we start the instance, so we map it to "Starting" here.
-            Observed::Creating | Observed::Starting => State::Starting,
-            Observed::Running => State::Running,
-            Observed::Stopping => State::Stopping,
-            Observed::Stopped => State::Stopped,
-            Observed::Rebooting => State::Rebooting,
-            Observed::Migrating => State::Migrating,
-            Observed::Repairing => State::Repairing,
-            Observed::Failed => State::Failed,
-            // NOTE: This is a bit of an odd one - we intentionally do *not*
-            // translate the "destroyed" propolis state to the destroyed instance
-            // API state.
-            //
-            // When a propolis instance reports that it has been destroyed,
-            // this does not necessarily mean the customer-visible instance
-            // should be torn down. Instead, it implies that the Propolis service
-            // should be stopped, but the VM could be allocated to a different
-            // machine.
-            Observed::Destroyed => State::Stopped,
-        };
-
-        let desired = self
-            .desired
-            .as_ref()
-            .and_then(|s| get_next_desired_state(&observed, s.run_state));
-
-        self.transition(current, desired);
+        let current = InstanceState::from(*observed).0;
+        self.transition(current);
 
         // Most commands to update Propolis are triggered via requests (from
         // Nexus), but if the instance reports that it has been destroyed,
         // we should clean it up.
-        if matches!(observed, Observed::Destroyed) {
+        if matches!(observed, PropolisInstanceState::Destroyed) {
             Some(Action::Destroy)
         } else {
             None
         }
     }
 
-    /// Attempts to move from the current state to the requested "target" state.
-    ///
-    /// On success, returns the action, if any, which is necessary to carry
-    /// out this state transition.
-    pub fn request_transition(
-        &mut self,
-        target: &InstanceRuntimeStateRequested,
-    ) -> Result<Option<Action>, Error> {
-        match target.run_state {
-            InstanceStateRequested::Running => self.request_running(),
-            InstanceStateRequested::Stopped => self.request_stopped(),
-            InstanceStateRequested::Reboot => self.request_reboot(),
-            InstanceStateRequested::Migrating => {
-                self.request_migrating(target.migration_params)
-            }
-            InstanceStateRequested::Destroyed => self.request_destroyed(),
-        }
-    }
-
     // Transitions to a new InstanceState value, updating the timestamp and
     // generation number.
-    //
-    // This transition always succeeds.
-    pub(crate) fn transition(
-        &mut self,
-        next: InstanceState,
-        desired: Option<InstanceStateRequested>,
-    ) {
+    pub(crate) fn transition(&mut self, next: ApiInstanceState) {
         self.current.run_state = next;
         self.current.gen = self.current.gen.next();
         self.current.time_updated = Utc::now();
-        self.desired = desired.map(|run_state| InstanceRuntimeStateRequested {
-            run_state,
-            migration_params: None,
-        });
-    }
-
-    fn request_running(&mut self) -> Result<Option<Action>, Error> {
-        match self.current.run_state {
-            // Early exit: Running request is no-op
-            InstanceState::Running
-            | InstanceState::Rebooting
-            | InstanceState::Migrating => return Ok(None),
-            // Valid states for a running request
-            InstanceState::Creating
-            | InstanceState::Starting
-            | InstanceState::Stopping
-            | InstanceState::Stopped => {
-                self.transition(
-                    InstanceState::Starting,
-                    Some(InstanceStateRequested::Running),
-                );
-                return Ok(Some(Action::Run));
-            }
-            // Invalid states for a running request
-            InstanceState::Repairing
-            | InstanceState::Failed
-            | InstanceState::Destroyed => {
-                return Err(Error::InvalidRequest {
-                    message: format!(
-                        "cannot run instance in state \"{}\"",
-                        self.current.run_state,
-                    ),
-                });
-            }
-        }
-    }
-
-    fn request_stopped(&mut self) -> Result<Option<Action>, Error> {
-        match self.current.run_state {
-            // Early exit: Stop request is a no-op
-            InstanceState::Stopped | InstanceState::Stopping => {
-                return Ok(None)
-            }
-            // Valid states for a stop request
-            InstanceState::Creating => {
-                // Already stopped, no action necessary.
-                self.transition(InstanceState::Stopped, None);
-                return Ok(None);
-            }
-            InstanceState::Starting
-            | InstanceState::Running
-            | InstanceState::Rebooting => {
-                // There's a propolis service, explicitly tell it to stop.
-                self.transition(
-                    InstanceState::Stopping,
-                    Some(InstanceStateRequested::Stopped),
-                );
-                return Ok(Some(Action::Stop));
-            }
-            // Invalid states for a stop request
-            InstanceState::Migrating
-            | InstanceState::Repairing
-            | InstanceState::Failed
-            | InstanceState::Destroyed => {
-                return Err(Error::InvalidRequest {
-                    message: format!(
-                        "cannot stop instance in state \"{}\"",
-                        self.current.run_state,
-                    ),
-                });
-            }
-        }
-    }
-
-    fn request_reboot(&mut self) -> Result<Option<Action>, Error> {
-        match self.current.run_state {
-            // Early exit: Reboot request is a no-op
-            InstanceState::Rebooting => return Ok(None),
-            // Valid states for a reboot request
-            InstanceState::Starting | InstanceState::Running => {
-                self.transition(
-                    InstanceState::Rebooting,
-                    Some(InstanceStateRequested::Reboot),
-                );
-                return Ok(Some(Action::Reboot));
-            }
-            // Invalid states for a reboot request
-            _ => {
-                return Err(Error::InvalidRequest {
-                    message: format!(
-                        "cannot reboot instance in state \"{}\"",
-                        self.current.run_state,
-                    ),
-                });
-            }
-        }
-    }
-
-    fn request_migrating(
-        &mut self,
-        migration_params: Option<InstanceRuntimeStateMigrateParams>,
-    ) -> Result<Option<Action>, Error> {
-        let InstanceRuntimeStateMigrateParams { migration_id, dst_propolis_id } =
-            migration_params.ok_or_else(|| {
-                Error::invalid_request(
-                "expected migration IDs to transition to \"migrating\" state",
-            )
-            })?;
-        match self.current.run_state {
-            // Valid states for a migration request
-            InstanceState::Running => {
-                self.current.dst_propolis_id = Some(dst_propolis_id);
-                self.current.migration_id = Some(migration_id);
-                self.transition(
-                    InstanceState::Migrating,
-                    Some(InstanceStateRequested::Running),
-                );
-                // We don't return any action here for propolis to take
-                // because the actual migration process will be driven
-                // via a followup request to sled agent.
-                Ok(None)
-            }
-            InstanceState::Migrating => match self.current.migration_id {
-                Some(id) if id == migration_id => {
-                    match self.current.dst_propolis_id {
-                        // We're already performing the given migration to the
-                        // given propolis instance: no-op
-                        Some(id) if id == dst_propolis_id => Ok(None),
-                        // The migration ID matched but not the propolis ID: bail out
-                        Some(id) => Err(Error::InvalidRequest {
-                                message: format!(
-                                    "already perfoming given migration to different propolis: {}",
-                                    id
-                                )
-                            }),
-                        // If we're marked as 'Migrating' but have no dst propolis
-                        // ID bail because that shouldn't be possible
-                        None => Err(Error::internal_error(
-                            "migrating but no dst propolis id present"
-                        )),
-                    }
-                }
-                // A different migration is already underway
-                Some(id) => Err(Error::InvalidRequest {
-                    message: format!("migration already in progress: {}", id),
-                }),
-                // If we're marked as 'Migrating' but have no migration
-                // id bail because that shouldn't be possible
-                None => Err(Error::internal_error(
-                    "migrating but no migration id present",
-                )),
-            },
-
-            // Invalid states for a migration request
-            InstanceState::Creating
-            | InstanceState::Starting
-            | InstanceState::Stopping
-            | InstanceState::Stopped
-            | InstanceState::Rebooting
-            | InstanceState::Repairing
-            | InstanceState::Failed
-            | InstanceState::Destroyed => {
-                return Err(Error::InvalidRequest {
-                    message: format!(
-                        "cannot migrate instance in state \"{}\"",
-                        self.current.run_state,
-                    ),
-                });
-            }
-        }
-    }
-
-    fn request_destroyed(&mut self) -> Result<Option<Action>, Error> {
-        if self.current.run_state.is_stopped() {
-            self.transition(InstanceState::Destroyed, None);
-            return Ok(Some(Action::Destroy));
-        } else {
-            self.transition(
-                InstanceState::Stopping,
-                Some(InstanceStateRequested::Destroyed),
-            );
-            return Ok(Some(Action::Stop));
-        }
     }
 }
 
@@ -353,14 +111,9 @@ impl InstanceStates {
 mod test {
     use super::{Action, InstanceStates};
 
-    use crate::params::{
-        InstanceRuntimeStateMigrateParams, InstanceRuntimeStateRequested,
-        InstanceStateRequested as Requested,
-    };
-    use assert_matches::assert_matches;
     use chrono::Utc;
     use omicron_common::api::external::{
-        ByteCount, Error, Generation, InstanceCpuCount, InstanceState as State,
+        ByteCount, Generation, InstanceCpuCount, InstanceState as State,
     };
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
     use propolis_client::api::InstanceState as Observed;
@@ -382,401 +135,15 @@ mod test {
         })
     }
 
-    fn verify_state(
-        instance: &InstanceStates,
-        expected_current: State,
-        expected_desired: Option<Requested>,
-    ) {
-        assert_eq!(expected_current, instance.current().run_state);
-        match expected_desired {
-            Some(desired) => {
-                assert_eq!(
-                    desired,
-                    instance.desired().as_ref().unwrap().run_state
-                );
-            }
-            None => assert!(instance.desired().is_none()),
-        }
-    }
-
-    fn runtime_state(run_state: Requested) -> InstanceRuntimeStateRequested {
-        InstanceRuntimeStateRequested { run_state, migration_params: None }
-    }
-
     #[test]
-    fn test_running_from_creating() {
+    fn propolis_destroy_requests_destroy_action() {
         let mut instance = make_instance();
+        let original_instance = instance.clone();
+        let requested_action =
+            instance.observe_transition(&Observed::Destroyed);
 
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-    }
-
-    #[test]
-    fn test_reboot() {
-        let mut instance = make_instance();
-
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-
-        // Normal reboot behavior:
-        // - Request Reboot
-        // - Observe Stopping, Starting, Running
-        assert_eq!(
-            Action::Reboot,
-            instance
-                .request_transition(&runtime_state(Requested::Reboot))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Rebooting, Some(Requested::Reboot));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Stopping));
-        verify_state(&instance, State::Stopping, Some(Requested::Reboot));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Starting));
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-    }
-
-    #[test]
-    fn test_reboot_skip_starting_converges_to_running() {
-        let mut instance = make_instance();
-
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-
-        // Unexpected reboot behavior:
-        // - Request Reboot
-        // - Observe Stopping, jump immediately to Running.
-        // - Ultimately, we should still end up "running".
-        assert_eq!(
-            Action::Reboot,
-            instance
-                .request_transition(&runtime_state(Requested::Reboot))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Rebooting, Some(Requested::Reboot));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Stopping));
-        verify_state(&instance, State::Stopping, Some(Requested::Reboot));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-    }
-
-    #[test]
-    fn test_reboot_skip_stopping_converges_to_running() {
-        let mut instance = make_instance();
-
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-
-        // Unexpected reboot behavior:
-        // - Request Reboot
-        // - Observe Starting then Running.
-        // - Ultimately, we should still end up "running".
-        assert_eq!(
-            Action::Reboot,
-            instance
-                .request_transition(&runtime_state(Requested::Reboot))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Rebooting, Some(Requested::Reboot));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Starting));
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-    }
-
-    #[test]
-    fn test_destroy_from_running_stops_first() {
-        let mut instance = make_instance();
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        assert_eq!(
-            Action::Stop,
-            instance
-                .request_transition(&runtime_state(Requested::Destroyed))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Stopping, Some(Requested::Destroyed));
-        assert_eq!(None, instance.observe_transition(&Observed::Stopped));
-        verify_state(&instance, State::Stopped, Some(Requested::Destroyed));
-        assert_eq!(
-            Action::Destroy,
-            instance.observe_transition(&Observed::Destroyed).unwrap()
-        );
-        verify_state(&instance, State::Stopped, None);
-    }
-
-    #[test]
-    fn test_destroy_from_stopped_destroys_immediately() {
-        let mut instance = make_instance();
-        assert_eq!(None, instance.observe_transition(&Observed::Stopped));
-        assert_eq!(
-            Action::Destroy,
-            instance
-                .request_transition(&runtime_state(Requested::Destroyed))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Destroyed, None);
-    }
-
-    fn migrating_req() -> InstanceRuntimeStateRequested {
-        InstanceRuntimeStateRequested {
-            run_state: Requested::Migrating,
-            migration_params: Some(InstanceRuntimeStateMigrateParams {
-                migration_id: Uuid::new_v4(),
-                dst_propolis_id: Uuid::new_v4(),
-            }),
-        }
-    }
-
-    #[test]
-    fn test_migrating_from_invalid_states_fails() {
-        let mut instance = make_instance();
-
-        let invalid_migrate_states = [
-            State::Creating,
-            State::Starting,
-            State::Stopping,
-            State::Stopped,
-            State::Rebooting,
-            State::Repairing,
-            State::Failed,
-            State::Destroyed,
-        ];
-
-        for state in invalid_migrate_states {
-            instance.current_mut().run_state = state;
-            assert_matches!(
-                // Match state here as well so failure shows which
-                // state we failed on.
-                (state, instance.request_transition(&migrating_req())),
-                (_, Err(Error::InvalidRequest { message }))
-                    if message.contains("cannot migrate instance")
-            );
-        }
-    }
-
-    #[test]
-    fn test_migrating_from_running() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-        assert_eq!(
-            migrating_req.migration_params.map(|m| m.migration_id),
-            instance.current().migration_id,
-        );
-        assert_eq!(
-            migrating_req.migration_params.map(|m| m.dst_propolis_id),
-            instance.current().dst_propolis_id,
-        );
-    }
-
-    #[test]
-    fn test_migrating_with_same_migration() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-
-        // A subsequent request for the same migration is a no-op
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-    }
-
-    #[test]
-    fn test_migrating_missing_params_fails() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        assert_matches!(
-            instance.request_transition(&runtime_state(Requested::Migrating)),
-            Err(Error::InvalidRequest { message })
-                if message.contains("expected migration IDs to transition")
-        );
-    }
-
-    #[test]
-    fn test_migrating_with_same_migration_different_propolis_fails() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        let mut migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-
-        // We keep the Migration ID the same but pass a different
-        // propolis ID to migrate too.
-        migrating_req.migration_params.as_mut().unwrap().dst_propolis_id =
-            Uuid::new_v4();
-        assert_matches!(
-            instance.request_transition(&migrating_req),
-            Err(Error::InvalidRequest { message })
-                if message.contains("already perfoming given migration to different propolis")
-        );
-    }
-
-    #[test]
-    fn test_migrating_with_new_migration_fails() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        assert_matches!(
-            instance.request_transition(&migrating_req()),
-            Ok(None)
-        );
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-
-        assert_matches!(
-            // NOTE: different migration parameters given in subsequent request
-            instance.request_transition(&migrating_req()),
-            Err(Error::InvalidRequest { message })
-                if message.contains("migration already in progress")
-        );
-    }
-
-    #[test]
-    fn test_migrating_inconsistent_internal_state() {
-        let mut instance = make_instance();
-
-        verify_state(&instance, State::Creating, None);
-        assert_eq!(
-            Action::Run,
-            instance
-                .request_transition(&runtime_state(Requested::Running))
-                .unwrap()
-                .unwrap()
-        );
-        verify_state(&instance, State::Starting, Some(Requested::Running));
-        assert_eq!(None, instance.observe_transition(&Observed::Running));
-        verify_state(&instance, State::Running, None);
-
-        let migrating_req = migrating_req();
-        assert_matches!(instance.request_transition(&migrating_req), Ok(None));
-        verify_state(&instance, State::Migrating, Some(Requested::Running));
-
-        // This shouldn't happen during the normal course of operation
-        // but we also don't want things to proceed if such a state is encountered.
-
-        // Instance is currently marked as 'Migrating' but we'll
-        // remove the destination propolis ID
-        instance.current_mut().dst_propolis_id = None;
-
-        // A subsequent migrate request that would've been a no-op
-        // otherwise should fail in this case
-        assert_matches!(
-            instance.request_transition(&migrating_req),
-            Err(Error::InternalError { internal_message })
-                if internal_message.contains("migrating but no dst propolis id present")
-        );
-
-        // Instance is still marked as 'Migrating' but we'll
-        // remove the Migration ID as well
-        instance.current_mut().migration_id = None;
-
-        // A subsequent migrate request that would've been a no-op
-        // otherwise should fail in this case
-        assert_matches!(
-            instance.request_transition(&migrating_req),
-            Err(Error::InternalError { internal_message })
-                if internal_message.contains("migrating but no migration id present")
-        );
+        assert!(matches!(requested_action, Some(Action::Destroy)));
+        assert!(instance.current.gen > original_instance.current.gen);
+        assert_eq!(instance.current.run_state, State::Stopped);
     }
 }

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -160,7 +160,7 @@ impl<S: Simulatable> SimObject<S> {
     }
 }
 
-/// The mdoes of operation for the "poke" operation.
+/// The modes of operation for the "poke" operation.
 pub enum PokeMode {
     /// Make the simulated object take a single step.
     SingleStep,

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -98,7 +98,7 @@ impl<S: Simulatable> SimObject<S> {
         &mut self,
         target: S::RequestedState,
     ) -> Result<Option<S::RequestedState>, Error> {
-        let dropped = self.object.desired().clone();
+        let dropped = self.object.desired();
         let old_gen = self.object.generation();
         let action = self.object.request_transition(&target)?;
         if old_gen == self.object.generation() {
@@ -148,7 +148,7 @@ impl<S: Simulatable> SimObject<S> {
 
     fn transition_finish(&mut self) {
         let current = self.object.current().clone();
-        let desired = self.object.desired().clone();
+        let desired = self.object.desired();
         let action = self.object.execute_desired_transition();
         info!(self.log, "simulated transition finish";
             "state_before" => ?current,
@@ -158,6 +158,16 @@ impl<S: Simulatable> SimObject<S> {
             "action" => ?action,
         );
     }
+}
+
+/// The mdoes of operation for the "poke" operation.
+pub enum PokeMode {
+    /// Make the simulated object take a single step.
+    SingleStep,
+
+    /// Make the simulated object take steps until it no longer reports an
+    /// explicit destination state.
+    Drain,
 }
 
 /// A collection of `Simulatable` objects, each represented by a `SimObject`
@@ -203,7 +213,7 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     async fn sim_step(&self, id: Uuid, mut rx: Receiver<()>) {
         while rx.next().await.is_some() {
             tokio::time::sleep(Duration::from_millis(1500)).await;
-            self.sim_poke(id).await;
+            self.sim_poke(id, PokeMode::SingleStep).await;
         }
     }
 
@@ -211,45 +221,57 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     /// This is invoked either by `sim_step()` (if the simulation mode is
     /// `SimMode::Auto`) or `instance_finish_transition` (if the simulation mode
     /// is `SimMode::Api).
-    pub async fn sim_poke(&self, id: Uuid) {
-        let (new_state, to_destroy) = {
-            // The object must be present in `objects` because it only gets
-            // removed when it comes to rest in the "Destroyed" state, but we
-            // can only get here if there's an asynchronous state transition
-            // desired.
-            //
-            // We do as little as possible with the lock held.  In particular,
-            // we want to finish this work before calling out to notify the
-            // nexus.
-            let mut objects = self.objects.lock().await;
-            let mut object = objects.remove(&id).unwrap();
-            object.transition_finish();
-            let after = object.object.current().clone();
-            if object.object.desired().is_none()
-                && object.object.ready_to_destroy()
-            {
-                (after, Some(object))
-            } else {
-                objects.insert(id, object);
-                (after, None)
-            }
-        };
+    pub async fn sim_poke(&self, id: Uuid, mode: PokeMode) {
+        let mut should_step = true;
 
-        // Notify Nexus that the object's state has changed.
-        // TODO-robustness: If this fails, we need to put it on some list of
-        // updates to retry later.
-        S::notify(&self.nexus_client, &id, new_state).await.unwrap();
+        while should_step {
+            let (new_state, to_destroy) = {
+                // The object must be present in `objects` because it only gets
+                // removed when it comes to rest in the "Destroyed" state, but
+                // we can only get here if there's an asynchronous state
+                // transition desired.
+                //
+                // We do as little as possible with the lock held.  In
+                // particular, we want to finish this work before calling out to
+                // notify the nexus.
+                let mut objects = self.objects.lock().await;
+                let mut object = objects.remove(&id).unwrap();
+                object.transition_finish();
+                let after = object.object.current().clone();
 
-        // If the object came to rest destroyed, complete any async cleanup
-        // needed now.
-        // TODO-debugging It would be nice to have visibility into objects that
-        // are cleaning up in case we have to debug resource leaks here.
-        // TODO-correctness Is it a problem that nobody waits on the background
-        // task?  If we did it here, we'd deadlock, since we're invoked from the
-        // background task.
-        if let Some(destroyed_object) = to_destroy {
-            if let Some(mut tx) = destroyed_object.channel_tx {
-                tx.close_channel();
+                if matches!(mode, PokeMode::SingleStep)
+                    || object.object.desired().is_none()
+                {
+                    should_step = false;
+                }
+
+                if object.object.desired().is_none()
+                    && object.object.ready_to_destroy()
+                {
+                    (after, Some(object))
+                } else {
+                    objects.insert(id, object);
+                    (after, None)
+                }
+            };
+
+            // Notify Nexus that the object's state has changed.
+            // TODO-robustness: If this fails, we need to put it on some list of
+            // updates to retry later.
+            S::notify(&self.nexus_client, &id, new_state).await.unwrap();
+
+            // If the object came to rest destroyed, complete any async cleanup
+            // needed now.
+            // TODO-debugging It would be nice to have visibility
+            // into objects that are cleaning up in case we have to debug
+            // resource leaks here.
+            // TODO-correctness Is it a problem that nobody
+            // waits on the background task?  If we did it here, we'd deadlock,
+            // since we're invoked from the background task.
+            if let Some(destroyed_object) = to_destroy {
+                if let Some(mut tx) = destroyed_object.channel_tx {
+                    tx.close_channel();
+                }
             }
         }
     }
@@ -329,10 +351,7 @@ impl<S: Simulatable + 'static> SimCollection<S> {
 
 #[cfg(test)]
 mod test {
-    use crate::params::{
-        DiskStateRequested, InstanceRuntimeStateRequested,
-        InstanceStateRequested,
-    };
+    use crate::params::{DiskStateRequested, InstanceStateRequested};
     use crate::sim::collection::SimObject;
     use crate::sim::disk::SimDisk;
     use crate::sim::instance::SimInstance;
@@ -407,39 +426,20 @@ mod test {
         assert_eq!(r1.gen, instance.object.current().gen);
         assert!(rx.try_next().is_err());
 
-        // We should be able to transition immediately to any other stopped
-        // state.  We can't do this for "Creating" because transition() treats
-        // that as a transition to "Running".
-        let stopped_states = vec![
-            InstanceStateRequested::Stopped,
-            InstanceStateRequested::Destroyed,
-        ];
-        let mut rprev = r1;
-        for state in stopped_states {
-            assert!(rprev.run_state.is_stopped());
-            let dropped = instance
-                .transition(InstanceRuntimeStateRequested {
-                    run_state: state,
-                    migration_params: None,
-                })
-                .unwrap();
-            assert!(dropped.is_none());
-            assert!(instance.object.desired().is_none());
-            let rnext = instance.object.current().clone();
-            assert!(rnext.gen > rprev.gen);
-            assert!(rnext.time_updated >= rprev.time_updated);
-            match state {
-                InstanceStateRequested::Stopped => {
-                    assert_eq!(rnext.run_state, InstanceState::Stopped);
-                }
-                InstanceStateRequested::Destroyed => {
-                    assert_eq!(rnext.run_state, InstanceState::Destroyed);
-                }
-                _ => panic!("Unexpected requested state: {}", state),
-            }
-            assert!(rx.try_next().is_err());
-            rprev = rnext;
-        }
+        // Stopping an instance that was never started synchronously destroys
+        // it.
+        let rprev = r1;
+        assert!(rprev.run_state.is_stopped());
+        let dropped =
+            instance.transition(InstanceStateRequested::Stopped).unwrap();
+        assert!(dropped.is_none());
+        assert!(instance.object.desired().is_none());
+        let rnext = instance.object.current().clone();
+        assert!(rnext.gen > rprev.gen);
+        assert!(rnext.time_updated >= rprev.time_updated);
+        assert_eq!(rnext.run_state, InstanceState::Destroyed);
+        assert!(rx.try_next().is_err());
+
         logctx.cleanup_successful();
     }
 
@@ -470,12 +470,8 @@ mod test {
         // process.
         let mut rprev = r1;
         assert!(rx.try_next().is_err());
-        let dropped = instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Running,
-                migration_params: None,
-            })
-            .unwrap();
+        let dropped =
+            instance.transition(InstanceStateRequested::Running).unwrap();
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_some());
         assert!(rx.try_next().is_ok());
@@ -502,12 +498,8 @@ mod test {
         // If we transition again to "Running", the process should complete
         // immediately.
         assert!(!rprev.run_state.is_stopped());
-        let dropped = instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Running,
-                migration_params: None,
-            })
-            .unwrap();
+        let dropped =
+            instance.transition(InstanceStateRequested::Running).unwrap();
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_none());
         assert!(rx.try_next().is_err());
@@ -521,12 +513,8 @@ mod test {
         // again.
         assert!(!rprev.run_state.is_stopped());
         assert!(rx.try_next().is_err());
-        let dropped = instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Destroyed,
-                migration_params: None,
-            })
-            .unwrap();
+        let dropped =
+            instance.transition(InstanceStateRequested::Stopped).unwrap();
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_some());
         let rnext = instance.object.current().clone();
@@ -536,91 +524,34 @@ mod test {
         assert!(!rnext.run_state.is_stopped());
         rprev = rnext;
 
+        // Propolis publishes its own transition to Stopping before it publishes
+        // Stopped.
         instance.transition_finish();
         let rnext = instance.object.current().clone();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
-        assert!(instance.object.desired().is_none());
-        assert_eq!(rprev.run_state, InstanceState::Stopping);
-        assert_eq!(rnext.run_state, InstanceState::Stopped);
-        rprev = rnext;
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rprev.gen, rnext.gen);
-        logctx.cleanup_successful();
-    }
-
-    #[tokio::test]
-    async fn test_sim_instance_preempt_transition() {
-        let logctx = test_setup_log("test_sim_instance_preempt_transition");
-        let (mut instance, mut rx) = make_instance(&logctx);
-        let r1 = instance.object.current().clone();
-
-        info!(logctx.log, "new instance"; "run_state" => ?r1.run_state);
-        assert_eq!(r1.run_state, InstanceState::Creating);
-        assert_eq!(r1.gen, Generation::new());
-
-        // There's no asynchronous transition going on yet so a
-        // transition_finish() shouldn't change anything.
-        assert!(instance.object.desired().is_none());
-        instance.transition_finish();
-        assert!(instance.object.desired().is_none());
-        assert_eq!(&r1.time_updated, &instance.object.current().time_updated);
-        assert_eq!(&r1.run_state, &instance.object.current().run_state);
-        assert_eq!(r1.gen, instance.object.current().gen);
-        assert!(rx.try_next().is_err());
-
-        // Now, if we transition to "Running", we must go through the async
-        // process.
-        let mut rprev = r1;
-        // Now let's test the behavior of dropping a transition.  We'll start
-        // transitioning back to "Running".  Then, while we're still in
-        // "Starting", will transition back to "Destroyed".  We should
-        // immediately go to "Stopping", and completing the transition should
-        // take us to "Destroyed".
-        assert!(rprev.run_state.is_stopped());
-        let dropped = instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Running,
-                migration_params: None,
-            })
-            .unwrap();
-        assert!(dropped.is_none());
         assert!(instance.object.desired().is_some());
-        let rnext = instance.object.current().clone();
-        assert!(rnext.gen > rprev.gen);
-        assert!(rnext.time_updated >= rprev.time_updated);
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        assert!(!rnext.run_state.is_stopped());
-        rprev = rnext;
-
-        // Interrupt the async transition with a new one.
-        let dropped = instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Destroyed,
-                migration_params: None,
-            })
-            .unwrap();
-        assert_eq!(dropped.unwrap().run_state, InstanceStateRequested::Running);
-        let rnext = instance.object.current().clone();
-        assert!(rnext.gen > rprev.gen);
-        assert!(rnext.time_updated >= rprev.time_updated);
+        assert_eq!(rprev.run_state, InstanceState::Stopping);
         assert_eq!(rnext.run_state, InstanceState::Stopping);
         rprev = rnext;
 
-        // Finish the async transition.
+        // Stopping goes to Stopped...
         instance.transition_finish();
         let rnext = instance.object.current().clone();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
-        assert!(instance.object.desired().is_none());
+        assert!(instance.object.desired().is_some());
         assert_eq!(rprev.run_state, InstanceState::Stopping);
         assert_eq!(rnext.run_state, InstanceState::Stopped);
         rprev = rnext;
+
+        // ...and Stopped (internally) goes to Destroyed, though the sled agent
+        // hides this state from clients.
         instance.transition_finish();
         let rnext = instance.object.current().clone();
-        assert_eq!(rprev.gen, rnext.gen);
-
+        assert!(rnext.gen > rprev.gen);
+        assert_eq!(rprev.run_state, InstanceState::Stopped);
+        assert_eq!(rnext.run_state, InstanceState::Stopped);
         logctx.cleanup_successful();
     }
 
@@ -637,10 +568,7 @@ mod test {
         assert_eq!(r1.run_state, InstanceState::Creating);
         assert_eq!(r1.gen, Generation::new());
         assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Running,
-                migration_params: None,
-            })
+            .transition(InstanceStateRequested::Running)
             .unwrap()
             .is_none());
         instance.transition_finish();
@@ -652,14 +580,18 @@ mod test {
         }
 
         assert!(rnext.gen > rprev.gen);
-        // Now, take it through a reboot sequence.
+
+        // Now reboot the instance. This is dispatched to Propolis, which will
+        // move to the Rebooting state and then back to Running.
         assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
+            .transition(InstanceStateRequested::Reboot)
             .unwrap()
             .is_none());
+        let (rprev, rnext) = (rnext, instance.object.current().clone());
+        assert!(rnext.gen > rprev.gen);
+        assert!(rnext.time_updated > rprev.time_updated);
+        assert_eq!(rnext.run_state, InstanceState::Rebooting);
+        instance.transition_finish();
         let (rprev, rnext) = (rnext, instance.object.current().clone());
 
         // Chrono doesn't give us enough precision, so sleep a bit
@@ -681,132 +613,7 @@ mod test {
 
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated > rprev.time_updated);
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        assert!(instance.object.desired().is_some());
-        instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
-        assert!(rnext.gen > rprev.gen);
-        assert!(rnext.time_updated > rprev.time_updated);
         assert_eq!(rnext.run_state, InstanceState::Running);
-        assert!(instance.object.desired().is_none());
-
-        // Begin a reboot.  Then, while it's still "Stopping", begin another
-        // reboot.  This should go through exactly one reboot sequence, as the
-        // second reboot is totally superfluous.
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_none());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Rebooting);
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_none());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Rebooting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Running);
-        assert!(instance.object.desired().is_none());
-        instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
-        assert_eq!(rprev.gen, rnext.gen);
-
-        // Begin a reboot.  Then, while it's "Starting" (on the way back up),
-        // begin another reboot.  This should go through a second reboot
-        // sequence.
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_none());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Rebooting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_some());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Rebooting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Running);
-        assert!(instance.object.desired().is_none());
-        instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
-        assert_eq!(rprev.gen, rnext.gen);
-
-        // At this point, we've exercised what happens when a reboot is issued
-        // from "Running", from "Starting" with a reboot in progress, from
-        // "Stopping" with a reboot in progress.  All that's left is "Starting"
-        // with no reboot in progress.  First, stop the instance.  Then start
-        // it.  Then, while it's starting, begin a reboot sequence.
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Stopped,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_none());
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Stopped);
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Running,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_none());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        assert!(instance
-            .transition(InstanceRuntimeStateRequested {
-                run_state: InstanceStateRequested::Reboot,
-                migration_params: None,
-            })
-            .unwrap()
-            .is_some());
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Rebooting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Starting);
-        instance.transition_finish();
-        let rnext = instance.object.current().clone();
-        assert_eq!(rnext.run_state, InstanceState::Running);
-        assert!(instance.object.desired().is_none());
-        instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
-        assert_eq!(rprev.gen, rnext.gen);
-
-        // Issuing a reboot from any other state is not defined, including from
-        // "Stopping" while not in the process of a reboot and from any
-        // "stopped" state.  instance_ensure() will prevent this, while
-        // transition() will allow it.  We don't test the behavior of
-        // transition() because it's subject to change.
-
         logctx.cleanup_successful();
     }
 

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -251,8 +251,8 @@ impl Simulatable for SimDisk {
         self.state.current()
     }
 
-    fn desired(&self) -> &Option<Self::RequestedState> {
-        self.state.desired()
+    fn desired(&self) -> Option<Self::RequestedState> {
+        self.state.desired().clone()
     }
 
     fn ready_to_destroy(&self) -> bool {

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -155,9 +155,11 @@ impl Simulatable for SimInstance {
             InstanceStateRequested::Reboot => match self.terminal_state() {
                 ApiInstanceState::Running => {
                     // Further requests to reboot are ignored if the instance
-                    // is currently rebooting or about to reboot (though in this
-                    // simulation reboot
-                    if !self.reboot_pending() {
+                    // is currently rebooting or about to reboot.
+                    if self.state.current().run_state
+                        != ApiInstanceState::Rebooting
+                        && !self.reboot_pending()
+                    {
                         self.state.transition(ApiInstanceState::Rebooting);
                         self.propolis_queue
                             .push_back(PropolisInstanceState::Rebooting);

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -6,35 +6,64 @@
 
 use super::simulatable::Simulatable;
 
+use crate::common::instance::InstanceState;
 use crate::nexus::NexusClient;
-use crate::params::{InstanceRuntimeStateRequested, InstanceStateRequested};
+use crate::params::InstanceStateRequested;
 use async_trait::async_trait;
 use nexus_client;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
-use omicron_common::api::external::InstanceState;
+use omicron_common::api::external::InstanceState as ApiInstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use propolis_client::api::InstanceState as PropolisInstanceState;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::common::instance::{Action as InstanceAction, InstanceStates};
 
-/// Simulated Instance (virtual machine), as created by the external Oxide API
+/// A simulation of an Instance created by the external Oxide API.
+///
+/// This simulation tries to emulate Propolis's state machine as faithfully as
+/// possible within reason so that it can be used as a test double in Nexus
+/// integration tests.
 #[derive(Debug)]
 pub struct SimInstance {
+    /// The current simulated instance state.
     state: InstanceStates,
+
+    /// A queue of Propolis instance states for the simulated state driver to
+    /// observe in response to calls to `execute_desired_transition`.
+    propolis_queue: VecDeque<PropolisInstanceState>,
+
+    /// Indicates whether the instance has been logically destroyed.
+    destroyed: bool,
+}
+
+impl SimInstance {
+    /// Returns the state the simulated instance will reach if its queue is
+    /// drained.
+    fn terminal_state(&self) -> ApiInstanceState {
+        match self.propolis_queue.back() {
+            None => self.state.current().run_state,
+            Some(p) => InstanceState::from(*p).0,
+        }
+    }
 }
 
 #[async_trait]
 impl Simulatable for SimInstance {
     type CurrentState = InstanceRuntimeState;
-    type RequestedState = InstanceRuntimeStateRequested;
+    type RequestedState = InstanceStateRequested;
     type ProducerArgs = ();
     type Action = InstanceAction;
 
     fn new(current: InstanceRuntimeState) -> Self {
-        SimInstance { state: InstanceStates::new(current) }
+        SimInstance {
+            state: InstanceStates::new(current),
+            propolis_queue: VecDeque::new(),
+            destroyed: false,
+        }
     }
 
     async fn set_producer(
@@ -47,33 +76,109 @@ impl Simulatable for SimInstance {
 
     fn request_transition(
         &mut self,
-        target: &InstanceRuntimeStateRequested,
+        target: &InstanceStateRequested,
     ) -> Result<Option<InstanceAction>, Error> {
-        self.state.request_transition(target)
+        match target {
+            InstanceStateRequested::Running => match self.terminal_state() {
+                ApiInstanceState::Creating => {
+                    // The non-simulated sled agent explicitly and synchronously
+                    // publishes the "Starting" state when cold-booting a new VM
+                    // (so that the VM appears to be starting while its Propolis
+                    // process is being launched).
+                    self.state.transition(ApiInstanceState::Starting);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Running);
+                }
+                ApiInstanceState::Starting
+                | ApiInstanceState::Running
+                | ApiInstanceState::Rebooting
+                | ApiInstanceState::Migrating => {}
+                ApiInstanceState::Stopping
+                | ApiInstanceState::Stopped
+                | ApiInstanceState::Failed
+                | ApiInstanceState::Destroyed => {
+                    // TODO: Normally, Propolis forbids direct transitions from
+                    // a stopped state back to a running state. Instead, Nexus
+                    // creates a new Propolis and sends state change requests to
+                    // that. This arm abstracts this behavior away and just
+                    // allows a fake instance to transition right back to a
+                    // running state after being stopped.
+                    //
+                    // This will change in the future when the sled agents (both
+                    // real and simulated) split "registering" an instance with
+                    // the agent and actually starting it into separate actions.
+                    self.state.transition(ApiInstanceState::Starting);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Starting);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Running);
+                }
+                ApiInstanceState::Repairing => {
+                    return Err(Error::invalid_request(&format!(
+                        "can't request state Running with terminal state {}",
+                        self.terminal_state()
+                    )))
+                }
+            },
+            InstanceStateRequested::Stopped => match self.terminal_state() {
+                ApiInstanceState::Creating => {
+                    self.state.transition(ApiInstanceState::Destroyed);
+                }
+                ApiInstanceState::Running => {
+                    self.state.transition(ApiInstanceState::Stopping);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Stopping);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Stopped);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Destroyed);
+                }
+                // Idempotently allow requests to stop an instance that is
+                // already stopping.
+                ApiInstanceState::Stopping
+                | ApiInstanceState::Stopped
+                | ApiInstanceState::Destroyed => {}
+                _ => {
+                    return Err(Error::invalid_request(&format!(
+                        "can't request state Stopped with terminal state {}",
+                        self.terminal_state()
+                    )))
+                }
+            },
+            InstanceStateRequested::Reboot => match self.terminal_state() {
+                ApiInstanceState::Running => {
+                    self.state.transition(ApiInstanceState::Rebooting);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Rebooting);
+                    self.propolis_queue
+                        .push_back(PropolisInstanceState::Running);
+                }
+                _ => {
+                    return Err(Error::invalid_request(&format!(
+                        "can't request Reboot with terminal state {}",
+                        self.terminal_state()
+                    )))
+                }
+            },
+            InstanceStateRequested::Migrating => {
+                unimplemented!("Migration not implemented yet");
+            }
+            InstanceStateRequested::Destroyed => {
+                self.state
+                    .observe_transition(&PropolisInstanceState::Destroyed);
+                self.propolis_queue.clear();
+            }
+        }
+
+        Ok(None)
     }
 
     fn execute_desired_transition(&mut self) -> Option<InstanceAction> {
-        if matches!(self.state.current().run_state, InstanceState::Rebooting) {
-            self.state.observe_transition(&PropolisInstanceState::Starting)
-        } else if let Some(desired) = self.state.desired() {
-            // These operations would typically be triggered via responses from
-            // Propolis, but for a simulated sled agent, this does not exist.
-            //
-            // Instead, we make transitions to new states based entirely on the
-            // value of "desired".
-            let observed = match desired.run_state {
-                InstanceStateRequested::Running => {
-                    PropolisInstanceState::Running
-                }
-                InstanceStateRequested::Stopped => {
-                    PropolisInstanceState::Stopped
-                }
-                InstanceStateRequested::Destroyed => {
-                    PropolisInstanceState::Destroyed
-                }
-                _ => panic!("Unexpected desired state: {}", desired.run_state),
-            };
-            self.state.observe_transition(&observed)
+        if let Some(propolis_state) = self.propolis_queue.pop_front() {
+            if matches!(propolis_state, PropolisInstanceState::Destroyed) {
+                self.destroyed = true;
+            }
+            self.state.observe_transition(&propolis_state)
         } else {
             None
         }
@@ -87,12 +192,28 @@ impl Simulatable for SimInstance {
         self.state.current()
     }
 
-    fn desired(&self) -> &Option<Self::RequestedState> {
-        self.state.desired()
+    fn desired(&self) -> Option<Self::RequestedState> {
+        self.propolis_queue.back().map(|terminal| match terminal {
+            PropolisInstanceState::Creating
+            | PropolisInstanceState::Starting
+            | PropolisInstanceState::Migrating
+            | PropolisInstanceState::Repairing
+            | PropolisInstanceState::Failed => panic!(
+                "terminal state {:?} doesn't map to a requested state",
+                terminal
+            ),
+            PropolisInstanceState::Running => InstanceStateRequested::Running,
+            PropolisInstanceState::Stopping
+            | PropolisInstanceState::Stopped
+            | PropolisInstanceState::Destroyed => {
+                InstanceStateRequested::Stopped
+            }
+            PropolisInstanceState::Rebooting => InstanceStateRequested::Reboot,
+        })
     }
 
     fn ready_to_destroy(&self) -> bool {
-        self.current().run_state == InstanceState::Destroyed
+        self.destroyed
     }
 
     async fn notify(

--- a/sled-agent/src/sim/simulatable.rs
+++ b/sled-agent/src/sim/simulatable.rs
@@ -103,7 +103,7 @@ pub trait Simulatable: fmt::Debug + Send + Sync {
     ///
     /// If this returns None, either no state was requested, or the desired
     /// state has been reached.
-    fn desired(&self) -> &Option<Self::RequestedState>;
+    fn desired(&self) -> Option<Self::RequestedState>;
 
     /// Returns true if the state `current` is a terminal state representing that
     /// the object has been destroyed.

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -28,7 +28,7 @@ use omicron_common::address::PROPOLIS_PORT;
 use propolis_client::Client as PropolisClient;
 use propolis_server::mock_server::Context as PropolisContext;
 
-use super::collection::SimCollection;
+use super::collection::{PokeMode, SimCollection};
 use super::config::Config;
 use super::disk::SimDisk;
 use super::instance::SimInstance;
@@ -314,7 +314,11 @@ impl SledAgent {
 
         let instance_run_time_state = self
             .instances
-            .sim_ensure(&instance_id, initial_hardware.runtime, target)
+            .sim_ensure(
+                &instance_id,
+                initial_hardware.runtime,
+                target.run_state,
+            )
             .await?;
 
         for disk_request in &initial_hardware.disks {
@@ -360,11 +364,11 @@ impl SledAgent {
     }
 
     pub async fn instance_poke(&self, id: Uuid) {
-        self.instances.sim_poke(id).await;
+        self.instances.sim_poke(id, PokeMode::Drain).await;
     }
 
     pub async fn disk_poke(&self, id: Uuid) {
-        self.disks.sim_poke(id).await;
+        self.disks.sim_poke(id, PokeMode::SingleStep).await;
     }
 
     /// Adds a Zpool to the simulated sled agent.


### PR DESCRIPTION
This is the first in a series of PRs that will add basic live migration support. To see the whole commit sequence, see [this branch](https://github.com/gjcolombo/omicron/tree/gjcolombo/lets-migrate/8-migration-end).

---

Today, sled agent and Propolis each implement an instance state machine that defines an instance's state and the set of allowed state transitions. Having a two-headed state machine is perilous because it requires us to reason about (and correctly implement) what happens when one state machine rejects a transition that another accepts.

Simplify matters by removing most of the sled agent state machine and delegating almost completely to Propolis's state machine. Delegating to Propolis is appropriate here because (a) at the end of the day, any state transition Propolis rejects is de facto inapplicable no matter what its caller thinks, and (b) Propolis's state machine can "lead" sled agent's, because instance state changes requested by a guest OS are known to and applied in Propolis before sled agent finds out about them.

The most immediate consequence of this is that simulated instances, which derive their states from the `InstanceStates` state machine, are left adrift. To fix them, reimplement `SimInstance` more explicitly as a test double that implements a fake Propolis state machine and state queue, then fix up the tests that relied on the old state machine's properties. For most tests, the problem is that a single state change request can now produce multiple state transitions; these are fixed by changing the "instance poke" operation to drive an instance to its next resting state.

Tested in part by deploying a non-simulated Omicron and starting/stopping a few instances.