### PR TITLE
Session cookie timeout fix

### DIFF
--- a/nexus/db-queries/src/authn/external/session_cookie.rs
+++ b/nexus/db-queries/src/authn/external/session_cookie.rs
@@ -11,6 +11,8 @@ use crate::authn::{Actor, Details};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
+use dropshot::HttpError;
+use http::HeaderValue;
 use uuid::Uuid;
 
 // many parts of the implementation will reference this OWASP guide
@@ -55,19 +57,29 @@ pub const SESSION_COOKIE_SCHEME_NAME: authn::SchemeName =
     authn::SchemeName("session_cookie");
 
 /// Generate session cookie header
-pub fn session_cookie_header_value(token: &str, max_age: Duration) -> String {
+pub fn session_cookie_header_value(
+    token: &str,
+    max_age: Duration,
+) -> Result<HeaderValue, HttpError> {
     // TODO-security:(https://github.com/oxidecomputer/omicron/issues/249): We
     // should insert "Secure;" back into this string.
-    format!(
+    let value = format!(
         "{}={}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
         SESSION_COOKIE_COOKIE_NAME,
         token,
         max_age.num_seconds()
-    )
+    );
+    // this will only fail if we accidentally stick a \n in there or something
+    http::HeaderValue::from_str(&value).map_err(|_e| {
+        HttpError::for_internal_error(format!(
+            "unsupported cookie value: {:#}",
+            value
+        ))
+    })
 }
 
 /// Generate session cookie with empty token and max-age=0 so browser deletes it
-pub fn clear_session_cookie_header_value() -> String {
+pub fn clear_session_cookie_header_value() -> Result<HeaderValue, HttpError> {
     session_cookie_header_value("", Duration::zero())
 }
 
@@ -411,18 +423,27 @@ mod test {
     #[test]
     fn test_session_cookie_value() {
         assert_eq!(
-            session_cookie_header_value("abc", Duration::seconds(5)),
+            session_cookie_header_value("abc", Duration::seconds(5)).unwrap(),
             "session=abc; Path=/; HttpOnly; SameSite=Lax; Max-Age=5"
         );
 
         assert_eq!(
-            session_cookie_header_value("abc", Duration::seconds(-5)),
+            session_cookie_header_value("abc", Duration::seconds(-5)).unwrap(),
             "session=abc; Path=/; HttpOnly; SameSite=Lax; Max-Age=-5"
         );
 
         assert_eq!(
-            session_cookie_header_value("", Duration::zero()),
+            session_cookie_header_value("", Duration::zero()).unwrap(),
             "session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+        );
+    }
+    #[test]
+    fn test_session_cookie_value_error() {
+        assert_eq!(
+            session_cookie_header_value("abc\ndef", Duration::seconds(5))
+                .unwrap_err()
+                .internal_message,
+            "unsupported cookie value: session=abc\ndef; Path=/; HttpOnly; SameSite=Lax; Max-Age=5".to_string(),
         );
     }
 }

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -89,16 +89,10 @@ pub async fn login_spoof(
             let headers = response.headers_mut();
             headers.append(
                 header::SET_COOKIE,
-                http::HeaderValue::from_str(&session_cookie_header_value(
+                session_cookie_header_value(
                     &session.token,
                     apictx.session_absolute_timeout(),
-                ))
-                .map_err(|error| {
-                    HttpError::for_internal_error(format!(
-                        "unsupported cookie value: {:#}",
-                        error
-                    ))
-                })?,
+                )?,
             );
         };
         Ok(response)
@@ -446,21 +440,15 @@ async fn login_finish(
 
     {
         let headers = response_with_headers.headers_mut();
-        let cookie = session_cookie_header_value(
-            &session.token,
-            // use absolute timeout even though session might idle out first.
-            // browser expiration is mostly for convenience, as the API will
-            // reject requests with an expired session regardless
-            apictx.session_absolute_timeout(),
-        );
         headers.append(
             header::SET_COOKIE,
-            http::HeaderValue::from_str(&cookie).map_err(|error| {
-                HttpError::for_internal_error(format!(
-                    "unsupported cookie value: {:#}",
-                    error
-                ))
-            })?,
+            session_cookie_header_value(
+                &session.token,
+                // use absolute timeout even though session might idle out first.
+                // browser expiration is mostly for convenience, as the API will
+                // reject requests with an expired session regardless
+                apictx.session_absolute_timeout(),
+            )?,
         );
     }
     Ok(response_with_headers)
@@ -506,15 +494,7 @@ pub async fn logout(
             let headers = response.headers_mut();
             headers.append(
                 header::SET_COOKIE,
-                http::HeaderValue::from_str(
-                    &clear_session_cookie_header_value(),
-                )
-                .map_err(|error| {
-                    HttpError::for_internal_error(format!(
-                        "unsupported cookie value: {:#}",
-                        error
-                    ))
-                })?,
+                clear_session_cookie_header_value()?,
             );
         };
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -455,7 +455,7 @@ async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
     let (session_token, rest) = session_cookie.split_once("; ").unwrap();
 
     assert!(session_token.starts_with("session="));
-    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=3600");
+    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=28800");
 
     session_token.to_string()
 }

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -448,7 +448,7 @@ async fn expect_login_success(
         .split_once("; ")
         .expect("session cookie: bad cookie header value (missing semicolon)");
     assert!(token_cookie.starts_with("session="));
-    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=3600");
+    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=28800");
     let (_, session_token) = token_cookie
         .split_once('=')
         .expect("session cookie: bad cookie header value (missing 'session=')");


### PR DESCRIPTION
Set session cookie max age based on absolute timeout instead of idle timeout. Think of the browser timeout as a convenient cleanup rather than an actual enforcement mechanism. If the cookie expires server-side but the browser still has it, it will 403 just the same.

The first commit 4fadc2a5b484d19b69b1fcd8b34c2f040bbed27a is short and makes the actual change. The second commit is some cleanup around error handling that makes the diff more annoying to read.

Closes #3048