### PR TITLE
configure dendrite for oximeter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ name = "dpd-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "futures",
  "omicron-zone-package",
  "progenitor",
@@ -1933,6 +1934,7 @@ dependencies = [
  "serde_json",
  "slog",
  "toml 0.7.3",
+ "uuid",
 ]
 
 [[package]]

--- a/dpd-client/Cargo.toml
+++ b/dpd-client/Cargo.toml
@@ -10,6 +10,8 @@ reqwest = { workspace = true, features = ["json", "stream", "rustls-tls"] }
 serde.workspace = true
 slog.workspace = true
 regress.workspace = true
+uuid.workspace = true
+chrono.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/dpd-client/src/lib.rs
+++ b/dpd-client/src/lib.rs
@@ -9,6 +9,11 @@
 #![allow(clippy::match_single_binding)]
 #![allow(clippy::clone_on_copy)]
 #![allow(clippy::unnecessary_to_owned)]
+// The progenitor-generated API for dpd currently incorporates a type from
+// oximeter, which includes a docstring that has a doc-test in it.
+// That test passes for code that lives in omicron, but fails for code imported
+// by omicron.
+#![allow(rustdoc::broken_intra_doc_links)]
 
 use slog::Logger;
 

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -79,18 +79,24 @@ impl Resolver {
     // nameservers is _itself_ provided by a DNS name.  We would periodically
     // re-resolve this.  That's how we'd learn about dynamic changes to the set
     // of DNS servers.
-    pub fn new_from_subnet(
-        log: slog::Logger,
+    pub fn servers_from_subnet(
         subnet: Ipv6Subnet<AZ_PREFIX>,
-    ) -> Result<Self, ResolveError> {
-        let dns_ips = ReservedRackSubnet::new(subnet)
+    ) -> Vec<SocketAddr> {
+        ReservedRackSubnet::new(subnet)
             .get_dns_subnets()
             .into_iter()
             .map(|dns_subnet| {
                 let ip_addr = IpAddr::V6(dns_subnet.dns_address().ip());
                 SocketAddr::new(ip_addr, DNS_PORT)
             })
-            .collect();
+            .collect()
+    }
+
+    pub fn new_from_subnet(
+        log: slog::Logger,
+        subnet: Ipv6Subnet<AZ_PREFIX>,
+    ) -> Result<Self, ResolveError> {
+        let dns_ips = Self::servers_from_subnet(subnet);
         Resolver::new_from_addrs(log, dns_ips)
     }
 

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -297,7 +297,6 @@ only_for_targets.image = "standard"
 #   1b. cargo build --features=tofino_stub --release
 #   1c. cargo xtask dist -o -r --features tofino_stub
 # 2. Copy dendrite.tar.gz from dendrite/out to omicron/out
-# 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
 source.commit = "7d4ab83dcfe1c95cd01e091f92eb9664c96930bb"
@@ -323,7 +322,6 @@ only_for_targets.image = "standard"
 #   1b. cargo build --features=tofino_asic --release
 #   1c. cargo xtask dist -o -r --features tofino_asic
 # 2. Copy the output zone image from dendrite/out to omicron/out
-# 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
 source.commit = "7d4ab83dcfe1c95cd01e091f92eb9664c96930bb"
@@ -342,7 +340,6 @@ only_for_targets.image = "standard"
 #   1b. cargo build --features=softnpu --release
 #   1c. cargo xtask dist -o -r --features softnpu
 # 2. Copy dendrite.tar.gz from dendrite/out to omicron/out/dendrite-softnpu.tar.gz
-# 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "dendrite"
 source.commit = "7d4ab83dcfe1c95cd01e091f92eb9664c96930bb"

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2152,7 +2152,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None, // skip_timesync
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2182,7 +2182,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None, // skip_timesync
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2220,7 +2220,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None, // skip_timesync
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2252,7 +2252,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None, // skip_timesync
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2152,7 +2152,6 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            Some(true),
             None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
@@ -2183,7 +2182,6 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            Some(true),
             None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
@@ -2222,7 +2220,6 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            Some(true),
             None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
@@ -2255,7 +2252,6 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            Some(true),
             None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -42,8 +42,10 @@ use illumos_utils::zfs::ZONE_ZFS_DATASET_MOUNTPOINT;
 use illumos_utils::zone::AddressRequest;
 use illumos_utils::zone::Zones;
 use illumos_utils::{execute, PFEXEC};
+use internal_dns::resolver::Resolver;
 use itertools::Itertools;
 use omicron_common::address::Ipv6Subnet;
+use omicron_common::address::AZ_PREFIX;
 use omicron_common::address::BOOTSTRAP_ARTIFACT_PORT;
 use omicron_common::address::CRUCIBLE_PANTRY_PORT;
 use omicron_common::address::DENDRITE_PORT;
@@ -188,6 +190,9 @@ type ConfigDirGetter = Box<dyn Fn(&str, &str) -> PathBuf + Send + Sync>;
 
 /// Configuration parameters which modify the [`ServiceManager`]'s behavior.
 pub struct Config {
+    /// Identifies the sled being configured
+    pub sled_id: Uuid,
+
     /// Identifies the revision of the sidecar to be used.
     pub sidecar_revision: String,
 
@@ -205,10 +210,12 @@ pub struct Config {
 
 impl Config {
     pub fn new(
+        sled_id: Uuid,
         sidecar_revision: String,
         gateway_address: Option<Ipv4Addr>,
     ) -> Self {
         Self {
+            sled_id,
             sidecar_revision,
             gateway_address,
             all_svcs_config_path: default_services_config_path(),
@@ -1142,12 +1149,34 @@ impl ServiceManager {
                 ServiceType::Dendrite { asic } => {
                     info!(self.inner.log, "Setting up dendrite service");
 
+                    if let Some(info) = self.inner.sled_info.get() {
+                        smfh.setprop("config/rack_id", info.rack_id)?;
+                        smfh.setprop("config/sled_id", info.config.sled_id)?;
+                    } else {
+                        info!(
+                            self.inner.log,
+                            "no rack_id/sled_id available yet"
+                        );
+                    }
+
                     smfh.delpropvalue("config/address", "*")?;
+                    smfh.delpropvalue("config/dns_server", "*")?;
                     for address in &request.addresses {
                         smfh.addpropvalue(
                             "config/address",
                             &format!("[{}]:{}", address, DENDRITE_PORT),
                         )?;
+                        if *address != Ipv6Addr::LOCALHOST {
+                            let az_prefix =
+                                Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                            for addr in Resolver::servers_from_subnet(az_prefix)
+                            {
+                                smfh.addpropvalue(
+                                    "config/dns_server",
+                                    &format!("{addr}"),
+                                )?;
+                            }
+                        }
                     }
                     match asic {
                         DendriteAsic::TofinoAsic => {
@@ -1748,12 +1777,38 @@ impl ServiceManager {
                             smfh.refresh()?;
                         }
                         ServiceType::Dendrite { .. } => {
+                            info!(self.inner.log, "configuring dendrite zone");
+                            if let Some(info) = self.inner.sled_info.get() {
+                                smfh.setprop("config/rack_id", info.rack_id)?;
+                                smfh.setprop(
+                                    "config/sled_id",
+                                    info.config.sled_id,
+                                )?;
+                            } else {
+                                info!(
+                                    self.inner.log,
+                                    "no rack_id/sled_id available yet"
+                                );
+                            }
                             smfh.delpropvalue("config/address", "*")?;
+                            smfh.delpropvalue("config/dns_server", "*")?;
                             for address in &request.addresses {
                                 smfh.addpropvalue(
                                     "config/address",
                                     &format!("[{}]:{}", address, DENDRITE_PORT),
                                 )?;
+                                if *address != Ipv6Addr::LOCALHOST {
+                                    let az_prefix =
+                                        Ipv6Subnet::<AZ_PREFIX>::new(*address);
+                                    for addr in
+                                        Resolver::servers_from_subnet(az_prefix)
+                                    {
+                                        smfh.addpropvalue(
+                                            "config/dns_server",
+                                            &format!("{addr}"),
+                                        )?;
+                                    }
+                                }
                             }
                             smfh.refresh()?;
                         }
@@ -1990,6 +2045,7 @@ mod test {
                 self.config_dir.path().join(SERVICE_CONFIG_FILENAME);
             let svc_config_dir = self.config_dir.path().to_path_buf();
             Config {
+                sled_id: Uuid::new_v4(),
                 sidecar_revision: "rev_whatever_its_a_test".to_string(),
                 gateway_address: None,
                 all_svcs_config_path,
@@ -2016,7 +2072,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2055,7 +2111,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2097,6 +2153,7 @@ mod test {
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
             Some(true),
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2127,6 +2184,7 @@ mod test {
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
             Some(true),
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2165,6 +2223,7 @@ mod test {
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
             Some(true),
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],
@@ -2197,6 +2256,7 @@ mod test {
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
             Some(true),
+            None, // skip_timesync
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
             vec![],

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -261,6 +261,7 @@ impl SledAgent {
         )?;
 
         let svc_config = services::Config::new(
+            request.id,
             config.sidecar_revision.clone(),
             request.gateway.address,
         );


### PR DESCRIPTION
To produce statistics for oximeter, dendrite needs to be given a unique ID to identify itself and it needs to be able to find a nexus daemon to register with.  The change passes a sidecar uuid and list of DNS server addresses to dendrite via `smf` properties,