### PR TITLE
nexus: release unused Propolis reservations after migration

### DIFF
--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -203,7 +203,8 @@ impl InstanceStates {
         //       target explicitly, but there currently isn't enough information
         //       to do that (the source doesn't know the target's sled ID or
         //       Propolis IP), so just let the target deal with updating
-        //       everything.
+        //       everything. TODO(#3139): fix this once this information is
+        //       available here.
         //
         //       This is the one case in which this routine explicitly *should
         //       not* transition the current state (to avoid having a "stopped"


### PR DESCRIPTION
This is the last "big rock" PR in the live migration series. There will be some follow-up work to do to polish things up once this lands (#3107, #3139), but with this in place it should be possible to exercise live migration in the dogfood environment without progressively exhausting sleds' resources.

---

When an instance's Propolis generation changes, examine how its Propolis ID and destination Propolis ID are changing and unregister and remove resource reservations from any Propolises that are no longer active.

Update the migration integration test to check this behavior by checking to make sure that a simulated cluster that can fit exactly two instances can start one instance, migrate it, and then start the second instance.