### PR TITLE
[wicketd] Poll MGS's individual SP endpoint instead of the bulk endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8796,6 +8796,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml 0.7.3",
  "tough",
  "tufaceous",

--- a/gateway-client/src/lib.rs
+++ b/gateway-client/src/lib.rs
@@ -48,7 +48,7 @@ progenitor::generate_api!(
     }),
     derives = [schemars::JsonSchema],
     patch = {
-        SpIdentifier = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
+        SpIdentifier = { derives = [Copy, PartialEq, Hash, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         SpIgnition = { derives = [PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         SpIgnitionSystemType = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },
         SpState = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize] },

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -1399,6 +1399,26 @@ async fn sp_local_switch_id(
     Ok(HttpResponseOk(id.into()))
 }
 
+/// Get the complete list of SP identifiers this MGS instance is configured to
+/// find and communicate with.
+///
+/// Note that unlike most MGS endpoints, this endpoint does not send any
+/// communication on the management network.
+#[endpoint {
+    method = GET,
+    path = "/local/all-sp-ids",
+}]
+async fn sp_all_ids(
+    rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<HttpResponseOk<Vec<SpIdentifier>>, HttpError> {
+    let apictx = rqctx.context();
+
+    let all_ids =
+        apictx.mgmt_switch.all_sps()?.map(|(id, _)| id.into()).collect();
+
+    Ok(HttpResponseOk(all_ids))
+}
+
 // TODO
 // The gateway service will get asynchronous notifications both from directly
 // SPs over the management network and indirectly from Ignition via the Sidecar
@@ -1444,6 +1464,7 @@ pub fn api() -> GatewayApiDescription {
         api.register(ignition_command)?;
         api.register(recovery_host_phase2_upload)?;
         api.register(sp_local_switch_id)?;
+        api.register(sp_all_ids)?;
         Ok(())
     }
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -131,6 +131,35 @@
         }
       }
     },
