### PR TITLE
OPTE ports for external services connectivity.

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -43,6 +43,14 @@ _exit_trap() {
 		--client /opt/oxide/softnpu/stuff/client \
 		standalone \
 		dump-state
+	pfexec /opt/oxide/opte/bin/opteadm list-ports
+	PORTS=$(pfexec /opt/oxide/opte/bin/opteadm list-ports | tail +2 | awk '{ print $1; }')
+	for p in $PORTS; do
+		LAYERS=$(pfexec /opt/oxide/opte/bin/opteadm list-layers -p $p | tail +2 | awk '{ print $1; }')
+		for l in $LAYERS; do
+			pfexec /opt/oxide/opte/bin/opteadm dump-layer -p $p $l
+		done
+	done
 
 	pfexec zfs list
 	pfexec zpool list
@@ -140,27 +148,6 @@ pfexec curl -sSfL -o /var/svc/manifest/site/tcpproxy.xml \
 pfexec svccfg import /var/svc/manifest/site/tcpproxy.xml
 
 #
-# XXX Right now, the Nexus external API is available on a specific IPv4 address
-# on a canned subnet.  We need to create an address in the global zone such
-# that we can, in the test below, reach Nexus.
-#
-# This must be kept in sync with the IP in "smf/sled-agent/non-gimlet/config-rss.toml" and
-# the prefix length which apparently defaults (in the Rust code) to /24.
-#
-pfexec ipadm create-addr -T static -a 192.168.1.199/24 igb0/sidehatch
-
-#
-# Modify config-rss.toml in the sled-agent zone to use our system's IP and MAC
-# address for upstream connectivity.
-#
-tar xf out/omicron-sled-agent.tar pkg/config-rss.toml
-sed -e 's/^# address =.*$/address = "192.168.1.199"/' \
-	-e "s/^mac =.*$/mac = \"$(dladm show-phys -m -p -o ADDRESS | head -n 1)\"/" \
-	-i pkg/config-rss.toml
-tar rf out/omicron-sled-agent.tar pkg/config-rss.toml
-rm -rf pkg
-
-#
 # This OMICRON_NO_UNINSTALL hack here is so that there is no implicit uninstall
 # before the install.  This doesn't work right now because, above, we made
 # /var/oxide a file system so you can't remove it (EBUSY) like a regular
@@ -171,25 +158,63 @@ rm -rf pkg
 OMICRON_NO_UNINSTALL=1 \
     ptime -m pfexec ./target/release/omicron-package -t test install
 
-./tests/bootstrap
-
-# NOTE: this script configures softnpu's "rack network" settings using swadm
-GATEWAY_IP=192.168.1.199 ./tools/scrimlet/softnpu-init.sh
-
 # NOTE: this command configures proxy arp for softnpu. This is needed if you want to be
 # able to reach instances from the same L2 network segment.
-# /out/softnpu/scadm standalone add-proxy-arp 192.168.1.50 192.168.1.90 a8:e1:de:01:70:1d
+# Keep consistent with `get_system_ip_pool` in `end-to-end-tests`.
+IP_POOL_START="192.168.1.50"
+IP_POOL_END="192.168.1.90"
+# `dladm` won't return leading zeroes but `scadm` expects them, use sed to add any missing zeroes
+SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | sed -E 's/[ :]/&0/g; s/0([^:]{2}(:|$))/\1/g')
 pfexec ./out/softnpu/scadm \
 	--server /opt/oxide/softnpu/stuff/server \
 	--client /opt/oxide/softnpu/stuff/client \
 	standalone \
-	add-proxy-arp 192.168.1.50 192.168.1.90 a8:e1:de:01:70:1d
+	add-proxy-arp $IP_POOL_START $IP_POOL_END $SOFTNPU_MAC
+
+# We also need to configure proxy arp for any services which use OPTE for external connectivity (e.g. Nexus)
+tar xf out/omicron-sled-agent.tar pkg/config-rss.toml
+SERVICE_IP_POOL_START="$(sed -n 's/first = "\(.*\)"/\1/p' pkg/config-rss.toml)"
+SERVICE_IP_POOL_END="$(sed -n 's/last = "\(.*\)"/\1/p' pkg/config-rss.toml)"
+rm -r pkg
+
+pfexec ./out/softnpu/scadm \
+	--server /opt/oxide/softnpu/stuff/server \
+	--client /opt/oxide/softnpu/stuff/client \
+	standalone \
+	add-proxy-arp $SERVICE_IP_POOL_START $SERVICE_IP_POOL_END $SOFTNPU_MAC
 
 pfexec ./out/softnpu/scadm \
 	--server /opt/oxide/softnpu/stuff/server \
 	--client /opt/oxide/softnpu/stuff/client \
 	standalone \
 	dump-state
