### PR TITLE
[tufaceous-lib] More structured support for composite artifacts

### DIFF
--- a/tufaceous-lib/src/artifact/composite.rs
+++ b/tufaceous-lib/src/artifact/composite.rs
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::CONTROL_PLANE_ARCHIVE_ZONE_DIRECTORY;
+use super::HOST_PHASE_1_FILE_NAME;
+use super::HOST_PHASE_2_FILE_NAME;
+use super::ROT_ARCHIVE_A_FILE_NAME;
+use super::ROT_ARCHIVE_B_FILE_NAME;
+use crate::oxide_metadata;
+use crate::oxide_metadata::Metadata;
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use camino::Utf8Path;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::io::BufWriter;
+use std::io::Read;
+use std::io::Write;
+
+pub struct CompositeControlPlaneArchiveBuilder<W: Write> {
+    inner: CompositeTarballBuilder<W>,
+}
+
+impl<W: Write> CompositeControlPlaneArchiveBuilder<W> {
+    pub fn new(writer: W) -> Result<Self> {
+        let metadata = oxide_metadata::MetadataBuilder::new(
+            oxide_metadata::ArchiveType::ControlPlane,
+        )
+        .build()
+        .context("error building oxide metadata")?;
+        let inner = CompositeTarballBuilder::new(writer, metadata)?;
+        Ok(Self { inner })
+    }
+
+    pub fn append_zone<R: Read>(
+        &mut self,
+        name: &str,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        let name_path = Utf8Path::new(name);
+        if name_path.file_name() != Some(name) {
+            bail!("control plane zone filenames should not contain paths");
+        }
+        let path =
+            Utf8Path::new(CONTROL_PLANE_ARCHIVE_ZONE_DIRECTORY).join(name_path);
+        self.inner.append_file(path.as_str(), size, data)
+    }
+
+    pub fn finish(self) -> Result<W> {
+        self.inner.finish()
+    }
+}
+
+pub struct CompositeRotArchiveBuilder<W: Write> {
+    inner: CompositeTarballBuilder<W>,
+}
+
+impl<W: Write> CompositeRotArchiveBuilder<W> {
+    pub fn new(writer: W) -> Result<Self> {
+        let metadata = oxide_metadata::MetadataBuilder::new(
+            oxide_metadata::ArchiveType::Rot,
+        )
+        .build()
+        .context("error building oxide metadata")?;
+        let inner = CompositeTarballBuilder::new(writer, metadata)?;
+        Ok(Self { inner })
+    }
+
+    pub fn append_archive_a<R: Read>(
+        &mut self,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        self.inner.append_file(ROT_ARCHIVE_A_FILE_NAME, size, data)
+    }
+
+    pub fn append_archive_b<R: Read>(
+        &mut self,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        self.inner.append_file(ROT_ARCHIVE_B_FILE_NAME, size, data)
+    }
+
+    pub fn finish(self) -> Result<W> {
+        self.inner.finish()
+    }
+}
+
+pub struct CompositeHostArchiveBuilder<W: Write> {
+    inner: CompositeTarballBuilder<W>,
+}
+
+impl<W: Write> CompositeHostArchiveBuilder<W> {
+    pub fn new(writer: W) -> Result<Self> {
+        let metadata = oxide_metadata::MetadataBuilder::new(
+            oxide_metadata::ArchiveType::Os,
+        )
+        .build()
+        .context("error building oxide metadata")?;
+        let inner = CompositeTarballBuilder::new(writer, metadata)?;
+        Ok(Self { inner })
+    }
+
+    pub fn append_phase_1<R: Read>(
+        &mut self,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        self.inner.append_file(HOST_PHASE_1_FILE_NAME, size, data)
+    }
+
+    pub fn append_phase_2<R: Read>(
+        &mut self,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        self.inner.append_file(HOST_PHASE_2_FILE_NAME, size, data)
+    }
+
+    pub fn finish(self) -> Result<W> {
+        self.inner.finish()
+    }
+}
+
+struct CompositeTarballBuilder<W: Write> {
+    builder: tar::Builder<GzEncoder<BufWriter<W>>>,
+}
+
+impl<W: Write> CompositeTarballBuilder<W> {
+    fn new(writer: W, metadata: Metadata) -> Result<Self> {
+        let mut builder = tar::Builder::new(GzEncoder::new(
+            BufWriter::new(writer),
+            Compression::fast(),
+        ));
+        metadata.append_to_tar(&mut builder)?;
+        Ok(Self { builder })
+    }
+
+    fn append_file<R: Read>(
+        &mut self,
+        path: &str,
+        size: usize,
+        data: R,
+    ) -> Result<()> {
+        let header = make_tar_header(path, size);
+        self.builder
+            .append(&header, data)
+            .with_context(|| format!("error append {path:?}"))
+    }
+
+    fn finish(self) -> Result<W> {
+        let gz_encoder =
+            self.builder.into_inner().context("error finalizing archive")?;
+        let buf_writer =
+            gz_encoder.finish().context("error finishing gz encoder")?;
+        buf_writer
+            .into_inner()
+            .map_err(|_| anyhow!("error flushing buffered archive writer"))
+    }
+}
+
+fn make_tar_header(path: &str, size: usize) -> tar::Header {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let mtime = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+    let mut header = tar::Header::new_ustar();
+    header.set_username("root").unwrap();
+    header.set_uid(0);
+    header.set_groupname("root").unwrap();
+    header.set_gid(0);
+    header.set_path(path).unwrap();
+    header.set_size(size as u64);
+    header.set_mode(0o444);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mtime(mtime);
+    header.set_cksum();
+
+    header
+}

