### PR TITLE
[wicket/wicketd] Add ignition control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7709,7 +7709,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/gateway-client/src/lib.rs
+++ b/gateway-client/src/lib.rs
@@ -49,6 +49,8 @@ progenitor::generate_api!(
     derives = [schemars::JsonSchema],
     patch = {
         SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
+        SpIgnition = { derives = [PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
+        SpIgnitionSystemType = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         RotState = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         RotImageDetails = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -35,6 +35,52 @@
         }
       }
     },
+    "/ignition/{type}/{slot}/{command}": {
+      "post": {
+        "summary": "Send an ignition command targeting a specific SP.",
+        "description": "This endpoint acts as a proxy to the MGS endpoint performing the same function, allowing wicket to communicate exclusively with wicketd (even though wicketd adds no meaningful functionality here beyond what MGS offers).",
+        "operationId": "post_ignition_command",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "command",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IgnitionCommand"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/inventory": {
       "get": {
         "summary": "A status endpoint used to report high level information known to wicketd.",
@@ -1946,6 +1992,15 @@
               "kind"
             ]
           }
+        ]
+      },
+      "IgnitionCommand": {
+        "description": "Ignition command.",
+        "type": "string",
+        "enum": [
+          "power_on",
+          "power_off",
+          "power_reset"
         ]
       }
     }

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -86,17 +86,16 @@
         "summary": "A status endpoint used to report high level information known to wicketd.",
         "description": "This endpoint can be polled to see if there have been state changes in the system that are useful to report to wicket.\nWicket, and possibly other callers, will retrieve the changed information, with follow up calls.",
         "operationId": "get_inventory",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "force_refresh",
-            "description": "If true, refresh inventory from MGS instead of returning cached data.",
-            "required": true,
-            "schema": {
-              "type": "boolean"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetInventoryParams"
+              }
             }
-          }
-        ],
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "successful operation",
@@ -712,6 +711,21 @@
         },
         "required": [
           "artifacts"
+        ]
+      },
+      "GetInventoryParams": {
+        "type": "object",
+        "properties": {
+          "force_refresh": {
+            "description": "If true, refresh the state of these SPs from MGS prior to returning (instead of returning cached data).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpIdentifier"
+            }
+          }
+        },
+        "required": [
+          "force_refresh"
         ]
       },
       "GetInventoryResponse": {

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -86,6 +86,17 @@
         "summary": "A status endpoint used to report high level information known to wicketd.",
         "description": "This endpoint can be polled to see if there have been state changes in the system that are useful to report to wicket.\nWicket, and possibly other callers, will retrieve the changed information, with follow up calls.",
         "operationId": "get_inventory",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force_refresh",
+            "description": "If true, refresh inventory from MGS instead of returning cached data.",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "successful operation",

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::time::{Duration, SystemTime};
 use wicketd_client::types::{
-    ArtifactId, RackV1Inventory, SemverVersion, UpdateLogAll,
+    ArtifactId, IgnitionCommand, RackV1Inventory, SemverVersion, UpdateLogAll,
 };
 
 /// An event that will update state
@@ -63,6 +63,7 @@ impl Event {
 pub enum Action {
     Redraw,
     Update(ComponentId),
+    Ignition(ComponentId, IgnitionCommand),
 }
 
 impl Action {
@@ -72,7 +73,7 @@ impl Action {
     /// Some downstream operations will not trigger this in the future.
     pub fn should_redraw(&self) -> bool {
         match self {
-            Action::Redraw | Action::Update(_) => true,
+            Action::Redraw | Action::Update(_) | Action::Ignition(_, _) => true,
         }
     }
 }

--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -46,6 +46,9 @@ pub enum Cmd {
     /// `Control`.
     Details,
 
+    /// Display ignition control for the given selection
+    Ignition,
+
     /// Move up or scroll up
     Up,
 
@@ -137,6 +140,7 @@ impl KeyHandler {
             KeyCode::Char('e') => Cmd::Expand,
             KeyCode::Char('c') => Cmd::Collapse,
             KeyCode::Char('d') => Cmd::Details,
+            KeyCode::Char('i') => Cmd::Ignition,
             KeyCode::Up => Cmd::Up,
             KeyCode::Down => Cmd::Down,
             KeyCode::Right => Cmd::Right,

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -146,6 +146,16 @@ impl RunnerCore {
                     ))?;
                 }
             }
+            Action::Ignition(component_id, ignition_command) => {
+                if let Some(wicketd) = wicketd {
+                    wicketd.tx.blocking_send(
+                        wicketd::Request::IgnitionCommand(
+                            component_id,
+                            ignition_command,
+                        ),
+                    )?;
+                }
+            }
         }
         Ok(())
     }

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -256,6 +256,9 @@ impl InventoryView {
                     Some(Action::Redraw)
                 }
                 Cmd::Enter => {
+                    // Note: If making changes here, consider making them to the
+                    // same arm of `UpdatePane::handle_cmd_in_popup()` in the
+                    // `update` pane.
                     let command = self.ignition.selected_command();
                     let selected = state.rack_state.selected;
                     self.popup = None;

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -10,12 +10,17 @@ use crate::state::{ComponentId, ALL_COMPONENT_IDS};
 use crate::ui::defaults::colors::*;
 use crate::ui::defaults::style;
 use crate::ui::panes::compute_scroll_offset;
+use crate::ui::widgets::IgnitionPopup;
 use crate::ui::widgets::{BoxConnector, BoxConnectorKind, Rack};
 use crate::{Action, Cmd, Frame, State};
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::Style;
 use tui::text::{Span, Spans, Text};
 use tui::widgets::{Block, BorderType, Borders, Paragraph};
+
+enum PopupKind {
+    Ignition,
+}
 
 /// The OverviewPane shows a rendering of the rack.
 ///
@@ -56,7 +61,7 @@ impl Control for OverviewPane {
                     self.rack_view_selected = false;
                     Some(Action::Redraw)
                 } else {
-                    None
+                    self.inventory_view.on(state, cmd)
                 }
             }
             Cmd::Exit => {
@@ -66,7 +71,7 @@ impl Control for OverviewPane {
                     self.rack_view_selected = true;
                     Some(Action::Redraw)
                 } else {
-                    None
+                    self.inventory_view.on(state, cmd)
                 }
             }
             _ => self.dispatch(state, cmd),
