### PR TITLE
`UpdateArtifact` and `ComponentUpdate` are the same thing, combine them

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1697,7 +1697,22 @@ CREATE UNIQUE INDEX ON omicron.public.system_update (
     version
 );
 
- 
+/*
+ * Associate system updates with artifacts. Not done with a system_update_id
+ * field on artifact because the same artifact may be part of more than one
+ * system update.
+ */
+CREATE TABLE omicron.public.system_update_update_artifact (
+    system_update_id UUID NOT NULL,
+    
+    -- this tuple is the PK on an artifact
+    artifact_name STRING(63) NOT NULL,
+    artifact_version STRING(63) NOT NULL,
+    artifact_kind omicron.public.update_artifact_kind NOT NULL,
+
+    PRIMARY KEY (system_update_id, artifact_name, artifact_kind, artifact_version)
+);
+
 CREATE TYPE omicron.public.updateable_component_type AS ENUM (
     'bootloader_for_rot',
     'bootloader_for_sp',

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1672,6 +1672,11 @@ CREATE INDEX ON omicron.public.update_artifact (
     targets_role_version
 );
 
+-- TODO: delete this once we can filter artifacts by system version
+CREATE INDEX ON omicron.public.update_artifact (
+    kind
+);
+
 /*
  * System updates
  */

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -791,6 +791,15 @@ table! {
 }
 
 table! {
+    system_update_update_artifact (system_update_id, artifact_name, artifact_version, artifact_kind) {
+        system_update_id -> Uuid,
+        artifact_name -> Text,
+        artifact_version -> Text,
+        artifact_kind -> crate::KnownArtifactKindEnum,
+    }
+}
+
+table! {
     update_deployment (id) {
         id -> Uuid,
         time_created -> Timestamptz,
@@ -841,6 +850,12 @@ allow_tables_to_appear_in_same_query!(
     system_update_component_update,
 );
 joinable!(system_update_component_update -> component_update (component_update_id));
+
+allow_tables_to_appear_in_same_query!(
+    system_update,
+    update_artifact,
+    system_update_update_artifact,
+);
 
 allow_tables_to_appear_in_same_query!(ip_pool_range, ip_pool);
 joinable!(ip_pool_range -> ip_pool (ip_pool_id));

--- a/nexus/db-model/src/system_update.rs
+++ b/nexus/db-model/src/system_update.rs
@@ -6,9 +6,9 @@ use crate::{
     impl_enum_type,
     schema::{
         component_update, system_update, system_update_component_update,
-        update_deployment, updateable_component,
+        system_update_update_artifact, update_deployment, updateable_component,
     },
-    SemverVersion,
+    KnownArtifactKind, SemverVersion,
 };
 use db_macros::Asset;
 use nexus_types::{
@@ -55,6 +55,17 @@ impl From<SystemUpdate> for views::SystemUpdate {
             version: system_update.version.into(),
         }
     }
+}
+
+#[derive(
+    Queryable, Insertable, Selectable, Clone, Debug, Serialize, Deserialize,
+)]
+#[diesel(table_name = system_update_update_artifact)]
+pub struct SystemUpdateUpdateArtifact {
+    pub system_update_id: Uuid,
+    pub artifact_name: String,
+    pub artifact_version: SemverVersion,
+    pub artifact_kind: KnownArtifactKind,
 }
 
 impl_enum_type!(

--- a/nexus/db-queries/src/db/datastore/update.rs
+++ b/nexus/db-queries/src/db/datastore/update.rs
@@ -89,6 +89,9 @@ impl DataStore {
                 // We use the `targets_role_version` column in the table to delete any
                 // old rows, keeping the table in sync with the current copy of
                 // artifacts.json.
+
+                // TODO: what is this about, and does it still exist in
+                // multi-system-version TUF repo world?
                 let _ = diesel::delete(ua::table)
                     .filter(ua::targets_role_version.lt(current_role_version))
                     .execute_async(&conn)
@@ -118,6 +121,7 @@ impl DataStore {
         // least.
         update_artifact
             .select(UpdateArtifact::as_select())
+            // TODO: join to system updates and select by system update version
             // TODO: get rid of this fake filter, which is needed to make CRDB
             // not complain about table scans, and instead paginate and/or list
             // artifacts for a single system version. Those could probably be

--- a/nexus/src/app/update.rs
+++ b/nexus/src/app/update.rs
@@ -95,6 +95,8 @@ impl super::Nexus {
 
     /// demo-grade update logic: tell all sleds to apply all artifacts
     pub async fn updates_apply(&self, opctx: &OpContext) -> Result<(), Error> {
+        // TODO: create system UpdateDeployment entry
+
         let sleds = self
             .db_datastore
             .sled_list(
@@ -469,6 +471,8 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
     ) -> CreateResult<()> {
+        // TODO: do all this with upsert_update_artifacts instead
+
         let types = vec![
             shared::UpdateableComponentType::HubrisForPscRot,
             shared::UpdateableComponentType::HubrisForPscSp,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -3825,6 +3825,7 @@ async fn system_update_refresh(
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         nexus.updates_refresh_metadata(&opctx).await?;
+        nexus.updates_apply(&opctx).await?;
         Ok(HttpResponseUpdatedNoContent())
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -3825,6 +3825,8 @@ async fn system_update_refresh(
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         nexus.updates_refresh_metadata(&opctx).await?;
+
+        // TODO: move this call to update start endpoint
         nexus.updates_apply(&opctx).await?;
         Ok(HttpResponseUpdatedNoContent())
     };

--- a/nexus/src/updates.rs
+++ b/nexus/src/updates.rs
@@ -3,15 +3,16 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::db;
-use omicron_common::update::ArtifactsDocument;
+use omicron_common::{api::external::SemverVersion, update::ArtifactsDocument};
 use std::convert::TryInto;
 
 // TODO(iliana): make async/.await. awslabs/tough#213
+// TODO(crespo): returning tuple of system version + artifacts is temporary
 pub fn read_artifacts(
     trusted_root: &[u8],
     mut base_url: String,
 ) -> Result<
-    Vec<db::model::UpdateArtifact>,
+    (SemverVersion, Vec<db::model::UpdateArtifact>),
     Box<dyn std::error::Error + Send + Sync>,
 > {
     use std::io::Read;
@@ -70,5 +71,5 @@ pub fn read_artifacts(
             target_length: target.length.try_into()?,
         });
     }
-    Ok(v)
+    Ok((artifacts.system_version, v))
 }

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -108,6 +108,8 @@ async fn test_update_end_to_end() {
     assert_eq!(updates.items.len(), 4);
     assert!(updates.items.iter().any(|u| u.version == SYSTEM_VERSION));
 
+    // TODO: confirm the artifacts are associated with the system version
+
     let artifact_path = cptestctx.sled_agent_storage.path();
     let component_path = artifact_path.join(UPDATE_COMPONENT);
     // check sled agent did the thing


### PR DESCRIPTION
WIP, still lots left to do here.

### Goals

- Combine `UpdateArtifact` and `ComponentUpdate`
  - Set up a join table between `UpdateArtifact` and `SystemUpdate` so we can get the artifacts for a particular system version
  - Make all the spots that currently use `ComponentUpdate` use `UpdateArtifact` instead
  - Delete `ComponentUpdate`
- Continue to rely on single-system-version TUF repo format because that's all there is, but factor the code so that switching to the new multi-system-version format is trivial
- Make `updates_apply` take a system version
  - Right now we loop through the sleds and call `update_artifact` with every artifact. We will keep doing that for now, except instead of all artifacts, we will do it for the list of artifacts associated with a specified system version
- Use the same rails as TUF repo scan when populating mock data at Nexus start

### Non-goals/future work

- Automatic periodic TUF repo scan
  - Do scan at Nexus startup, re-scans can be triggered manually through the API
- Do something smarter than re-scanning and upserting the entire TUF repo's artifacts every time

Closes #766