### PR TITLE
Fix bash variable collision

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -70,10 +70,10 @@ function retry
   attempts="${RETRY_ATTEMPTS}"
   # Always try at least once
   attempts=$((attempts < 1 ? 1 : attempts))
-  rc=0
+  retry_rc=0
   for i in $(seq 1 $attempts); do
-    "$@" || rc=$?;
-    if [[ "$rc" -eq 0 ]]; then
+    "$@" || retry_rc=$?;
+    if [[ "$retry_rc" -eq 0 ]]; then
       return
     fi
 
@@ -82,7 +82,7 @@ function retry
     fi
   done
 
-  exit $rc
+  exit $retry_rc
 }
 
 # Packages to be installed on all OSes:

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -69,10 +69,10 @@ function retry
   attempts="${RETRY_ATTEMPTS}"
   # Always try at least once
   attempts=$((attempts < 1 ? 1 : attempts))
-  rc=0
+  retry_rc=0
   for i in $(seq 1 $attempts); do
-    "$@" || rc=$?;
-    if [[ "$rc" -eq 0 ]]; then
+    "$@" || retry_rc=$?;
+    if [[ "$retry_rc" -eq 0 ]]; then
       return
     fi
 
@@ -81,7 +81,7 @@ function retry
     fi
   done
 
-  exit $rc
+  exit $retry_rc
 }
 
 # Packages to be installed Helios:


### PR DESCRIPTION
If the command `retry` calls succeeds but sets `$rc` to a value other than 0, `retry` was seeing that overwritten value of `$rc` and assuming the command failed. `install_packages` in particular uses `$rc` to catch "exit code 4 means no updates are necessary": https://github.com/oxidecomputer/omicron/blob/7d6eadfd6c5cf5c0e72796c98bd711dc35a9e1e6/tools/install_builder_prerequisites.sh#L142-L144

I'm not sure if there's a _cleaner_ fix to this (some way to scope variables?), but just changing the name solves the immediate problem.