### PR TITLE
Add some extra docs to the image type

### DIFF
--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -105,7 +105,11 @@ pub struct Certificate {
 
 // IMAGES
 
-/// Client view of images
+/// View of an image
+///
+/// If `project_id` is present then the image is only visible inside that
+/// project. If it's not present then the image is visible to all projects in
+/// the silo.
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Image {
     #[serde(flatten)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8563,7 +8563,7 @@
         ]
       },
       "Image": {
-        "description": "Client view of images",
+        "description": "View of an image\n\nIf `project_id` is present then the image is only visible inside that project. If it's not present then the image is visible to all projects in the silo.",
         "type": "object",
         "properties": {
           "block_size": {


### PR DESCRIPTION
As mentioned in #3084, this adds documentation to `Image` to clarify when the image is considered a project image vs when it's a silo image. 