### PR TITLE
[update-engine] improve jsonschema names for generated types

### DIFF
--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -27,6 +27,7 @@ pub enum Event<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case")]
+#[schemars(rename = "StepEventFor{S}")]
 pub struct StepEvent<S: StepSpec> {
     /// Total time elapsed since the start of execution.
     pub total_elapsed: Duration,
@@ -39,6 +40,7 @@ pub struct StepEvent<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case", tag = "kind")]
+#[schemars(rename = "StepEventKindFor{S}")]
 pub enum StepEventKind<S: StepSpec> {
     /// No steps were defined, and the executor exited without doing anything.
     ///
@@ -219,6 +221,7 @@ pub enum StepEventPriority {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case", tag = "kind")]
+#[schemars(rename = "StepOutcomeFor{S}")]
 pub enum StepOutcome<S: StepSpec> {
     /// The step completed successfully.
     Success {
@@ -248,6 +251,7 @@ pub enum StepOutcome<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case")]
+#[schemars(rename = "ProgressEventFor{S}")]
 pub struct ProgressEvent<S: StepSpec> {
     /// Total time elapsed since the start of execution.
     pub total_elapsed: Duration,
@@ -260,6 +264,7 @@ pub struct ProgressEvent<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case", tag = "kind")]
+#[schemars(rename = "ProgressEventKindFor{S}")]
 pub enum ProgressEventKind<S: StepSpec> {
     Progress {
         /// Information about the step.
@@ -291,6 +296,7 @@ pub enum ProgressEventKind<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case")]
+#[schemars(rename = "StepInfoFor{S}")]
 pub struct StepInfo<S: StepSpec> {
     /// An identifier for this step.
     pub id: S::StepId,
@@ -321,6 +327,7 @@ impl<S: StepSpec> StepInfo<S> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case")]
+#[schemars(rename = "StepComponentSummaryFor{S}")]
 pub struct StepComponentSummary<S: StepSpec> {
     /// The component.
     pub component: S::Component,
@@ -333,6 +340,7 @@ pub struct StepComponentSummary<S: StepSpec> {
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[derive_where(Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "", rename_all = "snake_case")]
+#[schemars(rename = "StepInfoWithMetadataFor{S}")]
 pub struct StepInfoWithMetadata<S: StepSpec> {
     /// Information about this step.
     pub info: StepInfo<S>,


### PR DESCRIPTION
As suggested in https://github.com/oxidecomputer/openapi-lint/issues/14,
use `schemars(rename = ...)` to generate names that pass openapi-lint
specifications.
