### PR TITLE
populate Silo DNS names in external DNS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,6 +3959,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crucible-agent-client",
+ "dns-server",
  "dropshot",
  "headers",
  "http",
@@ -3981,6 +3982,8 @@ dependencies = [
  "slog",
  "tempfile",
  "tokio",
+ "trust-dns-proto",
+ "trust-dns-resolver",
  "uuid",
 ]
 
@@ -4450,6 +4453,7 @@ dependencies = [
  "tokio-tungstenite 0.18.0",
  "toml 0.7.3",
  "tough",
+ "trust-dns-resolver",
  "usdt",
  "uuid",
 ]

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -1960,8 +1960,18 @@ CREATE TABLE omicron.public.dns_name (
     name TEXT NOT NULL,
     dns_record_data JSONB NOT NULL,
 
-    PRIMARY KEY (dns_zone_id, version_added, name)
+    PRIMARY KEY (dns_zone_id, name, version_added)
 );
+
+/*
+ * Any given live name should only exist once.  (Put differently: the primary
+ * key already prevents us from having the same name added twice in the same
+ * version.  But you should also not be able to add a name in any version if the
+ * name is currently still live (i.e., version_removed IS NULL).
+ */
+CREATE UNIQUE INDEX ON omicron.public.dns_name (
+    dns_zone_id, name
+) WHERE version_removed IS NULL;
 
 /*******************************************************************/
 

--- a/dev-tools/src/bin/omicron-dev.rs
+++ b/dev-tools/src/bin/omicron-dev.rs
@@ -357,6 +357,25 @@ async fn cmd_run_all(args: &RunAllArgs) -> Result<(), anyhow::Error> {
         "omicron-dev: cockroachdb directory: {}",
         cptestctx.database.temp_dir().display()
     );
+    println!(
+        "omicron-dev: external DNS name:     {}",
+        cptestctx.external_dns_zone_name,
+    );
+    println!(
+        "omicron-dev: external DNS HTTP:     http://{}",
+        cptestctx.external_dns_config_server.local_addr()
+    );
+    println!(
+        "omicron-dev: external DNS:          {}",
+        cptestctx.external_dns_server.local_address()
+    );
+    println!(
+        "                                    \
+        (e.g. `dig @{} -p {} SOME_DNS_NAME.{}`)",
+        cptestctx.external_dns_server.local_address().ip(),
+        cptestctx.external_dns_server.local_address().port(),
+        cptestctx.external_dns_zone_name,
+    );
 
     // Wait for a signal.
     let caught_signal = signal_stream.next().await;

--- a/dns-server/examples/config.toml
+++ b/dns-server/examples/config.toml
@@ -1,14 +1,12 @@
 [dropshot]
 # 100 MiB.  This ought to be large enough for a while, but not so large that
-# we'll use tons of memory parsing it.
+# we'll use tons of memory parsing incoming HTTP requests.
 request_body_max_bytes = 104857600
 
 [log]
 # Show log messages of this level and more severe
 level = "info"
