### PR TITLE
nexus: revamp live migration saga

### DIFF
--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -98,7 +98,10 @@ impl DatastoreAttachTargetConfig<Disk> for Instance {
     Serialize,
     Deserialize,
 )]
-#[diesel(table_name = instance)]
+// N.B. Setting `treat_none_as_null` is required for these fields to be cleared
+//      properly during live migrations. See the documentation for
+//      `diesel::prelude::AsChangeset`.
+#[diesel(table_name = instance, treat_none_as_null = true)]
 pub struct InstanceRuntimeState {
     /// The instance's current user-visible instance state.
     ///

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -143,3 +143,41 @@ impl DatastoreCollectionConfig<super::Service> for Sled {
     type CollectionTimeDeletedColumn = sled::dsl::time_deleted;
     type CollectionIdColumn = service::dsl::sled_id;
 }
+
+/// A set of constraints that can be placed on operations that select a sled.
+#[derive(Debug)]
+pub struct SledReservationConstraints {
+    must_select_from: Vec<Uuid>,
+}
+
+impl SledReservationConstraints {
+    pub fn none() -> Self {
+        Self { must_select_from: Vec::new() }
+    }
+
+    pub fn must_select_from(&self) -> &[Uuid] {
+        &self.must_select_from
+    }
+}
+
+#[derive(Debug)]
+pub struct SledReservationConstraintBuilder {
+    constraints: SledReservationConstraints,
+}
+
+impl SledReservationConstraintBuilder {
+    pub fn new() -> Self {
+        SledReservationConstraintBuilder {
+            constraints: SledReservationConstraints::none(),
+        }
+    }
+
+    pub fn must_select_from(mut self, sled_ids: &[Uuid]) -> Self {
+        self.constraints.must_select_from.extend(sled_ids);
+        self
+    }
+
+    pub fn build(self) -> SledReservationConstraints {
+        self.constraints
+    }
+}

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -151,12 +151,21 @@ pub struct SledReservationConstraints {
 }
 
 impl SledReservationConstraints {
+    /// Creates a constraint set with no constraints in it.
     pub fn none() -> Self {
         Self { must_select_from: Vec::new() }
     }
 
-    pub fn must_select_from(&self) -> &[Uuid] {
-        &self.must_select_from
+    /// If the constraints include a set of sleds that the caller must select
+    /// from, returns `Some` and a slice containing the members of that set.
+    ///
+    /// If no "must select from these" constraint exists, returns None.
+    pub fn must_select_from(&self) -> Option<&[Uuid]> {
+        if self.must_select_from.is_empty() {
+            None
+        } else {
+            Some(&self.must_select_from)
+        }
     }
 }
 
@@ -172,11 +181,15 @@ impl SledReservationConstraintBuilder {
         }
     }
 
+    /// Adds a "must select from the following sled IDs" constraint. If such a
+    /// constraint already exists, appends the supplied sled IDs to the "must
+    /// select from" list.
     pub fn must_select_from(mut self, sled_ids: &[Uuid]) -> Self {
         self.constraints.must_select_from.extend(sled_ids);
         self
     }
 
+    /// Builds a set of constraints from this builder's current state.
     pub fn build(self) -> SledReservationConstraints {
         self.constraints
     }

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -140,11 +140,9 @@ impl DataStore {
 
                 // Further constrain the sled IDs according to any caller-
                 // supplied constraints.
-                if !constraints.must_select_from().is_empty() {
-                    sled_targets = sled_targets.filter(
-                        sled_dsl::id
-                            .eq_any(constraints.must_select_from().to_vec()),
-                    );
+                if let Some(must_select_from) = constraints.must_select_from() {
+                    sled_targets = sled_targets
+                        .filter(sled_dsl::id.eq_any(must_select_from.to_vec()));
                 }
 
                 sql_function!(fn random() -> diesel::sql_types::Float);

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -367,8 +367,9 @@ impl super::Nexus {
                 .instance_refetch(opctx, &authz_instance)
                 .await?)
         } else {
-            Err(Error::internal_error(
-                "instance's Propolis generation is out of date",
+            Err(Error::unavail(
+                "instance is already migrating, or underwent an operation that \
+                 prevented this migration from proceeding"
             ))
         }
     }

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -828,9 +828,11 @@ impl super::Nexus {
                 // what to do with status codes.
                 error!(self.log, "saw {} from instance_put!", e);
 
-                // this is unfortunate, but sled_agent_client::Error doesn't
-                // implement Copy, and can't be match'ed upon below without this
-                // line.
+                // Convert to the Omicron API error type.
+                //
+                // N.B. The match below assumes that this conversion will turn
+                //      any 400-level error status from sled agent into an
+                //      `Error::InvalidRequest`.
                 let e = e.into();
 
                 match &e {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -366,7 +366,7 @@ impl super::Nexus {
                 .instance_refetch(opctx, &authz_instance)
                 .await?)
         } else {
-            Err(Error::unavail(
+            Err(Error::conflict(
                 "instance is already migrating, or underwent an operation that \
                  prevented this migration from proceeding"
             ))

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -338,8 +338,7 @@ impl super::Nexus {
         let (.., authz_instance) = LookupPath::new(opctx, &self.db_datastore)
             .instance_id(instance_id)
             .lookup_for(authz::Action::Modify)
-            .await
-            .unwrap();
+            .await?;
 
         let sa = self.instance_sled(&db_instance).await?;
         let instance_put_result = sa

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{NexusActionContext, NexusSaga, SagaInitError, ACTION_GENERATE_ID};
+use crate::app::instance::WriteBackUpdatedInstance;
 use crate::app::sagas::declare_saga_actions;
 use crate::app::sagas::disk_create::{self, SagaDiskCreate};
 use crate::app::{
@@ -1401,7 +1402,12 @@ async fn sic_instance_ensure_registered_undo(
 
     osagactx
         .nexus()
-        .instance_ensure_unregistered(&opctx, &authz_instance, &db_instance)
+        .instance_ensure_unregistered(
+            &opctx,
+            &authz_instance,
+            &db_instance,
+            WriteBackUpdatedInstance::WriteBack,
+        )
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1075,10 +1075,9 @@ async fn ensure_instance_disk_attach_state(
 pub(super) async fn allocate_sled_ipv6(
     opctx: &OpContext,
     sagactx: NexusActionContext,
-    sled_id_name: &str,
+    sled_uuid: Uuid,
 ) -> Result<Ipv6Addr, ActionError> {
     let osagactx = sagactx.user_data();
-    let sled_uuid = sagactx.lookup::<Uuid>(sled_id_name)?;
     osagactx
         .datastore()
         .next_ipv6_address(opctx, sled_uuid)
@@ -1145,7 +1144,8 @@ async fn sic_allocate_propolis_ip(
         &sagactx,
         &params.serialized_authn,
     );
-    allocate_sled_ipv6(&opctx, sagactx, "server_id").await
+    let sled_uuid = sagactx.lookup::<Uuid>("server_id")?;
+    allocate_sled_ipv6(&opctx, sagactx, sled_uuid).await
 }
 
 async fn sic_create_instance_record(

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -615,6 +615,7 @@ async fn sic_alloc_server(
             propolis_id,
             db::model::SledResourceKind::Instance,
             resources,
+            db::model::SledReservationConstraints::none(),
         )
         .await
         .map_err(ActionError::action_failed)?;

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -193,7 +193,7 @@ async fn sim_reserve_sled_resources(
     //      immutable despite being in the instance's "runtime" state.
     let resources = db::model::Resources::new(
         params.instance.runtime_state.ncpus.0 .0.into(),
-        params.instance.runtime_state.memory.into(),
+        params.instance.runtime_state.memory,
         // TODO(#2804): Properly specify reservoir size.
         omicron_common::api::external::ByteCount::from(0).into(),
     );

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -5,12 +5,17 @@
 use super::instance_create::allocate_sled_ipv6;
 use super::{NexusActionContext, NexusSaga, ACTION_GENERATE_ID};
 use crate::app::sagas::declare_saga_actions;
-use crate::authn;
-use crate::db::identity::Resource;
+use crate::db::{identity::Resource, lookup::LookupPath};
 use crate::external_api::params;
+use crate::{authn, authz, db};
+use omicron_common::api::external::InstanceState;
 use omicron_common::api::internal::nexus::InstanceRuntimeState;
 use serde::Deserialize;
 use serde::Serialize;
+use sled_agent_client::types::{
+    InstanceMigrationSourceParams, InstanceMigrationTargetParams,
+    InstanceStateRequested,
+};
 use std::net::Ipv6Addr;
 use steno::ActionError;
 use steno::Node;
@@ -21,32 +26,107 @@ use uuid::Uuid;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Params {
     pub serialized_authn: authn::saga::Serialized,
-    pub instance_id: Uuid,
+    pub instance: db::model::Instance,
     pub migrate_params: params::InstanceMigrate,
 }
 
-// instance migrate saga: actions
-
+// The migration saga is similar to the instance creation saga: get a
+// destination sled, allocate a Propolis process on it, and send it a request to
+// initialize via migration, then wait (outside the saga) for this to resolve.
+//
+// Most of the complexity in this saga comes from the fact that during
+// migration, there are two sleds with their own instance runtime states, and
+// both the saga and the work that happen after it have to specify carefully
+// which of the two participating VMMs is actually running the VM once the
+// migration is over.
 declare_saga_actions! {
     instance_migrate;
     ALLOCATE_PROPOLIS_IP -> "dst_propolis_ip" {
         + sim_allocate_propolis_ip
     }
-    MIGRATE_PREP -> "migrate_instance" {
-        + sim_migrate_prep
+
+    // This step sets the migration ID and destination Propolis ID fields in
+    // CRDB by asking the instance's current sled to paste them into its runtime
+    // state. Sled agent provides the synchronization here: while this operation
+    // is idempotent for any single transition between IDs, sled agent ensures
+    // that if multiple concurrent sagas try to set migration IDs at the same
+    // Propolis generation, then only one will win and get to proceed through
+    // the saga.
+    SET_MIGRATION_IDS -> "set_migration_ids" {
+        + sim_set_migration_ids
     }
+
+    // The instance state on the destination looks like the instance state on
+    // the source, except that it bears all of the destination's "location"
+    // information--its Propolis ID, sled ID, and Propolis IP--with the same
+    // Propolis generation number as the source set in the previous step.
+    // Consider an example:
+    //
+    // - Before the saga begins, the instance has Propolis generation 10 and no
+    //   migration IDs.
+    // - The previous step sets Propolis generation 11 and sets the instance's
+    //   migration ID.
+    // - This step synthesizes a record with Propolis generation 11 and the same
+    //   migration IDs, but with the Propolis identifiers set to the
+    //   destination's IDs.
+    //
+    // When the migration resolves one way or the other, one or both of the
+    // participating sleds will update CRDB with Propolis generation 12 and the
+    // Propolis ID set to whichever Propolis ended up running the instance.
+    //
+    // This step must be infallible and does not have an undo action for reasons
+    // described below.
+    CREATE_DESTINATION_STATE -> "dst_runtime_state" {
+        + sim_create_destination_state
+    }
+
+    // The next three steps are organized so that if the saga unwinds after the
+    // destination Propolis is created, the "set migration IDs" step is undone
+    // before the "ensure destination Propolis" step. Consider again the example
+    // above, but this time, let the saga unwind after the destination Propolis
+    // starts. If sled agent changes an instance's Propolis generation when a
+    // Propolis is destroyed, and the undo steps are specified in the
+    // traditional way, the following can occur:
+    //
+    // - After the steps above, the instance is registered with the source and
+    //   target sleds, both at Propolis generation 11.
+    // - Undoing the "ensure destination Propolis" step sets the Propolis
+    //   generation to 12, but with the location information from the target!
+    // - When the "set migration IDs" step is undone, the source will publish
+    //   Propolis generation 12, but this will be dropped because the generation
+    //   was already incremented.
+    //
+    // Now CRDB is pointing at the wrong Propolis, and instance state updates
+    // from the former migration source will be ignored. Oops.
+    //
+    // Instead of asking sled agent to reason about what steps in a migration
+    // have and haven't been undertaken, the following steps are arranged so
+    // that the update that clears migration IDs happens before the one that
+    // destroys the destination Propolis, which unwinds the saga to the expected
+    // state.
+    //
+    // Note that this implies that `sim_ensure_destination_propolis_undo` must
+    // be able to succeed even if the "ensure destination Propolis" step was
+    // never reached.
+    ENSURE_DESTINATION_PROPOLIS_UNDO -> "unused_ensure_destination_undo" {
+        + sim_noop
+        - sim_ensure_destination_propolis_undo
+    }
+    SET_MIGRATION_IDS_UNDO -> "unused_set_ids_undo" {
+        + sim_noop
+        - sim_clear_migration_ids
+    }
+    ENSURE_DESTINATION_PROPOLIS -> "ensure_destination" {
+        + sim_ensure_destination_propolis
+    }
+
+    // Note that this step only requests migration by sending a "migrate in"
+    // request to the destination sled. It does not wait for migration to
+    // finish. It cannot be unwound, either, because there is no way to cancel
+    // an in-progress migration (indeed, a requested migration might have
+    // finished entirely by the time the undo step runs).
     INSTANCE_MIGRATE -> "instance_migrate" {
-        // TODO robustness: This needs an undo action
         + sim_instance_migrate
-    }
-    V2P_ENSURE -> "v2p_ensure" {
-        // TODO robustness: This needs an undo action
-        + sim_v2p_ensure
-    }
-    CLEANUP_SOURCE -> "cleanup_source" {
-        // TODO robustness: This needs an undo action. Is it even possible
-        // to undo at this point?
-        + sim_cleanup_source
     }
 }
 
@@ -79,48 +159,23 @@ impl NexusSaga for SagaInstanceMigrate {
         ));
 
         builder.append(allocate_propolis_ip_action());
-        builder.append(migrate_prep_action());
+        builder.append(set_migration_ids_action());
+        builder.append(create_destination_state_action());
+        builder.append(ensure_destination_propolis_undo_action());
+        builder.append(set_migration_ids_undo_action());
+        builder.append(ensure_destination_propolis_action());
         builder.append(instance_migrate_action());
-        builder.append(v2p_ensure_action());
-        builder.append(cleanup_source_action());
 
         Ok(builder.build()?)
     }
 }
 
-async fn sim_migrate_prep(
-    sagactx: NexusActionContext,
-) -> Result<(Uuid, InstanceRuntimeState), ActionError> {
-    let osagactx = sagactx.user_data();
-    let params = sagactx.saga_params::<Params>()?;
-    let opctx = crate::context::op_context_for_saga_action(
-        &sagactx,
-        &params.serialized_authn,
-    );
-
-    let migrate_uuid = sagactx.lookup::<Uuid>("migrate_id")?;
-    let dst_propolis_uuid = sagactx.lookup::<Uuid>("dst_propolis_id")?;
-
-    // We have sled-agent (via Nexus) attempt to place
-    // the instance in a "Migrating" state w/ the given
-    // migration id. This will also update the instance
-    // state in the db
-    let instance = osagactx
-        .nexus()
-        .instance_start_migrate(
-            &opctx,
-            params.instance_id,
-            migrate_uuid,
-            dst_propolis_uuid,
-        )
-        .await
-        .map_err(ActionError::action_failed)?;
-    let instance_id = instance.id();
-
-    Ok((instance_id, instance.runtime_state.into()))
+/// A no-op forward action.
+async fn sim_noop(_sagactx: NexusActionContext) -> Result<(), ActionError> {
+    Ok(())
 }
 
-// Allocate an IP address on the destination sled for the Propolis server.
+/// Allocates an IP address on the destination sled for the Propolis server.
 async fn sim_allocate_propolis_ip(
     sagactx: NexusActionContext,
 ) -> Result<Ipv6Addr, ActionError> {
@@ -129,15 +184,12 @@ async fn sim_allocate_propolis_ip(
         &sagactx,
         &params.serialized_authn,
     );
-    allocate_sled_ipv6(&opctx, sagactx, "dst_sled_uuid").await
+    allocate_sled_ipv6(&opctx, sagactx, params.migrate_params.dst_sled_id).await
 }
 
-async fn sim_instance_migrate(
-    _sagactx: NexusActionContext,
-) -> Result<(), ActionError> {
-    todo!("Migration action not yet implemented");
-
-    /*
+async fn sim_set_migration_ids(
+    sagactx: NexusActionContext,
+) -> Result<db::model::Instance, ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
     let opctx = crate::context::op_context_for_saga_action(
@@ -145,129 +197,84 @@ async fn sim_instance_migrate(
         &params.serialized_authn,
     );
 
+    let db_instance = &params.instance;
     let migration_id = sagactx.lookup::<Uuid>("migrate_id")?;
-    let dst_sled_id = params.migrate_params.dst_sled_id;
     let dst_propolis_id = sagactx.lookup::<Uuid>("dst_propolis_id")?;
-    let (instance_id, old_runtime) =
-        sagactx.lookup::<(Uuid, InstanceRuntimeState)>("migrate_instance")?;
-
-    // Allocate an IP address the destination sled for the new Propolis server.
-    let propolis_addr = osagactx
-        .datastore()
-        .next_ipv6_address(&opctx, dst_sled_id)
-        .await
-        .map_err(ActionError::action_failed)?;
-
-    let runtime = InstanceRuntimeState {
-        sled_id: dst_sled_id,
-        propolis_id: dst_propolis_id,
-        propolis_addr: Some(std::net::SocketAddr::new(
-            propolis_addr.into(),
-            12400,
-        )),
-        ..old_runtime
-    };
-
-    // Collect the external IPs for the instance.
-    //  https://github.com/oxidecomputer/omicron/issues/1467
-    // TODO-correctness: Handle Floating IPs, see
-    //  https://github.com/oxidecomputer/omicron/issues/1334
-    let (snat_ip, external_ips): (Vec<_>, Vec<_>) = osagactx
-        .datastore()
-        .instance_lookup_external_ips(&opctx, instance_id)
-        .await
-        .map_err(ActionError::action_failed)?
-        .into_iter()
-        .partition(|ip| ip.kind == IpKind::SNat);
-
-    // Sanity checks on the number and kind of each IP address.
-    if external_ips.len() > crate::app::MAX_EXTERNAL_IPS_PER_INSTANCE {
-        return Err(ActionError::action_failed(Error::internal_error(
-            format!(
-                "Expected the number of external IPs to be limited to \
-                {}, but found {}",
-                crate::app::MAX_EXTERNAL_IPS_PER_INSTANCE,
-                external_ips.len(),
-            )
-            .as_str(),
-        )));
-    }
-    let external_ips =
-        external_ips.into_iter().map(|model| model.ip.ip()).collect();
-    if snat_ip.len() != 1 {
-        return Err(ActionError::action_failed(Error::internal_error(
-            "Expected exactly one SNAT IP address for an instance",
-        )));
-    }
-    let source_nat = SourceNatConfig::from(snat_ip.into_iter().next().unwrap());
-
-    // The TODO items below are tracked in
-    //   https://github.com/oxidecomputer/omicron/issues/1783
-    let instance_hardware = InstanceHardware {
-        runtime: runtime.into(),
-        // TODO: populate NICs
-        nics: vec![],
-        source_nat,
-        external_ips,
-        // TODO: populate firewall rules
-        firewall_rules: vec![],
-        // TODO: populate disks
-        disks: vec![],
-        // TODO: populate cloud init bytes
-        cloud_init_bytes: None,
-    };
-    let target = InstanceRuntimeStateRequested {
-        run_state: InstanceStateRequested::Migrating,
-        migration_params: Some(InstanceRuntimeStateMigrateParams {
-            migration_id,
-            dst_propolis_id,
-        }),
-    };
-
-    let src_propolis_id = old_runtime.propolis_id;
-    let src_propolis_addr = old_runtime.propolis_addr.ok_or_else(|| {
-        ActionError::action_failed(Error::invalid_request(
-            "expected source propolis-addr",
-        ))
-    })?;
-
-    let dst_sa = osagactx
-        .sled_client(&dst_sled_id)
-        .await
-        .map_err(ActionError::action_failed)?;
-
-    let new_runtime_state: InstanceRuntimeState = dst_sa
-        .instance_put(
-            &instance_id,
-            &InstanceEnsureBody {
-                initial: instance_hardware,
-                target,
-                migrate: Some(InstanceMigrationTargetParams {
-                    src_propolis_addr: src_propolis_addr.to_string(),
-                    src_propolis_id,
-                }),
-            },
+    let updated_record = osagactx
+        .nexus()
+        .instance_set_migration_ids(
+            &opctx,
+            db_instance.id(),
+            db_instance,
+            Some(InstanceMigrationSourceParams {
+                dst_propolis_id,
+                migration_id,
+            }),
         )
         .await
-        .map_err(omicron_common::api::external::Error::from)
-        .map_err(ActionError::action_failed)?
-        .into_inner()
-        .into();
-
-    osagactx
-        .datastore()
-        .instance_update_runtime(&instance_id, &new_runtime_state.into())
-        .await
         .map_err(ActionError::action_failed)?;
 
-    Ok(())
-        */
+    Ok(updated_record)
 }
 
-/// Add V2P mappings for the destination instance
-// Note this must run after sled_id of the instance is set to the destination
-// sled!
-async fn sim_v2p_ensure(
+async fn sim_clear_migration_ids(
+    sagactx: NexusActionContext,
+) -> Result<(), anyhow::Error> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+    let db_instance =
+        sagactx.lookup::<db::model::Instance>("set_migration_ids")?;
+
+    // The instance may have moved to another Propolis generation by this point
+    // (if e.g. it was stopped and restarted), so this is not guaranteed to
+    // succeed.
+    //
+    // REVIEW(gjc): This callee has enough information to distinguish "outdated
+    // generation" failures from other errors. What is the right way to handle
+    // that class of other errors? For example, suppose CRDB is totally
+    // unavailable right now, but becomes available again later. The migration
+    // IDs in this step need to be cleared so that the instance can try to
+    // migrate again. How should this step achieve that?
+    let _ = osagactx
+        .nexus()
+        .instance_set_migration_ids(
+            &opctx,
+            db_instance.id(),
+            &db_instance,
+            None,
+        )
+        .await;
+
+    Ok(())
+}
+
+async fn sim_create_destination_state(
+    sagactx: NexusActionContext,
+) -> Result<db::model::Instance, ActionError> {
+    let params = sagactx.saga_params::<Params>()?;
+    let mut db_instance =
+        sagactx.lookup::<db::model::Instance>("set_migration_ids")?;
+    let dst_propolis_id = sagactx.lookup::<Uuid>("dst_propolis_id")?;
+    let dst_propolis_ip = sagactx.lookup::<Ipv6Addr>("dst_propolis_ip")?;
+
+    // Update the runtime state to refer to the new Propolis.
+    let new_runtime = db::model::InstanceRuntimeState {
+        state: db::model::InstanceState::new(InstanceState::Creating),
+        sled_id: params.migrate_params.dst_sled_id,
+        propolis_id: dst_propolis_id,
+        propolis_ip: Some(ipnetwork::Ipv6Network::from(dst_propolis_ip).into()),
+        ..db_instance.runtime_state
+    };
+
+    db_instance.runtime_state = new_runtime;
+    Ok(db_instance)
+}
+
+async fn sim_ensure_destination_propolis(
     sagactx: NexusActionContext,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
@@ -276,35 +283,428 @@ async fn sim_v2p_ensure(
         &sagactx,
         &params.serialized_authn,
     );
-    let (instance_id, _) =
-        sagactx.lookup::<(Uuid, InstanceRuntimeState)>("migrate_instance")?;
+    let db_instance =
+        sagactx.lookup::<db::model::Instance>("dst_runtime_state")?;
+    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
+        .instance_id(db_instance.id())
+        .lookup_for(authz::Action::Modify)
+        .await
+        .map_err(ActionError::action_failed)?;
 
-    // TODO-performance the instance_put in sim_instance_migrate will *start* a
-    // migration, but the source and destination propolis servers will perform
-    // it asynchronously. If this step occurs before the source instance vCPUs
-    // are paused, updating the mappings here will briefly "disconnect" the
-    // source instance in the sense that it will be able to send packets out (as
-    // other instance's V2P mappings will be untouched) but will not be able to
-    // receive any packets (other instances will send packets to the destination
-    // propolis' sled but the destination instance vCPUs may not have started
-    // yet). Until the destination propolis takes over, there will be a inbound
-    // network outage for the instance.
-    //
-    // TODO-correctness if the migration fails, there's nothing that will unwind
-    // this and restore the original V2P mappings
     osagactx
         .nexus()
-        .create_instance_v2p_mappings(&opctx, instance_id)
+        .instance_ensure_registered(&opctx, &authz_instance, &db_instance)
         .await
         .map_err(ActionError::action_failed)?;
 
     Ok(())
 }
 
-async fn sim_cleanup_source(
-    _sagactx: NexusActionContext,
-) -> Result<(), ActionError> {
-    // TODO: clean up the previous instance whether it's on the same sled or a
-    // different one
+async fn sim_ensure_destination_propolis_undo(
+    sagactx: NexusActionContext,
+) -> Result<(), anyhow::Error> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+    let db_instance =
+        sagactx.lookup::<db::model::Instance>("dst_runtime_state")?;
+    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
+        .instance_id(db_instance.id())
+        .lookup_for(authz::Action::Modify)
+        .await
+        .map_err(ActionError::action_failed)?;
+
+    // Ensure that the destination sled has no Propolis matching the description
+    // the saga previously generated.
+    //
+    // Note that this step can run before the instance was actually ensured.
+    // This is OK; sled agent will quietly succeed if asked to unregister an
+    // unregistered instance.
+    osagactx
+        .nexus()
+        .instance_ensure_unregistered(&opctx, &authz_instance, &db_instance)
+        .await
+        .map_err(ActionError::action_failed)?;
+
     Ok(())
+}
+
+async fn sim_instance_migrate(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+    let src_runtime: InstanceRuntimeState = sagactx
+        .lookup::<db::model::Instance>("set_migration_ids")?
+        .runtime()
+        .clone()
+        .into();
+    let dst_db_instance =
+        sagactx.lookup::<db::model::Instance>("dst_runtime_state")?;
+    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
+        .instance_id(dst_db_instance.id())
+        .lookup_for(authz::Action::Modify)
+        .await
+        .map_err(ActionError::action_failed)?;
+
+    // TODO-correctness: This needs to be retried if a transient error occurs to
+    // avoid a problem like the following:
+    //
+    // 1. The saga executor runs this step and successfully starts migration.
+    // 2. The executor crashes.
+    // 3. Migration completes.
+    // 4. The executor restarts, runs this step, encounters a transient error,
+    //    and then tries to unwind the saga.
+    //
+    // Now the "ensure destination" undo step will tear down the (running)
+    // migration target.
+    //
+    // Possibly sled agent can help with this by using state or Propolis
+    // generation numbers to filter out stale destruction requests.
+    osagactx
+        .nexus()
+        .instance_request_state(
+            &opctx,
+            &authz_instance,
+            &dst_db_instance,
+            InstanceStateRequested::MigrationTarget(
+                InstanceMigrationTargetParams {
+                    src_propolis_addr: src_runtime
+                        .propolis_addr
+                        .unwrap()
+                        .to_string(),
+                    src_propolis_id: src_runtime.propolis_id,
+                },
+            ),
+        )
+        .await
+        .map_err(ActionError::action_failed)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        app::{saga::create_saga_dag, sagas::instance_create},
+        Nexus, TestInterfaces as _,
+    };
+
+    use dropshot::test_util::ClientTestContext;
+    use http::{method::Method, StatusCode};
+    use nexus_test_interface::NexusServer;
+    use nexus_test_utils::{
+        http_testing::{AuthnMode, NexusRequest, RequestBuilder},
+        resource_helpers::{create_project, object_create, populate_ip_pool},
+        start_sled_agent,
+    };
+    use nexus_test_utils_macros::nexus_test;
+    use omicron_common::api::external::{
+        ByteCount, IdentityMetadataCreateParams, InstanceCpuCount,
+    };
+    use omicron_sled_agent::sim::Server;
+    use sled_agent_client::TestInterfaces as _;
+
+    use super::*;
+
+    type ControlPlaneTestContext =
+        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+    const PROJECT_NAME: &str = "test-project";
+    const INSTANCE_NAME: &str = "test-instance";
+
+    async fn setup_test_project(client: &ClientTestContext) -> Uuid {
+        populate_ip_pool(&client, "default", None).await;
+        let project = create_project(&client, PROJECT_NAME).await;
+        project.identity.id
+    }
+
+    async fn add_sleds(
+        cptestctx: &ControlPlaneTestContext,
+        num_sleds: usize,
+    ) -> Vec<(Uuid, Server)> {
+        let mut sas = Vec::with_capacity(num_sleds);
+        for _ in 0..num_sleds {
+            let sa_id = Uuid::new_v4();
+            let log =
+                cptestctx.logctx.log.new(o!("sled_id" => sa_id.to_string()));
+            let addr =
+                cptestctx.server.get_http_server_internal_address().await;
+
+            info!(&cptestctx.logctx.log, "Adding simulated sled"; "sled_id" => %sa_id);
+            let update_dir = std::path::Path::new("/should/be/unused");
+            let sa = start_sled_agent(
+                log,
+                addr,
+                sa_id,
+                &update_dir,
+                omicron_sled_agent::sim::SimMode::Explicit,
+            )
+            .await
+            .unwrap();
+            sas.push((sa_id, sa));
+        }
+
+        sas
+    }
+
+    async fn create_instance(
+        client: &ClientTestContext,
+    ) -> omicron_common::api::external::Instance {
+        let instances_url = format!("/v1/instances?project={}", PROJECT_NAME);
+        object_create(
+            client,
+            &instances_url,
+            &params::InstanceCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: INSTANCE_NAME.parse().unwrap(),
+                    description: format!("instance {:?}", INSTANCE_NAME),
+                },
+                ncpus: InstanceCpuCount(2),
+                memory: ByteCount::from_gibibytes_u32(2),
+                hostname: String::from(INSTANCE_NAME),
+                user_data: b"#cloud-config".to_vec(),
+                network_interfaces:
+                    params::InstanceNetworkInterfaceAttachment::None,
+                external_ips: vec![],
+                disks: vec![],
+                start: true,
+            },
+        )
+        .await
+    }
+
+    async fn instance_simulate(
+        cptestctx: &ControlPlaneTestContext,
+        nexus: &Arc<Nexus>,
+        instance_id: &Uuid,
+    ) {
+        info!(&cptestctx.logctx.log, "Poking simulated instance";
+              "instance_id" => %instance_id);
+        let sa = nexus.instance_sled_by_id(instance_id).await.unwrap();
+        sa.instance_finish_transition(*instance_id).await;
+    }
+
+    async fn fetch_db_instance(
+        cptestctx: &ControlPlaneTestContext,
+        opctx: &nexus_db_queries::context::OpContext,
+        id: Uuid,
+    ) -> nexus_db_model::Instance {
+        let datastore = cptestctx.server.apictx().nexus.datastore().clone();
+        let (.., db_instance) = LookupPath::new(&opctx, &datastore)
+            .instance_id(id)
+            .fetch()
+            .await
+            .expect("test instance should be present in datastore");
+
+        info!(&cptestctx.logctx.log, "refetched instance from db";
+              "instance" => ?db_instance);
+
+        db_instance
+    }
+
+    async fn instance_start(cptestctx: &ControlPlaneTestContext, id: &Uuid) {
+        let client = &cptestctx.external_client;
+        let instance_stop_url = format!("/v1/instances/{}/start", id);
+        NexusRequest::new(
+            RequestBuilder::new(client, Method::POST, &instance_stop_url)
+                .body(None as Option<&serde_json::Value>)
+                .expect_status(Some(StatusCode::ACCEPTED)),
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("Failed to start instance");
+    }
+
+    async fn instance_stop(cptestctx: &ControlPlaneTestContext, id: &Uuid) {
+        let client = &cptestctx.external_client;
+        let instance_stop_url = format!("/v1/instances/{}/stop", id);
+        NexusRequest::new(
+            RequestBuilder::new(client, Method::POST, &instance_stop_url)
+                .body(None as Option<&serde_json::Value>)
+                .expect_status(Some(StatusCode::ACCEPTED)),
+        )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("Failed to stop instance");
+    }
+
+    fn select_first_alternate_sled(
+        db_instance: &db::model::Instance,
+        other_sleds: &[(Uuid, Server)],
+    ) -> Uuid {
+        let default_sled_uuid =
+            Uuid::parse_str(nexus_test_utils::SLED_AGENT_UUID).unwrap();
+        if other_sleds.is_empty() {
+            panic!("need at least one other sled");
+        }
+
+        if other_sleds.iter().any(|sled| sled.0 == default_sled_uuid) {
+            panic!("default test sled agent was in other_sleds");
+        }
+
+        if db_instance.runtime().sled_id == default_sled_uuid {
+            other_sleds[0].0
+        } else {
+            default_sled_uuid
+        }
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_saga_basic_usage_succeeds(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let other_sleds = add_sleds(cptestctx, 1).await;
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.apictx().nexus;
+        let _project_id = setup_test_project(&client).await;
+
+        let opctx = instance_create::test::test_opctx(cptestctx);
+        let instance = create_instance(client).await;
+
+        // Poke the instance to get it into the Running state.
+        instance_simulate(cptestctx, nexus, &instance.identity.id).await;
+
+        let db_instance =
+            fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;
+        let old_runtime = db_instance.runtime().clone();
+        let dst_sled_id =
+            select_first_alternate_sled(&db_instance, &other_sleds);
+        let params = Params {
+            serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
+            instance: db_instance,
+            migrate_params: params::InstanceMigrate { dst_sled_id },
+        };
+
+        let dag = create_saga_dag::<SagaInstanceMigrate>(params).unwrap();
+        let saga = nexus.create_runnable_saga(dag).await.unwrap();
+        nexus.run_saga(saga).await.expect("Migration saga should succeed");
+
+        // Merely running the migration saga (without simulating any completion
+        // steps in the simulated agents) should not change where the instance
+        // is running.
+        let new_db_instance =
+            fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;
+        assert_eq!(new_db_instance.runtime().sled_id, old_runtime.sled_id);
+        assert_eq!(
+            new_db_instance.runtime().propolis_id,
+            old_runtime.propolis_id
+        );
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_action_failure_can_unwind(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let log = &cptestctx.logctx.log;
+        let other_sleds = add_sleds(cptestctx, 1).await;
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.apictx().nexus;
+        let _project_id = setup_test_project(&client).await;
+
+        let opctx = instance_create::test::test_opctx(cptestctx);
+        let instance = create_instance(client).await;
+
+        // Poke the instance to get it into the Running state.
+        instance_simulate(cptestctx, nexus, &instance.identity.id).await;
+
+        let db_instance =
+            fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;
+        let old_runtime = db_instance.runtime().clone();
+        let dst_sled_id =
+            select_first_alternate_sled(&db_instance, &other_sleds);
+        let params = Params {
+            serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
+            instance: db_instance,
+            migrate_params: params::InstanceMigrate { dst_sled_id },
+        };
+
+        let dag = create_saga_dag::<SagaInstanceMigrate>(params).unwrap();
+
+        // Some of the nodes in the DAG are expected to be infallible to allow
+        // certain undo steps to be reordered. Specify these nodes here, then
+        // verify that every infallible node actually appears in the DAG (to try
+        // to detect drift between the saga specification and the test).
+        let infallible_nodes = vec![
+            "dst_runtime_state",
+            "unused_ensure_destination_undo",
+            "unused_set_ids_undo",
+        ];
+        let dag_node_names: Vec<String> =
+            dag.get_nodes().map(|n| n.name().as_ref().to_owned()).collect();
+        assert!(infallible_nodes
+            .iter()
+            .all(|n| dag_node_names.iter().any(|d| d == n)));
+
+        for node in dag.get_nodes() {
+            if infallible_nodes.contains(&node.name().as_ref()) {
+                info!(log, "Skipping infallible node";
+                      "node_name" => node.name().as_ref());
+                continue;
+            }
+
+            info!(
+                log,
+                "Creating new saga which will fail at index {:?}", node.index();
+                "node_name" => node.name().as_ref(),
+                "label" => node.label(),
+            );
+
+            let runnable_saga =
+                nexus.create_runnable_saga(dag.clone()).await.unwrap();
+            nexus
+                .sec()
+                .saga_inject_error(runnable_saga.id(), node.index())
+                .await
+                .unwrap();
+            nexus
+                .run_saga(runnable_saga)
+                .await
+                .expect_err("Saga should have failed");
+
+            // Unwinding at any step should clear the migration IDs from the
+            // instance record and leave the instance's location otherwise
+            // untouched.
+            let new_db_instance =
+                fetch_db_instance(cptestctx, &opctx, instance.identity.id)
+                    .await;
+
+            assert!(new_db_instance.runtime().migration_id.is_none());
+            assert!(new_db_instance.runtime().dst_propolis_id.is_none());
+            assert_eq!(new_db_instance.runtime().sled_id, old_runtime.sled_id);
+            assert_eq!(
+                new_db_instance.runtime().propolis_id,
+                old_runtime.propolis_id
+            );
+
+            // Ensure the instance can stop. This helps to check that destroying
+            // the migration destination (if one was ensured) doesn't advance
+            // the Propolis ID generation in a way that prevents the source from
+            // issuing further state updates.
+            instance_stop(cptestctx, &instance.identity.id).await;
+            instance_simulate(cptestctx, nexus, &instance.identity.id).await;
+            let new_db_instance =
+                fetch_db_instance(cptestctx, &opctx, instance.identity.id)
+                    .await;
+            assert_eq!(
+                new_db_instance.runtime().state.0,
+                InstanceState::Stopped
+            );
+
+            // Restart the instance for the next iteration.
+            instance_start(cptestctx, &instance.identity.id).await;
+            instance_simulate(cptestctx, nexus, &instance.identity.id).await;
+        }
+    }
 }

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -304,9 +304,12 @@ async fn sim_clear_migration_ids(
     // clear them. The only exception is if the instance stopped, but that also
     // clears its migration IDs; in that case there is no work to do here.
     //
-    // Other error cases (e.g. an unreachable sled agent) are handled by this
-    // callee using the standard discipline for handling failed requests to
-    // change an instance's state. Warn for these errors.
+    // Other failures to clear migration IDs are handled like any other failure
+    // to update an instance's state: the callee attempts to mark the instance
+    // as failed; if the failure occurred because the instance changed state
+    // such that sled agent could not fulfill the request, the callee will
+    // produce a stale generation number and will not actually mark the instance
+    // as failed.
     if let Err(e) = osagactx
         .nexus()
         .instance_clear_migration_ids(db_instance.id(), &db_instance)

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -155,7 +155,8 @@ impl super::Nexus {
                 | Error::InternalError { .. }
                 | Error::ServiceUnavailable { .. }
                 | Error::MethodNotAllowed { .. }
-                | Error::TypeVersionMismatch { .. } => {
+                | Error::TypeVersionMismatch { .. }
+                | Error::Conflict { .. } => {
                     Reason::UnknownError { source: error }
                 }
             })?;

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -113,6 +113,7 @@ impl super::Nexus {
         resource_id: Uuid,
         resource_kind: db::model::SledResourceKind,
         resources: db::model::Resources,
+        constraints: db::model::SledReservationConstraints,
     ) -> Result<db::model::SledResource, Error> {
         self.db_datastore
             .sled_reservation_create(
@@ -120,6 +121,7 @@ impl super::Nexus {
                 resource_id,
                 resource_kind,
                 resources,
+                constraints,
             )
             .await
     }

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -729,8 +729,8 @@ impl Instance {
             }
 
             return Err(Error::Transition(
-                omicron_common::api::external::Error::InvalidRequest {
-                    message: format!(
+                omicron_common::api::external::Error::Conflict {
+                    internal_message: format!(
                         "wrong Propolis ID generation: expected {}, got {}",
                         inner.state.current().propolis_gen,
                         old_runtime.propolis_gen

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -325,7 +325,15 @@ impl SledAgent {
         instance_id: Uuid,
     ) -> Result<InstanceUnregisterResponse, Error> {
         let instance =
-            self.instances.sim_get_cloned_object(&instance_id).await?;
+            match self.instances.sim_get_cloned_object(&instance_id).await {
+                Ok(instance) => instance,
+                Err(Error::ObjectNotFound { .. }) => {
+                    return Ok(InstanceUnregisterResponse {
+                        updated_runtime: None,
+                    })
+                }
+                Err(e) => return Err(e),
+            };
 
         self.detach_disks_from_instance(instance_id).await?;
         Ok(InstanceUnregisterResponse {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -119,10 +119,14 @@ impl From<Error> for dropshot::HttpError {
                                 }
                             }
                         }
-
+                        crate::instance::Error::Transition(omicron_error) => {
+                            // Preserve the status associated with the wrapped
+                            // Omicron error so that Nexus will see it in the
+                            // Progenitor client error it gets back.
+                            HttpError::from(omicron_error)
+                        }
                         e => HttpError::for_internal_error(e.to_string()),
                     },
-
                     e => HttpError::for_internal_error(e.to_string()),
                 }
             }


### PR DESCRIPTION
Yet another PR--the seventh--in the live migration series. It may be helpful to refer to #2862 while reading parts of the saga, since that PR introduced some of the sled agent primitives the saga now uses.

The next few changes in this sequence will do the following:

- Implement sled agent's logic to observe that migrations have finished & push the appropriate updates to Nexus
- Add Nexus logic to update V2P mappings when an instance's sled is about to change
- Add sled agent/Nexus logic to drop Propolis resource reservations that are no longer needed

---

Revamp the live migration saga to implement (more or less, anyway) the design described in RFD 361. See that RFD and the theory statements in `instance_migrate.rs` for more details.

The new saga starts migrations, but more sled agent and Nexus changes are needed for migration to succeed end-to-end. Specifically, sled agent needs to be taught to send the correct updates when a migration ends, and Nexus needs to be taught to handle those updates; see below for more commentary.

Remove OPTE V2P mapping management from the migration saga proper. This will come back in a separate change that detects when an instance has moved between sleds and updates the mappings. This will fix the "can't roll back V2P mappings if the migration ultimately fails" issue identified in the old code's comments.

To maintain the shape of the existing external live migration API (which accepts an explicit destination sled), extend the sled resource reservation logic to accept a "must select from the following sleds" constraint. (This is not meant to be a final decision about the shape of the migration API; this is just meant to keep from piling still more changes into an already large PR.)

Also fix an idempotency bug in simulated sled agent's instance unregistration routine.