### PR TITLE
[update-engine] simplify event annotations

### DIFF
--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -26,9 +26,7 @@ pub enum Event<S: StepSpec> {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case")]
+#[serde(bound = "", rename_all = "snake_case")]
 pub struct StepEvent<S: StepSpec> {
     /// Total time elapsed since the start of execution.
     pub total_elapsed: Duration,
@@ -40,9 +38,7 @@ pub struct StepEvent<S: StepSpec> {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case", tag = "kind")]
+#[serde(bound = "", rename_all = "snake_case", tag = "kind")]
 pub enum StepEventKind<S: StepSpec> {
     /// No steps were defined, and the executor exited without doing anything.
     ///
@@ -222,9 +218,7 @@ pub enum StepEventPriority {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case", tag = "kind")]
+#[serde(bound = "", rename_all = "snake_case", tag = "kind")]
 pub enum StepOutcome<S: StepSpec> {
     /// The step completed successfully.
     Success {
@@ -253,9 +247,7 @@ pub enum StepOutcome<S: StepSpec> {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case")]
+#[serde(bound = "", rename_all = "snake_case")]
 pub struct ProgressEvent<S: StepSpec> {
     /// Total time elapsed since the start of execution.
     pub total_elapsed: Duration,
@@ -267,9 +259,7 @@ pub struct ProgressEvent<S: StepSpec> {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case", tag = "kind")]
+#[serde(bound = "", rename_all = "snake_case", tag = "kind")]
 pub enum ProgressEventKind<S: StepSpec> {
     Progress {
         /// Information about the step.
@@ -300,9 +290,7 @@ pub enum ProgressEventKind<S: StepSpec> {
 /// Serializable information about a step.
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case")]
+#[serde(bound = "", rename_all = "snake_case")]
 pub struct StepInfo<S: StepSpec> {
     /// An identifier for this step.
     pub id: S::StepId,
@@ -332,9 +320,7 @@ impl<S: StepSpec> StepInfo<S> {
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case")]
+#[serde(bound = "", rename_all = "snake_case")]
 pub struct StepComponentSummary<S: StepSpec> {
     /// The component.
     pub component: S::Component,
@@ -346,9 +332,7 @@ pub struct StepComponentSummary<S: StepSpec> {
 /// Serializable information about a step.
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
-#[serde(bound = "")]
-#[schemars(bound = "")]
-#[serde(rename_all = "snake_case")]
+#[serde(bound = "", rename_all = "snake_case")]
 pub struct StepInfoWithMetadata<S: StepSpec> {
     /// Information about this step.
     pub info: StepInfo<S>,


### PR DESCRIPTION
schemars inherits serde attributes so `#[schemars(bound = "")]` isn't
necessary. (Thanks to @ahl for pointing this out!)