+    "/local/all-sp-ids": {
+      "get": {
+        "summary": "Get the complete list of SP identifiers this MGS instance is configured to",
+        "description": "find and communicate with.\nNote that unlike most MGS endpoints, this endpoint does not send any communication on the management network.",
+        "operationId": "sp_all_ids",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SpIdentifier",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SpIdentifier"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/local/switch-id": {
       "get": {
         "summary": "Get the identifier for the switch this MGS instance is connected to.",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -740,13 +740,13 @@
                   "inventory": {
                     "$ref": "#/components/schemas/RackV1Inventory"
                   },
-                  "received_ago": {
+                  "mgs_last_seen": {
                     "$ref": "#/components/schemas/Duration"
                   }
                 },
                 "required": [
                   "inventory",
-                  "received_ago"
+                  "mgs_last_seen"
                 ]
               },
               "type": {
@@ -1309,20 +1309,28 @@
             "$ref": "#/components/schemas/SpIdentifier"
           },
           "ignition": {
-            "$ref": "#/components/schemas/SpIgnition"
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpIgnition"
+              }
+            ]
           },
           "rot": {
             "$ref": "#/components/schemas/RotInventory"
           },
           "state": {
-            "$ref": "#/components/schemas/SpState"
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpState"
+              }
+            ]
           }
         },
         "required": [
           "id",
-          "ignition",
-          "rot",
-          "state"
+          "rot"
         ]
       },
       "SpState": {

--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -102,8 +102,8 @@ impl Inventory {
 #[allow(unused)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Sp {
-    ignition: SpIgnition,
-    state: SpState,
+    ignition: Option<SpIgnition>,
+    state: Option<SpState>,
     caboose: Option<SpComponentCaboose>,
     components: Option<Vec<SpComponentInfo>>,
     rot: RotInventory,

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -248,11 +248,11 @@ impl WicketdManager {
                     Ok(val) => match val.into_inner().into() {
                         GetInventoryResponse::Response {
                             inventory,
-                            received_ago,
+                            mgs_last_seen,
                         } => {
                             let _ = tx.send(Event::Inventory {
                                 inventory,
-                                mgs_last_seen: received_ago,
+                                mgs_last_seen,
                             });
                         }
                         GetInventoryResponse::Unavailable => {
@@ -261,8 +261,11 @@ impl WicketdManager {
                             // ticks in the runner;
                         }
                     },
-                    Err(e) => {
-                        warn!(log, "{e}");
+                    Err(err) => {
+                        warn!(
+                            log, "Getting inventory from wicketd failed";
+                            "err" => %err,
+                        );
                     }
                 }
             }

--- a/wicketd-client/src/lib.rs
+++ b/wicketd-client/src/lib.rs
@@ -49,7 +49,7 @@ progenitor::generate_api!(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
 pub enum GetInventoryResponse {
-    Response { inventory: RackV1Inventory, received_ago: Duration },
+    Response { inventory: RackV1Inventory, mgs_last_seen: Duration },
     Unavailable,
 }
 
@@ -58,11 +58,11 @@ impl From<types::GetInventoryResponse> for GetInventoryResponse {
         match response {
             types::GetInventoryResponse::Response {
                 inventory,
-                received_ago,
+                mgs_last_seen,
             } => {
-                let received_ago =
-                    Duration::new(received_ago.secs, received_ago.nanos);
-                Self::Response { inventory, received_ago }
+                let mgs_last_seen =
+                    Duration::new(mgs_last_seen.secs, mgs_last_seen.nanos);
+                Self::Response { inventory, mgs_last_seen }
             }
             types::GetInventoryResponse::Unavailable => Self::Unavailable,
         }

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -28,6 +28,7 @@ slog-dtrace.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
+tokio-stream.workspace = true
 tough.workspace = true
 snafu.workspace = true
 toml.workspace = true

--- a/wicketd/src/inventory.rs
+++ b/wicketd/src/inventory.rs
@@ -15,25 +15,22 @@ use serde::Serialize;
 #[serde(tag = "sp_inventory", rename_all = "snake_case")]
 pub struct SpInventory {
     pub id: SpIdentifier,
-    pub ignition: SpIgnition,
-    pub state: SpState,
+    pub ignition: Option<SpIgnition>,
+    pub state: Option<SpState>,
     pub components: Option<Vec<SpComponentInfo>>,
     pub caboose: Option<SpComponentCaboose>,
     pub rot: RotInventory,
 }
+
 impl SpInventory {
-    /// The ignition info and state of the SP are retrieved initiailly
+    /// Create an empty inventory with the given id.
     ///
-    /// The components are filled in via a separate call
-    pub fn new(
-        id: SpIdentifier,
-        ignition: SpIgnition,
-        state: SpState,
-    ) -> SpInventory {
+    /// All remaining fields are populated later as MGS responds.
+    pub fn new(id: SpIdentifier) -> SpInventory {
         SpInventory {
             id,
-            ignition,
-            state,
+            ignition: None,
+            state: None,
             components: None,
             caboose: None,
             rot: RotInventory::default(),

--- a/wicketd/src/mgs.rs
+++ b/wicketd/src/mgs.rs
@@ -5,23 +5,24 @@
 //! The collection of tasks used for interacting with MGS and maintaining
 //! runtime state.
 
-use crate::inventory::RotInventory;
 use crate::{RackV1Inventory, SpInventory};
-use futures::stream::FuturesUnordered;
-use futures::{Future, StreamExt};
-use gateway_client::types::{
-    SpComponentCaboose, SpComponentInfo, SpIdentifier, SpInfo,
-};
-use gateway_messages::SpComponent;
+use futures::StreamExt;
+use gateway_client::types::{SpIdentifier, SpIgnition};
 use schemars::JsonSchema;
 use serde::Serialize;
 use slog::{info, o, warn, Logger};
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddrV6;
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::{interval, Duration, Instant, MissedTickBehavior};
+use tokio::time::{Duration, Instant};
+use tokio_stream::StreamMap;
 
-const MGS_POLL_INTERVAL: Duration = Duration::from_secs(10);
+use self::inventory::{
+    IgnitionPoller, IgnitionState, PollIgnition, PollSp, SpPoller,
+};
+
+mod inventory;
+
 const MGS_TIMEOUT: Duration = Duration::from_secs(10);
 
 // We support:
@@ -30,17 +31,13 @@ const MGS_TIMEOUT: Duration = Duration::from_secs(10);
 //   * Room for some timeouts and re-requests from wicket.
 const CHANNEL_CAPACITY: usize = 8;
 
-/// Channel errors result only from system shutdown. We have to report them to
-/// satisfy function calls, so we define an error type here.
-#[derive(Debug, PartialEq, Eq)]
-pub struct ShutdownInProgress;
-
 #[derive(Debug)]
 enum MgsRequest {
     GetInventory {
         #[allow(dead_code)]
         etag: Option<String>,
-        reply_tx: oneshot::Sender<GetInventoryResponse>,
+        reply_tx:
+            oneshot::Sender<Result<GetInventoryResponse, GetInventoryError>>,
         force_refresh: Vec<SpIdentifier>,
     },
 }
@@ -56,34 +53,32 @@ pub struct MgsHandle {
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum GetInventoryResponse {
-    Response { inventory: RackV1Inventory, received_ago: Duration },
+    Response { inventory: RackV1Inventory, mgs_last_seen: Duration },
     Unavailable,
 }
 
-impl GetInventoryResponse {
-    fn new(inventory: Option<(RackV1Inventory, Instant)>) -> Self {
-        match inventory {
-            Some((inventory, received_at)) => GetInventoryResponse::Response {
-                inventory,
-                received_ago: received_at.elapsed(),
-            },
-            None => GetInventoryResponse::Unavailable,
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GetInventoryError {
+    /// Channel errors result only from system shutdown.
+    ShutdownInProgress,
+
+    /// The client specified an invalid SP identifier in a `force_refresh`
+    /// request.
+    InvalidSpIdentifier,
 }
 
 impl MgsHandle {
     pub async fn get_inventory(
         &self,
         force_refresh: Vec<SpIdentifier>,
-    ) -> Result<GetInventoryResponse, ShutdownInProgress> {
+    ) -> Result<GetInventoryResponse, GetInventoryError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let etag = None;
         self.tx
             .send(MgsRequest::GetInventory { etag, reply_tx, force_refresh })
             .await
-            .map_err(|_| ShutdownInProgress)?;
-        reply_rx.await.map_err(|_| ShutdownInProgress)
+            .map_err(|_| GetInventoryError::ShutdownInProgress)?;
+        reply_rx.await.map_err(|_| GetInventoryError::ShutdownInProgress)?
     }
 }
 
@@ -124,8 +119,15 @@ pub struct MgsManager {
     tx: mpsc::Sender<MgsRequest>,
     rx: mpsc::Receiver<MgsRequest>,
     mgs_client: gateway_client::Client,
-    // The Instant indicates the moment at which the inventory was received.
-    inventory: Option<(RackV1Inventory, Instant)>,
+    inventory: BTreeMap<SpIdentifier, SpInventory>,
+
+    // Our clients can request an immediate refresh for a particular set of SPs.
+    // When they do, we don't want to reply to them until we get updates for
+    // those SPs, so we hold the set of reply channels along with the list of
+    // SPs they're waiting for in this vector. We expect this vec to be small
+    // (almost always empty); whenever we get a poll update for an SP, we scan
+    // this vec and check if any reply channels can now be satisfied.
+    waiting_for_update: Vec<WaitingForRefresh>,
 }
 
 impl MgsManager {
@@ -133,8 +135,14 @@ impl MgsManager {
         let log = log.new(o!("component" => "wicketd MgsManager"));
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         let mgs_client = make_mgs_client(log.clone(), mgs_addr);
-        let inventory = None;
-        MgsManager { log, tx, rx, mgs_client, inventory }
+        MgsManager {
+            log,
+            tx,
+            rx,
+            mgs_client,
+            inventory: BTreeMap::new(),
+            waiting_for_update: Vec::new(),
+        }
     }
 
     pub fn get_handle(&self) -> MgsHandle {
@@ -142,303 +150,226 @@ impl MgsManager {
     }
 
     pub async fn run(mut self) {
-        let mgs_client = self.mgs_client;
-        let (poll_inventory_now_tx, poll_inventory_now_rx) = mpsc::channel(1);
-        let mut inventory_rx =
-            poll_sps(&self.log, mgs_client, poll_inventory_now_rx).await;
-        let mut waiting_for_inventory: Vec<
-            oneshot::Sender<GetInventoryResponse>,
-        > = Vec::new();
+        // First, wait until we get a list of SP identifiers that MGS knows how
+        // to talk to. We use this to know how many (and which) SP polling tasks
+        // to create. This does not induce any management network traffic, and
+        // if we can't get a response from this endpoint we're not going to get
+        // responses from any other endpoint anyway, so it's fine to wait until
+        // this succeeds.
+        let all_sp_ids = loop {
+            match self.mgs_client.sp_all_ids().await {
+                Ok(response) => break response.into_inner(),
+                Err(err) => {
+                    const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+                    warn!(
+                        self.log,
+                        "Failed to get SP IDs from MGS (will retry after {:?})",
+                        RETRY_INTERVAL;
+                        "err" => %err,
+                    );
+                    tokio::time::sleep(RETRY_INTERVAL).await;
+                }
+            }
+        };
+
+        // We just fetched all SP IDs from MGS. We'll update this timestamp
+        // below as we get results from the polling tasks we're about to spawn.
+        let mut last_successful_mgs_response = Instant::now();
+
+        let mut ignition_poller =
+            IgnitionPoller::spawn(self.mgs_client.clone(), self.log.clone());
+
+        // We build two maps, both with the same keys (i.e., all SP IDs MGS
+        // knows about): one map to the poller handles, and the other is a
+        // `StreamMap` that allows us to poll the merged receiver streams
+        // concurrently.
+        let mut sp_poller_handles = BTreeMap::new();
+        let mut sp_poller_streams = StreamMap::with_capacity(all_sp_ids.len());
+        for id in all_sp_ids {
+            let (handle, stream) =
+                SpPoller::spawn(id, self.mgs_client.clone(), self.log.clone());
+            sp_poller_handles.insert(id, handle);
+            sp_poller_streams.insert(id, stream);
+        }
 
         loop {
             tokio::select! {
-                // Poll MGS inventory
-                Some(PollSps { changed_inventory, mgs_received }) = inventory_rx.recv() => {
-                    let inventory = match (changed_inventory, self.inventory.take())
-                    {
-                        (Some(inventory), _) => inventory,
-                        (None, Some((inventory, _))) => inventory,
-                        (None, None) => return,
-                    };
-                    self.inventory = Some((inventory, mgs_received));
-                    for reply_tx in waiting_for_inventory.drain(..) {
-                        let response = GetInventoryResponse::new(self.inventory.clone());
-                        let _ = reply_tx.send(response);
-                    }
+                ignition = ignition_poller.recv() => {
+                    last_successful_mgs_response =
+                        last_successful_mgs_response.max(ignition.mgs_received);
+                    self.update_inventory_with_ignition(
+                        ignition,
+                        &sp_poller_handles,
+                        last_successful_mgs_response,
+                    );
                 }
 
-                // Handle requests from clients
+                Some((_, sp)) = sp_poller_streams.next() => {
+                    last_successful_mgs_response =
+                        last_successful_mgs_response.max(sp.mgs_received);
+                    self.update_inventory_with_sp(
+                        sp,
+                        last_successful_mgs_response,
+                    );
+                }
+
                 Some(request) = self.rx.recv() => {
                     match request {
-                        MgsRequest::GetInventory {reply_tx, force_refresh, ..} => {
-                            // For now, we ignore the specific contents of
-                            // `force_refresh` because we're hitting MGS's bulk
-                            // `/sp` state endpoint. If wicket wanted us to
-                            // refresh _any_ SPs, we therefore refresh them all.
-                            if !force_refresh.is_empty() {
-                                // Try to send; if the channel is full, we've
-                                // already requested a refresh and we can just
-                                // wait for a response.
-                                _ = poll_inventory_now_tx.try_send(());
-
-                                // We don't want to respond on `reply_tx` until
-                                // we get a new inventory, but we don't want to
-                                // `inventory_rx.recv().await` here because that
-                                // would block non-force-refresh requests.
-                                // Instead, we'll push `reply_tx` onto a queue
-                                // of waiters and respond as soon as we get our
-                                // next inventory update from our polling task
-                                // (which should come soon since we just told it
-                                // to refresh).
-                                waiting_for_inventory.push(reply_tx);
-                            } else {
-                                let response = GetInventoryResponse::new(self.inventory.clone());
-                                let _ = reply_tx.send(response);
-                            }
+                        MgsRequest::GetInventory { reply_tx, force_refresh, .. } => {
+                            self.handle_get_inventory_request(
+                                &ignition_poller,
+                                &sp_poller_handles,
+                                last_successful_mgs_response,
+                                reply_tx,
+                                force_refresh,
+                            );
                         }
                     }
                 }
             }
         }
     }
-}
 
-type InventoryMap = BTreeMap<SpIdentifier, SpInventory>;
+    fn current_inventory(
+        &self,
+        mgs_last_seen: Instant,
+    ) -> GetInventoryResponse {
+        if self.inventory.is_empty() {
+            GetInventoryResponse::Unavailable
+        } else {
+            let inventory = RackV1Inventory {
+                sps: self.inventory.values().cloned().collect(),
+            };
 
-// For the latest set of sps returned from MGS:
-//  1. Update their state if it has changed
-//  2. Remove any SPs in our current inventory that aren't in the new state
-//
-// Return `true` if inventory was updated, `false` otherwise
-async fn update_inventory(
-    log: &Logger,
-    inventory: &mut InventoryMap,
-    sps: Vec<SpInfo>,
-    client: &gateway_client::Client,
-) -> bool {
-    let new_keys: BTreeSet<SpIdentifier> =
-        sps.iter().map(|sp| sp.info.id).collect();
+            GetInventoryResponse::Response {
+                inventory,
+                mgs_last_seen: mgs_last_seen.elapsed(),
+            }
+        }
+    }
 
-    let old_inventory_len = inventory.len();
+    fn check_completed_waiters(&mut self, mgs_last_seen: Instant) {
+        // This really wants `Vec::drain_filter()`, but it's unstable; instead,
+        // use its sample code (but use `swap_remove()` instead of `remove()`
+        // because we don't care about order).
+        let mut i = 0;
+        while i < self.waiting_for_update.len() {
+            if self.waiting_for_update[i].sps_to_refresh.is_empty()
+                && !self.waiting_for_update[i].need_ignition_refresh
+            {
+                let waiter = self.waiting_for_update.swap_remove(i);
+                _ = waiter
+                    .reply_tx
+                    .send(Ok(self.current_inventory(mgs_last_seen)));
+            } else {
+                i += 1;
+            }
+        }
+    }
 
-    // Remove all keys that are not in the latest update
-    inventory.retain(|k, _| new_keys.contains(k));
+    fn handle_get_inventory_request(
+        &mut self,
+        ignition_handle: &IgnitionPoller,
+        sp_poller_handles: &BTreeMap<SpIdentifier, SpPoller>,
+        mgs_last_seen: Instant,
+        reply_tx: oneshot::Sender<
+            Result<GetInventoryResponse, GetInventoryError>,
+        >,
+        force_refresh: Vec<SpIdentifier>,
+    ) {
+        if force_refresh.is_empty() {
+            // No force refresh: just return our latest cached inventory.
+            _ = reply_tx.send(Ok(self.current_inventory(mgs_last_seen)));
+            return;
+        }
 
-    // Did we remove any keys?
-    let mut inventory_changed = inventory.len() != old_inventory_len;
+        // Trigger immediate polls for all SPs listed in `force_refresh`.
+        for &id in &force_refresh {
+            let Some(handle) = sp_poller_handles.get(&id) else {
+                _ = reply_tx.send(Err(GetInventoryError::InvalidSpIdentifier));
+                return;
+            };
 
-    // Build a stream of futures that fetch additional details about the SP's
-    // state that require extra requests to MGS (e.g., to fetch the caboose). We
-    // only update these details if either (1) the SP's state has changed (in
-    // which case we discard all cached details we have) or (2) we don't yet
-    // have the details (e.g., the state previously changed and our attempt to
-    // fetch details at the time failed).
-    let mut details_stream = sps
-        .into_iter()
-        .filter_map(|sp| {
-            let state = sp.details;
-            let id: SpIdentifier = sp.info.id;
-            let ignition = sp.info.details;
+            handle.poll_now();
+        }
 
-            let curr = inventory
+        // Also poll ignition for any force refresh request; this is only
+        // called once and covers all SPs simultaneously.
+        ignition_handle.poll_now();
+
+        // We don't want to respond on `reply_tx` until we get a response to
+        // the polls we just triggered, so push `reply_tx` onto our queue of
+        // waiters. We'll respond as soon as we get updates for all SPs
+        // listen in `force_refresh` (which should come soon since we just
+        // told their polling tasks to refresh ASAP).
+        self.waiting_for_update.push(WaitingForRefresh {
+            reply_tx,
+            sps_to_refresh: force_refresh.into_iter().collect(),
+            need_ignition_refresh: true,
+        });
+    }
+
+    fn update_inventory_with_ignition(
+        &mut self,
+        ignition: PollIgnition,
+        sp_poller_handles: &BTreeMap<SpIdentifier, SpPoller>,
+        mgs_last_seen: Instant,
+    ) {
+        for (id, ignition) in ignition.sps {
+            let entry = self
+                .inventory
                 .entry(id)
-                .and_modify(|curr| {
-                    if curr.state != state || curr.ignition != ignition {
-                        // state has changed - discard cached details
-                        inventory_changed = true;
-                        curr.components = None;
-                        curr.caboose = None;
-                        curr.rot.caboose = None;
+                .or_insert_with(|| SpInventory::new(id));
+
+            // Update our poller with the current ignition state so it can
+            // (potentially) adjust its polling frequency.
+            if let Some(sp_poller) = sp_poller_handles.get(&id) {
+                match &ignition {
+                    SpIgnition::No => {
+                        sp_poller.set_ignition_state(IgnitionState::Absent);
                     }
+                    SpIgnition::Yes { .. } => {
+                        sp_poller.set_ignition_state(IgnitionState::Present);
+                    }
+                    // TODO can we remove this case from MGS too?
+                    SpIgnition::Error { .. } => (),
+                }
+            }
 
-                    curr.state = state.clone();
-                    curr.ignition = ignition.clone();
-                })
-                .or_insert_with(|| SpInventory::new(id, ignition, state));
+            entry.ignition = Some(ignition);
+        }
 
-            fetch_sp_details_if_needed(curr, client, log)
-        })
-        .collect::<FuturesUnordered<_>>();
-
-    // Wait for all our requests to come back - if any of them successfully
-    // fetched any of the detail fields we needed, update our `inventory` and
-    // note that it has changed.
-    while let Some(details) = details_stream.next().await {
-        let item = inventory.get_mut(&details.id).unwrap();
-        if let Some(components) = details.components {
-            item.components = Some(components);
-            inventory_changed = true;
+        // Scan any pending waiters and clear their "waiting for ignition" bit;
+        // if that was the last thing they needed, `check_completed_waiters()`
+        // will send them a response.
+        for waiting in &mut self.waiting_for_update {
+            waiting.need_ignition_refresh = false;
         }
-        if let Some(sp_caboose) = details.caboose {
-            item.caboose = Some(sp_caboose);
-            inventory_changed = true;
-        }
-        if let Some(rot_caboose) = details.rot.caboose {
-            item.rot.caboose = Some(rot_caboose);
-            inventory_changed = true;
-        }
+        self.check_completed_waiters(mgs_last_seen);
     }
 
-    inventory_changed
-}
+    fn update_inventory_with_sp(&mut self, sp: PollSp, mgs_last_seen: Instant) {
+        let entry = self
+            .inventory
+            .entry(sp.id)
+            .or_insert_with(|| SpInventory::new(sp.id));
+        entry.state = Some(sp.state);
+        entry.components = sp.components;
+        entry.caboose = sp.caboose;
+        entry.rot = sp.rot;
 
-fn fetch_sp_details_if_needed<'a>(
-    item: &SpInventory,
-    client: &'a gateway_client::Client,
-    log: &'a Logger,
-) -> Option<impl Future<Output = SpDetails> + 'a> {
-    let need_components = item.components.is_none();
-    let need_sp_caboose = item.caboose.is_none();
-    let need_rot_caboose = item.rot.caboose.is_none();
-
-    // If all fields of `item` that we know how to populate are already set, we
-    // have nothing to do.
-    if !need_components && !need_sp_caboose && !need_rot_caboose {
-        return None;
+        // Scan any pending waiters and remove this SP from their list; if that
+        // was the last thing they needed, `check_completed_waiters()` will send
+        // them a response.
+        for waiting in &mut self.waiting_for_update {
+            waiting.sps_to_refresh.remove(&sp.id);
+        }
+        self.check_completed_waiters(mgs_last_seen);
     }
-
-    let id = item.id;
-    Some(async move {
-        let mut details = SpDetails {
-            id,
-            components: None,
-            caboose: None,
-            rot: RotInventory { caboose: None },
-        };
-
-        if need_components {
-            match client.sp_component_list(id.type_, id.slot).await {
-                Ok(val) => {
-                    details.components = Some(val.into_inner().components);
-                }
-                Err(err) => {
-                    warn!(
-                        log, "Failed to get component list for sp";
-                        "sp" => ?id,
-                        "err" => %err,
-                    );
-                }
-            }
-        }
-
-        if need_sp_caboose {
-            match client
-                .sp_component_caboose_get(
-                    id.type_,
-                    id.slot,
-                    SpComponent::SP_ITSELF.const_as_str(),
-                )
-                .await
-            {
-                Ok(val) => {
-                    details.caboose = Some(val.into_inner());
-                }
-                Err(err) => {
-                    warn!(
-                        log, "Failed to get caboose for sp";
-                        "sp" => ?id,
-                        "err" => %err,
-                    );
-                }
-            }
-        }
-
-        if need_rot_caboose {
-            match client
-                .sp_component_caboose_get(
-                    id.type_,
-                    id.slot,
-                    SpComponent::ROT.const_as_str(),
-                )
-                .await
-            {
-                Ok(val) => {
-                    details.rot.caboose = Some(val.into_inner());
-                }
-                Err(err) => {
-                    warn!(
-                        log, "Failed to get caboose for rot";
-                        "sp" => ?id,
-                        "err" => %err,
-                    );
-                }
-            }
-        }
-
-        details
-    })
 }
 
-// Container for details of an SP we have to fetch with separate MGS requests
-// from the main `sp_list()`.
-#[derive(Debug)]
-struct SpDetails {
-    id: SpIdentifier,
-    caboose: Option<SpComponentCaboose>,
-    components: Option<Vec<SpComponentInfo>>,
-    rot: RotInventory,
-}
-
-async fn poll_sps(
-    log: &Logger,
-    client: gateway_client::Client,
-    mut poll_now: mpsc::Receiver<()>,
-) -> mpsc::Receiver<PollSps> {
-    let log = log.clone();
-
-    // We only want one outstanding inventory request at a time
-    let (tx, rx) = mpsc::channel(1);
-
-    // This is a BTreeMap version of inventory that we maintain for the lifetime
-    // of the process.
-    let mut inventory = InventoryMap::default();
-
-    tokio::spawn(async move {
-        let mut ticker = interval(MGS_POLL_INTERVAL);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        loop {
-            // Wait until either our tick interval _or_ we get an explicit
-            // request to update our inventory (in which case we reset our
-            // ticker).
-            tokio::select! {
-                _ = ticker.tick() => (),
-                Some(()) = poll_now.recv() => {
-                    ticker.reset();
-                }
-            }
-
-            match client.sp_list().await {
-                Ok(val) => {
-                    let changed_inventory = update_inventory(
-                        &log,
-                        &mut inventory,
-                        val.into_inner(),
-                        &client,
-                    )
-                    .await
-                    .then(|| RackV1Inventory {
-                        sps: inventory.values().cloned().collect(),
-                    });
-
-                    let _ = tx
-                        .send(PollSps {
-                            changed_inventory,
-                            mgs_received: Instant::now(),
-                        })
-                        .await;
-                }
-                Err(e) => {
-                    warn!(log, "{e}");
-                }
-            }
-        }
-    });
-
-    rx
-}
-
-#[derive(Debug)]
-struct PollSps {
-    changed_inventory: Option<RackV1Inventory>,
-    mgs_received: Instant,
+struct WaitingForRefresh {
+    reply_tx: oneshot::Sender<Result<GetInventoryResponse, GetInventoryError>>,
+    sps_to_refresh: BTreeSet<SpIdentifier>,
+    need_ignition_refresh: bool,
 }

--- a/wicketd/src/mgs/inventory.rs
+++ b/wicketd/src/mgs/inventory.rs
@@ -1,0 +1,399 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Implementation details for polling MGS for rack inventory details.
+
+use gateway_client::types::SpComponentCaboose;
+use gateway_client::types::SpComponentInfo;
+use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpIgnition;
+use gateway_client::types::SpState;
+use gateway_messages::SpComponent;
+use slog::warn;
+use slog::Logger;
+use std::collections::BTreeMap;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::task;
+use tokio::time::interval;
+use tokio::time::Duration;
+use tokio::time::Instant;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::inventory::RotInventory;
+
+// Frequency at which we poll our local ignition controller (via our local
+// sidecar SP) for the ignition state of all ignition targets in the rack.
+const POLL_FREQ_IGNITION: Duration = Duration::from_secs(5);
+
+// Frequency at which we poll SPs we believe to be present based on ignition
+// results.
+const POLL_FREQ_PRESENT_SP: Duration = Duration::from_secs(10);
+
+// Frequence at which we poll SPs we believe are _not_ present based on ignition
+// results. We still poll these SPs (albeit less frequently) to account for
+// problems with ignition (either incorrect results, which should be extremely
+// rare, or problems getting the state, which should also be rare).
+const POLL_FREQ_MISSING_SP: Duration = Duration::from_secs(30);
+
+pub(super) struct PollIgnition {
+    pub(super) sps: BTreeMap<SpIdentifier, SpIgnition>,
+    pub(super) mgs_received: Instant,
+}
+
+// Handle to the tokio task responsible for polling MGS for ignition state. When
+// dropped, the polling task is cancelled.
+pub(super) struct IgnitionPoller {
+    task: task::JoinHandle<()>,
+    rx: mpsc::Receiver<PollIgnition>,
+    poll_now_tx: mpsc::Sender<()>,
+}
+
+impl Drop for IgnitionPoller {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl IgnitionPoller {
+    /// Spawn the ignition polling task.
+    pub(super) fn spawn(
+        mgs_client: gateway_client::Client,
+        log: Logger,
+    ) -> Self {
+        // We only want one outstanding ignition request at a time; if our
+        // consumer is behind, we don't need to poll MGS until they can handle
+        // our results.
+        let (tx, rx) = mpsc::channel(1);
+
+        // "Poll immediately" also only needs a channel depth of 1: if there is
+        // already a message in this channel, we're already trying to poll ASAP.
+        let (poll_now_tx, poll_now_rx) = mpsc::channel(1);
+
+        let task = tokio::spawn(ignition_poller_task(
+            tx,
+            poll_now_rx,
+            mgs_client,
+            log,
+        ));
+
+        Self { task, rx, poll_now_tx }
+    }
+
+    /// Receive the next result from the ignition polling task.
+    pub(super) async fn recv(&mut self) -> PollIgnition {
+        // The task we spawned holds `tx` either until `rx` is dropped (which it
+        // obviously is not here, since we're using it!) or it panics, so we can
+        // unwrap here. The only way we panic is if our inner task already did.
+        self.rx.recv().await.expect("ignition polling task panicked")
+    }
+
+    pub(super) fn poll_now(&self) {
+        match self.poll_now_tx.try_send(()) {
+            // If we succeeded or there's already a "poll now" request sitting
+            // in the channel, we're done.
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => (),
+            // If the channel is closed, that means our task has panicked -
+            // propogate that panic.
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                panic!("ignition polling task panicked")
+            }
+        }
+    }
+}
+
+async fn ignition_poller_task(
+    tx: mpsc::Sender<PollIgnition>,
+    mut poll_now_rx: mpsc::Receiver<()>,
+    mgs_client: gateway_client::Client,
+    log: Logger,
+) {
+    let mut ticker = interval(POLL_FREQ_IGNITION);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => (),
+            _ = poll_now_rx.recv() => {
+                ticker.reset();
+            }
+        }
+
+        let results = match mgs_client.ignition_list().await {
+            Ok(response) => response.into_inner(),
+            Err(err) => {
+                warn!(
+                    log, "Failed to poll MGS for ignition";
+                    "err" => %err,
+                );
+                continue;
+            }
+        };
+
+        let mut sps = BTreeMap::new();
+        let mgs_received = Instant::now();
+        for result in results {
+            sps.insert(result.id, result.details);
+        }
+
+        let emit = PollIgnition { sps, mgs_received };
+
+        // If our receiver is gone, we'll exit - there's no one left for
+        // us to send results to!
+        if tx.send(emit).await.is_err() {
+            warn!(log, "Receiver for ignition polling task is gone");
+            break;
+        }
+    }
+}
+
+pub(super) struct PollSp {
+    pub(super) id: SpIdentifier,
+    pub(super) state: SpState,
+    pub(super) components: Option<Vec<SpComponentInfo>>,
+    pub(super) caboose: Option<SpComponentCaboose>,
+    pub(super) rot: RotInventory,
+    pub(super) mgs_received: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IgnitionState {
+    Present,
+    Absent,
+}
+
+impl IgnitionState {
+    fn poll_frequency(self) -> Duration {
+        match self {
+            IgnitionState::Present => POLL_FREQ_PRESENT_SP,
+            IgnitionState::Absent => POLL_FREQ_MISSING_SP,
+        }
+    }
+}
+
+pub(super) struct SpPoller {
+    task: task::JoinHandle<()>,
+    ignition_state_tx: watch::Sender<Option<IgnitionState>>,
+    poll_now_tx: mpsc::Sender<()>,
+}
+
+impl Drop for SpPoller {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl SpPoller {
+    /// Spawn a polling task for a single SP.
+    ///
+    /// Returns a handle for interacting with the task and a stream that emits
+    /// polling results.
+    pub(super) fn spawn(
+        id: SpIdentifier,
+        mgs_client: gateway_client::Client,
+        log: Logger,
+    ) -> (Self, ReceiverStream<PollSp>) {
+        // We only want one outstanding request at a time; if our consumer is
+        // behind, we don't need to poll MGS until they can handle our results.
+        let (poll_tx, poll_rx) = mpsc::channel(1);
+
+        // "Poll immediately" also only needs a channel depth of 1: if there is
+        // already a message in this channel, we're already trying to poll ASAP.
+        let (poll_now_tx, poll_now_rx) = mpsc::channel(1);
+
+        let (ignition_state_tx, ignition_state_rx) = watch::channel(None);
+
+        let task = tokio::spawn(sp_poller_task(
+            id,
+            poll_tx,
+            poll_now_rx,
+            ignition_state_rx,
+            mgs_client,
+            log,
+        ));
+
+        (
+            Self { task, ignition_state_tx, poll_now_tx },
+            ReceiverStream::new(poll_rx),
+        )
+    }
+
+    pub(super) fn set_ignition_state(&self, state: IgnitionState) {
+        // `tokio::watch::Sender` doesn't check for equality: only send an
+        // update if this state is actually different.
+        if *self.ignition_state_tx.borrow() != Some(state) {
+            match self.ignition_state_tx.send(Some(state)) {
+                Ok(()) => (),
+                Err(_) => panic!("SP polling task panicked"),
+            }
+        }
+    }
+
+    pub(super) fn poll_now(&self) {
+        match self.poll_now_tx.try_send(()) {
+            // If we succeeded or there's already a "poll now" request sitting
+            // in the channel, we're done.
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => (),
+            // If the channel is closed, that means our task has panicked -
+            // propogate that panic.
+            Err(mpsc::error::TrySendError::Closed(())) => {
+                panic!("SP polling task panicked")
+            }
+        }
+    }
+}
+
+async fn sp_poller_task(
+    id: SpIdentifier,
+    tx: mpsc::Sender<PollSp>,
+    mut poll_now: mpsc::Receiver<()>,
+    mut ignition_state: watch::Receiver<Option<IgnitionState>>,
+    mgs_client: gateway_client::Client,
+    log: Logger,
+) {
+    let mut ticker = interval(
+        ignition_state
+            .borrow()
+            .map_or(POLL_FREQ_PRESENT_SP, IgnitionState::poll_frequency),
+    );
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let mut prev_state = None;
+    let mut components = None;
+    let mut caboose = None;
+    let mut rot = RotInventory { caboose: None };
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => (),
+            _ = poll_now.recv() => {
+                ticker.reset();
+            }
+            _ = ignition_state.changed() => {
+                // When our ignition state changes, clear out all cached data
+                // and recreate `ticker`.
+                prev_state = None;
+                components = None;
+                caboose = None;
+                rot = RotInventory { caboose: None };
+
+                ticker = interval(
+                    ignition_state
+                        .borrow()
+                        .map_or(
+                            POLL_FREQ_PRESENT_SP,
+                            IgnitionState::poll_frequency,
+                        ),
+                );
+                ticker.set_missed_tick_behavior(
+                    tokio::time::MissedTickBehavior::Delay);
+                ticker.reset();
+            }
+        }
+
+        let state = match mgs_client.sp_get(id.type_, id.slot).await {
+            // TODO Can we remove the ignition info from MGS's sp_get?
+            Ok(response) => response.into_inner().details,
+            Err(err) => {
+                warn!(
+                    log, "Failed to get state for SP";
+                    "sp" => ?id,
+                    "err" => %err,
+                );
+                continue;
+            }
+        };
+        let mut mgs_received = Instant::now();
+
+        // For each of our cached items that require additional MGS requests (SP
+        // components, SP caboose, RoT caboose), only fetch them if either our
+        // state has changed or we previously failed to fetch them after such a
+        // state change.
+
+        if prev_state.as_ref() != Some(&state) || components.is_none() {
+            components =
+                match mgs_client.sp_component_list(id.type_, id.slot).await {
+                    Ok(response) => {
+                        mgs_received = Instant::now();
+                        Some(response.into_inner().components)
+                    }
+                    Err(err) => {
+                        warn!(
+                            log, "Failed to get component list for sp";
+                            "sp" => ?id,
+                            "err" => %err,
+                        );
+                        None
+                    }
+                };
+        }
+
+        if prev_state.as_ref() != Some(&state) || caboose.is_none() {
+            caboose = match mgs_client
+                .sp_component_caboose_get(
+                    id.type_,
+                    id.slot,
+                    SpComponent::SP_ITSELF.const_as_str(),
+                )
+                .await
+            {
+                Ok(response) => {
+                    mgs_received = Instant::now();
+                    Some(response.into_inner())
+                }
+                Err(err) => {
+                    warn!(
+                        log, "Failed to get caboose for sp";
+                        "sp" => ?id,
+                        "err" => %err,
+                    );
+                    None
+                }
+            };
+        }
+
+        if prev_state.as_ref() != Some(&state) || rot.caboose.is_none() {
+            rot.caboose = match mgs_client
+                .sp_component_caboose_get(
+                    id.type_,
+                    id.slot,
+                    SpComponent::ROT.const_as_str(),
+                )
+                .await
+            {
+                Ok(response) => {
+                    mgs_received = Instant::now();
+                    Some(response.into_inner())
+                }
+                Err(err) => {
+                    warn!(
+                        log, "Failed to get RoT caboose for sp";
+                        "sp" => ?id,
+                        "err" => %err,
+                    );
+                    None
+                }
+            };
+        }
+
+        let emit = PollSp {
+            id,
+            state,
+            components: components.clone(),
+            caboose: caboose.clone(),
+            rot: rot.clone(),
+            mgs_received,
+        };
+
+        // If our receiver is gone, we'll exit - there's no one left for
+        // us to send results to!
+        if tx.send(emit).await.is_err() {
+            warn!(
+                log, "Receiver for ignition polling task is gone";
+                "sp" => ?id,
+            );
+            break;
+        }
+    }
+}


### PR DESCRIPTION
This reworks wicketd's internal polling of MGS; it now spawns N+1 tokio tasks (where N is the number of SPs in the rack, and the +1 is for polling ignition state), each of which is responsible for polling MGS on some interval (which can vary over time, based on whether ignition reports that that SP is present) for the state of its single target SP. The end result of this is that `wicket`'s inventory display is much snappier, particularly when the user interacts with ignition: we now see an update in the UI nearly instantaneously, whereas previously it could take several seconds.

There is one small change to wicketd's API: the `ignition` and `state` fields of the SP inventory are now both optional, as they're being polled separately and either could be missing if the other is present. The way it is currently implemented, it's not possible for wicket to observe an inventory response where both ignition and state are `None` (i.e., at least one of them is guaranteed to be `Some(_)`). This isn't represented in the type system but I'm not sure it necessarily needs to be? Currently wicket only dumps this data as a debug string anyway - if we need a stricter representation in the future, we could make that change.

This PR adds one small endpoint to MGS: returning a list of all SPs MGS is configured to talk to. This way `wicketd` doesn't need to hardcode "32 gimlets, 2 pscs, 2 sidecars" to know how many tasks to spawn: it can just ask MGS.

In a followup PR I'd like to make a cleanup pass over MGS's API to address a couple TODO comments introduced in this PR:

1. Remove the bulk `/sp` endpoint altogether
2. Remove the ignition state from the `/sp/{type}/{slot}` endpoint, as it's not actually fetchable atomically (i.e., MGS has to make two separate management network requests to fulfill it) and `wicket` is ignoring the ignition portion of the response anyway (since it's polling ignition separately).