### PR TITLE
Explicitly configure services IP pool as part of RSS

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -7,11 +7,11 @@
 //! This addressing functionality is shared by both initialization services
 //! and Nexus, who need to agree upon addressing schemes.
 
-use crate::api::external::Ipv6Net;
+use crate::api::external::{self, Error, Ipv6Net};
 use ipnetwork::Ipv6Network;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::net::{Ipv6Addr, SocketAddrV6};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
 
 pub const AZ_PREFIX: u8 = 48;
 pub const RACK_PREFIX: u8 = 56;
@@ -177,6 +177,187 @@ pub fn get_64_subnet(
     Ipv6Subnet::<SLED_PREFIX>::new(Ipv6Addr::from(rack_network))
 }
 
+/// An IP Range is a contiguous range of IP addresses, usually within an IP
+/// Pool.
+///
+/// The first address in the range is guaranteed to be no greater than the last
+/// address.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum IpRange {
+    V4(Ipv4Range),
+    V6(Ipv6Range),
+}
+
+// NOTE: We don't derive JsonSchema. That's intended so that we can use an
+// untagged enum for `IpRange`, and use this method to annotate schemars output
+// for client-generators (e.g., progenitor) to use in generating a better
+// client.
+impl JsonSchema for IpRange {
+    fn schema_name() -> String {
+        "IpRange".to_string()
+    }
+
+    fn json_schema(
+        gen: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        schemars::schema::SchemaObject {
+            subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
+                one_of: Some(vec![
+                    external::label_schema(
+                        "v4",
+                        gen.subschema_for::<Ipv4Range>(),
+                    ),
+                    external::label_schema(
+                        "v6",
+                        gen.subschema_for::<Ipv6Range>(),
+                    ),
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl IpRange {
+    pub fn first_address(&self) -> IpAddr {
+        match self {
+            IpRange::V4(inner) => IpAddr::from(inner.first),
+            IpRange::V6(inner) => IpAddr::from(inner.first),
+        }
+    }
+
+    pub fn last_address(&self) -> IpAddr {
+        match self {
+            IpRange::V4(inner) => IpAddr::from(inner.last),
+            IpRange::V6(inner) => IpAddr::from(inner.last),
+        }
+    }
+}
+
+impl From<IpAddr> for IpRange {
+    fn from(addr: IpAddr) -> Self {
+        match addr {
+            IpAddr::V4(addr) => IpRange::V4(Ipv4Range::from(addr)),
+            IpAddr::V6(addr) => IpRange::V6(Ipv6Range::from(addr)),
+        }
+    }
+}
+
+impl TryFrom<(Ipv4Addr, Ipv4Addr)> for IpRange {
+    type Error = String;
+
+    fn try_from(pair: (Ipv4Addr, Ipv4Addr)) -> Result<Self, Self::Error> {
+        Ipv4Range::new(pair.0, pair.1).map(IpRange::V4)
+    }
+}
+
+impl TryFrom<(Ipv6Addr, Ipv6Addr)> for IpRange {
+    type Error = String;
+
+    fn try_from(pair: (Ipv6Addr, Ipv6Addr)) -> Result<Self, Self::Error> {
+        Ipv6Range::new(pair.0, pair.1).map(IpRange::V6)
+    }
+}
+
+/// A non-decreasing IPv4 address range, inclusive of both ends.
+///
+/// The first address must be less than or equal to the last address.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(try_from = "AnyIpv4Range")]
+pub struct Ipv4Range {
+    first: Ipv4Addr,
+    last: Ipv4Addr,
+}
+
+impl Ipv4Range {
+    pub fn new(first: Ipv4Addr, last: Ipv4Addr) -> Result<Self, String> {
+        if first <= last {
+            Ok(Self { first, last })
+        } else {
+            Err(String::from("IP address ranges must be non-decreasing"))
+        }
+    }
+
+    pub fn first_address(&self) -> Ipv4Addr {
+        self.first
+    }
+
+    pub fn last_address(&self) -> Ipv4Addr {
+        self.last
+    }
+}
+
+impl From<Ipv4Addr> for Ipv4Range {
+    fn from(addr: Ipv4Addr) -> Self {
+        Self { first: addr, last: addr }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct AnyIpv4Range {
+    first: Ipv4Addr,
+    last: Ipv4Addr,
+}
+
+impl TryFrom<AnyIpv4Range> for Ipv4Range {
+    type Error = Error;
+    fn try_from(r: AnyIpv4Range) -> Result<Self, Self::Error> {
+        Ipv4Range::new(r.first, r.last)
+            .map_err(|msg| Error::invalid_request(msg.as_str()))
+    }
+}
+
+/// A non-decreasing IPv6 address range, inclusive of both ends.
+///
+/// The first address must be less than or equal to the last address.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(try_from = "AnyIpv6Range")]
+pub struct Ipv6Range {
+    first: Ipv6Addr,
+    last: Ipv6Addr,
+}
+
+impl Ipv6Range {
+    pub fn new(first: Ipv6Addr, last: Ipv6Addr) -> Result<Self, String> {
+        if first <= last {
+            Ok(Self { first, last })
+        } else {
+            Err(String::from("IP address ranges must be non-decreasing"))
+        }
+    }
+
+    pub fn first_address(&self) -> Ipv6Addr {
+        self.first
+    }
+
+    pub fn last_address(&self) -> Ipv6Addr {
+        self.last
+    }
+}
+
+impl From<Ipv6Addr> for Ipv6Range {
+    fn from(addr: Ipv6Addr) -> Self {
+        Self { first: addr, last: addr }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct AnyIpv6Range {
+    first: Ipv6Addr,
+    last: Ipv6Addr,
+}
+
+impl TryFrom<AnyIpv6Range> for Ipv6Range {
+    type Error = Error;
+    fn try_from(r: AnyIpv6Range) -> Result<Self, Self::Error> {
+        Ipv6Range::new(r.first, r.last)
+            .map_err(|msg| Error::invalid_request(msg.as_str()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -227,5 +408,63 @@ mod test {
             "[fd00:1122:3344:0308::1]:12345".parse::<SocketAddrV6>().unwrap(),
             get_sled_address(subnet)
         );
+    }
+
+    #[test]
+    fn test_ip_range_checks_non_decreasing() {
+        let lo = Ipv4Addr::new(10, 0, 0, 1);
+        let hi = Ipv4Addr::new(10, 0, 0, 3);
+        assert!(Ipv4Range::new(lo, hi).is_ok());
+        assert!(Ipv4Range::new(lo, lo).is_ok());
+        assert!(Ipv4Range::new(hi, lo).is_err());
+
+        let lo = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1);
+        let hi = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 3);
+        assert!(Ipv6Range::new(lo, hi).is_ok());
+        assert!(Ipv6Range::new(lo, lo).is_ok());
+        assert!(Ipv6Range::new(hi, lo).is_err());
+    }
+
+    #[test]
+    fn test_ip_range_enum_deserialization() {
+        let data = r#"{"first": "10.0.0.1", "last": "10.0.0.3"}"#;
+        let expected = IpRange::V4(
+            Ipv4Range::new(
+                Ipv4Addr::new(10, 0, 0, 1),
+                Ipv4Addr::new(10, 0, 0, 3),
+            )
+            .unwrap(),
+        );
+        assert_eq!(expected, serde_json::from_str(data).unwrap());
+
+        let data = r#"{"first": "fd00::", "last": "fd00::3"}"#;
+        let expected = IpRange::V6(
+            Ipv6Range::new(
+                Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0),
+                Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 3),
+            )
+            .unwrap(),
+        );
+        assert_eq!(expected, serde_json::from_str(data).unwrap());
+
+        let data = r#"{"first": "fd00::3", "last": "fd00::"}"#;
+        assert!(
+            serde_json::from_str::<IpRange>(data).is_err(),
+            "Expected an error deserializing an IP range with first address \
+            greater than last address",
+        );
+    }
+
+    #[test]
+    fn test_ip_range_try_from() {
+        let lo = Ipv4Addr::new(10, 0, 0, 1);
+        let hi = Ipv4Addr::new(10, 0, 0, 3);
+        assert!(IpRange::try_from((lo, hi)).is_ok());
+        assert!(IpRange::try_from((hi, lo)).is_err());
+
+        let lo = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1);
+        let hi = Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 3);
+        assert!(IpRange::try_from((lo, hi)).is_ok());
+        assert!(IpRange::try_from((hi, lo)).is_err());
     }
 }

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -275,8 +275,8 @@ impl TryFrom<(Ipv6Addr, Ipv6Addr)> for IpRange {
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(try_from = "AnyIpv4Range")]
 pub struct Ipv4Range {
-    first: Ipv4Addr,
-    last: Ipv4Addr,
+    pub first: Ipv4Addr,
+    pub last: Ipv4Addr,
 }
 
 impl Ipv4Range {
@@ -327,8 +327,8 @@ impl TryFrom<AnyIpv4Range> for Ipv4Range {
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(try_from = "AnyIpv6Range")]
 pub struct Ipv6Range {
-    first: Ipv6Addr,
-    last: Ipv6Addr,
+    pub first: Ipv6Addr,
+    pub last: Ipv6Addr,
 }
 
 impl Ipv6Range {

--- a/end-to-end-tests/src/helpers/ctx.rs
+++ b/end-to-end-tests/src/helpers/ctx.rs
@@ -84,12 +84,20 @@ pub fn nexus_addr() -> SocketAddr {
         return host;
     }
 
-    // If we can find config-rss.toml, look for an external_address.
+    // If we can find config-rss.toml, grab the first address from the
+    // configured services IP pool.
     let rss_config_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../smf/sled-agent/non-gimlet/config-rss.toml");
     if rss_config_path.exists() {
         if let Ok(config) = SetupServiceConfig::from_file(rss_config_path) {
-            return (config.nexus_external_address, 80).into();
+            if let Some(addr) = config
+                .internal_services_ip_pool_ranges
+                .iter()
+                .flat_map(|range| range.iter())
+                .next()
+            {
+                return (addr, 80).into();
+            }
         }
     }
 

--- a/nexus-client/src/lib.rs
+++ b/nexus-client/src/lib.rs
@@ -224,3 +224,25 @@ impl From<std::time::Duration> for types::Duration {
         Self { secs: s.as_secs(), nanos: s.subsec_nanos() }
     }
 }
+
+impl From<omicron_common::address::IpRange> for types::IpRange {
+    fn from(r: omicron_common::address::IpRange) -> Self {
+        use omicron_common::address::IpRange;
+        match r {
+            IpRange::V4(r) => types::IpRange::V4(r.into()),
+            IpRange::V6(r) => types::IpRange::V6(r.into()),
+        }
+    }
+}
+
+impl From<omicron_common::address::Ipv4Range> for types::Ipv4Range {
+    fn from(r: omicron_common::address::Ipv4Range) -> Self {
+        Self { first: r.first, last: r.last }
+    }
+}
+
+impl From<omicron_common::address::Ipv6Range> for types::Ipv6Range {
+    fn from(r: omicron_common::address::Ipv6Range) -> Self {
+        Self { first: r.first, last: r.last }
+    }
+}

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -158,13 +158,7 @@ pub struct DatasetPutRequest {
 pub enum ServiceKind {
     InternalDNS,
     InternalDNSConfig,
-    Nexus {
-        // TODO(https://github.com/oxidecomputer/omicron/issues/1530):
-        // While it's true that Nexus will only run with a single address,
-        // we want to convey information about the available pool of addresses
-        // when handing off from RSS -> Nexus.
-        external_address: IpAddr,
-    },
+    Nexus { external_address: IpAddr },
     Oximeter,
     Dendrite,
     Tfport,

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -170,6 +170,62 @@
           "mac"
         ]
       },
+      "IpRange": {
+        "oneOf": [
+          {
+            "title": "v4",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Range"
+              }
+            ]
+          },
+          {
+            "title": "v6",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Range"
+              }
+            ]
+          }
+        ]
+      },
+      "Ipv4Range": {
+        "description": "A non-decreasing IPv4 address range, inclusive of both ends.\n\nThe first address must be less than or equal to the last address.",
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "format": "ipv4"
+          },
+          "last": {
+            "type": "string",
+            "format": "ipv4"
+          }
+        },
+        "required": [
+          "first",
+          "last"
+        ]
+      },
+      "Ipv6Range": {
+        "description": "A non-decreasing IPv6 address range, inclusive of both ends.\n\nThe first address must be less than or equal to the last address.",
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "last": {
+            "type": "string",
+            "format": "ipv6"
+          }
+        },
+        "required": [
+          "first",
+          "last"
+        ]
+      },
       "MacAddr": {
         "example": "ff:ff:ff:ff:ff:ff",
         "title": "A MAC address",
@@ -198,10 +254,12 @@
               }
             ]
           },
