### PR TITLE
Clear existing console assets when downloading new ones

### DIFF
--- a/tools/ci_download_console
+++ b/tools/ci_download_console
@@ -45,7 +45,6 @@ function main
 	fi
 
 	mkdir -p "$DOWNLOAD_DIR"
-	mkdir -p "$DEST_DIR"
 
 	if [ "$DO_DOWNLOAD" == "true" ]; then
 	echo "Downloading..."
@@ -61,6 +60,10 @@ function main
 		fi
 
 	fi
+
+	# clear out existing console assets
+	rm -rf "$DEST_DIR"
+	mkdir -p "$DEST_DIR"
 
 	# Unpack the tarball into a local directory
 	do_untar "$TARBALL_FILE" "$DEST_DIR"


### PR DESCRIPTION
I noticed on the dogfood Gimlet that there are a bajillion old console assets hanging around. It seems like whatever is running the prereqs script and downloading the latest assets is persisting across installs. 

<img width="644" alt="image" src="https://github.com/oxidecomputer/omicron/assets/3612203/dd58c836-b0a8-4ae9-991c-a75fb714193e">

The dates are all fresh in the nexus zone because they were just written, but I see indications some of these are quite old — these `mockServiceWorker.js` files shouldn't have been in the bundle for a while. There are 13 versions present of some files, and going back 13 [console version bumps](https://github.com/search?q=repo%3Aoxidecomputer%2Fomicron+bump+console&type=commits&s=committer-date&o=desc) takes us back to March.

```
BRM42220026 # ls -alh /zone/oxz_nexus/root/var/nexus/static
total 45
drwxr-xr-x   3 root     root           7 May 14 16:46 .
drwxr-xr-x   3 root     root           3 May 14 16:45 ..
drwxr-xr-x   2 root     root         376 May 14 16:46 assets
-rw-r--r--   1 root     root       2.26K May 14 16:46 index.html
-rw-r--r--   1 root     root       3.06K May 14 16:46 mockServiceWorker.js
-rw-r--r--   1 root     root       12.0K May 14 16:46 mockServiceWorker.js.map
-rw-r--r--   1 root     root          41 May 14 16:45 VERSION
```

In any case, while I'm not sure existing where these are being persisted across installs, there is no reason not to clear the existing files when downloading a new version of the console. So that's what I do there.