### PR TITLE
ci: enable the crates.io sparse protocol

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -16,6 +16,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 #
 # Set up a custom temporary directory within whatever one we were given so that

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -16,6 +16,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 #
 # Set up a custom temporary directory within whatever one we were given so that

--- a/.github/buildomat/jobs/build-end-to-end-tests.sh
+++ b/.github/buildomat/jobs/build-end-to-end-tests.sh
@@ -14,6 +14,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 ptime -m ./tools/install_builder_prerequisites.sh -yp
 

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -15,6 +15,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 #
 # Set up our PATH for use with this workspace.

--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -39,6 +39,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 TOP=$PWD
 

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -27,6 +27,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 ptime -m ./tools/install_builder_prerequisites.sh -yp
 ptime -m ./tools/ci_download_softnpu_machinery

--- a/.github/buildomat/jobs/recovery-image.sh
+++ b/.github/buildomat/jobs/recovery-image.sh
@@ -39,6 +39,7 @@ set -o xtrace
 
 cargo --version
 rustc --version
+export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 TOP=$PWD
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ name: Rust
 
 on: [ push, pull_request ]
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   check-style:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This exports [`CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse`](https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html) across all of our CI jobs that touch cargo. As I'm about to add yet another job onto the very long chain of Buildomat jobs, I wanted to get an easy win in time spent waiting for CI.

| job | `main` sample, n=10 | this commit, n=1 |
| - | - | - |
| `helios / deploy`[^1] | 92s | [22s](https://buildomat.eng.oxide.computer/wg/0/details/01H05Y3TPX4PNE2YYHW1Y5THEW/82ZeGXmpOYTzxFzT63IOvzQdygjD5lCMlE5rJA2dhQwNKstf/01H05Y4366GZFN7RC3TPD9V09R#S490) |

The amount of time spent in this step depends on how recently [the git index](https://github.com/rust-lang/crates.io-index) was compacted; it was most recently compacted in April, so this is on the lower end of how long updating the crates.io index takes.

(I'm unsure yet if this is impacting build times for the OS image tasks.)

[^1]: Measured from first `+ ptime -m cargo run` to `Downloading crates ...`