### PR TITLE
silo creation should accept TLS certificates

### DIFF
--- a/nexus/db-queries/src/db/datastore/silo.rs
+++ b/nexus/db-queries/src/db/datastore/silo.rs
@@ -27,6 +27,8 @@ use async_bb8_diesel::AsyncRunQueryDsl;
 use async_bb8_diesel::PoolError;
 use chrono::Utc;
 use diesel::prelude::*;
+use nexus_db_model::Certificate;
+use nexus_db_model::ServiceKind;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
 use omicron_common::api::external::http_pagination::PaginatedBy;
@@ -39,8 +41,6 @@ use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use ref_cast::RefCast;
 use uuid::Uuid;
-use nexus_db_model::ServiceKind;
-use nexus_db_model::Certificate;
 
 impl DataStore {
     /// Load built-in silos into the database

--- a/nexus/db-queries/src/db/fixed_data/silo.rs
+++ b/nexus/db-queries/src/db/fixed_data/silo.rs
@@ -21,6 +21,7 @@ lazy_static! {
             discoverable: false,
             identity_mode: shared::SiloIdentityMode::LocalOnly,
             admin_group_name: None,
+            tls_certificates: vec![],
         },
     );
 }

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -88,7 +88,7 @@ impl super::Nexus {
             .collect();
 
         let service_ip_pool_ranges = request.internal_services_ip_pool_ranges;
-        let certificates: Vec<_> = request
+        let tls_certificates: Vec<_> = request
             .certs
             .into_iter()
             .enumerate()
@@ -168,6 +168,7 @@ impl super::Nexus {
             discoverable: false,
             identity_mode: SiloIdentityMode::LocalOnly,
             admin_group_name: None,
+            tls_certificates,
         };
 
         self.db_datastore
@@ -178,7 +179,6 @@ impl super::Nexus {
                     services: request.services,
                     datasets,
                     service_ip_pool_ranges,
-                    certificates,
                     internal_dns,
                     external_dns,
                     recovery_silo,

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -262,6 +262,7 @@ pub async fn create_silo(
             discoverable,
             identity_mode,
             admin_group_name: None,
+            tls_certificates: vec![],
         },
     )
     .await

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -68,6 +68,7 @@ lazy_static! {
             discoverable: true,
             identity_mode: shared::SiloIdentityMode::SamlJit,
             admin_group_name: None,
+            tls_certificates: vec![],
         };
     // Use the default Silo for testing the local IdP
     pub static ref DEMO_SILO_USERS_CREATE_URL: String = format!(

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -65,6 +65,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
                 discoverable: false,
                 identity_mode: shared::SiloIdentityMode::LocalOnly,
                 admin_group_name: None,
+                tls_certificates: vec![],
             },
         )
         .authn_as(AuthnMode::PrivilegedUser)
@@ -283,6 +284,7 @@ async fn test_silo_admin_group(cptestctx: &ControlPlaneTestContext) {
             discoverable: false,
             identity_mode: shared::SiloIdentityMode::SamlJit,
             admin_group_name: Some("administrator".into()),
+            tls_certificates: vec![],
         },
     )
     .await;

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -290,6 +290,10 @@ pub struct SiloCreate {
     /// group_attribute_name must be set for users to be considered part of a
     /// group. See `SamlIdentityProviderCreate` for more information.
     pub admin_group_name: Option<String>,
+
+    /// Initial TLS certificates to be used for the new Silo's console and API
+    /// endpoints.  These should be valid for the Silo's DNS name(s).
+    pub tls_certificates: Vec<CertificateCreate>,
 }
 
 /// Create-time parameters for a `User`

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10595,13 +10595,21 @@
           },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "tls_certificates": {
+            "description": "Initial TLS certificates to be used for the new Silo's console and API endpoints.  These should be valid for the Silo's DNS name(s).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CertificateCreate"
+            }
           }
         },
         "required": [
           "description",
           "discoverable",
           "identity_mode",
-          "name"
+          "name",
+          "tls_certificates"
         ]
       },
       "SiloIdentityMode": {


### PR DESCRIPTION
This is necessary because in a real system:

1. You may only be able to access a Silo from its own console/API endpoint (this is not yet implemented, but I assume it's coming)
2. Nexus will not be listening on HTTP (only HTTPS).  (This isn't true today, but needs to be soon outside of development.)
3. There is currently no way to administer the certificates of another Silo.  (We generally don't want to allow this sort of thing.  See #1681.  The list of TLS certificates is probably an exception similar to identity providers -- if it gets messed up, you can't log into the Silo directly to fix it.  But anyway, we haven't implemented it yet.)

Thus, without providing certificates when you create the Silo, you'd have no way to log into it.  We get away without this today because (1) and (2) aren't true yet.  Nexus _does_ listen on HTTP and you can currently use any Silo's endpoint to log into any other Silo.  Also, until recently (with #3095), certificates were fleet-wide.