### PR TITLE
[wicketd] Refuse to update the sled where wicketd is running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8934,6 +8934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
+ "sled-hardware",
  "slog",
  "slog-dtrace",
  "snafu",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -696,14 +696,6 @@
           "pool_name"
         ]
       },
-      "DendriteAsic": {
-        "type": "string",
-        "enum": [
-          "tofino_asic",
-          "tofino_stub",
-          "soft_npu"
-        ]
-      },
       "DiskEnsureBody": {
         "description": "Sent from to a sled agent to establish the runtime state of a Disk",
         "type": "object",
@@ -1872,70 +1864,6 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "management_gateway_service"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "wicketd"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "asic": {
-                "$ref": "#/components/schemas/DendriteAsic"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "dendrite"
-                ]
-              }
-            },
-            "required": [
-              "asic",
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "pkt_source": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "tfport"
-                ]
-              }
-            },
-            "required": [
-              "pkt_source",
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
                   "crucible_pantry"
                 ]
               }
@@ -2023,24 +1951,6 @@
             "required": [
               "dns_servers",
               "ntp_servers",
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "mode": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "maghemite"
-                ]
-              }
-            },
-            "required": [
-              "mode",
               "type"
             ]
           },

--- a/sled-agent/src/bootstrap/hardware.rs
+++ b/sled-agent/src/bootstrap/hardware.rs
@@ -68,8 +68,12 @@ impl HardwareMonitorWorker {
                     match update {
                         Ok(update) => match update {
                             sled_hardware::HardwareUpdate::TofinoLoaded => {
+                                let baseboard = self.hardware.baseboard();
                                 let switch_zone_ip = None;
-                                if let Err(e) = self.services.activate_switch(switch_zone_ip).await {
+                                if let Err(e) = self.services.activate_switch(
+                                    switch_zone_ip,
+                                    baseboard,
+                                ).await {
                                     warn!(self.log, "Failed to activate switch: {e}");
                                 }
                             }
@@ -107,8 +111,10 @@ impl HardwareMonitorWorker {
     async fn full_hardware_scan(&self) {
         info!(self.log, "Performing full hardware scan");
         if self.hardware.is_scrimlet_driver_loaded() {
+            let baseboard = self.hardware.baseboard();
             let switch_zone_ip = None;
-            if let Err(e) = self.services.activate_switch(switch_zone_ip).await
+            if let Err(e) =
+                self.services.activate_switch(switch_zone_ip, baseboard).await
             {
                 warn!(self.log, "Failed to activate switch: {e}");
             }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -420,11 +420,11 @@ impl crate::smf_helper::Service for ServiceType {
 /// started autonomously by sled-agent) into a
 /// `sled_agent_client::types::ServiceType` to be sent to a remote sled-agent.
 #[derive(Debug, Clone, Copy, Error)]
-#[error("This service may not be requested externally")]
-pub struct InternalServiceOnlyError;
+#[error("This service may only be started autonomously by sled-agent")]
+pub struct AutonomousServiceOnlyError;
 
 impl TryFrom<ServiceType> for sled_agent_client::types::ServiceType {
-    type Error = InternalServiceOnlyError;
+    type Error = AutonomousServiceOnlyError;
 
     fn try_from(s: ServiceType) -> Result<Self, Self::Error> {
         use sled_agent_client::types::ServiceType as AutoSt;
@@ -472,7 +472,7 @@ impl TryFrom<ServiceType> for sled_agent_client::types::ServiceType {
             | St::Wicketd { .. }
             | St::Dendrite { .. }
             | St::Tfport { .. }
-            | St::Maghemite { .. } => Err(InternalServiceOnlyError),
+            | St::Maghemite { .. } => Err(AutonomousServiceOnlyError),
         }
     }
 }
@@ -576,7 +576,7 @@ impl ServiceZoneRequest {
 impl TryFrom<ServiceZoneRequest>
     for sled_agent_client::types::ServiceZoneRequest
 {
-    type Error = InternalServiceOnlyError;
+    type Error = AutonomousServiceOnlyError;
 
     fn try_from(s: ServiceZoneRequest) -> Result<Self, Self::Error> {
         let mut services = Vec::with_capacity(s.services.len());
@@ -607,7 +607,7 @@ pub struct ServiceZoneService {
 impl TryFrom<ServiceZoneService>
     for sled_agent_client::types::ServiceZoneService
 {
-    type Error = InternalServiceOnlyError;
+    type Error = AutonomousServiceOnlyError;
 
     fn try_from(s: ServiceZoneService) -> Result<Self, Self::Error> {
         let details = s.details.try_into()?;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -10,8 +10,10 @@ use omicron_common::api::internal::shared::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sled_hardware::Baseboard;
 use std::fmt::{Debug, Display, Formatter, Result as FormatResult};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use thiserror::Error;
 use uuid::Uuid;
 
 pub use illumos_utils::opte::params::VpcFirewallRule;
@@ -328,13 +330,29 @@ pub enum ServiceType {
         dns_address: SocketAddrV6,
     },
     Oximeter,
+    // We should never receive external requests to start wicketd, MGS,
+    // dendrite, tfport, or maghemite: these are all services running in the
+    // global zone or switch zone that we start autonomously. We tag them with
+    // `serde(skip)` both to omit them from our OpenAPI definition and to avoid
+    // needing their contained types to implement `JsonSchema + Deserialize +
+    // Serialize`.
+    #[serde(skip)]
     ManagementGatewayService,
-    Wicketd,
+    #[serde(skip)]
+    Wicketd {
+        baseboard: Baseboard,
+    },
+    #[serde(skip)]
     Dendrite {
         asic: DendriteAsic,
     },
+    #[serde(skip)]
     Tfport {
         pkt_source: String,
+    },
+    #[serde(skip)]
+    Maghemite {
+        mode: String,
     },
     CruciblePantry,
     BoundaryNtp {
@@ -351,9 +369,6 @@ pub enum ServiceType {
         dns_servers: Vec<String>,
         domain: Option<String>,
     },
-    Maghemite {
-        mode: String,
-    },
     Clickhouse,
     CockroachDb,
     Crucible,
@@ -367,7 +382,7 @@ impl std::fmt::Display for ServiceType {
             ServiceType::InternalDns { .. } => write!(f, "internal_dns"),
             ServiceType::Oximeter => write!(f, "oximeter"),
             ServiceType::ManagementGatewayService => write!(f, "mgs"),
-            ServiceType::Wicketd => write!(f, "wicketd"),
+            ServiceType::Wicketd { .. } => write!(f, "wicketd"),
             ServiceType::Dendrite { .. } => write!(f, "dendrite"),
             ServiceType::Tfport { .. } => write!(f, "tfport"),
             ServiceType::CruciblePantry => write!(f, "crucible/pantry"),
@@ -401,62 +416,63 @@ impl crate::smf_helper::Service for ServiceType {
     }
 }
 
-impl From<ServiceType> for sled_agent_client::types::ServiceType {
-    fn from(s: ServiceType) -> Self {
+/// Error returned by attempting to convert an internal service (i.e., a service
+/// started autonomously by sled-agent) into a
+/// `sled_agent_client::types::ServiceType` to be sent to a remote sled-agent.
+#[derive(Debug, Clone, Copy, Error)]
+#[error("This service may not be requested externally")]
+pub struct InternalServiceOnlyError;
+
+impl TryFrom<ServiceType> for sled_agent_client::types::ServiceType {
+    type Error = InternalServiceOnlyError;
+
+    fn try_from(s: ServiceType) -> Result<Self, Self::Error> {
         use sled_agent_client::types::ServiceType as AutoSt;
         use ServiceType as St;
 
         match s {
             St::Nexus { internal_ip, external_ip, nic } => {
-                AutoSt::Nexus { internal_ip, external_ip, nic: nic.into() }
+                Ok(AutoSt::Nexus { internal_ip, external_ip, nic: nic.into() })
             }
             St::ExternalDns { http_address, dns_address, nic } => {
-                AutoSt::ExternalDns {
+                Ok(AutoSt::ExternalDns {
                     http_address: http_address.to_string(),
                     dns_address: dns_address.to_string(),
                     nic: nic.into(),
-                }
+                })
             }
             St::InternalDns { http_address, dns_address } => {
-                AutoSt::InternalDns {
+                Ok(AutoSt::InternalDns {
                     http_address: http_address.to_string(),
                     dns_address: dns_address.to_string(),
-                }
+                })
             }
-            St::Oximeter => AutoSt::Oximeter,
-            St::ManagementGatewayService => AutoSt::ManagementGatewayService,
-            St::Wicketd => AutoSt::Wicketd,
-            St::Dendrite { asic } => {
-                use sled_agent_client::types::DendriteAsic as AutoAsic;
-                let asic = match asic {
-                    DendriteAsic::TofinoAsic => AutoAsic::TofinoAsic,
-                    DendriteAsic::TofinoStub => AutoAsic::TofinoStub,
-                    DendriteAsic::SoftNpu => AutoAsic::SoftNpu,
-                };
-                AutoSt::Dendrite { asic }
-            }
-            St::Tfport { pkt_source } => AutoSt::Tfport { pkt_source },
-            St::CruciblePantry => AutoSt::CruciblePantry,
+            St::Oximeter => Ok(AutoSt::Oximeter),
+            St::CruciblePantry => Ok(AutoSt::CruciblePantry),
             St::BoundaryNtp {
                 ntp_servers,
                 dns_servers,
                 domain,
                 nic,
                 snat_cfg,
-            } => AutoSt::BoundaryNtp {
+            } => Ok(AutoSt::BoundaryNtp {
                 ntp_servers,
                 dns_servers,
                 domain,
                 nic: nic.into(),
                 snat_cfg: snat_cfg.into(),
-            },
+            }),
             St::InternalNtp { ntp_servers, dns_servers, domain } => {
-                AutoSt::InternalNtp { ntp_servers, dns_servers, domain }
+                Ok(AutoSt::InternalNtp { ntp_servers, dns_servers, domain })
             }
-            St::Maghemite { mode } => AutoSt::Maghemite { mode },
-            St::Clickhouse => AutoSt::Clickhouse,
-            St::CockroachDb => AutoSt::CockroachDb,
-            St::Crucible => AutoSt::Crucible,
+            St::Clickhouse => Ok(AutoSt::Clickhouse),
+            St::CockroachDb => Ok(AutoSt::CockroachDb),
+            St::Crucible => Ok(AutoSt::Crucible),
+            St::ManagementGatewayService
+            | St::Wicketd { .. }
+            | St::Dendrite { .. }
+            | St::Tfport { .. }
+            | St::Maghemite { .. } => Err(InternalServiceOnlyError),
         }
     }
 }
@@ -557,21 +573,25 @@ impl ServiceZoneRequest {
     }
 }
 
-impl From<ServiceZoneRequest> for sled_agent_client::types::ServiceZoneRequest {
-    fn from(s: ServiceZoneRequest) -> Self {
-        let mut services = Vec::new();
+impl TryFrom<ServiceZoneRequest>
+    for sled_agent_client::types::ServiceZoneRequest
+{
+    type Error = InternalServiceOnlyError;
+
+    fn try_from(s: ServiceZoneRequest) -> Result<Self, Self::Error> {
+        let mut services = Vec::with_capacity(s.services.len());
         for service in s.services {
-            services.push(service.into())
+            services.push(service.try_into()?);
         }
 
-        Self {
+        Ok(Self {
             id: s.id,
             zone_type: s.zone_type.into(),
             addresses: s.addresses,
             dataset: s.dataset.map(|d| d.into()),
             gz_addresses: s.gz_addresses,
             services,
-        }
+        })
     }
 }
 
@@ -584,9 +604,14 @@ pub struct ServiceZoneService {
     pub details: ServiceType,
 }
 
-impl From<ServiceZoneService> for sled_agent_client::types::ServiceZoneService {
-    fn from(s: ServiceZoneService) -> Self {
-        Self { id: s.id, details: s.details.into() }
+impl TryFrom<ServiceZoneService>
+    for sled_agent_client::types::ServiceZoneService
+{
+    type Error = InternalServiceOnlyError;
+
+    fn try_from(s: ServiceZoneService) -> Result<Self, Self::Error> {
+        let details = s.details.try_into()?;
+        Ok(Self { id: s.id, details })
     }
 }
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -60,7 +60,7 @@ use crate::bootstrap::params::SledAgentRequest;
 use crate::bootstrap::rss_handle::BootstrapAgentHandle;
 use crate::nexus::d2n_params;
 use crate::params::{
-    DatasetEnsureBody, InternalServiceOnlyError, ServiceType,
+    AutonomousServiceOnlyError, DatasetEnsureBody, ServiceType,
     ServiceZoneRequest, TimeSync, ZoneType,
 };
 use crate::rack_setup::plan::service::{
@@ -308,7 +308,7 @@ impl ServiceInner {
         let services = services
             .iter()
             .map(|s| s.clone().try_into())
-            .collect::<Result<Vec<_>, InternalServiceOnlyError>>()
+            .collect::<Result<Vec<_>, AutonomousServiceOnlyError>>()
             .map_err(|err| {
                 SetupServiceError::SledInitialization(err.to_string())
             })?;

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -60,7 +60,8 @@ use crate::bootstrap::params::SledAgentRequest;
 use crate::bootstrap::rss_handle::BootstrapAgentHandle;
 use crate::nexus::d2n_params;
 use crate::params::{
-    DatasetEnsureBody, ServiceType, ServiceZoneRequest, TimeSync, ZoneType,
+    DatasetEnsureBody, InternalServiceOnlyError, ServiceType,
+    ServiceZoneRequest, TimeSync, ZoneType,
 };
 use crate::rack_setup::plan::service::{
     Plan as ServicePlan, PlanError as ServicePlanError,
@@ -304,15 +305,20 @@ impl ServiceInner {
             self.log.new(o!("SledAgentClient" => sled_address.to_string())),
         );
 
+        let services = services
+            .iter()
+            .map(|s| s.clone().try_into())
+            .collect::<Result<Vec<_>, InternalServiceOnlyError>>()
+            .map_err(|err| {
+                SetupServiceError::SledInitialization(err.to_string())
+            })?;
+
         info!(self.log, "sending service requests...");
         let services_put = || async {
             info!(self.log, "initializing sled services: {:?}", services);
             client
                 .services_put(&SledAgentTypes::ServiceEnsureBody {
-                    services: services
-                        .iter()
-                        .map(|s| s.clone().into())
-                        .collect(),
+                    services: services.clone(),
                 })
                 .await
                 .map_err(BackoffError::transient)?;

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -328,9 +328,13 @@ impl SledAgent {
         let scrimlet = self.inner.hardware.is_scrimlet_driver_loaded();
 
         if scrimlet {
+            let baseboard = self.inner.hardware.baseboard();
             let switch_zone_ip = Some(self.inner.switch_zone_ip());
-            if let Err(e) =
-                self.inner.services.activate_switch(switch_zone_ip).await
+            if let Err(e) = self
+                .inner
+                .services
+                .activate_switch(switch_zone_ip, baseboard)
+                .await
             {
                 warn!(log, "Failed to activate switch: {e}");
             }
@@ -368,11 +372,12 @@ impl SledAgent {
                         self.notify_nexus_about_self(&log);
                     }
                     HardwareUpdate::TofinoLoaded => {
+                        let baseboard = self.inner.hardware.baseboard();
                         let switch_zone_ip = Some(self.inner.switch_zone_ip());
                         if let Err(e) = self
                             .inner
                             .services
-                            .activate_switch(switch_zone_ip)
+                            .activate_switch(switch_zone_ip, baseboard)
                             .await
                         {
                             warn!(log, "Failed to activate switch: {e}");

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -73,7 +73,7 @@ pub enum SledMode {
 }
 
 /// Describes properties that should uniquely identify a Gimlet.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Baseboard {
     identifier: String,
     model: String,

--- a/smf/wicketd/manifest.xml
+++ b/smf/wicketd/manifest.xml
@@ -12,7 +12,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/wicketd/bin/wicketd run /var/svc/manifest/site/wicketd/config.toml --address %{config/address} --artifact-address %{config/artifact-address} --mgs-address %{config/mgs-address}  &amp;'
+      exec='ctrun -l child -o noorphan,regent /opt/oxide/wicketd/bin/wicketd run /var/svc/manifest/site/wicketd/config.toml --address %{config/address} --artifact-address %{config/artifact-address} --mgs-address %{config/mgs-address} --baseboard-identifier %{config/baseboard-identifier} --baseboard-model %{config/baseboard-model} --baseboard-revision %{config/baseboard-revision} &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 
@@ -24,6 +24,9 @@
     <propval name='address' type='astring' value='unknown' />
     <propval name='artifact-address' type='astring' value='unknown' />
     <propval name='mgs-address' type='astring' value='unknown' />
+    <propval name='baseboard-identifier' type='astring' value='unknown' />
+    <propval name='baseboard-model' type='astring' value='unknown' />
+    <propval name='baseboard-revision' type='astring' value='unknown' />
   </property_group>
 
   <stability value='Unstable' />

--- a/tools/ci_download_dendrite_openapi
+++ b/tools/ci_download_dendrite_openapi
@@ -6,7 +6,9 @@
 
 set -o pipefail
 set -o xtrace
-set -o errexit
+set -o errtrace
+
+trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ARG0="$(basename ${BASH_SOURCE[0]})"

--- a/tools/ci_download_dendrite_openapi
+++ b/tools/ci_download_dendrite_openapi
@@ -6,9 +6,7 @@
 
 set -o pipefail
 set -o xtrace
-set -o errtrace
-
-trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ARG0="$(basename ${BASH_SOURCE[0]})"

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -70,8 +70,8 @@ function retry
   attempts="${RETRY_ATTEMPTS}"
   # Always try at least once
   attempts=$((attempts < 1 ? 1 : attempts))
-  retry_rc=0
   for i in $(seq 1 $attempts); do
+    retry_rc=0
     "$@" || retry_rc=$?;
     if [[ "$retry_rc" -eq 0 ]]; then
       return

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -39,6 +39,7 @@ gateway-client.workspace = true
 installinator-artifactd.workspace = true
 installinator-common.workspace = true
 omicron-common.workspace = true
+sled-hardware.workspace = true
 tufaceous-lib.workspace = true
 update-engine.workspace = true
 

--- a/wicketd/src/bin/wicketd.rs
+++ b/wicketd/src/bin/wicketd.rs
@@ -85,9 +85,15 @@ async fn do_run() -> Result<(), CmdError> {
             mgs_address,
             baseboard,
         } => {
-            let baseboard = baseboard
-                .map(sled_hardware::Baseboard::from)
-                .unwrap_or_else(sled_hardware::Baseboard::unknown);
+            let mut baseboard = baseboard.map(sled_hardware::Baseboard::from);
+
+            // TODO-correctness `Baseboard::unknown()` is slated for removal
+            // after some refactoring in sled-agent, at which point we'll need a
+            // different way for sled-agent to tell us it doesn't know our
+            // baseboard.
+            if baseboard == Some(sled_hardware::Baseboard::unknown()) {
+                baseboard = None;
+            }
 
             let config = Config::from_file(&config_file_path).map_err(|e| {
                 CmdError::Failure(format!(

--- a/wicketd/src/context.rs
+++ b/wicketd/src/context.rs
@@ -7,9 +7,6 @@
 use crate::artifacts::WicketdArtifactStore;
 use crate::update_tracker::UpdateTracker;
 use crate::MgsHandle;
-use gateway_client::types::SpIdentifier;
-use gateway_client::types::SpState;
-use gateway_client::types::SpType;
 use sled_hardware::Baseboard;
 
 /// Shared state used by API handlers
@@ -18,34 +15,5 @@ pub struct ServerContext {
     pub mgs_client: gateway_client::Client,
     pub(crate) artifact_store: WicketdArtifactStore,
     pub(crate) update_tracker: UpdateTracker,
-    pub(crate) baseboard: Baseboard,
-}
-
-impl ServerContext {
-    pub(crate) fn can_update_target_sp(
-        &self,
-        id: SpIdentifier,
-        state: &SpState,
-    ) -> bool {
-        // If we failed don't know our own baseboard, fall back to just using
-        // the id, from which we know whether or not the target sled is one
-        // of the scrimlets. If it is, refuse to update, because it might be
-        // where we're running now.
-        if self.baseboard == Baseboard::unknown() {
-            !is_scrimlet(id)
-        } else {
-            // Otherwise, we can update this SP as long as it isn't ours.
-            self.baseboard.identifier() != state.serial_number
-                || self.baseboard.model() != state.model
-                || self.baseboard.revision() != i64::from(state.revision)
-        }
-    }
-}
-
-/// TODO-correctness This function hardcodes the cubby locations that identify
-/// scrimlets. This may be wrong in the future! We only use it as a fallback if
-/// we aren't given a baseboard when we're launched by sled-agen; we should
-/// decide if there's a more futureproof way to handle that failure.
-fn is_scrimlet(id: SpIdentifier) -> bool {
-    matches!((id.type_, id.slot), (SpType::Sled, 14 | 16))
+    pub(crate) baseboard: Option<Baseboard>,
 }

--- a/wicketd/src/context.rs
+++ b/wicketd/src/context.rs
@@ -7,6 +7,10 @@
 use crate::artifacts::WicketdArtifactStore;
 use crate::update_tracker::UpdateTracker;
 use crate::MgsHandle;
+use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpState;
+use gateway_client::types::SpType;
+use sled_hardware::Baseboard;
 
 /// Shared state used by API handlers
 pub struct ServerContext {
@@ -14,4 +18,34 @@ pub struct ServerContext {
     pub mgs_client: gateway_client::Client,
     pub(crate) artifact_store: WicketdArtifactStore,
     pub(crate) update_tracker: UpdateTracker,
+    pub(crate) baseboard: Baseboard,
+}
+
+impl ServerContext {
+    pub(crate) fn can_update_target_sp(
+        &self,
+        id: SpIdentifier,
+        state: &SpState,
+    ) -> bool {
+        // If we failed don't know our own baseboard, fall back to just using
+        // the id, from which we know whether or not the target sled is one
+        // of the scrimlets. If it is, refuse to update, because it might be
+        // where we're running now.
+        if self.baseboard == Baseboard::unknown() {
+            !is_scrimlet(id)
+        } else {
+            // Otherwise, we can update this SP as long as it isn't ours.
+            self.baseboard.identifier() != state.serial_number
+                || self.baseboard.model() != state.model
+                || self.baseboard.revision() != i64::from(state.revision)
+        }
+    }
+}
+
+/// TODO-correctness This function hardcodes the cubby locations that identify
+/// scrimlets. This may be wrong in the future! We only use it as a fallback if
+/// we aren't given a baseboard when we're launched by sled-agen; we should
+/// decide if there's a more futureproof way to handle that failure.
+fn is_scrimlet(id: SpIdentifier) -> bool {
+    matches!((id.type_, id.slot), (SpType::Sled, 14 | 16))
 }

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -150,6 +150,7 @@ async fn post_start_update(
     target: Path<SpIdentifier>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let rqctx = rqctx.context();
+    let target = target.into_inner();
 
     // Do we have a plan with which we can apply updates (i.e., has a valid TUF
     // repository been uploaded)?
@@ -165,13 +166,65 @@ async fn post_start_update(
         )
     })?;
 
+    // Can we update the target SP? We refuse to update if:
+    //
+    // 1. We haven't pulled its state in our inventory (most likely cause: the
+    //    cubby is empty; less likely cause: the SP is misbehaving, which will
+    //    make updating it very unlikely to work anyway)
+    // 2. We have pulled its state but our hardware manager says we can't update
+    //    it (most likely cause: the target is the sled we're currently running
+    //    on; less likely cause: our hardware manager failed to get our local
+    //    identifying information, and it refuses to update this target out of
+    //    an abundance of caution).
+    //
+    // First, get our most-recently-cached inventory view.
+    let inventory = match rqctx.mgs_handle.get_inventory(Vec::new()).await {
+        Ok(inventory) => inventory,
+        Err(GetInventoryError::ShutdownInProgress) => {
+            return Err(HttpError::for_unavail(
+                None,
+                "Server is shutting down".into(),
+            ));
+        }
+        // We didn't specify any SP ids to refresh, so this error is impossible.
+        Err(GetInventoryError::InvalidSpIdentifier) => unreachable!(),
+    };
+
+    // Next, do we have the state of the target SP?
+    let sp_state = match inventory {
+        GetInventoryResponse::Response { inventory, .. } => inventory
+            .sps
+            .into_iter()
+            .filter_map(|sp| if sp.id == target { sp.state } else { None })
+            .next(),
+        GetInventoryResponse::Unavailable => None,
+    };
+
+    match sp_state {
+        Some(sp_state) => {
+            // If we have the state of the SP, are we allowed to update it?
+            if !rqctx.can_update_target_sp(target, &sp_state) {
+                return Err(HttpError::for_bad_request(
+                    None,
+                    "sleds cannot update themselves".into(),
+                ));
+            }
+        }
+        None => {
+            return Err(HttpError::for_bad_request(
+                None,
+                "cannot update target sled (no inventory state present?)"
+                    .into(),
+            ));
+        }
+    }
+
     // Generate an ID for this update; the update tracker will send it to the
     // sled as part of the InstallinatorImageId, and installinator will send it
     // back to our artifact server with its progress reports.
     let update_id = Uuid::new_v4();
 
-    match rqctx.update_tracker.start(target.into_inner(), plan, update_id).await
-    {
+    match rqctx.update_tracker.start(target, plan, update_id).await {
         Ok(()) => Ok(HttpResponseUpdatedNoContent {}),
         Err(err) => Err(err.to_http_error()),
     }

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -20,6 +20,7 @@ pub use installinator_progress::{IprUpdateTracker, RunningUpdateState};
 pub use inventory::{RackV1Inventory, SpInventory};
 use mgs::make_mgs_client;
 pub(crate) use mgs::{MgsHandle, MgsManager};
+use sled_hardware::Baseboard;
 
 use dropshot::{ConfigDropshot, HttpServer};
 use slog::{debug, error, o, Drain};
@@ -43,6 +44,7 @@ pub struct Args {
     pub address: SocketAddrV6,
     pub artifact_address: SocketAddrV6,
     pub mgs_address: SocketAddrV6,
+    pub baseboard: Baseboard,
 }
 
 pub struct Server {
@@ -101,6 +103,7 @@ impl Server {
                     mgs_client,
                     artifact_store: store.clone(),
                     update_tracker,
+                    baseboard: args.baseboard,
                 },
                 &log,
             )

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -44,7 +44,7 @@ pub struct Args {
     pub address: SocketAddrV6,
     pub artifact_address: SocketAddrV6,
     pub mgs_address: SocketAddrV6,
-    pub baseboard: Baseboard,
+    pub baseboard: Option<Baseboard>,
 }
 
 pub struct Server {

--- a/wicketd/tests/integration_tests/setup.rs
+++ b/wicketd/tests/integration_tests/setup.rs
@@ -8,6 +8,7 @@ use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use dropshot::test_util::ClientTestContext;
 use gateway_test_utils::setup::GatewayTestContext;
+use sled_hardware::Baseboard;
 
 pub struct WicketdTestContext {
     pub wicketd_addr: SocketAddrV6,
@@ -40,6 +41,7 @@ impl WicketdTestContext {
             address: localhost_port_0,
             artifact_address: localhost_port_0,
             mgs_address,
+            baseboard: Baseboard::unknown(),
         };
 
         let server = wicketd::Server::start(log.clone(), args)

--- a/wicketd/tests/integration_tests/setup.rs
+++ b/wicketd/tests/integration_tests/setup.rs
@@ -8,7 +8,6 @@ use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use dropshot::test_util::ClientTestContext;
 use gateway_test_utils::setup::GatewayTestContext;
-use sled_hardware::Baseboard;
 
 pub struct WicketdTestContext {
     pub wicketd_addr: SocketAddrV6,
@@ -41,7 +40,7 @@ impl WicketdTestContext {
             address: localhost_port_0,
             artifact_address: localhost_port_0,
             mgs_address,
-            baseboard: Baseboard::unknown(),
+            baseboard: None,
         };
 
         let server = wicketd::Server::start(log.clone(), args)


### PR DESCRIPTION
The point of the PR is in 49af4230ba1f8927ca85ece8c1200d6397aab8ba: wicketd now refuses to update the sled on which it is running, by comparing the baseboard info it retries from the SP of the to-be-updated sled against the baseboard info of its own host. However, the _bulk_ of the PR is in 917996fa10fa9659f28040ffbbdf51f2b82766a6, which plumbs that baseboard info through sled-agent down into wicketd. A nontrivial byproduct of this is the addition of `#[serde(skip)]` on several `ServiceType` variants that should not be passed in from external clients (i.e., services that sled agent itself is responsible for starting autonomously, either in the gz (maghemite) or in the switch zone (the rest)).

Builds on #2939 