### PR TITLE
Bump syn to 2.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7709,7 +7709,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.13",
 ]
 
 [[package]]


### PR DESCRIPTION
Looks like https://github.com/oxidecomputer/omicron/pull/2774 bumped syn but missed one introduced by https://github.com/oxidecomputer/omicron/pull/2734.