### PR TITLE
fix case of DNS, NTP enums

### DIFF
--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -426,7 +426,7 @@ mod test {
     fn display_srv_service() {
         assert_eq!(ServiceName::Clickhouse.dns_name(), "_clickhouse._tcp",);
         assert_eq!(ServiceName::Cockroach.dns_name(), "_cockroach._tcp",);
-        assert_eq!(ServiceName::InternalDNS.dns_name(), "_nameservice._tcp",);
+        assert_eq!(ServiceName::InternalDns.dns_name(), "_nameservice._tcp",);
         assert_eq!(ServiceName::Nexus.dns_name(), "_nexus._tcp",);
         assert_eq!(ServiceName::Oximeter.dns_name(), "_oximeter._tcp",);
         assert_eq!(ServiceName::Dendrite.dns_name(), "_dendrite._tcp",);

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -14,8 +14,8 @@ pub const DNS_ZONE: &str = "control-plane.oxide.internal";
 pub enum ServiceName {
     Clickhouse,
     Cockroach,
-    InternalDNS,
-    ExternalDNS,
+    InternalDns,
+    ExternalDns,
     Nexus,
     Oximeter,
     ManagementGatewayService,
@@ -35,8 +35,8 @@ impl ServiceName {
         match self {
             ServiceName::Clickhouse => "clickhouse",
             ServiceName::Cockroach => "cockroach",
-            ServiceName::ExternalDNS => "external-dns",
-            ServiceName::InternalDNS => "nameservice",
+            ServiceName::ExternalDns => "external-dns",
+            ServiceName::InternalDns => "nameservice",
             ServiceName::Nexus => "nexus",
             ServiceName::Oximeter => "oximeter",
             ServiceName::ManagementGatewayService => "mgs",
@@ -58,8 +58,8 @@ impl ServiceName {
         match self {
             ServiceName::Clickhouse
             | ServiceName::Cockroach
-            | ServiceName::InternalDNS
-            | ServiceName::ExternalDNS
+            | ServiceName::InternalDns
+            | ServiceName::ExternalDns
             | ServiceName::Nexus
             | ServiceName::Oximeter
             | ServiceName::ManagementGatewayService

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -75,7 +75,7 @@ impl From<internal_api::params::ServiceKind> for ServiceKind {
             internal_api::params::ServiceKind::CruciblePantry => {
                 ServiceKind::CruciblePantry
             }
-            internal_api::params::ServiceKind::NTP => ServiceKind::NTP,
+            internal_api::params::ServiceKind::Ntp => ServiceKind::Ntp,
         }
     }
 }

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -19,10 +19,10 @@ impl_enum_type!(
     // Enum values
     CruciblePantry => b"crucible_pantry"
     Dendrite => b"dendrite"
-    ExternalDNS => b"external_dns"
-    ExternalDNSConfig => b"external_dns_config"
-    InternalDNS => b"internal_dns"
-    InternalDNSConfig => b"internal_dns_config"
+    ExternalDns => b"external_dns"
+    ExternalDnsConfig => b"external_dns_config"
+    InternalDns => b"internal_dns"
+    InternalDnsConfig => b"internal_dns_config"
     Nexus => b"nexus"
     Oximeter => b"oximeter"
     Tfport => b"tfport"
@@ -50,17 +50,17 @@ impl From<ServiceUsingCertificate> for ServiceKind {
 impl From<internal_api::params::ServiceKind> for ServiceKind {
     fn from(k: internal_api::params::ServiceKind) -> Self {
         match k {
-            internal_api::params::ServiceKind::ExternalDNS => {
-                ServiceKind::ExternalDNS
+            internal_api::params::ServiceKind::ExternalDns => {
+                ServiceKind::ExternalDns
             }
-            internal_api::params::ServiceKind::ExternalDNSConfig => {
-                ServiceKind::ExternalDNSConfig
+            internal_api::params::ServiceKind::ExternalDnsConfig => {
+                ServiceKind::ExternalDnsConfig
             }
-            internal_api::params::ServiceKind::InternalDNS => {
-                ServiceKind::InternalDNS
+            internal_api::params::ServiceKind::InternalDns => {
+                ServiceKind::InternalDns
             }
-            internal_api::params::ServiceKind::InternalDNSConfig => {
-                ServiceKind::InternalDNSConfig
+            internal_api::params::ServiceKind::InternalDnsConfig => {
+                ServiceKind::InternalDnsConfig
             }
             internal_api::params::ServiceKind::Nexus { .. } => {
                 ServiceKind::Nexus

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -26,7 +26,7 @@ impl_enum_type!(
     Nexus => b"nexus"
     Oximeter => b"oximeter"
     Tfport => b"tfport"
-    NTP => b"ntp"
+    Ntp => b"ntp"
 );
 
 impl TryFrom<ServiceKind> for ServiceUsingCertificate {

--- a/nexus/src/app/background/dns_servers.rs
+++ b/nexus/src/app/background/dns_servers.rs
@@ -80,8 +80,8 @@ impl BackgroundTask for DnsServersWatcher {
 
             // Read the latest service configuration for this DNS group.
             let service_kind = match self.dns_group {
-                DnsGroup::Internal => ServiceKind::InternalDNSConfig,
-                DnsGroup::External => ServiceKind::ExternalDNSConfig,
+                DnsGroup::Internal => ServiceKind::InternalDnsConfig,
+                DnsGroup::External => ServiceKind::ExternalDnsConfig,
             };
 
             let pagparams = DataPageParams {
@@ -234,7 +234,7 @@ mod test {
                     Uuid::new_v4(),
                     Uuid::new_v4(),
                     SocketAddrV6::new(Ipv6Addr::LOCALHOST, 1, 0, 0),
-                    ServiceKind::InternalDNSConfig,
+                    ServiceKind::InternalDnsConfig,
                 ))
                 .execute_async(datastore.pool_for_tests().await.unwrap())
                 .await
@@ -256,7 +256,7 @@ mod test {
                         Uuid::new_v4(),
                         Uuid::new_v4(),
                         SocketAddrV6::new(Ipv6Addr::LOCALHOST, i + 2, 0, 0),
-                        ServiceKind::InternalDNSConfig,
+                        ServiceKind::InternalDnsConfig,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -278,7 +278,7 @@ mod test {
             use crate::db::schema::service::dsl;
             diesel::delete(
                 dsl::service
-                    .filter(dsl::kind.eq(ServiceKind::InternalDNSConfig)),
+                    .filter(dsl::kind.eq(ServiceKind::InternalDnsConfig)),
             )
             .execute_async(datastore.pool_for_tests().await.unwrap())
             .await

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -211,7 +211,7 @@ pub mod test {
                 Uuid::new_v4(),
                 cptestctx.sled_agent.sled_agent.id,
                 new_dns_addr,
-                ServiceKind::InternalDNSConfig.into(),
+                ServiceKind::InternalDnsConfig.into(),
             )
             .await
             .unwrap();

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -273,9 +273,9 @@ impl super::Nexus {
         let service = db::model::Service::new(id, sled_id, address, kind);
         self.db_datastore.service_upsert(opctx, service).await?;
 
-        if kind == ServiceKind::ExternalDNSConfig {
+        if kind == ServiceKind::ExternalDnsConfig {
             self.background_tasks.activate(&self.task_external_dns_servers);
-        } else if kind == ServiceKind::InternalDNSConfig {
+        } else if kind == ServiceKind::InternalDnsConfig {
             self.background_tasks.activate(&self.task_internal_dns_servers);
         }
 

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn test_setup_with_config<N: NexusServer>(
         service_id: Uuid::new_v4(),
         sled_id: sa_id,
         address: dns_server_address,
-        kind: ServiceKind::InternalDNSConfig,
+        kind: ServiceKind::InternalDnsConfig,
     };
     let server = N::start(nexus_internal, &config, vec![dns_service]).await;
 

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -170,7 +170,7 @@ pub enum ServiceKind {
     Dendrite,
     Tfport,
     CruciblePantry,
-    NTP,
+    Ntp,
 }
 
 impl fmt::Display for ServiceKind {
@@ -186,7 +186,7 @@ impl fmt::Display for ServiceKind {
             Dendrite => "dendrite",
             Tfport => "tfport",
             CruciblePantry => "crucible_pantry",
-            NTP => "ntp",
+            Ntp => "ntp",
         };
         write!(f, "{}", s)
     }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -161,10 +161,10 @@ pub struct DatasetPutRequest {
 )]
 #[serde(rename_all = "snake_case", tag = "type", content = "content")]
 pub enum ServiceKind {
-    ExternalDNS,
-    ExternalDNSConfig,
-    InternalDNS,
-    InternalDNSConfig,
+    ExternalDns,
+    ExternalDnsConfig,
+    InternalDns,
+    InternalDnsConfig,
     Nexus { external_address: IpAddr },
     Oximeter,
     Dendrite,
@@ -177,10 +177,10 @@ impl fmt::Display for ServiceKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ServiceKind::*;
         let s = match self {
-            ExternalDNSConfig => "external_dns_config",
-            ExternalDNS => "external_dns",
-            InternalDNSConfig => "internal_dns_config",
-            InternalDNS => "internal_dns",
+            ExternalDnsConfig => "external_dns_config",
+            ExternalDns => "external_dns",
+            InternalDnsConfig => "internal_dns_config",
+            InternalDns => "internal_dns",
             Nexus { .. } => "nexus",
             Oximeter => "oximeter",
             Dendrite => "dendrite",

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2403,7 +2403,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "n_t_p"
+                  "ntp"
                 ]
               }
             },

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2264,7 +2264,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "external_d_n_s"
+                  "external_dns"
                 ]
               }
             },
@@ -2278,7 +2278,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "external_d_n_s_config"
+                  "external_dns_config"
                 ]
               }
             },
@@ -2292,7 +2292,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "internal_d_n_s"
+                  "internal_dns"
                 ]
               }
             },
@@ -2306,7 +2306,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "internal_d_n_s_config"
+                  "internal_dns_config"
                 ]
               }
             },

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -380,9 +380,9 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
 )]
 pub enum ZoneType {
     #[serde(rename = "external_dns")]
-    ExternalDNS,
+    ExternalDns,
     #[serde(rename = "internal_dns")]
-    InternalDNS,
+    InternalDns,
     #[serde(rename = "nexus")]
     Nexus,
     #[serde(rename = "oximeter")]
@@ -398,8 +398,8 @@ pub enum ZoneType {
 impl From<ZoneType> for sled_agent_client::types::ZoneType {
     fn from(zt: ZoneType) -> Self {
         match zt {
-            ZoneType::InternalDNS => Self::InternalDns,
-            ZoneType::ExternalDNS => Self::ExternalDns,
+            ZoneType::InternalDns => Self::InternalDns,
+            ZoneType::ExternalDns => Self::ExternalDns,
             ZoneType::Nexus => Self::Nexus,
             ZoneType::Oximeter => Self::Oximeter,
             ZoneType::Switch => Self::Switch,
@@ -413,8 +413,8 @@ impl std::fmt::Display for ZoneType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ZoneType::*;
         let name = match self {
-            ExternalDNS => "external_dns",
-            InternalDNS => "internal_dns",
+            ExternalDns => "external_dns",
+            InternalDns => "internal_dns",
             Nexus => "nexus",
             Oximeter => "oximeter",
             Switch => "switch",

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -378,21 +378,15 @@ impl From<ServiceType> for sled_agent_client::types::ServiceType {
 #[derive(
     Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum ZoneType {
-    #[serde(rename = "external_dns")]
     ExternalDns,
-    #[serde(rename = "internal_dns")]
     InternalDns,
-    #[serde(rename = "nexus")]
     Nexus,
-    #[serde(rename = "oximeter")]
     Oximeter,
-    #[serde(rename = "switch")]
     Switch,
-    #[serde(rename = "crucible_pantry")]
     CruciblePantry,
-    #[serde(rename = "ntp")]
-    NTP,
+    Ntp,
 }
 
 impl From<ZoneType> for sled_agent_client::types::ZoneType {
@@ -404,7 +398,7 @@ impl From<ZoneType> for sled_agent_client::types::ZoneType {
             ZoneType::Oximeter => Self::Oximeter,
             ZoneType::Switch => Self::Switch,
             ZoneType::CruciblePantry => Self::CruciblePantry,
-            ZoneType::NTP => Self::Ntp,
+            ZoneType::Ntp => Self::Ntp,
         }
     }
 }
@@ -419,7 +413,7 @@ impl std::fmt::Display for ZoneType {
             Oximeter => "oximeter",
             Switch => "switch",
             CruciblePantry => "crucible_pantry",
-            NTP => "ntp",
+            Ntp => "ntp",
         };
         write!(f, "{name}")
     }

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -512,7 +512,7 @@ impl Plan {
 
                 request.services.push(ServiceZoneRequest {
                     id,
-                    zone_type: ZoneType::NTP,
+                    zone_type: ZoneType::Ntp,
                     addresses: vec![address],
                     gz_addresses: vec![],
                     services: services,

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -276,14 +276,14 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, internal_ip).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        ServiceName::ExternalDNS,
+                        ServiceName::ExternalDns,
                         &zone,
                         http_port,
                     )
                     .unwrap();
                 request.services.push(ServiceZoneRequest {
                     id,
-                    zone_type: ZoneType::ExternalDNS,
+                    zone_type: ZoneType::ExternalDns,
                     addresses: vec![internal_ip],
                     gz_addresses: vec![],
                     services: vec![ServiceType::ExternalDns {
@@ -426,14 +426,14 @@ impl Plan {
                 let zone = dns_builder.host_zone(id, dns_addr).unwrap();
                 dns_builder
                     .service_backend_zone(
-                        ServiceName::InternalDNS,
+                        ServiceName::InternalDns,
                         &zone,
                         DNS_HTTP_PORT,
                     )
                     .unwrap();
                 request.services.push(ServiceZoneRequest {
                     id,
-                    zone_type: ZoneType::InternalDNS,
+                    zone_type: ZoneType::InternalDns,
                     addresses: vec![dns_addr],
                     gz_addresses: vec![dns_subnet.gz_address().ip()],
                     services: vec![ServiceType::InternalDns {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -996,7 +996,7 @@ impl ServiceInner {
                     .filter_map(|svc| {
                         if matches!(
                             svc.zone_type,
-                            ZoneType::InternalDns | ZoneType::NTP
+                            ZoneType::InternalDns | ZoneType::Ntp
                         ) {
                             Some(svc.clone())
                         } else {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -741,7 +741,7 @@ impl ServiceInner {
                                     0,
                                 )
                                 .to_string(),
-                                kind: NexusTypes::ServiceKind::NTP,
+                                kind: NexusTypes::ServiceKind::Ntp,
                             });
                         }
                         _ => {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -348,7 +348,7 @@ impl ServiceInner {
                         .services
                         .iter()
                         .filter_map(|svc| {
-                            if !matches!(svc.zone_type, ZoneType::InternalDNS) {
+                            if !matches!(svc.zone_type, ZoneType::InternalDns) {
                                 // This is not an internal DNS zone.
                                 None
                             } else {
@@ -370,7 +370,7 @@ impl ServiceInner {
                                         log,
                                         "DNS configuration: expected one \
                                         InternalDns service for zone with \
-                                        type ZoneType::InternalDNS, but \
+                                        type ZoneType::InternalDns, but \
                                         found {} (zone {})",
                                         svc.id,
                                         addrs.len()
@@ -681,7 +681,7 @@ impl ServiceInner {
                                 sled_id,
                                 address: http_address.to_string(),
                                 kind:
-                                    NexusTypes::ServiceKind::ExternalDNSConfig,
+                                    NexusTypes::ServiceKind::ExternalDnsConfig,
                             });
                         }
                         ServiceType::InternalDns {
@@ -693,13 +693,13 @@ impl ServiceInner {
                                 sled_id,
                                 address: http_address.to_string(),
                                 kind:
-                                    NexusTypes::ServiceKind::InternalDNSConfig,
+                                    NexusTypes::ServiceKind::InternalDnsConfig,
                             });
                             services.push(NexusTypes::ServicePutRequest {
                                 service_id: zone.id,
                                 sled_id,
                                 address: dns_address.to_string(),
-                                kind: NexusTypes::ServiceKind::InternalDNS,
+                                kind: NexusTypes::ServiceKind::InternalDns,
                             });
                         }
                         ServiceType::Oximeter => {
@@ -996,7 +996,7 @@ impl ServiceInner {
                     .filter_map(|svc| {
                         if matches!(
                             svc.zone_type,
-                            ZoneType::InternalDNS | ZoneType::NTP
+                            ZoneType::InternalDns | ZoneType::NTP
                         ) {
                             Some(svc.clone())
                         } else {

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -399,7 +399,7 @@ impl ServiceManager {
                     .filter(|svc| {
                         matches!(
                             svc.zone_type,
-                            ZoneType::InternalDNS | ZoneType::NTP
+                            ZoneType::InternalDns | ZoneType::NTP
                         )
                     })
                     .collect(),

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -399,7 +399,7 @@ impl ServiceManager {
                     .filter(|svc| {
                         matches!(
                             svc.zone_type,
-                            ZoneType::InternalDns | ZoneType::NTP
+                            ZoneType::InternalDns | ZoneType::Ntp
                         )
                     })
                     .collect(),
@@ -1434,7 +1434,7 @@ impl ServiceManager {
         };
 
         let ntp_zone_name =
-            InstalledZone::get_zone_name(&ZoneType::NTP.to_string(), None);
+            InstalledZone::get_zone_name(&ZoneType::Ntp.to_string(), None);
 
         let ntp_zone = existing_zones
             .iter()

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -248,13 +248,13 @@ impl Server {
         let services = vec![
             NexusTypes::ServicePutRequest {
                 address: dns_bound.to_string(),
-                kind: NexusTypes::ServiceKind::InternalDNS,
+                kind: NexusTypes::ServiceKind::InternalDns,
                 service_id: Uuid::new_v4(),
                 sled_id: config.id,
             },
             NexusTypes::ServicePutRequest {
                 address: http_bound.to_string(),
-                kind: NexusTypes::ServiceKind::InternalDNSConfig,
+                kind: NexusTypes::ServiceKind::InternalDnsConfig,
                 service_id: Uuid::new_v4(),
                 sled_id: config.id,
             },


### PR DESCRIPTION
We have several enums whose variants include `InternalDNS`, `ExternalDNS`, `NTP`, etc.  [Rust's naming conventions](https://rust-lang.github.io/api-guidelines/naming.html) suggest these should be `InternalDns`, `ExternalDns`, `Ntp`, etc:

> In UpperCamelCase, acronyms and contractions of compound words count as one word: use Uuid rather than UUID, Usize rather than USize or Stdin rather than StdIn.

I don't really care, but what we're doing right now confuses tooling like serde/json-schema:
https://github.com/oxidecomputer/omicron/blob/9d6aeab9d14c6ca7ef32cfca9bc11f147b7bfff6/openapi/nexus-internal.json#L2267

It only affects the internal API right now.  But it seems like we should standardize on one convention here and it may as well be the Rust convention that existing tooling expects.