### PR TITLE
sled agent: add facility to set/clear instances' migration IDs

### DIFF
--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -210,6 +210,50 @@
         }
       }
     },
+    "/instances/{instance_id}/migration-ids": {
+      "put": {
+        "operationId": "instance_put_migration_ids",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstancePutMigrationIdsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceRuntimeState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/instances/{instance_id}/state": {
       "put": {
         "operationId": "instance_put_state",
@@ -1174,6 +1218,24 @@
           "snapshot_id"
         ]
       },
+      "InstanceMigrationSourceParams": {
+        "description": "Instance runtime state to update for a migration.",
+        "type": "object",
+        "properties": {
+          "dst_propolis_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "migration_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "dst_propolis_id",
+          "migration_id"
+        ]
+      },
       "InstanceMigrationTargetParams": {
         "description": "Parameters used when directing Propolis to initialize itself via live migration.",
         "type": "object",
@@ -1191,6 +1253,32 @@
         "required": [
           "src_propolis_addr",
           "src_propolis_id"
+        ]
+      },
+      "InstancePutMigrationIdsBody": {
+        "description": "The body of a request to set or clear the migration identifiers from a sled agent's instance state records.",
+        "type": "object",
+        "properties": {
+          "migration_params": {
+            "nullable": true,
+            "description": "The migration identifiers to set. If `None`, this operation clears the migration IDs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMigrationSourceParams"
+              }
+            ]
+          },
+          "old_runtime": {
+            "description": "The last runtime state known to this requestor. This request will succeed if either (a) the Propolis generation in the sled agent's runtime state matches the generation in this record, or (b) the sled agent's runtime state matches what would result from applying this request to the caller's runtime state. This latter condition provides idempotency.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceRuntimeState"
+              }
+            ]
+          }
+        },
+        "required": [
+          "old_runtime"
         ]
       },
       "InstancePutStateBody": {

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -243,7 +243,7 @@ mod test {
 
         // If the generation numbers are right, but either requested ID is not
         // present in the current instance, the requested IDs aren't set.
-        old_instance = orig_instance.clone();
+        old_instance = orig_instance;
         new_instance.current.migration_id = Some(Uuid::new_v4());
         assert!(!new_instance.migration_ids_already_set(
             old_instance.current(),

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -4,6 +4,7 @@
 
 //! Describes the states of VM instances.
 
+use crate::params::InstanceMigrationSourceParams;
 use chrono::Utc;
 use omicron_common::api::external::InstanceState as ApiInstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
@@ -105,11 +106,65 @@ impl InstanceStates {
         self.current.gen = self.current.gen.next();
         self.current.time_updated = Utc::now();
     }
+
+    /// Sets or clears this instance's migration IDs and advances its Propolis
+    /// generation number.
+    pub(crate) fn set_migration_ids(
+        &mut self,
+        ids: &Option<InstanceMigrationSourceParams>,
+    ) {
+        if let Some(ids) = ids {
+            self.current.migration_id = Some(ids.migration_id);
+            self.current.dst_propolis_id = Some(ids.dst_propolis_id);
+        } else {
+            self.current.migration_id = None;
+            self.current.dst_propolis_id = None;
+        }
+
+        self.current.propolis_gen = self.current.propolis_gen.next();
+    }
+
+    /// Returns true if the migration IDs in this instance are already set as they
+    /// would be on a successful transition from the migration IDs in
+    /// `old_runtime` to the ones in `migration_ids`.
+    pub(crate) fn migration_ids_already_set(
+        &self,
+        old_runtime: &InstanceRuntimeState,
+        migration_ids: &Option<InstanceMigrationSourceParams>,
+    ) -> bool {
+        // For the old and new records to match, the new record's Propolis
+        // generation must succeed the old record's.
+        if old_runtime.propolis_gen.next() != self.current.propolis_gen {
+            return false;
+        }
+
+        match (self.current.migration_id, migration_ids) {
+            // If the migration ID is already set, and this is a request to set
+            // IDs, the records match if the relevant IDs match.
+            (Some(current_migration_id), Some(ids)) => {
+                let current_dst_id = self.current.dst_propolis_id.expect(
+                    "migration ID and destination ID must be set together",
+                );
+
+                current_migration_id == ids.migration_id
+                    && current_dst_id == ids.dst_propolis_id
+            }
+            // If the migration ID is already cleared, and this is a request to
+            // clear IDs, the records match.
+            (None, None) => {
+                assert!(self.current.dst_propolis_id.is_none());
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::{Action, InstanceStates};
+
+    use crate::params::InstanceMigrationSourceParams;
 
     use chrono::Utc;
     use omicron_common::api::external::{
@@ -146,5 +201,67 @@ mod test {
         assert!(matches!(requested_action, Some(Action::Destroy)));
         assert!(instance.current.gen > original_instance.current.gen);
         assert_eq!(instance.current.run_state, State::Stopped);
+    }
+
+    #[test]
+    fn test_migration_ids_already_set() {
+        let orig_instance = make_instance();
+        let mut old_instance = orig_instance.clone();
+        let mut new_instance = old_instance.clone();
+
+        // Advancing the old instance's migration IDs and then asking if the
+        // new IDs are present should indicate that they are indeed present.
+        let migration_ids = InstanceMigrationSourceParams {
+            migration_id: Uuid::new_v4(),
+            dst_propolis_id: Uuid::new_v4(),
+        };
+
+        new_instance.set_migration_ids(&Some(migration_ids));
+        assert!(new_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
+
+        // The IDs aren't already set if the new record has an ID that's
+        // advanced from the old record by more than one generation.
+        let mut newer_instance = new_instance.clone();
+        newer_instance.current.propolis_gen =
+            newer_instance.current.propolis_gen.next();
+        assert!(!newer_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
+
+        // They also aren't set if the old generation has somehow equaled or
+        // surpassed the current generation.
+        old_instance.current.propolis_gen =
+            old_instance.current.propolis_gen.next();
+        assert!(!new_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
+
+        // If the generation numbers are right, but either requested ID is not
+        // present in the current instance, the requested IDs aren't set.
+        old_instance = orig_instance.clone();
+        new_instance.current.migration_id = Some(Uuid::new_v4());
+        assert!(!new_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
+
+        new_instance.current.migration_id = Some(migration_ids.migration_id);
+        new_instance.current.dst_propolis_id = Some(Uuid::new_v4());
+        assert!(!new_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
+
+        new_instance.current.migration_id = None;
+        new_instance.current.dst_propolis_id = None;
+        assert!(!new_instance.migration_ids_already_set(
+            old_instance.current(),
+            &Some(migration_ids)
+        ));
     }
 }

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -6,8 +6,9 @@
 
 use crate::params::{
     DatasetEnsureBody, DiskEnsureBody, InstanceEnsureBody,
-    InstancePutStateBody, InstancePutStateResponse, InstanceUnregisterResponse,
-    ServiceEnsureBody, SledRole, TimeSync, VpcFirewallRulesEnsureBody, Zpool,
+    InstancePutMigrationIdsBody, InstancePutStateBody,
+    InstancePutStateResponse, InstanceUnregisterResponse, ServiceEnsureBody,
+    SledRole, TimeSync, VpcFirewallRulesEnsureBody, Zpool,
 };
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk,
@@ -32,6 +33,7 @@ pub fn api() -> SledApiDescription {
         api.register(disk_put)?;
         api.register(filesystem_put)?;
         api.register(instance_issue_disk_snapshot_request)?;
+        api.register(instance_put_migration_ids)?;
         api.register(instance_put_state)?;
         api.register(instance_register)?;
         api.register(instance_unregister)?;
@@ -168,6 +170,29 @@ async fn instance_put_state(
         sa.instance_ensure_state(instance_id, body_args.state)
             .await
             .map_err(Error::from)?,
+    ))
+}
+
+#[endpoint {
+    method = PUT,
+    path = "/instances/{instance_id}/migration-ids",
+}]
+async fn instance_put_migration_ids(
+    rqctx: RequestContext<SledAgent>,
+    path_params: Path<InstancePathParam>,
+    body: TypedBody<InstancePutMigrationIdsBody>,
+) -> Result<HttpResponseOk<InstanceRuntimeState>, HttpError> {
+    let sa = rqctx.context();
+    let instance_id = path_params.into_inner().instance_id;
+    let body_args = body.into_inner();
+    Ok(HttpResponseOk(
+        sa.instance_put_migration_ids(
+            instance_id,
+            &body_args.old_runtime,
+            &body_args.migration_params,
+        )
+        .await
+        .map_err(Error::from)?,
     ))
 }
 

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -164,6 +164,23 @@ pub struct InstanceMigrationSourceParams {
     pub dst_propolis_id: Uuid,
 }
 
+/// The body of a request to set or clear the migration identifiers from a
+/// sled agent's instance state records.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct InstancePutMigrationIdsBody {
+    /// The last runtime state known to this requestor. This request will
+    /// succeed if either (a) the Propolis generation in the sled agent's
+    /// runtime state matches the generation in this record, or (b) the sled
+    /// agent's runtime state matches what would result from applying this
+    /// request to the caller's runtime state. This latter condition provides
+    /// idempotency.
+    pub old_runtime: InstanceRuntimeState,
+
+    /// The migration identifiers to set. If `None`, this operation clears the
+    /// migration IDs.
+    pub migration_params: Option<InstanceMigrationSourceParams>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub enum DiskType {
     U2,

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -13,8 +13,9 @@ use super::storage::Storage;
 
 use crate::nexus::NexusClient;
 use crate::params::{
-    DiskStateRequested, InstanceHardware, InstancePutStateResponse,
-    InstanceStateRequested, InstanceUnregisterResponse,
+    DiskStateRequested, InstanceHardware, InstanceMigrationSourceParams,
+    InstancePutStateResponse, InstanceStateRequested,
+    InstanceUnregisterResponse,
 };
 use crate::sim::simulatable::Simulatable;
 use crate::updates::UpdateManager;
@@ -410,6 +411,18 @@ impl SledAgent {
             .await?;
 
         Ok(())
+    }
+
+    pub async fn instance_put_migration_ids(
+        self: &Arc<Self>,
+        instance_id: Uuid,
+        old_runtime: &InstanceRuntimeState,
+        migration_ids: &Option<InstanceMigrationSourceParams>,
+    ) -> Result<InstanceRuntimeState, Error> {
+        let instance =
+            self.instances.sim_get_cloned_object(&instance_id).await?;
+
+        instance.put_migration_ids(old_runtime, migration_ids).await
     }
 
     /// Idempotently ensures that the given API Disk (described by `api_disk`)


### PR DESCRIPTION
This is PR no. 6 in the [live migration series](https://github.com/oxidecomputer/omicron/compare/main...gjcolombo:omicron:gjcolombo/lets-migrate/8-migration-end). The work in this PR will be used in the next PR in this sequence.

---

Add a sled agent API that allows Nexus to set or clear the migration ID and destination Propolis ID in an instance's runtime state. This advances the instance's Propolis generation number.

Sled agent requires callers to furnish the instance runtime state they intend to transition from. This lets Nexus use this API and an instance's migration ID field to arbitrate between multiple concurrent migration attempts: if an instance is running with Propolis generation X, and two (or more) migration sagas observe that generation, then only one will successfully set migration IDs and be allowed to continue migration.

Subsequent commits will update the migration saga to use this API.