### PR TITLE
sim sled agent: use PokeMode::Drain for automatic transitions

### DIFF
--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -213,7 +213,7 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     async fn sim_step(&self, id: Uuid, mut rx: Receiver<()>) {
         while rx.next().await.is_some() {
             tokio::time::sleep(Duration::from_millis(1500)).await;
-            self.sim_poke(id, PokeMode::SingleStep).await;
+            self.sim_poke(id, PokeMode::Drain).await;
         }
     }
 


### PR DESCRIPTION
This maintains compatibility with the behavior of the automatic simulated sled agent prior to commit 4e172d0.

When an instance (or a disk, but we'll focus on instances here) changes state in auto mode, the following things happen:

1. Client requests a state change
2. Simulated sled agent calls the simulated object's transition function
3. Transition function sets the object's desired state
4. Transition function signals a per-object task to effect the queued transition
5. Task calls the object's `sim_poke` method to drive the object's state machine

Before commit 4e172d0, simulated instance state transitions required only one poke to reach an acceptable resting state. That is, if a user asked to stop a simulated instance, a single loop of the background task and a single call to `sim_poke` was sufficient to drive the instance to the Stopped state.

With commit 4e172d0, simulated instances now require several pokes to reach their expected final resting states, but a single external request to change an instance's state (steps 1-3 above) only wakes the background task and pokes the instance once (steps 4-5). This causes simulated instances to get stuck in unexpected states.

Get around this problem by changing the automatic transition function to apply all pending state changes to a simulated instance instead of just one.

A nicer solution (left for another day for expediency) is to have `sim_poke` re-arm the state driver if there are still pending transitions after a single transition has been applied. This allows the state driver to delay each individual state transition, such that an instance will e.g. sit in the Stopping state for a bit and then transition to Stopped. For now, though, focus on restoring the old simulation's behavior.

Tested by creating and stopping a simulated instance.

Fixes #2802.