### PR TITLE
"omicron-dev run-all" test could be more debuggable

### DIFF
--- a/dev-tools/tests/test_omicron_dev.rs
+++ b/dev-tools/tests/test_omicron_dev.rs
@@ -74,7 +74,9 @@ fn run_db_run(exec: Exec, wait_for_populate: bool) -> DbRun {
             Err(e) => {
                 panic!("unexpected error reading child process stdout: {}", e);
             }
-            _ => (),
+            Ok(_) => {
+                print!("subproc stdout: {}", buf);
+            }
         }
 
         if let Some(s) = buf.strip_prefix("omicron-dev: temporary directory: ")
@@ -167,7 +169,9 @@ fn run_run_all(exec: Exec) -> RunAll {
             Err(e) => {
                 panic!("unexpected error reading child process stdout: {}", e);
             }
-            _ => (),
+            Ok(_) => {
+                print!("subproc stdout: {}", buf);
+            }
         }
 
         if let Some(s) =


### PR DESCRIPTION
Before, if `dpd` was not on your PATH:

```
$ cargo test --test=test_omicron_dev -- test_run_all
    Finished test [unoptimized + debuginfo] target(s) in 0.71s
     Running tests/test_omicron_dev.rs (target/debug/deps/test_omicron_dev-9210c51c7240c9ec)

running 1 test
test test_run_all ... FAILED

failures:

---- test_run_all stdout ----
will run: bash -c '( set -o monitor; /home/dap/omicron-external-dns/target/debug/omicron-dev run-all --nexus-listen-port 0)'
waiting for stdout from child process
thread 'test_run_all' panicked at 'unexpected EOF from child process stdout', dev-tools/tests/test_omicron_dev.rs:165:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_run_all

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 6 filtered out; finished in 2.54s

error: test failed, to rerun pass `-p omicron-dev-tools --test test_omicron_dev`

```

Why did it fail?  We don't know!  With this change, we print the output from the subprocess:

```
$ cargo test --test=test_omicron_dev -- test_run_all
   Compiling omicron-dev-tools v0.1.0 (/home/dap/omicron-external-dns/dev-tools)
    Finished test [unoptimized + debuginfo] target(s) in 30.88s
     Running tests/test_omicron_dev.rs (target/debug/deps/test_omicron_dev-9210c51c7240c9ec)

running 1 test
test test_run_all ... FAILED

failures:

---- test_run_all stdout ----
will run: bash -c '( set -o monitor; /home/dap/omicron-external-dns/target/debug/omicron-dev run-all --nexus-listen-port 0)'
waiting for stdout from child process
subproc stdout: omicron-dev: setting up all services ... 
subproc stdout: log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.23475.0.log
subproc stdout: note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.23475.0.log"
subproc stdout: thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: failed to spawn `dpd` (with args: ["run", "--listen-addresses", "[::1]:0"])
subproc stdout: 
subproc stdout: Caused by:
subproc stdout:     No such file or directory (os error 2)', /home/dap/omicron-external-dns/nexus/test-utils/src/lib.rs:144:68
subproc stdout: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
subproc stdout: bash: line 1: 23475 Abort                   (core dumped) /home/dap/omicron-external-dns/target/debug/omicron-dev run-all --nexus-listen-port 0
thread 'test_run_all' panicked at 'unexpected EOF from child process stdout', dev-tools/tests/test_omicron_dev.rs:167:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_run_all

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 6 filtered out; finished in 1.97s

error: test failed, to rerun pass `-p omicron-dev-tools --test test_omicron_dev`
```

Much better.