### PR TITLE
[wicket / wicketd] Minor cleanup from Mupdate testing

### DIFF
--- a/wicket-dbg/src/runner.rs
+++ b/wicket-dbg/src/runner.rs
@@ -13,7 +13,6 @@ use crossterm::terminal::{
 };
 use slog::Logger;
 use std::collections::BTreeSet;
-use std::io::stdout;
 use std::time::Duration;
 use tokio::fs::read;
 use tokio::sync::{
@@ -21,8 +20,6 @@ use tokio::sync::{
     oneshot,
 };
 use tokio::time::sleep;
-use tui::backend::CrosstermBackend;
-use tui::Terminal;
 use wicket::{Event, RunnerCore, Screen, Snapshot, State, TICK_INTERVAL};
 
 // Max speedup/slowdown factor for playback rate
@@ -65,13 +62,7 @@ pub struct Runner {
 
 impl Runner {
     pub fn new(log: Logger) -> (Runner, RunnerHandle) {
-        let backend = CrosstermBackend::new(stdout());
-        let core = RunnerCore {
-            screen: Screen::new(&log),
-            state: State::new(),
-            terminal: Terminal::new(backend).unwrap(),
-            log,
-        };
+        let core = RunnerCore::new(log);
         // We only allow one request at a time
         let (tx, rx) = mpsc::channel(1);
         let (event_tx, event_rx) = mpsc::channel(1);

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -364,7 +364,7 @@ struct EventReportLogThrottler {
 
 impl Default for EventReportLogThrottler {
     fn default() -> Self {
-        const DEFAULT_TIME_BETWEEN_LOGS: Duration = Duration::from_secs(60);
+        const DEFAULT_TIME_BETWEEN_LOGS: Duration = Duration::from_secs(15);
         Self::new(DEFAULT_TIME_BETWEEN_LOGS)
     }
 }

--- a/wicket/src/ui/main.rs
+++ b/wicket/src/ui/main.rs
@@ -282,7 +282,6 @@ impl Control for Sidebar {
         let panes = List::new(items)
             .block(
                 Block::default()
-                    .title("<ESC>")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .style(border_style),

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -65,13 +65,19 @@ impl Control for OverviewPane {
                 }
             }
             Cmd::Exit => {
-                // Transition to the rack view. `Exit` makes sense here
-                // because we are exiting a subview of the rack.
-                if !self.rack_view_selected {
+                if self.inventory_view.popup.is_some() {
+                    // If we're showing a popup, pass this event through so we
+                    // can close it.
+                    self.inventory_view.on(state, cmd)
+                } else if !self.rack_view_selected {
+                    // Otherwise, transition to the rack view. `Exit` makes
+                    // sense here because we are exiting a subview of the rack.
                     self.rack_view_selected = true;
                     Some(Action::Redraw)
                 } else {
-                    self.inventory_view.on(state, cmd)
+                    // We're already on the rack view - there's nowhere to exit
+                    // to, so this is a no-op.
+                    None
                 }
             }
             _ => self.dispatch(state, cmd),

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -157,7 +157,7 @@ impl Control for RackView {
             "OXIDE RACK",
             component_style,
         )]))
-        .block(border.clone().title("<ENTER>"));
+        .block(border.clone());
         frame.render_widget(title_bar, chunks[0]);
 
         // Draw the pane border
@@ -207,7 +207,7 @@ impl InventoryView {
     pub fn new() -> InventoryView {
         InventoryView {
             help: vec![
-                ("Rack View", "<ENTER>"),
+                ("Rack View", "<ESC>"),
                 ("Switch Component", "<LEFT/RIGHT>"),
                 ("Scroll", "<UP/DOWN>"),
                 ("Ignition", "<I>"),
@@ -309,7 +309,7 @@ impl Control for InventoryView {
                 component_style,
             ),
         ]))
-        .block(block.clone().title("<ENTER>"));
+        .block(block.clone());
         frame.render_widget(title_bar, chunks[0]);
 
         // Draw the contents

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -657,7 +657,7 @@ impl UpdatePane {
             "UPDATE STATUS",
             header_style,
         )]))
-        .block(block.clone().title("<ENTER>"));
+        .block(block.clone());
         frame.render_widget(title_bar, self.title_rect);
 
         // Draw the table headers
@@ -722,7 +722,7 @@ impl UpdatePane {
             Span::styled("UPDATE STATUS / ", border_style),
             Span::styled(state.rack_state.selected.to_string(), header_style),
         ]))
-        .block(block.clone().title("<ENTER>"));
+        .block(block.clone());
         frame.render_widget(title_bar, self.title_rect);
 
         let versions = &state.update_state.artifact_versions;

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -315,14 +315,12 @@ impl ArtifactsWithPlan {
                 }
             }
 
