### PR TITLE
[illumos-utils] Better dataset deletion handling

### DIFF
--- a/illumos-utils/src/zfs.rs
+++ b/illumos-utils/src/zfs.rs
@@ -261,10 +261,13 @@ pub fn get_all_omicron_datasets_for_delete() -> anyhow::Result<Vec<String>> {
         }
     }
 
-    // Collect all datasets for ramdisk-based Oxide zones.
-    for dataset in &Zfs::list_datasets(&ZONE_ZFS_RAMDISK_DATASET)? {
-        datasets.push(format!("{}/{dataset}", ZONE_ZFS_RAMDISK_DATASET));
-    }
-
+    // Collect all datasets for ramdisk-based Oxide zones,
+    // if any exist.
+    if let Ok(ramdisk_datasets) = Zfs::list_datasets(&ZONE_ZFS_RAMDISK_DATASET)
+    {
+        for dataset in &ramdisk_datasets {
+            datasets.push(format!("{}/{dataset}", ZONE_ZFS_RAMDISK_DATASET));
+        }
+    };
     Ok(datasets)
 }

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -569,7 +569,7 @@ fn uninstall_all_omicron_datasets(config: &Config) -> Result<()> {
     let datasets = match zfs::get_all_omicron_datasets_for_delete() {
         Err(e) => {
             warn!(config.log, "Failed to get omicron datasets: {}", e);
-            return Ok(());
+            return Err(e);
         }
         Ok(datasets) => datasets,
     };


### PR DESCRIPTION
- if `rpool/zone` doesn't exist, ignore it
- if any datasets cannot be queried, throw an error more explicitly