### PR TITLE
Allow building an oximeter producer using a concrete logger

### DIFF
--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -22,6 +22,7 @@ use omicron_common::nexus_config;
 use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
 use oximeter_collector::Oximeter;
+use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
 use slog::o;
 use slog::Logger;
@@ -499,13 +500,13 @@ pub async fn start_producer_server(
     let config = oximeter_producer::Config {
         server_info,
         registration_address: nexus_address,
-        dropshot_config: ConfigDropshot {
+        dropshot: ConfigDropshot {
             bind_address: producer_address,
             ..Default::default()
         },
-        logging_config: ConfigLogging::StderrTerminal {
+        log: LogConfig::Config(ConfigLogging::StderrTerminal {
             level: ConfigLoggingLevel::Error,
-        },
+        }),
     };
     let server =
         ProducerServer::start(&config).await.map_err(|e| e.to_string())?;

--- a/oximeter/producer/examples/producer.rs
+++ b/oximeter/producer/examples/producer.rs
@@ -3,16 +3,24 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Integration test running a producer that exports a few basic metrics.
-// Copyright 2021 Oxide Computer Company
 
-use chrono::{DateTime, Utc};
-use dropshot::{ConfigDropshot, ConfigLogging, ConfigLoggingLevel};
+// Copyright 2023 Oxide Computer Company
+
+use chrono::DateTime;
+use chrono::Utc;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
-use oximeter::{
-    types::{Cumulative, Sample},
-    Metric, MetricsError, Producer, Target,
-};
-use oximeter_producer::{Config, Server};
+use oximeter::types::Cumulative;
+use oximeter::types::Sample;
+use oximeter::Metric;
+use oximeter::MetricsError;
+use oximeter::Producer;
+use oximeter::Target;
+use oximeter_producer::Config;
+use oximeter_producer::LogConfig;
+use oximeter_producer::Server;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -86,13 +94,14 @@ impl Producer for CpuBusyProducer {
 #[tokio::main]
 async fn main() {
     let address = "[::1]:0".parse().unwrap();
-    let dropshot_config = ConfigDropshot {
+    let dropshot = ConfigDropshot {
         bind_address: address,
         request_body_max_bytes: 2048,
         tls: None,
     };
-    let logging_config =
-        ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug };
+    let log = LogConfig::Config(ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Debug,
+    });
     let server_info = ProducerEndpoint {
         id: Uuid::new_v4(),
         address,
@@ -102,8 +111,8 @@ async fn main() {
     let config = Config {
         server_info,
         registration_address: "[::1]:12221".parse().unwrap(),
-        dropshot_config,
-        logging_config,
+        dropshot,
+        log,
     };
     let server = Server::start(&config).await.unwrap();
     let producer = CpuBusyProducer::new(4);

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -17,6 +17,7 @@ use omicron_common::api::external::Generation;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
 use propolis_client::api::DiskAttachmentState as PropolisDiskState;
 use std::net::{Ipv6Addr, SocketAddr};
@@ -174,13 +175,13 @@ impl SimDisk {
         let config = oximeter_producer::Config {
             server_info,
             registration_address: nexus_address,
-            dropshot_config: ConfigDropshot {
+            dropshot: ConfigDropshot {
                 bind_address: producer_address,
                 ..Default::default()
             },
-            logging_config: ConfigLogging::StderrTerminal {
+            log: LogConfig::Config(ConfigLogging::StderrTerminal {
                 level: ConfigLoggingLevel::Error,
-            },
+            }),
         };
         let server =
             ProducerServer::start(&config).await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
- Add `LogConfig` enum which supports either configuration for building a new logger, or an actual logger from which to create a child for the producer.
- Update consuming code.