### PR TITLE
[update-engine] add an event_index to StepEvent

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1484,6 +1484,12 @@
               }
             ]
           },
+          "event_index": {
+            "description": "A monotonically increasing index for this `StepEvent`.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
           "execution_id": {
             "description": "The execution ID.",
             "type": "string",
@@ -1500,6 +1506,7 @@
         },
         "required": [
           "data",
+          "event_index",
           "execution_id",
           "total_elapsed"
         ]
@@ -1515,6 +1522,12 @@
               }
             ]
           },
+          "event_index": {
+            "description": "A monotonically increasing index for this `StepEvent`.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
           "execution_id": {
             "description": "The execution ID.",
             "type": "string",
@@ -1531,6 +1544,7 @@
         },
         "required": [
           "data",
+          "event_index",
           "execution_id",
           "total_elapsed"
         ]

--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -66,6 +66,9 @@ pub struct StepEvent<S: StepSpec> {
     /// The execution ID.
     pub execution_id: ExecutionId,
 
+    /// A monotonically increasing index for this `StepEvent`.
+    pub event_index: usize,
+
     /// Total time elapsed since the start of execution.
     pub total_elapsed: Duration,
 
@@ -172,6 +175,7 @@ impl<S: StepSpec> StepEvent<S> {
     ) -> Result<Self, ConvertGenericError> {
         Ok(StepEvent {
             execution_id: value.execution_id,
+            event_index: value.event_index,
             total_elapsed: value.total_elapsed,
             kind: StepEventKind::from_generic(value.kind)
                 .map_err(|error| error.parent("kind"))?,
@@ -186,6 +190,7 @@ impl<S: StepSpec> StepEvent<S> {
     ) -> Result<StepEvent<GenericSpec<E>>, ConvertGenericError> {
         Ok(StepEvent {
             execution_id: self.execution_id,
+            event_index: self.event_index,
             total_elapsed: self.total_elapsed,
             kind: self
                 .kind
@@ -1290,6 +1295,7 @@ mod tests {
                 r#"
                   {
                     "execution_id": "2cc08a14-5e96-4917-bc70-e98293a3b703",
+                    "event_index": 0,
                     "total_elapsed": {
                       "secs": 0,
                       "nanos": 0
@@ -1325,6 +1331,7 @@ mod tests {
                 "#,
                 StepEvent {
                     execution_id,
+                    event_index: 0,
                     total_elapsed: Duration::ZERO,
                     kind: StepEventKind::Unknown,
                 },
@@ -1333,6 +1340,7 @@ mod tests {
                 r#"
                   {
                     "execution_id": "2cc08a14-5e96-4917-bc70-e98293a3b703",
+                    "event_index": 1,
                     "total_elapsed": {
                       "secs": 0,
                       "nanos": 0
@@ -1369,6 +1377,7 @@ mod tests {
                 "#,
                 StepEvent::<TestSpec> {
                     execution_id,
+                    event_index: 1,
                     total_elapsed: Duration::ZERO,
                     kind: StepEventKind::ExecutionCompleted {
                         last_step: StepInfoWithMetadata {

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1300,7 +1300,12 @@ impl UpdateContext {
                 }
             };
 
-            StepEvent { execution_id, total_elapsed: event.total_elapsed, kind }
+            StepEvent {
+                execution_id,
+                event_index: 0,
+                total_elapsed: event.total_elapsed,
+                kind,
+            }
         });
 
         // TODO: This races with our task that receives events from the update


### PR DESCRIPTION
This provides an index to key events against and sort by.

Note the workaround for a bug in rustc. Once omicron is on Rust 1.70 we
can get rid of the workaround.
