### PR TITLE
nexus: update instance networking config after live migration

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1025,7 +1025,13 @@ impl super::Nexus {
         //   race with this one.
         // - This work is not done in a saga. The presumption is instead that
         //   if any of these operations fail, the entire update will fail, and
-        //   sled agent will retry the update.
+        //   sled agent will retry the update. Unwinding on failure isn't needed
+        //   because (a) any partially-applied configuration is correct
+        //   configuration, (b) if the instance is migrating, it can't migrate
+        //   again until this routine successfully updates configuration and
+        //   writes an update back to CRDB, and (c) sled agent won't process any
+        //   new instance state changes (e.g. a change that stops an instance)
+        //   until this state change is successfully committed.
         let (.., db_instance) = LookupPath::new(&opctx, &self.db_datastore)
             .instance_id(*id)
             .fetch_for(authz::Action::Read)

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1343,7 +1343,7 @@ impl super::Nexus {
                 ))
             })?;
 
-            debug!(log, "creation of nat entry successful for: {target_ip:#?}");
+            info!(log, "creation of nat entry successful for: {target_ip:#?}");
         }
 
         Ok(())

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -42,6 +42,7 @@ use sled_agent_client::types::InstanceStateRequested;
 use sled_agent_client::types::SourceNatConfig;
 use sled_agent_client::Client as SledAgentClient;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
