### PR TITLE
Add retries to downloading scripts

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -157,7 +157,7 @@ function install_packages {
   fi
 }
 
-install_packages
+retry install_packages
 
 # CockroachDB and Clickhouse are used by Omicron for storage of
 # control plane metadata and metrics.

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -32,7 +32,7 @@ function usage
 ASSUME_YES="false"
 SKIP_PATH_CHECK="false"
 RETRY_ATTEMPTS=3
-while getopts yp:r: flag
+while getopts ypr: flag
 do
   case "${flag}" in
     y) ASSUME_YES="true" ;;

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -29,13 +29,9 @@ function usage
   exit 1
 }
 
-# Parse command line options:
-#
-# -y  Assume "yes" intead of showing confirmation prompts.
-# -p  Skip checking paths (currently unused)
 ASSUME_YES="false"
 RETRY_ATTEMPTS=3
-while getopts yp:r: flag
+while getopts ypr: flag
 do
   case "${flag}" in
     y) ASSUME_YES="true" ;;


### PR DESCRIPTION
This seems to be a common source of CI failure -- some request to an external server fails when installing prerequisites, and that whole job needs to be restarted.

To mitigate, build a concept of "automatic retries" into the downloader scripts.