### PR TITLE
Add API endpoints for retrieving IP pools available to projects (#2148)

### DIFF
--- a/nexus/db-queries/src/db/datastore/project.rs
+++ b/nexus/db-queries/src/db/datastore/project.rs
@@ -329,4 +329,33 @@ impl DataStore {
                 )
             })
     }
+
+    /// List IP Pools accessible to a project
+    pub async fn project_ip_pools_list(
+        &self,
+        opctx: &OpContext,
+        authz_project: &authz::Project,
+        pagparams: &PaginatedBy<'_>,
+    ) -> ListResultVec<db::model::IpPool> {
+        use db::schema::ip_pool::dsl;
+        opctx.authorize(authz::Action::ListChildren, authz_project).await?;
+        match pagparams {
+            PaginatedBy::Id(pagparams) => {
+                paginated(dsl::ip_pool, dsl::id, pagparams)
+            }
+            PaginatedBy::Name(pagparams) => paginated(
+                dsl::ip_pool,
+                dsl::name,
+                &pagparams.map_name(|n| Name::ref_cast(n)),
+            ),
+        }
+        // TODO(2148, 2056): filter only pools accessible by the given
+        // project, once specific projects for pools are implemented
+        .filter(dsl::internal.eq(false))
+        .filter(dsl::time_deleted.is_null())
+        .select(db::model::IpPool::as_select())
+        .get_results_async(self.pool_authorized(opctx).await?)
+        .await
+        .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
+    }
 }

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -13,6 +13,7 @@ use crate::db::lookup::LookupPath;
 use crate::external_api::params;
 use crate::external_api::shared;
 use anyhow::Context;
+use nexus_db_model::Name;
 use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
@@ -23,6 +24,7 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
+use ref_cast::RefCast;
 use std::sync::Arc;
 
 impl super::Nexus {
@@ -146,5 +148,41 @@ impl super::Nexus {
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, _>>()?;
         Ok(shared::Policy { role_assignments })
+    }
+
+    pub async fn project_ip_pools_list(
+        &self,
+        opctx: &OpContext,
+        project_lookup: &lookup::Project<'_>,
+        pagparams: &PaginatedBy<'_>,
+    ) -> ListResultVec<db::model::IpPool> {
+        let (.., authz_project) =
+            project_lookup.lookup_for(authz::Action::ListChildren).await?;
+
+        self.db_datastore
+            .project_ip_pools_list(opctx, &authz_project, pagparams)
+            .await
+    }
+
+    pub fn project_ip_pool_lookup<'a>(
+        &'a self,
+        opctx: &'a OpContext,
+        pool: &'a NameOrId,
+        _project_lookup: &Option<lookup::Project<'_>>,
+    ) -> LookupResult<lookup::IpPool<'a>> {
+        // TODO(2148, 2056): check that the given project has access (if one
+        // is provided to the call) once that relation is implemented
+        match pool {
+            NameOrId::Name(name) => {
+                let pool = LookupPath::new(opctx, &self.db_datastore)
+                    .ip_pool_name(Name::ref_cast(name));
+                Ok(pool)
+            }
+            NameOrId::Id(id) => {
+                let pool =
+                    LookupPath::new(opctx, &self.db_datastore).ip_pool_id(*id);
+                Ok(pool)
+            }
+        }
     }
 }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -348,7 +348,9 @@ pub async fn create_instance(
         instance_name,
         &params::InstanceNetworkInterfaceAttachment::Default,
         // Disks=
-        vec![],
+        Vec::<params::InstanceDiskAttachment>::new(),
+        // External IPs=
+        Vec::<params::ExternalIpCreate>::new(),
     )
     .await
 }
@@ -360,6 +362,7 @@ pub async fn create_instance_with(
     instance_name: &str,
     nics: &params::InstanceNetworkInterfaceAttachment,
     disks: Vec<params::InstanceDiskAttachment>,
+    external_ips: Vec<params::ExternalIpCreate>,
 ) -> Instance {
     let url = format!("/v1/instances?project={}", project_name);
     object_create(
@@ -377,7 +380,7 @@ pub async fn create_instance_with(
                 b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                     .to_vec(),
             network_interfaces: nics.clone(),
-            external_ips: vec![],
+            external_ips,
             disks,
             start: true,
         },

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -1357,6 +1357,7 @@ async fn create_instance_with_disk(client: &ClientTestContext) {
         vec![params::InstanceDiskAttachment::Attach(
             params::InstanceDiskAttach { name: DISK_NAME.parse().unwrap() },
         )],
+        Vec::<params::ExternalIpCreate>::new(),
     )
     .await;
 }

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -441,6 +441,8 @@ lazy_static! {
         };
 
     // IP Pools
+    pub static ref DEMO_IP_POOLS_PROJ_URL: String =
+        format!("/v1/ip-pools?project={}", *DEMO_PROJECT_NAME);
     pub static ref DEMO_IP_POOLS_URL: &'static str = "/v1/system/ip-pools";
     pub static ref DEMO_IP_POOL_NAME: Name = "default".parse().unwrap();
     pub static ref DEMO_IP_POOL_CREATE: params::IpPoolCreate =
@@ -450,6 +452,8 @@ lazy_static! {
                 description: String::from("an IP pool"),
             },
         };
