### PR TITLE
[console] cache assets in browser for a year, index.html not at all

### DIFF
--- a/common/src/nexus_config.rs
+++ b/common/src/nexus_config.rs
@@ -152,8 +152,6 @@ pub struct AuthnConfig {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConsoleConfig {
     pub static_dir: PathBuf,
-    /// how long the browser can cache static assets
-    pub cache_control_max_age_minutes: u32,
     /// how long a session can be idle before expiring
     pub session_idle_timeout_minutes: u32,
     /// how long a session can exist before expiring
@@ -499,7 +497,6 @@ mod test {
             r##"
             [console]
             static_dir = "tests/static"
-            cache_control_max_age_minutes = 10
             session_idle_timeout_minutes = 60
             session_absolute_timeout_minutes = 480
             [authn]
@@ -570,7 +567,6 @@ mod test {
                 pkg: PackageConfig {
                     console: ConsoleConfig {
                         static_dir: "tests/static".parse().unwrap(),
-                        cache_control_max_age_minutes: 10,
                         session_idle_timeout_minutes: 60,
                         session_absolute_timeout_minutes: 480
                     },
@@ -617,7 +613,6 @@ mod test {
             r##"
             [console]
             static_dir = "tests/static"
-            cache_control_max_age_minutes = 10
             session_idle_timeout_minutes = 60
             session_absolute_timeout_minutes = 480
             [authn]
@@ -670,7 +665,6 @@ mod test {
             r##"
             [console]
             static_dir = "tests/static"
-            cache_control_max_age_minutes = 10
             session_idle_timeout_minutes = 60
             session_absolute_timeout_minutes = 480
             [authn]
@@ -721,7 +715,6 @@ mod test {
             r##"
             [console]
             static_dir = "tests/static"
-            cache_control_max_age_minutes = 10
             session_idle_timeout_minutes = 60
             session_absolute_timeout_minutes = 480
             [authn]

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -5,7 +5,6 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "out/console-assets"
-cache_control_max_age_minutes = 10
 session_idle_timeout_minutes = 480 # 6 hours
 session_absolute_timeout_minutes = 1440 # 24 hours
 

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -57,8 +57,6 @@ pub struct ConsoleConfig {
     pub session_idle_timeout: Duration,
     /// how long a session can exist before expiring
     pub session_absolute_timeout: Duration,
-    /// how long browsers can cache static assets
-    pub cache_control_max_age: Duration,
     /// directory containing static file to serve
     pub static_dir: Option<PathBuf>,
 }
@@ -191,9 +189,6 @@ impl ServerContext {
                     config.pkg.console.session_absolute_timeout_minutes.into(),
                 ),
                 static_dir,
-                cache_control_max_age: Duration::minutes(
-                    config.pkg.console.cache_control_max_age_minutes.into(),
-                ),
             },
         }))
     }

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -8,7 +8,6 @@ nexus_https_port = 0
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "tests/static"
-cache_control_max_age_minutes = 10
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -240,6 +240,10 @@ async fn test_assets(cptestctx: &ControlPlaneTestContext) {
     // existing file is returned
     let resp = RequestBuilder::new(&testctx, Method::GET, "/assets/hello.txt")
         .expect_status(Some(StatusCode::OK))
+        .expect_response_header(
+            http::header::CACHE_CONTROL,
+            "max-age=31536000, immutable",
+        )
         .execute()
         .await
         .expect("failed to get existing file");
@@ -255,6 +259,10 @@ async fn test_assets(cptestctx: &ControlPlaneTestContext) {
         "/assets/a_directory/another_file.txt",
     )
     .expect_status(Some(StatusCode::OK))
+    .expect_response_header(
+        http::header::CACHE_CONTROL,
+        "max-age=31536000, immutable",
+    )
     .execute()
     .await
     .expect("failed to get existing file");
@@ -288,6 +296,10 @@ async fn test_assets(cptestctx: &ControlPlaneTestContext) {
             .header(http::header::ACCEPT_ENCODING, "gzip")
             .expect_status(Some(StatusCode::OK))
             .expect_response_header(http::header::CONTENT_ENCODING, "gzip")
+            .expect_response_header(
+                http::header::CACHE_CONTROL,
+                "max-age=31536000, immutable",
+            )
             .execute()
             .await
             .expect("failed to get existing file");

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -183,6 +183,7 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
                 http::header::CONTENT_TYPE,
                 "text/html; charset=UTF-8",
             )
+            .expect_response_header(http::header::CACHE_CONTROL, "no-store")
             .execute()
             .await
             .expect("failed to get console index");

--- a/smf/nexus/config-partial.toml
+++ b/smf/nexus/config-partial.toml
@@ -5,7 +5,7 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "/var/nexus/static"
-cache_control_max_age_minutes = 10
+cache_control_max_age_minutes = 10080 # 7 days (assets have hashes in filenames)
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480
 

--- a/smf/nexus/config-partial.toml
+++ b/smf/nexus/config-partial.toml
@@ -5,7 +5,6 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "/var/nexus/static"
-cache_control_max_age_minutes = 10080 # 7 days (assets have hashes in filenames)
 session_idle_timeout_minutes = 60
 session_absolute_timeout_minutes = 480
 


### PR DESCRIPTION
The assets have content hashes in the filenames, so whenever there's a new version, `index.html` (which is not cached at all) will point to the new filename, making the cache irrelevant.

Decided to hard code the cache time on the assets. I don't see a point in plumbing it through as a configurable value.

```
dist
├── assets
│  ├── app-2b12dbb1.js
│  ├── app-2b12dbb1.js.map
│  ├── favicon-f85aa1d6.svg
│  ├── GT-America-Mono-Medium-3af01ada.woff
│  ├── GT-America-Mono-Medium-14eb7e1f.woff2
│  ├── GT-America-Mono-Regular-OCC-4a8bb2aa.woff2
│  ├── GT-America-Mono-Regular-OCC-9b5fa807.woff
│  ├── index-1b4af6c1.css
│  ├── oxide-hero-rack-fa9186cf.webp
│  ├── SuisseIntl-Book-WebS-a34a1356.woff
│  ├── SuisseIntl-Book-WebS-fdc357d4.woff2
│  ├── SuisseIntl-Light-WebS-02ceb8ff.woff
│  ├── SuisseIntl-Light-WebS-d4cb666c.woff2
│  ├── SuisseIntl-Regular-WebS-9b09c5ee.woff
│  ├── SuisseIntl-Regular-WebS-bfa8da72.woff2
│  ├── SuisseIntl-RegularItalic-WebS-3bd20b80.woff2
│  ├── SuisseIntl-RegularItalic-WebS-d96d0ab7.woff
│  ├── Terminal-93061908.js
│  ├── Terminal-93061908.js.map
│  ├── TimeSeriesChart-0ea03c61.js
│  └── TimeSeriesChart-0ea03c61.js.map
└── index.html
```