### PR TITLE
Fix SMF service race during zone boot

### DIFF
--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -182,9 +182,13 @@ impl RunningZone {
 
         Zones::boot(&zone.name).await?;
 
-        // Wait for the network services to come online, so future
-        // requests to create addresses can operate immediately.
-        let fmri = "svc:/milestone/network:default";
+        // Wait until the zone reaches the 'single-user' SMF milestone.
+        // At this point, we know that the dependent
+        //  - svc:/milestone/network
+        //  - svc:/system/manifest-import
+        // services are up, so future requests to create network addresses
+        // or manipulate services will work.
+        let fmri = "svc:/milestone/single-user:default";
         wait_for_service(Some(&zone.name), fmri).await.map_err(|_| {
             BootError::Timeout {
                 service: fmri.to_string(),


### PR DESCRIPTION
When a zone boots, we should wait until it reaches the
single-user SMF milestone before reaching in and
configuring network interfaces or manipulating SMF services.
Any earlier and we risk racing with system boot tasks.

Fixes https://github.com/oxidecomputer/stlouis/issues/386
