### PR TITLE
Split starting running snapshots into two steps

### DIFF
--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -979,6 +979,8 @@ pub(crate) mod test {
         );
         assert!(no_region_allocations_exist(datastore, &test).await);
         assert!(no_regions_ensured(&sled_agent, &test).await);
+
+        assert!(test.crucible_resources_deleted().await);
     }
 
     #[nexus_test(server = crate::Server)]

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -37,6 +37,7 @@ struct CrucibleDataInner {
     snapshots: HashMap<Uuid, Vec<Snapshot>>,
     running_snapshots: HashMap<Uuid, HashMap<String, RunningSnapshot>>,
     on_create: Option<CreateCallback>,
+    creating_a_running_snapshot_should_fail: bool,
     next_port: u16,
 }
 
@@ -47,6 +48,7 @@ impl CrucibleDataInner {
             snapshots: HashMap::new(),
             running_snapshots: HashMap::new(),
             on_create: None,
+            creating_a_running_snapshot_should_fail: false,
             next_port: crucible_port,
         }
     }
@@ -175,11 +177,19 @@ impl CrucibleDataInner {
         Ok(())
     }
 
+    fn set_creating_a_running_snapshot_should_fail(&mut self) {
+        self.creating_a_running_snapshot_should_fail = true;
+    }
+
     fn create_running_snapshot(
         &mut self,
         id: &RegionId,
         name: &str,
     ) -> Result<RunningSnapshot> {
+        if self.creating_a_running_snapshot_should_fail {
+            bail!("failure creating running snapshot");
+        }
+
         let id = Uuid::from_str(&id.0).unwrap();
 
         let map =
@@ -306,6 +316,10 @@ impl CrucibleData {
         name: &str,
     ) -> Result<()> {
         self.inner.lock().await.delete_snapshot(id, name)
+    }
+
+    pub async fn set_creating_a_running_snapshot_should_fail(&self) {
+        self.inner.lock().await.set_creating_a_running_snapshot_should_fail();
     }
 
     pub async fn create_running_snapshot(


### PR DESCRIPTION
When Saga nodes fail, the corresponding undo function is not executed. If a saga node can partially succeed before failing, the undo function has to be split into a separate saga step in order to properly unwind the created resources. This wasn't being done for running snapshots, so this commit corrects that and adds a test for it.

Fixes #3085