### PR TITLE
sled agent: remove unused migration-related types

### DIFF
--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -27,7 +27,6 @@ use omicron_common::api::external::Name;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use serde::Deserialize;
 use serde::Serialize;
-use sled_agent_client::types::InstanceRuntimeStateRequested;
 use sled_agent_client::types::InstanceStateRequested;
 use slog::warn;
 use std::convert::TryFrom;
@@ -1241,10 +1240,6 @@ async fn sic_instance_ensure(
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
     let datastore = osagactx.datastore();
-    let runtime_params = InstanceRuntimeStateRequested {
-        run_state: InstanceStateRequested::Running,
-        migration_params: None,
-    };
 
     // TODO-correctness TODO-security It's not correct to re-resolve the
     // instance name now.  See oxidecomputer/omicron#1536.
@@ -1297,7 +1292,7 @@ async fn sic_instance_ensure(
                 &opctx,
                 &authz_instance,
                 &db_instance,
-                runtime_params,
+                InstanceStateRequested::Running,
             )
             .await
             .map_err(ActionError::action_failed)?;

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -7,19 +7,10 @@ use super::{NexusActionContext, NexusSaga, ACTION_GENERATE_ID};
 use crate::app::sagas::declare_saga_actions;
 use crate::authn;
 use crate::db::identity::Resource;
-use crate::db::model::IpKind;
 use crate::external_api::params;
-use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use serde::Deserialize;
 use serde::Serialize;
-use sled_agent_client::types::InstanceEnsureBody;
-use sled_agent_client::types::InstanceHardware;
-use sled_agent_client::types::InstanceMigrateParams;
-use sled_agent_client::types::InstanceRuntimeStateMigrateParams;
-use sled_agent_client::types::InstanceRuntimeStateRequested;
-use sled_agent_client::types::InstanceStateRequested;
-use sled_agent_client::types::SourceNatConfig;
 use std::net::Ipv6Addr;
 use steno::ActionError;
 use steno::Node;
@@ -137,8 +128,11 @@ async fn sim_allocate_propolis_ip(
 }
 
 async fn sim_instance_migrate(
-    sagactx: NexusActionContext,
+    _sagactx: NexusActionContext,
 ) -> Result<(), ActionError> {
+    todo!("Migration action not yet implemented");
+
+    /*
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
     let opctx = crate::context::op_context_for_saga_action(
@@ -243,7 +237,7 @@ async fn sim_instance_migrate(
             &InstanceEnsureBody {
                 initial: instance_hardware,
                 target,
-                migrate: Some(InstanceMigrateParams {
+                migrate: Some(InstanceMigrationTargetParams {
                     src_propolis_addr: src_propolis_addr.to_string(),
                     src_propolis_id,
                 }),
@@ -262,6 +256,7 @@ async fn sim_instance_migrate(
         .map_err(ActionError::action_failed)?;
 
     Ok(())
+        */
 }
 
 async fn sim_cleanup_source(

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -927,7 +927,7 @@
             "description": "If we're migrating this instance, the details needed to drive the migration",
             "allOf": [
               {
-                "$ref": "#/components/schemas/InstanceMigrateParams"
+                "$ref": "#/components/schemas/InstanceMigrationTargetParams"
               }
             ]
           },
@@ -935,7 +935,7 @@
             "description": "requested runtime state of the Instance",
             "allOf": [
               {
-                "$ref": "#/components/schemas/InstanceRuntimeStateRequested"
+                "$ref": "#/components/schemas/InstanceStateRequested"
               }
             ]
           }
@@ -1019,7 +1019,7 @@
           "snapshot_id"
         ]
       },
