### PR TITLE
[wicket] Fix updating switch SPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2d8598404cc3fd86104681ae25a86a17fe5a0773#2d8598404cc3fd86104681ae25a86a17fe5a0773"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=5ab6fbe65b24c6018fc0bbf95917370a8b9cb349#5ab6fbe65b24c6018fc0bbf95917370a8b9cb349"
 dependencies = [
  "bitflags",
  "hubpack 0.1.2",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2d8598404cc3fd86104681ae25a86a17fe5a0773#2d8598404cc3fd86104681ae25a86a17fe5a0773"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=5ab6fbe65b24c6018fc0bbf95917370a8b9cb349#5ab6fbe65b24c6018fc0bbf95917370a8b9cb349"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,8 +167,8 @@ flate2 = "1.0.26"
 fs-err = "2.9.0"
 futures = "0.3.28"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "2d8598404cc3fd86104681ae25a86a17fe5a0773" }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2d8598404cc3fd86104681ae25a86a17fe5a0773" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "5ab6fbe65b24c6018fc0bbf95917370a8b9cb349" }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "5ab6fbe65b24c6018fc0bbf95917370a8b9cb349" }
 gateway-test-utils = { path = "gateway-test-utils" }
 headers = "0.3.8"
 heck = "0.4"

--- a/wicketd/src/mgs.rs
+++ b/wicketd/src/mgs.rs
@@ -24,7 +24,10 @@ use self::inventory::{
 
 mod inventory;
 
-const MGS_TIMEOUT: Duration = Duration::from_secs(10);
+// This timeout feels long, but needs to be long for the case where we update
+// our sidecar's SP: we won't get a respose until the SP brings back the
+// management network, which often takes 15+ seconds.
+const MGS_TIMEOUT: Duration = Duration::from_secs(30);
 
 // We support:
 //   * One outstanding query request from wicket


### PR DESCRIPTION
Prior to this change, we bumped into two issues when updating a switch SP:

1. The final request to MGS to reset the SP would time out; this was fixed by an upstream change in `gateway-sp-comms`
2. `wicket`'s detection of component update completion was insufficient and more fragile than it needed to be. We now check for either `StepCompleted` or `ExecutionCompleted`, and check for the last step involving the component instead of hard coding the final step ID for each of RoT/SP/Host.

Builds on #3055 