### PR TITLE
Allow .webp console assets

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -804,7 +804,7 @@ lazy_static! {
     static ref ALLOWED_EXTENSIONS: HashSet<OsString> = HashSet::from(
         [
             "js", "css", "html", "ico", "map", "otf", "png", "svg", "ttf",
-            "txt", "woff", "woff2",
+            "txt", "webp", "woff", "woff2",
         ]
         .map(|s| OsString::from(s))
     );


### PR DESCRIPTION
Thanks for the bug report, @rcgoodfellow 

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/3612203/229688847-78461976-3743-41af-af22-d618eca3c9b5.png">