-            slog::debug!(
-                log,
-                "added artifact with kind {}, id {}:{}, hash {}, length {}",
-                artifact_id.kind,
-                artifact_id.name,
-                artifact_id.version,
-                artifact_hash,
-                num_bytes,
+            slog::info!(
+                log, "added artifact";
+                "kind" => %artifact_id.kind,
+                "id" => format!("{}:{}", artifact_id.name, artifact_id.version),
+                "hash" => %artifact_hash,
+                "length" => num_bytes,
             );
         }
 
@@ -681,6 +679,11 @@ impl UpdatePlan {
                 ));
             }
             Entry::Vacant(entry) => {
+                slog::info!(log, "added host phase 2 artifact";
+                    "kind" => %host_phase_2_hash_id.kind,
+                    "hash" => %host_phase_2_hash_id.hash,
+                    "length" => host_phase_2.data.len(),
+                );
                 entry.insert(host_phase_2.data.0.clone());
             }
         }

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -155,11 +155,6 @@ impl UpdateTracker {
                         // this update's artifact ID? If not, cancel the old
                         // task (which might still be trying to upload) and
                         // start a new one with our current image.
-                        //
-                        // TODO-correctness If we still have updates running
-                        // that expect the old image, they're probably going to
-                        // fail. Should we handle that more cleanly or just let
-                        // them fail?
                         if prev.status.borrow().id != plan.trampoline_phase_2.id
                         {
                             // It does _not_ match - we have a new plan with a

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -151,19 +151,20 @@ impl UpdateTracker {
 
                 match upload_trampoline_phase_2_to_mgs.as_mut() {
                     Some(prev) => {
-                        // We've previously started an upload - does it match this
-                        // update's artifact ID? If not, cancel the old task (which
-                        // might still be trying to upload) and start a new one with
-                        // our current image.
+                        // We've previously started an upload - does it match
+                        // this update's artifact ID? If not, cancel the old
+                        // task (which might still be trying to upload) and
+                        // start a new one with our current image.
                         //
-                        // TODO-correctness If we still have updates running that
-                        // expect the old image, they're probably going to fail.
-                        // Should we handle that more cleanly or just let them fail?
+                        // TODO-correctness If we still have updates running
+                        // that expect the old image, they're probably going to
+                        // fail. Should we handle that more cleanly or just let
+                        // them fail?
                         if prev.status.borrow().id != plan.trampoline_phase_2.id
                         {
                             // It does _not_ match - we have a new plan with a
-                            // different trampoline image. If the old task is still
-                            // running, cancel it, and start a new one.
+                            // different trampoline image. If the old task is
+                            // still running, cancel it, and start a new one.
                             prev.task.abort();
                             *prev = self
                                 .spawn_upload_trampoline_phase_2_to_mgs(&plan);
@@ -176,8 +177,9 @@ impl UpdateTracker {
                     }
                 }
 
-                // Both branches above leave `upload_trampoline_phase_2_to_mgs` with
-                // data, so we can unwrap here to clone the `watch` channel.
+                // Both branches above leave `upload_trampoline_phase_2_to_mgs`
+                // with data, so we can unwrap here to clone the `watch`
+                // channel.
                 upload_trampoline_phase_2_to_mgs
                     .as_ref()
                     .unwrap()
@@ -286,7 +288,7 @@ impl UpdateTracker {
         let plan = update_data
             .artifact_store
             .current_plan()
-            .ok_or_else(|| StartUpdateError::TufRepositoryUnavailable)?;
+            .ok_or(StartUpdateError::TufRepositoryUnavailable)?;
 
         match update_data.sp_update_data.entry(sp) {
             // Vacant: this is the first time we've started an update to this
@@ -813,7 +815,6 @@ impl UpdateDriver {
             )
             .register();
 
-        // TODO: this should most likely use nested steps.
         host_registrar
             .new_step(
                 UpdateStepId::RunningInstallinator,


### PR DESCRIPTION
This is a PR that rolls up several small cleanups/bug fixes from testing MUpdate last week:

1. wicketd: Log the hash of the extracted host phase 2 artifact (we already log the hashes of the other artifacts, and at one point I wanted to find this - cracking open the tuf repo and then untarring the composite host artifact was annoying)
2. wicket: Only log the full EventReport we receive about one per minute. We were hitting #3102 so these were huge, but even after that's fixed I don't think we need to log these every second.
3. wicket: Remove the ESC/ENTER titles on the main panes. Switching between panes now happens via TAB.
4. wicket: Fix ESC closing the ignition popup - previously it always sent us back to the rack view, and there was no way to close the ignition popup other than running one of the commands.