### PR TITLE
[update-engine] dedup remote nested events

### DIFF
--- a/openapi/installinator-artifactd.json
+++ b/openapi/installinator-artifactd.json
@@ -215,6 +215,12 @@
               "$ref": "#/components/schemas/ProgressEventForInstallinatorSpec"
             }
           },
+          "root_execution_id": {
+            "nullable": true,
+            "description": "The root execution ID for this report.\n\nEach report has a root execution ID, which ties together all step and progress events. This is always filled out if the list of step events is non-empty.",
+            "type": "string",
+            "format": "uuid"
+          },
           "step_events": {
             "description": "A list of step events.\n\nStep events include success and failure events.",
             "type": "array",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -426,6 +426,12 @@
               "$ref": "#/components/schemas/ProgressEventForWicketdEngineSpec"
             }
           },
+          "root_execution_id": {
+            "nullable": true,
+            "description": "The root execution ID for this report.\n\nEach report has a root execution ID, which ties together all step and progress events. This is always filled out if the list of step events is non-empty.",
+            "type": "string",
+            "format": "uuid"
+          },
           "step_events": {
             "description": "A list of step events.\n\nStep events include success and failure events.",
             "type": "array",

--- a/update-engine/src/buffer.rs
+++ b/update-engine/src/buffer.rs
@@ -131,9 +131,10 @@ impl<S: StepSpec> EventBuffer<S> {
         // Gather step events across all keys.
         let mut step_events = Vec::new();
         let mut progress_events = Vec::new();
-        for value in self.event_store.map.values() {
-            step_events.extend(value.step_events_since(last_seen).cloned());
-            progress_events.extend(value.step_status.progress_event().cloned());
+        for (_, step_data) in self.steps().as_slice() {
+            step_events.extend(step_data.step_events_since(last_seen).cloned());
+            progress_events
+                .extend(step_data.step_status.progress_event().cloned());
         }
 
         // Sort events.
@@ -145,7 +146,12 @@ impl<S: StepSpec> EventBuffer<S> {
             last_seen = Some(last.event_index);
         }
 
-        EventReport { step_events, progress_events, last_seen }
+        EventReport {
+            step_events,
+            progress_events,
+            root_execution_id: self.root_execution_id(),
+            last_seen,
+        }
     }
 
     /// Returns true if any further step events are pending since `last_seen`.
@@ -154,8 +160,8 @@ impl<S: StepSpec> EventBuffer<S> {
     /// step events. A typical use for this is to check that all step events
     /// have been reported before a sender shuts down.
     pub fn has_pending_events_since(&self, last_seen: Option<usize>) -> bool {
-        for value in self.event_store.map.values() {
-            if value.step_events_since(last_seen).next().is_some() {
+        for (_, step_data) in self.steps().as_slice() {
+            if step_data.step_events_since(last_seen).next().is_some() {
                 return true;
             }
         }
@@ -719,6 +725,8 @@ impl<S: StepSpec> EventBufferStepData<S> {
     }
 
     fn add_high_priority_step_event(&mut self, event: StepEvent<S>) {
+        // Dedup by the *leaf index* in case nested reports aren't deduped
+        // coming in.
         match self.high_priority.binary_search_by(|probe| {
             probe.leaf_event_index().cmp(&event.leaf_event_index())
         }) {
@@ -745,6 +753,8 @@ impl<S: StepSpec> EventBufferStepData<S> {
                 );
             }
             StepStatus::Running { low_priority, .. } => {
+                // Dedup by the *leaf index* in case nested reports aren't
+                // deduped coming in.
                 match low_priority.binary_search_by(|probe| {
                     probe.leaf_event_index().cmp(&event.leaf_event_index())
                 }) {
@@ -1092,7 +1102,7 @@ mod tests {
             .new_step(
                 "nested".to_owned(),
                 3,
-                "Step 3 (this is nested",
+                "Step 3 (this is nested)",
                 move |parent_cx| async move {
                     parent_cx
                         .with_nested_engine(|engine| {
@@ -1107,10 +1117,48 @@ mod tests {
             )
             .register();
 
-        // The step index here (20) is large enough to be higher than all nested
+        let log = logctx.log.clone();
+        engine
+            .new_step(
+                "remote-nested".to_owned(),
+                20,
+                "Step 4 (remote nested)",
+                move |cx| async move {
+                    let (sender, mut receiver) = mpsc::channel(16);
+                    let mut engine = UpdateEngine::new(&log, sender);
+                    define_remote_nested_engine(&mut engine, 20);
+
+                    let mut buffer = EventBuffer::default();
+
+                    let mut execute_fut = std::pin::pin!(engine.execute());
+                    let mut execute_done = false;
+                    loop {
+                        tokio::select! {
+                            res = &mut execute_fut, if !execute_done => {
+                                res.expect("remote nested engine completed successfully");
+                                execute_done = true;
+                            }
+                            Some(event) = receiver.recv() => {
+                                // Generate complete reports to ensure deduping
+                                // happens within StepContexts.
+                                buffer.add_event(event);
+                                cx.send_nested_report(buffer.generate_report()).await?;
+                            }
+                            else => {
+                                break;
+                            }
+                        }
+                    }
+
+                    StepResult::success((), Default::default())
+                },
+            )
+            .register();
+
+        // The step index here (100) is large enough to be higher than all nested
         // steps.
         engine
-            .new_step("baz".to_owned(), 20, "Step 4", move |_cx| async move {
+            .new_step("baz".to_owned(), 100, "Step 5", move |_cx| async move {
                 StepResult::success((), Default::default())
             })
             .register();
@@ -1229,10 +1277,36 @@ mod tests {
                         panic!("first event should always be a step event")
                     }
                 };
+
+            // Ensure that events are never seen twice.
+            let mut event_indexes_seen = HashSet::new();
+            let mut leaf_event_indexes_seen = HashSet::new();
             let generated_step_events: Vec<_> = generated_events
                 .iter()
                 .filter_map(|event| match event {
-                    Event::Step(event) => Some(event.clone()),
+                    Event::Step(event) => {
+                        if event_indexes_seen.contains(&event.event_index) {
+                            panic!(
+                                "duplicate event seen for index {}",
+                                event.event_index
+                            );
+                        }
+                        event_indexes_seen.insert(event.event_index);
+
+                        let leaf_event_key = (
+                            event.leaf_execution_id(),
+                            event.leaf_event_index(),
+                        );
+                        if leaf_event_indexes_seen.contains(&leaf_event_key) {
+                            panic!(
+                                "duplicate leaf event seen \
+                                 for key {leaf_event_key:?}",
+                            );
+                        }
+                        leaf_event_indexes_seen.insert(leaf_event_key);
+
+                        Some(event.clone())
+                    }
                     Event::Progress(_) => None,
                 })
                 .collect();
@@ -1489,19 +1563,32 @@ mod tests {
                     ),
                     "this is the last event so ExecutionStatus must be completed"
                 );
-                // There is one nested engine.
+                // There are two nested engines.
                 ensure!(
-                    summary.len() == 2,
-                    "one nested engine must be defined"
+                    summary.len() == 3,
+                    "two nested engines must be defined"
                 );
-                let (_, nested_summary) =
-                    summary.last().expect("this is the second nested engine");
+
+                let (_, nested_summary) = summary
+                    .get_index(1)
+                    .expect("this is the first nested engine");
                 ensure!(
                     matches!(
                         nested_summary.execution_status,
                         ExecutionStatus::Failed { .. },
                     ),
                     "for this engine, the ExecutionStatus must be failed"
+                );
+
+                let (_, nested_summary) = summary
+                    .get_index(2)
+                    .expect("this is the second nested engine");
+                ensure!(
+                    matches!(
+                        nested_summary.execution_status,
+                        ExecutionStatus::Completed { .. },
+                    ),
+                    "for this engine, the ExecutionStatus must be succeeded"
                 );
             } else {
                 ensure!(
@@ -1610,6 +1697,43 @@ mod tests {
                     .await;
 
                     bail!("failing step")
+                },
+            )
+            .register();
+    }
+
+    fn define_remote_nested_engine(
+        engine: &mut UpdateEngine<'_, TestSpec>,
+        start_id: usize,
+    ) {
+        engine
+            .new_step(
+                "nested-foo".to_owned(),
+                start_id + 1,
+                "Nested step 1",
+                move |cx| async move {
+                    cx.send_progress(
+                        StepProgress::progress(Default::default()),
+                    )
+                    .await;
+                    StepResult::success((), Default::default())
+                },
+            )
+            .register();
+
+        engine
+            .new_step::<_, _, ()>(
+                "nested-bar".to_owned(),
+                start_id + 2,
+                "Nested step 2",
+                move |cx| async move {
+                    cx.send_progress(StepProgress::with_current(
+                        20,
+                        Default::default(),
+                    ))
+                    .await;
+
+                    StepResult::success((), Default::default())
                 },
             )
             .register();

--- a/update-engine/src/buffer.rs
+++ b/update-engine/src/buffer.rs
@@ -719,10 +719,9 @@ impl<S: StepSpec> EventBufferStepData<S> {
     }
 
     fn add_high_priority_step_event(&mut self, event: StepEvent<S>) {
-        match self
-            .high_priority
-            .binary_search_by(|probe| probe.event_index.cmp(&event.event_index))
-        {
+        match self.high_priority.binary_search_by(|probe| {
+            probe.leaf_event_index().cmp(&event.leaf_event_index())
+        }) {
             Ok(_) => {
                 // This is a duplicate.
             }
@@ -747,7 +746,7 @@ impl<S: StepSpec> EventBufferStepData<S> {
             }
             StepStatus::Running { low_priority, .. } => {
                 match low_priority.binary_search_by(|probe| {
-                    probe.event_index.cmp(&event.event_index)
+                    probe.leaf_event_index().cmp(&event.leaf_event_index())
                 }) {
                     Ok(_) => {
                         // This is a duplicate.

--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -193,6 +193,15 @@ impl<S: StepSpec> StepEvent<S> {
         }
     }
 
+    /// Returns the execution ID for the leaf event, recursing into nested
+    /// events if necessary.
+    pub fn leaf_execution_id(&self) -> ExecutionId {
+        match &self.kind {
+            StepEventKind::Nested { event, .. } => event.leaf_execution_id(),
+            _ => self.execution_id,
+        }
+    }
+
     /// Returns the event index for the leaf event, recursing into nested events
     /// if necessary.
     pub fn leaf_event_index(&self) -> usize {
@@ -1426,6 +1435,13 @@ pub struct EventReport<S: StepSpec> {
     /// nested event in progress.
     pub progress_events: Vec<ProgressEvent<S>>,
 
+    /// The root execution ID for this report.
+    ///
+    /// Each report has a root execution ID, which ties together all step and
+    /// progress events. This is always filled out if the list of step events is
+    /// non-empty.
+    pub root_execution_id: Option<ExecutionId>,
+
     /// The last event seen.
     ///
     /// `last_seen` can be used to retrieve deltas of events.
@@ -1461,6 +1477,7 @@ impl<S: StepSpec> EventReport<S> {
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,
+            root_execution_id: value.root_execution_id,
             last_seen: value.last_seen,
         })
     }
@@ -1487,6 +1504,7 @@ impl<S: StepSpec> EventReport<S> {
                 .into_iter()
                 .map(|event| event.into_generic())
                 .collect(),
+            root_execution_id: self.root_execution_id,
             last_seen: self.last_seen,
         }
     }

--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -192,6 +192,16 @@ impl<S: StepSpec> StepEvent<S> {
             | StepEventKind::Unknown => None,
         }
     }
+
+    /// Returns the event index for the leaf event, recursing into nested events
+    /// if necessary.
+    pub fn leaf_event_index(&self) -> usize {
+        match &self.kind {
+            StepEventKind::Nested { event, .. } => event.leaf_event_index(),
+            _ => self.event_index,
+        }
+    }
+
     /// Converts a generic version into self.
     ///
     /// This version can be used to convert a generic type into a more concrete

--- a/wicket/src/ui/wrap.rs
+++ b/wicket/src/ui/wrap.rs
@@ -295,7 +295,8 @@ impl<'a> Fragment for StyledWord<'a> {
     }
 
     fn whitespace_width(&self) -> f64 {
-        // Since whitespace is always ASCII spaces, this is
+        // Since whitespace is always ASCII spaces, this is equal to the number
+        // of whitespace characters.
         self.whitespace.len() as f64
     }
 


### PR DESCRIPTION
Deduplicate nested events coming from remote machines in a couple of spots:

1. When we're generating nested events, such that duplicate events don't make their way over the event channel. Maintain event buffers within `StepContext`s to handle that.
2. In `EventBuffer` itself, dedup events based on the leaf index rather than the root index. If two events have the same leaf event index and leaf execution ID, they can always be deduped.

While testing this, I also realized it would be really useful to add a `root_execution_id` to every event report: do so, and depend on it (note that you'll have to rebuild installinator with this PR to pick up support for that).

Finally, address the review comment in https://github.com/oxidecomputer/omicron/pull/3081 -- do it here to avoid having to create a whole separate PR for this.

Fixes #3102.