### PR TITLE
[installinator] Write host OS to M.2 block device in appropriately-sized chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,6 +3206,7 @@ dependencies = [
  "omicron-test-utils",
  "once_cell",
  "partial-io",
+ "pin-project-lite",
  "progenitor-client",
  "proptest",
  "reqwest",

--- a/illumos-utils/src/dkio.rs
+++ b/illumos-utils/src/dkio.rs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Utilities for interacting with disk control operations (`man dkio`).
+
+use std::io;
+
+use libc::c_int;
+use libc::c_uint;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MediaInfoExtended {
+    pub media_type: MediaType,
+    pub logical_block_size: u32,
+    /// Capacity is in units of logical blocks.
+    pub capacity: u64,
+    pub physical_block_size: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaType {
+    Unknown,
+    MoErasable,
+    MoWriteOnce,
+    AsMo,
+    Cdrom,
+    Cdr,
+    Cdrw,
+    Dvdrom,
+    Dvdr,
+    Dvdram,
+    FixedDisk,
+    Floppy,
+    Zip,
+    Jaz,
+}
+
+impl MediaInfoExtended {
+    pub fn from_fd(fd: i32) -> Result<Self, io::Error> {
+        let mut minfo = dk_minfo_ext::default();
+
+        // Safety: We are issuing the `DKIOCGMEDIAINFOEXT` ioctl which is
+        // documented to take a struct of type `dk_minfo_ext`. Assuming our type
+        // definitions below (which are a combination of man page details and
+        // headers) are correct, this call is safe.
+        let rc =
+            unsafe { libc::ioctl(fd, DKIOCGMEDIAINFOEXT as _, &mut minfo) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let media_type = match minfo.dki_media_type {
+            DK_MO_ERASABLE => MediaType::MoErasable,
+            DK_MO_WRITEONCE => MediaType::MoWriteOnce,
+            DK_AS_MO => MediaType::AsMo,
+            DK_CDROM => MediaType::Cdrom,
+            DK_CDR => MediaType::Cdr,
+            DK_CDRW => MediaType::Cdrw,
+            DK_DVDROM => MediaType::Dvdrom,
+            DK_DVDR => MediaType::Dvdr,
+            DK_DVDRAM => MediaType::Dvdram,
+            DK_FIXED_DISK => MediaType::FixedDisk,
+            DK_FLOPPY => MediaType::Floppy,
+            DK_ZIP => MediaType::Zip,
+            DK_JAZ => MediaType::Jaz,
+            _ => MediaType::Unknown,
+        };
+
+        Ok(Self {
+            media_type,
+            logical_block_size: minfo.dki_lbsize,
+            capacity: minfo.dki_capacity,
+            physical_block_size: minfo.dki_pbsize,
+        })
+    }
+}
+
+// Types and constants from `man dkio` under `DKIOCGMEDIAINFOEXT`
+
+#[derive(Debug, Default, Clone, Copy)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct dk_minfo_ext {
+    dki_media_type: c_uint,
+    dki_lbsize: c_uint,
+    dki_capacity: diskaddr_t,
+    dki_pbsize: c_uint,
+}
+
+// We map all unknown values to `Unknown`, including `DK_UNKNOWN`, so we prefix
+// it with `_` to show it's not forgotten but not used.
+const _DK_UNKNOWN: c_uint = 0x00; /* Media inserted - type unknown */
+
+const DK_MO_ERASABLE: c_uint = 0x03; /* MO Erasable */
+const DK_MO_WRITEONCE: c_uint = 0x04; /* MO Write once */
+const DK_AS_MO: c_uint = 0x05; /* AS MO */
+const DK_CDROM: c_uint = 0x08; /* CDROM */
+const DK_CDR: c_uint = 0x09; /* CD-R */
+const DK_CDRW: c_uint = 0x0A; /* CD-RW */
+const DK_DVDROM: c_uint = 0x10; /* DVD-ROM */
+const DK_DVDR: c_uint = 0x11; /* DVD-R */
+const DK_DVDRAM: c_uint = 0x12; /* DVD_RAM or DVD-RW */
+
+const DK_FIXED_DISK: c_uint = 0x10001; /* Fixed disk SCSI or otherwise */
+const DK_FLOPPY: c_uint = 0x10002; /* Floppy media */
+const DK_ZIP: c_uint = 0x10003; /* IOMEGA ZIP media */
+const DK_JAZ: c_uint = 0x10004; /* IOMEGA JAZ media */
+
+// Related types and constants from `/usr/include/sys/types.h`
+
+#[allow(non_camel_case_types)]
+type diskaddr_t = libc::c_ulonglong;
+
+// Related types and constants from `/usr/include/sys/dkio.h`
+
+const DKIOC: c_int = 0x04 << 8;
+const DKIOCGMEDIAINFOEXT: c_int = DKIOC | 48;

--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -8,6 +8,7 @@ use cfg_if::cfg_if;
 
 pub mod addrobj;
 pub mod destructor;
+pub mod dkio;
 pub mod dladm;
 pub mod fstyp;
 pub mod link;

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -23,6 +23,7 @@ ipcc-key-value.workspace = true
 itertools.workspace = true
 once_cell.workspace = true
 omicron-common.workspace = true
+pin-project-lite.workspace = true
 progenitor-client.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/installinator/src/block_size_writer.rs
+++ b/installinator/src/block_size_writer.rs
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use pin_project_lite::pin_project;
+use std::io;
+use std::pin::Pin;
+use std::task::ready;
+use std::task::Context;
+use std::task::Poll;
+use tokio::io::AsyncWrite;
+
+pin_project! {
+    /// `BlockSizeWriter` is analogous to a tokio's `BufWriter`, except it
+    /// guarantees that writes made to the underlying writer are always
+    /// _exactly_ the requested block size, with two exceptions: explicitly
+    /// calling (1) `flush()` or (2) `shutdown()` will write any
+    /// buffered-but-not-yet-written data to the underlying buffer regardless of
+    /// its length.
+    pub(crate) struct BlockSizeWriter<W> {
+        #[pin]
+        inner: W,
+        buf: Vec<u8>,
+        block_size: usize,
+    }
+}
+
+impl<W: AsyncWrite> BlockSizeWriter<W> {
+    pub(crate) fn with_block_size(block_size: usize, inner: W) -> Self {
+        Self { inner, buf: Vec::with_capacity(block_size), block_size }
+    }
+
+    #[cfg(test)]
+    fn into_inner(self) -> W {
+        self.inner
+    }
+
+    fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().inner
+    }
+
+    fn flush_buf(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        let mut me = self.project();
+        let mut written = 0;
+        let mut ret = Ok(());
+        while written < me.buf.len() {
+            match ready!(me.inner.as_mut().poll_write(cx, &me.buf[written..])) {
+                Ok(0) => {
+                    ret = Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write the buffered data",
+                    ));
+                    break;
+                }
+                Ok(n) => written += n,
+                Err(e) => {
+                    ret = Err(e);
+                    break;
+                }
+            }
+        }
+        if written > 0 {
+            me.buf.drain(..written);
+        }
+        Poll::Ready(ret)
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for BlockSizeWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        // We should never buffer up more than `block_size` data.
+        assert!(self.buf.len() <= self.block_size);
+
+        // If we already have exactly `block_size` bytes, begin by flushing.
+        if self.buf.len() == self.block_size {
+            ready!(self.as_mut().flush_buf(cx))?;
+        }
+
+        let me = self.project();
+        if me.buf.is_empty() {
+            // If our buffer is empty, either directly write `block_size` bytes
+            // from `buf` to `inner` (if there's enough data in `buf`) or just
+            // copy it into our buffer.
+            if buf.len() >= *me.block_size {
+                me.inner.poll_write(cx, &buf[..*me.block_size])
+            } else {
+                // `me.buf` is empty and `buf` is strictly less than
+                // `self.block_size`, so just copy it.
+                me.buf.extend_from_slice(buf);
+                Poll::Ready(Ok(buf.len()))
+            }
+        } else {
+            // Our buffer already has data - just copy as much of `buf` as we
+            // can onto the end of it.
+            let n = usize::min(*me.block_size - me.buf.len(), buf.len());
+            me.buf.extend_from_slice(&buf[..n]);
+            Poll::Ready(Ok(n))
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.get_pin_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.get_pin_mut().poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::with_test_runtime;
+    use anyhow::Result;
+    use test_strategy::proptest;
+    use tokio::io::AsyncWriteExt;
+
+    // Dummy `AsyncWrite` that always accepts all data and keeps track of the
+    // sizes of the buffers it was given to write.
+    #[derive(Debug, Default)]
+    struct InnerWriter {
+        data: Vec<u8>,
+        write_requests: Vec<usize>,
+    }
+
+    impl AsyncWrite for InnerWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            self.data.extend_from_slice(buf);
+            self.write_requests.push(buf.len());
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[proptest]
+    fn proptest_block_writer(
+        chunks: Vec<Vec<u8>>,
+        #[strategy((16_usize..4096))] block_size: usize,
+    ) {
+        with_test_runtime(move || async move {
+            proptest_block_writer_impl(chunks, block_size)
+                .await
+                .expect("test failed");
+        })
+    }
+
+    async fn proptest_block_writer_impl(
+        chunks: Vec<Vec<u8>>,
+        block_size: usize,
+    ) -> Result<()> {
+        // Construct our block writer.
+        let inner = InnerWriter::default();
+        let mut block_writer =
+            BlockSizeWriter::with_block_size(block_size, inner);
+        let mut expected_data = Vec::new();
+
+        // Feed all chunks into it.
+        for chunk in chunks {
+            expected_data.extend_from_slice(&chunk);
+            block_writer.write_all(&chunk).await.unwrap();
+        }
+        block_writer.flush().await.unwrap();
+
+        let inner = block_writer.into_inner();
+
+        // Check properties: the underlying writer should have received all the
+        // data of `chunks` in order...
+        assert_eq!(inner.data, expected_data);
+
+        // ...and all writes to it (except the last) should be exactly the block
+        // size; the last should be at most the block size.
+        if !inner.write_requests.is_empty() {
+            let last = inner.write_requests.len() - 1;
+            assert!(
+                inner.write_requests[last]
+                    <= block_size,
+                "last block size too large (expected at most {block_size}, got {})",
+                inner.write_requests[last],
+            );
+            for (i, &wr) in inner.write_requests.iter().take(last).enumerate() {
+                assert_eq!(
+                    wr,
+                    block_size,
+                    "write request {i} had size {wr} (expected block size {block_size})",
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/installinator/src/block_size_writer.rs
+++ b/installinator/src/block_size_writer.rs
@@ -17,6 +17,10 @@ pin_project! {
     /// calling (1) `flush()` or (2) `shutdown()` will write any
     /// buffered-but-not-yet-written data to the underlying buffer regardless of
     /// its length.
+    ///
+    /// When `BlockSizeWriter` is dropped, any buffered data its holding will be
+    /// discarded. It is critical to manually call `BlockSizeWriter:flush()`
+    /// or `BlockSizeWriter::shutdown()` prior to dropping to avoid data loss.
     pub(crate) struct BlockSizeWriter<W> {
         #[pin]
         inner: W,

--- a/installinator/src/block_size_writer.rs
+++ b/installinator/src/block_size_writer.rs
@@ -18,8 +18,8 @@ pin_project! {
     /// buffered-but-not-yet-written data to the underlying buffer regardless of
     /// its length.
     ///
-    /// When `BlockSizeWriter` is dropped, any buffered data its holding will be
-    /// discarded. It is critical to manually call `BlockSizeWriter:flush()`
+    /// When `BlockSizeWriter` is dropped, any buffered data it's holding will
+    /// be discarded. It is critical to manually call `BlockSizeWriter:flush()`
     /// or `BlockSizeWriter::shutdown()` prior to dropping to avoid data loss.
     pub(crate) struct BlockSizeWriter<W> {
         #[pin]

--- a/installinator/src/lib.rs
+++ b/installinator/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod artifact;
+mod block_size_writer;
 mod bootstrap;
 mod dispatch;
 mod errors;

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -476,7 +476,7 @@ impl WriteTransport for FileTransport {
         tokio::fs::OpenOptions::new()
             .create(create)
             .write(true)
-            .truncate(true)
+            .truncate(create)
             .open(destination)
             .await
             .map_err(|error| WriteError {

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -23,7 +23,7 @@ use omicron_common::update::ArtifactHashId;
 use slog::{info, warn, Logger};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
-use crate::{block_size_writer::BlockSizeWriter, hardware::Hardware};
+use crate::{block_size_writer::BlockSizeBufWriter, hardware::Hardware};
 
 #[derive(Clone, Debug)]
 struct ArtifactDestination {
@@ -527,7 +527,7 @@ struct BlockDeviceTransport;
 
 #[async_trait]
 impl WriteTransport for BlockDeviceTransport {
-    type W = BlockSizeWriter<tokio::fs::File>;
+    type W = BlockSizeBufWriter<tokio::fs::File>;
 
     async fn make_writer(
         &mut self,
@@ -580,7 +580,7 @@ impl WriteTransport for BlockDeviceTransport {
             });
         }
 
-        Ok(BlockSizeWriter::with_block_size(block_size as usize, f))
+        Ok(BlockSizeBufWriter::with_block_size(block_size as usize, f))
     }
 }
 


### PR DESCRIPTION
This adds a couple utility modules:

* `illumos_utils::dkio` contains a wrapper for the `dkio` ioctl we need to call to ask a device what its block size is.
* `installinator::block_size_writer` implements an `AsyncWrite` adapter that buffers data and always passes exactly block-size bytes down to its inner writer (except when explicitly flushed).

and then uses them in `installinator` to ensure that when we've found the host OS destination by scanning hardware for M.2s, we configure our writing transport to use a block-size writer configured for the target device.

Builds on #2949.