--- a/tufaceous-lib/src/assemble/manifest.rs
+++ b/tufaceous-lib/src/assemble/manifest.rs
@@ -2,20 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use bytesize::ByteSize;
 use camino::{Utf8Path, Utf8PathBuf};
 use omicron_common::api::{
     external::SemverVersion, internal::nexus::KnownArtifactKind,
 };
-use serde::{de::Visitor, Deserialize};
+use serde::Deserialize;
 
-use crate::ArtifactSource;
+use crate::{
+    make_filler_text, ArtifactSource, CompositeControlPlaneArchiveBuilder,
+    CompositeHostArchiveBuilder, CompositeRotArchiveBuilder,
+};
 
 /// A list of components in a TUF repo representing a single update.
 #[derive(Clone, Debug)]
@@ -40,7 +40,24 @@ impl ArtifactManifest {
         let manifest: DeserializedManifest =
             serde_path_to_error::deserialize(de)?;
 
-        // Replace all paths in the deserialized manifest with absolute ones.
+        // Replace all paths in the deserialized manifest with absolute ones,
+        // and do some processing to support flexible manifests:
+        //
+        // 1. assemble any composite artifacts from their pieces
+        // 2. replace any "fake" artifacts with in-memory buffers
+        //
+        // Currently both of those transformations produce
+        // `ArtifactSource::Memory(_)` variants (i.e., composite and fake
+        // artifacts all sit in-memory until we're done with the manifest),
+        // which puts some limits on how large the inputs to the manifest can
+        // practically be. If this becomes onerous, we could instead write the
+        // transformed artifacts to temporary files.
+        //
+        // We do some additional error checking here to make sure the
+        // `CompositeZZZ` variants are only used with their corresponding
+        // `KnownArtifactKind`s. It would be nicer to enforce this more
+        // statically and let serde do these checks, but that seems relatively
+        // tricky in comparison to these checks.
         Ok(ArtifactManifest {
             system_version: manifest.system_version,
             artifacts: manifest
@@ -48,11 +65,95 @@ impl ArtifactManifest {
                 .into_iter()
                 .map(|(kind, data)| {
                     let source = match data.source {
-                        DeserializedArtifactSource::File(path) => {
-                            ArtifactSource::File(base_dir.join(&path))
+                        DeserializedArtifactSource::File { path } => {
+                            ArtifactSource::File(base_dir.join(path))
                         }
                         DeserializedArtifactSource::Fake { size } => {
-                            ArtifactSource::Fake { size }
+                            let fake_data = make_filler_text(size.0 as usize);
+                            ArtifactSource::Memory(fake_data.into())
+                        }
+                        DeserializedArtifactSource::CompositeHost {
+                            phase_1,
+                            phase_2,
+                        } => {
+                            ensure!(
+                                matches!(
+                                    kind,
+                                    KnownArtifactKind::Host
+                                        | KnownArtifactKind::Trampoline
+                                ),
+                                "`composite_host` source cannot be used with \
+                                artifact kind {kind:?}"
+                            );
+
+                            let data = Vec::new();
+                            let mut builder =
+                                CompositeHostArchiveBuilder::new(data)?;
+                            phase_1.with_data(|data| {
+                                builder
+                                    .append_phase_1(data.len(), data.as_slice())
+                            })?;
+                            phase_2.with_data(|data| {
+                                builder
+                                    .append_phase_2(data.len(), data.as_slice())
+                            })?;
+                            ArtifactSource::Memory(builder.finish()?.into())
+                        }
+                        DeserializedArtifactSource::CompositeRot {
+                            archive_a,
+                            archive_b,
+                        } => {
+                            ensure!(
+                                matches!(
+                                    kind,
+                                    KnownArtifactKind::GimletRot
+                                        | KnownArtifactKind::SwitchRot
+                                        | KnownArtifactKind::PscRot
+                                ),
+                                "`composite_rot` source cannot be used with \
+                                artifact kind {kind:?}"
+                            );
+
+                            let data = Vec::new();
+                            let mut builder =
+                                CompositeRotArchiveBuilder::new(data)?;
+                            archive_a.with_data(|data| {
+                                builder.append_archive_a(
+                                    data.len(),
+                                    data.as_slice(),
+                                )
+                            })?;
+                            archive_b.with_data(|data| {
+                                builder.append_archive_b(
+                                    data.len(),
+                                    data.as_slice(),
+                                )
+                            })?;
+                            ArtifactSource::Memory(builder.finish()?.into())
+                        }
+                        DeserializedArtifactSource::CompositeControlPlane {
+                            zones,
+                        } => {
+                            ensure!(
+                                kind == KnownArtifactKind::ControlPlane,
+                                "`composite_control_plane` source cannot be \
+                                used with artifact kind {kind:?}"
+                            );
+
+                            let data = Vec::new();
+                            let mut builder =
+                                CompositeControlPlaneArchiveBuilder::new(data)?;
+
+                            for zone in zones {
+                                zone.with_name_and_data(|name, data| {
+                                    builder.append_zone(
+                                        name,
+                                        data.len(),
+                                        data.as_slice(),
+                                    )
+                                })?;
+                            }
+                            ArtifactSource::Memory(builder.finish()?.into())
                         }
                     };
                     let data = ArtifactData {
@@ -60,9 +161,9 @@ impl ArtifactManifest {
                         version: data.version,
                         source,
                     };
-                    (kind, data)
+                    Ok((kind, data))
                 })
-                .collect(),
+                .collect::<Result<_, _>>()?,
         })
     }
 
@@ -124,66 +225,79 @@ struct DeserializedArtifactData {
     pub source: DeserializedArtifactSource,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
 enum DeserializedArtifactSource {
-    File(Utf8PathBuf),
-    Fake { size: u64 },
+    File {
+        path: Utf8PathBuf,
+    },
+    Fake {
+        size: ByteSize,
+    },
+    CompositeHost {
+        phase_1: DeserializedFileArtifactSource,
+        phase_2: DeserializedFileArtifactSource,
+    },
+    CompositeRot {
+        archive_a: DeserializedFileArtifactSource,
+        archive_b: DeserializedFileArtifactSource,
+    },
+    CompositeControlPlane {
+        zones: Vec<DeserializedControlPlaneZoneSource>,
+    },
 }
 
-impl<'de> Deserialize<'de> for DeserializedArtifactSource {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum DeserializedFileArtifactSource {
+    File { path: Utf8PathBuf },
+    Fake { size: ByteSize },
+}
+
+impl DeserializedFileArtifactSource {
+    fn with_data<F, T>(&self, f: F) -> Result<T>
     where
-        D: serde::Deserializer<'de>,
+        F: FnOnce(Vec<u8>) -> Result<T>,
     {
-        // This is similar to DeserializedArtifactSource except with an
-        // auto-derived impl, which we'll use in visit_map below.
-        #[derive(Clone, Debug, Deserialize)]
-        #[serde(tag = "kind", rename_all = "snake_case")]
-        enum AsMap {
-            File { path: Utf8PathBuf },
-            Fake { size: ByteSize },
-        }
-
-        impl From<AsMap> for DeserializedArtifactSource {
-            fn from(value: AsMap) -> Self {
-                match value {
-                    AsMap::File { path } => Self::File(path),
-                    AsMap::Fake { size } => Self::Fake { size: size.0 },
-                }
+        let data = match self {
+            DeserializedFileArtifactSource::File { path } => {
+                std::fs::read(path)
+                    .with_context(|| format!("failed to read {path}"))?
             }
-        }
-
-        struct V;
-
-        impl<'de2> Visitor<'de2> for V {
-            type Value = DeserializedArtifactSource;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(
-                    formatter,
-                    "a file name or a table {{ fake = true, size = 1048576 }}"
-                )
+            DeserializedFileArtifactSource::Fake { size } => {
+                make_filler_text(size.0 as usize)
             }
+        };
+        f(data)
+    }
+}
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                // Currently, a string always represents a file name.
-                Ok(DeserializedArtifactSource::File(v.into()))
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum DeserializedControlPlaneZoneSource {
+    File { path: Utf8PathBuf },
+    Fake { name: String, size: ByteSize },
+}
+
+impl DeserializedControlPlaneZoneSource {
+    fn with_name_and_data<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&str, Vec<u8>) -> Result<T>,
+    {
+        let (name, data) = match self {
+            DeserializedControlPlaneZoneSource::File { path } => {
+                let data = std::fs::read(path)
+                    .with_context(|| format!("failed to read {path}"))?;
+                let name = path.file_name().with_context(|| {
+                    format!("zone path missing file name: {path}")
+                })?;
+                (name, data)
             }
-
-            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de2>,
-            {
-                AsMap::deserialize(
-                    serde::de::value::MapAccessDeserializer::new(map),
-                )
-                .map(DeserializedArtifactSource::from)
+            DeserializedControlPlaneZoneSource::Fake { name, size } => {
+                let data = make_filler_text(size.0 as usize);
+                (name.as_str(), data)
             }
-        }
-
-        deserializer.deserialize_any(V)
+        };
+        f(name, data)
     }
 }

--- a/tufaceous-lib/src/oxide_metadata.rs
+++ b/tufaceous-lib/src/oxide_metadata.rs
@@ -25,6 +25,7 @@ pub enum ArchiveType {
     Layer,
     Os,
     Rot,
+    ControlPlane,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/tufaceous/manifests/fake.toml
+++ b/tufaceous/manifests/fake.toml
@@ -12,22 +12,36 @@ source = { kind = "fake", size = "1MiB" }
 [artifact.gimlet_rot]
 name = "fake-gimlet-rot"
 version = "1.0.0"
-source = { kind = "fake", size = "1MiB" }
+[artifact.gimlet_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
 
 [artifact.host]
 name = "fake-host"
 version = "1.0.0"
-source = { kind = "fake", size = "4MiB" }
+[artifact.host.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "3MiB" }
 
 [artifact.trampoline]
 name = "fake-trampoline"
 version = "1.0.0"
-source = { kind = "fake", size = "4MiB" }
+[artifact.trampoline.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "3MiB" }
 
 [artifact.control_plane]
 name = "fake-control-plane"
 version = "1.0.0"
-source = { kind = "fake", size = "1MiB" }
+[artifact.control_plane.source]
+kind = "composite-control-plane"
+zones = [
+    { kind = "fake", name = "zone1.tar.gz", size = "1MiB" },
+    { kind = "fake", name = "zone2.tar.gz", size = "1MiB" },
+]
 
 [artifact.psc_sp]
 name = "fake-psc-sp"
@@ -37,7 +51,10 @@ source = { kind = "fake", size = "1MiB" }
 [artifact.psc_rot]
 name = "fake-psc-rot"
 version = "1.0.0"
-source = { kind = "fake", size = "1MiB" }
+[artifact.psc_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
 
 [artifact.switch_sp]
 name = "fake-switch-sp"
@@ -47,4 +64,7 @@ source = { kind = "fake", size = "1MiB" }
 [artifact.switch_rot]
 name = "fake-switch-rot"
 version = "1.0.0"
-source = { kind = "fake", size = "1MiB" }
+[artifact.switch_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }


### PR DESCRIPTION
We previously had some support for two kinds of composite artifacts:

* Host/Trampoline OS images (phase1/phase2)
* RoT archives (A/B images)

but it had grown a bit organically. This PR attempts to add more structured
support for defining composite artifacts in the manifest used by
`tufaceous assemble`, and adds support for the control plane composite
artifacts (which holds an arbitrary number of control plane zone
tarballs).

This is partly followup from #3019 (specifically https://github.com/oxidecomputer/omicron/pull/3019#discussion_r1186772275) and partly to move toward installinator understanding how to write real control plane artifacts.