-      "InstanceMigrateParams": {
+      "InstanceMigrationTargetParams": {
         "type": "object",
         "properties": {
           "src_propolis_addr": {
@@ -1119,44 +1119,6 @@
           "time_updated"
         ]
       },
-      "InstanceRuntimeStateMigrateParams": {
-        "description": "Instance runtime state to update for a migration.",
-        "type": "object",
-        "properties": {
-          "dst_propolis_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "migration_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "dst_propolis_id",
-          "migration_id"
-        ]
-      },
-      "InstanceRuntimeStateRequested": {
-        "description": "Used to request an Instance state change from a sled agent\n\nRight now, it's only the run state and migration id that can be changed, though we might want to support changing properties like \"ncpus\" here.",
-        "type": "object",
-        "properties": {
-          "migration_params": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/InstanceRuntimeStateMigrateParams"
-              }
-            ]
-          },
-          "run_state": {
-            "$ref": "#/components/schemas/InstanceStateRequested"
-          }
-        },
-        "required": [
-          "run_state"
-        ]
-      },
       "InstanceState": {
         "description": "Running state of an Instance (primarily: booted or stopped)\n\nThis typically reflects whether it's starting, running, stopping, or stopped, but also includes states related to the Instance's lifecycle",
         "oneOf": [
@@ -1254,13 +1216,6 @@
             "type": "string",
             "enum": [
               "reboot"
-            ]
-          },
-          {
-            "description": "Migrate the instance to another node.",
-            "type": "string",
-            "enum": [
-              "migrating"
             ]
           },
           {

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -7,7 +7,7 @@
 use crate::nexus::LazyNexusClient;
 use crate::params::VpcFirewallRule;
 use crate::params::{
-    InstanceHardware, InstanceMigrateParams, InstanceRuntimeStateRequested,
+    InstanceHardware, InstanceMigrationTargetParams, InstanceStateRequested,
 };
 use illumos_utils::dladm::Etherstub;
 use illumos_utils::link::VnicAllocator;
@@ -93,8 +93,8 @@ impl InstanceManager {
         &self,
         instance_id: Uuid,
         initial_hardware: InstanceHardware,
-        target: InstanceRuntimeStateRequested,
-        migrate: Option<InstanceMigrateParams>,
+        target: InstanceStateRequested,
+        migrate: Option<InstanceMigrationTargetParams>,
     ) -> Result<InstanceRuntimeState, Error> {
         info!(
             &self.inner.log,
@@ -363,10 +363,7 @@ mod test {
             .ensure(
                 test_uuid(),
                 new_initial_instance(),
-                InstanceRuntimeStateRequested {
-                    run_state: InstanceStateRequested::Running,
-                    migration_params: None,
-                },
+                InstanceStateRequested::Running,
                 None,
             )
             .await
@@ -453,15 +450,12 @@ mod test {
 
         let id = test_uuid();
         let rt = new_initial_instance();
-        let target = InstanceRuntimeStateRequested {
-            run_state: InstanceStateRequested::Running,
-            migration_params: None,
-        };
+        let target = InstanceStateRequested::Running;
 
         // Creates instance, start + transition.
-        im.ensure(id, rt.clone(), target.clone(), None).await.unwrap();
+        im.ensure(id, rt.clone(), target, None).await.unwrap();
         // Transition only.
-        im.ensure(id, rt.clone(), target.clone(), None).await.unwrap();
+        im.ensure(id, rt.clone(), target, None).await.unwrap();
         // Transition only.
         im.ensure(id, rt, target, None).await.unwrap();
 

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -72,13 +72,13 @@ pub struct InstanceEnsureBody {
     /// has never seen this Instance before).
     pub initial: InstanceHardware,
     /// requested runtime state of the Instance
-    pub target: InstanceRuntimeStateRequested,
+    pub target: InstanceStateRequested,
     /// If we're migrating this instance, the details needed to drive the migration
-    pub migrate: Option<InstanceMigrateParams>,
+    pub migrate: Option<InstanceMigrationTargetParams>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceMigrateParams {
+pub struct InstanceMigrationTargetParams {
     pub src_propolis_id: Uuid,
     pub src_propolis_addr: SocketAddr,
 }
@@ -107,8 +107,6 @@ pub enum InstanceStateRequested {
     /// Issue a reset command to the instance, such that it should
     /// stop and then immediately become running.
     Reboot,
-    /// Migrate the instance to another node.
-    Migrating,
     /// Stop the instance and delete it.
     Destroyed,
 }
@@ -125,7 +123,6 @@ impl InstanceStateRequested {
             InstanceStateRequested::Running => "running",
             InstanceStateRequested::Stopped => "stopped",
             InstanceStateRequested::Reboot => "reboot",
-            InstanceStateRequested::Migrating => "migrating",
             InstanceStateRequested::Destroyed => "destroyed",
         }
     }
@@ -136,7 +133,6 @@ impl InstanceStateRequested {
             InstanceStateRequested::Running => false,
             InstanceStateRequested::Stopped => true,
             InstanceStateRequested::Reboot => false,
-            InstanceStateRequested::Migrating => false,
             InstanceStateRequested::Destroyed => true,
         }
     }
@@ -144,20 +140,9 @@ impl InstanceStateRequested {
 
 /// Instance runtime state to update for a migration.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceRuntimeStateMigrateParams {
+pub struct InstanceMigrationSourceParams {
     pub migration_id: Uuid,
     pub dst_propolis_id: Uuid,
-}
-
-/// Used to request an Instance state change from a sled agent
-///
-/// Right now, it's only the run state and migration id that can
-/// be changed, though we might want to support changing properties
-/// like "ncpus" here.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceRuntimeStateRequested {
-    pub run_state: InstanceStateRequested,
-    pub migration_params: Option<InstanceRuntimeStateMigrateParams>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -183,9 +183,6 @@ impl Simulatable for SimInstance {
                     )))
                 }
             },
-            InstanceStateRequested::Migrating => {
-                unimplemented!("Migration not implemented yet");
-            }
             InstanceStateRequested::Destroyed => {
                 self.state
                     .observe_transition(&PropolisInstanceState::Destroyed);

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -10,8 +10,9 @@ use crate::instance_manager::InstanceManager;
 use crate::nexus::{LazyNexusClient, NexusRequestQueue};
 use crate::params::VpcFirewallRule;
 use crate::params::{
-    DatasetKind, DiskStateRequested, InstanceHardware, InstanceMigrateParams,
-    InstanceRuntimeStateRequested, ServiceEnsureBody, TimeSync, Zpool,
+    DatasetKind, DiskStateRequested, InstanceHardware,
+    InstanceMigrationTargetParams, InstanceStateRequested, ServiceEnsureBody,
+    TimeSync, Zpool,
 };
 use crate::services::{self, ServiceManager};
 use crate::storage_manager::StorageManager;
@@ -519,8 +520,8 @@ impl SledAgent {
         &self,
         instance_id: Uuid,
         initial: InstanceHardware,
-        target: InstanceRuntimeStateRequested,
-        migrate: Option<InstanceMigrateParams>,
+        target: InstanceStateRequested,
+        migrate: Option<InstanceMigrationTargetParams>,
     ) -> Result<InstanceRuntimeState, Error> {
         self.inner
             .instances


### PR DESCRIPTION
Tidy up the migration-related types in sled agent's Nexus API. This is just a bit of pre-work to reduce the size of subsequent commits that change this API.

In `sled-agent/src/params.rs`:

- Rename migration-related types so that they indicate whether they're used with migration sources or migration targets (without having to look at their fields' names).
- Remove types and variants that were only used for migration sources.
  - Remove `InstanceRuntimeStateRequested` and replace it with `InstanceStateRequested`.
  - Remove the `Migrating` variant from `InstanceStateRequested`.

Sled agent does need an API that allows Nexus to set an instance's migration ID, but this doesn't (won't) actually change any Propolis state or user-visible instance state, so subsequent changes will implement this in a separate API.

Clean up the call sites that are affected by this change. For now, just add `todo!()`s and comment out the Nexus call sites that use migration types that were removed here. These will be replaced in subsequent commits that create sled agent's new migration APIs.