### PR TITLE
Stop skipping timesync on a real gimlet

### DIFF
--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -14,10 +14,6 @@ sled_mode = "auto"
 # this information.
 sidecar_revision = "b"
 
-# Setting this to true causes sled-agent to always report that its time is
-# in-sync, rather than querying its NTP zone.
-skip_timesync = true
-
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #


### PR DESCRIPTION

The NTP zones are now working and able to synchronise.
In the output below you can see the two boundary servers
(sleds 10 and 17) and the rest synchronised to them.

Let's start waiting for time to settle before launching the
rest of the control plane.

```
BRM42220051-switch # pilot host exec -c \
    'zlogin oxz_ntp chronyc tracking' 0-31 | grep BRM
 8  BRM44220011 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
10  BRM42220009 ok: Reference ID    : AC140005 (172.20.0.5)
11  BRM42220057 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
12  BRM42220018 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
13  BRM44220005 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
16  BRM42220086 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
17  BRM42220006 ok: Reference ID    : AC140005 (172.20.0.5)
18  BRM44220004 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
23  BRM42220031 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
24  BRM42220014 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
28  BRM44220010 ok: Reference ID    : DAE5E7E1 (fd00:1122:3344:109::d)
```

