### PR TITLE
sim sled agent: allow direct access to simulated instances

### DIFF
--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -393,6 +393,19 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     }
 }
 
+impl<S: Simulatable + Clone + 'static> SimCollection<S> {
+    pub async fn sim_get_cloned_object(
+        self: &Arc<Self>,
+        id: &Uuid,
+    ) -> Result<S, Error> {
+        let objects = self.objects.lock().await;
+        let instance = objects
+            .get(id)
+            .ok_or_else(|| Error::not_found_by_id(S::resource_type(), id))?;
+        Ok(instance.object.clone())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::params::{DiskStateRequested, InstanceStateRequested};

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -147,7 +147,7 @@ impl<S: Simulatable> SimObject<S> {
     }
 
     fn transition_finish(&mut self) {
-        let current = self.object.current().clone();
+        let current = self.object.current();
         let desired = self.object.desired();
         let action = self.object.execute_desired_transition();
         info!(self.log, "simulated transition finish";
@@ -337,7 +337,7 @@ impl<S: Simulatable + 'static> SimCollection<S> {
         };
 
         let rv = if let Some(target) = target {
-            object.transition(target).map(|_| object.object.current().clone())
+            object.transition(target).map(|_| object.object.current())
         } else {
             Ok(current.clone())
         };
@@ -360,7 +360,7 @@ impl<S: Simulatable + 'static> SimCollection<S> {
         let instance = objects
             .get(id)
             .ok_or_else(|| Error::not_found_by_id(S::resource_type(), id))?;
-        Ok(instance.object.current().clone())
+        Ok(instance.object.current())
     }
 
     /// Iterates over all of the existing objects in the collection and, for any

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -457,7 +457,7 @@ mod test {
     async fn test_sim_instance_creating_to_stop() {
         let logctx = test_setup_log("test_sim_instance_creating_to_stop");
         let (mut instance, mut rx) = make_instance(&logctx);
-        let r1 = instance.object.current().clone();
+        let r1 = instance.object.current();
 
         info!(logctx.log, "new instance"; "run_state" => ?r1.run_state);
         assert_eq!(r1.run_state, InstanceState::Creating);
@@ -481,7 +481,7 @@ mod test {
             instance.transition(InstanceStateRequested::Stopped).unwrap();
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_none());
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert_eq!(rnext.run_state, InstanceState::Destroyed);
@@ -497,7 +497,7 @@ mod test {
     async fn test_sim_instance_running_then_destroyed() {
         let logctx = test_setup_log("test_sim_instance_running_then_destroyed");
         let (mut instance, mut rx) = make_instance(&logctx);
-        let r1 = instance.object.current().clone();
+        let r1 = instance.object.current();
 
         info!(logctx.log, "new instance"; "run_state" => ?r1.run_state);
         assert_eq!(r1.run_state, InstanceState::Creating);
@@ -522,7 +522,7 @@ mod test {
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_some());
         assert!(rx.try_next().is_ok());
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert_eq!(rnext.run_state, InstanceState::Starting);
@@ -530,7 +530,7 @@ mod test {
         rprev = rnext;
 
         instance.transition_finish();
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert!(instance.object.desired().is_none());
@@ -539,7 +539,7 @@ mod test {
         assert_eq!(rnext.run_state, InstanceState::Running);
         rprev = rnext;
         instance.transition_finish();
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert_eq!(rprev.gen, rnext.gen);
 
         // If we transition again to "Running", the process should complete
@@ -550,7 +550,7 @@ mod test {
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_none());
         assert!(rx.try_next().is_err());
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert_eq!(rnext.gen, rprev.gen);
         assert_eq!(rnext.time_updated, rprev.time_updated);
         assert_eq!(rnext.run_state, rprev.run_state);
@@ -564,7 +564,7 @@ mod test {
             instance.transition(InstanceStateRequested::Stopped).unwrap();
         assert!(dropped.is_none());
         assert!(instance.object.desired().is_some());
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert_eq!(rnext.run_state, InstanceState::Stopping);
@@ -574,7 +574,7 @@ mod test {
         // Propolis publishes its own transition to Stopping before it publishes
         // Stopped.
         instance.transition_finish();
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert!(instance.object.desired().is_some());
@@ -584,7 +584,7 @@ mod test {
 
         // Stopping goes to Stopped...
         instance.transition_finish();
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert!(instance.object.desired().is_some());
@@ -595,7 +595,7 @@ mod test {
         // ...and Stopped (internally) goes to Destroyed, though the sled agent
         // hides this state from clients.
         instance.transition_finish();
-        let rnext = instance.object.current().clone();
+        let rnext = instance.object.current();
         assert!(rnext.gen > rprev.gen);
         assert_eq!(rprev.run_state, InstanceState::Stopped);
         assert_eq!(rnext.run_state, InstanceState::Stopped);
@@ -609,7 +609,7 @@ mod test {
 
         // Get an initial instance up to "Running".
         let (mut instance, _rx) = make_instance(&logctx);
-        let r1 = instance.object.current().clone();
+        let r1 = instance.object.current();
 
         info!(logctx.log, "new instance"; "run_state" => ?r1.run_state);
         assert_eq!(r1.run_state, InstanceState::Creating);
@@ -619,7 +619,7 @@ mod test {
             .unwrap()
             .is_none());
         instance.transition_finish();
-        let (rprev, rnext) = (r1, instance.object.current().clone());
+        let (rprev, rnext) = (r1, instance.object.current());
 
         // Chrono doesn't give us enough precision, so sleep a bit
         if cfg!(windows) {
@@ -634,12 +634,12 @@ mod test {
             .transition(InstanceStateRequested::Reboot)
             .unwrap()
             .is_none());
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
+        let (rprev, rnext) = (rnext, instance.object.current());
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated > rprev.time_updated);
         assert_eq!(rnext.run_state, InstanceState::Rebooting);
         instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
+        let (rprev, rnext) = (rnext, instance.object.current());
 
         // Chrono doesn't give us enough precision, so sleep a bit
         if cfg!(windows) {
@@ -651,7 +651,7 @@ mod test {
         assert_eq!(rnext.run_state, InstanceState::Rebooting);
         assert!(instance.object.desired().is_some());
         instance.transition_finish();
-        let (rprev, rnext) = (rnext, instance.object.current().clone());
+        let (rprev, rnext) = (rnext, instance.object.current());
 
         // Chrono doesn't give us enough precision, so sleep a bit
         if cfg!(windows) {
@@ -675,7 +675,7 @@ mod test {
         let logctx =
             test_setup_log("test_sim_disk_transition_to_detached_states");
         let (mut disk, _rx) = make_disk(&logctx, DiskState::Creating);
-        let r1 = disk.object.current().clone();
+        let r1 = disk.object.current();
 
         info!(logctx.log, "new disk"; "disk_state" => ?r1.disk_state);
         assert_eq!(r1.disk_state, DiskState::Creating);
@@ -704,7 +704,7 @@ mod test {
     async fn test_sim_disk_attach_then_destroy() {
         let logctx = test_setup_log("test_sim_disk_attach_then_destroy");
         let (mut disk, _rx) = make_disk(&logctx, DiskState::Creating);
-        let r1 = disk.object.current().clone();
+        let r1 = disk.object.current();
 
         info!(logctx.log, "new disk"; "disk_state" => ?r1.disk_state);
         assert_eq!(r1.disk_state, DiskState::Creating);
@@ -717,7 +717,7 @@ mod test {
             .transition(DiskStateRequested::Attached(id))
             .unwrap()
             .is_none());
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         assert_eq!(rnext.disk_state, DiskState::Attaching(id));
@@ -726,14 +726,14 @@ mod test {
         let rprev = rnext;
 
         disk.transition_finish();
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert_eq!(rnext.disk_state, DiskState::Attached(id));
         assert!(rnext.gen > rprev.gen);
         assert!(rnext.time_updated >= rprev.time_updated);
         let rprev = rnext;
 
         disk.transition_finish();
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert_eq!(rnext.gen, rprev.gen);
         assert_eq!(rnext.disk_state, DiskState::Attached(id));
         assert!(rnext.disk_state.is_attached());
@@ -744,7 +744,7 @@ mod test {
             .transition(DiskStateRequested::Attached(id))
             .unwrap()
             .is_none());
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert_eq!(rnext.gen, rprev.gen);
         let rprev = rnext;
 
@@ -758,21 +758,21 @@ mod test {
         } else {
             panic!("unexpected error type");
         }
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert_eq!(rprev.gen, rnext.gen);
         let rprev = rnext;
 
         // If we go to a different detached state, we go through the async
         // transition again.
         disk.transition(DiskStateRequested::Detached).unwrap();
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert!(rnext.gen > rprev.gen);
         assert_eq!(rnext.disk_state, DiskState::Detaching(id));
         assert!(rnext.disk_state.is_attached());
         let rprev = rnext;
 
         disk.transition_finish();
-        let rnext = disk.object.current().clone();
+        let rnext = disk.object.current();
         assert_eq!(rnext.disk_state, DiskState::Detached);
         assert!(rnext.gen > rprev.gen);
 
@@ -791,7 +791,7 @@ mod test {
     async fn test_sim_disk_attach_then_fault() {
         let logctx = test_setup_log("test_sim_disk_attach_then_fault");
         let (mut disk, _rx) = make_disk(&logctx, DiskState::Creating);
-        let r1 = disk.object.current().clone();
+        let r1 = disk.object.current();
 
         info!(logctx.log, "new disk"; "disk_state" => ?r1.disk_state);
         assert_eq!(r1.disk_state, DiskState::Creating);

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -352,17 +352,6 @@ impl<S: Simulatable + 'static> SimCollection<S> {
         self.objects.lock().await.contains_key(id)
     }
 
-    pub async fn sim_get_current_state(
-        self: &Arc<Self>,
-        id: &Uuid,
-    ) -> Result<S::CurrentState, Error> {
-        let objects = self.objects.lock().await;
-        let instance = objects
-            .get(id)
-            .ok_or_else(|| Error::not_found_by_id(S::resource_type(), id))?;
-        Ok(instance.object.current())
-    }
-
     /// Iterates over all of the existing objects in the collection and, for any
     /// that meet `condition`, asks to transition them into the supplied target
     /// state.

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -248,8 +248,8 @@ impl Simulatable for SimDisk {
         self.state.current().gen
     }
 
-    fn current(&self) -> &Self::CurrentState {
-        self.state.current()
+    fn current(&self) -> Self::CurrentState {
+        self.state.current().clone()
     }
 
     fn desired(&self) -> Option<Self::RequestedState> {

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -214,6 +214,12 @@ impl SimInstanceInner {
             .iter()
             .any(|s| matches!(s, PropolisInstanceState::Rebooting))
     }
+
+    fn terminate(&mut self) -> InstanceRuntimeState {
+        self.state.transition(ApiInstanceState::Destroyed);
+        self.propolis_queue.clear();
+        self.state.current().clone()
+    }
 }
 
 /// A simulation of an Instance created by the external Oxide API.
@@ -234,6 +240,12 @@ impl SimInstanceInner {
 #[derive(Debug, Clone)]
 pub struct SimInstance {
     inner: Arc<Mutex<SimInstanceInner>>,
+}
+
+impl SimInstance {
+    pub fn terminate(&self) -> InstanceRuntimeState {
+        self.inner.lock().unwrap().terminate()
+    }
 }
 
 #[async_trait]

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -19,6 +19,7 @@ use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use propolis_client::api::InstanceState as PropolisInstanceState;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::Mutex;
 use uuid::Uuid;
 
 use crate::common::instance::{Action as InstanceAction, InstanceStates};
@@ -29,7 +30,7 @@ use crate::common::instance::{Action as InstanceAction, InstanceStates};
 /// possible within reason so that it can be used as a test double in Nexus
 /// integration tests.
 #[derive(Debug)]
-pub struct SimInstance {
+struct SimInstanceInner {
     /// The current simulated instance state.
     state: InstanceStates,
 
@@ -41,48 +42,7 @@ pub struct SimInstance {
     destroyed: bool,
 }
 
-impl SimInstance {
-    /// Returns the "resting" state the simulated instance will reach if its
-    /// queue is drained.
-    fn next_resting_state(&self) -> ApiInstanceState {
-        match self.propolis_queue.back() {
-            None => self.state.current().run_state,
-            Some(p) => InstanceState::from(*p).0,
-        }
-    }
-
-    /// Indicates whether there is a reboot transition pending for this
-    /// instance.
-    fn reboot_pending(&self) -> bool {
-        self.propolis_queue
-            .iter()
-            .any(|s| matches!(s, PropolisInstanceState::Rebooting))
-    }
-}
-
-#[async_trait]
-impl Simulatable for SimInstance {
-    type CurrentState = InstanceRuntimeState;
-    type RequestedState = InstanceStateRequested;
-    type ProducerArgs = ();
-    type Action = InstanceAction;
-
-    fn new(current: InstanceRuntimeState) -> Self {
-        SimInstance {
-            state: InstanceStates::new(current),
-            propolis_queue: VecDeque::new(),
-            destroyed: false,
-        }
-    }
-
-    async fn set_producer(
-        &mut self,
-        _args: Self::ProducerArgs,
-    ) -> Result<(), Error> {
-        // NOTE: Not implemented, yet.
-        Ok(())
-    }
-
+impl SimInstanceInner {
     fn request_transition(
         &mut self,
         target: &InstanceStateRequested,
@@ -204,15 +164,11 @@ impl Simulatable for SimInstance {
         }
     }
 
-    fn generation(&self) -> Generation {
-        self.state.current().gen
+    fn current(&self) -> InstanceRuntimeState {
+        self.state.current().clone()
     }
 
-    fn current(&self) -> &Self::CurrentState {
-        self.state.current()
-    }
-
-    fn desired(&self) -> Option<Self::RequestedState> {
+    fn desired(&self) -> Option<InstanceStateRequested> {
         self.propolis_queue.back().map(|terminal| match terminal {
             // State change requests may queue these states as intermediate
             // states, but the simulation (and the tests that rely on it) is
@@ -240,6 +196,96 @@ impl Simulatable for SimInstance {
 
     fn ready_to_destroy(&self) -> bool {
         self.destroyed
+    }
+
+    /// Returns the "resting" state the simulated instance will reach if its
+    /// queue is drained.
+    fn next_resting_state(&self) -> ApiInstanceState {
+        match self.propolis_queue.back() {
+            None => self.state.current().run_state,
+            Some(p) => InstanceState::from(*p).0,
+        }
+    }
+
+    /// Indicates whether there is a reboot transition pending for this
+    /// instance.
+    fn reboot_pending(&self) -> bool {
+        self.propolis_queue
+            .iter()
+            .any(|s| matches!(s, PropolisInstanceState::Rebooting))
+    }
+}
+
+/// A simulation of an Instance created by the external Oxide API.
+///
+/// Normally, to change a simulated object's state, the simulated sled agent
+/// invokes a generic routine on the object's `SimCollection` that calls the
+/// appropriate `Simulatable` routine on the object in question while holding
+/// the collection's (private) lock. This works fine for generic functionality
+/// that all `Simulatable`s share, but instances have some instance-specific
+/// extensions that are not appropriate to implement in that trait.
+///
+/// To allow sled agent to modify instances in instance-specific ways without
+/// having to hold a `SimCollection` lock, this struct wraps the instance state
+/// in an `Arc` and `Mutex` and then derives `Clone`. This way, the simulated
+/// sled agent proper can ask the instance collection for a clone of a specific
+/// registered instance and get back a reference to the same instance the
+/// `SimCollection` APIs will operate on.
+#[derive(Debug, Clone)]
+pub struct SimInstance {
+    inner: Arc<Mutex<SimInstanceInner>>,
+}
+
+#[async_trait]
+impl Simulatable for SimInstance {
+    type CurrentState = InstanceRuntimeState;
+    type RequestedState = InstanceStateRequested;
+    type ProducerArgs = ();
+    type Action = InstanceAction;
+
+    fn new(current: InstanceRuntimeState) -> Self {
+        SimInstance {
+            inner: Arc::new(Mutex::new(SimInstanceInner {
+                state: InstanceStates::new(current),
+                propolis_queue: VecDeque::new(),
+                destroyed: false,
+            })),
+        }
+    }
+
+    async fn set_producer(
+        &mut self,
+        _args: Self::ProducerArgs,
+    ) -> Result<(), Error> {
+        // NOTE: Not implemented, yet.
+        Ok(())
+    }
+
+    fn request_transition(
+        &mut self,
+        target: &InstanceStateRequested,
+    ) -> Result<Option<InstanceAction>, Error> {
+        self.inner.lock().unwrap().request_transition(target)
+    }
+
+    fn execute_desired_transition(&mut self) -> Option<InstanceAction> {
+        self.inner.lock().unwrap().execute_desired_transition()
+    }
+
+    fn generation(&self) -> Generation {
+        self.inner.lock().unwrap().current().gen
+    }
+
+    fn current(&self) -> Self::CurrentState {
+        self.inner.lock().unwrap().current()
+    }
+
+    fn desired(&self) -> Option<Self::RequestedState> {
+        self.inner.lock().unwrap().desired()
+    }
+
+    fn ready_to_destroy(&self) -> bool {
+        self.inner.lock().unwrap().ready_to_destroy()
     }
 
     async fn notify(

--- a/sled-agent/src/sim/simulatable.rs
+++ b/sled-agent/src/sim/simulatable.rs
@@ -98,7 +98,7 @@ pub trait Simulatable: fmt::Debug + Send + Sync {
     fn generation(&self) -> Generation;
 
     /// Returns the current state.
-    fn current(&self) -> &Self::CurrentState;
+    fn current(&self) -> Self::CurrentState;
 
     /// Returns the "desired" state, if one exists.
     ///

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -323,31 +323,12 @@ impl SledAgent {
         self: &Arc<Self>,
         instance_id: Uuid,
     ) -> Result<InstanceUnregisterResponse, Error> {
-        if !self.instances.contains_key(&instance_id).await {
-            return Ok(InstanceUnregisterResponse { updated_runtime: None });
-        }
+        let instance =
+            self.instances.sim_get_cloned_object(&instance_id).await?;
 
         self.detach_disks_from_instance(instance_id).await?;
-
-        // TODO: Simulated instances can currently only be accessed via their
-        // collections, which only support operations that are generic across
-        // all simulated object types. Instantly destroying an object is not
-        // such an operation. Work around this for now by stopping the instance
-        // and immediately draining its state queue so that the instance is
-        // destroyed before this call returns.
-        self.instances
-            .sim_ensure(
-                &instance_id,
-                self.instances.sim_get_current_state(&instance_id).await?,
-                Some(InstanceStateRequested::Stopped),
-            )
-            .await?;
-        self.instances.sim_poke(instance_id, PokeMode::Drain).await;
-
         Ok(InstanceUnregisterResponse {
-            updated_runtime: Some(
-                self.instances.sim_get_current_state(&instance_id).await?,
-            ),
+            updated_runtime: Some(instance.terminate()),
         })
     }
 


### PR DESCRIPTION
No. 5 in the [live migration series](https://github.com/oxidecomputer/omicron/compare/main...gjcolombo:omicron:gjcolombo/lets-migrate/8-migration-end). I suggest reading individual commits for this one to avoid the Clippy debris that's scattered about the overall PR.

---

Wrap `SimInstance`'s current state in an `Arc`/`Mutex` so that `SimInstance`s can be `Clone`. Then add a `SimCollection` impl that returns a clone of one of the objects in the collection.

This allows simulated sled agent code sitting above `SimCollection` to access a `SimInstance` in its collection and call methods on directly (with side effects that are visible to other users of the collection). Previously, the sled agent was more or less restricted to calling generic `Simulatable` methods for which `SimCollection` provided an appropriate proxy.

This allows the `InstanceStates` struct to implement interesting methods (e.g. setting and clearing migration IDs) that regular and simulated sled agents can share (previously such methods had to map to generic functionality in the `Simulatable` trait). Subsequent changes will use this heavily. For now, use it to clean up a bit of other simulated instance code.