+    pub static ref DEMO_IP_POOL_PROJ_URL: String =
+        format!("/v1/ip-pools/{}?project={}", *DEMO_IP_POOL_NAME, *DEMO_PROJECT_NAME);
     pub static ref DEMO_IP_POOL_URL: String = format!("/v1/system/ip-pools/{}", *DEMO_IP_POOL_NAME);
     pub static ref DEMO_IP_POOL_UPDATE: params::IpPoolUpdate =
         params::IpPoolUpdate {
@@ -721,6 +725,14 @@ lazy_static! {
                 ),
             ],
         },
+        VerifyEndpoint {
+            url: &DEMO_IP_POOLS_PROJ_URL,
+            visibility: Visibility::Public,
+            unprivileged_access: UnprivilegedAccess::ReadOnly,
+            allowed_methods: vec![
+                AllowedMethod::Get
+            ],
+        },
 
         // Single IP Pool endpoint
         VerifyEndpoint {
@@ -733,6 +745,14 @@ lazy_static! {
                     serde_json::to_value(&*DEMO_IP_POOL_UPDATE).unwrap()
                 ),
                 AllowedMethod::Delete,
+            ],
+        },
+        VerifyEndpoint {
+            url: &DEMO_IP_POOL_PROJ_URL,
+            visibility: Visibility::Protected,
+            unprivileged_access: UnprivilegedAccess::ReadOnly,
+            allowed_methods: vec![
+                AllowedMethod::Get
             ],
         },
 

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -522,7 +522,8 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
         PROJECT_NAME,
         instance_name,
         &params::InstanceNetworkInterfaceAttachment::Default,
-        vec![],
+        Vec::<params::InstanceDiskAttachment>::new(),
+        Vec::<params::ExternalIpCreate>::new(),
     )
     .await;
     let instance_id = instance.identity.id;
@@ -609,7 +610,8 @@ async fn test_instance_migrate_v2p(cptestctx: &ControlPlaneTestContext) {
         &params::InstanceNetworkInterfaceAttachment::Default,
         // Omit disks: simulated sled agent assumes that disks are always co-
         // located with their instances.
-        vec![],
+        Vec::<params::InstanceDiskAttachment>::new(),
+        Vec::<params::ExternalIpCreate>::new(),
     )
     .await;
     let instance_id = instance.identity.id;

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -140,7 +140,9 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
             &format!("i{}", i),
             &nic,
             // Disks=
-            vec![],
+            Vec::<params::InstanceDiskAttachment>::new(),
+            // External IPs=
+            Vec::<params::ExternalIpCreate>::new(),
         )
         .await;
     }

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -64,6 +64,8 @@ API operations found with tag "projects"
 OPERATION ID                             METHOD   URL PATH
 project_create                           POST     /v1/projects
 project_delete                           DELETE   /v1/projects/{project}
+project_ip_pool_list                     GET      /v1/ip-pools
+project_ip_pool_view                     GET      /v1/ip-pools/{pool}
 project_list                             GET      /v1/projects
 project_policy_update                    PUT      /v1/projects/{project}/policy
 project_policy_view                      GET      /v1/projects/{project}/policy

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2056,6 +2056,121 @@
         }
       }
     },
+    "/v1/ip-pools": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List all IP Pools that can be used by a given project.",
+        "operationId": "project_ip_pool_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrIdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpPoolResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": [
+            "project"
+          ]
+        }
+      }
+    },
+    "/v1/ip-pools/{pool}": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Fetch an IP pool",
+        "operationId": "project_ip_pool_view",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pool",
+            "description": "Name or ID of the IP pool",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpPool"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/login/{silo_name}/local": {
       "post": {
         "tags": [


### PR DESCRIPTION
Per discussion in #2148, this is a future-looking API that's functionally equivalent to the `/v1/system/`-prefixed IP-pool-viewing routes we already have, but with room to grow into project-level scoping when it's implemented, so they can be used optatively wherever appropriate.

(This PR doesn't yet add a `GET /v1/ip-pools/{pool}/ranges` -- should it?)