+
+# Wait for switch zone to come up so that we can configure it
+retry=0
+until curl --head --silent -o /dev/null "http://[fd00:1122:3344:101::2]:12224/"
+do
+	if [[ $retry -gt 30 ]]; then
+		echo "Failed to reach switch zone after 30 seconds"
+		exit 1
+	fi
+	sleep 1
+	retry=$((retry + 1))
+done
+
+# Nexus (and any instances using the above IP pool) are configured to use external
+# IPs from a fixed subnet (192.168.1.0/24). OPTE/SoftNPU/Boundary Services take care
+# of NATing between the private VPC networks and this "external network".
+# We create a static IP in this subnet in the global zone and configure the switch
+# to use it as the default gateway.
+# NOTE: Keep in sync with $[SERVICE_]IP_POOL_{START,END}
+export GATEWAY_IP=192.168.1.199
+export GATEWAY_MAC=$(dladm show-phys -m -p -o ADDRESS | head -n 1)
+pfexec ipadm create-addr -T static -a $GATEWAY_IP/24 igb0/sidehatch
+
+# NOTE: this script configures softnpu's "rack network" settings using swadm
+./tools/scrimlet/softnpu-init.sh
+
+./tests/bootstrap
 
 rm ./tests/bootstrap
 for test_bin in tests/*; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "ddm-admin-client",
  "dns-server",
  "dns-service-client",
+ "dpd-client",
  "dropshot",
  "expectorate",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "http",
  "hyper",
  "ipnetwork",
+ "lazy_static",
  "libc",
  "macaddr",
  "parse-display",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,7 @@ http.workspace = true
 hyper.workspace = true
 ipnetwork.workspace = true
 macaddr.workspace = true
+lazy_static.workspace = true
 proptest = { workspace = true, optional = true }
 rand.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -7,8 +7,8 @@
 //! This addressing functionality is shared by both initialization services
 //! and Nexus, who need to agree upon addressing schemes.
 
-use crate::api::external::{self, Error, Ipv6Net};
-use ipnetwork::Ipv6Network;
+use crate::api::external::{self, Error, Ipv4Net, Ipv6Net};
+use ipnetwork::{Ipv4Network, Ipv6Network};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
@@ -62,6 +62,52 @@ pub const NTP_PORT: u16 = 123;
 // port range, which is more complicated. That's deferred until we actually have
 // that situation (which may be as soon as allocating ephemeral IPs).
 pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
+
+lazy_static::lazy_static! {
+    /// The IPv6 prefix assigned to the built-in services VPC.
+    pub static ref SERVICE_VPC_IPV6_PREFIX: Ipv6Net = Ipv6Net(
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 0, 0, 0, 0, 0),
+            Ipv6Net::VPC_IPV6_PREFIX_LENGTH,
+        ).unwrap(),
+    );
+
+    /// The IPv4 subnet for External DNS OPTE portsv
+    pub static ref DNS_OPTE_IPV4_SUBNET: Ipv4Net =
+        Ipv4Net(Ipv4Network::new(Ipv4Addr::new(172, 30, 0, 0), 24).unwrap());
+
+    /// The IPv6 subnet for External DNS OPTE ports.
+    pub static ref DNS_OPTE_IPV6_SUBNET: Ipv6Net = Ipv6Net(
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 0, 0, 0, 0, 0),
+            Ipv6Net::VPC_SUBNET_IPV6_PREFIX_LENGTH,
+        ).unwrap(),
+    );
+
+    /// The IPv4 subnet for Nexus OPTE ports.
+    pub static ref NEXUS_OPTE_IPV4_SUBNET: Ipv4Net =
+        Ipv4Net(Ipv4Network::new(Ipv4Addr::new(172, 30, 1, 0), 24).unwrap());
+
+    /// The IPv6 subnet for Nexus OPTE ports.
+    pub static ref NEXUS_OPTE_IPV6_SUBNET: Ipv6Net = Ipv6Net(
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 1, 0, 0, 0, 0),
+            Ipv6Net::VPC_SUBNET_IPV6_PREFIX_LENGTH,
+        ).unwrap(),
+    );
+
+    /// The IPv4 subnet for Boundary NTP OPTE ports.
+    pub static ref NTP_OPTE_IPV4_SUBNET: Ipv4Net =
+        Ipv4Net(Ipv4Network::new(Ipv4Addr::new(172, 30, 2, 0), 24).unwrap());
+
+    /// The IPv6 subnet for Boundary NTP OPTE ports.
+    pub static ref NTP_OPTE_IPV6_SUBNET: Ipv6Net = Ipv6Net(
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 2, 0, 0, 0, 0),
+            Ipv6Net::VPC_SUBNET_IPV6_PREFIX_LENGTH,
+        ).unwrap(),
+    );
+}
 
 // Anycast is a mechanism in which a single IP address is shared by multiple
 // devices, and the destination is located based on routing distance.

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -47,6 +47,22 @@ pub const NEXUS_INTERNAL_PORT: u16 = 12221;
 
 pub const NTP_PORT: u16 = 123;
 
+// The number of ports available to an SNAT IP.
+// Note that for static NAT, this value isn't used, and all ports are available.
+//
+// NOTE: This must be a power of 2. We're expecting to provide the Tofino with a
+// port mask, e.g., a 16-bit mask such as `0b01...`, where those dots are any 14
+// bits. This signifies the port range `[16384, 32768)`. Such a port mask only
+// works when the port-ranges are limited to powers of 2, not arbitrary ranges.
+//
+// Also NOTE: This is not going to work if we modify this value across different
+// versions of Nexus. Currently, we're considering a port range free simply by
+// checking if the _first_ address in a range is free. However, we'll need to
+// instead to check if a candidate port range has any overlap with an existing
+// port range, which is more complicated. That's deferred until we actually have
+// that situation (which may be as soon as allocating ephemeral IPs).
+pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
+
 // Anycast is a mechanism in which a single IP address is shared by multiple
 // devices, and the destination is located based on routing distance.
 //

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -64,7 +64,21 @@ pub const NTP_PORT: u16 = 123;
 pub const NUM_SOURCE_NAT_PORTS: u16 = 1 << 14;
 
 lazy_static::lazy_static! {
+    // Services that require external connectivity are given an OPTE port
+    // with a "Service VNIC" record. Like a "Guest VNIC", a service is
+    // placed within a VPC (a built-in services VPC), along with a VPC subnet.
+    // But unlike guest instances which are created at runtime by Nexus, these
+    // services are created by RSS early on. So, we have some fixed values
+    // used to bootstrap service OPTE ports. Each service kind uses a distinct
+    // VPC subnet which RSS will allocate addresses from for those services.
+    // The specific values aren't deployment-specific as they are virtualized
+    // within OPTE.
+
     /// The IPv6 prefix assigned to the built-in services VPC.
+    // The specific prefix here was randomly chosen from the expected VPC
+    // prefix range (`fd00::/48`). See `random_vpc_ipv6_prefix`.
+    // Furthermore, all the below *_OPTE_IPV6_SUBNET constants are
+    // /64's within this prefix.
     pub static ref SERVICE_VPC_IPV6_PREFIX: Ipv6Net = Ipv6Net(
         Ipv6Network::new(
             Ipv6Addr::new(0xfd77, 0xe9d2, 0x9cd9, 0, 0, 0, 0, 0),
@@ -72,7 +86,7 @@ lazy_static::lazy_static! {
         ).unwrap(),
     );
 
-    /// The IPv4 subnet for External DNS OPTE portsv
+    /// The IPv4 subnet for External DNS OPTE ports.
     pub static ref DNS_OPTE_IPV4_SUBNET: Ipv4Net =
         Ipv4Net(Ipv4Network::new(Ipv4Addr::new(172, 30, 0, 0), 24).unwrap());
 

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1151,7 +1151,7 @@ impl From<steno::SagaStateView> for SagaState {
 }
 
 /// An `Ipv4Net` represents a IPv4 subnetwork, including the address and network mask.
-#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
 pub struct Ipv4Net(pub ipnetwork::Ipv4Network);
 
 impl Ipv4Net {
@@ -1306,7 +1306,7 @@ impl JsonSchema for Ipv6Net {
 }
 
 /// An `IpNet` represents an IP network, either IPv4 or IPv6.
-#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
@@ -1912,7 +1912,14 @@ impl JsonSchema for L4PortRange {
 // NOTE: We're using the `macaddr` crate for the internal representation. But as with the `ipnet`,
 // this crate does not implement `JsonSchema`.
 #[derive(
-    Clone, Copy, Debug, DeserializeFromStr, PartialEq, SerializeDisplay,
+    Clone,
+    Copy,
+    Debug,
+    DeserializeFromStr,
+    PartialEq,
+    Eq,
+    SerializeDisplay,
+    Hash,
 )]
 pub struct MacAddr(pub macaddr::MacAddr6);
 

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2073,6 +2073,9 @@ impl Vni {
     /// Virtual Network Identifiers are constrained to be 24-bit values.
     pub const MAX_VNI: u32 = 0xFF_FFFF;
 
+    /// The VNI for the builtin services VPC.
+    pub const SERVICES_VNI: Self = Self(100);
+
     /// Oxide reserves a slice of initial VNIs for its own use.
     pub const MIN_GUEST_VNI: u32 = 1024;
 

--- a/common/src/api/internal/mod.rs
+++ b/common/src/api/internal/mod.rs
@@ -5,3 +5,4 @@
 //! Internally facing APIs.
 
 pub mod nexus;
+pub mod shared;

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Types shared between across Nexus and Sled Agent.
+
+use crate::api::external;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use uuid::Uuid;
+
+/// The type of network interface
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    Hash,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NetworkInterfaceKind {
+    /// A vNIC attached to a guest instance
+    Instance { id: Uuid },
+    /// A vNIC associated with an internal service
+    Service { id: Uuid },
+}
+
+/// Information required to construct a virtual network interface
+#[derive(
+    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+)]
+pub struct NetworkInterface {
+    pub id: Uuid,
+    pub kind: NetworkInterfaceKind,
+    pub name: external::Name,
+    pub ip: IpAddr,
+    pub mac: external::MacAddr,
+    pub subnet: external::IpNet,
+    pub vni: external::Vni,
+    pub primary: bool,
+    pub slot: u8,
+}
+
+/// An IP address and port range used for source NAT, i.e., making
+/// outbound network connections from guests or services.
+#[derive(
+    Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+)]
+pub struct SourceNatConfig {
+    /// The external address provided to the instance or service.
+    pub ip: IpAddr,
+    /// The first port used for source NAT, inclusive.
+    pub first_port: u16,
+    /// The last port used for source NAT, also inclusive.
+    pub last_port: u16,
+}

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Types shared between across Nexus and Sled Agent.
+//! Types shared between Nexus and Sled Agent.
 
 use crate::api::external;
 use schemars::JsonSchema;

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -279,9 +279,26 @@ unique local addresses in the subnet of the first Sled Agent: `fd00:1122:3344:1:
 If you'd like to modify these values to suit your local network, you can modify
 them within the https://github.com/oxidecomputer/omicron/tree/main/smf[`smf/` subdirectory].
 Notably, Nexus is being served from IPv4 address, which may be configured to be
-external. By default, it uses a private IPv4 address and no Internet gateway, but may
-be configured to use a public-facing IP address with an Internet gateway that may
-be set as a default route for the Nexus zone.
+external. By default, it uses a private IPv4 address but may be configured to use
+a public-facing IP address.
+
+NOTE: Internal services that require external connectivity (e.g. Nexus, Boundary NTP,
+External DNS) do so via OPTE. When using SoftNPU we'll need to configure Proxy ARP for
+the services IP Pool.
+
+[source,console]
+----
+# dladm won't return leading zeroes but `scadm` expects them
+$ SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | gsed 's/\b\(\w\)\b/0\1/g')
+$ pfexec /opt/oxide/softnpu/stuff/scadm \
+  --server /opt/oxide/softnpu/stuff/server \
+  --client /opt/oxide/softnpu/stuff/client \
+  standalone \
+  add-proxy-arp \
+  $SERVICE_IP_POOL_START \
+  $SERVICE_IP_POOL_END \
+  $SOFTNPU_MAC
+----
 
 [options="header"]
 |===================================================================================================
@@ -299,7 +316,6 @@ be set as a default route for the Nexus zone.
 | Internal DNS Service       | `[fd00:1122:3344:0001::1]:5353`
 | External DNS               | `192.168.1.20:53`
 | Nexus: External API        | `192.168.1.21:80`
-| Internet Gateway           | None, but can be set in `smf/sled-agent/config-rss.toml`
 |===================================================================================================
 
 Note that Sled Agent runs in the global zone and is the one responsible for bringing up all the other

--- a/illumos-utils/src/opte/illumos.rs
+++ b/illumos-utils/src/opte/illumos.rs
@@ -6,6 +6,7 @@
 
 use crate::addrobj::AddrObject;
 use crate::dladm;
+use omicron_common::api::internal::shared::NetworkInterfaceKind;
 use opte_ioctl::OpteHdl;
 use slog::info;
 use slog::Logger;
@@ -44,7 +45,7 @@ pub enum Error {
     InvalidPortIpConfig,
 
     #[error("Tried to release non-existent port ({0}, {1:?})")]
-    ReleaseMissingPort(uuid::Uuid, super::params::NetworkInterfaceKind),
+    ReleaseMissingPort(uuid::Uuid, NetworkInterfaceKind),
 }
 
 /// Delete all xde devices on the system.

--- a/illumos-utils/src/opte/mod.rs
+++ b/illumos-utils/src/opte/mod.rs
@@ -77,4 +77,8 @@ impl Gateway {
                 .expect("IP subnet must have at least 2 addresses"),
         }
     }
+
+    pub fn ip(&self) -> &IpAddr {
+        &self.ip
+    }
 }

--- a/illumos-utils/src/opte/non_illumos.rs
+++ b/illumos-utils/src/opte/non_illumos.rs
@@ -7,6 +7,7 @@
 use slog::Logger;
 
 use crate::addrobj::AddrObject;
+use omicron_common::api::internal::shared::NetworkInterfaceKind;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -14,7 +15,7 @@ pub enum Error {
     InvalidPortIpConfig,
 
     #[error("Tried to release non-existent port ({0}, {1:?})")]
-    ReleaseMissingPort(uuid::Uuid, super::params::NetworkInterfaceKind),
+    ReleaseMissingPort(uuid::Uuid, NetworkInterfaceKind),
 }
 
 pub fn initialize_xde_driver(

--- a/illumos-utils/src/opte/params.rs
+++ b/illumos-utils/src/opte/params.rs
@@ -4,58 +4,11 @@
 
 use omicron_common::api::external;
 use omicron_common::api::internal::nexus::HostIdentifier;
+use omicron_common::api::internal::shared::NetworkInterface;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::net::Ipv6Addr;
-use uuid::Uuid;
-
-/// The type of network interface
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Deserialize,
-    Serialize,
-    JsonSchema,
-)]
-#[serde(rename_all = "snake_case")]
-pub enum NetworkInterfaceKind {
-    /// A vNIC attached to a guest instance
-    Instance { id: Uuid },
-    /// A vNIC associated with an internal service
-    Service { id: Uuid },
-}
-
-/// Information required to construct a virtual network interface
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct NetworkInterface {
-    pub id: Uuid,
-    pub kind: NetworkInterfaceKind,
-    pub name: external::Name,
-    pub ip: IpAddr,
-    pub mac: external::MacAddr,
-    pub subnet: external::IpNet,
-    pub vni: external::Vni,
-    pub primary: bool,
-    pub slot: u8,
-}
-
-/// An IP address and port range used for instance source NAT, i.e., making
-/// outbound network connections from guests or services.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
-pub struct SourceNatConfig {
-    /// The external address provided to the instance
-    pub ip: IpAddr,
-    /// The first port used for instance NAT, inclusive.
-    pub first_port: u16,
-    /// The last port used for instance NAT, also inclusive.
-    pub last_port: u16,
-}
 
 /// Update firewall rules for a VPC
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/illumos-utils/src/opte/port.rs
+++ b/illumos-utils/src/opte/port.rs
@@ -23,7 +23,7 @@ struct PortInner {
     // Geneve VNI for the VPC
     vni: Vni,
     // Information about the virtual gateway, aka OPTE
-    _gateway: Gateway,
+    gateway: Gateway,
     // TODO-correctness: Remove this once we can put Viona directly on top of an
     // OPTE port device.
     //
@@ -99,7 +99,7 @@ impl Port {
                 mac,
                 slot,
                 vni,
-                _gateway: gateway,
+                gateway,
                 vnic,
             }),
         }
@@ -107,6 +107,10 @@ impl Port {
 
     pub fn name(&self) -> &str {
         &self.inner.name
+    }
+
+    pub fn gateway(&self) -> &Gateway {
+        &self.inner.gateway
     }
 
     #[allow(dead_code)]

--- a/illumos-utils/src/opte/port.rs
+++ b/illumos-utils/src/opte/port.rs
@@ -24,7 +24,7 @@ struct PortInner {
     vni: Vni,
     // Information about the virtual gateway, aka OPTE
     gateway: Gateway,
-    // TODO-correctness: Remove this once we can put Viona directly on top of an
+    // TODO-remove(#2932): Remove this once we can put Viona directly on top of an
     // OPTE port device.
     //
     // NOTE: This is intentionally not an actual `Vnic` object. We'd like to

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -6,10 +6,7 @@
 
 use crate::opte::default_boundary_services;
 use crate::opte::opte_firewall_rules;
-use crate::opte::params::NetworkInterface;
-use crate::opte::params::NetworkInterfaceKind;
 use crate::opte::params::SetVirtualNetworkInterfaceHost;
-use crate::opte::params::SourceNatConfig;
 use crate::opte::params::VpcFirewallRule;
 use crate::opte::Error;
 use crate::opte::Gateway;
@@ -17,6 +14,9 @@ use crate::opte::Port;
 use crate::opte::Vni;
 use ipnetwork::IpNetwork;
 use macaddr::MacAddr6;
+use omicron_common::api::internal::shared::NetworkInterface;
+use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use omicron_common::api::internal::shared::SourceNatConfig;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::IpCfg;
 use oxide_vpc::api::IpCidr;

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -269,6 +269,11 @@ impl PortManager {
             "dir=in priority=65534 protocol=arp action=allow".parse().unwrap(),
         );
 
+        // TODO-remove: Nexus will plumb proper service fw rules
+        if let NetworkInterfaceKind::Service { .. } = nic.kind {
+            rules.push("dir=in priority=100 action=allow".parse().unwrap());
+        }
+
         debug!(
             self.inner.log,
             "Setting firewall rules";

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -269,7 +269,7 @@ impl PortManager {
             "dir=in priority=65534 protocol=arp action=allow".parse().unwrap(),
         );
 
-        // TODO-remove: Nexus will plumb proper service fw rules
+        // TODO-remove(#2930): Nexus will plumb proper service fw rules
         if let NetworkInterfaceKind::Service { .. } = nic.kind {
             rules.push("dir=in priority=100 action=allow".parse().unwrap());
         }
@@ -286,7 +286,7 @@ impl PortManager {
             rules,
         })?;
 
-        // Create a VNIC on top of this device, to hook Viona into.
+        // TODO-remove(#2932): Create a VNIC on top of this device, to hook Viona into.
         //
         // Viona is the illumos MAC provider that implements the VIRTIO
         // specification. It sits on top of a MAC provider, which is responsible

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -76,7 +76,7 @@ pub enum EnsureAddressError {
     )]
     MissingOptePort { zone: String, port_idx: usize },
 
-    // TODO-remove: See comment in `ensure_address_for_port`
+    // TODO-remove(#2931): See comment in `ensure_address_for_port`
     #[error(transparent)]
     OpteGatewayConfig(#[from] RunCommandError),
 }
@@ -263,7 +263,7 @@ impl RunningZone {
                 port_idx,
             }
         })?;
-        // TODO-remove: Switch to using port directly once vnic is no longer needed.
+        // TODO-remove(#2932): Switch to using port directly once vnic is no longer needed.
         let addrobj =
             AddrObject::new(port.vnic_name(), name).map_err(|err| {
                 EnsureAddressError::AddrObject {
@@ -276,11 +276,10 @@ impl RunningZone {
         if let IpAddr::V4(gateway) = port.gateway().ip() {
             let addr =
                 Zones::ensure_address(zone, &addrobj, AddressRequest::Dhcp)?;
-            // TODO-remove: OPTE's DHCP "server" returns the list of routes to add
-            // via option 121 (Classless Static Route). The illumos DHCP client
-            // currently does not support this option, so we add the routes
+            // TODO-remove(#2931): OPTE's DHCP "server" returns the list of routes
+            // to add via option 121 (Classless Static Route). The illumos DHCP
+            // client currently does not support this option, so we add the routes
             // manually here.
-            // https://www.illumos.org/issues/11990
             let gateway_ip = gateway.to_string();
             let private_ip = addr.ip();
             self.run_cmd(&[

--- a/illumos-utils/src/zone.rs
+++ b/illumos-utils/src/zone.rs
@@ -130,6 +130,16 @@ pub struct EnsureGzAddressError {
     extra_note: String,
 }
 
+/// Errors which may be encountered getting addresses.
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to get addresses with name {name} in {zone}: {err}")]
+pub struct GetAddressesError {
+    zone: String,
+    name: AddrObject,
+    #[source]
+    err: anyhow::Error,
+}
+
 /// Describes the type of addresses which may be requested from a zone.
 #[derive(Copy, Clone, Debug)]
 // TODO-cleanup: Remove, along with moving to IPv6 addressing everywhere.
@@ -465,7 +475,7 @@ impl Zones {
 
     /// Gets the IP address of an interface.
     ///
-    /// This address may optionally be within a zone named `zone`.
+    /// This `addrobj` may optionally be within a zone named `zone`.
     /// If `None` is supplied, the address is queried from the Global Zone.
     #[allow(clippy::needless_lifetimes)]
     fn get_address<'a>(
@@ -488,6 +498,37 @@ impl Zones {
             .lines()
             .find_map(|s| s.parse().ok())
             .ok_or(Error::AddressNotFound { addrobj: addrobj.clone() })
+    }
+
+    /// Gets all IP address of an interface.
+    ///
+    /// This `addrobj` may optionally be within a zone named `zone`.
+    /// If `None` is supplied, the address is queried from the Global Zone.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn get_all_addresses<'a>(
+        zone: Option<&'a str>,
+        addrobj: &AddrObject,
+    ) -> Result<Vec<IpNetwork>, GetAddressesError> {
+        let mut command = std::process::Command::new(PFEXEC);
+
+        let mut args = vec![];
+        if let Some(zone) = zone {
+            args.push(ZLOGIN);
+            args.push(zone);
+        };
+        let addrobj_str = addrobj.to_string();
+        args.extend(&[IPADM, "show-addr", "-p", "-o", "ADDR", &addrobj_str]);
+
+        let cmd = command.args(args);
+        let output = execute(cmd).map_err(|err| GetAddressesError {
+            zone: zone.unwrap_or("global").to_string(),
+            name: addrobj.clone(),
+            err: err.into(),
+        })?;
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|s| s.parse().ok())
+            .collect::<Vec<_>>())
     }
 
     /// Returns Ok(()) if `addrobj` has a corresponding link-local IPv6 address.

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -29,8 +29,8 @@ pub enum ServiceName {
     CruciblePantry,
     SledAgent(Uuid),
     Crucible(Uuid),
-    BoundaryNTP,
-    InternalNTP,
+    BoundaryNtp,
+    InternalNtp,
     Maghemite,
 }
 
@@ -50,8 +50,8 @@ impl ServiceName {
             ServiceName::CruciblePantry => "crucible-pantry",
             ServiceName::SledAgent(_) => "sledagent",
             ServiceName::Crucible(_) => "crucible",
-            ServiceName::BoundaryNTP => "boundary-ntp",
-            ServiceName::InternalNTP => "internal-ntp",
+            ServiceName::BoundaryNtp => "boundary-ntp",
+            ServiceName::InternalNtp => "internal-ntp",
             ServiceName::Maghemite => "maghemite",
         }
     }
@@ -71,8 +71,8 @@ impl ServiceName {
             | ServiceName::Dendrite
             | ServiceName::Tfport
             | ServiceName::CruciblePantry
-            | ServiceName::BoundaryNTP
-            | ServiceName::InternalNTP
+            | ServiceName::BoundaryNtp
+            | ServiceName::InternalNtp
             | ServiceName::Maghemite => {
                 format!("_{}._tcp", self.service_kind())
             }

--- a/nexus/db-model/src/macaddr.rs
+++ b/nexus/db-model/src/macaddr.rs
@@ -8,70 +8,10 @@ use diesel::pg::Pg;
 use diesel::serialize::{self, ToSql};
 use diesel::sql_types;
 use omicron_common::api::external;
-use rand::thread_rng;
-use rand::Rng;
 
 #[derive(Clone, Copy, Debug, PartialEq, AsExpression, FromSqlRow)]
 #[diesel(sql_type = sql_types::BigInt)]
 pub struct MacAddr(pub external::MacAddr);
-
-impl MacAddr {
-    // Guest MAC addresses begin with the Oxide OUI A8:40:25. Further, guest
-    // address are constrained to be in the virtual address range
-    // A8:40:25:F_:__:__. Even further, the range F0:00:00 - FE:FF:FF is
-    // reserved for customer-visible addresses (FF:00:00-FF:FF:FF is for
-    // system MAC addresses). See RFD 174 for the discussion of the virtual
-    // range, and
-    // https://github.com/oxidecomputer/omicron/pull/955#discussion_r856432498
-    // for an initial discussion of the customer/system address range split.
-    // The system range is further split between FF:00:00-FF:7F:FF for
-    // fixed addresses (e.g., the OPTE virtual gateway MAC) and
-    // FF:80:00-FF:FF:FF for dynamically allocated addresses (e.g., service
-    // vNICs).
-    //
-    // F0:00:00 - FF:FF:FF    Oxide Virtual Address Range
-    //     F0:00:00 - FE:FF:FF    Guest Addresses
-    //     FF:00:00 - FF:FF:FF    System Addresses
-    //         FF:00:00 - FF:7F:FF    Reserved Addresses
-    //         FF:80:00 - FF:FF:FF    Runtime allocatable
-    pub const MIN_GUEST_ADDR: i64 = 0xA8_40_25_F0_00_00;
-    pub const MAX_GUEST_ADDR: i64 = 0xA8_40_25_FE_FF_FF;
-    pub const MIN_SYSTEM_ADDR: i64 = 0xA8_40_25_FF_00_00;
-    pub const MAX_SYSTEM_RESV: i64 = 0xA8_40_25_FF_7F_FF;
-    pub const MAX_SYSTEM_ADDR: i64 = 0xA8_40_25_FF_FF_FF;
-
-    /// Generate a random MAC address for a guest network interface
-    pub fn random_guest() -> Self {
-        let value =
-            thread_rng().gen_range(Self::MIN_GUEST_ADDR..=Self::MAX_GUEST_ADDR);
-        Self::from_i64(value)
-    }
-
-    /// Generate a random MAC address in the system address range
-    pub fn random_system() -> Self {
-        let value = thread_rng()
-            .gen_range((Self::MAX_SYSTEM_RESV + 1)..=Self::MAX_SYSTEM_ADDR);
-        Self::from_i64(value)
-    }
-
-    /// Construct a MAC address from its i64 big-endian byte representation.
-    // NOTE: This is the representation used in the database.
-    pub(crate) fn from_i64(value: i64) -> Self {
-        let bytes = value.to_be_bytes();
-        Self(external::MacAddr(macaddr::MacAddr6::new(
-            bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-        )))
-    }
-
-    /// Convert a MAC address to its i64 big-endian byte representation
-    // NOTE: This is the representation used in the database.
-    pub fn to_i64(self) -> i64 {
-        let bytes = self.0.as_bytes();
-        i64::from_be_bytes([
-            0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
-        ])
-    }
-}
 
 NewtypeFrom! { () pub struct MacAddr(external::MacAddr); }
 NewtypeDeref! { () pub struct MacAddr(external::MacAddr); }
@@ -95,20 +35,6 @@ where
 {
     fn from_sql(bytes: RawValue<DB>) -> deserialize::Result<Self> {
         let value = i64::from_sql(bytes)?;
-        Ok(MacAddr::from_i64(value))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::MacAddr;
-
-    #[test]
-    fn test_mac_to_int_conversions() {
-        let original: i64 = 0xa8_40_25_ff_00_01;
-        let mac = MacAddr::from_i64(original);
-        assert_eq!(mac.0.as_bytes(), &[0xa8, 0x40, 0x25, 0xff, 0x00, 0x01]);
-        let conv = mac.to_i64();
-        assert_eq!(original, conv);
+        Ok(MacAddr(external::MacAddr::from_i64(value)))
     }
 }

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -66,14 +66,10 @@ impl From<NicInfo> for sled_client_types::NetworkInterface {
         };
         let kind = match nic.kind {
             NetworkInterfaceKind::Instance => {
-                sled_client_types::NetworkInterfaceKind::Instance {
-                    id: nic.parent_id,
-                }
+                sled_client_types::NetworkInterfaceKind::Instance(nic.parent_id)
             }
             NetworkInterfaceKind::Service => {
-                sled_client_types::NetworkInterfaceKind::Service {
-                    id: nic.parent_id,
-                }
+                sled_client_types::NetworkInterfaceKind::Service(nic.parent_id)
             }
         };
         sled_client_types::NetworkInterface {

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -6,7 +6,6 @@
 
 use crate::db;
 use crate::db::model::IncompleteNetworkInterface;
-use crate::db::model::MacAddr;
 use crate::db::pool::DbConnection;
 use crate::db::queries::next_item::DefaultShiftGenerator;
 use crate::db::queries::next_item::NextItem;
@@ -27,6 +26,7 @@ use ipnetwork::Ipv4Network;
 use nexus_db_model::NetworkInterfaceKind;
 use nexus_db_model::NetworkInterfaceKindEnum;
 use omicron_common::api::external;
+use omicron_common::api::external::MacAddr;
 use omicron_common::nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
 use std::net::IpAddr;
 use uuid::Uuid;
@@ -557,7 +557,7 @@ impl QueryFragment<Pg> for NextNicSlot {
 pub struct NextMacAddress {
     inner: NextItem<
         db::schema::network_interface::table,
-        MacAddr,
+        db::model::MacAddr,
         db::schema::network_interface::dsl::mac,
         Uuid,
         db::schema::network_interface::dsl::vpc_id,
@@ -572,14 +572,14 @@ impl NextMacAddress {
                 let x = base.to_i64();
                 let max_shift = MacAddr::MAX_GUEST_ADDR - x;
                 let min_shift = x - MacAddr::MIN_GUEST_ADDR;
-                (base, max_shift, min_shift)
+                (base.into(), max_shift, min_shift)
             }
             NetworkInterfaceKind::Service => {
                 let base = MacAddr::random_system();
                 let x = base.to_i64();
                 let max_shift = MacAddr::MAX_SYSTEM_ADDR - x;
                 let min_shift = x - MacAddr::MAX_SYSTEM_ADDR;
-                (base, max_shift, min_shift)
+                (base.into(), max_shift, min_shift)
             }
         };
         let generator = DefaultShiftGenerator { base, max_shift, min_shift };
@@ -1641,7 +1641,6 @@ mod tests {
     use crate::db::model;
     use crate::db::model::IncompleteNetworkInterface;
     use crate::db::model::Instance;
-    use crate::db::model::MacAddr;
     use crate::db::model::NetworkInterface;
     use crate::db::model::Project;
     use crate::db::model::VpcSubnet;
@@ -1664,6 +1663,7 @@ mod tests {
     use omicron_common::api::external::InstanceState;
     use omicron_common::api::external::Ipv4Net;
     use omicron_common::api::external::Ipv6Net;
+    use omicron_common::api::external::MacAddr;
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
     use omicron_test_utils::dev;
     use omicron_test_utils::dev::db::CockroachInstance;

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1759,12 +1759,22 @@
             "type": "object",
             "properties": {
               "external_ip": {
+                "description": "The address at which the external nexus server is reachable.",
                 "type": "string",
                 "format": "ip"
               },
               "internal_ip": {
+                "description": "The address at which the internal nexus server is reachable.",
                 "type": "string",
                 "format": "ipv6"
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
               },
               "type": {
                 "type": "string",
@@ -1776,6 +1786,7 @@
             "required": [
               "external_ip",
               "internal_ip",
+              "nic",
               "type"
             ]
           },
@@ -1783,10 +1794,20 @@
             "type": "object",
             "properties": {
               "dns_address": {
+                "description": "The address at which the external DNS server is reachable.",
                 "type": "string"
               },
               "http_address": {
+                "description": "The address at which the external DNS server API is reachable.",
                 "type": "string"
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
               },
               "type": {
                 "type": "string",
@@ -1798,6 +1819,7 @@
             "required": [
               "dns_address",
               "http_address",
+              "nic",
               "type"
             ]
           },
@@ -1928,15 +1950,13 @@
                 "nullable": true,
                 "type": "string"
               },
-              "first_port": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
-              },
-              "last_port": {
-                "type": "integer",
-                "format": "uint16",
-                "minimum": 0
+              "nic": {
+                "description": "The service vNIC providing outbound connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
               },
               "ntp_servers": {
                 "type": "array",
@@ -1944,9 +1964,13 @@
                   "type": "string"
                 }
               },
-              "snat_ip": {
-                "type": "string",
-                "format": "ip"
+              "snat_cfg": {
+                "description": "The SNAT configuration for outbound connections.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SourceNatConfig"
+                  }
+                ]
               },
               "type": {
                 "type": "string",
@@ -1957,10 +1981,9 @@
             },
             "required": [
               "dns_servers",
-              "first_port",
-              "last_port",
+              "nic",
               "ntp_servers",
-              "snat_ip",
+              "snat_cfg",
               "type"
             ]
           },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1695,45 +1695,41 @@
             "description": "A vNIC attached to a guest instance",
             "type": "object",
             "properties": {
-              "instance": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "required": [
-                  "id"
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
                 ]
               }
             },
             "required": [
-              "instance"
-            ],
-            "additionalProperties": false
+              "id",
+              "type"
+            ]
           },
           {
             "description": "A vNIC associated with an internal service",
             "type": "object",
             "properties": {
-              "service": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "required": [
-                  "id"
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "service"
                 ]
               }
             },
             "required": [
-              "service"
-            ],
-            "additionalProperties": false
+              "id",
+              "type"
+            ]
           }
         ]
       },
@@ -2111,22 +2107,22 @@
         "minimum": 0
       },
       "SourceNatConfig": {
-        "description": "An IP address and port range used for instance source NAT, i.e., making outbound network connections from guests or services.",
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
         "type": "object",
         "properties": {
           "first_port": {
-            "description": "The first port used for instance NAT, inclusive.",
+            "description": "The first port used for source NAT, inclusive.",
             "type": "integer",
             "format": "uint16",
             "minimum": 0
           },
           "ip": {
-            "description": "The external address provided to the instance",
+            "description": "The external address provided to the instance or service.",
             "type": "string",
             "format": "ip"
           },
           "last_port": {
-            "description": "The last port used for instance NAT, also inclusive.",
+            "description": "The last port used for source NAT, also inclusive.",
             "type": "integer",
             "format": "uint16",
             "minimum": 0

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1932,11 +1932,25 @@
                 "nullable": true,
                 "type": "string"
               },
+              "first_port": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "last_port": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
               "ntp_servers": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
+              },
+              "snat_ip": {
+                "type": "string",
+                "format": "ip"
               },
               "type": {
                 "type": "string",
@@ -1947,7 +1961,10 @@
             },
             "required": [
               "dns_servers",
+              "first_port",
+              "last_port",
               "ntp_servers",
+              "snat_ip",
               "type"
             ]
           },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1922,9 +1922,6 @@
           {
             "type": "object",
             "properties": {
-              "boundary": {
-                "type": "boolean"
-              },
               "dns_servers": {
                 "type": "array",
                 "items": {
@@ -1944,12 +1941,43 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "ntp"
+                  "boundary_ntp"
                 ]
               }
             },
             "required": [
-              "boundary",
+              "dns_servers",
+              "ntp_servers",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dns_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "domain": {
+                "nullable": true,
+                "type": "string"
+              },
+              "ntp_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_ntp"
+                ]
+              }
+            },
+            "required": [
               "dns_servers",
               "ntp_servers",
               "type"

--- a/sled-agent-client/src/lib.rs
+++ b/sled-agent-client/src/lib.rs
@@ -416,6 +416,48 @@ impl From<omicron_common::api::external::VpcFirewallRuleProtocol>
     }
 }
 
+impl From<omicron_common::api::internal::shared::NetworkInterfaceKind>
+    for types::NetworkInterfaceKind
+{
+    fn from(
+        s: omicron_common::api::internal::shared::NetworkInterfaceKind,
+    ) -> Self {
+        use omicron_common::api::internal::shared::NetworkInterfaceKind::*;
+        match s {
+            Instance { id } => Self::Instance(id),
+            Service { id } => Self::Service(id),
+        }
+    }
+}
+
+impl From<omicron_common::api::internal::shared::NetworkInterface>
+    for types::NetworkInterface
+{
+    fn from(
+        s: omicron_common::api::internal::shared::NetworkInterface,
+    ) -> Self {
+        Self {
+            id: s.id,
+            kind: s.kind.into(),
+            name: (&s.name).into(),
+            ip: s.ip,
+            mac: s.mac.into(),
+            subnet: s.subnet.into(),
+            vni: s.vni.into(),
+            primary: s.primary,
+            slot: s.slot,
+        }
+    }
+}
+
+impl From<omicron_common::api::internal::shared::SourceNatConfig>
+    for types::SourceNatConfig
+{
+    fn from(s: omicron_common::api::internal::shared::SourceNatConfig) -> Self {
+        Self { ip: s.ip, first_port: s.first_port, last_port: s.last_port }
+    }
+}
+
 /// Exposes additional [`Client`] interfaces for use by the test suite. These
 /// are bonus endpoints, not generated in the real client.
 #[async_trait]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -21,6 +21,7 @@ crucible-agent-client.workspace = true
 ddm-admin-client.workspace = true
 dns-server.workspace = true
 dns-service-client.workspace = true
+dpd-client.workspace = true
 dropshot.workspace = true
 flate2.workspace = true
 futures.workspace = true

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -9,8 +9,7 @@ use crate::instance_manager::InstanceTicket;
 use crate::nexus::LazyNexusClient;
 use crate::params::{
     InstanceHardware, InstanceMigrationSourceParams,
-    InstanceMigrationTargetParams, InstanceStateRequested, NetworkInterface,
-    SourceNatConfig, VpcFirewallRule,
+    InstanceMigrationTargetParams, InstanceStateRequested, VpcFirewallRule,
 };
 use anyhow::anyhow;
 use futures::lock::{Mutex, MutexGuard};
@@ -26,6 +25,9 @@ use omicron_common::address::NEXUS_INTERNAL_PORT;
 use omicron_common::address::PROPOLIS_PORT;
 use omicron_common::api::external::InstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
+use omicron_common::api::internal::shared::{
+    NetworkInterface, SourceNatConfig,
+};
 use omicron_common::backoff;
 //use propolis_client::generated::DiskRequest;
 use propolis_client::Client as PropolisClient;
@@ -987,7 +989,6 @@ mod test {
     use crate::instance_manager::InstanceManager;
     use crate::nexus::LazyNexusClient;
     use crate::params::InstanceStateRequested;
-    use crate::params::SourceNatConfig;
     use chrono::Utc;
     use illumos_utils::dladm::Etherstub;
     use illumos_utils::opte::PortManager;
@@ -996,6 +997,7 @@ mod test {
         ByteCount, Generation, InstanceCpuCount, InstanceState,
     };
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
+    use omicron_common::api::internal::shared::SourceNatConfig;
     use omicron_test_utils::dev::test_setup_log;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1074,8 +1074,7 @@ mod test {
             log.clone(),
             lazy_nexus_client.clone(),
             Etherstub("mylink".to_string()),
-            underlay_ip,
-            Some(mac),
+            port_manager.clone(),
         )
         .unwrap();
 

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -352,7 +352,6 @@ mod test {
     use crate::instance::MockInstance;
     use crate::nexus::LazyNexusClient;
     use crate::params::InstanceStateRequested;
-    use crate::params::SourceNatConfig;
     use chrono::Utc;
     use illumos_utils::dladm::Etherstub;
     use illumos_utils::{dladm::MockDladm, zone::MockZones};
@@ -361,6 +360,7 @@ mod test {
         ByteCount, Generation, InstanceCpuCount, InstanceState,
     };
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
+    use omicron_common::api::internal::shared::SourceNatConfig;
     use omicron_test_utils::dev::test_setup_log;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -13,11 +13,9 @@ use illumos_utils::dladm::Etherstub;
 use illumos_utils::link::VnicAllocator;
 use illumos_utils::opte::params::SetVirtualNetworkInterfaceHost;
 use illumos_utils::opte::PortManager;
-use macaddr::MacAddr6;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use slog::Logger;
 use std::collections::BTreeMap;
-use std::net::Ipv6Addr;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -39,9 +37,6 @@ pub enum Error {
 
     #[error("Cannot find data link: {0}")]
     Underlay(#[from] sled_hardware::underlay::Error),
-
-    #[error("No datalinks found")]
-    NoDatalinks,
 }
 
 struct InstanceManagerInternal {
@@ -69,8 +64,7 @@ impl InstanceManager {
         log: Logger,
         lazy_nexus_client: LazyNexusClient,
         etherstub: Etherstub,
-        underlay_ip: Ipv6Addr,
-        gateway_mac: Option<MacAddr6>,
+        port_manager: PortManager,
     ) -> Result<InstanceManager, Error> {
         Ok(InstanceManager {
             inner: Arc::new(InstanceManagerInternal {
@@ -78,11 +72,7 @@ impl InstanceManager {
                 lazy_nexus_client,
                 instances: Mutex::new(BTreeMap::new()),
                 vnic_allocator: VnicAllocator::new("Instance", etherstub),
-                port_manager: PortManager::new(
-                    log.new(o!("component" => "PortManager")),
-                    underlay_ip,
-                    gateway_mac,
-                ),
+                port_manager,
             }),
         })
     }
@@ -418,14 +408,18 @@ mod test {
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
         dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
 
-        let im = InstanceManager::new(
+        let port_manager = PortManager::new(
             log.clone(),
-            lazy_nexus_client,
-            Etherstub("mylink".to_string()),
             std::net::Ipv6Addr::new(
                 0xfd00, 0x1de, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
             ),
             Some(MacAddr6::from([0u8; 6])),
+        );
+        let im = InstanceManager::new(
+            log.clone(),
+            lazy_nexus_client,
+            Etherstub("mylink".to_string()),
+            port_manager,
         )
         .unwrap();
 
@@ -530,14 +524,18 @@ mod test {
         let dladm_get_vnics_ctx = MockDladm::get_vnics_context();
         dladm_get_vnics_ctx.expect().return_once(|| Ok(vec![]));
 
-        let im = InstanceManager::new(
+        let port_manager = PortManager::new(
             log.clone(),
-            lazy_nexus_client,
-            Etherstub("mylink".to_string()),
             std::net::Ipv6Addr::new(
                 0xfd00, 0x1de, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
             ),
             Some(MacAddr6::from([0u8; 6])),
+        );
+        let im = InstanceManager::new(
+            log.clone(),
+            lazy_nexus_client,
+            Etherstub("mylink".to_string()),
+            port_manager,
         )
         .unwrap();
 

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -5,14 +5,15 @@
 use omicron_common::api::internal::nexus::{
     DiskRuntimeState, InstanceRuntimeState,
 };
+use omicron_common::api::internal::shared::{
+    NetworkInterface, SourceNatConfig,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter, Result as FormatResult};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use uuid::Uuid;
 
-pub use illumos_utils::opte::params::NetworkInterface;
-pub use illumos_utils::opte::params::SourceNatConfig;
 pub use illumos_utils::opte::params::VpcFirewallRule;
 pub use illumos_utils::opte::params::VpcFirewallRulesEnsureBody;
 pub use sled_hardware::DendriteAsic;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -311,6 +311,9 @@ pub enum ServiceType {
         ntp_servers: Vec<String>,
         dns_servers: Vec<String>,
         domain: Option<String>,
+        snat_ip: IpAddr,
+        first_port: u16,
+        last_port: u16,
     },
     InternalNtp {
         ntp_servers: Vec<String>,
@@ -396,9 +399,21 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
             }
             St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
             St::CruciblePantry => AutoSt::CruciblePantry,
-            St::BoundaryNtp { ntp_servers, dns_servers, domain } => {
-                AutoSt::BoundaryNtp { ntp_servers, dns_servers, domain }
-            }
+            St::BoundaryNtp {
+                ntp_servers,
+                dns_servers,
+                domain,
+                snat_ip,
+                first_port,
+                last_port,
+            } => AutoSt::BoundaryNtp {
+                ntp_servers,
+                dns_servers,
+                domain,
+                snat_ip,
+                first_port,
+                last_port,
+            },
             St::InternalNtp { ntp_servers, dns_servers, domain } => {
                 AutoSt::InternalNtp { ntp_servers, dns_servers, domain }
             }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -307,9 +307,13 @@ pub enum ServiceType {
         pkt_source: String,
     },
     CruciblePantry,
-    Ntp {
+    BoundaryNtp {
         ntp_servers: Vec<String>,
-        boundary: bool,
+        dns_servers: Vec<String>,
+        domain: Option<String>,
+    },
+    InternalNtp {
+        ntp_servers: Vec<String>,
         dns_servers: Vec<String>,
         domain: Option<String>,
     },
@@ -330,7 +334,8 @@ impl std::fmt::Display for ServiceType {
             ServiceType::Dendrite { .. } => write!(f, "dendrite"),
             ServiceType::Tfport { .. } => write!(f, "tfport"),
             ServiceType::CruciblePantry => write!(f, "crucible/pantry"),
-            ServiceType::Ntp { .. } => write!(f, "ntp"),
+            ServiceType::BoundaryNtp { .. }
+            | ServiceType::InternalNtp { .. } => write!(f, "ntp"),
             ServiceType::Maghemite { .. } => write!(f, "mg-ddm"),
         }
     }
@@ -391,8 +396,11 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
             }
             St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
             St::CruciblePantry => AutoSt::CruciblePantry,
-            St::Ntp { ntp_servers, boundary, dns_servers, domain } => {
-                AutoSt::Ntp { ntp_servers, boundary, dns_servers, domain }
+            St::BoundaryNtp { ntp_servers, dns_servers, domain } => {
+                AutoSt::BoundaryNtp { ntp_servers, dns_servers, domain }
+            }
+            St::InternalNtp { ntp_servers, dns_servers, domain } => {
+                AutoSt::InternalNtp { ntp_servers, dns_servers, domain }
             }
             St::Maghemite { mode } => AutoSt::Maghemite { mode },
         }

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -494,7 +494,7 @@ impl Plan {
                             dns_servers: config.dns_servers.clone(),
                             domain: None,
                         }],
-                        ServiceName::BoundaryNTP,
+                        ServiceName::BoundaryNtp,
                     )
                 } else {
                     (
@@ -503,7 +503,7 @@ impl Plan {
                             dns_servers: rack_dns_servers.clone(),
                             domain: None,
                         }],
-                        ServiceName::InternalNTP,
+                        ServiceName::InternalNtp,
                     )
                 };
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -489,11 +489,8 @@ impl Plan {
                     boundary_ntp_servers
                         .push(format!("{}.host.{}", id, DNS_ZONE));
                     (
-                        // XXXNTP - these boundary servers need a path to the
-                        // external network via OPTE.
-                        vec![ServiceType::Ntp {
+                        vec![ServiceType::BoundaryNtp {
                             ntp_servers: config.ntp_servers.clone(),
-                            boundary: true,
                             dns_servers: config.dns_servers.clone(),
                             domain: None,
                         }],
@@ -501,9 +498,8 @@ impl Plan {
                     )
                 } else {
                     (
-                        vec![ServiceType::Ntp {
+                        vec![ServiceType::InternalNtp {
                             ntp_servers: boundary_ntp_servers.clone(),
-                            boundary: false,
                             dns_servers: rack_dns_servers.clone(),
                             domain: None,
                         }],

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -16,6 +16,10 @@ use omicron_common::address::{
     DENDRITE_PORT, DNS_HTTP_PORT, DNS_PORT, NTP_PORT, NUM_SOURCE_NAT_PORTS,
     RSS_RESERVED_ADDRESSES, SLED_PREFIX,
 };
+use omicron_common::api::external::{MacAddr, Vni};
+use omicron_common::api::internal::shared::{
+    NetworkInterface, NetworkInterfaceKind, SourceNatConfig,
+};
 use omicron_common::backoff::{
     retry_notify_ext, retry_policy_internal_service_aggressive, BackoffError,
 };
@@ -24,8 +28,8 @@ use sled_agent_client::{
     types as SledAgentTypes, Client as SledAgentClient, Error as SledAgentError,
 };
 use slog::Logger;
-use std::collections::HashMap;
-use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::num::Wrapping;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -239,30 +243,10 @@ impl Plan {
             .iter()
             .flat_map(|range| range.iter());
 
+        let mut boundary_ntp_servers = vec![];
         let mut seen_any_scrimlet = false;
 
-        let mut boundary_ntp_servers = vec![];
-        let mut boundary_ntp_snat_ip = services_ip_pool
-            .next()
-            .ok_or_else(|| PlanError::ServiceIp("Boundary NTP"))?;
-        let mut boundary_ntp_snat_first_port = Wrapping(0u16);
-        let mut boundary_ntp_snat_config =
-            |services_ip_pool: &mut dyn Iterator<Item = _>| {
-                // Grab the next available values
-                let snat_ip = boundary_ntp_snat_ip;
-                let first_port = boundary_ntp_snat_first_port.0;
-                let last_port = first_port + (NUM_SOURCE_NAT_PORTS - 1);
-
-                boundary_ntp_snat_first_port += NUM_SOURCE_NAT_PORTS;
-                if boundary_ntp_snat_first_port.0 == 0 {
-                    // Grab another IP if we wrapped around
-                    boundary_ntp_snat_ip = services_ip_pool
-                        .next()
-                        .ok_or_else(|| PlanError::ServiceIp("Boundary NTP"))?;
-                }
-
-                Ok::<_, PlanError>((snat_ip, first_port, last_port))
-            };
+        let mut svc_port_builder = ServicePortBuilder::new();
 
         for (idx, (_bootstrap_address, sled_request)) in
             sleds.iter().enumerate()
@@ -295,12 +279,6 @@ impl Plan {
             // TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove
             if idx < EXTERNAL_DNS_COUNT {
                 let internal_ip = addr_alloc.next().expect("Not enough addrs");
-                let external_ip = services_ip_pool.next().ok_or_else(|| {
-                    PlanError::SledInitialization(
-                        "no IP available in services IP pool for External DNS"
-                            .to_string(),
-                    )
-                })?;
                 let http_port = omicron_common::address::DNS_HTTP_PORT;
                 let dns_port = omicron_common::address::DNS_PORT;
                 let id = Uuid::new_v4();
@@ -312,6 +290,8 @@ impl Plan {
                         http_port,
                     )
                     .unwrap();
+                let (nic, external_ip) =
+                    svc_port_builder.next_dns(id, &mut services_ip_pool)?;
                 request.services.push(ServiceZoneRequest {
                     id,
                     zone_type: ZoneType::ExternalDns,
@@ -325,6 +305,7 @@ impl Plan {
                             0,
                         ),
                         dns_address: SocketAddr::new(external_ip, dns_port),
+                        nic,
                     }],
                 })
             }
@@ -342,9 +323,8 @@ impl Plan {
                         omicron_common::address::NEXUS_INTERNAL_PORT,
                     )
                     .unwrap();
-                let external_ip = services_ip_pool
-                    .next()
-                    .ok_or_else(|| PlanError::ServiceIp("Nexus"))?;
+                let (nic, external_ip) =
+                    svc_port_builder.next_nexus(id, &mut services_ip_pool)?;
                 request.services.push(ServiceZoneRequest {
                     id,
                     zone_type: ZoneType::Nexus,
@@ -353,6 +333,7 @@ impl Plan {
                     services: vec![ServiceType::Nexus {
                         internal_ip: address,
                         external_ip,
+                        nic,
                     }],
                 })
             }
@@ -511,16 +492,15 @@ impl Plan {
                 let (services, svcname) = if idx < BOUNDARY_NTP_COUNT {
                     boundary_ntp_servers
                         .push(format!("{}.host.{}", id, DNS_ZONE));
-                    let (snat_ip, first_port, last_port) =
-                        boundary_ntp_snat_config(&mut services_ip_pool)?;
+                    let (nic, snat_cfg) = svc_port_builder
+                        .next_snat(id, &mut services_ip_pool)?;
                     (
                         vec![ServiceType::BoundaryNtp {
                             ntp_servers: config.ntp_servers.clone(),
                             dns_servers: config.dns_servers.clone(),
                             domain: None,
-                            snat_ip,
-                            first_port,
-                            last_port,
+                            nic,
+                            snat_cfg,
                         }],
                         ServiceName::BoundaryNtp,
                     )
@@ -604,6 +584,211 @@ impl AddressBumpAllocator {
         }
         self.last_addr = Ipv6Addr::from(segments);
         Some(self.last_addr)
+    }
+}
+
+struct ServicePortBuilder {
+    next_snat_ip: Option<IpAddr>,
+    next_snat_port: Wrapping<u16>,
+
+    dns_v4_ips: Box<dyn Iterator<Item = Ipv4Addr> + Send>,
+    dns_v6_ips: Box<dyn Iterator<Item = Ipv6Addr> + Send>,
+
+    nexus_v4_ips: Box<dyn Iterator<Item = Ipv4Addr> + Send>,
+    nexus_v6_ips: Box<dyn Iterator<Item = Ipv6Addr> + Send>,
+
+    ntp_v4_ips: Box<dyn Iterator<Item = Ipv4Addr> + Send>,
+    ntp_v6_ips: Box<dyn Iterator<Item = Ipv6Addr> + Send>,
+
+    used_macs: HashSet<MacAddr>,
+}
+
+impl ServicePortBuilder {
+    fn new() -> Self {
+        use omicron_common::address::{
+            DNS_OPTE_IPV4_SUBNET, DNS_OPTE_IPV6_SUBNET, NEXUS_OPTE_IPV4_SUBNET,
+            NEXUS_OPTE_IPV6_SUBNET, NTP_OPTE_IPV4_SUBNET, NTP_OPTE_IPV6_SUBNET,
+        };
+        use omicron_common::nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
+
+        let dns_v4_ips = Box::new(
+            DNS_OPTE_IPV4_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        let dns_v6_ips = Box::new(
+            DNS_OPTE_IPV6_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        let nexus_v4_ips = Box::new(
+            NEXUS_OPTE_IPV4_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        let nexus_v6_ips = Box::new(
+            NEXUS_OPTE_IPV6_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        let ntp_v4_ips = Box::new(
+            NTP_OPTE_IPV4_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        let ntp_v6_ips = Box::new(
+            NTP_OPTE_IPV6_SUBNET
+                .0
+                .iter()
+                .skip(NUM_INITIAL_RESERVED_IP_ADDRESSES),
+        );
+        Self {
+            next_snat_ip: None,
+            next_snat_port: Wrapping(0),
+            dns_v4_ips,
+            dns_v6_ips,
+            nexus_v4_ips,
+            nexus_v6_ips,
+            ntp_v4_ips,
+            ntp_v6_ips,
+            used_macs: HashSet::new(),
+        }
+    }
+
+    fn random_mac(&mut self) -> MacAddr {
+        let mut mac = MacAddr::random_system();
+        while !self.used_macs.insert(mac) {
+            mac = MacAddr::random_system();
+        }
+        mac
+    }
+
+    fn next_dns(
+        &mut self,
+        svc_id: Uuid,
+        ip_pool: &mut dyn Iterator<Item = IpAddr>,
+    ) -> Result<(NetworkInterface, IpAddr), PlanError> {
+        use omicron_common::address::{
+            DNS_OPTE_IPV4_SUBNET, DNS_OPTE_IPV6_SUBNET,
+        };
+        let external_ip = ip_pool
+            .next()
+            .ok_or_else(|| PlanError::ServiceIp("External DNS"))?;
+
+        let (ip, subnet) = match external_ip {
+            IpAddr::V4(_) => (
+                self.dns_v4_ips.next().unwrap().into(),
+                (*DNS_OPTE_IPV4_SUBNET).into(),
+            ),
+            IpAddr::V6(_) => (
+                self.dns_v6_ips.next().unwrap().into(),
+                (*DNS_OPTE_IPV6_SUBNET).into(),
+            ),
+        };
+
+        let nic = NetworkInterface {
+            id: Uuid::new_v4(),
+            kind: NetworkInterfaceKind::Service { id: svc_id },
+            name: format!("external-dns-{svc_id}").parse().unwrap(),
+            ip,
+            mac: self.random_mac(),
+            subnet,
+            vni: Vni::SERVICES_VNI,
+            primary: true,
+            slot: 0,
+        };
+
+        Ok((nic, external_ip))
+    }
+
+    fn next_nexus(
+        &mut self,
+        svc_id: Uuid,
+        ip_pool: &mut dyn Iterator<Item = IpAddr>,
+    ) -> Result<(NetworkInterface, IpAddr), PlanError> {
+        use omicron_common::address::{
+            NEXUS_OPTE_IPV4_SUBNET, NEXUS_OPTE_IPV6_SUBNET,
+        };
+        let external_ip =
+            ip_pool.next().ok_or_else(|| PlanError::ServiceIp("Nexus"))?;
+
+        let (ip, subnet) = match external_ip {
+            IpAddr::V4(_) => (
+                self.nexus_v4_ips.next().unwrap().into(),
+                (*NEXUS_OPTE_IPV4_SUBNET).into(),
+            ),
+            IpAddr::V6(_) => (
+                self.nexus_v6_ips.next().unwrap().into(),
+                (*NEXUS_OPTE_IPV6_SUBNET).into(),
+            ),
+        };
+
+        let nic = NetworkInterface {
+            id: Uuid::new_v4(),
+            kind: NetworkInterfaceKind::Service { id: svc_id },
+            name: format!("nexus-{svc_id}").parse().unwrap(),
+            ip,
+            mac: self.random_mac(),
+            subnet,
+            vni: Vni::SERVICES_VNI,
+            primary: true,
+            slot: 0,
+        };
+
+        Ok((nic, external_ip))
+    }
+
+    fn next_snat(
+        &mut self,
+        svc_id: Uuid,
+        ip_pool: &mut dyn Iterator<Item = IpAddr>,
+    ) -> Result<(NetworkInterface, SourceNatConfig), PlanError> {
+        use omicron_common::address::{
+            NTP_OPTE_IPV4_SUBNET, NTP_OPTE_IPV6_SUBNET,
+        };
+        let snat_ip = self
+            .next_snat_ip
+            .or_else(|| ip_pool.next())
+            .ok_or_else(|| PlanError::ServiceIp("Boundary NTP"))?;
+        let first_port = self.next_snat_port.0;
+        let last_port = first_port + (NUM_SOURCE_NAT_PORTS - 1);
+
+        self.next_snat_port += NUM_SOURCE_NAT_PORTS;
+        if self.next_snat_port.0 == 0 {
+            self.next_snat_ip = None;
+        }
+
+        let snat_cfg = SourceNatConfig { ip: snat_ip, first_port, last_port };
+
+        let (ip, subnet) = match snat_ip {
+            IpAddr::V4(_) => (
+                self.ntp_v4_ips.next().unwrap().into(),
+                (*NTP_OPTE_IPV4_SUBNET).into(),
+            ),
+            IpAddr::V6(_) => (
+                self.ntp_v6_ips.next().unwrap().into(),
+                (*NTP_OPTE_IPV6_SUBNET).into(),
+            ),
+        };
+
+        let nic = NetworkInterface {
+            id: Uuid::new_v4(),
+            kind: NetworkInterfaceKind::Service { id: svc_id },
+            name: format!("ntp-{svc_id}").parse().unwrap(),
+            ip,
+            mac: self.random_mac(),
+            subnet,
+            vni: Vni::SERVICES_VNI,
+            primary: true,
+            slot: 0,
+        };
+
+        Ok((nic, snat_cfg))
     }
 }
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -643,7 +643,11 @@ impl ServiceInner {
                     // more easily support things running on different ports
                     // (which is useful in dev/test situations).
                     match svc {
-                        ServiceType::Nexus { external_ip, internal_ip: _ } => {
+                        ServiceType::Nexus {
+                            external_ip,
+                            internal_ip: _,
+                            ..
+                        } => {
                             services.push(NexusTypes::ServicePutRequest {
                                 service_id: zone.id,
                                 sled_id,

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -336,9 +336,33 @@ impl ServiceInner {
         service_plan: &ServicePlan,
     ) -> Result<(), SetupServiceError> {
         let log = &self.log;
+        // Start up the internal DNS services
+        futures::future::join_all(service_plan.services.iter().map(
+            |(sled_address, services_request)| async move {
+                let services: Vec<_> = services_request
+                    .services
+                    .iter()
+                    .filter_map(|svc| {
+                        if matches!(svc.zone_type, ZoneType::InternalDns) {
+                            Some(svc.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if !services.is_empty() {
+                    self.initialize_services(*sled_address, &services).await?;
+                }
+
+                Ok(())
+            },
+        ))
+        .await
+        .into_iter()
+        .collect::<Result<_, SetupServiceError>>()?;
 
         // Determine the list of DNS servers that are supposed to exist based on
-        // the service plan that has already been deployed.
+        // the service plan that has just been deployed.
         let dns_server_ips =
             // iterate sleds
             service_plan.services.iter().filter_map(
@@ -372,8 +396,8 @@ impl ServiceInner {
                                         InternalDns service for zone with \
                                         type ZoneType::InternalDns, but \
                                         found {} (zone {})",
+                                        addrs.len(),
                                         svc.id,
-                                        addrs.len()
                                     );
                                     None
                                 }
@@ -994,7 +1018,13 @@ impl ServiceInner {
                 ServicePlan::create(&self.log, &config, &plan.sleds).await?
             };
 
-        // Set up internal DNS and NTP services.
+        // Set up internal DNS services first and write the initial
+        // DNS configuration to the internal DNS servers.
+        self.initialize_dns(&service_plan).await?;
+
+        // Next start up the NTP services.
+        // Note we also specify internal DNS services again because it
+        // can ony be additive.
         futures::future::join_all(service_plan.services.iter().map(
             |(sled_address, services_request)| async move {
                 let services: Vec<_> = services_request
@@ -1020,9 +1050,6 @@ impl ServiceInner {
         .await
         .into_iter()
         .collect::<Result<_, SetupServiceError>>()?;
-
-        // Write the initial DNS configuration to the internal DNS servers.
-        self.initialize_dns(&service_plan).await?;
 
         // Wait until time is synchronized on all sleds before proceeding.
         self.wait_for_timesync(&sled_addresses).await?;

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -728,7 +728,8 @@ impl ServiceInner {
                                 kind: NexusTypes::ServiceKind::CruciblePantry,
                             });
                         }
-                        ServiceType::Ntp { .. } => {
+                        ServiceType::BoundaryNtp { .. }
+                        | ServiceType::InternalNtp { .. } => {
                             services.push(NexusTypes::ServicePutRequest {
                                 service_id: zone.id,
                                 sled_id,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1238,6 +1238,7 @@ impl ServiceManager {
                     ntp_servers,
                     dns_servers,
                     domain,
+                    ..
                 }
                 | ServiceType::InternalNtp {
                     ntp_servers,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1032,11 +1032,7 @@ impl ServiceManager {
                     // atop an OPTE port which operates on a VPC private IP. OPTE will
                     // map the private IP to the external IP automatically.
                     let port_ip = running_zone
-                        .ensure_address_for_port(
-                            AddressRequest::Dhcp,
-                            "public",
-                            0,
-                        )
+                        .ensure_address_for_port("public", 0)
                         .await?
                         .ip();
 
@@ -1107,11 +1103,7 @@ impl ServiceManager {
                     // directly but instead on a VPC private IP. OPTE will
                     // en/decapsulate as appropriate.
                     let port_ip = running_zone
-                        .ensure_address_for_port(
-                            AddressRequest::Dhcp,
-                            "public",
-                            0,
-                        )
+                        .ensure_address_for_port("public", 0)
                         .await?
                         .ip();
                     let dns_address =
@@ -1357,11 +1349,7 @@ impl ServiceManager {
                     if boundary {
                         // Configure OPTE port for boundary NTP
                         running_zone
-                            .ensure_address_for_port(
-                                AddressRequest::Dhcp,
-                                "public",
-                                0,
-                            )
+                            .ensure_address_for_port("public", 0)
                             .await?;
                     }
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -904,7 +904,7 @@ impl ServiceManager {
             smfh.import_manifest()?;
 
             match &service {
-                ServiceType::Nexus { internal_ip, external_ip } => {
+                ServiceType::Nexus { internal_ip, external_ip, .. } => {
                     info!(self.inner.log, "Setting up Nexus service");
 
                     let sled_info =
@@ -998,7 +998,9 @@ impl ServiceManager {
                         .await
                         .map_err(|err| Error::io_path(&config_path, err))?;
                 }
-                ServiceType::ExternalDns { http_address, dns_address } => {
+                ServiceType::ExternalDns {
+                    http_address, dns_address, ..
+                } => {
                     info!(self.inner.log, "Setting up external-dns service");
 
                     // Like Nexus, we have to set up a possible IPv4 address for

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -697,6 +697,8 @@ impl ServiceManager {
                 None => (external_ips[0], 0, u16::MAX),
             };
 
+            // TODO-correctness(#2933): If we fail part-way we need to
+            // clean up previous entries instead of leaking them.
             let nat_create = || async {
                 info!(
                     self.inner.log, "creating NAT entry for service";

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -19,7 +19,7 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # pool as its external IP.
 [[internal_services_ip_pool_ranges]]
 first = "192.168.1.20"
-last = "192.168.1.21"
+last = "192.168.1.22"
 
 [gateway]
 

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -19,7 +19,7 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # pool as its external IP.
 [[internal_services_ip_pool_ranges]]
 first = "192.168.1.20"
-last = "192.168.1.21"
+last = "192.168.1.22"
 
 [gateway]
 


### PR DESCRIPTION
Update RSS & Sled Agent to configure and create OPTE ports for Nexus, External DNS and Boundary NTP services. Nexus side DB updates in subsequent PR.

Based on https://github.com/oxidecomputer/omicron/pull/2856.