### PR TITLE
`omicron-dev run-all` ought to use `SimMode::Auto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,7 @@ dependencies = [
  "omicron-common 0.1.0",
  "omicron-nexus",
  "omicron-rpaths",
+ "omicron-sled-agent",
  "omicron-test-utils",
  "oxide-client",
  "pq-sys",

--- a/dev-tools/Cargo.toml
+++ b/dev-tools/Cargo.toml
@@ -17,6 +17,7 @@ nexus-test-interface.workspace = true
 omicron-common.workspace = true
 omicron-nexus.workspace = true
 omicron-test-utils.workspace = true
+omicron-sled-agent.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
 signal-hook.workspace = true

--- a/dev-tools/src/bin/omicron-dev.rs
+++ b/dev-tools/src/bin/omicron-dev.rs
@@ -13,6 +13,7 @@ use futures::stream::StreamExt;
 use nexus_test_interface::NexusServer;
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
+use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
 use signal_hook::consts::signal::SIGINT;
 use signal_hook_tokio::Signals;
@@ -328,7 +329,7 @@ async fn cmd_run_all(args: &RunAllArgs) -> Result<(), anyhow::Error> {
     println!("omicron-dev: setting up all services ... ");
     let cptestctx = nexus_test_utils::test_setup_with_config::<
         omicron_nexus::Server,
-    >("omicron-dev", &mut config)
+    >("omicron-dev", &mut config, sim::SimMode::Auto)
     .await;
     println!("omicron-dev: services are running.");
 

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -124,12 +124,14 @@ pub async fn test_setup<N: NexusServer>(
     test_name: &str,
 ) -> ControlPlaneTestContext<N> {
     let mut config = load_test_config();
-    test_setup_with_config::<N>(test_name, &mut config).await
+    test_setup_with_config::<N>(test_name, &mut config, sim::SimMode::Explicit)
+        .await
 }
 
 pub async fn test_setup_with_config<N: NexusServer>(
     test_name: &str,
     config: &mut omicron_common::nexus_config::Config,
+    sim_mode: sim::SimMode,
 ) -> ControlPlaneTestContext<N> {
     let logctx = LogContext::new(test_name, &config.pkg.log);
     let log = &logctx.log;
@@ -188,6 +190,7 @@ pub async fn test_setup_with_config<N: NexusServer>(
         internal_server_addr,
         sa_id,
         tempdir.path(),
+        sim_mode,
     )
     .await
     .unwrap();
@@ -241,10 +244,11 @@ pub async fn start_sled_agent(
     nexus_address: SocketAddr,
     id: Uuid,
     update_directory: &Path,
+    sim_mode: sim::SimMode,
 ) -> Result<sim::Server, String> {
     let config = sim::Config {
         id,
-        sim_mode: sim::SimMode::Explicit,
+        sim_mode,
         nexus_address,
         dropshot: ConfigDropshot {
             bind_address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0),

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -22,6 +22,7 @@ use omicron_nexus::db::identity::{Asset, Resource};
 use omicron_nexus::external_api::console_api::SpoofLoginBody;
 use omicron_nexus::external_api::params::ProjectCreate;
 use omicron_nexus::external_api::{shared, views};
+use omicron_sled_agent::sim;
 
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
@@ -309,6 +310,7 @@ async fn test_absolute_static_dir() {
     let cptestctx = test_setup_with_config::<omicron_nexus::Server>(
         "test_absolute_static_dir",
         &mut config,
+        sim::SimMode::Explicit,
     )
     .await;
     let testctx = &cptestctx.external_client;

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -57,6 +57,7 @@ use dropshot::{HttpErrorResponseBody, ResultsPage};
 use nexus_test_utils::identity_eq;
 use nexus_test_utils::resource_helpers::{create_instance, create_project};
 use nexus_test_utils_macros::nexus_test;
+use omicron_sled_agent::sim;
 
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
@@ -3056,9 +3057,15 @@ async fn test_instance_v2p_mappings(cptestctx: &ControlPlaneTestContext) {
         let addr = cptestctx.server.get_http_server_internal_address().await;
         let update_directory = std::path::Path::new("/should/not/be/used");
         additional_sleds.push(
-            start_sled_agent(log, addr, sa_id, &update_directory)
-                .await
-                .unwrap(),
+            start_sled_agent(
+                log,
+                addr,
+                sa_id,
+                &update_directory,
+                sim::SimMode::Explicit,
+            )
+            .await
+            .unwrap(),
         );
     }
 

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -16,6 +16,7 @@ use omicron_nexus::external_api::views::{
     PhysicalDisk, PhysicalDiskType, Sled,
 };
 use omicron_nexus::internal_api::params as internal_params;
+use omicron_sled_agent::sim;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -51,9 +52,15 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
         let addr = cptestctx.server.get_http_server_internal_address().await;
         let update_directory = std::path::Path::new("/should/not/be/used");
         sas.push(
-            start_sled_agent(log, addr, sa_id, &update_directory)
-                .await
-                .unwrap(),
+            start_sled_agent(
+                log,
+                addr,
+                sa_id,
+                &update_directory,
+                sim::SimMode::Explicit,
+            )
+            .await
+            .unwrap(),
         );
     }
 

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -20,6 +20,7 @@ use nexus_test_utils::{load_test_config, test_setup, test_setup_with_config};
 use omicron_common::api::internal::nexus::KnownArtifactKind;
 use omicron_common::update::{Artifact, ArtifactKind, ArtifactsDocument};
 use omicron_nexus::config::UpdatesConfig;
+use omicron_sled_agent::sim;
 use ring::pkcs8::Document;
 use ring::rand::{SecureRandom, SystemRandom};
 use ring::signature::Ed25519KeyPair;
@@ -69,6 +70,7 @@ async fn test_update_end_to_end() {
     let cptestctx = test_setup_with_config::<omicron_nexus::Server>(
         "test_update_end_to_end",
         &mut config,
+        sim::SimMode::Explicit,
     )
     .await;
     let client = &cptestctx.external_client;


### PR DESCRIPTION
Fix #2810