### PR TITLE
(Fix build breakage) Dendrite address in configuration is now optional

### DIFF
--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -154,7 +154,13 @@ pub async fn test_setup_with_config<N: NexusServer>(
         .expect("Tests expect to set a port of Clickhouse")
         .set_port(clickhouse.port());
 
-    config.pkg.dendrite.address.set_port(dendrite.port);
+    config
+        .pkg
+        .dendrite
+        .address
+        .as_mut()
+        .expect("Tests expect an explicit dendrite address")
+        .set_port(dendrite.port);
 
     let server = N::start_and_populate(&config, &logctx.log).await;
 


### PR DESCRIPTION
I believe this happened as a racy merge of #2579 and #2694 .

At the end of the day, this configuration value is now optional, so treat it as such, but require it in the tests.