-          "nexus_external_address": {
-            "description": "The address on which Nexus should serve an external interface.",
-            "type": "string",
-            "format": "ip"
+          "internal_services_ip_pool_ranges": {
+            "description": "Ranges of the service IP pool which may be used for internal services.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpRange"
+            }
           },
           "ntp_servers": {
             "description": "The external NTP server addresses.",
@@ -224,7 +282,7 @@
         "required": [
           "dns_servers",
           "gateway",
-          "nexus_external_address",
+          "internal_services_ip_pool_ranges",
           "ntp_servers",
           "rack_secret_threshold",
           "rack_subnet"

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::borrow::Cow;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV6};
 use uuid::Uuid;
 
 /// Configuration for the "rack setup service".
@@ -39,10 +39,10 @@ pub struct RackInitializeRequest {
     /// The external DNS server addresses.
     pub dns_servers: Vec<String>,
 
-    /// The address on which Nexus should serve an external interface.
+    /// Ranges of the service IP pool which may be used for internal services.
     // TODO(https://github.com/oxidecomputer/omicron/issues/1530): Eventually,
-    // this should be pulled from a pool of addresses.
-    pub nexus_external_address: IpAddr,
+    // we want to configure multiple pools.
+    pub internal_services_ip_pool_ranges: Vec<address::IpRange>,
 }
 
 /// Information about the internet gateway used for externally-facing services.

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -40,7 +40,8 @@ impl SetupServiceConfig {
 mod test {
     use super::*;
     use crate::bootstrap::params::Gateway;
-    use std::net::Ipv6Addr;
+    use omicron_common::address::IpRange;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn test_subnets() {
@@ -53,7 +54,9 @@ mod test {
             },
             ntp_servers: vec![String::from("test.pool.example.com")],
             dns_servers: vec![String::from("1.1.1.1")],
-            nexus_external_address: "192.168.1.20".parse().unwrap(),
+            internal_services_ip_pool_ranges: vec![IpRange::from(IpAddr::V4(
+                Ipv4Addr::new(129, 168, 1, 20),
+            ))],
         };
 
         assert_eq!(

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -11,11 +11,16 @@ rack_subnet = "fd00:1122:3344:0100::"
 # For values less than 2, no rack secret will be generated.
 rack_secret_threshold = 1
 
-# NOTE: In the lab, use "172.20.15.226"
-nexus_external_address = "192.168.1.20"
-
 ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
+# The IP ranges configured as part of the services IP Pool.
+# e.g., Nexus will be configured to use an address from this
+# pool as its external IP.
+# NOTE: In the lab, use "172.20.15.226"
+[[internal_services_ip_pool_ranges]]
+first = "192.168.1.20"
+last = "192.168.1.20"
 
 [gateway]
 

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -17,7 +17,6 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # The IP ranges configured as part of the services IP Pool.
 # e.g., Nexus will be configured to use an address from this
 # pool as its external IP.
-# NOTE: In the lab, use "172.20.15.226"
 [[internal_services_ip_pool_ranges]]
 first = "192.168.1.20"
 last = "192.168.1.20"

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -11,11 +11,16 @@ rack_subnet = "fd00:1122:3344:0100::"
 # For values less than 2, no rack secret will be generated.
 rack_secret_threshold = 1
 
-# NOTE: In the lab, use "172.20.15.226"
-nexus_external_address = "192.168.1.20"
-
 ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
+# The IP ranges configured as part of the services IP Pool.
+# e.g., Nexus will be configured to use an address from this
+# pool as its external IP.
+# NOTE: In the lab, use "172.20.15.226"
+[[internal_services_ip_pool_ranges]]
+first = "192.168.1.20"
+last = "192.168.1.20"
 
 [gateway]
 

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -17,7 +17,6 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # The IP ranges configured as part of the services IP Pool.
 # e.g., Nexus will be configured to use an address from this
 # pool as its external IP.
-# NOTE: In the lab, use "172.20.15.226"
 [[internal_services_ip_pool_ranges]]
 first = "192.168.1.20"
 last = "192.168.1.20"


### PR DESCRIPTION
We've been populating the services IP pool with a single address (the external IP configured for Nexus) up til now. This flips that around by instead requiring a list of IP ranges be given as part of rack initialization. We can then pull addresses from there for Nexus (and any other services as needed).

Further work is still needed to support multiple IP pools and allowing services to utilize addresses across all (or some) of them.

Part of https://github.com/oxidecomputer/omicron/issues/1530.