### PR TITLE
Add swadm & ddmadm to default PATH in switch zone.

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -273,6 +273,7 @@ source.paths = [
   { from = "smf/switch_zone_setup/manifest.xml", to = "/var/svc/manifest/site/switch_zone_setup/manifest.xml" },
   { from = "smf/switch_zone_setup/switch_zone_setup", to = "/opt/oxide/bin/switch_zone_setup" },
   { from = "smf/switch_zone_setup/support_authorized_keys", to = "/opt/oxide/support/authorized_keys" },
+  { from = "smf/switch_zone_setup/root.profile", to = "/root/.profile" },
 ]
 output.type = "zone"
 output.intermediate_only = true

--- a/smf/switch_zone_setup/root.profile
+++ b/smf/switch_zone_setup/root.profile
@@ -1,3 +1,3 @@
-# Add tools like swadm & ddmadm to the PATH by default
-export PATH=$PATH:/opt/oxide/dendrite/bin:/opt/oxide/mg-ddm/bin
+# Add tools like xcvradm, swadm & ddmadm to the PATH by default
+export PATH=$PATH:/opt/oxide/bin:/opt/oxide/dendrite/bin:/opt/oxide/mg-ddm/bin
 

--- a/smf/switch_zone_setup/root.profile
+++ b/smf/switch_zone_setup/root.profile
@@ -1,0 +1,3 @@
+# Add tools like swadm & ddmadm to the PATH by default
+export PATH=$PATH:/opt/oxide/dendrite/bin:/opt/oxide/mg-ddm/bin
+

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -71,7 +71,7 @@ function main
     fi
     trap 'cd /; rm -rf "$tmp_gz"' EXIT
 
-    # Extract the trampoline global zone tarball into a tmp_gz directory
+    # Extract the global zone tarball into a tmp_gz directory
     echo "Extracting gz packages into $tmp_gz"
     ptime -m tar xvzf $GLOBAL_ZONE_TARBALL_PATH -C $tmp_gz
 
@@ -81,6 +81,11 @@ function main
     if [ "x$SWITCH_ZONE" != "x" ]; then
         mkdir -p "$tmp_gz/root/opt/oxide"
         cp "$SWITCH_ZONE" "$tmp_gz/root/opt/oxide/switch.tar.gz"
+    fi
+
+    if [ "x$BUILD_STANDARD" != "x" ]; then
+        echo "# Add opteadm, ddmadm to PATH" >> "$tmp_gz/root/root/.profile"
+        echo 'export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm' >> "$tmp_gz/root/root/.profile"
     fi
 
     # Move to the helios checkout

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -84,6 +84,7 @@ function main
     fi
 
     if [ "x$BUILD_STANDARD" != "x" ]; then
+        mkdir -p "$tmp_gz/root/root"
         echo "# Add opteadm, ddmadm to PATH" >> "$tmp_gz/root/root/.profile"
         echo 'export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm' >> "$tmp_gz/root/root/.profile"
     fi


### PR DESCRIPTION
Bringing up dogfood rack still requires some manual config in the switch zone so let's make it a bit easier.