### PR TITLE
Nexus tests do not need rustls's dangerous_configuration feature

### DIFF
--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -105,7 +105,7 @@ pem.workspace = true
 petgraph.workspace = true
 rcgen.workspace = true
 regex.workspace = true
-rustls = { workspace = true, features = ["dangerous_configuration"] }
+rustls = { workspace = true }
 subprocess.workspace = true
 term.workspace = true
 trust-dns-resolver.workspace = true

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -18,7 +18,6 @@ use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_nexus::external_api::params;
 use omicron_nexus::external_api::shared;
 use std::io::Write;
-use std::sync::Arc;
 
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
@@ -93,12 +92,6 @@ impl CertificateChain {
         tls_cert_to_pem(&self.cert_chain())
     }
 
-    fn make_pki_verifier(&self) -> rustls::client::WebPkiVerifier {
-        let mut root_store = rustls::RootCertStore { roots: vec![] };
-        root_store.add(&self.root_cert).expect("adding root cert");
-        rustls::client::WebPkiVerifier::new(root_store, None)
-    }
-
     // Issues a GET request using the certificate chain.
     async fn do_request(
         &self,
@@ -121,11 +114,11 @@ impl CertificateChain {
                 http_client.request(request).await.map(|_| ())
             }
             "https" => {
+                let mut root_store = rustls::RootCertStore { roots: vec![] };
+                root_store.add(&self.root_cert).expect("adding root cert");
                 let tls_config = rustls::ClientConfig::builder()
                     .with_safe_defaults()
-                    .with_custom_certificate_verifier(Arc::new(
-                        self.make_pki_verifier(),
-                    ))
+                    .with_root_certificates(root_store)
                     .with_no_client_auth();
                 let https_connector =
                     hyper_rustls::HttpsConnectorBuilder::new()


### PR DESCRIPTION
I just happened to notice this.  This feature came in with a recent rustls dependabot update because rustls 0.20.8 put `WebPkiVerifier` behind the `dangerous_configuration` feature.  We were only using `dangerous_configuration` in the Nexus test suite, but it still made me nervous and I found it was easy to avoid.