### PR TITLE
Set failmode=continue on zpools in sled-agent.

### DIFF
--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -213,6 +213,19 @@ impl Zpool {
         }
     }
 
+    /// zpool set failmode=continue <name>
+    pub fn set_failmode_continue(name: &ZpoolName) -> Result<(), Error> {
+        let mut cmd = std::process::Command::new(PFEXEC);
+        cmd.env_clear();
+        cmd.env("LC_ALL", "C.UTF-8");
+        cmd.arg(ZPOOL)
+            .arg("set")
+            .arg("failmode=continue")
+            .arg(&name.to_string());
+        execute(&mut cmd).map_err(Error::from)?;
+        Ok(())
+    }
+
     pub fn list() -> Result<Vec<ZpoolName>, ListError> {
         let mut command = std::process::Command::new(ZPOOL);
         let cmd = command.args(&["list", "-Hpo", "name"]);


### PR DESCRIPTION
fixes #2766

Each pool is only backed by one vdev. There is no recovery if one starts breaking, so if connectivity to one dies it's actively harmful to try to wait for it to come back; we'll be waiting forever and get stuck. We'd rather get the errors so we can deal with them ourselves.

This change unconditionally sets failmode=continue on zpools in sled-hardware's Disk::new(). That's the codepath all zpools go through when they're created or imported. This won't apply to virtual hardware because those go through the SyntheticDisk codepath, so if anyone cares about failmode=continue on virtual hardware we should modify `create_virtual_hardware.sh`.

I've tested this on dogfood cubby 20.

Before:
```
root@BRM42220014:/tmp/artemis# zpool get failmode                                                             
NAME                                      PROPERTY  VALUE     SOURCE                                                                                           
oxi_55d7e113-05f1-4af7-acc7-2205d016aab2  failmode  wait      default                                                                                          
oxi_9058a1f2-99cb-40ad-8fcd-55adf8cfb127  failmode  wait      default                                                                                          
oxp_1b125d25-1e86-4d9e-8d6a-8157b4775cf6  failmode  wait      default                                                                                          
oxp_2f00ff04-dfee-4c5d-bc66-91266a0fc7a6  failmode  wait      default                                                                                          
oxp_30b34c2a-901a-4582-8e8a-a2b0368bd868  failmode  wait      default                                                                                          
oxp_4d750b62-760b-43b4-9d6e-a4b02c893673  failmode  wait      default                                                                                          
oxp_6a03c94a-48bc-45e7-8f4c-bed46e897027  failmode  wait      default                                                                                          
oxp_70c4b238-cc1b-478f-a818-d15ec09dcb5d  failmode  wait      default                                                                                          
oxp_7a7d6fef-27f1-47de-b05f-e48f1555c81d  failmode  wait      default
oxp_7c3e8a93-6660-4632-9db4-8a09bb6bffff  failmode  wait      default
oxp_d8b6a101-bd4f-4921-9723-fd4707fde84f  failmode  wait      default          
oxp_fc53d384-6eb5-4754-b4e9-7bce5474e58c  failmode  wait      default
rpool                                     failmode  wait      default
```

After:
```
root@BRM42220014:/tmp/artemis# zpool get failmode                                                                                                             
NAME                                      PROPERTY  VALUE     SOURCE
oxi_55d7e113-05f1-4af7-acc7-2205d016aab2  failmode  continue  local
oxi_9058a1f2-99cb-40ad-8fcd-55adf8cfb127  failmode  continue  local
oxp_1b125d25-1e86-4d9e-8d6a-8157b4775cf6  failmode  continue  local
oxp_2f00ff04-dfee-4c5d-bc66-91266a0fc7a6  failmode  continue  local
oxp_30b34c2a-901a-4582-8e8a-a2b0368bd868  failmode  continue  local
oxp_4d750b62-760b-43b4-9d6e-a4b02c893673  failmode  continue  local
oxp_6a03c94a-48bc-45e7-8f4c-bed46e897027  failmode  continue  local
oxp_70c4b238-cc1b-478f-a818-d15ec09dcb5d  failmode  continue  local
oxp_7a7d6fef-27f1-47de-b05f-e48f1555c81d  failmode  continue  local
oxp_7c3e8a93-6660-4632-9db4-8a09bb6bffff  failmode  continue  local
oxp_d8b6a101-bd4f-4921-9723-fd4707fde84f  failmode  continue  local
oxp_fc53d384-6eb5-4754-b4e9-7bce5474e58c  failmode  continue  local
rpool                                     failmode  wait      default
```