### PR TITLE
Time sync: Start DNS/NTP first, wait for sync

### DIFF
--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1722,14 +1722,17 @@
         "type": "object",
         "properties": {
           "correction": {
+            "description": "The current offset between the NTP clock and system clock.",
             "type": "number",
             "format": "double"
           },
           "skew": {
+            "description": "The estimated error bound on the frequency.",
             "type": "number",
             "format": "double"
           },
           "sync": {
+            "description": "The synchronization state of the sled, true when the system clock and the NTP clock are in sync (to within a small window).",
             "type": "boolean"
           }
         },

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -439,11 +439,15 @@ pub struct ServiceEnsureBody {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct TimeSync {
+    /// The synchronization state of the sled, true when the system clock
+    /// and the NTP clock are in sync (to within a small window).
     pub sync: bool,
     // These could both be f32, but there is a problem with progenitor/typify
     // where, although the f32 correctly becomes "float" (and not "double") in
     // the API spec, that "float" gets converted back to f64 when generating
     // the client.
+    /// The estimated error bound on the frequency.
     pub skew: f64,
+    /// The current offset between the NTP clock and system clock.
     pub correction: f64,
 }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -963,9 +963,10 @@ impl ServiceInner {
                 // we must provide the set of *all* services that should be
                 // executing on a sled.
                 //
-                // This means re-requesting the DNS service, even if it is
-                // already running - this is fine, however, as the receiving
-                // sled agent doesn't modify the already-running service.
+                // This means re-requesting the DNS and NTP services, even if
+                // they are already running - this is fine, however, as the
+                // receiving sled agent doesn't modify the already-running
+                // service.
                 self.initialize_services(
                     *sled_address,
                     &services_request.services,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1797,7 +1797,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
         )
@@ -1826,7 +1826,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
         )
@@ -1863,7 +1863,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
         )
@@ -1894,7 +1894,7 @@ mod test {
             EtherstubVnic(UNDERLAY_ETHERSTUB_VNIC_NAME.to_string()),
             Etherstub(BOOTSTRAP_ETHERSTUB_NAME.to_string()),
             SledMode::Auto,
-            None,
+            Some(true),
             "rev-test".to_string(),
             SWITCH_ZONE_BOOTSTRAP_IP,
         )


### PR DESCRIPTION
```
{"msg":"Sled services found at /var/oxide/service.toml; loading","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:09.781857129Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
...
{"msg":"Ensuring service zone is initialized: InternalDNS","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:09.782120513Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
...
{"msg":"Ensuring service zone is initialized: NTP","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:18.092085847Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Zone booting","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:21.189166421Z","hostname":"gimlet-sn06","pid":329892,"zone":"oxz_ntp","component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Set up NTP service boundary=true, Servers=[\"ntp.eng.oxide.computer\"]","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:25.618293856Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
...
{"msg":"Waiting for sled time synchronization","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:26.054538116Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"chronyc command failed: Error running command in zone 'oxz_ntp': Command [/usr/sbin/zlogin oxz_ntp /usr/bin/chronyc -c tracking] executed and failed with status: exit status: 1  stdout: 506 Cannot talk to daemon\n  stderr: ","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:26.103273307Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
...
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.0 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:30.151380961Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.0 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:33:31.20112156Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
...
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.199323639 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:22.113274588Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.165790841 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:23.195534695Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.095632367 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:25.460863086Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Time not yet synchronized TimeSync { sync: false, skew: 0.0, correction: 0.062072344 }","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:26.543216255Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Time is synchronized","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:29.152124812Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
{"msg":"Ensuring service zone is initialized: Nexus","v":0,"name":"SledAgent","level":30,"time":"2023-04-04T15:34:29.152208643Z","hostname":"gimlet-sn06","pid":329892,"component":"ServiceManager","component":"BootstrapAgent"}
```