@@ -194,20 +199,70 @@ pub struct InventoryView {
     help: Vec<(&'static str, &'static str)>,
     // Vertical offset used for scrolling
     scroll_offsets: BTreeMap<ComponentId, usize>,
+    ignition: IgnitionPopup,
+    popup: Option<PopupKind>,
 }
 
 impl InventoryView {
     pub fn new() -> InventoryView {
         InventoryView {
             help: vec![
-                ("RACK VIEW", "<ENTER>"),
-                ("SWITCH COMPONENT", "<LEFT/RIGHT>"),
-                ("SCROLL", "<UP/DOWN>"),
+                ("Rack View", "<ENTER>"),
+                ("Switch Component", "<LEFT/RIGHT>"),
+                ("Scroll", "<UP/DOWN>"),
+                ("Ignition", "<I>"),
             ],
             scroll_offsets: ALL_COMPONENT_IDS
                 .iter()
                 .map(|id| (*id, 0))
                 .collect(),
+            ignition: IgnitionPopup::default(),
+            popup: None,
+        }
+    }
+
+    pub fn draw_ignition_popup(
+        &mut self,
+        state: &State,
+        frame: &mut Frame<'_>,
+    ) {
+        let popup = self.ignition.popup(state.rack_state.selected);
+        let full_screen = Rect {
+            width: state.screen_width,
+            height: state.screen_height,
+            x: 0,
+            y: 0,
+        };
+        frame.render_widget(popup, full_screen);
+    }
+
+    fn handle_cmd_in_popup(
+        &mut self,
+        state: &mut State,
+        cmd: Cmd,
+    ) -> Option<Action> {
+        if cmd == Cmd::Exit {
+            self.popup = None;
+            return Some(Action::Redraw);
+        }
+        match self.popup.as_ref().unwrap() {
+            PopupKind::Ignition => match cmd {
+                Cmd::Up => {
+                    self.ignition.key_up();
+                    Some(Action::Redraw)
+                }
+                Cmd::Down => {
+                    self.ignition.key_down();
+                    Some(Action::Redraw)
+                }
+                Cmd::Enter => {
+                    let command = self.ignition.selected_command();
+                    let selected = state.rack_state.selected;
+                    self.popup = None;
+                    Some(Action::Ignition(selected, command))
+                }
+                _ => None,
+            },
         }
     }
 }
@@ -289,9 +344,17 @@ impl Control for InventoryView {
             BoxConnector::new(BoxConnectorKind::Bottom),
             chunks[1],
         );
