### PR TITLE
[mgs] Add /local/switch-id endpoint

### DIFF
--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -1382,12 +1382,14 @@ async fn recovery_host_phase2_upload(
 ///
 /// Note that most MGS endpoints behave identically regardless of which scrimlet
 /// the MGS instance is running on; this one, however, is intentionally
-/// different.
+/// different. This endpoint is _probably_ only useful for clients communicating
+/// with MGS over localhost (i.e., other services in the switch zone) who need
+/// to know which sidecar they are connected to.
 #[endpoint {
     method = GET,
     path = "/local/switch-id",
 }]
-async fn sp_local(
+async fn sp_local_switch_id(
     rqctx: RequestContext<Arc<ServerContext>>,
 ) -> Result<HttpResponseOk<SpIdentifier>, HttpError> {
     let apictx = rqctx.context();
@@ -1441,7 +1443,7 @@ pub fn api() -> GatewayApiDescription {
         api.register(ignition_get)?;
         api.register(ignition_command)?;
         api.register(recovery_host_phase2_upload)?;
-        api.register(sp_local)?;
+        api.register(sp_local_switch_id)?;
         Ok(())
     }
 

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -1378,6 +1378,25 @@ async fn recovery_host_phase2_upload(
     Ok(HttpResponseOk(HostPhase2RecoveryImageId { sha256_hash }))
 }
 
+/// Get the identifier for the switch this MGS instance is connected to.
+///
+/// Note that most MGS endpoints behave identically regardless of which scrimlet
+/// the MGS instance is running on; this one, however, is intentionally
+/// different.
+#[endpoint {
+    method = GET,
+    path = "/local/switch-id",
+}]
+async fn sp_local(
+    rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<HttpResponseOk<SpIdentifier>, HttpError> {
+    let apictx = rqctx.context();
+
+    let id = apictx.mgmt_switch.local_switch()?;
+
+    Ok(HttpResponseOk(id.into()))
+}
+
 // TODO
 // The gateway service will get asynchronous notifications both from directly
 // SPs over the management network and indirectly from Ignition via the Sidecar
@@ -1422,6 +1441,7 @@ pub fn api() -> GatewayApiDescription {
         api.register(ignition_get)?;
         api.register(ignition_command)?;
         api.register(recovery_host_phase2_upload)?;
+        api.register(sp_local)?;
         Ok(())
     }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -21,6 +21,7 @@ use gateway_sp_comms::InMemoryHostPhase2Provider;
 pub use management_switch::LocationConfig;
 pub use management_switch::LocationDeterminationConfig;
 pub use management_switch::ManagementSwitch;
+pub use management_switch::SpIdentifier;
 pub use management_switch::SpType;
 pub use management_switch::SwitchPortConfig;
 pub use management_switch::SwitchPortDescription;

--- a/gateway/src/management_switch.rs
+++ b/gateway/src/management_switch.rs
@@ -284,12 +284,10 @@ impl ManagementSwitch {
             .map_err(|s| SpCommsError::DiscoveryFailed { reason: s.clone() })
     }
 
-    /// Get the name of our location.
-    ///
-    /// This matches one of the names specified as a possible location in the
-    /// configuration we were given.
-    pub fn location_name(&self) -> Result<&str, SpCommsError> {
-        self.location_map().map(|m| m.location_name())
+    /// Get the identifier of our local switch.
+    pub fn local_switch(&self) -> Result<SpIdentifier, SpCommsError> {
+        let location_map = self.location_map()?;
+        Ok(location_map.port_to_id(self.local_ignition_controller_port))
     }
 
     /// Get the handle for communicating with an SP by its switch port.

--- a/gateway/src/management_switch/location_map.rs
+++ b/gateway/src/management_switch/location_map.rs
@@ -98,7 +98,6 @@ pub struct LocationDeterminationConfig {
 
 #[derive(Debug)]
 pub(super) struct LocationMap {
-    location_name: String,
     port_to_id: HashMap<SwitchPort, SpIdentifier>,
     id_to_port: HashMap<SpIdentifier, SwitchPort>,
 }
@@ -152,15 +151,7 @@ impl LocationMap {
             id_to_port.insert(id, port);
         }
 
-        Ok(Self { location_name: location, port_to_id, id_to_port })
-    }
-
-    /// Get the name of our location.
-    ///
-    /// This matches one of the names specified as a possible location in the
-    /// configuration we were given.
-    pub(super) fn location_name(&self) -> &str {
-        &self.location_name
+        Ok(Self { port_to_id, id_to_port })
     }
 
     /// Get the ID of a given port.

--- a/gateway/tests/integration_tests/location_discovery.rs
+++ b/gateway/tests/integration_tests/location_discovery.rs
@@ -9,6 +9,8 @@ use gateway_messages::SpPort;
 use gateway_test_utils::setup;
 use omicron_gateway::http_entrypoints::SpInfo;
 use omicron_gateway::http_entrypoints::SpState;
+use omicron_gateway::http_entrypoints::SpType;
+use omicron_gateway::SpIdentifier;
 
 #[tokio::test]
 async fn discovery_both_locations() {
@@ -23,12 +25,12 @@ async fn discovery_both_locations() {
     // the two instances should've discovered that they were switch0 and
     // switch1, respectively
     assert_eq!(
-        testctx0.server.management_switch().location_name().unwrap(),
-        "switch0"
+        testctx0.server.management_switch().local_switch().unwrap(),
+        SpIdentifier { typ: SpType::Switch.into(), slot: 0 },
     );
     assert_eq!(
-        testctx1.server.management_switch().location_name().unwrap(),
-        "switch1"
+        testctx1.server.management_switch().local_switch().unwrap(),
+        SpIdentifier { typ: SpType::Switch.into(), slot: 1 },
     );
 
     // both instances should report the same serial number for switch 0 and

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -134,8 +134,8 @@
     "/local/switch-id": {
       "get": {
         "summary": "Get the identifier for the switch this MGS instance is connected to.",
-        "description": "Note that most MGS endpoints behave identically regardless of which scrimlet the MGS instance is running on; this one, however, is intentionally different.",
-        "operationId": "sp_local",
+        "description": "Note that most MGS endpoints behave identically regardless of which scrimlet the MGS instance is running on; this one, however, is intentionally different. This endpoint is _probably_ only useful for clients communicating with MGS over localhost (i.e., other services in the switch zone) who need to know which sidecar they are connected to.",
+        "operationId": "sp_local_switch_id",
         "responses": {
           "200": {
             "description": "successful operation",

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -131,6 +131,31 @@
         }
       }
     },
+    "/local/switch-id": {
+      "get": {
+        "summary": "Get the identifier for the switch this MGS instance is connected to.",
+        "description": "Note that most MGS endpoints behave identically regardless of which scrimlet the MGS instance is running on; this one, however, is intentionally different.",
+        "operationId": "sp_local",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpIdentifier"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/recovery/host-phase2": {
       "post": {
         "summary": "Upload a host phase2 image that can be served to recovering hosts via the",


### PR DESCRIPTION
This adds a `/local/switch-id` endpoint, which will return either

```json
{"type":"switch","slot":0}
```

or

```json
{"type":"switch","slot":1}
```

identifying the physical location of the switch this MGS instance is connected to. Additional details about the switch's SP (serial number, etc.) can then be fetched using the existing endpoints (e.g., `/sp/switch/0` or `/sp/switch/1`).

Note that like all other MGS endpoints, this requires MGS's location discovery process (RFD 250) to have completed; on "human scale" this is usually quite fast, but if dendrite is using this early in switch zone bringup it may be able to ask MGS before MGS knows an answer (in which case it will get back an error response and will need to retry).