### PR TITLE
[dns-server] Convert DNS panic to logged error

### DIFF
--- a/dns-server/src/storage.rs
+++ b/dns-server/src/storage.rs
@@ -715,7 +715,7 @@ impl<'a, 'b> Drop for UpdateGuard<'a, 'b> {
         // could use a semaphore like tokio's MutexGuard does, but that would
         // involve unsafe code.)
         if !self.finished {
-            panic!("attempted to return early without finishing update!");
+            error!(self.store.log, "DNS UpdateGuard attempted to return early without finishing update!");
         }
     }
 }


### PR DESCRIPTION
In the context of https://github.com/oxidecomputer/omicron/issues/2720 , this makes errors easier to parse, as it prevents "panic-while-panicking" during an unwind.