### PR TITLE
[installinator] Sync I/O before reporting completion to wicketd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,7 @@ dependencies = [
  "installinator-common",
  "ipcc-key-value",
  "itertools",
+ "libc",
  "omicron-common 0.1.0",
  "omicron-test-utils",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
+ "illumos-utils",
  "omicron-common 0.1.0",
  "schemars",
  "serde",

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -218,7 +218,7 @@ impl Zpool {
         cmd.env_clear();
         cmd.env("LC_ALL", "C.UTF-8");
         cmd.arg(ZPOOL).arg("export").arg(&name.to_string());
-        execute(&mut cmd).map_err(Error::from)?;
+        execute(&mut cmd)?;
 
         Ok(())
     }
@@ -232,7 +232,7 @@ impl Zpool {
             .arg("set")
             .arg("failmode=continue")
             .arg(&name.to_string());
-        execute(&mut cmd).map_err(Error::from)?;
+        execute(&mut cmd)?;
         Ok(())
     }
 

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -217,9 +217,7 @@ impl Zpool {
         let mut cmd = std::process::Command::new(PFEXEC);
         cmd.env_clear();
         cmd.env("LC_ALL", "C.UTF-8");
-        cmd.arg(ZPOOL)
-            .arg("export")
-            .arg(&name.to_string());
+        cmd.arg(ZPOOL).arg("export").arg(&name.to_string());
         execute(&mut cmd).map_err(Error::from)?;
 
         Ok(())

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -213,6 +213,18 @@ impl Zpool {
         }
     }
 
+    pub fn export(name: &ZpoolName) -> Result<(), Error> {
+        let mut cmd = std::process::Command::new(PFEXEC);
+        cmd.env_clear();
+        cmd.env("LC_ALL", "C.UTF-8");
+        cmd.arg(ZPOOL)
+            .arg("export")
+            .arg(&name.to_string());
+        execute(&mut cmd).map_err(Error::from)?;
+
+        Ok(())
+    }
+
     /// `zpool set failmode=continue <name>`
     pub fn set_failmode_continue(name: &ZpoolName) -> Result<(), Error> {
         let mut cmd = std::process::Command::new(PFEXEC);

--- a/installinator-common/Cargo.toml
+++ b/installinator-common/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true
+illumos-utils.workspace = true
 omicron-common.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -281,7 +281,10 @@ pub enum WriteError {
     #[error("error fsyncing output directory: {error}")]
     SyncOutputDirError { error: std::io::Error },
     #[error("error interacting with zpool: {error}")]
-    ZpoolError { #[from] error: zpool::Error },
+    ZpoolError {
+        #[from]
+        error: zpool::Error,
+    },
 }
 
 impl AsError for WriteError {

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -266,7 +266,7 @@ pub enum WriteStepId {
 pub enum WriteError {
     #[error(
         "writing {component} to slot {slot} failed \
-     after {written_bytes}/{total_bytes} bytes"
+         after {written_bytes}/{total_bytes} bytes"
     )]
     WriteError {
         component: WriteComponent,

--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -324,6 +324,9 @@ pub enum ControlPlaneZonesStepId {
     /// Writing a zone.
     Zone { name: String },
 
+    /// Syncing writes to disk.
+    Fsync,
+
     /// Future variants that might be unknown.
     #[serde(other, deserialize_with = "deserialize_ignore_any")]
     Unknown,

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -21,6 +21,7 @@ installinator-artifact-client.workspace = true
 installinator-common.workspace = true
 ipcc-key-value.workspace = true
 itertools.workspace = true
+libc.workspace = true
 once_cell.workspace = true
 omicron-common.workspace = true
 pin-project-lite.workspace = true

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -34,6 +34,7 @@ slog-async.workspace = true
 slog-envlogger.workspace = true
 slog-term.workspace = true
 smf.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml.workspace = true

--- a/installinator/src/async_temp_file.rs
+++ b/installinator/src/async_temp_file.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use camino::Utf8PathBuf;
+use pin_project_lite::pin_project;
+use std::io;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+use tempfile::NamedTempFile;
+use tempfile::PathPersistError;
+use tempfile::TempPath;
+use tokio::fs::File;
+use tokio::io::AsyncWrite;
+
+pin_project! {
+    pub(crate) struct AsyncNamedTempFile {
+        // `temp_path` is _always_ `Some(_)`, except when we `.take()` from it
+        // in our `persist()` method below. This allows us to drop the temp path
+        // (deleting the temporary file) if we're dropped before `persist()` is
+        // called.
+        temp_path: Option<TempPath>,
+        destination: Utf8PathBuf,
+        #[pin]
+        inner: File,
+    }
+}
+
+impl AsyncNamedTempFile {
+    pub(crate) async fn with_destination<T: Into<Utf8PathBuf>>(
+        destination: T,
+    ) -> io::Result<Self> {
+        let destination = destination.into();
+        let parent = destination
+            .parent()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "destination {destination} has no parent directory"
+                    ),
+                )
+            })?
+            .to_owned();
+
+        let temp_file =
+            tokio::task::spawn_blocking(|| NamedTempFile::new_in(parent))
+                .await
+                .unwrap()?;
+        let temp_path = temp_file.into_temp_path();
+
+        let inner = File::create(&temp_path).await?;
+
+        Ok(Self { temp_path: Some(temp_path), destination, inner })
+    }
+
+    pub(crate) async fn sync_all(&self) -> io::Result<()> {
+        self.inner.sync_all().await
+    }
+
+    pub(crate) async fn persist(mut self) -> io::Result<()> {
+        // self.temp_path is always `Some(_)` until we `take()` it here.
+        let temp_path = self.temp_path.take().unwrap();
+        let destination = self.destination;
+        tokio::task::spawn_blocking(move || temp_path.persist(&destination))
+            .await
+            .unwrap()
+            .map_err(|PathPersistError { error, .. }| error)
+    }
+}
+
+impl AsyncWrite for AsyncNamedTempFile {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+}

--- a/installinator/src/block_size_writer.rs
+++ b/installinator/src/block_size_writer.rs
@@ -35,8 +35,7 @@ impl<W: AsyncWrite> BlockSizeBufWriter<W> {
         Self { inner, buf: Vec::with_capacity(block_size), block_size }
     }
 
-    #[cfg(test)]
-    fn into_inner(self) -> W {
+    pub(crate) fn into_inner(self) -> W {
         self.inner
     }
 

--- a/installinator/src/lib.rs
+++ b/installinator/src/lib.rs
@@ -15,6 +15,7 @@ mod reporter;
 #[cfg(test)]
 mod test_helpers;
 mod write;
+mod async_temp_file;
 
 pub use dispatch::*;
 pub use write::*;

--- a/installinator/src/lib.rs
+++ b/installinator/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod artifact;
+mod async_temp_file;
 mod block_size_writer;
 mod bootstrap;
 mod dispatch;
@@ -15,7 +16,6 @@ mod reporter;
 #[cfg(test)]
 mod test_helpers;
 mod write;
-mod async_temp_file;
 
 pub use dispatch::*;
 pub use write::*;

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -597,6 +597,7 @@ impl WriteTransport for BlockDeviceTransport {
             .create(create)
             .write(true)
             .truncate(create)
+            .custom_flags(libc::O_SYNC)
             .open(destination)
             .await
             .map_err(|error| WriteError {

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -605,6 +605,10 @@ impl ControlPlaneZoneWriteContext<'_> {
                         WriteError::SyncOutputDirError { error }
                     })?;
 
+                    // Drop `output_directory` to close it so we can export the
+                    // zpool.
+                    std::mem::drop(output_directory);
+
                     if let Some(zpool) = zpool {
                         Zpool::export(zpool)?;
                     }

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -250,7 +250,9 @@ async fn test_installinator_fetch() {
     //
     // The control plane zone names here are defined in `fake.toml` which we
     // load above.
-    for file_name in [HOST_PHASE_2_FILE_NAME, "zone1.tar.gz", "zone2.tar.gz"] {
+    for file_name in
+        [HOST_PHASE_2_FILE_NAME, "zones/zone1.tar.gz", "zones/zone2.tar.gz"]
+    {
         let path = dest_path.join(file_name);
         assert!(path.is_file(), "{path} was written out");
     }


### PR DESCRIPTION
Today when mupdating `madrid` we observed data loss: `installinator` reported it wrote the control plane zones to both M.2s, but after a reboot they were only present on one. Under the hypothesis that we could have lost data because wicketd reboots the sled as soon as installinator reports success and installinator had no filesystem sync operations after finishing writing, this PR contains several sync operations, most of which came from a conversation with @rmustacc and @jclulow:

1. When opening the M.2 raw device, pass `O_SYNC`.
2. After writing the OS to the M.2 raw device, call `ioctl(fd, DKIOFLUSHWRITECACHE, NULL)`.
3. Before writing the control plane zones, remove any files present in the directory. (Expectation: these are old control plane zones. There should be nothing else here.)
4. After writing each control plane zone, `fsync()` the file descriptor.
5. When writing each control plane zone, write to a temp file in that directory first, then rename it after writing is finished.
6. After writing all control plane zones, open and `fsync()` the directory in which we wrote the files.
7. As a final step after all control plane zones have been written and all the above `fsync()`s are done, `zpool export` the M.2 datasets we wrote to.

~~I want to test this several times on `madrid` before merging, but I think it's sufficiently close to done for review.~~ Pushed a couple small fixes after testing on `madrid`:

* Ignore `ENOTSUP` when attempting to `DKIOFLUSHWRITECACHE`; our current devices down't support this, but we can still leave it in case future drives do.
* Drop the open control plane directory handle before attempting to `zpool export` (holding it open causes the export to fail because the zpool is still busy).

I'll continue testing on `madrid` to see if anything else shakes out after more tries, but this has now worked a couple times.