### PR TITLE
Fix silo image lookup using wrong id; add tests

### DIFF
--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -48,7 +48,7 @@ impl super::Nexus {
                         .project_image_id(id)),
                     None => {
                         ImageLookup::SiloImage(LookupPath::new(opctx, &self.db_datastore)
-                            .silo_image_id(db_image.silo_id))
+                            .silo_image_id(id))
                     },
                 };
                 Ok(lookup)


### PR DESCRIPTION
Fixes #2873 

When looking up a silo image by ID I was accidentally passing the silo id instead of the image's id. 