### PR TITLE
Minor fixes to tools/build-host-image.sh

### DIFF
--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -19,23 +19,21 @@ function main
         case $opt in
             f)
                 FORCE=1
-                shift
                 ;;
             R)
                 BUILD_RECOVERY=1
                 HELIOS_BUILD_EXTRA_ARGS=-R
-                shift
                 ;;
             B)
                 BUILD_STANDARD=1
                 HELIOS_BUILD_EXTRA_ARGS=-B
-                shift
                 ;;
             h | \?)
                 usage
                 ;;
         esac
     done
+    shift $((OPTIND-1))
 
     # Ensure we got either -R or -B but not both
     case "x$BUILD_RECOVERY$BUILD_STANDARD" in

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -65,8 +65,8 @@ function main
         *) HELIOS_PATH=$(pwd)/$1 ;;
     esac
     case $2 in
-        /*) TRAMPOLINE_PATH=$2 ;;
-        *) TRAMPOLINE_PATH=$(pwd)/$2 ;;
+        /*) GLOBAL_ZONE_TARBALL_PATH=$2 ;;
+        *) GLOBAL_ZONE_TARBALL_PATH=$(pwd)/$2 ;;
     esac
 
     # Extract the trampoline global zone tarball into a tmp_gz directory
@@ -75,8 +75,8 @@ function main
     fi
     trap 'cd /; rm -rf "$tmp_gz"' EXIT
 
-    echo "Extracting trampoline gz packages into $tmp_gz"
-    ptime -m tar xvzf $TRAMPOLINE_PATH -C $tmp_gz
+    echo "Extracting gz packages into $tmp_gz"
+    ptime -m tar xvzf $GLOBAL_ZONE_TARBALL_PATH -C $tmp_gz
 
     # Move to the helios checkout
     cd $HELIOS_PATH


### PR DESCRIPTION
I was doing some testing with different `helios` branches and found that the parsing of the `FORCE` option was incorrect. This fixes that parsing, and clarifies that the second arg is for the global zone package tarball (not only the trampoline global zone).