### PR TITLE
Remove DNSClient from ServiceKind

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -114,8 +114,7 @@ CREATE TYPE omicron.public.service_kind AS ENUM (
   'dendrite',
   'tfport',
   'crucible_pantry',
-  'ntp',
-  'dns_client'
+  'ntp'
 );
 
 CREATE TABLE omicron.public.service (

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -24,7 +24,6 @@ impl_enum_type!(
     Tfport => b"tfport"
     CruciblePantry => b"crucible_pantry"
     NTP => b"ntp"
-    DNSClient => b"dns_client"
 );
 
 impl TryFrom<ServiceKind> for ServiceUsingCertificate {
@@ -65,9 +64,6 @@ impl From<internal_api::params::ServiceKind> for ServiceKind {
                 ServiceKind::CruciblePantry
             }
             internal_api::params::ServiceKind::NTP => ServiceKind::NTP,
-            internal_api::params::ServiceKind::DNSClient => {
-                ServiceKind::DNSClient
-            }
         }
     }
 }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -170,7 +170,6 @@ pub enum ServiceKind {
     Tfport,
     CruciblePantry,
     NTP,
-    DNSClient,
 }
 
 impl fmt::Display for ServiceKind {
@@ -184,7 +183,6 @@ impl fmt::Display for ServiceKind {
             Tfport => "tfport",
             CruciblePantry => "crucible_pantry",
             NTP => "ntp",
-            DNSClient => "dns_client",
         };
         write!(f, "{}", s)
     }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2359,20 +2359,6 @@
             "required": [
               "type"
             ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "d_n_s_client"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
           }
         ]
       },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1507,7 +1507,17 @@
               "boundary": {
                 "type": "boolean"
               },
-              "servers": {
+              "dns_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "domain": {
+                "nullable": true,
+                "type": "string"
+              },
+              "ntp_servers": {
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -1522,32 +1532,8 @@
             },
             "required": [
               "boundary",
-              "servers",
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "domain": {
-                "nullable": true,
-                "type": "string"
-              },
-              "servers": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "dns_client"
-                ]
-              }
-            },
-            "required": [
-              "servers",
+              "dns_servers",
+              "ntp_servers",
               "type"
             ]
           }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -249,16 +249,30 @@ impl From<DatasetEnsureBody> for sled_agent_client::types::DatasetEnsureBody {
 )]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServiceType {
-    Nexus { internal_ip: Ipv6Addr, external_ip: IpAddr },
-    InternalDns { server_address: SocketAddrV6, dns_address: SocketAddrV6 },
+    Nexus {
+        internal_ip: Ipv6Addr,
+        external_ip: IpAddr,
+    },
+    InternalDns {
+        server_address: SocketAddrV6,
+        dns_address: SocketAddrV6,
+    },
     Oximeter,
     ManagementGatewayService,
     Wicketd,
-    Dendrite { asic: DendriteAsic },
-    Tfport { pkt_source: String },
+    Dendrite {
+        asic: DendriteAsic,
+    },
+    Tfport {
+        pkt_source: String,
+    },
     CruciblePantry,
-    Ntp { servers: Vec<String>, boundary: bool },
-    DnsClient { servers: Vec<String>, domain: Option<String> },
+    Ntp {
+        ntp_servers: Vec<String>,
+        boundary: bool,
+        dns_servers: Vec<String>,
+        domain: Option<String>,
+    },
 }
 
 impl std::fmt::Display for ServiceType {
@@ -273,8 +287,19 @@ impl std::fmt::Display for ServiceType {
             ServiceType::Tfport { .. } => write!(f, "tfport"),
             ServiceType::CruciblePantry => write!(f, "crucible_pantry"),
             ServiceType::Ntp { .. } => write!(f, "ntp"),
-            ServiceType::DnsClient { .. } => write!(f, "dns_client"),
         }
+    }
+}
+
+impl crate::smf_helper::Service for ServiceType {
+    fn service_name(&self) -> String {
+        self.to_string()
+    }
+    fn smf_name(&self) -> String {
+        format!("svc:/system/illumos/{}", self.service_name())
+    }
+    fn should_import(&self) -> bool {
+        true
     }
 }
 
@@ -307,9 +332,8 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
             }
             St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
             St::CruciblePantry => AutoSt::CruciblePantry,
-            St::Ntp { servers, boundary } => AutoSt::Ntp { servers, boundary },
-            St::DnsClient { servers, domain } => {
-                AutoSt::DnsClient { servers, domain }
+            St::Ntp { ntp_servers, boundary, dns_servers, domain } => {
+                AutoSt::Ntp { ntp_servers, boundary, dns_servers, domain }
             }
         }
     }

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -391,30 +391,22 @@ impl Plan {
                     (
                         // XXXNTP - these boundary servers need a path to the
                         // external network via OPTE.
-                        vec![
-                            ServiceType::Ntp {
-                                servers: config.ntp_servers.clone(),
-                                boundary: true,
-                            },
-                            ServiceType::DnsClient {
-                                servers: config.dns_servers.clone(),
-                                domain: None,
-                            },
-                        ],
+                        vec![ServiceType::Ntp {
+                            ntp_servers: config.ntp_servers.clone(),
+                            boundary: true,
+                            dns_servers: config.dns_servers.clone(),
+                            domain: None,
+                        }],
                         ServiceName::BoundaryNTP,
                     )
                 } else {
                     (
-                        vec![
-                            ServiceType::Ntp {
-                                servers: boundary_ntp_servers.clone(),
-                                boundary: false,
-                            },
-                            ServiceType::DnsClient {
-                                servers: rack_dns_servers.clone(),
-                                domain: None,
-                            },
-                        ],
+                        vec![ServiceType::Ntp {
+                            ntp_servers: boundary_ntp_servers.clone(),
+                            boundary: false,
+                            dns_servers: rack_dns_servers.clone(),
+                            domain: None,
+                        }],
                         ServiceName::InternalNTP,
                     )
                 };

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -655,9 +655,6 @@ impl ServiceInner {
                             NexusTypes::ServiceKind::CruciblePantry
                         }
                         ServiceType::Ntp { .. } => NexusTypes::ServiceKind::NTP,
-                        ServiceType::DnsClient { .. } => {
-                            NexusTypes::ServiceKind::DNSClient
-                        }
                         _ => {
                             return Err(SetupServiceError::BadConfig(format!(
                                 "RSS should not request service of type: {}",


### PR DESCRIPTION
This PR aims to launch the `svc:/network/dns/client` identically to the way we did before, but by coupling it with the "NTP service". The DNSClient is an SMF service that we **do** want to launch, but it's not a "network service" which would receive an internal IP address.

Fixes https://github.com/oxidecomputer/omicron/issues/2761