### PR TITLE
[console] `/sys/*` can be `/system/*` now that `/system/images` is gone

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -677,7 +677,7 @@ pub async fn console_settings_page(
 
 #[endpoint {
    method = GET,
-   path = "/sys/{path:.*}",
+   path = "/system/{path:.*}",
    unpublished = true,
 }]
 pub async fn console_system_page(

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -168,7 +168,7 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
         "/projects/irrelevant-path",
         "/projects-new",
         "/settings/irrelevant-path",
-        "/sys/irrelevant-path",
+        "/system/irrelevant-path",
         "/device/success",
         "/device/verify",
         "/utilization",


### PR DESCRIPTION
This requires the corresponding console change to be made at the same time, so I'll merge https://github.com/oxidecomputer/console/pull/1475, bump console here, and let CI pass on both so I can merge them at the same time.