### PR TITLE
Initial pass at unifying identification of oxide hardware components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6972,6 +6972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8626,6 +8632,7 @@ checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ tufaceous = { path = "tufaceous" }
 tufaceous-lib = { path = "tufaceous-lib" }
 tui = "0.19.0"
 update-engine = { path = "update-engine" }
-uuid = { version = "1.3.2", features = ["serde", "v4"] }
+uuid = { version = "1.3.2", features = ["serde", "v4", "v5"] }
 usdt = "0.3"
 vsss-rs = { version = "2.7", default-features = false, features = ["std"] }
 walkdir = "2.3"

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2228,7 +2228,7 @@ mod test {
             revision: 3,
         };
         let uuid1: Uuid = hardware_id.clone().into();
-        let uuid2: Uuid = hardware_id.clone().into();
+        let uuid2: Uuid = hardware_id.into();
 
         // ID generation should be deterministic.
         assert_eq!(uuid1, uuid2);

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -9,19 +9,10 @@ use crate::schema::{physical_disk, service, sled, zpool};
 use chrono::{DateTime, Utc};
 use db_macros::Asset;
 use nexus_types::{external_api::views, identity::Asset};
+use omicron_common::api::external::OxideHardwareIdentifier;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
-
-/// Baseboard information about a sled.
-///
-/// The combination of these columns may be used as a unique identifier for the
-/// sled.
-pub struct SledBaseboard {
-    pub serial_number: String,
-    pub part_number: String,
-    pub revision: i64,
-}
 
 /// Hardware information about the sled.
 pub struct SledSystemHardware {
@@ -61,7 +52,7 @@ impl Sled {
     pub fn new(
         id: Uuid,
         addr: SocketAddrV6,
-        baseboard: SledBaseboard,
+        baseboard: OxideHardwareIdentifier,
         hardware: SledSystemHardware,
         rack_id: Uuid,
     ) -> Self {
@@ -111,9 +102,9 @@ impl From<Sled> for views::Sled {
         Self {
             identity: sled.identity(),
             rack_id: sled.rack_id,
-            baseboard: views::Baseboard {
-                serial: sled.serial_number,
-                part: sled.part_number,
+            baseboard: OxideHardwareIdentifier {
+                serial_number: sled.serial_number,
+                part_number: sled.part_number,
                 revision: sled.revision,
             },
             usable_hardware_threads: sled.usable_hardware_threads.0,

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -278,8 +278,8 @@ mod test {
         BlockSize, ComponentUpdate, ComponentUpdateIdentity, ConsoleSession,
         Dataset, DatasetKind, ExternalIp, PhysicalDisk, PhysicalDiskKind,
         Project, Rack, Region, Service, ServiceKind, SiloUser, Sled,
-        SledBaseboard, SledSystemHardware, SshKey, SystemUpdate,
-        UpdateableComponentType, VpcSubnet, Zpool,
+        SledSystemHardware, SshKey, SystemUpdate, UpdateableComponentType,
+        VpcSubnet, Zpool,
     };
     use crate::db::queries::vpc_subnet::FilterConflictingVpcSubnetRangesQuery;
     use assert_matches::assert_matches;
@@ -287,6 +287,7 @@ mod test {
     use nexus_test_utils::db::test_setup_database;
     use nexus_types::external_api::params;
     use omicron_common::api::external::DataPageParams;
+    use omicron_common::api::external::OxideHardwareIdentifier;
     use omicron_common::api::external::{
         self, ByteCount, Error, IdentityMetadataCreateParams, LookupType, Name,
     };
@@ -298,8 +299,8 @@ mod test {
     use uuid::Uuid;
 
     // Creates a "fake" Sled Baseboard.
-    pub fn sled_baseboard_for_test() -> SledBaseboard {
-        SledBaseboard {
+    pub fn sled_baseboard_for_test() -> OxideHardwareIdentifier {
+        OxideHardwareIdentifier {
             serial_number: Uuid::new_v4().to_string(),
             part_number: String::from("test-part"),
             revision: 1,

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -19,6 +19,7 @@ use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::OxideHardwareIdentifier;
 use sled_agent_client::types::SetVirtualNetworkInterfaceHost;
 use sled_agent_client::Client as SledAgentClient;
 use std::net::SocketAddrV6;
@@ -32,9 +33,9 @@ impl super::Nexus {
     // be (for graceful degradation at large scale).
     pub async fn upsert_sled(
         &self,
-        id: Uuid,
         info: SledAgentStartupInfo,
     ) -> Result<(), Error> {
+        let id: Uuid = info.baseboard.clone().into();
         info!(self.log, "registered sled agent"; "sled_uuid" => id.to_string());
 
         let is_scrimlet = match info.role {
@@ -45,9 +46,9 @@ impl super::Nexus {
         let sled = db::model::Sled::new(
             id,
             info.sa_address,
-            db::model::SledBaseboard {
-                serial_number: info.baseboard.identifier,
-                part_number: info.baseboard.model,
+            OxideHardwareIdentifier {
+                serial_number: info.baseboard.serial_number,
+                part_number: info.baseboard.part_number,
                 revision: info.baseboard.revision,
             },
             db::model::SledSystemHardware {

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -73,29 +73,20 @@ pub fn internal_api() -> NexusApiDescription {
     api
 }
 
-/// Path parameters for Sled Agent requests (internal API)
-#[derive(Deserialize, JsonSchema)]
-struct SledAgentPathParam {
-    sled_id: Uuid,
-}
-
 /// Report that the sled agent for the specified sled has come online.
 #[endpoint {
      method = POST,
-     path = "/sled-agents/{sled_id}",
+     path = "/sled-agents",
  }]
 async fn sled_agent_put(
     rqctx: RequestContext<Arc<ServerContext>>,
-    path_params: Path<SledAgentPathParam>,
     sled_info: TypedBody<SledAgentStartupInfo>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
-    let path = path_params.into_inner();
     let info = sled_info.into_inner();
-    let sled_id = &path.sled_id;
     let handler = async {
-        nexus.upsert_sled(*sled_id, info).await?;
+        nexus.upsert_sled(info).await?;
         Ok(HttpResponseUpdatedNoContent())
     };
     apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -13,7 +13,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use omicron_common::api::external::{
     ByteCount, Digest, IdentityMetadata, Ipv4Net, Ipv6Net, Name,
-    ObjectIdentity, RoleName, SemverVersion,
+    ObjectIdentity, OxideHardwareIdentifier, RoleName, SemverVersion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -283,20 +283,13 @@ pub struct Rack {
 
 // SLEDS
 
-/// Properties that should uniquely identify a Sled.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Baseboard {
-    pub serial: String,
-    pub part: String,
-    pub revision: i64,
-}
-
 /// An operator's view of a Sled.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Sled {
     #[serde(flatten)]
     pub identity: AssetIdentityMetadata,
-    pub baseboard: Baseboard,
+    #[serde(flatten)]
+    pub baseboard: OxideHardwareIdentifier,
     /// The rack to which this Sled is currently attached
     pub rack_id: Uuid,
     /// The number of hardware threads which can execute on this sled

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -8,6 +8,7 @@ use crate::external_api::params::UserId;
 use crate::external_api::shared::IpRange;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Name;
+use omicron_common::api::external::OxideHardwareIdentifier;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -31,14 +32,6 @@ pub enum SledRole {
     Scrimlet,
 }
 
-/// Describes properties that should uniquely identify a Gimlet.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Baseboard {
-    pub identifier: String,
-    pub model: String,
-    pub revision: i64,
-}
-
 /// Sent by a sled agent on startup to Nexus to request further instruction
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct SledAgentStartupInfo {
@@ -49,7 +42,7 @@ pub struct SledAgentStartupInfo {
     pub role: SledRole,
 
     /// Describes the sled's identity
-    pub baseboard: Baseboard,
+    pub baseboard: OxideHardwareIdentifier,
 
     /// The number of hardware threads which can execute on this sled
     pub usable_hardware_threads: u32,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -446,21 +446,10 @@
         }
       }
     },
-    "/sled-agents/{sled_id}": {
+    "/sled-agents": {
       "post": {
         "summary": "Report that the sled agent for the specified sled has come online.",
         "operationId": "sled_agent_put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sled_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -582,27 +571,6 @@
       }
     },
     "schemas": {
-      "Baseboard": {
-        "description": "Describes properties that should uniquely identify a Gimlet.",
-        "type": "object",
-        "properties": {
-          "identifier": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "revision": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "required": [
-          "identifier",
-          "model",
-          "revision"
-        ]
-      },
       "BinRangedouble": {
         "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
         "oneOf": [
@@ -2122,6 +2090,27 @@
         "description": "Unique name for a saga [`Node`]\n\nEach node requires a string name that's unique within its DAG.  The name is used to identify its output.  Nodes that depend on a given node (either directly or indirectly) can access the node's output using its name.",
         "type": "string"
       },
+      "OxideHardwareIdentifier": {
+        "description": "Unique identifiers associated with Oxide produced hardware like sleds and switches. Hardware not produced by Oxide (such as NVMe drives) will have different means of identification.",
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "serial_number": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "part_number",
+          "revision",
+          "serial_number"
+        ]
+      },
       "OximeterInfo": {
         "description": "Message used to notify Nexus that this oximeter instance is up and running.",
         "type": "object",
@@ -2796,7 +2785,7 @@
             "description": "Describes the sled's identity",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Baseboard"
+                "$ref": "#/components/schemas/OxideHardwareIdentifier"
               }
             ]
           },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6995,27 +6995,6 @@
       }
     },
     "schemas": {
-      "Baseboard": {
-        "description": "Properties that should uniquely identify a Sled.",
-        "type": "object",
-        "properties": {
-          "part": {
-            "type": "string"
-          },
-          "revision": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "serial": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "part",
-          "revision",
-          "serial"
-        ]
-      },
       "BinRangedouble": {
         "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
         "oneOf": [
@@ -10844,18 +10823,25 @@
         "description": "An operator's view of a Sled.",
         "type": "object",
         "properties": {
-          "baseboard": {
-            "$ref": "#/components/schemas/Baseboard"
-          },
           "id": {
             "description": "unique, immutable, system-controlled identifier for each resource",
             "type": "string",
             "format": "uuid"
           },
+          "part_number": {
+            "type": "string"
+          },
           "rack_id": {
             "description": "The rack to which this Sled is currently attached",
             "type": "string",
             "format": "uuid"
+          },
+          "revision": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "serial_number": {
+            "type": "string"
           },
           "time_created": {
             "description": "timestamp when this resource was created",
@@ -10883,9 +10869,11 @@
           }
         },
         "required": [
-          "baseboard",
           "id",
+          "part_number",
           "rack_id",
+          "revision",
+          "serial_number",
           "time_created",
           "time_modified",
           "usable_hardware_threads",

--- a/sled-agent/src/mocks/mod.rs
+++ b/sled-agent/src/mocks/mod.rs
@@ -26,7 +26,6 @@ mock! {
         pub fn baseurl(&self) -> &'static str;
         pub async fn sled_agent_put(
             &self,
-            id: &Uuid,
             info: &SledAgentStartupInfo,
         ) -> Result<()>;
         pub async fn physical_disk_put(

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -90,25 +90,20 @@ impl Server {
         let notify_nexus = || async {
             debug!(log, "contacting server nexus");
             (nexus_client
-                .sled_agent_put(
-                    &config.id,
-                    &NexusTypes::SledAgentStartupInfo {
-                        sa_address: sa_address.to_string(),
-                        role: NexusTypes::SledRole::Gimlet,
-                        baseboard: NexusTypes::Baseboard {
-                            identifier: format!("Simulated sled {}", config.id),
-                            model: String::from("Unknown"),
-                            revision: 0,
-                        },
-                        usable_hardware_threads: config
-                            .hardware
-                            .hardware_threads,
-                        usable_physical_ram: NexusTypes::ByteCount::try_from(
-                            config.hardware.physical_ram,
-                        )
-                        .unwrap(),
+                .sled_agent_put(&NexusTypes::SledAgentStartupInfo {
+                    sa_address: sa_address.to_string(),
+                    role: NexusTypes::SledRole::Gimlet,
+                    baseboard: NexusTypes::OxideHardwareIdentifier {
+                        serial_number: format!("Simulated sled {}", config.id),
+                        part_number: String::from("Unknown"),
+                        revision: 0,
                     },
-                )
+                    usable_hardware_threads: config.hardware.hardware_threads,
+                    usable_physical_ram: NexusTypes::ByteCount::try_from(
+                        config.hardware.physical_ram,
+                    )
+                    .unwrap(),
+                })
                 .await)
                 .map_err(BackoffError::transient)
         };

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -410,7 +410,7 @@ impl SledAgent {
         let lazy_nexus_client = self.inner.lazy_nexus_client.clone();
         let sled_address = self.inner.sled_address();
         let is_scrimlet = self.inner.hardware.is_scrimlet();
-        let baseboard = nexus_client::types::Baseboard::from(
+        let baseboard = nexus_client::types::OxideHardwareIdentifier::from(
             self.inner.hardware.baseboard(),
         );
         let usable_hardware_threads =
@@ -445,7 +445,6 @@ impl SledAgent {
                     .map_err(|err| BackoffError::transient(err.to_string()))?;
                 nexus_client
                     .sled_agent_put(
-                        &sled_id,
                         &nexus_client::types::SledAgentStartupInfo {
                             sa_address: sled_address.to_string(),
                             role,

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -109,11 +109,11 @@ impl Baseboard {
     }
 }
 
-impl From<Baseboard> for nexus_client::types::Baseboard {
-    fn from(b: Baseboard) -> nexus_client::types::Baseboard {
-        nexus_client::types::Baseboard {
-            identifier: b.identifier,
-            model: b.model,
+impl From<Baseboard> for nexus_client::types::OxideHardwareIdentifier {
+    fn from(b: Baseboard) -> nexus_client::types::OxideHardwareIdentifier {
+        nexus_client::types::OxideHardwareIdentifier {
+            serial_number: b.identifier,
+            part_number: b.model,
             revision: b.revision,
         }
     }


### PR DESCRIPTION
There's likely more to be done here to get this completely ready, but I wanted to put it up for some feedback on the approach before moving forward any further. 

This is, in part, meant to address #2984. As a recap, Oxide manufactured hardware uses a tuple of `serial_number`, `part_number`, and `revision` as a unique identifier (which is currently called baseboard). @smklein added uniqueness constraints to these in #2979. Outlined by @rmustacc in [RFD-360 § 7.1](https://rfd.shared.oxide.computer/rfd/360#_hardware_uuids), it's desirable to have our IDs tied to stable hardware identifiers and (eventually) to be able to query hardware endpoints with these hardware identifiers (.e.g `/v1/system/hardware/sleds/<serial_number>:<revision>:<part_number>`). 

This PR aims to do a few things:
1. Make Oxide manufactured hardware (gimlets, sidecars, etc) have stable, deterministic UUIDs
2. Consolidate the disparate definitions of basedboard into a unified interface
3. Hopefully come up with a better name for this*

_*note: This is really just something I want. `baseboard` has little contextual meaning and it's not clear to me that the identifier scheme laid out in [RFD-308](https://rfd.shared.oxide.computer/rfd/0308) is only for baseboard identifiers. Also, we were exposing the baseboard name directly to operators which I've removed by flattening the output struct. That said, if we do expose it, we should consider the name carefully._ 

This change allows us to do things like remove the UUID call from the sled agent startup given that it can just be generated from the hardware identifier. 

I _do_ understand that hardware not manufactured by Oxide (like NVMe drives) will have a different format which is why I've explicitly named the struct _OxideHardwareIdentifier_. I'm not married to the name. 

## Considering collision risks

The potential for collisions has been raised in chat and it's a good idea for us to investigate the potential for that failure mode. First it's important to note that the unique constraint of the generated UUID is by _device kind_ (which theoretically maps to part number). E.g. the same UUID being generated for a sidecar as is generated for a gimlet isn't a problem. 

You can check out the implementation of UUIDv5 below, but the TL;DR is that it takes a sha1 hash of namespace + name, truncates it to 16 bytes (from 20 bytes), and generates the UUID from that.

<details>
<summary> UUID v5 Implementation</summary>

```rust
pub fn new_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
    crate::Builder::from_sha1_bytes(crate::sha1::hash(namespace.as_bytes(), name)).into_uuid()
}
```

```rust
pub(crate) fn hash(ns: &[u8], src: &[u8]) -> [u8; 16] {
    use sha1_smol::Sha1;

    let mut hasher = Sha1::new();

    hasher.update(ns);
    hasher.update(src);

    let mut bytes = [0; 16];
    bytes.copy_from_slice(&hasher.digest().bytes()[..16]);

    bytes
}
```

</details>

