### PR TITLE
Spawn a task to run services_ensure

### DIFF
--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -77,9 +77,10 @@ async fn services_put(
         Ok(result) => result.map_err(|e| Error::from(e))?,
 
         Err(e) => {
-            return Err(HttpError::for_internal_error(
-                format!("unexpected failure awaiting \"services_ensure\": {:#}", e)
-            ));
+            return Err(HttpError::for_internal_error(format!(
+                "unexpected failure awaiting \"services_ensure\": {:#}",
+                e
+            )));
         }
     }
 


### PR DESCRIPTION
dropshot/hyper will cancel an endpoint's task if the call times out or is otherwise cancelled, and this leads to a specific issue where booting all the service zones takes longer than the progenitor client default timeout. The request times out, `services_ensure` gets cancelled, and this leaves zones partially configured but not added to the list of `existing_zones`. When the next `PUT /services` call is made, `services_ensure` will eventually try to bring up the same zone it was interrupted at, leading to configuration issues.

Fixes #3098