### PR TITLE
[wicketd] assert that once the installinator completes, the state is closed

### DIFF
--- a/wicketd/src/installinator_progress.rs
+++ b/wicketd/src/installinator_progress.rs
@@ -124,6 +124,16 @@ impl IprUpdateTracker {
         running_updates.insert(update_id, RunningUpdate::Initial(start_sender));
         start_receiver
     }
+
+    /// Returns the status of a running update, or None if the update ID hasn't
+    /// been registered.
+    pub async fn update_state(
+        &self,
+        update_id: Uuid,
+    ) -> Option<RunningUpdateState> {
+        let running_updates = self.running_updates.lock().await;
+        running_updates.get(&update_id).map(|x| x.to_state())
+    }
 }
 
 /// Type alias for the receiver that resolves when the first message from the
@@ -160,6 +170,18 @@ enum RunningUpdate {
 }
 
 impl RunningUpdate {
+    fn to_state(&self) -> RunningUpdateState {
+        match self {
+            RunningUpdate::Initial(_) => RunningUpdateState::Initial,
+            RunningUpdate::ReportsReceived(_) => {
+                RunningUpdateState::ReportsReceived
+            }
+            RunningUpdate::Closed => RunningUpdateState::Closed,
+            RunningUpdate::Invalid => {
+                unreachable!("invalid is a transient state")
+            }
+        }
+    }
     fn take(&mut self) -> Self {
         std::mem::replace(self, Self::Invalid)
     }
@@ -181,6 +203,27 @@ impl RunningUpdate {
         report.completion_events.last().map(|e| &e.kind)
             == Some(&CompletionEventKind::Completed)
     }
+}
+
+/// The current status of a running update.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunningUpdateState {
+    /// The initial state: the first message from the installinator hasn't been
+    /// received yet.
+    Initial,
+
+    /// Reports from the installinator have been received.
+    ReportsReceived,
+
+    /// All messages have been received.
+    ///
+    /// We might receive multiple "completed" updates from the installinator in
+    /// case there's a network issue between wicketd and installinator. This
+    /// state builds in idempotency to ensure that the installinator doesn't
+    /// fail for that reason: rather than removing the UUID from the running
+    /// update map once it's done, we move to this state while keeping the UUID
+    /// in the map.
+    Closed,
 }
 
 #[cfg(test)]

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -16,7 +16,7 @@ use anyhow::{anyhow, Result};
 use artifacts::{WicketdArtifactServer, WicketdArtifactStore};
 pub use config::Config;
 pub(crate) use context::ServerContext;
-use installinator_progress::IprUpdateTracker;
+pub use installinator_progress::{IprUpdateTracker, RunningUpdateState};
 pub use inventory::{RackV1Inventory, SpInventory};
 use mgs::make_mgs_client;
 pub(crate) use mgs::{MgsHandle, MgsManager};

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -18,6 +18,7 @@ use omicron_common::{
 };
 use tempfile::TempDir;
 use uuid::Uuid;
+use wicketd::RunningUpdateState;
 use wicketd_client::types::{UpdateEventKind, UpdateTerminalEventKind};
 
 #[tokio::test]
@@ -208,6 +209,13 @@ async fn test_installinator_fetch() {
     args.exec(&log.new(slog::o!("crate" => "installinator")))
         .await
         .expect("installinator succeeded");
+
+    // Check that the update status is marked as closed.
+    assert_eq!(
+        wicketd_testctx.server.ipr_update_tracker.update_state(update_id).await,
+        Some(RunningUpdateState::Closed),
+        "update should be marked as closed at the end of the run"
+    );
 
     // Check that the host and control plane artifacts were downloaded
     // correctly.


### PR DESCRIPTION
We're updating the wire protocol between wicketd and installinator, so
assert that it currently works as expected.