+
+        match self.popup {
+            Some(PopupKind::Ignition) => self.draw_ignition_popup(state, frame),
+            None => (),
+        }
     }
 
     fn on(&mut self, state: &mut State, cmd: Cmd) -> Option<Action> {
+        if self.popup.is_some() {
+            return self.handle_cmd_in_popup(state, cmd);
+        }
         match cmd {
             Cmd::Left => {
                 state.rack_state.prev();
@@ -346,6 +409,11 @@ impl Control for InventoryView {
                 } else {
                     None
                 }
+            }
+            Cmd::Ignition => {
+                self.ignition.reset();
+                self.popup = Some(PopupKind::Ignition);
+                Some(Action::Redraw)
             }
             _ => None,
         }

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeMap;
 use super::{align_by, help_text, Control};
 use crate::state::{artifact_title, ComponentId, Inventory, ALL_COMPONENT_IDS};
 use crate::ui::defaults::style;
-use crate::ui::widgets::{BoxConnector, BoxConnectorKind, ButtonText, Popup, IgnitionPopup};
+use crate::ui::widgets::{
+    BoxConnector, BoxConnectorKind, ButtonText, IgnitionPopup, Popup,
+};
 use crate::{Action, Cmd, Frame, State};
 use omicron_common::api::internal::nexus::KnownArtifactKind;
 use slog::{info, o, Logger};

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -250,6 +250,9 @@ impl UpdatePane {
                     Some(Action::Redraw)
                 }
                 Cmd::Enter => {
+                    // Note: If making changes here, consider making them to the
+                    // same arm of `InventoryView::handle_cmd_in_popup()` in the
+                    // `overview` pane.
                     let command = self.ignition.selected_command();
                     let selected = state.rack_state.selected;
                     info!(self.log, "Sending {command:?} to {selected}");

--- a/wicket/src/ui/widgets/ignition.rs
+++ b/wicket/src/ui/widgets/ignition.rs
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A popup dialog box widget for ignition control
+
+use super::ButtonText;
+use super::Popup;
+use crate::state::ComponentId;
+use crate::ui::defaults::style;
+use tui::text::Span;
+use tui::text::Spans;
+use tui::text::Text;
+use wicketd_client::types::IgnitionCommand;
+
+pub struct IgnitionPopup {
+    selected_command: IgnitionCommand,
+}
+
+impl Default for IgnitionPopup {
+    fn default() -> Self {
+        Self { selected_command: IgnitionCommand::PowerOn }
+    }
+}
+
+impl IgnitionPopup {
+    pub fn selected_command(&self) -> IgnitionCommand {
+        self.selected_command
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn key_up(&mut self) {
+        self.selected_command = match self.selected_command {
+            IgnitionCommand::PowerOn => IgnitionCommand::PowerReset,
+            IgnitionCommand::PowerOff => IgnitionCommand::PowerOn,
+            IgnitionCommand::PowerReset => IgnitionCommand::PowerOff,
+        };
+    }
+
+    pub fn key_down(&mut self) {
+        self.selected_command = match self.selected_command {
+            IgnitionCommand::PowerOn => IgnitionCommand::PowerOff,
+            IgnitionCommand::PowerOff => IgnitionCommand::PowerReset,
+            IgnitionCommand::PowerReset => IgnitionCommand::PowerOn,
+        };
+    }
+
+    pub fn popup(&self, component: ComponentId) -> Popup<'static> {
+        Popup {
+            header: Text::from(vec![Spans::from(vec![Span::styled(
+                format!(" IGNITION: {}", component),
+                style::header(true),
+            )])]),
+            body: Text {
+                lines: vec![
+                    Spans::from(vec![Span::styled(
+                        "Power On",
+                        style::line(
+                            self.selected_command == IgnitionCommand::PowerOn,
+                        ),
+                    )]),
+                    Spans::from(vec![Span::styled(
+                        "Power Off",
+                        style::line(
+                            self.selected_command == IgnitionCommand::PowerOff,
+                        ),
+                    )]),
+                    Spans::from(vec![Span::styled(
+                        "Power Reset",
+                        style::line(
+                            self.selected_command
+                                == IgnitionCommand::PowerReset,
+                        ),
+                    )]),
+                ],
+            },
+            buttons: vec![ButtonText { instruction: "CLOSE", key: "ESC" }],
+        }
+    }
+}

--- a/wicket/src/ui/widgets/mod.rs
+++ b/wicket/src/ui/widgets/mod.rs
@@ -14,6 +14,6 @@ mod rack;
 pub use animated_logo::{Logo, LogoState, LOGO_HEIGHT, LOGO_WIDTH};
 pub use box_connector::{BoxConnector, BoxConnectorKind};
 pub use fade::Fade;
-pub use popup::{ButtonText, Popup};
 pub use ignition::IgnitionPopup;
+pub use popup::{ButtonText, Popup};
 pub use rack::Rack;

--- a/wicket/src/ui/widgets/mod.rs
+++ b/wicket/src/ui/widgets/mod.rs
@@ -7,6 +7,7 @@
 mod animated_logo;
 mod box_connector;
 mod fade;
+mod ignition;
 mod popup;
 mod rack;
 
@@ -14,4 +15,5 @@ pub use animated_logo::{Logo, LogoState, LOGO_HEIGHT, LOGO_WIDTH};
 pub use box_connector::{BoxConnector, BoxConnectorKind};
 pub use fade::Fade;
 pub use popup::{ButtonText, Popup};
+pub use ignition::IgnitionPopup;
 pub use rack::Rack;

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -6,13 +6,13 @@
 
 use crate::mgs::GetInventoryResponse;
 use crate::update_events::UpdateLog;
-use dropshot::Query;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Path;
+use dropshot::Query;
 use dropshot::RequestContext;
 use dropshot::UntypedBody;
 use gateway_client::types::IgnitionCommand;

--- a/wicketd/src/mgs.rs
+++ b/wicketd/src/mgs.rs
@@ -209,8 +209,9 @@ async fn update_inventory(
             let curr = inventory
                 .entry(id)
                 .and_modify(|curr| {
-                    if curr.state != state {
+                    if curr.state != state || curr.ignition != ignition {
                         // state has changed - discard cached details
+                        inventory_changed = true;
                         curr.components = None;
                         curr.caboose = None;
                         curr.rot.caboose = None;

--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -16,12 +16,13 @@ async fn test_inventory() {
     let gateway =
         gateway_setup::test_setup("test_inventory", SpPort::One).await;
     let wicketd_testctx = WicketdTestContext::setup(gateway).await;
+    let force_refresh = false;
 
     let inventory_fut = async {
         loop {
             let response = wicketd_testctx
                 .wicketd_client
-                .get_inventory()
+                .get_inventory(force_refresh)
                 .await
                 .expect("get_inventory succeeded")
                 .into_inner();

--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use super::setup::WicketdTestContext;
 use gateway_messages::SpPort;
 use gateway_test_utils::setup as gateway_setup;
+use wicketd_client::types::GetInventoryParams;
 use wicketd_client::GetInventoryResponse;
 
 #[tokio::test]
@@ -16,13 +17,13 @@ async fn test_inventory() {
     let gateway =
         gateway_setup::test_setup("test_inventory", SpPort::One).await;
     let wicketd_testctx = WicketdTestContext::setup(gateway).await;
-    let force_refresh = false;
+    let params = GetInventoryParams { force_refresh: Vec::new() };
 
     let inventory_fut = async {
         loop {
             let response = wicketd_testctx
                 .wicketd_client
-                .get_inventory(force_refresh)
+                .get_inventory(&params)
                 .await
                 .expect("get_inventory succeeded")
                 .into_inner();


### PR DESCRIPTION
This PR adds a few related-but-not-entirely-the-same things; if I need to break this up into separate bits (or only keep some of them), that's fine. In order from "most sure it's fine to merge" to "lease sure":

1. Adds an ignition command endpoint to `wicketd`; this just acts as a proxy for the same endpoint in MGS.
2. Adds a `force_refresh` query parameter to `wicketd`'s `get_inventory` endpoint. If the caller passes `true`, wicketd will immediately trigger a poll to MGS and only return a response to the caller after the next MGS poll comes back instead of returning the latest cached data.
3. Adds some mechanics in `wicket` to use `force_refresh` after a user interaction that we know should change the inventory state. Currently this is only used by 4.
4. Adds an ignition control popup to `wicket`. This is reachable by pressing `<i>` on either the inventory or update screens:

![ignition-popup](https://user-images.githubusercontent.com/1435635/230470012-719def88-b527-472a-afa5-4f436356a468.png)

I'm _very much_ not sold on the UI here, but wanted to put something in for now. One major flaw currently is that there is no place for feedback (either success or failure); pressing enter sends the command to `wicketd`, but results can only be observed indirectly (e.g., by seeing the ignition power state in the inventory screen change).