### PR TITLE
set RUST_BACKTRACE=1 when running tests

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -63,7 +63,7 @@ ptime -m cargo build --locked --all-targets --verbose
 #
 
 banner test
-ptime -m cargo test --locked --verbose --no-fail-fast
+RUST_BACKTRACE=1 ptime -m cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -63,7 +63,7 @@ ptime -m cargo build --locked --all-targets --verbose
 #
 
 banner test
-ptime -m cargo test --locked --verbose --no-fail-fast
+RUST_BACKTRACE=1 ptime -m cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -214,6 +214,7 @@ pfexec ipadm create-addr -T static -a $GATEWAY_IP/24 igb0/sidehatch
 # NOTE: this script configures softnpu's "rack network" settings using swadm
 ./tools/scrimlet/softnpu-init.sh
 
+export RUST_BACKTRACE=1
 ./tests/bootstrap
 
 rm ./tests/bootstrap


### PR DESCRIPTION
I've been meaning to do this for a while by #2994 finally pushed me to do it.

I considered just setting RUST_BACKTRACE=1 everywhere but I find that annoying on my own machine so I took a conservative approach here, only adding it where we expect the backtraces to be useful.

I considered RUST_BACKTRACE=full but I also find that usually isn't what I want.  If folks feel differently though we could do that!