### PR TITLE
[sled-hardware] Add `is_book_disk` property to disks

### DIFF
--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -138,6 +138,7 @@ pub struct UnparsedDisk {
     slot: i64,
     variant: DiskVariant,
     identity: DiskIdentity,
+    is_boot_disk: bool,
 }
 
 impl UnparsedDisk {
@@ -148,12 +149,14 @@ impl UnparsedDisk {
         slot: i64,
         variant: DiskVariant,
         identity: DiskIdentity,
+        is_boot_disk: bool,
     ) -> Self {
         Self {
             paths: DiskPaths { devfs_path, dev_path },
             slot,
             variant,
             identity,
+            is_boot_disk,
         }
     }
 
@@ -177,6 +180,7 @@ pub struct Disk {
     slot: i64,
     variant: DiskVariant,
     identity: DiskIdentity,
+    is_boot_disk: bool,
     partitions: Vec<Partition>,
 
     // This embeds the assumtion that there is exactly one parsed zpool per
@@ -249,6 +253,7 @@ impl Disk {
             slot: unparsed_disk.slot,
             variant: unparsed_disk.variant,
             identity: unparsed_disk.identity,
+            is_boot_disk: unparsed_disk.is_boot_disk,
             partitions,
             zpool_name,
         })
@@ -337,6 +342,10 @@ impl Disk {
             )?;
         }
         Ok(())
