### PR TITLE
[sled-hardware] Don't pass DI_MAKE_LINK to `di_devlink_init`

### DIFF
--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -311,9 +311,9 @@ fn get_dev_path_of_whole_disk(
             continue;
         }
         let links = {
-            match DevLinks::new(true) {
+            match DevLinks::new(false) {
                 Ok(links) => links,
-                Err(_) => DevLinks::new(false).map_err(Error::DevInfo)?,
+                Err(_) => DevLinks::new(true).map_err(Error::DevInfo)?,
             }
         };
         let devfs_path = m.devfs_path().map_err(Error::DevInfo)?;


### PR DESCRIPTION
Experimentally, calling `DevLinks::new(true)` results in installinator failing to find M.2s, even in a retry loop after they have definitely been attached; calling `DevLinks::new(false)` allows the retry loop to succeed once they have attached. It seems like `true` (which corresponds to a call to `di_devlink_init(NULL, DI_MAKE_LINK)`) results in us seeing cached data, and `false` forces a sync that lets us see up-to-date data. This is the opposite of what I'd expect from the `di_devlink_init` manpage, so I posted a question in the host-software channel to ask for clarification. But I'm going to go ahead and open this PR so CI will build me a complete trampoline image with this change for me to test tomorrow.