### PR TITLE
[sled-agent] Allow synthetic disks to be used as M.2s and U.2s.

### DIFF
--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -230,11 +230,9 @@ impl StorageResources {
         disks
             .values()
             .filter_map(|disk| {
-                if let DiskWrapper::Real { disk, .. } = disk {
-                    if disk.variant() == variant {
-                        return Some(disk.zpool_name().clone());
-                    }
-                };
+                if disk.variant() == variant {
+                    return Some(disk.zpool_name().clone());
+                }
                 None
             })
             .collect()


### PR DESCRIPTION
This fixes a bug where the internal zpools created by `./tools/create_virtual_hardware.sh` were ignored by the sled agent - this utility is used in other locations to access "m.2 datasets".