+    }
+
+    pub fn is_boot_disk(&self) -> bool {
+        self.is_boot_disk
     }
 
     pub fn identity(&self) -> &DiskIdentity {

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -37,6 +37,9 @@ enum Error {
     #[error("Node {node} missing device property {name}")]
     MissingDeviceProperty { node: String, name: String },
 
+    #[error("Invalid value for boot-storage-unit property: {0}")]
+    InvalidBootStorageUnitValue(i64),
+
     #[error("Unrecognized slot for device {slot}")]
     UnrecognizedSlot { slot: i64 },
 
@@ -75,6 +78,25 @@ impl TofinoSnapshot {
     }
 }
 
+// Which BSU (i.e., host flash rom) slot did we boot from?
+#[derive(Debug, Clone, Copy)]
+enum BootStorageUnit {
+    A,
+    B,
+}
+
+impl TryFrom<i64> for BootStorageUnit {
+    type Error = Error;
+
+    fn try_from(raw: i64) -> Result<Self, Self::Error> {
+        match raw {
+            0x41 => Ok(Self::A),
+            0x42 => Ok(Self::B),
+            _ => Err(Error::InvalidBootStorageUnitValue(raw)),
+        }
+    }
+}
+
 // A snapshot of information about the underlying hardware
 struct HardwareSnapshot {
     tofino: TofinoSnapshot,
@@ -101,13 +123,20 @@ impl HardwareSnapshot {
 
         let properties = find_properties(
             &root,
-            ["baseboard-identifier", "baseboard-model", "baseboard-revision"],
+            [
+                "baseboard-identifier",
+                "baseboard-model",
+                "baseboard-revision",
+                "boot-storage-unit",
+            ],
         )?;
         let baseboard = Baseboard::new(
             string_from_property(&properties[0])?,
             string_from_property(&properties[1])?,
             i64_from_property(&properties[2])?,
         );
+        let boot_storage_unit =
+            BootStorageUnit::try_from(i64_from_property(&properties[3])?)?;
 
         // Monitor for the Tofino device and driver.
         let tofino = get_tofino_snapshot(log, &mut device_info);
@@ -118,7 +147,7 @@ impl HardwareSnapshot {
         while let Some(node) =
             node_walker.next().transpose().map_err(Error::DevInfo)?
         {
-            poll_blkdev_node(&log, &mut disks, node)?;
+            poll_blkdev_node(&log, &mut disks, node, boot_storage_unit)?;
         }
 
         Ok(Self { tofino, disks, baseboard })
@@ -237,6 +266,14 @@ fn slot_to_disk_variant(slot: i64) -> Option<DiskVariant> {
         0x00..=0x09 => Some(DiskVariant::U2),
         0x11..=0x12 => Some(DiskVariant::M2),
         _ => None,
+    }
+}
+
+fn slot_is_boot_disk(slot: i64, boot_storage_unit: BootStorageUnit) -> bool {
+    match (boot_storage_unit, slot) {
+        // See reference for these values in `slot_to_disk_variant` above.
+        (BootStorageUnit::A, 0x11) | (BootStorageUnit::B, 0x12) => true,
+        _ => false,
     }
 }
 
@@ -377,6 +414,7 @@ fn poll_blkdev_node(
     log: &Logger,
     disks: &mut HashSet<UnparsedDisk>,
     node: Node<'_>,
+    boot_storage_unit: BootStorageUnit,
 ) -> Result<(), Error> {
     let Some(driver_name) = node.driver_name() else {
         return Ok(());
@@ -448,6 +486,7 @@ fn poll_blkdev_node(
         slot,
         variant,
         device_id,
+        slot_is_boot_disk(slot, boot_storage_unit),
     );
     disks.insert(disk);
     Ok(())


### PR DESCRIPTION
Building block necessary to solve #2989.

Running a `HardwareManager` on a gimlet that booted off of bsu slot 0 (the M2 in slot 17 is marked as the boot disk):

```
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@1,3/pci1344,3100@0/blkdev@w00A0750132752F12,0", dev_path: Some("/dev/dsk/c1t00A0750132752F12d0") }, slot: 17, variant: M2, identity: DiskIdentity { vendor: "1344", serial: "214132752F12", model: "Micron_7300_MTFDHBG1T9TDF" }, is_boot_disk: true }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,1/pci1b96,0@0/blkdev@w0014EE81000D2E59,0", dev_path: Some("/dev/dsk/c8t0014EE81000D2E59d0") }, slot: 0, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A693", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,3/pci1b96,0@0/blkdev@w0014EE81000D306A,0", dev_path: Some("/dev/dsk/c10t0014EE81000D306Ad0") }, slot: 2, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A5AC", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,2/pci1b96,0@0/blkdev@w0014EE81000D2E57,0", dev_path: Some("/dev/dsk/c2t0014EE81000D2E57d0") }, slot: 6, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A691", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,2/pci1b96,0@0/blkdev@w0014EE81000D2E5C,0", dev_path: Some("/dev/dsk/c9t0014EE81000D2E5Cd0") }, slot: 1, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A69A", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,4/pci1b96,0@0/blkdev@w0014EE81000D2EA3,0", dev_path: Some("/dev/dsk/c4t0014EE81000D2EA3d0") }, slot: 4, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A67D", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,4/pci1b96,0@0/blkdev@w0014EE81000D2EF9,0", dev_path: Some("/dev/dsk/c11t0014EE81000D2EF9d0") }, slot: 3, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A657", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,3/pci1b96,0@0/blkdev@w0014EE81000D2E77,0", dev_path: Some("/dev/dsk/c3t0014EE81000D2E77d0") }, slot: 5, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A651", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@3,3/pci1344,3100@0/blkdev@w00A0750132748127,0", dev_path: Some("/dev/dsk/c7t00A0750132748127d0") }, slot: 18, variant: M2, identity: DiskIdentity { vendor: "1344", serial: "214132748127", model: "Micron_7300_MTFDHBG1T9TDF" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@1,2/pci1b96,0@0/blkdev@w0014EE81000D2E65,0", dev_path: Some("/dev/dsk/c5t0014EE81000D2E65d0") }, slot: 8, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A63F", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@1,3/pci1b96,0@0/blkdev@w0014EE81000D2E79,0", dev_path: Some("/dev/dsk/c6t0014EE81000D2E79d0") }, slot: 7, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A653", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
```

and on a gimlet that booted off of bsu slot 1 (M2 in slot 18 is marked as the boot disk):

```
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,1/pci1b96,0@0/blkdev@w0014EE81000D2E59,0", dev_path: Some("/dev/dsk/c8t0014EE81000D2E59d0") }, slot: 0, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A693", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@3,3/pci1344,3100@0/blkdev@w00A0750132748127,0", dev_path: None }, slot: 18, variant: M2, identity: DiskIdentity { vendor: "1344", serial: "214132748127", model: "Micron_7300_MTFDHBG1T9TDF" }, is_boot_disk: true }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,2/pci1b96,0@0/blkdev@w0014EE81000D2E5C,0", dev_path: Some("/dev/dsk/c9t0014EE81000D2E5Cd0") }, slot: 1, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A69A", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,3/pci1b96,0@0/blkdev@w0014EE81000D306A,0", dev_path: Some("/dev/dsk/c10t0014EE81000D306Ad0") }, slot: 2, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A5AC", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@1,3/pci1b96,0@0/blkdev@w0014EE81000D2E79,0", dev_path: Some("/dev/dsk/c6t0014EE81000D2E79d0") }, slot: 7, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A653", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,4/pci1b96,0@0/blkdev@w0014EE81000D2EA3,0", dev_path: Some("/dev/dsk/c4t0014EE81000D2EA3d0") }, slot: 4, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A67D", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,3/pci1b96,0@0/blkdev@w0014EE81000D2E77,0", dev_path: Some("/dev/dsk/c3t0014EE81000D2E77d0") }, slot: 5, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A651", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@ab,0/pci1022,1483@1,4/pci1b96,0@0/blkdev@w0014EE81000D2EF9,0", dev_path: Some("/dev/dsk/c11t0014EE81000D2EF9d0") }, slot: 3, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A657", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@1,3/pci1344,3100@0/blkdev@w00A0750132752F12,0", dev_path: Some("/dev/dsk/c1t00A0750132752F12d0") }, slot: 17, variant: M2, identity: DiskIdentity { vendor: "1344", serial: "214132752F12", model: "Micron_7300_MTFDHBG1T9TDF" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@0,0/pci1022,1483@3,2/pci1b96,0@0/blkdev@w0014EE81000D2E57,0", dev_path: Some("/dev/dsk/c2t0014EE81000D2E57d0") }, slot: 6, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A691", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
UnparsedDisk { paths: DiskPaths { devfs_path: "/devices/pci@38,0/pci1022,1483@1,2/pci1b96,0@0/blkdev@w0014EE81000D2E65,0", dev_path: Some("/dev/dsk/c5t0014EE81000D2E65d0") }, slot: 8, variant: U2, identity: DiskIdentity { vendor: "1b96", serial: "A084A63F", model: "WUS4C6432DSP3X3" }, is_boot_disk: false }
```
