### PR TITLE
Add missing console routes

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -526,22 +526,6 @@ pub struct RestPathParam {
     path: Vec<String>,
 }
 
-// Serve the console bundle without an auth gate just for the login form. This
-// is meant to stand in for the customers identity provider. Since this is a
-// placeholder, it's easiest to build the form into the console bundle. If we
-// really wanted a login form, we would probably make it a standalone page,
-// otherwise the user is downloading a bunch of JS for nothing.
-#[endpoint {
-   method = GET,
-   path = "/spoof_login",
-   unpublished = true,
-}]
-pub async fn login_spoof_begin(
-    rqctx: RequestContext<Arc<ServerContext>>,
-) -> Result<Response<Body>, HttpError> {
-    serve_console_index(rqctx.context()).await
-}
-
 #[derive(Deserialize, JsonSchema)]
 pub struct StateParam {
     state: Option<String>,
@@ -638,6 +622,22 @@ pub async fn console_index_or_login_redirect(
         .body("".into())?)
 }
 
+// Serve the console bundle without an auth gate just for the login form. This
+// is meant to stand in for the customers identity provider. Since this is a
+// placeholder, it's easiest to build the form into the console bundle. If we
+// really wanted a login form, we would probably make it a standalone page,
+// otherwise the user is downloading a bunch of JS for nothing.
+#[endpoint {
+   method = GET,
+   path = "/spoof_login",
+   unpublished = true,
+}]
+pub async fn login_spoof_begin(
+    rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<Response<Body>, HttpError> {
+    serve_console_index(rqctx.context()).await
+}
+
 // Dropshot does not have route match ranking and does not allow overlapping
 // route definitions, so we cannot have a catchall `/*` route for console pages
 // and then also define, e.g., `/api/blah/blah` and give the latter priority
@@ -645,14 +645,37 @@ pub async fn console_index_or_login_redirect(
 // catchall route a prefix to avoid overlap. Long-term, if a route prefix is
 // part of the solution, we would probably prefer it to be on the API endpoints,
 // not on the console pages.
+//
+#[endpoint {
+   method = GET,
+   path = "/",
+   unpublished = true,
+}]
+pub async fn console_root(
+    rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<Response<Body>, HttpError> {
+    console_index_or_login_redirect(rqctx).await
+}
+
 #[endpoint {
    method = GET,
    path = "/projects/{path:.*}",
    unpublished = true,
 }]
-pub async fn console_page(
+pub async fn console_projects(
     rqctx: RequestContext<Arc<ServerContext>>,
     _path_params: Path<RestPathParam>,
+) -> Result<Response<Body>, HttpError> {
+    console_index_or_login_redirect(rqctx).await
+}
+
+#[endpoint {
+   method = GET,
+   path = "/projects-new",
+   unpublished = true,
+}]
+pub async fn console_projects_new(
+    rqctx: RequestContext<Arc<ServerContext>>,
 ) -> Result<Response<Body>, HttpError> {
     console_index_or_login_redirect(rqctx).await
 }
@@ -683,10 +706,21 @@ pub async fn console_system_page(
 
 #[endpoint {
    method = GET,
-   path = "/",
+   path = "/utilization",
    unpublished = true,
 }]
-pub async fn console_root(
+pub async fn console_silo_utilization(
+    rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<Response<Body>, HttpError> {
+    console_index_or_login_redirect(rqctx).await
+}
+
+#[endpoint {
+   method = GET,
+   path = "/access",
+   unpublished = true,
+}]
+pub async fn console_silo_access(
     rqctx: RequestContext<Arc<ServerContext>>,
 ) -> Result<Response<Body>, HttpError> {
     console_index_or_login_redirect(rqctx).await

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -259,7 +259,10 @@ pub fn external_api() -> NexusApiDescription {
         api.register(console_api::login_saml)?;
         api.register(console_api::logout)?;
 
-        api.register(console_api::console_page)?;
+        api.register(console_api::console_projects)?;
+        api.register(console_api::console_projects_new)?;
+        api.register(console_api::console_silo_utilization)?;
+        api.register(console_api::console_silo_access)?;
         api.register(console_api::console_root)?;
         api.register(console_api::console_settings_page)?;
         api.register(console_api::console_system_page)?;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -166,10 +166,13 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
     let console_paths = &[
         "/",
         "/projects/irrelevant-path",
+        "/projects-new",
         "/settings/irrelevant-path",
         "/sys/irrelevant-path",
         "/device/success",
         "/device/verify",
+        "/utilization",
+        "/access",
     ];
 
     for path in console_paths {


### PR DESCRIPTION
Closes #3029 

Console source of truth is here https://github.com/oxidecomputer/console/blob/main/app/routes.tsx. Not the easiest thing to read. 