### PR TITLE
nexus: don't error on omitted signing_keypair SamlIdentityProviderCreate

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -571,6 +571,7 @@ pub struct SamlIdentityProviderCreate {
     pub technical_contact_email: String,
 
     /// request signing key pair
+    #[serde(default)]
     #[serde(deserialize_with = "validate_key_pair")]
     pub signing_keypair: Option<DerEncodedKeyPair>,
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10900,6 +10900,7 @@
           "signing_keypair": {
             "nullable": true,
             "description": "request signing key pair",
+            "default": null,
             "allOf": [
               {
                 "$ref": "#/components/schemas/DerEncodedKeyPair"


### PR DESCRIPTION
A different behind the scenes demo fix. The console doesn't have fields for providing a signing keypair but it's meant to be optional.

The default deserialization behaviour is to set a field to it's default value if it's not present so we'd expect `None` if the request didn't include `signing_keypair`. But `#[serde(deserialize_with = ...)]` changes that subtly such that `None` is present but empty / null. We can use `#[serde(default)]` to make it more permissive. I don't think we need to distinguish between "not present" vs "present but empty/null".