### PR TITLE
Generalize network_interface table to allow for new kinds of NICs.

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -698,7 +698,7 @@ pub enum ResourceType {
     Image,
     Instance,
     IpPool,
-    NetworkInterface,
+    InstanceNetworkInterface,
     PhysicalDisk,
     Rack,
     Service,
@@ -2044,9 +2044,10 @@ impl TryFrom<i32> for Vni {
     }
 }
 
-/// A `NetworkInterface` represents a virtual network interface device.
+/// An `InstanceNetworkInterface` represents a virtual network interface device
+/// attached to an instance.
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, JsonSchema, Serialize)]
-pub struct NetworkInterface {
+pub struct InstanceNetworkInterface {
     /// common identifying metadata
     #[serde(flatten)]
     pub identity: IdentityMetadata,
@@ -2064,9 +2065,9 @@ pub struct NetworkInterface {
     pub mac: MacAddr,
 
     /// The IP address assigned to this interface.
-    pub ip: IpAddr,
     // TODO-correctness: We need to split this into an optional V4 and optional
     // V6 address, at least one of which must be specified.
+    pub ip: IpAddr,
     /// True if this interface is the primary for the instance to which it's
     /// attached.
     pub primary: bool,

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1036,6 +1036,15 @@ CREATE UNIQUE INDEX ON omicron.public.vpc_subnet (
 ) WHERE
     time_deleted IS NULL;
 
+/* The kind of network interface. */
+CREATE TYPE omicron.public.network_interface_kind AS ENUM (
+    /* An interface attached to a guest instance. */
+    'instance',
+
+    /* An interface attached to a service. */
+    'service'
+);
+
 CREATE TABLE omicron.public.network_interface (
     /* Identity metadata (resource) */
     id UUID PRIMARY KEY,
@@ -1046,11 +1055,14 @@ CREATE TABLE omicron.public.network_interface (
     /* Indicates that the object has been deleted */
     time_deleted TIMESTAMPTZ,
 
-    /* FK into Instance table.
-     * Note that interfaces are always attached to a particular instance.
-     * IP addresses may be reserved, but this is a different resource.
+    /* The kind of network interface, e.g., instance */
+    kind omicron.public.network_interface_kind NOT NULL,
+
+    /*
+     * FK into the parent resource of this interface (e.g. Instance, Service)
+     * as determined by the `kind`.
      */
-    instance_id UUID NOT NULL,
+    parent_id UUID NOT NULL,
 
     /* FK into VPC table */
     vpc_id UUID NOT NULL,
@@ -1065,20 +1077,64 @@ CREATE TABLE omicron.public.network_interface (
      */
     mac INT8 NOT NULL,
 
+    /* The private VPC IP address of the interface. */
     ip INET NOT NULL,
+
     /*
      * Limited to 8 NICs per instance. This value must be kept in sync with
      * `crate::nexus::MAX_NICS_PER_INSTANCE`.
      */
     slot INT2 NOT NULL CHECK (slot >= 0 AND slot < 8),
 
-    /* True if this interface is the primary interface for the instance.
+    /* True if this interface is the primary interface.
      *
      * The primary interface appears in DNS and its address is used for external
-     * connectivity for the instance.
+     * connectivity.
      */
     is_primary BOOL NOT NULL
 );
+
+/* A view of the network_interface table for just instance-kind records. */
+CREATE VIEW omicron.public.instance_network_interface AS
+SELECT
+    id,
+    name,
+    description,
+    time_created,
+    time_modified,
+    time_deleted,
+    parent_id AS instance_id,
+    vpc_id,
+    subnet_id,
+    mac,
+    ip,
+    slot,
+    is_primary
+FROM
+    omicron.public.network_interface
+WHERE
+    kind = 'instance';
+
+/* A view of the network_interface table for just service-kind records. */
+CREATE VIEW omicron.public.service_network_interface AS
+SELECT
+    id,
+    name,
+    description,
+    time_created,
+    time_modified,
+    time_deleted,
+    parent_id AS service_id,
+    vpc_id,
+    subnet_id,
+    mac,
+    ip,
+    slot,
+    is_primary
+FROM
+    omicron.public.network_interface
+WHERE
+    kind = 'service';
 
 /* TODO-completeness
 
@@ -1105,17 +1161,18 @@ CREATE UNIQUE INDEX ON omicron.public.network_interface (
     time_deleted IS NULL;
 
 /*
- * Index used to verify that an Instance's networking is contained
- * within a single VPC, and that all interfaces are in unique VPC
- * Subnets.
+ * Index used to verify that all interfaces for a resource (e.g. Instance,
+ * Service) are contained within a single VPC, and that all interfaces are
+ * in unique VPC Subnets.
  *
- * This is also used to quickly find the primary interface for an
- * instance, since we store the `is_primary` column. Such queries are
- * mostly used when setting a new primary interface for an instance.
+ * This is also used to quickly find the primary interface since
+ * we store the `is_primary` column. Such queries are mostly used
+ * when setting a new primary interface.
  */
 CREATE UNIQUE INDEX ON omicron.public.network_interface (
-    instance_id,
-    name
+    parent_id,
+    name,
+    kind
 )
 STORING (vpc_id, subnet_id, is_primary)
 WHERE

--- a/nexus/db-model/src/macaddr.rs
+++ b/nexus/db-model/src/macaddr.rs
@@ -26,11 +26,20 @@ impl MacAddr {
     // for an initial discussion of the customer/system address range split.
     pub const MIN_GUEST_ADDR: i64 = 0xA8_40_25_F0_00_00;
     pub const MAX_GUEST_ADDR: i64 = 0xA8_40_25_FE_FF_FF;
+    pub const MIN_SYSTEM_ADDR: i64 = 0xA8_40_25_FF_00_00;
+    pub const MAX_SYSTEM_ADDR: i64 = 0xA8_40_25_FF_FF_FF;
 
     /// Generate a random MAC address for a guest network interface
     pub fn random_guest() -> Self {
         let value =
             thread_rng().gen_range(Self::MIN_GUEST_ADDR..=Self::MAX_GUEST_ADDR);
+        Self::from_i64(value)
+    }
+
+    /// Generate a random MAC address in the system address range
+    pub fn random_system() -> Self {
+        let value = thread_rng()
+            .gen_range(Self::MIN_SYSTEM_ADDR..=Self::MAX_SYSTEM_ADDR);
         Self::from_i64(value)
     }
 

--- a/nexus/db-model/src/network_interface.rs
+++ b/nexus/db-model/src/network_interface.rs
@@ -45,7 +45,7 @@ pub struct NetworkInterface {
 
     pub mac: MacAddr,
     // TODO-correctness: We need to split this into an optional V4 and optional V6 address, at
-    // least one of which will lways be specified.
+    // least one of which will always be specified.
     //
     // If user requests an address of either kind, give exactly that and not the other.
     // If neither is specified, auto-assign one of each?

--- a/nexus/db-model/src/network_interface.rs
+++ b/nexus/db-model/src/network_interface.rs
@@ -3,7 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{MacAddr, VpcSubnet};
+use crate::impl_enum_type;
+use crate::schema::instance_network_interface;
 use crate::schema::network_interface;
+use crate::schema::service_network_interface;
 use crate::Name;
 use chrono::DateTime;
 use chrono::Utc;
@@ -14,36 +17,184 @@ use nexus_types::identity::Resource;
 use omicron_common::api::external;
 use uuid::Uuid;
 
-#[derive(Selectable, Queryable, Insertable, Clone, Debug, Resource)]
+impl_enum_type! {
+    #[derive(SqlType, QueryId, Debug, Clone, Copy)]
+    #[diesel(postgres_type(name = "network_interface_kind"))]
+    pub struct NetworkInterfaceKindEnum;
+
+    #[derive(Clone, Copy, Debug, AsExpression, FromSqlRow, PartialEq)]
+    #[diesel(sql_type = NetworkInterfaceKindEnum)]
+    pub enum NetworkInterfaceKind;
+
+    Instance => b"instance"
+    Service => b"service"
+}
+
+/// Generic Network Interface DB model.
+#[derive(Selectable, Queryable, Clone, Debug, Resource)]
 #[diesel(table_name = network_interface)]
 pub struct NetworkInterface {
     #[diesel(embed)]
     pub identity: NetworkInterfaceIdentity,
 
-    pub instance_id: Uuid,
+    pub kind: NetworkInterfaceKind,
+    pub parent_id: Uuid,
+
     pub vpc_id: Uuid,
     pub subnet_id: Uuid,
+
     pub mac: MacAddr,
     // TODO-correctness: We need to split this into an optional V4 and optional V6 address, at
-    // least one of which will always be specified.
+    // least one of which will lways be specified.
     //
     // If user requests an address of either kind, give exactly that and not the other.
     // If neither is specified, auto-assign one of each?
     pub ip: ipnetwork::IpNetwork,
+
     pub slot: i16,
     #[diesel(column_name = is_primary)]
     pub primary: bool,
 }
 
-impl From<NetworkInterface> for external::NetworkInterface {
-    fn from(iface: NetworkInterface) -> Self {
-        Self {
-            identity: iface.identity(),
-            instance_id: iface.instance_id,
+/// Instance Network Interface DB model.
+///
+/// The underlying "table" (`instance_network_interface`) is actually a view
+/// over the `network_interface` table, that contains only rows with
+/// `kind = 'instance'`.
+#[derive(Selectable, Queryable, Clone, Debug, Resource)]
+#[diesel(table_name = instance_network_interface)]
+pub struct InstanceNetworkInterface {
+    #[diesel(embed)]
+    pub identity: InstanceNetworkInterfaceIdentity,
+
+    pub instance_id: Uuid,
+    pub vpc_id: Uuid,
+    pub subnet_id: Uuid,
+
+    pub mac: MacAddr,
+    pub ip: ipnetwork::IpNetwork,
+
+    pub slot: i16,
+    #[diesel(column_name = is_primary)]
+    pub primary: bool,
+}
+
+/// Service Network Interface DB model.
+///
+/// The underlying "table" (`service_network_interface`) is actually a view
+/// over the `network_interface` table, that contains only rows with
+/// `kind = 'service'`.
+#[derive(Selectable, Queryable, Clone, Debug, Resource)]
+#[diesel(table_name = service_network_interface)]
+pub struct ServiceNetworkInterface {
+    #[diesel(embed)]
+    pub identity: ServiceNetworkInterfaceIdentity,
+
+    pub service_id: Uuid,
+    pub vpc_id: Uuid,
+    pub subnet_id: Uuid,
+
+    pub mac: MacAddr,
+    pub ip: ipnetwork::IpNetwork,
+
+    pub slot: i16,
+    #[diesel(column_name = is_primary)]
+    pub primary: bool,
+}
+
+impl NetworkInterface {
+    /// Treat this `NetworkInterface` as an `InstanceNetworkInterface`.
+    ///
+    /// # Panics
+    /// Panics if this isn't an 'instance' kind network interface.
+    pub fn as_instance(self) -> InstanceNetworkInterface {
+        assert_eq!(self.kind, NetworkInterfaceKind::Instance);
+        InstanceNetworkInterface {
+            identity: InstanceNetworkInterfaceIdentity {
+                id: self.identity.id,
+                name: self.identity.name,
+                description: self.identity.description,
+                time_created: self.identity.time_created,
+                time_modified: self.identity.time_modified,
+                time_deleted: self.identity.time_deleted,
+            },
+            instance_id: self.parent_id,
+            vpc_id: self.vpc_id,
+            subnet_id: self.subnet_id,
+            mac: self.mac,
+            ip: self.ip,
+            slot: self.slot,
+            primary: self.primary,
+        }
+    }
+
+    /// Treat this `NetworkInterface` as a `ServiceNetworkInterface`.
+    ///
+    /// # Panics
+    /// Panics if this isn't a 'service' kind network interface.
+    pub fn as_service(self) -> ServiceNetworkInterface {
+        assert_eq!(self.kind, NetworkInterfaceKind::Service);
+        ServiceNetworkInterface {
+            identity: ServiceNetworkInterfaceIdentity {
+                id: self.identity.id,
+                name: self.identity.name,
+                description: self.identity.description,
+                time_created: self.identity.time_created,
+                time_modified: self.identity.time_modified,
+                time_deleted: self.identity.time_deleted,
+            },
+            service_id: self.parent_id,
+            vpc_id: self.vpc_id,
+            subnet_id: self.subnet_id,
+            mac: self.mac,
+            ip: self.ip,
+            slot: self.slot,
+            primary: self.primary,
+        }
+    }
+}
+
+impl From<InstanceNetworkInterface> for NetworkInterface {
+    fn from(iface: InstanceNetworkInterface) -> Self {
+        NetworkInterface {
+            identity: NetworkInterfaceIdentity {
+                id: iface.identity.id,
+                name: iface.identity.name,
+                description: iface.identity.description,
+                time_created: iface.identity.time_created,
+                time_modified: iface.identity.time_modified,
+                time_deleted: iface.identity.time_deleted,
+            },
+            kind: NetworkInterfaceKind::Instance,
+            parent_id: iface.instance_id,
             vpc_id: iface.vpc_id,
             subnet_id: iface.subnet_id,
-            ip: iface.ip.ip(),
-            mac: *iface.mac,
+            mac: iface.mac,
+            ip: iface.ip,
+            slot: iface.slot,
+            primary: iface.primary,
+        }
+    }
+}
+
+impl From<ServiceNetworkInterface> for NetworkInterface {
+    fn from(iface: ServiceNetworkInterface) -> Self {
+        NetworkInterface {
+            identity: NetworkInterfaceIdentity {
+                id: iface.identity.id,
+                name: iface.identity.name,
+                description: iface.identity.description,
+                time_created: iface.identity.time_created,
+                time_modified: iface.identity.time_modified,
+                time_deleted: iface.identity.time_deleted,
+            },
+            kind: NetworkInterfaceKind::Service,
+            parent_id: iface.service_id,
+            vpc_id: iface.vpc_id,
+            subnet_id: iface.subnet_id,
+            mac: iface.mac,
+            ip: iface.ip,
+            slot: iface.slot,
             primary: iface.primary,
         }
     }
@@ -54,16 +205,18 @@ impl From<NetworkInterface> for external::NetworkInterface {
 #[derive(Clone, Debug)]
 pub struct IncompleteNetworkInterface {
     pub identity: NetworkInterfaceIdentity,
-    pub instance_id: Uuid,
+    pub kind: NetworkInterfaceKind,
+    pub parent_id: Uuid,
     pub vpc_id: Uuid,
     pub subnet: VpcSubnet,
     pub ip: Option<std::net::IpAddr>,
 }
 
 impl IncompleteNetworkInterface {
-    pub fn new(
+    fn new(
         interface_id: Uuid,
-        instance_id: Uuid,
+        kind: NetworkInterfaceKind,
+        parent_id: Uuid,
         vpc_id: Uuid,
         subnet: VpcSubnet,
         identity: external::IdentityMetadataCreateParams,
@@ -73,7 +226,52 @@ impl IncompleteNetworkInterface {
             subnet.check_requestable_addr(ip)?;
         };
         let identity = NetworkInterfaceIdentity::new(interface_id, identity);
-        Ok(Self { identity, instance_id, subnet, vpc_id, ip })
+        Ok(IncompleteNetworkInterface {
+            identity,
+            kind,
+            parent_id,
+            subnet,
+            vpc_id,
+            ip,
+        })
+    }
+
+    pub fn new_instance(
+        interface_id: Uuid,
+        instance_id: Uuid,
+        vpc_id: Uuid,
+        subnet: VpcSubnet,
+        identity: external::IdentityMetadataCreateParams,
+        ip: Option<std::net::IpAddr>,
+    ) -> Result<Self, external::Error> {
+        Self::new(
+            interface_id,
+            NetworkInterfaceKind::Instance,
+            instance_id,
+            vpc_id,
+            subnet,
+            identity,
+            ip,
+        )
+    }
+
+    pub fn new_service(
+        interface_id: Uuid,
+        service_id: Uuid,
+        vpc_id: Uuid,
+        subnet: VpcSubnet,
+        identity: external::IdentityMetadataCreateParams,
+        ip: Option<std::net::IpAddr>,
+    ) -> Result<Self, external::Error> {
+        Self::new(
+            interface_id,
+            NetworkInterfaceKind::Service,
+            service_id,
+            vpc_id,
+            subnet,
+            identity,
+            ip,
+        )
     }
 }
 
@@ -88,8 +286,22 @@ pub struct NetworkInterfaceUpdate {
     pub primary: Option<bool>,
 }
 
-impl From<params::NetworkInterfaceUpdate> for NetworkInterfaceUpdate {
-    fn from(params: params::NetworkInterfaceUpdate) -> Self {
+impl From<InstanceNetworkInterface> for external::InstanceNetworkInterface {
+    fn from(iface: InstanceNetworkInterface) -> Self {
+        Self {
+            identity: iface.identity(),
+            instance_id: iface.instance_id,
+            vpc_id: iface.vpc_id,
+            subnet_id: iface.subnet_id,
+            ip: iface.ip.ip(),
+            mac: *iface.mac,
+            primary: iface.primary,
+        }
+    }
+}
+
+impl From<params::InstanceNetworkInterfaceUpdate> for NetworkInterfaceUpdate {
+    fn from(params: params::InstanceNetworkInterfaceUpdate) -> Self {
         let primary = if params.primary { Some(true) } else { None };
         Self {
             name: params.identity.name.map(|n| n.into()),

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -133,7 +133,44 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
+        kind -> crate::NetworkInterfaceKindEnum,
+        parent_id -> Uuid,
+        vpc_id -> Uuid,
+        subnet_id -> Uuid,
+        mac -> Int8,
+        ip -> Inet,
+        slot -> Int2,
+        is_primary -> Bool,
+    }
+}
+
+table! {
+    instance_network_interface (id) {
+        id -> Uuid,
+        name -> Text,
+        description -> Text,
+        time_created -> Timestamptz,
+        time_modified -> Timestamptz,
+        time_deleted -> Nullable<Timestamptz>,
         instance_id -> Uuid,
+        vpc_id -> Uuid,
+        subnet_id -> Uuid,
+        mac -> Int8,
+        ip -> Inet,
+        slot -> Int2,
+        is_primary -> Bool,
+    }
+}
+
+table! {
+    service_network_interface (id) {
+        id -> Uuid,
+        name -> Text,
+        description -> Text,
+        time_created -> Timestamptz,
+        time_modified -> Timestamptz,
+        time_deleted -> Nullable<Timestamptz>,
+        service_id -> Uuid,
         vpc_id -> Uuid,
         subnet_id -> Uuid,
         mac -> Int8,
@@ -802,6 +839,8 @@ allow_tables_to_appear_in_same_query!(
     instance,
     metric_producer,
     network_interface,
+    instance_network_interface,
+    service_network_interface,
     oximeter,
     project,
     rack,

--- a/nexus/db-queries/src/authz/api_resources.rs
+++ b/nexus/db-queries/src/authz/api_resources.rs
@@ -708,7 +708,7 @@ authz_resource! {
 }
 
 authz_resource! {
-    name = "NetworkInterface",
+    name = "InstanceNetworkInterface",
     parent = "Instance",
     primary_key = Uuid,
     roles_allowed = false,

--- a/nexus/db-queries/src/authz/oso_generic.rs
+++ b/nexus/db-queries/src/authz/oso_generic.rs
@@ -124,7 +124,7 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<OsoInit, anyhow::Error> {
         Image::init(),
         Instance::init(),
         IpPool::init(),
-        NetworkInterface::init(),
+        InstanceNetworkInterface::init(),
         Vpc::init(),
         VpcRouter::init(),
         RouterRoute::init(),

--- a/nexus/db-queries/src/authz/policy_test/resources.rs
+++ b/nexus/db-queries/src/authz/policy_test/resources.rs
@@ -236,7 +236,7 @@ async fn make_project(
         LookupType::ByName(disk_name.clone()),
     ));
     builder.new_resource(instance.clone());
-    builder.new_resource(authz::NetworkInterface::new(
+    builder.new_resource(authz::InstanceNetworkInterface::new(
         instance,
         Uuid::new_v4(),
         LookupType::ByName(format!("{}-nic1", instance_name)),

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -163,7 +163,7 @@ impl DataStore {
         Ok(())
     }
 
-    /// Delete an instance attached to a provided instance.
+    /// Delete an `InstanceNetworkInterface` attached to a provided instance.
     ///
     /// Note that the primary interface for an instance cannot be deleted if
     /// there are any secondary interfaces.

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -16,8 +16,10 @@ use crate::db::error::ErrorHandler;
 use crate::db::error::TransactionError;
 use crate::db::model::IncompleteNetworkInterface;
 use crate::db::model::Instance;
+use crate::db::model::InstanceNetworkInterface;
 use crate::db::model::Name;
 use crate::db::model::NetworkInterface;
+use crate::db::model::NetworkInterfaceKind;
 use crate::db::model::NetworkInterfaceUpdate;
 use crate::db::model::VpcSubnet;
 use crate::db::pagination::paginated;
@@ -78,7 +80,7 @@ impl DataStore {
         authz_subnet: &authz::VpcSubnet,
         authz_instance: &authz::Instance,
         interface: IncompleteNetworkInterface,
-    ) -> Result<NetworkInterface, network_interface::InsertError> {
+    ) -> Result<InstanceNetworkInterface, network_interface::InsertError> {
         opctx
             .authorize(authz::Action::CreateChild, authz_instance)
             .await
@@ -94,8 +96,15 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         interface: IncompleteNetworkInterface,
-    ) -> Result<NetworkInterface, network_interface::InsertError> {
+    ) -> Result<InstanceNetworkInterface, network_interface::InsertError> {
         use db::schema::network_interface::dsl;
+        if interface.kind != NetworkInterfaceKind::Instance {
+            return Err(network_interface::InsertError::External(
+                Error::invalid_request(
+                    "expected instance type network interface",
+                ),
+            ));
+        }
         let subnet_id = interface.subnet.identity.id;
         let query = network_interface::InsertQuery::new(interface.clone());
         VpcSubnet::insert_resource(
@@ -108,6 +117,9 @@ impl DataStore {
                 .map_err(network_interface::InsertError::External)?,
         )
         .await
+        // Convert to `InstanceNetworkInterface` before returning; we know
+        // this is valid as we've checked the condition on-entry.
+        .map(NetworkInterface::as_instance)
         .map_err(|e| match e {
             AsyncInsertError::CollectionNotFound => {
                 network_interface::InsertError::External(
@@ -134,7 +146,8 @@ impl DataStore {
         use db::schema::network_interface::dsl;
         let now = Utc::now();
         diesel::update(dsl::network_interface)
-            .filter(dsl::instance_id.eq(authz_instance.id()))
+            .filter(dsl::parent_id.eq(authz_instance.id()))
+            .filter(dsl::kind.eq(NetworkInterfaceKind::Instance))
             .filter(dsl::time_deleted.is_null())
             .set(dsl::time_deleted.eq(now))
             .execute_async(self.pool_authorized(opctx).await?)
@@ -148,7 +161,7 @@ impl DataStore {
         Ok(())
     }
 
-    /// Delete a `NetworkInterface` attached to a provided instance.
+    /// Delete an instance attached to a provided instance.
     ///
     /// Note that the primary interface for an instance cannot be deleted if
     /// there are any secondary interfaces.
@@ -156,13 +169,14 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         authz_instance: &authz::Instance,
-        authz_interface: &authz::NetworkInterface,
+        authz_interface: &authz::InstanceNetworkInterface,
     ) -> Result<(), network_interface::DeleteError> {
         opctx
             .authorize(authz::Action::Delete, authz_interface)
             .await
             .map_err(network_interface::DeleteError::External)?;
         let query = network_interface::DeleteQuery::new(
+            NetworkInterfaceKind::Instance,
             authz_instance.id(),
             authz_interface.id(),
         );
@@ -183,7 +197,7 @@ impl DataStore {
     /// Return information about network interfaces required for the sled
     /// agent to instantiate or modify them via OPTE. This function takes
     /// a partially constructed query over the network interface table so
-    /// that we can use it for instances, VPCs, and subnets.
+    /// that we can use it for instances, services, VPCs, and subnets.
     async fn derive_network_interface_info(
         &self,
         opctx: &OpContext,
@@ -238,7 +252,10 @@ impl DataStore {
         self.derive_network_interface_info(
             opctx,
             network_interface::table
-                .filter(network_interface::instance_id.eq(authz_instance.id()))
+                .filter(network_interface::parent_id.eq(authz_instance.id()))
+                .filter(
+                    network_interface::kind.eq(NetworkInterfaceKind::Instance),
+                )
                 .into_boxed(),
         )
         .await
@@ -288,24 +305,26 @@ impl DataStore {
         opctx: &OpContext,
         authz_instance: &authz::Instance,
         pagparams: &PaginatedBy<'_>,
-    ) -> ListResultVec<NetworkInterface> {
+    ) -> ListResultVec<InstanceNetworkInterface> {
         opctx.authorize(authz::Action::ListChildren, authz_instance).await?;
 
-        use db::schema::network_interface::dsl;
+        use db::schema::instance_network_interface::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::network_interface, dsl::id, &pagparams)
+                paginated(dsl::instance_network_interface, dsl::id, &pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
-                dsl::network_interface,
+                dsl::instance_network_interface,
                 dsl::name,
                 &pagparams.map_name(|n| Name::ref_cast(n)),
             ),
         }
         .filter(dsl::time_deleted.is_null())
         .filter(dsl::instance_id.eq(authz_instance.id()))
-        .select(NetworkInterface::as_select())
-        .load_async::<NetworkInterface>(self.pool_authorized(opctx).await?)
+        .select(InstanceNetworkInterface::as_select())
+        .load_async::<InstanceNetworkInterface>(
+            self.pool_authorized(opctx).await?,
+        )
         .await
         .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
     }
@@ -315,11 +334,9 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         authz_instance: &authz::Instance,
-        authz_interface: &authz::NetworkInterface,
+        authz_interface: &authz::InstanceNetworkInterface,
         updates: NetworkInterfaceUpdate,
-    ) -> UpdateResult<NetworkInterface> {
-        use crate::db::schema::network_interface::dsl;
-
+    ) -> UpdateResult<InstanceNetworkInterface> {
         // This database operation is surprisingly subtle. It's possible to
         // express this in a single query, with multiple common-table
         // expressions for the updated rows. For example, if we're setting a new
@@ -334,33 +351,54 @@ impl DataStore {
         //
         // See https://github.com/oxidecomputer/omicron/issues/1204 for the
         // issue tracking the work to move this into a CTE.
+        //
+        // It's also further complicated by the fact we're updating a row
+        // in the `network_interface` table but will return a `InstanceNetworkInterface`
+        // which represents a row in the `instance_network_interface`. This is
+        // fine because `instance_network_interface` is just a view over
+        // `network_interface` constrained to rows of `kind = 'instance'`.
 
         // Build up some of the queries first, outside the transaction.
         //
         // This selects the existing primary interface.
+        // Note we consult only `kind = 'instance'` rows by querying from
+        // `instance_network_interface`.
         let instance_id = authz_instance.id();
         let interface_id = authz_interface.id();
-        let find_primary_query = dsl::network_interface
-            .filter(dsl::instance_id.eq(instance_id))
-            .filter(dsl::is_primary.eq(true))
-            .filter(dsl::time_deleted.is_null())
-            .select(NetworkInterface::as_select());
+        let find_primary_query = {
+            use crate::db::schema::instance_network_interface::dsl;
+            dsl::instance_network_interface
+                .filter(dsl::instance_id.eq(instance_id))
+                .filter(dsl::is_primary.eq(true))
+                .filter(dsl::time_deleted.is_null())
+                .select(InstanceNetworkInterface::as_select())
+        };
 
         // This returns the state of the associated instance.
-        let instance_query = db::schema::instance::dsl::instance
-            .filter(db::schema::instance::dsl::id.eq(instance_id))
-            .filter(db::schema::instance::dsl::time_deleted.is_null())
-            .select(Instance::as_select());
+        let instance_query = {
+            use crate::db::schema::instance::dsl;
+            dsl::instance
+                .filter(dsl::id.eq(instance_id))
+                .filter(dsl::time_deleted.is_null())
+                .select(Instance::as_select())
+        };
         let stopped =
             db::model::InstanceState::new(external::InstanceState::Stopped);
 
         // This is the actual query to update the target interface.
+        // Unlike Postgres, CockroachDB doesn't support inserting or updating a view
+        // so we need to use the underlying table, taking care to constrain
+        // the update to rows of `kind = 'instance'`.
         let primary = matches!(updates.primary, Some(true));
-        let update_target_query = diesel::update(dsl::network_interface)
-            .filter(dsl::id.eq(interface_id))
-            .filter(dsl::time_deleted.is_null())
-            .set(updates)
-            .returning(NetworkInterface::as_returning());
+        let update_target_query = {
+            use crate::db::schema::network_interface::dsl;
+            diesel::update(dsl::network_interface)
+                .filter(dsl::id.eq(interface_id))
+                .filter(dsl::kind.eq(NetworkInterfaceKind::Instance))
+                .filter(dsl::time_deleted.is_null())
+                .set(updates)
+                .returning(NetworkInterface::as_returning())
+        };
 
         // Errors returned from the below transactions.
         #[derive(Debug)]
@@ -390,8 +428,10 @@ impl DataStore {
                 // If the target and primary are different, we need to toggle
                 // the primary into a secondary.
                 if primary_interface.identity.id != interface_id {
+                    use crate::db::schema::network_interface::dsl;
                     if let Err(e) = diesel::update(dsl::network_interface)
                         .filter(dsl::id.eq(primary_interface.identity.id))
+                        .filter(dsl::kind.eq(NetworkInterfaceKind::Instance))
                         .filter(dsl::time_deleted.is_null())
                         .set(dsl::is_primary.eq(false))
                         .execute_async(&conn)
@@ -429,6 +469,9 @@ impl DataStore {
             })
         }
         .await
+        // Convert to `InstanceNetworkInterface` before returning, we know
+        // this is valid as we've filtered appropriately above.
+        .map(NetworkInterface::as_instance)
         .map_err(|e| match e {
             TxnError::CustomError(
                 NetworkInterfaceUpdateError::InstanceNotStopped,

--- a/nexus/db-queries/src/db/lookup.rs
+++ b/nexus/db-queries/src/db/lookup.rs
@@ -175,9 +175,12 @@ impl<'a> LookupPath<'a> {
         Snapshot::PrimaryKey(Root { lookup_root: self }, id)
     }
 
-    /// Select a resource of type NetworkInterface, identified by its id
-    pub fn network_interface_id(self, id: Uuid) -> NetworkInterface<'a> {
-        NetworkInterface::PrimaryKey(Root { lookup_root: self }, id)
+    /// Select a resource of type InstanceNetworkInterface, identified by its id
+    pub fn instance_network_interface_id(
+        self,
+        id: Uuid,
+    ) -> InstanceNetworkInterface<'a> {
+        InstanceNetworkInterface::PrimaryKey(Root { lookup_root: self }, id)
     }
 
     /// Select a resource of type Vpc, identified by its id
@@ -523,14 +526,14 @@ lookup_resource! {
 lookup_resource! {
     name = "Instance",
     ancestors = [ "Silo", "Project" ],
-    children = [ "NetworkInterface" ],
+    children = [ "InstanceNetworkInterface" ],
     lookup_by_name = true,
     soft_deletes = true,
     primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
 }
 
 lookup_resource! {
-    name = "NetworkInterface",
+    name = "InstanceNetworkInterface",
     ancestors = [ "Silo", "Project", "Instance" ],
     children = [],
     lookup_by_name = true,

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -236,7 +236,7 @@ resource: Instance "silo1-proj1-instance1"
   silo1-proj1-viewer               ✘  ✔  ✔  ✔  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
-resource: NetworkInterface "silo1-proj1-instance1-nic1"
+resource: InstanceNetworkInterface "silo1-proj1-instance1-nic1"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
@@ -348,7 +348,7 @@ resource: Instance "silo1-proj2-instance1"
   silo1-proj1-viewer               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
-resource: NetworkInterface "silo1-proj2-instance1-nic1"
+resource: InstanceNetworkInterface "silo1-proj2-instance1-nic1"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
@@ -572,7 +572,7 @@ resource: Instance "silo2-proj1-instance1"
   silo1-proj1-viewer               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
-resource: NetworkInterface "silo2-proj1-instance1-nic1"
+resource: InstanceNetworkInterface "silo2-proj1-instance1-nic1"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘

--- a/nexus/src/app/network_interface.rs
+++ b/nexus/src/app/network_interface.rs
@@ -75,14 +75,6 @@ impl super::Nexus {
 
         // NOTE: We need to lookup the VPC and VPC Subnet, since we need both
         // IDs for creating the network interface.
-        //
-        // TODO-correctness: There are additional races here. The VPC and VPC
-        // Subnet could both be deleted between the time we fetch them and
-        // actually insert the record for the interface. The solution is likely
-        // to make both objects implement `DatastoreCollection` for their
-        // children, and then use `VpcSubnet::insert_resource` inside the
-        // `instance_create_network_interface` method. See
-        // https://github.com/oxidecomputer/omicron/issues/738.
         let vpc_name = db::model::Name(params.vpc_name.clone());
         let subnet_name = db::model::Name(params.subnet_name.clone());
         let (.., authz_vpc, authz_subnet, db_subnet) =

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -252,16 +252,20 @@ impl super::Nexus {
             .await
     }
 
-    pub async fn subnet_list_network_interfaces(
+    pub async fn subnet_list_instance_network_interfaces(
         &self,
         opctx: &OpContext,
         subnet_lookup: &lookup::VpcSubnet<'_>,
         pagparams: &PaginatedBy<'_>,
-    ) -> ListResultVec<db::model::NetworkInterface> {
+    ) -> ListResultVec<db::model::InstanceNetworkInterface> {
         let (.., authz_subnet) =
             subnet_lookup.lookup_for(authz::Action::ListChildren).await?;
         self.db_datastore
-            .subnet_list_network_interfaces(opctx, &authz_subnet, pagparams)
+            .subnet_list_instance_network_interfaces(
+                opctx,
+                &authz_subnet,
+                pagparams,
+            )
             .await
     }
 }

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -298,8 +298,8 @@ lazy_static! {
         nexus_defaults::DEFAULT_PRIMARY_NIC_NAME.parse().unwrap();
     pub static ref DEMO_INSTANCE_NIC_URL: String =
         format!("/v1/network-interfaces/{}?project={}&instance={}", *DEMO_INSTANCE_NIC_NAME, *DEMO_PROJECT_NAME, *DEMO_INSTANCE_NAME);
-    pub static ref DEMO_INSTANCE_NIC_CREATE: params::NetworkInterfaceCreate =
-        params::NetworkInterfaceCreate {
+    pub static ref DEMO_INSTANCE_NIC_CREATE: params::InstanceNetworkInterfaceCreate =
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: DEMO_INSTANCE_NIC_NAME.clone(),
                 description: String::from(""),
@@ -308,8 +308,8 @@ lazy_static! {
             subnet_name: DEMO_VPC_SUBNET_NAME.clone(),
             ip: None,
         };
-    pub static ref DEMO_INSTANCE_NIC_PUT: params::NetworkInterfaceUpdate = {
-        params::NetworkInterfaceUpdate {
+    pub static ref DEMO_INSTANCE_NIC_PUT: params::InstanceNetworkInterfaceUpdate = {
+        params::InstanceNetworkInterfaceUpdate {
             identity: IdentityMetadataUpdateParams {
                 name: None,
                 description: Some(String::from("an updated description")),

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -2973,9 +2973,10 @@ async fn test_instance_v2p_mappings(cptestctx: &ControlPlaneTestContext) {
     let nics_url =
         format!("/v1/network-interfaces?instance={}", instance.identity.id,);
 
-    let nics = objects_list_page_authz::<NetworkInterface>(client, &nics_url)
-        .await
-        .items;
+    let nics =
+        objects_list_page_authz::<InstanceNetworkInterface>(client, &nics_url)
+            .await
+            .items;
 
     // The default config is one NIC
     assert_eq!(nics.len(), 1);

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -29,10 +29,10 @@ use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
+use omicron_common::api::external::InstanceNetworkInterface;
 use omicron_common::api::external::InstanceState;
 use omicron_common::api::external::Ipv4Net;
 use omicron_common::api::external::Name;
-use omicron_common::api::external::NetworkInterface;
 use omicron_nexus::authz::SiloRole;
 use omicron_nexus::db::fixed_data::silo::SILO_ID;
 use omicron_nexus::external_api::shared::IpKind;
@@ -256,7 +256,7 @@ async fn test_instances_create_reboot_halt(
         PROJECT_NAME
     );
     let network_interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &nics_url)
+        objects_list_page_authz::<InstanceNetworkInterface>(client, &nics_url)
             .await
             .items;
     assert_eq!(network_interfaces.len(), 1);
@@ -433,10 +433,12 @@ async fn test_instances_create_reboot_halt(
         "/v1/vpc-subnets/default/network-interfaces?project={}&vpc=default",
         PROJECT_NAME,
     );
-    let interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &url_interfaces)
-            .await
-            .items;
+    let interfaces = objects_list_page_authz::<InstanceNetworkInterface>(
+        client,
+        &url_interfaces,
+    )
+    .await
+    .items;
     assert!(
         interfaces.is_empty(),
         "Expected all network interfaces for the instance to be deleted"
@@ -825,7 +827,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
     // The network interface parameters.
     let default_name = "default".parse::<Name>().unwrap();
     let requested_address = "172.30.0.10".parse::<std::net::IpAddr>().unwrap();
-    let if0_params = params::NetworkInterfaceCreate {
+    let if0_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if0")).unwrap(),
             description: String::from("first custom interface"),
@@ -898,7 +900,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
     // as-is. This would fail with a conflict on the instance name, if we don't
     // fully unwind the saga and delete the instance database record.
     let requested_address = "172.30.0.11".parse::<std::net::IpAddr>().unwrap();
-    let if0_params = params::NetworkInterfaceCreate {
+    let if0_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if0")).unwrap(),
             description: String::from("first custom interface"),
@@ -940,7 +942,7 @@ async fn test_instance_with_single_explicit_ip_address(
     // Create the parameters for the interface.
     let default_name = "default".parse::<Name>().unwrap();
     let requested_address = "172.30.0.10".parse::<std::net::IpAddr>().unwrap();
-    let if0_params = params::NetworkInterfaceCreate {
+    let if0_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if0")).unwrap(),
             description: String::from("first custom interface"),
@@ -992,7 +994,7 @@ async fn test_instance_with_single_explicit_ip_address(
         .execute()
         .await
         .expect("Failed to get network interface for new instance")
-        .parsed_body::<NetworkInterface>()
+        .parsed_body::<InstanceNetworkInterface>()
         .expect("Failed to parse a network interface");
     assert_eq!(interface.instance_id, instance.identity.id);
     assert_eq!(interface.identity.name, if0_params.identity.name);
@@ -1043,7 +1045,7 @@ async fn test_instance_with_new_custom_network_interfaces(
 
     // Create the parameters for the interfaces. These will be created during
     // the saga for instance creation.
-    let if0_params = params::NetworkInterfaceCreate {
+    let if0_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if0")).unwrap(),
             description: String::from("first custom interface"),
@@ -1052,7 +1054,7 @@ async fn test_instance_with_new_custom_network_interfaces(
         subnet_name: default_name.clone(),
         ip: None,
     };
-    let if1_params = params::NetworkInterfaceCreate {
+    let if1_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if1")).unwrap(),
             description: String::from("second custom interface"),
@@ -1102,11 +1104,10 @@ async fn test_instance_with_new_custom_network_interfaces(
     };
 
     // The first interface is in the default VPC Subnet
-    let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
-        client,
-        nics_url(&default_name).as_str(),
-        "",
-        Some(100),
+    let interfaces = NexusRequest::iter_collection_authn::<
+        InstanceNetworkInterface,
+    >(
+        client, nics_url(&default_name).as_str(), "", Some(100)
     )
     .await
     .expect("Failed to get interfaces in default VPC Subnet");
@@ -1121,14 +1122,15 @@ async fn test_instance_with_new_custom_network_interfaces(
     assert_eq!(if0.instance_id, instance.identity.id);
     assert_eq!(if0.ip, std::net::IpAddr::V4("172.30.0.5".parse().unwrap()));
 
-    let interfaces1 = NexusRequest::iter_collection_authn::<NetworkInterface>(
-        client,
-        nics_url(&non_default_subnet_name).as_str(),
-        "",
-        Some(100),
-    )
-    .await
-    .expect("Failed to get interfaces in non-default VPC Subnet");
+    let interfaces1 =
+        NexusRequest::iter_collection_authn::<InstanceNetworkInterface>(
+            client,
+            nics_url(&non_default_subnet_name).as_str(),
+            "",
+            Some(100),
+        )
+        .await
+        .expect("Failed to get interfaces in non-default VPC Subnet");
     assert_eq!(
         interfaces1.all_items.len(),
         1,
@@ -1211,12 +1213,9 @@ async fn test_instance_create_delete_network_interface(
         "/v1/network-interfaces?project={}&instance={}",
         PROJECT_NAME, instance.identity.name,
     );
-    let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
-        client,
-        url_interfaces.as_str(),
-        "",
-        Some(100),
-    )
+    let interfaces = NexusRequest::iter_collection_authn::<
+        InstanceNetworkInterface,
+    >(client, url_interfaces.as_str(), "", Some(100))
     .await
     .expect("Failed to get interfaces for instance");
     assert!(
@@ -1226,7 +1225,7 @@ async fn test_instance_create_delete_network_interface(
 
     // Parameters for the interfaces to create/attach
     let if_params = vec![
-        params::NetworkInterfaceCreate {
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "if0".parse().unwrap(),
                 description: String::from("a new nic"),
@@ -1235,7 +1234,7 @@ async fn test_instance_create_delete_network_interface(
             subnet_name: "default".parse().unwrap(),
             ip: Some("172.30.0.10".parse().unwrap()),
         },
-        params::NetworkInterfaceCreate {
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "if1".parse().unwrap(),
                 description: String::from("a new nic"),
@@ -1286,7 +1285,7 @@ async fn test_instance_create_delete_network_interface(
         .execute()
         .await
         .expect("Failed to create network interface on stopped instance");
-        let iface = response.parsed_body::<NetworkInterface>().unwrap();
+        let iface = response.parsed_body::<InstanceNetworkInterface>().unwrap();
         assert_eq!(iface.identity.name, params.identity.name);
         assert_eq!(iface.ip, params.ip.unwrap());
         assert_eq!(
@@ -1303,10 +1302,12 @@ async fn test_instance_create_delete_network_interface(
     instance_simulate(nexus, &instance.identity.id).await;
 
     // Get all interfaces in one request.
-    let other_interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &url_interfaces)
-            .await
-            .items;
+    let other_interfaces = objects_list_page_authz::<InstanceNetworkInterface>(
+        client,
+        &url_interfaces,
+    )
+    .await
+    .items;
     for (iface0, iface1) in interfaces.iter().zip(other_interfaces) {
         assert_eq!(iface0.identity.id, iface1.identity.id);
         assert_eq!(iface0.vpc_id, iface1.vpc_id);
@@ -1363,7 +1364,7 @@ async fn test_instance_create_delete_network_interface(
     .expect("Failed to parse error response body");
     assert_eq!(
         err.message,
-        "The primary interface for an instance \
+        "The primary interface \
         may not be deleted while secondary interfaces \
         are still attached",
         "Expected an InvalidRequest response when detaching \
@@ -1453,7 +1454,7 @@ async fn test_instance_update_network_interfaces(
 
     // Parameters for each interface to try to modify.
     let if_params = vec![
-        params::NetworkInterfaceCreate {
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "if0".parse().unwrap(),
                 description: String::from("a new nic"),
@@ -1462,7 +1463,7 @@ async fn test_instance_update_network_interfaces(
             subnet_name: "default".parse().unwrap(),
             ip: Some("172.30.0.10".parse().unwrap()),
         },
-        params::NetworkInterfaceCreate {
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "if1".parse().unwrap(),
                 description: String::from("a new nic"),
@@ -1487,7 +1488,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to create network interface on stopped instance")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
     assert_eq!(primary_iface.identity.name, if_params[0].identity.name);
     assert_eq!(primary_iface.ip, if_params[0].ip.unwrap());
@@ -1502,7 +1503,7 @@ async fn test_instance_update_network_interfaces(
     // We'll change the interface's name and description
     let new_name = Name::try_from(String::from("new-if0")).unwrap();
     let new_description = String::from("new description");
-    let updates = params::NetworkInterfaceUpdate {
+    let updates = params::InstanceNetworkInterfaceUpdate {
         identity: IdentityMetadataUpdateParams {
             name: Some(new_name.clone()),
             description: Some(new_description.clone()),
@@ -1545,7 +1546,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to update an interface")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
 
     // Verify the modifications have taken effect, updating the name,
@@ -1558,7 +1559,8 @@ async fn test_instance_update_network_interfaces(
     // interface, and that the modification time for the new is later than the
     // old.
     let verify_unchanged_attributes =
-        |original_iface: &NetworkInterface, new_iface: &NetworkInterface| {
+        |original_iface: &InstanceNetworkInterface,
+         new_iface: &InstanceNetworkInterface| {
             assert_eq!(
                 original_iface.identity.time_created,
                 new_iface.identity.time_created
@@ -1577,7 +1579,7 @@ async fn test_instance_update_network_interfaces(
 
     // Try with the same request again, but this time only changing
     // `primary`. This should have no effect.
-    let updates = params::NetworkInterfaceUpdate {
+    let updates = params::InstanceNetworkInterfaceUpdate {
         identity: IdentityMetadataUpdateParams {
             name: None,
             description: None,
@@ -1596,7 +1598,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to update an interface")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
 
     // Everything should still be the same, except the modification time.
@@ -1626,7 +1628,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to create network interface on stopped instance")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
     assert_eq!(secondary_iface.identity.name, if_params[1].identity.name);
     assert_eq!(secondary_iface.ip, if_params[1].ip.unwrap());
@@ -1671,7 +1673,7 @@ async fn test_instance_update_network_interfaces(
 
     // Verify that we can set the secondary as the new primary, and that nothing
     // else changes about the NICs.
-    let updates = params::NetworkInterfaceUpdate {
+    let updates = params::InstanceNetworkInterfaceUpdate {
         identity: IdentityMetadataUpdateParams {
             name: None,
             description: None,
@@ -1687,7 +1689,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to update an interface")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
 
     // It should now be the primary and have an updated modification time
@@ -1713,7 +1715,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to get the old primary / new secondary interface")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
 
     // The now-secondary interface should be, well, secondary
@@ -1742,10 +1744,12 @@ async fn test_instance_update_network_interfaces(
         .execute()
         .await
         .expect("Failed to delete original secondary interface");
-    let all_interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &url_interfaces)
-            .await
-            .items;
+    let all_interfaces = objects_list_page_authz::<InstanceNetworkInterface>(
+        client,
+        &url_interfaces,
+    )
+    .await
+    .items;
     assert_eq!(
         all_interfaces.len(),
         1,
@@ -1764,7 +1768,7 @@ async fn test_instance_update_network_interfaces(
     .execute()
     .await
     .expect("Failed to create network interface on stopped instance")
-    .parsed_body::<NetworkInterface>()
+    .parsed_body::<InstanceNetworkInterface>()
     .unwrap();
     assert!(!iface.primary);
     assert_eq!(iface.identity.name, if_params[0].identity.name);
@@ -1786,7 +1790,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
     // error on creation of the second NIC, and we'll make sure that both are
     // deleted.
     let default_name = "default".parse::<Name>().unwrap();
-    let if0_params = params::NetworkInterfaceCreate {
+    let if0_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if0")).unwrap(),
             description: String::from("first custom interface"),
@@ -1795,7 +1799,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         subnet_name: default_name.clone(),
         ip: Some("172.30.0.6".parse().unwrap()),
     };
-    let if1_params = params::NetworkInterfaceCreate {
+    let if1_params = params::InstanceNetworkInterfaceCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(String::from("if1")).unwrap(),
             description: String::from("second custom interface"),
@@ -1841,9 +1845,9 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         "/v1/vpc-subnets/default/network-interfaces?project={}&vpc=default",
         PROJECT_NAME,
     );
-    let interfaces = NexusRequest::iter_collection_authn::<NetworkInterface>(
-        client, &url_nics, "", None,
-    )
+    let interfaces = NexusRequest::iter_collection_authn::<
+        InstanceNetworkInterface,
+    >(client, &url_nics, "", None)
     .await
     .expect("failed to list network interfaces")
     .all_items;

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -19,8 +19,8 @@ use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::external::{
-    ByteCount, IdentityMetadataCreateParams, InstanceCpuCount, Ipv4Net,
-    NetworkInterface,
+    ByteCount, IdentityMetadataCreateParams, InstanceCpuCount,
+    InstanceNetworkInterface, Ipv4Net,
 };
 use omicron_common::nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
 use omicron_nexus::external_api::params;
@@ -37,7 +37,7 @@ async fn create_instance_expect_failure(
 ) -> HttpErrorResponseBody {
     let network_interfaces =
         params::InstanceNetworkInterfaceAttachment::Create(vec![
-            params::NetworkInterfaceCreate {
+            params::InstanceNetworkInterfaceCreate {
                 identity: IdentityMetadataCreateParams {
                     // We're using the name of the instance purposefully, to
                     // avoid any naming conflicts on the interface.
@@ -116,7 +116,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     // The valid addresses for allocation in `subnet` are 192.168.42.5 and
     // 192.168.42.6. The rest are reserved as described in RFD21.
     let nic = params::InstanceNetworkInterfaceAttachment::Create(vec![
-        params::NetworkInterfaceCreate {
+        params::InstanceNetworkInterfaceCreate {
             identity: IdentityMetadataCreateParams {
                 name: "eth0".parse().unwrap(),
                 description: String::from("some iface"),
@@ -161,7 +161,7 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
         subnet_name, vpc_selector
     );
     let mut network_interfaces =
-        objects_list_page_authz::<NetworkInterface>(client, &url_ips)
+        objects_list_page_authz::<InstanceNetworkInterface>(client, &url_ips)
             .await
             .items;
     assert_eq!(network_interfaces.len(), subnet_size);

--- a/nexus/tests/integration_tests/vpc_subnets.rs
+++ b/nexus/tests/integration_tests/vpc_subnets.rs
@@ -70,8 +70,8 @@ async fn test_delete_vpc_subnet_with_interfaces_fails(
     .unwrap();
     assert_eq!(
         err.message,
-        "VPC Subnet cannot be deleted while instances \
-        with network interfaces in the subnet exist",
+        "VPC Subnet cannot be deleted while \
+        network interfaces in the subnet exist",
     );
 
     // Stop and then delete the instance

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -139,7 +139,7 @@ pub struct OptionalInstanceSelector {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct NetworkInterfaceSelector {
+pub struct InstanceNetworkInterfaceSelector {
     #[serde(flatten)]
     pub instance_selector: Option<InstanceSelector>,
     /// Name or ID of the network interface
@@ -602,10 +602,10 @@ pub struct ProjectUpdate {
 
 // NETWORK INTERFACES
 
-/// Create-time parameters for a
-/// [`NetworkInterface`](omicron_common::api::external::NetworkInterface)
+/// Create-time parameters for an
+/// [`InstanceNetworkInterface`](omicron_common::api::external::InstanceNetworkInterface).
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct NetworkInterfaceCreate {
+pub struct InstanceNetworkInterfaceCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
     /// The VPC in which to create the interface.
@@ -616,13 +616,13 @@ pub struct NetworkInterfaceCreate {
     pub ip: Option<IpAddr>,
 }
 
-/// Parameters for updating a
-/// [`NetworkInterface`](omicron_common::api::external::NetworkInterface).
+/// Parameters for updating an
+/// [`InstanceNetworkInterface`](omicron_common::api::external::InstanceNetworkInterface).
 ///
 /// Note that modifying IP addresses for an interface is not yet supported, a
 /// new interface must be created instead.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct NetworkInterfaceUpdate {
+pub struct InstanceNetworkInterfaceUpdate {
     #[serde(flatten)]
     pub identity: IdentityMetadataUpdateParams,
 
@@ -692,8 +692,8 @@ pub struct IpPoolUpdate {
 
 pub const MIN_MEMORY_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
 
-/// Describes an attachment of a `NetworkInterface` to an `Instance`, at the
-/// time the instance is created.
+/// Describes an attachment of an `InstanceNetworkInterface` to an `Instance`,
+/// at the time the instance is created.
 // NOTE: VPC's are an organizing concept for networking resources, not for
 // instances. It's true that all networking resources for an instance must
 // belong to a single VPC, but we don't consider instances to be "scoped" to a
@@ -711,11 +711,11 @@ pub const MIN_MEMORY_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", content = "params", rename_all = "snake_case")]
 pub enum InstanceNetworkInterfaceAttachment {
-    /// Create one or more `NetworkInterface`s for the `Instance`.
+    /// Create one or more `InstanceNetworkInterface`s for the `Instance`.
     ///
     /// If more than one interface is provided, then the first will be
     /// designated the primary interface for the instance.
-    Create(Vec<NetworkInterfaceCreate>),
+    Create(Vec<InstanceNetworkInterfaceCreate>),
 
     /// The default networking configuration for an instance is to create a
     /// single primary interface with an automatically-assigned IP address. The

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2388,7 +2388,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkInterfaceResultsPage"
+                  "$ref": "#/components/schemas/InstanceNetworkInterfaceResultsPage"
                 }
               }
             }
@@ -2431,7 +2431,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NetworkInterfaceCreate"
+                "$ref": "#/components/schemas/InstanceNetworkInterfaceCreate"
               }
             }
           },
@@ -2443,7 +2443,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkInterface"
+                  "$ref": "#/components/schemas/InstanceNetworkInterface"
                 }
               }
             }
@@ -2497,7 +2497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkInterface"
+                  "$ref": "#/components/schemas/InstanceNetworkInterface"
                 }
               }
             }
@@ -2547,7 +2547,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NetworkInterfaceUpdate"
+                "$ref": "#/components/schemas/InstanceNetworkInterfaceUpdate"
               }
             }
           },
@@ -2559,7 +2559,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkInterface"
+                  "$ref": "#/components/schemas/InstanceNetworkInterface"
                 }
               }
             }
@@ -6754,7 +6754,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NetworkInterfaceResultsPage"
+                  "$ref": "#/components/schemas/InstanceNetworkInterfaceResultsPage"
                 }
               }
             }
@@ -9218,17 +9218,95 @@
           "dst_sled_id"
         ]
       },
+      "InstanceNetworkInterface": {
+        "description": "An `InstanceNetworkInterface` represents a virtual network interface device attached to an instance.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "instance_id": {
+            "description": "The Instance to which the interface belongs.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "ip": {
+            "description": "The IP address assigned to this interface.",
+            "type": "string",
+            "format": "ip"
+          },
+          "mac": {
+            "description": "The MAC address assigned to this interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MacAddr"
+              }
+            ]
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "primary": {
+            "description": "True if this interface is the primary for the instance to which it's attached.",
+            "type": "boolean"
+          },
+          "subnet_id": {
+            "description": "The subnet to which the interface belongs.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
+          "vpc_id": {
+            "description": "The VPC to which the interface belongs.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "instance_id",
+          "ip",
+          "mac",
+          "name",
+          "primary",
+          "subnet_id",
+          "time_created",
+          "time_modified",
+          "vpc_id"
+        ]
+      },
       "InstanceNetworkInterfaceAttachment": {
-        "description": "Describes an attachment of a `NetworkInterface` to an `Instance`, at the time the instance is created.",
+        "description": "Describes an attachment of an `InstanceNetworkInterface` to an `Instance`, at the time the instance is created.",
         "oneOf": [
           {
-            "description": "Create one or more `NetworkInterface`s for the `Instance`.\n\nIf more than one interface is provided, then the first will be designated the primary interface for the instance.",
+            "description": "Create one or more `InstanceNetworkInterface`s for the `Instance`.\n\nIf more than one interface is provided, then the first will be designated the primary interface for the instance.",
             "type": "object",
             "properties": {
               "params": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/NetworkInterfaceCreate"
+                  "$ref": "#/components/schemas/InstanceNetworkInterfaceCreate"
                 }
               },
               "type": {
@@ -9274,6 +9352,90 @@
             ]
           }
         ]
+      },
+      "InstanceNetworkInterfaceCreate": {
+        "description": "Create-time parameters for an [`InstanceNetworkInterface`](omicron_common::api::external::InstanceNetworkInterface).",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "ip": {
+            "nullable": true,
+            "description": "The IP address for the interface. One will be auto-assigned if not provided.",
+            "type": "string",
+            "format": "ip"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "subnet_name": {
+            "description": "The VPC Subnet in which to create the interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "vpc_name": {
+            "description": "The VPC in which to create the interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "subnet_name",
+          "vpc_name"
+        ]
+      },
+      "InstanceNetworkInterfaceResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstanceNetworkInterface"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "InstanceNetworkInterfaceUpdate": {
+        "description": "Parameters for updating an [`InstanceNetworkInterface`](omicron_common::api::external::InstanceNetworkInterface).\n\nNote that modifying IP addresses for an interface is not yet supported, a new interface must be created instead.",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "primary": {
+            "description": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error.",
+            "default": false,
+            "type": "boolean"
+          }
+        }
       },
       "InstanceResultsPage": {
         "description": "A single page of results",
@@ -9715,168 +9877,6 @@
             ]
           }
         ]
-      },
-      "NetworkInterface": {
-        "description": "A `NetworkInterface` represents a virtual network interface device.",
-        "type": "object",
-        "properties": {
-          "description": {
-            "description": "human-readable free-form text about a resource",
-            "type": "string"
-          },
-          "id": {
-            "description": "unique, immutable, system-controlled identifier for each resource",
-            "type": "string",
-            "format": "uuid"
-          },
-          "instance_id": {
-            "description": "The Instance to which the interface belongs.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "ip": {
-            "description": "The IP address assigned to this interface.",
-            "type": "string",
-            "format": "ip"
-          },
-          "mac": {
-            "description": "The MAC address assigned to this interface.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MacAddr"
-              }
-            ]
-          },
-          "name": {
-            "description": "unique, mutable, user-controlled identifier for each resource",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
-          },
-          "primary": {
-            "description": "True if this interface is the primary for the instance to which it's attached.",
-            "type": "boolean"
-          },
-          "subnet_id": {
-            "description": "The subnet to which the interface belongs.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "time_created": {
-            "description": "timestamp when this resource was created",
-            "type": "string",
-            "format": "date-time"
-          },
-          "time_modified": {
-            "description": "timestamp when this resource was last modified",
-            "type": "string",
-            "format": "date-time"
-          },
-          "vpc_id": {
-            "description": "The VPC to which the interface belongs.",
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "description",
-          "id",
-          "instance_id",
-          "ip",
-          "mac",
-          "name",
-          "primary",
-          "subnet_id",
-          "time_created",
-          "time_modified",
-          "vpc_id"
-        ]
-      },
-      "NetworkInterfaceCreate": {
-        "description": "Create-time parameters for a [`NetworkInterface`](omicron_common::api::external::NetworkInterface)",
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "ip": {
-            "nullable": true,
-            "description": "The IP address for the interface. One will be auto-assigned if not provided.",
-            "type": "string",
-            "format": "ip"
-          },
-          "name": {
-            "$ref": "#/components/schemas/Name"
-          },
-          "subnet_name": {
-            "description": "The VPC Subnet in which to create the interface.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
-          },
-          "vpc_name": {
-            "description": "The VPC in which to create the interface.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
-          }
-        },
-        "required": [
-          "description",
-          "name",
-          "subnet_name",
-          "vpc_name"
-        ]
-      },
-      "NetworkInterfaceResultsPage": {
-        "description": "A single page of results",
-        "type": "object",
-        "properties": {
-          "items": {
-            "description": "list of items on this page of results",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NetworkInterface"
-            }
-          },
-          "next_page": {
-            "nullable": true,
-            "description": "token used to fetch the next page of results (if any)",
-            "type": "string"
-          }
-        },
-        "required": [
-          "items"
-        ]
-      },
-      "NetworkInterfaceUpdate": {
-        "description": "Parameters for updating a [`NetworkInterface`](omicron_common::api::external::NetworkInterface).\n\nNote that modifying IP addresses for an interface is not yet supported, a new interface must be created instead.",
-        "type": "object",
-        "properties": {
-          "description": {
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
-          },
-          "primary": {
-            "description": "Make a secondary interface the instance's primary interface.\n\nIf applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.\n\nNote that this can only be used to select a new primary interface for an instance. Requests to change the primary interface into a secondary will return an error.",
-            "default": false,
-            "type": "boolean"
-          }
-        }
       },
       "NodeName": {
         "description": "Unique name for a saga [`Node`]\n\nEach node requires a string name that's unique within its DAG.  The name is used to identify its output.  Nodes that depend on a given node (either directly or indirectly) can access the node's output using its name.",


### PR DESCRIPTION
Since I wanted to split up #2419 a bit, took the opportunity to get rid of the
duplicate table I added to get going initially.

Previously, all NIC records in the DB were tied to a guest instance. In
enabling OPTE usage for services, it'd be nice to be able to reuse a lot
of the same NetworkInterface machinery we already have without
duplicating it completely. This commit adds a new `kind` column to the
`network_interface` table which at the moment will be either 'instance'
(NICs attached to a guest VM and exposed in the external API) or
'service' (NIC associated with an internal control plane service). The
previous `instance_id` column is renamed to `parent_id` and the table to
which it refers to as a FK is now dependant on the kind (either
`instance` or `service`).

Since a lot of the db and authz lookup macros end up relying on the
specific column name, this also introduces database views for each kind
which can be queried as if they were their own tables. This also allows
differentiating the different kinds of NICs as necessary.

CockroachDB, unlike Postgres, does not allow inserting or updating into
simple view and so we also model the base table itself to execute
queries that modify it.

From an external perspective, this doesn't change anything (modulo some
renaming from `NetworkInterface*` -> `InstanceNetworkInterface*`) in
that all external APIs still only deal with instance NICs.

There are some basic definitions for service NICs included but those
will be more fleshed in subsequent commits.