-mode = "file"
-path = "/dev/stdout"
-if_exists = "append"
+mode = "stderr-terminal"
 
 [storage]
 storage_path = "./dns-storage"

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -231,6 +231,14 @@ async fn handle_dns_message(
     let response_records = records
         .into_iter()
         .map(|record| match record {
+            DnsRecord::A(addr) => {
+                let mut a = Record::new();
+                a.set_name(name.clone())
+                    .set_rr_type(RecordType::A)
+                    .set_data(Some(RData::A(addr)));
+                Ok(a)
+            }
+
             DnsRecord::AAAA(addr) => {
                 let mut aaaa = Record::new();
                 aaaa.set_name(name.clone())

--- a/dns-server/src/dns_types.rs
+++ b/dns-server/src/dns_types.rs
@@ -7,6 +7,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -34,6 +35,7 @@ pub struct DnsConfigZone {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "type", content = "data")]
 pub enum DnsRecord {
+    A(Ipv4Addr),
     AAAA(Ipv6Addr),
     SRV(SRV),
 }

--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -54,9 +54,12 @@ log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.4647.0.log
 note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.4647.0.log"
 omicron-dev: services are running.
 omicron-dev: nexus external API:    127.0.0.1:12220
-omicron-dev: nexus internal API:    127.0.0.1:12221
+omicron-dev: nexus internal API:    [::1]:12221
+omicron-dev: cockroachdb pid:       7180
 omicron-dev: cockroachdb:           postgresql://root@127.0.0.1:54649/omicron?sslmode=disable
 omicron-dev: cockroachdb directory: /dangerzone/omicron_tmp/.tmpB8FNBT
+omicron-dev: external DNS:          [::1]:54342
+omicron-dev: external DNS HTTP:     [::1]:38374
 ----
 +
 . If you use CTRL-C to shut this down, it will gracefully terminate CockroachDB and remove the temporary directory:
@@ -139,16 +142,20 @@ omicron-dev: using /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot f
 [source,text]
 ----
 $ cargo run --bin=nexus -- nexus/examples/config.toml
-...
-listening: http://127.0.0.1:12220
 ----
 Nexus can also serve the web console. Instructions for downloading (or building) the console's static assets and pointing Nexus to them are https://github.com/oxidecomputer/console/blob/main/docs/serve-from-nexus.md[here]. Without console assets, Nexus will still start and run normally as an API. A few link:./nexus/src/external_api/console_api.rs[console-specific routes] will 404.
 
-. `sled-agent-sim` only accepts configuration on the command line.  Run it with a uuid identifying itself (this would be a uuid for the sled it's managing), an IP:port for itself, and the IP:port of `nexus`'s _internal_ interface.  Using default config, this might look like this:
+. `dns-server` is run similar to Nexus, except that the bind addresses are specified on the command line:
 +
 [source,text]
 ----
-$ cargo run --bin=sled-agent-sim -- $(uuidgen) [::1]:12345 127.0.0.1:12221
+$ cargo run --bin=dns-server -- --config-file dns-server/examples/config.toml --http-address [::1]:5353 --dns-address [::1]:5354
+----
+. `sled-agent-sim` only accepts configuration on the command line.  Run it with a uuid identifying itself (this would be a uuid for the sled it's managing), an IP:port for itself, and the IP:port of `nexus`'s _internal_ interface.  It's recommended that you also provide some arguments specific to RSS (the rack setup service): Nexus's _external_ address and the external DNS server's _internal_ address.  Using default config, this might look like this:
++
+[source,text]
+----
+$ cargo run --bin=sled-agent-sim -- $(uuidgen) [::1]:12345 [::1]:12221 --rss-nexus-external-addr 127.0.0.1:12220 --rss-external-dns-internal-addr [::1]:5353
 ----
 
 . `oximeter` is similar to `nexus`, requiring a configuration file. You can use `oximeter/collector/config.toml`, and the whole thing can be run with:

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -9,6 +9,10 @@ use uuid::Uuid;
 /// Name for the control plane DNS zone
 pub const DNS_ZONE: &str = "control-plane.oxide.internal";
 
+/// Name for the delegated external DNS zone that's used in testing and
+/// development
+pub const DNS_ZONE_EXTERNAL_TESTING: &str = "oxide-dev.test";
+
 /// Names of services within the control plane
 #[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ServiceName {

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -107,6 +107,7 @@ regex.workspace = true
 rustls = { workspace = true, features = ["dangerous_configuration"] }
 subprocess.workspace = true
 term.workspace = true
+trust-dns-resolver.workspace = true
 httptest.workspace = true
 strum.workspace = true
 

--- a/nexus/db-model/src/dns.rs
+++ b/nexus/db-model/src/dns.rs
@@ -10,6 +10,7 @@ use omicron_common::api::external::Error;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::{fmt, net::Ipv6Addr};
 use uuid::Uuid;
 
@@ -128,6 +129,7 @@ impl DnsName {
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DnsRecord {
+    A(Ipv4Addr),
     AAAA(Ipv6Addr),
     SRV(SRV),
 }
@@ -135,6 +137,7 @@ pub enum DnsRecord {
 impl From<params::DnsRecord> for DnsRecord {
     fn from(value: params::DnsRecord) -> Self {
         match value {
+            params::DnsRecord::A(addr) => DnsRecord::A(addr),
             params::DnsRecord::Aaaa(addr) => DnsRecord::AAAA(addr),
             params::DnsRecord::Srv(srv) => DnsRecord::SRV(SRV::from(srv)),
         }
@@ -144,6 +147,7 @@ impl From<params::DnsRecord> for DnsRecord {
 impl From<DnsRecord> for params::DnsRecord {
     fn from(value: DnsRecord) -> Self {
         match value {
+            DnsRecord::A(addr) => params::DnsRecord::A(addr),
             DnsRecord::AAAA(addr) => params::DnsRecord::Aaaa(addr),
             DnsRecord::SRV(srv) => {
                 params::DnsRecord::Srv(params::Srv::from(srv))

--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -22,7 +22,7 @@ use std::net::IpAddr;
 use uuid::Uuid;
 
 impl_enum_type!(
-    #[derive(SqlType, Debug, Clone, Copy)]
+    #[derive(SqlType, Debug, Clone, Copy, QueryId)]
     #[diesel(postgres_type(name = "ip_kind"))]
      pub struct IpKindEnum;
 

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -923,3 +923,4 @@ allow_tables_to_appear_in_same_query!(
 );
 
 allow_tables_to_appear_in_same_query!(dns_zone, dns_version, dns_name);
+allow_tables_to_appear_in_same_query!(external_ip, nexus_service);

--- a/nexus/db-queries/src/authz/omicron.polar
+++ b/nexus/db-queries/src/authz/omicron.polar
@@ -327,6 +327,24 @@ has_relation(fleet: Fleet, "parent_fleet", collection: SamlIdentityProvider)
 # Fleet.  None of these resources defines their own roles.
 #
 
+# Describes the policy for reading and modifying DNS configuration
+# (both internal and external)
+resource DnsConfig {
+	permissions = [ "read", "modify" ];
+	relations = { parent_fleet: Fleet };
+	# "external-authenticator" requires these permissions because that's the
+	# context that Nexus uses when creating and deleting Silos.  These
+	# operations necessarily need to read and modify DNS configuration.
+	"read" if "external-authenticator" on "parent_fleet";
+	"modify" if "external-authenticator" on "parent_fleet";
+	# "admin" on the parent fleet also gets these permissions, primarily for
+	# the test suite.
+	"read" if "admin" on "parent_fleet";
+	"modify" if "admin" on "parent_fleet";
+}
+has_relation(fleet: Fleet, "parent_fleet", dns_config: DnsConfig)
+	if dns_config.fleet = fleet;
+
 # Describes the policy for accessing "/v1/system/ip-pools" in the API
 resource IpPoolList {
 	permissions = [

--- a/nexus/db-queries/src/authz/oso_generic.rs
+++ b/nexus/db-queries/src/authz/oso_generic.rs
@@ -104,6 +104,7 @@ pub fn make_omicron_oso(log: &slog::Logger) -> Result<OsoInit, anyhow::Error> {
         AnyActor::get_polar_class(),
         AuthenticatedActor::get_polar_class(),
         Database::get_polar_class(),
+        DnsConfig::get_polar_class(),
         Fleet::get_polar_class(),
         IpPoolList::get_polar_class(),
         GlobalImageList::get_polar_class(),

--- a/nexus/db-queries/src/authz/policy_test/resource_builder.rs
+++ b/nexus/db-queries/src/authz/policy_test/resource_builder.rs
@@ -244,6 +244,7 @@ macro_rules! impl_dyn_authorized_resource_for_global {
 
 impl_dyn_authorized_resource_for_global!(authz::oso_generic::Database);
 impl_dyn_authorized_resource_for_global!(authz::ConsoleSessionList);
+impl_dyn_authorized_resource_for_global!(authz::DnsConfig);
 impl_dyn_authorized_resource_for_global!(authz::GlobalImageList);
 impl_dyn_authorized_resource_for_global!(authz::IpPoolList);
 impl_dyn_authorized_resource_for_global!(authz::DeviceAuthRequestList);

--- a/nexus/db-queries/src/authz/policy_test/resources.rs
+++ b/nexus/db-queries/src/authz/policy_test/resources.rs
@@ -65,6 +65,7 @@ pub async fn make_resources(
     builder.new_resource(authz::DATABASE);
     builder.new_resource_with_users(authz::FLEET).await;
     builder.new_resource(authz::CONSOLE_SESSION_LIST);
+    builder.new_resource(authz::DNS_CONFIG);
     builder.new_resource(authz::DEVICE_AUTH_REQUEST_LIST);
     builder.new_resource(authz::GLOBAL_IMAGE_LIST);
     builder.new_resource(authz::IP_POOL_LIST);

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -75,6 +75,7 @@ mod volume;
 mod vpc;
 mod zpool;
 
+pub use dns::DnsVersionUpdateBuilder;
 pub use rack::RackInit;
 pub use virtual_provisioning_collection::StorageType;
 pub use volume::CrucibleResources;

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -26,10 +26,12 @@ use crate::db::model::Zpool;
 use crate::db::pagination::paginated;
 use async_bb8_diesel::AsyncConnection;
 use async_bb8_diesel::AsyncRunQueryDsl;
+use async_bb8_diesel::AsyncSimpleConnection;
 use async_bb8_diesel::PoolError;
 use chrono::Utc;
 use diesel::prelude::*;
 use diesel::upsert::excluded;
+use nexus_db_model::ExternalIp;
 use nexus_db_model::InitialDnsGroup;
 use nexus_types::external_api::shared::IpRange;
 use nexus_types::identity::Resource;
@@ -40,6 +42,7 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
+use std::net::IpAddr;
 use uuid::Uuid;
 
 /// Groups arguments related to rack initialization
@@ -400,6 +403,46 @@ impl DataStore {
             })?;
 
         Ok(())
+    }
+
+    pub async fn nexus_external_addresses(
+        &self,
+        opctx: &OpContext,
+    ) -> Result<Vec<IpAddr>, Error> {
+        opctx.authorize(authz::Action::Read, &authz::DNS_CONFIG).await?;
+
+        use crate::db::schema::external_ip::dsl as extip_dsl;
+        use crate::db::schema::nexus_service::dsl as nexus_dsl;
+        type TxnError = TransactionError<()>;
+        self.pool_authorized(opctx)
+            .await?
+            .transaction_async(|conn| async move {
+                // This is the rare case where we want to allow table scans.
+                // There must not be enough Nexus instances for this to be a
+                // problem.  If there were, we couldn't fit them in DNS anyway.
+                let sql = crate::db::queries::ALLOW_FULL_TABLE_SCAN_SQL;
+                conn.batch_execute_async(sql).await?;
+                Ok(extip_dsl::external_ip
+                    .filter(
+                        extip_dsl::id.eq_any(
+                            nexus_dsl::nexus_service
+                                .select(nexus_dsl::external_ip_id),
+                        ),
+                    )
+                    .select(ExternalIp::as_select())
+                    .get_results_async(&conn)
+                    .await?
+                    .into_iter()
+                    .map(|external_ip| external_ip.ip.ip())
+                    .collect())
+            })
+            .await
+            .map_err(|error: TxnError| match error {
+                TransactionError::CustomError(()) => unimplemented!(),
+                TransactionError::Pool(e) => {
+                    public_error_from_diesel_pool(e, ErrorHandler::Server)
+                }
+            })
     }
 }
 

--- a/nexus/db-queries/src/db/queries/mod.rs
+++ b/nexus/db-queries/src/db/queries/mod.rs
@@ -14,3 +14,25 @@ pub mod region_allocation;
 pub mod virtual_provisioning_collection_update;
 pub mod vpc;
 pub mod vpc_subnet;
+
+/// SQL used to enable full table scans for the duration of the current
+/// transaction.
+///
+/// We normally disallow table scans in effort to identify scalability issues
+/// during development.  There are some rare cases where we do want to do full
+/// scans on small tables.  This SQL can be used to re-enable table scans for
+/// the duration of the current transaction.
+///
+/// This should only be used when we know a table will be very small, it's not
+/// paginated (if it were paginated, we could scan an index), and there's no
+/// good way to limit the query based on an index.
+///
+/// This SQL appears to have no effect when used outside of a transaction.
+/// That's intentional.  We do not want to use `SET` (rather than `SET LOCAL`)
+/// here because that would change the behavior for any code that happens to use
+/// the same pooled connection after this SQL gets run.
+///
+/// **BE VERY CAREFUL WHEN USING THIS.**
+pub const ALLOW_FULL_TABLE_SCAN_SQL: &str =
+    "set local disallow_full_table_scans = off; \
+     set local large_full_scan_rows = 1000;";

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -40,6 +40,20 @@ resource: authz::ConsoleSessionList
   silo1-proj1-viewer               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
+resource: authz::DnsConfig
+
+  USER                             Q  R LC RP  M MP CC  D
+  fleet-admin                      ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
+  fleet-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  fleet-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-admin                      ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-collaborator               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-viewer                     ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-proj1-admin                ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-proj1-collaborator         ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  silo1-proj1-viewer               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
+  unauthenticated                  !  !  !  !  !  !  !  !
+
 resource: authz::DeviceAuthRequestList
 
   USER                             Q  R LC RP  M MP CC  D

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -47,7 +47,7 @@ request_body_max_bytes = 1048576
 
 [deployment.dropshot_internal]
 # IP Address and TCP port on which to listen for the internal API
-bind_address = "127.0.0.1:12221"
+bind_address = "[::1]:12221"
 request_body_max_bytes = 1048576
 
 [deployment.subnet]

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -24,8 +24,13 @@ pub fn init(
     opctx: &OpContext,
     datastore: Arc<DataStore>,
     config: &BackgroundTaskConfig,
-) -> (common::Driver, common::TaskHandle, common::TaskHandle, common::TaskHandle)
-{
+) -> (
+    common::Driver,
+    common::TaskHandle,
+    common::TaskHandle,
+    common::TaskHandle,
+    common::TaskHandle,
+) {
     let mut driver = common::Driver::new();
 
     let (task_config, task_servers) = init_dns(
@@ -35,7 +40,7 @@ pub fn init(
         DnsGroup::Internal,
         &config.dns_internal,
     );
-    let (_, external_task_servers) = init_dns(
+    let (external_task_config, external_task_servers) = init_dns(
         &mut driver,
         opctx,
         datastore,
@@ -43,7 +48,13 @@ pub fn init(
         &config.dns_external,
     );
 
-    (driver, task_config, task_servers, external_task_servers)
+    (
+        driver,
+        task_config,
+        task_servers,
+        external_task_config,
+        external_task_servers,
+    )
 }
 
 fn init_dns(

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -177,6 +177,9 @@ pub struct Nexus {
     /// task handle for the internal DNS servers background task
     task_internal_dns_servers: background::TaskHandle,
 
+    /// task handle for the external DNS config background task
+    task_external_dns_config: background::TaskHandle,
+
     /// task handle for the external DNS servers background task
     task_external_dns_servers: background::TaskHandle,
 }
@@ -272,6 +275,7 @@ impl Nexus {
             background_tasks,
             task_internal_dns_config,
             task_internal_dns_servers,
+            task_external_dns_config,
             task_external_dns_servers,
         ) = background::init(
             &background_ctx,
@@ -314,6 +318,7 @@ impl Nexus {
             background_tasks,
             task_internal_dns_config,
             task_internal_dns_servers,
+            task_external_dns_config,
             task_external_dns_servers,
         };
 

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -130,11 +130,9 @@ impl super::Nexus {
             dns_zone.records,
         );
 
-        // TODO the initial external DNS zone name and potentially record
-        // name(s) need to come in with the rack initialization request.
         let external_dns = InitialDnsGroup::new(
             DnsGroup::External,
-            "oxide-dev.test",
+            request.external_dns_zone_name.as_str(),
             &self.id.to_string(),
             "rack setup",
             HashMap::new(),
@@ -156,9 +154,12 @@ impl super::Nexus {
             .await?;
 
         // We've potentially updated both the list of DNS servers and the DNS
-        // configuration.  Activate both background tasks.
+        // configuration.  Activate both background tasks, for both internal and
+        // external DNS.
         self.background_tasks.activate(&self.task_internal_dns_config);
         self.background_tasks.activate(&self.task_internal_dns_servers);
+        self.background_tasks.activate(&self.task_external_dns_config);
+        self.background_tasks.activate(&self.task_external_dns_servers);
 
         Ok(())
     }

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1571,11 +1571,12 @@ pub mod test {
     }
 
     async fn no_external_ip_records_exist(datastore: &DataStore) -> bool {
-        use crate::db::model::ExternalIp;
+        use crate::db::model::{ExternalIp, IpKind};
         use crate::db::schema::external_ip::dsl;
 
         dsl::external_ip
             .filter(dsl::time_deleted.is_null())
+            .filter(dsl::kind.ne(IpKind::Service))
             .select(ExternalIp::as_select())
             .first_async::<ExternalIp>(
                 datastore.pool_for_tests().await.unwrap(),

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -16,6 +16,8 @@ use crate::{authn, authz};
 use anyhow::Context;
 use nexus_db_model::UserProvisionType;
 use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::datastore::DnsVersionUpdateBuilder;
+use nexus_types::internal_api::params::DnsRecord;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
@@ -26,6 +28,7 @@ use omicron_common::api::external::{DeleteResult, NameOrId};
 use omicron_common::api::external::{Error, InternalContext};
 use omicron_common::bail_unless;
 use ref_cast::RefCast;
+use std::net::IpAddr;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -61,6 +64,17 @@ impl super::Nexus {
         }
     }
 
+    /// Returns the (relative) DNS name for this Silo's API and console endpoints
+    /// _within_ the control plane DNS zone (i.e., without that zone's suffix)
+    ///
+    /// This specific naming scheme is determined under RFD 357.
+    fn silo_dns_name(name: &omicron_common::api::external::Name) -> String {
+        // RFD 4 constrains resource names (including Silo names) to DNS-safe
+        // strings, which is why it's safe to directly put the name of the
+        // resource into the DNS name rather than doing any kind of escaping.
+        format!("{}.sys", name)
+    }
+
     pub async fn silo_create(
         &self,
         opctx: &OpContext,
@@ -71,9 +85,38 @@ impl super::Nexus {
         // create arbitrary groups in the Silo, but we allow them to create
         // this one in this case.
         let external_authn_opctx = self.opctx_external_authn();
-        self.datastore()
-            .silo_create(&opctx, &external_authn_opctx, new_silo_params)
-            .await
+        let datastore = self.datastore();
+
+        // Set up an external DNS name for this Silo's API and console
+        // endpoints (which are the same endpoint).
+        let dns_records: Vec<DnsRecord> = datastore
+            .nexus_external_addresses(external_authn_opctx)
+            .await?
+            .into_iter()
+            .map(|addr| match addr {
+                IpAddr::V4(addr) => DnsRecord::A(addr),
+                IpAddr::V6(addr) => DnsRecord::Aaaa(addr),
+            })
+            .collect();
+
+        let silo_name = &new_silo_params.identity.name;
+        let mut dns_update = DnsVersionUpdateBuilder::new(
+            datastore.dns_zone_external(external_authn_opctx).await?,
+            format!("create silo: {:?}", silo_name),
+            self.id.to_string(),
+        );
+        dns_update.add_name(Self::silo_dns_name(silo_name), dns_records)?;
+
+        let silo = datastore
+            .silo_create(
+                &opctx,
+                &external_authn_opctx,
+                new_silo_params,
+                dns_update,
+            )
+            .await?;
+        self.background_tasks.activate(&self.task_external_dns_config);
+        Ok(silo)
     }
 
     pub async fn silos_list(
@@ -89,9 +132,21 @@ impl super::Nexus {
         opctx: &OpContext,
         silo_lookup: &lookup::Silo<'_>,
     ) -> DeleteResult {
+        let dns_opctx = self.opctx_external_authn();
+        let datastore = self.datastore();
         let (.., authz_silo, db_silo) =
             silo_lookup.fetch_for(authz::Action::Delete).await?;
-        self.db_datastore.silo_delete(opctx, &authz_silo, &db_silo).await
+        let mut dns_update = DnsVersionUpdateBuilder::new(
+            datastore.dns_zone_external(opctx).await?,
+            format!("delete silo: {:?}", db_silo.name()),
+            self.id.to_string(),
+        );
+        dns_update.remove_name(Self::silo_dns_name(&db_silo.name()))?;
+        datastore
+            .silo_delete(opctx, &authz_silo, &db_silo, dns_opctx, dns_update)
+            .await?;
+        self.background_tasks.activate(&self.task_external_dns_config);
+        Ok(())
     }
 
     // Role assignments

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -30,8 +30,10 @@ pub use crucible_agent_client;
 use external_api::http_entrypoints::external_api;
 use internal_api::http_entrypoints::internal_api;
 use internal_dns::DnsConfigBuilder;
+use nexus_types::internal_api::params::ServiceKind;
+use omicron_common::address::{IpRange, Ipv4Range, Ipv6Range};
 use slog::Logger;
-use std::net::{SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -205,11 +207,39 @@ impl nexus_test_interface::NexusServer for Server {
         internal_server: InternalServer,
         config: &Config,
         services: Vec<nexus_types::internal_api::params::ServicePutRequest>,
+        external_dns_zone_name: &str,
     ) -> Self {
         // Perform the "handoff from RSS".
         //
         // However, RSS isn't running, so we'll do the handoff ourselves.
         let opctx = internal_server.apictx.nexus.opctx_for_service_balancer();
+
+        // Allocation of the initial Nexus's external IP is a little funny.  In
+        // a real system, it'd be allocated by RSS and provided with the rack
+        // initialization request (which we're about to simulate).  RSS also
+        // provides information about the external IP pool ranges available for
+        // system services.  The Nexus external IP that it picks comes from this
+        // range.  During rack initialization, Nexus "allocates" the IP (which
+        // was really already allocated) -- recording that allocation like any
+        // other one.
+        //
+        // In this context, the IP was "allocated" by the user.  Most likely,
+        // it's 127.0.0.1, having come straight from the stock testing config
+        // file.  Whatever it is, we fake up an IP pool range for use by system
+        // services that includes solely this IP.
+        let internal_services_ip_pool_ranges = services
+            .iter()
+            .filter_map(|s| match s.kind {
+                ServiceKind::Nexus { external_address: IpAddr::V4(addr) } => {
+                    Some(IpRange::V4(Ipv4Range::new(addr, addr).unwrap()))
+                }
+                ServiceKind::Nexus { external_address: IpAddr::V6(addr) } => {
+                    Some(IpRange::V6(Ipv6Range::new(addr, addr).unwrap()))
+                }
+                _ => None,
+            })
+            .collect();
+
         internal_server
             .apictx
             .nexus
@@ -219,9 +249,10 @@ impl nexus_test_interface::NexusServer for Server {
                 internal_api::params::RackInitializationRequest {
                     services,
                     datasets: vec![],
-                    internal_services_ip_pool_ranges: vec![],
+                    internal_services_ip_pool_ranges,
                     certs: vec![],
                     internal_dns_zone_config: DnsConfigBuilder::new().build(),
+                    external_dns_zone_name: external_dns_zone_name.to_owned(),
                 },
             )
             .await

--- a/nexus/test-interface/src/lib.rs
+++ b/nexus/test-interface/src/lib.rs
@@ -50,6 +50,7 @@ pub trait NexusServer {
         internal_server: Self::InternalServer,
         config: &Config,
         services: Vec<nexus_types::internal_api::params::ServicePutRequest>,
+        external_dns_zone_name: &str,
     ) -> Self;
 
     async fn get_http_server_external_address(&self) -> Option<SocketAddr>;

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 crucible-agent-client.workspace = true
+dns-server.workspace = true
 dropshot.workspace = true
 headers.workspace = true
 http.workspace = true
@@ -30,6 +31,8 @@ serde_json.workspace = true
 serde_urlencoded.workspace = true
 slog.workspace = true
 tempfile.workspace = true
+trust-dns-proto.workspace = true
+trust-dns-resolver.workspace = true
 uuid.workspace = true
 
 [build-dependencies]

--- a/nexus/test-utils/src/db.rs
+++ b/nexus/test-utils/src/db.rs
@@ -27,17 +27,10 @@ pub async fn test_setup_database(log: &Logger) -> dev::db::CockroachInstance {
     dev::test_setup_database(log, &dir).await
 }
 
-/// SQL used to enable full table scans for the duration of the current
-/// transaction.
+/// See the definition of this constant in nexus_db_queries.
 ///
-/// We normally disallow table scans in effort to identify scalability issues
-/// during development. But it's preferable for some ad hoc test-only queries to
-/// do table scans (rather than add indexes that are only used for the test
-/// suite).
-///
-/// This SQL appears to have no effect when used outside of a transaction.
-/// That's intentional.  We do not want to use `SET` (rather than `SET LOCAL`)
-/// here because that would change the behavior for any code that happens to use
-/// the same pooled connection after this SQL gets run.
+/// Besides the cases mentioned there, it's also preferable for some ad hoc
+/// test-only queries to do table scans rather than add indexes that are only
+/// used for the test suite.
 pub const ALLOW_FULL_TABLE_SCAN_SQL: &str =
-    "set local disallow_full_table_scans = off; set local large_full_scan_rows = 1000;";
+    nexus_db_queries::db::queries::ALLOW_FULL_TABLE_SCAN_SQL;

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! Integration testing facilities for Nexus
 
+use anyhow::Context;
 use dropshot::test_util::ClientTestContext;
 use dropshot::test_util::LogContext;
 use dropshot::ConfigDropshot;
@@ -25,6 +26,11 @@ use std::fmt::Debug;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::path::Path;
 use std::time::Duration;
+use trust_dns_resolver::config::NameServerConfig;
+use trust_dns_resolver::config::Protocol;
+use trust_dns_resolver::config::ResolverConfig;
+use trust_dns_resolver::config::ResolverOpts;
+use trust_dns_resolver::TokioAsyncResolver;
 use uuid::Uuid;
 
 pub mod db;
@@ -53,6 +59,11 @@ pub struct ControlPlaneTestContext<N> {
     pub oximeter: Oximeter,
     pub producer: ProducerServer,
     pub dendrite: dev::dendrite::DendriteInstance,
+    pub external_dns_zone_name: String,
+    pub external_dns_server: dns_server::dns_server::ServerHandle,
+    pub external_dns_config_server:
+        dropshot::HttpServer<dns_server::http_server::Context>,
+    pub external_dns_resolver: trust_dns_resolver::TokioAsyncResolver,
 }
 
 impl<N: NexusServer> ControlPlaneTestContext<N> {
@@ -185,20 +196,77 @@ pub async fn test_setup_with_config<N: NexusServer>(
     .await
     .unwrap();
 
+    // Set up an external DNS server.
+    let (
+        external_dns_server,
+        external_dns_config_server,
+        external_dns_resolver,
+    ) = start_dns_server(
+        logctx.log.new(o!(
+            "component" => "external_dns_server",
+        )),
+        tempdir.path(),
+    )
+    .await
+    .unwrap();
+
     // Finish setting up Nexus by initializing the rack.  We need to include
     // information about the internal DNS server started within the simulated
     // Sled Agent.
-    let dns_server_address = match sled_agent.dns_dropshot_server.local_addr() {
+    let dns_server_address_internal = match sled_agent
+        .dns_dropshot_server
+        .local_addr()
+    {
         SocketAddr::V4(_) => panic!("expected DNS server to have IPv6 address"),
         SocketAddr::V6(addr) => addr,
     };
-    let dns_service = ServicePutRequest {
+    let dns_service_internal = ServicePutRequest {
         service_id: Uuid::new_v4(),
         sled_id: sa_id,
-        address: dns_server_address,
+        address: dns_server_address_internal,
         kind: ServiceKind::InternalDnsConfig,
     };
-    let server = N::start(nexus_internal, &config, vec![dns_service]).await;
+    let dns_server_address_external = match external_dns_config_server
+        .local_addr()
+    {
+        SocketAddr::V4(_) => panic!("expected DNS server to have IPv6 address"),
+        SocketAddr::V6(addr) => addr,
+    };
+    let dns_service_external = ServicePutRequest {
+        service_id: Uuid::new_v4(),
+        sled_id: sa_id,
+        address: dns_server_address_external,
+        kind: ServiceKind::ExternalDnsConfig,
+    };
+    let nexus_service = ServicePutRequest {
+        service_id: Uuid::new_v4(),
+        sled_id: sa_id,
+        address: SocketAddrV6::new(
+            match nexus_internal_addr.ip() {
+                IpAddr::V4(addr) => addr.to_ipv6_mapped(),
+                IpAddr::V6(addr) => addr,
+            },
+            nexus_internal_addr.port(),
+            0,
+            0,
+        ),
+        kind: ServiceKind::Nexus {
+            external_address: config
+                .deployment
+                .dropshot_external
+                .bind_address
+                .ip(),
+        },
+    };
+    let external_dns_zone_name =
+        internal_dns::names::DNS_ZONE_EXTERNAL_TESTING.to_string();
+    let server = N::start(
+        nexus_internal,
+        &config,
+        vec![dns_service_internal, dns_service_external, nexus_service],
+        &external_dns_zone_name,
+    )
+    .await;
 
     let external_server_addr =
         server.get_http_server_external_address().await.unwrap();
@@ -254,6 +322,10 @@ pub async fn test_setup_with_config<N: NexusServer>(
         producer,
         logctx,
         dendrite,
+        external_dns_zone_name,
+        external_dns_server,
+        external_dns_config_server,
+        external_dns_resolver,
     }
 }
 
@@ -289,7 +361,7 @@ pub async fn start_sled_agent(
     };
 
     let (server, _rack_init_request) =
-        sim::Server::start(&config, &log).await?;
+        sim::Server::start(&config, &log, &sim::RssArgs::default()).await?;
     Ok(server)
 }
 
@@ -422,4 +494,55 @@ pub fn assert_same_items<T: PartialEq + Debug>(v1: Vec<T>, v2: Vec<T>) {
     for item in v1.iter() {
         assert!(v2.contains(item), "{:?} and {:?} don't match", v1, v2);
     }
+}
+
+pub async fn start_dns_server(
+    log: slog::Logger,
+    storage_path: &Path,
+) -> Result<
+    (
+        dns_server::dns_server::ServerHandle,
+        dropshot::HttpServer<dns_server::http_server::Context>,
+        TokioAsyncResolver,
+    ),
+    anyhow::Error,
+> {
+    let config_store = dns_server::storage::Config {
+        keep_old_generations: 3,
+        storage_path: storage_path.to_string_lossy().into_owned().into(),
+    };
+    let store = dns_server::storage::Store::new(
+        log.new(o!("component" => "DnsStore")),
+        &config_store,
+    )
+    .unwrap();
+
+    let (dns_server, http_server) = dns_server::start_servers(
+        log,
+        store,
+        &dns_server::dns_server::Config {
+            bind_address: "[::1]:0".parse().unwrap(),
+        },
+        &dropshot::ConfigDropshot {
+            bind_address: "[::1]:0".parse().unwrap(),
+            request_body_max_bytes: 8 * 1024,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut resolver_config = ResolverConfig::new();
+    resolver_config.add_name_server(NameServerConfig {
+        socket_addr: *dns_server.local_address(),
+        protocol: Protocol::Udp,
+        tls_dns_name: None,
+        trust_nx_responses: false,
+        bind_addr: None,
+    });
+    let resolver =
+        TokioAsyncResolver::tokio(resolver_config, ResolverOpts::default())
+            .context("creating DNS resolver")?;
+
+    Ok((dns_server, http_server, resolver))
 }

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -25,6 +25,7 @@ use omicron_nexus::external_api::views::{
     self, IdentityProvider, Project, SamlIdentityProvider, Silo,
 };
 use omicron_nexus::external_api::{params, shared};
+use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
@@ -34,6 +35,11 @@ use base64::Engine;
 use http::method::Method;
 use http::StatusCode;
 use httptest::{matchers::*, responders::*, Expectation, Server};
+use internal_dns::names::DNS_ZONE_EXTERNAL_TESTING;
+use std::convert::Infallible;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use trust_dns_resolver::error::ResolveErrorKind;
 use uuid::Uuid;
 
 type ControlPlaneTestContext =
@@ -54,6 +60,10 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
     .await;
     create_silo(&client, "hidden", false, shared::SiloIdentityMode::LocalOnly)
         .await;
+
+    // Verify that an external DNS name was propagated for these Silos.
+    verify_silo_dns_name(cptestctx, "discoverable", true).await;
+    verify_silo_dns_name(cptestctx, "hidden", true).await;
 
     // Verify GET /v1/system/silos/{silo} works for both discoverable and not
     let discoverable_url = "/v1/system/silos/discoverable";
@@ -219,6 +229,9 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         .execute()
         .await
         .expect("failed to make request");
+
+    // Verify the DNS name was removed.
+    verify_silo_dns_name(cptestctx, "discoverable", false).await;
 
     // Verify silo user was also deleted
     LookupPath::new(&authn_opctx, nexus.datastore())
@@ -2084,4 +2097,57 @@ async fn run_user_tests(
         .items;
     println!("last_users: {:?}", last_users);
     assert_eq!(last_users, existing_users);
+}
+
+async fn verify_silo_dns_name(
+    cptestctx: &ControlPlaneTestContext,
+    silo_name: &str,
+    should_exist: bool,
+) {
+    // The DNS naming scheme for Silo DNS names is just:
+    //     $silo_name.sys.$delegated_name
+    // This is determined by RFD 357 and also implemented in Nexus.
+    let dns_name = format!("{}.sys.{}", silo_name, DNS_ZONE_EXTERNAL_TESTING);
+
+    // We assume that in the test suite, Nexus's "external" address is
+    // localhost.
+    let nexus_ip = Ipv4Addr::LOCALHOST;
+
+    wait_for_condition(
+        || async {
+            let found = match cptestctx
+                .external_dns_resolver
+                .ipv4_lookup(&dns_name)
+                .await
+            {
+                Ok(result) => {
+                    let addrs: Vec<_> = result.iter().collect();
+                    if addrs.is_empty() {
+                        false
+                    } else {
+                        assert_eq!(addrs, [&nexus_ip]);
+                        true
+                    }
+                }
+                Err(error) => match error.kind() {
+                    ResolveErrorKind::NoRecordsFound { .. } => false,
+                    _ => panic!(
+                        "unexpected error querying external \
+                            DNS server for Silo DNS name {:?}: {:#}",
+                        dns_name, error
+                    ),
+                },
+            };
+
+            if should_exist == found {
+                Ok(())
+            } else {
+                Err::<_, CondCheckError<Infallible>>(CondCheckError::NotYet)
+            }
+        },
+        &Duration::from_millis(50),
+        &Duration::from_secs(15),
+    )
+    .await
+    .expect("failed to verify external DNS configuration");
 }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -240,6 +240,8 @@ pub struct RackInitializationRequest {
     pub certs: Vec<Certificate>,
     /// initial internal DNS config
     pub internal_dns_zone_config: dns_service_client::types::DnsConfigParams,
+    /// delegated DNS name for external DNS
+    pub external_dns_zone_name: String,
 }
 
 pub type DnsConfigParams = dns_service_client::types::DnsConfigParams;

--- a/openapi/dns-server.json
+++ b/openapi/dns-server.json
@@ -150,6 +150,25 @@
             "properties": {
               "data": {
                 "type": "string",
+                "format": "ipv4"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "A"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "string",
                 "format": "ipv6"
               },
               "type": {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1280,6 +1280,25 @@
             "properties": {
               "data": {
                 "type": "string",
+                "format": "ipv4"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "A"
+                ]
+              }
+            },
+            "required": [
+              "data",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "string",
                 "format": "ipv6"
               },
               "type": {
@@ -2194,6 +2213,10 @@
               "$ref": "#/components/schemas/DatasetCreateRequest"
             }
           },
+          "external_dns_zone_name": {
+            "description": "delegated DNS name for external DNS",
+            "type": "string"
+          },
           "internal_dns_zone_config": {
             "description": "initial internal DNS config",
             "allOf": [
@@ -2220,6 +2243,7 @@
         "required": [
           "certs",
           "datasets",
+          "external_dns_zone_name",
           "internal_dns_zone_config",
           "internal_services_ip_pool_ranges",
           "services"

--- a/oximeter/collector/config.toml
+++ b/oximeter/collector/config.toml
@@ -1,6 +1,6 @@
 # Example configuration file for running an oximeter collector server
 
-nexus_address = "127.0.0.1:12221"
+nexus_address = "[::1]:12221"
 
 [db]
 address = "[::1]:8123"

--- a/oximeter/producer/examples/producer.rs
+++ b/oximeter/producer/examples/producer.rs
@@ -101,7 +101,7 @@ async fn main() {
     };
     let config = Config {
         server_info,
-        registration_address: "127.0.0.1:12221".parse().unwrap(),
+        registration_address: "[::1]:12221".parse().unwrap(),
         dropshot_config,
         logging_config,
     };

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -131,6 +131,9 @@ fn d2n_record(
     record: &dns_service_client::types::DnsRecord,
 ) -> nexus_client::types::DnsRecord {
     match record {
+        dns_service_client::types::DnsRecord::A(addr) => {
+            nexus_client::types::DnsRecord::A(*addr)
+        }
         dns_service_client::types::DnsRecord::Aaaa(addr) => {
             nexus_client::types::DnsRecord::Aaaa(*addr)
         }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -783,6 +783,10 @@ impl ServiceInner {
             // the need for unencrypted communication.
             certs: vec![],
             internal_dns_zone_config: d2n_params(&service_plan.dns_config),
+            // TODO This eventually needs to come from the person setting up the
+            // system.
+            external_dns_zone_name:
+                internal_dns::names::DNS_ZONE_EXTERNAL_TESTING.to_owned(),
         };
 
         let notify_nexus = || async {

--- a/sled-agent/src/sim/mod.rs
+++ b/sled-agent/src/sim/mod.rs
@@ -18,5 +18,5 @@ mod storage;
 
 pub use crate::updates::ConfigUpdates;
 pub use config::{Config, ConfigHardware, ConfigStorage, ConfigZpool, SimMode};
-pub use server::{run_server, Server};
+pub use server::{run_server, RssArgs, Server};
 pub use sled_agent::SledAgent;

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -14,11 +14,14 @@ use anyhow::Context;
 use crucible_agent_client::types::State as RegionState;
 use internal_dns::ServiceName;
 use nexus_client::types as NexusTypes;
+use nexus_client::types::{IpRange, Ipv4Range, Ipv6Range};
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
 };
 use slog::{info, Drain, Logger};
+use std::net::IpAddr;
 use std::net::SocketAddr;
+use std::net::SocketAddrV6;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -45,6 +48,7 @@ impl Server {
     pub async fn start(
         config: &Config,
         log: &Logger,
+        rss_args: &RssArgs,
     ) -> Result<(Server, NexusTypes::RackInitializationRequest), String> {
         info!(log, "setting up sled agent server");
 
@@ -245,7 +249,7 @@ impl Server {
             SocketAddr::V4(_) => panic!("did not expect v4 address"),
             SocketAddr::V6(a) => a,
         };
-        let services = vec![
+        let mut services = vec![
             NexusTypes::ServicePutRequest {
                 address: dns_bound.to_string(),
                 kind: NexusTypes::ServiceKind::InternalDns,
@@ -260,12 +264,46 @@ impl Server {
             },
         ];
 
+        let mut internal_services_ip_pool_ranges = vec![];
+        if let Some(nexus_external_addr) = rss_args.nexus_external_addr {
+            let ip = nexus_external_addr.ip();
+
+            services.push(NexusTypes::ServicePutRequest {
+                address: config.nexus_address.to_string(),
+                kind: NexusTypes::ServiceKind::Nexus { external_address: ip },
+                service_id: Uuid::new_v4(),
+                sled_id: config.id,
+            });
+
+            internal_services_ip_pool_ranges.push(match ip {
+                IpAddr::V4(addr) => {
+                    IpRange::V4(Ipv4Range { first: addr, last: addr })
+                }
+                IpAddr::V6(addr) => {
+                    IpRange::V6(Ipv6Range { first: addr, last: addr })
+                }
+            });
+        }
+
+        if let Some(external_dns_internal_addr) =
+            rss_args.external_dns_internal_addr
+        {
+            services.push(NexusTypes::ServicePutRequest {
+                address: external_dns_internal_addr.to_string(),
+                kind: NexusTypes::ServiceKind::ExternalDnsConfig,
+                service_id: Uuid::new_v4(),
+                sled_id: config.id,
+            });
+        }
+
         let rack_init_request = NexusTypes::RackInitializationRequest {
             services,
             datasets,
-            internal_services_ip_pool_ranges: vec![],
+            internal_services_ip_pool_ranges,
             certs: vec![],
             internal_dns_zone_config: d2n_params(&dns_config),
+            external_dns_zone_name:
+                internal_dns::names::DNS_ZONE_EXTERNAL_TESTING.to_owned(),
         };
 
         Ok((
@@ -321,8 +359,22 @@ async fn handoff_to_nexus(
     Ok(())
 }
 
+/// RSS-related arguments for the simulated sled agent
+#[derive(Default)]
+pub struct RssArgs {
+    /// Specify the external address of Nexus so that we can include it in
+    /// external DNS
+    pub nexus_external_addr: Option<SocketAddr>,
+    /// Specify the (internal) address of an external DNS server so that Nexus
+    /// will know about it and keep it up to date
+    pub external_dns_internal_addr: Option<SocketAddrV6>,
+}
+
 /// Run an instance of the `Server`
-pub async fn run_server(config: &Config) -> Result<(), String> {
+pub async fn run_server(
+    config: &Config,
+    rss_args: &RssArgs,
+) -> Result<(), String> {
     let (drain, registration) = slog_dtrace::with_drain(
         config
             .log
@@ -338,7 +390,8 @@ pub async fn run_server(config: &Config) -> Result<(), String> {
         debug!(log, "registered DTrace probes");
     }
 
-    let (server, rack_init_request) = Server::start(config, &log).await?;
+    let (server, rack_init_request) =
+        Server::start(config, &log, rss_args).await?;
     info!(log, "sled agent started successfully");
 
     handoff_to_nexus(&log, &config, &rack_init_request).await?;


### PR DESCRIPTION
This change causes Nexus to populate external DNS names for each Silo's console/API endpoint, as determined in RFD 357.  This includes some generic infrastructure in the datastore for constructing an update to the DNS configuration, plus a bunch of closely related changes:

* The test suite, `omicron-dev run-all`, and the "how-to-run-simulated" instructions all start up an external DNS server now.
* The DNS server now has support for A records (since external addresses can be IPv4 addresses).
* Authz for DNS operations now uses a synthetic resource for the global DnsConfig (rather than having various authz checks bake in that you need specific permissions on the Fleet).
* The test suite and simulated sled agent, which are both responsible for initializing the rack as RSS, now include the "Nexus" service and External DNS service during rack initialization.  This is important so that Nexus's external IP gets recorded in the database, in turn so that it can be filled into each Silo's external DNS name.
    * As a consequence, the default Nexus config now listens on IPv6 loopback for the internal API rather than the IPv4 loopback.  (The database configuration only supports v6 addresses for internal services.)
    * As another consequence, these pieces now include with rack initialization an internal service IP pool containing 127.0.0.1.  This is a little funny and may need to be revisited.  But right now, this does reflect what's already happening, and I don't think there's a better way to do this given the way the underlying pieces work today (which is that they assume Nexus's external addresses come from this pool).
* The name of the DNS zone being delegated to the rack now comes in during rack initialization.  It used to be hardcoded inside Nexus.  (It's still hardcoded, but now that's in the various places we do rack initialization, and they all use one definition.)  This was to avoid hardcoding the value in multiple places _inside_ Nexus, given that the eventual plan is for this to come from the user.

One caveat: this does _not_ generate names for the built-in Silo because that doesn't go through the normal silo-create path.  That Silo should be removed by the time we're ready to ship so I didn't think it was worth adding one-off code to support it.