@@ -993,6 +994,7 @@ impl super::Nexus {
     /// Instance.
     pub async fn notify_instance_updated(
         &self,
+        opctx: &OpContext,
         id: &Uuid,
         new_runtime_state: &nexus::InstanceRuntimeState,
     ) -> Result<(), Error> {
@@ -1001,6 +1003,43 @@ impl super::Nexus {
         slog::debug!(log, "received new runtime state from sled agent";
                      "instance_id" => %id,
                      "runtime_state" => ?new_runtime_state);
+
+        // If the new state has a newer Propolis ID generation than the current
+        // instance state in CRDB, notify interested parties of this change.
+        //
+        // The synchronization rules here are as follows:
+        //
+        // - Sled agents own an instance's runtime state while an instance is
+        //   running on a sled. Each sled agent prevents concurrent conflicting
+        //   Propolis identifier updates from being sent until previous updates
+        //   are processed.
+        // - Operations that can dispatch an instance to a brand-new sled (e.g.
+        //   live migration) can only start if the appropriate instance runtime
+        //   state fields are cleared in CRDB. For example, while a live
+        //   migration is in progress, the instance's `migration_id` field will
+        //   be non-NULL, and a new migration cannot start until it is cleared.
+        //   This routine must notify recipients before writing new records
+        //   back to CRDB so that these "locks" remain held until all
+        //   notifications have been sent. Otherwise, Nexus might allow new
+        //   operations to proceed that will produce system updates that might
+        //   race with this one.
+        // - This work is not done in a saga. The presumption is instead that
+        //   if any of these operations fail, the entire update will fail, and
+        //   sled agent will retry the update.
+        let (.., db_instance) = LookupPath::new(&opctx, &self.db_datastore)
+            .instance_id(*id)
+            .fetch_for(authz::Action::Read)
+            .await?;
+
+        if new_runtime_state.propolis_gen > *db_instance.runtime().propolis_gen
+        {
+            self.handle_instance_propolis_gen_change(
+                opctx,
+                new_runtime_state,
+                &db_instance,
+            )
+            .await?;
+        }
 
         let result = self
             .db_datastore
@@ -1050,6 +1089,264 @@ impl super::Nexus {
                 Err(error)
             }
         }
+    }
+
+    async fn handle_instance_propolis_gen_change(
+        &self,
+        opctx: &OpContext,
+        new_runtime: &nexus::InstanceRuntimeState,
+        db_instance: &nexus_db_model::Instance,
+    ) -> Result<(), Error> {
+        let log = &self.log;
+        let instance_id = db_instance.id();
+
+        info!(log,
+              "updating configuration after Propolis generation change";
+              "instance_id" => %instance_id,
+              "new_sled_id" => %new_runtime.sled_id,
+              "old_sled_id" => %db_instance.runtime().sled_id);
+
+        // Push updated V2P mappings to all interested sleds. This needs to be
+        // done irrespective of whether the sled ID actually changed, because
+        // merely creating the target Propolis on the target sled will create
+        // XDE devices for its NICs, and creating an XDE device for a virtual IP
+        // creates a V2P mapping that maps that IP to that sled. This is fine if
+        // migration succeeded, but if it failed, the instance is running on the
+        // source sled, and the incorrect mapping needs to be replaced.
+        //
+        // TODO(#3107): When XDE no longer creates mappings implicitly, this
+        // can be restricted to cases where an instance's sled has actually
+        // changed.
+        self.create_instance_v2p_mappings(
+            opctx,
+            instance_id,
+            new_runtime.sled_id,
+        )
+        .await?;
+
+        let (.., sled) = LookupPath::new(opctx, &self.db_datastore)
+            .sled_id(new_runtime.sled_id)
+            .fetch()
+            .await?;
+
+        self.instance_ensure_dpd_config(
+            opctx,
+            db_instance.id(),
+            &sled.address(),
+            None,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Ensures that the Dendrite configuration for the supplied instance is
+    /// up-to-date.
+    ///
+    /// # Parameters
+    ///
+    /// - `opctx`: An operation context that grants read and list-children
+    ///   permissions on the identified instance.
+    /// - `instance_id`: The ID of the instance to act on.
+    /// - `sled_ip_address`: The internal IP address assigned to the sled's
+    ///   sled agent.
+    /// - `ip_index_filter`: An optional filter on the index into the instance's
+    ///   external IP array.
+    ///   - If this is `Some(n)`, this routine configures DPD state for only the
+    ///     Nth external IP in the collection returned from CRDB. The caller is
+    ///     responsible for ensuring that the IP collection has stable indices
+    ///     when making this call.
+    ///   - If this is `None`, this routine configures DPD for all external
+    ///     IPs.
+    pub(crate) async fn instance_ensure_dpd_config(
+        &self,
+        opctx: &OpContext,
+        instance_id: Uuid,
+        sled_ip_address: &std::net::SocketAddrV6,
+        ip_index_filter: Option<usize>,
+    ) -> Result<(), Error> {
+        let log = &self.log;
+        let dpd_client = &self.dpd_client;
+
+        info!(log, "looking up instance's primary network interface";
+              "instance_id" => %instance_id);
+
+        let (.., authz_instance) = LookupPath::new(opctx, &self.db_datastore)
+            .instance_id(instance_id)
+            .lookup_for(authz::Action::ListChildren)
+            .await?;
+
+        let network_interface = match self
+            .db_datastore
+            .derive_guest_network_interface_info(&opctx, &authz_instance)
+            .await?
+            .into_iter()
+            .find(|interface| interface.primary)
+        {
+            Some(interface) => interface,
+            // Return early if instance does not have a primary network
+            // interface
+            None => {
+                info!(log, "Instance has no primary network interface";
+                      "instance_id" => %instance_id);
+                return Ok(());
+            }
+        };
+
+        let mac_address =
+            macaddr::MacAddr6::from_str(&network_interface.mac.to_string())
+                .map_err(|e| {
+                    Error::internal_error(&format!(
+                        "failed to convert mac address: {e}"
+                    ))
+                })?;
+
+        let vni: u32 = network_interface.vni.into();
+
+        info!(log, "looking up instance's external IPs";
+              "instance_id" => %instance_id);
+
+        let ips = self
+            .db_datastore
+            .instance_lookup_external_ips(&opctx, instance_id)
+            .await?;
+
+        if let Some(wanted_index) = ip_index_filter {
+            if let None = ips.get(wanted_index) {
+                return Err(Error::internal_error(&format!(
+                    "failed to find external ip address at index: {}",
+                    wanted_index
+                )));
+            }
+        }
+
+        for target_ip in ips
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| {
+                if let Some(wanted_index) = ip_index_filter {
+                    *index == wanted_index
+                } else {
+                    true
+                }
+            })
+            .map(|(_, ip)| ip)
+        {
+            info!(log, "setting up dpd for external IP";
+                  "instance_id" => %instance_id,
+                  "external_ip" => ?target_ip);
+
+            let existing_nat = match target_ip.ip {
+                ipnetwork::IpNetwork::V4(network) => {
+                    dpd_client
+                        .nat_ipv4_get(&network.ip(), *target_ip.first_port)
+                        .await
+                }
+                ipnetwork::IpNetwork::V6(network) => {
+                    dpd_client
+                        .nat_ipv6_get(&network.ip(), *target_ip.first_port)
+                        .await
+                }
+            };
+
+            // If a NAT entry already exists, but has the wrong internal
+            // IP address, delete the old entry before continuing (the
+            // DPD entry-creation API won't replace an existing entry).
+            // If the entry exists and has the right internal IP, there's
+            // no more work to do for this external IP.
+            match existing_nat {
+                Ok(existing) => {
+                    let existing = existing.into_inner();
+                    if existing.internal_ip != *sled_ip_address.ip() {
+                        info!(log, "deleting old nat entry";
+                          "instance_id" => %instance_id,
+                          "external_ip" => ?target_ip);
+
+                        match target_ip.ip {
+                            ipnetwork::IpNetwork::V4(network) => {
+                                dpd_client
+                                    .nat_ipv4_delete(
+                                        &network.ip(),
+                                        *target_ip.first_port,
+                                    )
+                                    .await
+                            }
+                            ipnetwork::IpNetwork::V6(network) => {
+                                dpd_client
+                                    .nat_ipv6_delete(
+                                        &network.ip(),
+                                        *target_ip.first_port,
+                                    )
+                                    .await
+                            }
+                        }
+                        .map_err(|e| {
+                            Error::internal_error(&format!(
+                                "failed to clear dpd entry: {e}"
+                            ))
+                        })?;
+                    } else {
+                        info!(log,
+                          "nat entry with expected internal ip exists, continuing";
+                          "instance_id" => %instance_id,
+                          "external_ip" => ?target_ip,
+                          "existing_entry" => ?existing);
+
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    if e.status() == Some(http::StatusCode::NOT_FOUND) {
+                        info!(log, "no nat entry found for: {target_ip:#?}");
+                    } else {
+                        return Err(Error::internal_error(&format!(
+                            "failed to query dpd: {e}"
+                        )));
+                    }
+                }
+            }
+
+            info!(log, "creating nat entry for: {target_ip:#?}");
+            let nat_target = dpd_client::types::NatTarget {
+                inner_mac: dpd_client::types::MacAddr {
+                    a: mac_address.into_array(),
+                },
+                internal_ip: *sled_ip_address.ip(),
+                vni: vni.into(),
+            };
+
+            match target_ip.ip {
+                ipnetwork::IpNetwork::V4(network) => {
+                    dpd_client
+                        .nat_ipv4_create(
+                            &network.ip(),
+                            *target_ip.first_port,
+                            *target_ip.last_port,
+                            &nat_target,
+                        )
+                        .await
+                }
+                ipnetwork::IpNetwork::V6(network) => {
+                    dpd_client
+                        .nat_ipv6_create(
+                            &network.ip(),
+                            *target_ip.first_port,
+                            *target_ip.last_port,
+                            &nat_target,
+                        )
+                        .await
+                }
+            }
+            .map_err(|e| {
+                Error::internal_error(&format!(
+                    "failed to create nat entry: {e}"
+                ))
+            })?;
+
+            debug!(log, "creation of nat entry successful for: {target_ip:#?}");
+        }
+
+        Ok(())
     }
 
     /// Returns the requested range of serial console output bytes,

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -377,8 +377,7 @@ async fn sic_add_network_config(
         .instance_id(instance_id)
         .fetch()
         .await
-        .map_err(ActionError::action_failed)
-        .unwrap();
+        .map_err(ActionError::action_failed)?;
 
     // Read the sled record from the database. This needs to use the instance-
     // create context (and not the regular saga context) to leverage its fleet-

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -34,7 +34,6 @@ use slog::warn;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::net::Ipv6Addr;
-use std::str::FromStr;
 use steno::ActionError;
 use steno::Node;
 use steno::{DagBuilder, SagaName};
@@ -373,131 +372,36 @@ async fn sic_add_network_config(
         &params.serialized_authn,
     );
     let osagactx = sagactx.user_data();
-    let dpd_client: &dpd_client::Client = &osagactx.nexus().dpd_client;
-    let datastore = &osagactx.datastore();
-    let log = sagactx.user_data().log();
-
-    let (.., authz_instance, db_instance) = LookupPath::new(&opctx, &datastore)
+    let datastore = osagactx.datastore();
+    let (.., db_instance) = LookupPath::new(&opctx, &datastore)
         .instance_id(instance_id)
         .fetch()
         .await
-        .map_err(ActionError::action_failed)?;
+        .map_err(ActionError::action_failed)
+        .unwrap();
 
-    let instance_id = db_instance.id();
+    // Read the sled record from the database. This needs to use the instance-
+    // create context (and not the regular saga context) to leverage its fleet-
+    // read permissions.
     let sled_uuid = db_instance.runtime_state.sled_id;
-
     let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, &datastore)
         .sled_id(sled_uuid)
         .fetch()
         .await
         .map_err(ActionError::action_failed)?;
 
-    let sled_ip_address = sled.address();
-
-    debug!(log, "fetching network interfaces");
-
-    let network_interface = match datastore
-        .derive_guest_network_interface_info(&opctx, &authz_instance)
+    // Set up Dendrite configuration using the saga context, which supplies
+    // access to the instance's device configuration.
+    osagactx
+        .nexus()
+        .instance_ensure_dpd_config(
+            &opctx,
+            instance_id,
+            &sled.address(),
+            Some(which),
+        )
         .await
-        .map_err(ActionError::action_failed)?
-        .into_iter()
-        .find(|interface| interface.primary)
-    {
-        Some(interface) => interface,
-        // Return early if instance does not have a primary network
-        // interface
-        None => return Ok(()),
-    };
-
-    let mac_address =
-        macaddr::MacAddr6::from_str(&network_interface.mac.to_string())
-            .map_err(|e| {
-                ActionError::action_failed(Error::internal_error(&format!(
-                    "failed to convert mac address: {e}"
-                )))
-            })?;
-
-    let vni: u32 = network_interface.vni.into();
-
-    debug!(log, "fetching external ip addresses");
-
-    let target_ip = &datastore
-        .instance_lookup_external_ips(&opctx, instance_id)
-        .await
-        .map_err(ActionError::action_failed)?
-        .get(which)
-        .ok_or_else(|| {
-            ActionError::action_failed(Error::internal_error(&format!(
-                "failed to find external ip address at index: {which}"
-            )))
-        })?
-        .to_owned();
-
-    debug!(log, "checking for existing nat mapping for {target_ip:#?}");
-
-    let existing_nat = match target_ip.ip {
-        ipnetwork::IpNetwork::V4(network) => {
-            dpd_client.nat_ipv4_get(&network.ip(), *target_ip.first_port).await
-        }
-        ipnetwork::IpNetwork::V6(network) => {
-            dpd_client.nat_ipv6_get(&network.ip(), *target_ip.first_port).await
-        }
-    };
-
-    match existing_nat {
-        Ok(_) => {
-            // nat entry already exists, do nothing
-            return Ok(());
-        }
-        Err(e) => {
-            if e.status() == Some(http::StatusCode::NOT_FOUND) {
-                debug!(log, "no nat entry found for: {target_ip:#?}");
-            } else {
-                return Err(ActionError::action_failed(Error::internal_error(
-                    &format!("failed to query dpd: {e}"),
-                )));
-            }
-        }
-    }
-
-    debug!(log, "creating nat entry for: {target_ip:#?}");
-
-    let nat_target = dpd_client::types::NatTarget {
-        inner_mac: dpd_client::types::MacAddr { a: mac_address.into_array() },
-        internal_ip: *sled_ip_address.ip(),
-        vni: vni.into(),
-    };
-
-    match target_ip.ip {
-        ipnetwork::IpNetwork::V4(network) => {
-            dpd_client
-                .nat_ipv4_create(
-                    &network.ip(),
-                    *target_ip.first_port,
-                    *target_ip.last_port,
-                    &nat_target,
-                )
-                .await
-        }
-        ipnetwork::IpNetwork::V6(network) => {
-            dpd_client
-                .nat_ipv6_create(
-                    &network.ip(),
-                    *target_ip.first_port,
-                    *target_ip.last_port,
-                    &nat_target,
-                )
-                .await
-        }
-    }
-    .map_err(|e| {
-        ActionError::action_failed(Error::internal_error(&format!(
-            "failed to create nat entry via dpd: {e}"
-        )))
-    })?;
-
-    debug!(log, "creation of nat entry successful for: {target_ip:#?}");
-    Ok(())
+        .map_err(ActionError::action_failed)
 }
 
 async fn sic_remove_network_config(
@@ -1280,10 +1184,11 @@ async fn sic_v2p_ensure(
         &params.serialized_authn,
     );
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
+    let sled_id = sagactx.lookup::<Uuid>("server_id")?;
 
     osagactx
         .nexus()
-        .create_instance_v2p_mappings(&opctx, instance_id)
+        .create_instance_v2p_mappings(&opctx, instance_id, sled_id)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -290,12 +290,18 @@ impl super::Nexus {
 
     // OPTE V2P mappings
 
-    /// Ensure that the necessary v2p mappings for an instance are created
+    /// Ensures that V2P mappings exist that indicate that the instance with ID
+    /// `instance_id` is resident on the sled with ID `sled_id`.
     pub async fn create_instance_v2p_mappings(
         &self,
         opctx: &OpContext,
         instance_id: Uuid,
+        sled_id: Uuid,
     ) -> Result<(), Error> {
+        info!(&self.log, "creating V2P mappings for instance";
+              "instance_id" => %instance_id,
+              "sled_id" => %sled_id);
+
         // For every sled that isn't the sled this instance was allocated to, create
         // a virtual to physical mapping for each of this instance's NICs.
         //
@@ -329,22 +335,19 @@ impl super::Nexus {
         // instances in different VPCs from connecting to each other. If it ever
         // stops doing this, the broadcast approach will create V2P mappings
         // that shouldn't exist.
-
-        let (.., authz_instance, db_instance) =
-            LookupPath::new(&opctx, &self.db_datastore)
-                .instance_id(instance_id)
-                .fetch_for(authz::Action::Read)
-                .await?;
+        let (.., authz_instance) = LookupPath::new(&opctx, &self.db_datastore)
+            .instance_id(instance_id)
+            .lookup_for(authz::Action::Read)
+            .await?;
 
         let instance_nics = self
             .db_datastore
             .derive_guest_network_interface_info(&opctx, &authz_instance)
             .await?;
 
-        // Lookup the physical host IP of the sled hosting this instance
-        let instance_sled_id = db_instance.runtime().sled_id;
+        // Look up the supplied sled's physical host IP.
         let physical_host_ip =
-            *self.sled_lookup(&self.opctx_alloc, &instance_sled_id).await?.ip;
+            *self.sled_lookup(&self.opctx_alloc, &sled_id).await?.ip;
 
         let mut last_sled_id: Option<Uuid> = None;
         loop {
@@ -362,7 +365,10 @@ impl super::Nexus {
             for sled in &sleds_page {
                 // set_v2p not required for sled instance was allocated to, OPTE
                 // currently does that automatically
-                if sled.id() == instance_sled_id {
+                //
+                // TODO(#3107): Remove this when XDE stops creating mappings
+                // implicitly.
+                if sled.id() == sled_id {
                     continue;
                 }
 
@@ -458,6 +464,9 @@ impl super::Nexus {
             for sled in &sleds_page {
                 // del_v2p not required for sled instance was allocated to, OPTE
                 // currently does that automatically
+                //
+                // TODO(#3107): Remove this when XDE stops deleting mappings
+                // implicitly.
                 if sled.id() == instance_sled_id {
                     continue;
                 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -250,8 +250,11 @@ async fn cpapi_instances_put(
     let nexus = &apictx.nexus;
     let path = path_params.into_inner();
     let new_state = new_runtime_state.into_inner();
+    let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
     let handler = async {
-        nexus.notify_instance_updated(&path.instance_id, &new_state).await?;
+        nexus
+            .notify_instance_updated(&opctx, &path.instance_id, &new_state)
+            .await?;
         Ok(HttpResponseUpdatedNoContent())
     };
     apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await


### PR DESCRIPTION
Whenever Nexus gets a new instance runtime state from a sled agent, compare the state to the existing runtime state to see if applying the new state will update the instance's Propolis generation. If it will, use the sled ID in the new record to create updated OPTE V2P mappings and Dendrite NAT entries for the instance.

Retry with backoff when sled agent fails to publish a state update to Nexus. This was required for correctness anyway (see #2727) but is especially important now that there are many more ways for Nexus to fail to apply a state update. See the comments in the new code for more details.

In the future, it might be better to update this configuration using a reliable persistent workflow that's triggered by Propolis location changes. This approach will require at least some additional work in OPTE to assign generation numbers to V2P mappings (Dendrite might have a similar problem but I'm not as familiar with the tables Nexus is trying to maintain in this change).