### PR TITLE
Nexus services ought to include ports

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -108,13 +108,16 @@ CREATE INDEX ON omicron.public.sled (
  */
 
 CREATE TYPE omicron.public.service_kind AS ENUM (
+  'crucible_pantry',
+  'dendrite',
+  'external_dns_config',
+  'external_dns',
+  'internal_dns_config',
   'internal_dns',
   'nexus',
+  'ntp',
   'oximeter',
-  'dendrite',
-  'tfport',
-  'crucible_pantry',
-  'ntp'
+  'tfport'
 );
 
 CREATE TABLE omicron.public.service (
@@ -127,13 +130,21 @@ CREATE TABLE omicron.public.service (
     sled_id UUID NOT NULL,
     /* The IP address of the service. */
     ip INET NOT NULL,
+    /* The UDP or TCP port on which the service listens. */
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
     /* Indicates the type of service. */
     kind omicron.public.service_kind NOT NULL
 );
 
 /* Add an index which lets us look up the services on a sled */
 CREATE INDEX ON omicron.public.service (
-    sled_id
+    sled_id,
+    id
+);
+
+CREATE INDEX ON omicron.public.service (
+    kind,
+    id
 );
 
 -- Extended information for services where "service.kind = nexus"

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -437,6 +437,7 @@ table! {
 
         sled_id -> Uuid,
         ip -> Inet,
+        port -> Int4,
         kind -> crate::ServiceKindEnum,
     }
 }

--- a/nexus/db-model/src/service.rs
+++ b/nexus/db-model/src/service.rs
@@ -5,8 +5,9 @@
 use super::ServiceKind;
 use crate::ipv6;
 use crate::schema::service;
+use crate::SqlU16;
 use db_macros::Asset;
-use std::net::Ipv6Addr;
+use std::net::SocketAddrV6;
 use uuid::Uuid;
 
 /// Representation of services which may run on Sleds.
@@ -18,6 +19,7 @@ pub struct Service {
 
     pub sled_id: Uuid,
     pub ip: ipv6::Ipv6Addr,
+    pub port: SqlU16,
     pub kind: ServiceKind,
 }
 
@@ -25,13 +27,14 @@ impl Service {
     pub fn new(
         id: Uuid,
         sled_id: Uuid,
-        addr: Ipv6Addr,
+        addr: SocketAddrV6,
         kind: ServiceKind,
     ) -> Self {
         Self {
             identity: ServiceIdentity::new(id),
             sled_id,
-            ip: addr.into(),
+            ip: addr.ip().into(),
+            port: addr.port().into(),
             kind,
         }
     }

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -17,12 +17,15 @@ impl_enum_type!(
     pub enum ServiceKind;
 
     // Enum values
+    CruciblePantry => b"crucible_pantry"
+    Dendrite => b"dendrite"
+    ExternalDNS => b"external_dns"
+    ExternalDNSConfig => b"external_dns_config"
     InternalDNS => b"internal_dns"
+    InternalDNSConfig => b"internal_dns_config"
     Nexus => b"nexus"
     Oximeter => b"oximeter"
-    Dendrite => b"dendrite"
     Tfport => b"tfport"
-    CruciblePantry => b"crucible_pantry"
     NTP => b"ntp"
 );
 
@@ -49,6 +52,9 @@ impl From<internal_api::params::ServiceKind> for ServiceKind {
         match k {
             internal_api::params::ServiceKind::InternalDNS => {
                 ServiceKind::InternalDNS
+            }
+            internal_api::params::ServiceKind::InternalDNSConfig => {
+                ServiceKind::InternalDNSConfig
             }
             internal_api::params::ServiceKind::Nexus { .. } => {
                 ServiceKind::Nexus

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -1041,7 +1041,7 @@ mod test {
 
         // Create a new service to exist on this sled.
         let service_id = Uuid::new_v4();
-        let addr = Ipv6Addr::LOCALHOST;
+        let addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0);
         let kind = ServiceKind::Nexus;
 
         let service = Service::new(service_id, sled_id, addr, kind);

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -589,7 +589,7 @@ mod test {
         let services = vec![internal_params::ServicePutRequest {
             service_id: Uuid::new_v4(),
             sled_id: sled.id(),
-            address: Ipv6Addr::LOCALHOST,
+            address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0),
             kind: internal_params::ServiceKind::Nexus {
                 external_address: nexus_ip,
             },
@@ -625,6 +625,8 @@ mod test {
         assert_eq!(observed_services.len(), 1);
         assert_eq!(observed_services[0].sled_id, sled.id());
         assert_eq!(observed_services[0].kind, ServiceKind::Nexus);
+        assert_eq!(*observed_services[0].ip, Ipv6Addr::LOCALHOST);
+        assert_eq!(*observed_services[0].port, 123);
 
         // It should have a corresponding "Nexus service record"
         assert_eq!(observed_nexus_services.len(), 1);
@@ -682,7 +684,7 @@ mod test {
             internal_params::ServicePutRequest {
                 service_id: Uuid::new_v4(),
                 sled_id: sled.id(),
-                address: Ipv6Addr::LOCALHOST,
+                address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0),
                 kind: internal_params::ServiceKind::Nexus {
                     external_address: IpAddr::V4(nexus_ip_start),
                 },
@@ -690,7 +692,7 @@ mod test {
             internal_params::ServicePutRequest {
                 service_id: Uuid::new_v4(),
                 sled_id: sled.id(),
-                address: Ipv6Addr::LOCALHOST,
+                address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 456, 0, 0),
                 kind: internal_params::ServiceKind::Nexus {
                     external_address: IpAddr::V4(nexus_ip_end),
                 },
@@ -759,6 +761,10 @@ mod test {
         assert_eq!(observed_services[1].sled_id, sled.id());
         assert_eq!(observed_services[0].kind, ServiceKind::Nexus);
         assert_eq!(observed_services[1].kind, ServiceKind::Nexus);
+        assert_eq!(*observed_services[0].ip, Ipv6Addr::LOCALHOST);
+        assert_eq!(*observed_services[1].ip, Ipv6Addr::LOCALHOST);
+        assert_eq!(*observed_services[0].port, 123);
+        assert_eq!(*observed_services[1].port, 456);
 
         // It should have a corresponding "Nexus service record"
         assert_eq!(observed_nexus_services.len(), 2);
@@ -863,7 +869,7 @@ mod test {
         let services = vec![internal_params::ServicePutRequest {
             service_id: Uuid::new_v4(),
             sled_id: sled.id(),
-            address: Ipv6Addr::LOCALHOST,
+            address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0),
             kind: internal_params::ServiceKind::Nexus {
                 external_address: nexus_ip,
             },
@@ -918,7 +924,7 @@ mod test {
             internal_params::ServicePutRequest {
                 service_id: Uuid::new_v4(),
                 sled_id: sled.id(),
-                address: Ipv6Addr::LOCALHOST,
+                address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0),
                 kind: internal_params::ServiceKind::Nexus {
                     external_address: nexus_ip,
                 },
@@ -926,7 +932,7 @@ mod test {
             internal_params::ServicePutRequest {
                 service_id: Uuid::new_v4(),
                 sled_id: sled.id(),
-                address: Ipv6Addr::LOCALHOST,
+                address: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0),
                 kind: internal_params::ServiceKind::Nexus {
                     external_address: nexus_ip,
                 },

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -21,7 +21,7 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use sled_agent_client::types::SetVirtualNetworkInterfaceHost;
 use sled_agent_client::Client as SledAgentClient;
-use std::net::{Ipv6Addr, SocketAddrV6};
+use std::net::SocketAddrV6;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -225,7 +225,7 @@ impl super::Nexus {
         opctx: &OpContext,
         id: Uuid,
         sled_id: Uuid,
-        address: Ipv6Addr,
+        address: SocketAddrV6,
         kind: ServiceKind,
     ) -> Result<(), Error> {
         info!(

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -69,3 +69,13 @@ url = "postgresql://root@127.0.0.1:0/omicron?sslmode=disable"
 # Dendrite (dataplane daemon) API configuration
 [dendrite]
 address = "[::1]:12224"
+
+[background_tasks]
+dns_internal.period_secs_config = 60
+dns_internal.period_secs_servers = 60
+dns_internal.period_secs_propagation = 60
+dns_internal.max_concurrent_server_updates = 5
+dns_external.period_secs_config = 60
+dns_external.period_secs_servers = 60
+dns_external.period_secs_propagation = 60
+dns_external.max_concurrent_server_updates = 5

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -10,7 +10,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::IpAddr;
-use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 use std::str::FromStr;
@@ -158,6 +157,7 @@ pub struct DatasetPutRequest {
 #[serde(rename_all = "snake_case", tag = "type", content = "content")]
 pub enum ServiceKind {
     InternalDNS,
+    InternalDNSConfig,
     Nexus {
         // TODO(https://github.com/oxidecomputer/omicron/issues/1530):
         // While it's true that Nexus will only run with a single address,
@@ -176,6 +176,7 @@ impl fmt::Display for ServiceKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ServiceKind::*;
         let s = match self {
+            InternalDNSConfig => "internal_dns_config",
             InternalDNS => "internal_dns",
             Nexus { .. } => "nexus",
             Oximeter => "oximeter",
@@ -195,7 +196,7 @@ pub struct ServicePutRequest {
     pub sled_id: Uuid,
 
     /// Address on which a service is responding to requests.
-    pub address: Ipv6Addr,
+    pub address: SocketAddrV6,
 
     /// Type of service being inserted.
     pub kind: ServiceKind,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2266,6 +2266,20 @@
           {
             "type": "object",
             "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_d_n_s_config"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
               "content": {
                 "type": "object",
                 "properties": {
@@ -2368,8 +2382,7 @@
         "properties": {
           "address": {
             "description": "Address on which a service is responding to requests.",
-            "type": "string",
-            "format": "ipv6"
+            "type": "string"
           },
           "kind": {
             "description": "Type of service being inserted.",

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -74,7 +74,10 @@ use internal_dns::ServiceName;
 use nexus_client::{
     types as NexusTypes, Client as NexusClient, Error as NexusError,
 };
-use omicron_common::address::{get_sled_address, NEXUS_INTERNAL_PORT};
+use omicron_common::address::{
+    get_sled_address, CRUCIBLE_PANTRY_PORT, NEXUS_INTERNAL_PORT, NTP_PORT,
+    OXIMETER_PORT,
+};
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
 };
@@ -620,7 +623,23 @@ impl ServiceInner {
 
             for zone in &service_request.services {
                 for svc in &zone.services {
-                    let kind = match svc {
+                    // TODO-cleanup Here, we take the ServiceZoneRequests that
+                    // were constructed with the ServicePlan and turn them into
+                    // Nexus ServicePutRequest objects.  For Nexus, we need to
+                    // specify a SocketAddr -- both an IP address and a port on
+                    // which the service is listening.  The code here hardcodes
+                    // the default ports for each service.  This happens to be
+                    // correct because the ServicePlan uses the same hardcoded
+                    // ports when it sets up the DNS zone and the Sled Agent
+                    // uses the same hardcoded ports when configuring each of
+                    // these services.  It would be more robust to pick the
+                    // (hardcoded) port when constructing the ServicePlan and
+                    // plumb the SocketAddr (with port) everywhere that needs it
+                    // (including both here and DNS).  That way we don't bake
+                    // the port assumption into multiple places and we can also
+                    // more easily support things running on different ports
+                    // (which is useful in dev/test situations).
+                    match svc {
                         ServiceType::Nexus { external_ip, internal_ip: _ } => {
                             // NOTE: Eventually, this IP pool will be entirely
                             // user-supplied. For now, however, it's inferred
@@ -641,35 +660,88 @@ impl ServiceInner {
                             };
                             internal_services_ip_pool_ranges.push(range);
 
-                            NexusTypes::ServiceKind::Nexus {
-                                external_address: *external_ip,
-                            }
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: SocketAddrV6::new(
+                                    zone.addresses[0],
+                                    NEXUS_INTERNAL_PORT,
+                                    0,
+                                    0,
+                                )
+                                .to_string(),
+                                kind: NexusTypes::ServiceKind::Nexus {
+                                    external_address: *external_ip,
+                                },
+                            });
                         }
-                        ServiceType::InternalDns { .. } => {
-                            NexusTypes::ServiceKind::InternalDNS
+                        ServiceType::InternalDns {
+                            server_address,
+                            dns_address,
+                        } => {
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: server_address.to_string(),
+                                kind:
+                                    NexusTypes::ServiceKind::InternalDNSConfig,
+                            });
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: dns_address.to_string(),
+                                kind: NexusTypes::ServiceKind::InternalDNS,
+                            });
                         }
                         ServiceType::Oximeter => {
-                            NexusTypes::ServiceKind::Oximeter
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: SocketAddrV6::new(
+                                    zone.addresses[0],
+                                    OXIMETER_PORT,
+                                    0,
+                                    0,
+                                )
+                                .to_string(),
+                                kind: NexusTypes::ServiceKind::Oximeter,
+                            });
                         }
                         ServiceType::CruciblePantry => {
-                            NexusTypes::ServiceKind::CruciblePantry
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: SocketAddrV6::new(
+                                    zone.addresses[0],
+                                    CRUCIBLE_PANTRY_PORT,
+                                    0,
+                                    0,
+                                )
+                                .to_string(),
+                                kind: NexusTypes::ServiceKind::CruciblePantry,
+                            });
                         }
-                        ServiceType::Ntp { .. } => NexusTypes::ServiceKind::NTP,
+                        ServiceType::Ntp { .. } => {
+                            services.push(NexusTypes::ServicePutRequest {
+                                service_id: zone.id,
+                                sled_id,
+                                address: SocketAddrV6::new(
+                                    zone.addresses[0],
+                                    NTP_PORT,
+                                    0,
+                                    0,
+                                )
+                                .to_string(),
+                                kind: NexusTypes::ServiceKind::NTP,
+                            });
+                        }
                         _ => {
                             return Err(SetupServiceError::BadConfig(format!(
                                 "RSS should not request service of type: {}",
                                 svc
                             )));
                         }
-                    };
-
-                    services.push(NexusTypes::ServicePutRequest {
-                        service_id: zone.id,
-                        sled_id,
-                        // TODO: Should this be a vec, or a single value?
-                        address: zone.addresses[0],
-                        kind,
-                    })
+                    }
                 }
             }
 

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -20,6 +20,7 @@ use omicron_common::backoff::{
 use slog::{info, Drain, Logger};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use uuid::Uuid;
 
 /// Packages up a [`SledAgent`], running the sled agent API under a Dropshot
 /// server wired up to the sled agent
@@ -216,8 +217,33 @@ impl Server {
             .context("initializing DNS")
             .map_err(|e| e.to_string())?;
 
+        // Record the internal DNS server as though RSS had provisioned it so
+        // that Nexus knows about it.
+        let dns_bound = match dns_server.local_address() {
+            SocketAddr::V4(_) => panic!("did not expect v4 address"),
+            SocketAddr::V6(a) => *a,
+        };
+        let http_bound = match dns_dropshot_server.local_addr() {
+            SocketAddr::V4(_) => panic!("did not expect v4 address"),
+            SocketAddr::V6(a) => a,
+        };
+        let services = vec![
+            NexusTypes::ServicePutRequest {
+                address: dns_bound.to_string(),
+                kind: NexusTypes::ServiceKind::InternalDNS,
+                service_id: Uuid::new_v4(),
+                sled_id: config.id,
+            },
+            NexusTypes::ServicePutRequest {
+                address: http_bound.to_string(),
+                kind: NexusTypes::ServiceKind::InternalDNSConfig,
+                service_id: Uuid::new_v4(),
+                sled_id: config.id,
+            },
+        ];
+
         let rack_init_request = NexusTypes::RackInitializationRequest {
-            services: vec![],
+            services,
             datasets,
             internal_services_ip_pool_ranges: vec![],
             certs: vec![],


### PR DESCRIPTION
After [discussing with @smklein])(https://github.com/oxidecomputer/omicron/pull/2753#issuecomment-1495142734), "services" in Omicron correspond with the traditional idea of network services -- things available over the network via TCP or UDP and typically discovered by DNS.  This change updates the Nexus internal API to expect that and updates Sled Agent to provide it.

This also means that _each_ of the current DNS services (InternalDNS and ExternalDNS) are really two different services: one DNS-protocol service on UDP port 53, and one HTTP-protocol service for configuring the server.  So I split up InternalDNS and ExternalDNS into two separate services (each).  This is still kind of an intermediate state because we're not reporting all of these to Nexus yet.  But I wanted to split this PR out from #2753 and I think this is pretty logically consistent as-is.