### PR TITLE
tufaceous-lib: `load` => `load_untrusted`

### DIFF
--- a/tufaceous-lib/src/archive.rs
+++ b/tufaceous-lib/src/archive.rs
@@ -170,8 +170,8 @@ where
     /// Extracts this archive into the specified directory.
     ///
     /// Once this is completed, use
-    /// [`OmicronRepo::load`](crate::OmicronRepo::load) to load the archive from
-    /// `output_dir`.
+    /// [`OmicronRepo::load_untrusted`](crate::OmicronRepo::load_untrusted) to
+    /// load the archive from `output_dir`.
     ///
     /// [`ZIP_BASE_DIR`] will be stripped from output paths.
     pub fn extract(&mut self, output_dir: &Utf8Path) -> Result<()> {

--- a/tufaceous-lib/src/assemble/build.rs
+++ b/tufaceous-lib/src/assemble/build.rs
@@ -119,7 +119,7 @@ impl OmicronRepoAssembler {
         repository.sign_and_finish(self.keys.clone(), self.expiry)?;
 
         // Now reopen the repository to archive it into a zip file.
-        let repo2 = OmicronRepo::load(&self.log, build_dir)
+        let repo2 = OmicronRepo::load_untrusted(&self.log, build_dir)
             .context("error reopening repository to archive")?;
         repo2
             .archive(&self.output_path)

--- a/tufaceous-lib/src/repository.rs
+++ b/tufaceous-lib/src/repository.rs
@@ -54,7 +54,7 @@ impl OmicronRepo {
     /// Loads a repository from the given path.
     ///
     /// This method enforces expirations. To load without expiration enforcement, use
-    /// [`Self::load_ignore_expiration`].
+    /// [`Self::load_untrusted_ignore_expiration`].
     pub fn load_untrusted(
         log: &slog::Logger,
         repo_path: &Utf8Path,

--- a/tufaceous-lib/src/repository.rs
+++ b/tufaceous-lib/src/repository.rs
@@ -46,15 +46,20 @@ impl OmicronRepo {
             .sign_and_finish(keys, expiry)
             .context("error signing new repository")?;
 
-        Self::load(log, repo_path)
+        // In theory we "trust" the key we just used to sign this repository,
+        // but the code path is equivalent to `load_untrusted`.
+        Self::load_untrusted(log, repo_path)
     }
 
     /// Loads a repository from the given path.
     ///
     /// This method enforces expirations. To load without expiration enforcement, use
     /// [`Self::load_ignore_expiration`].
-    pub fn load(log: &slog::Logger, repo_path: &Utf8Path) -> Result<Self> {
-        Self::load_impl(log, repo_path, ExpirationEnforcement::Safe)
+    pub fn load_untrusted(
+        log: &slog::Logger,
+        repo_path: &Utf8Path,
+    ) -> Result<Self> {
+        Self::load_untrusted_impl(log, repo_path, ExpirationEnforcement::Safe)
     }
 
     /// Loads a repository from the given path, ignoring expiration.
@@ -63,14 +68,14 @@ impl OmicronRepo {
     ///
     /// 1. When you're editing an existing repository and will re-sign it afterwards.
     /// 2. In an environment in which time isn't available.
-    pub fn load_ignore_expiration(
+    pub fn load_untrusted_ignore_expiration(
         log: &slog::Logger,
         repo_path: &Utf8Path,
     ) -> Result<Self> {
-        Self::load_impl(log, repo_path, ExpirationEnforcement::Unsafe)
+        Self::load_untrusted_impl(log, repo_path, ExpirationEnforcement::Unsafe)
     }
 
-    fn load_impl(
+    fn load_untrusted_impl(
         log: &slog::Logger,
         repo_path: &Utf8Path,
         exp: ExpirationEnforcement,

--- a/tufaceous/src/dispatch.rs
+++ b/tufaceous/src/dispatch.rs
@@ -85,8 +85,9 @@ impl Args {
                     }
                 }
 
-                let repo =
-                    OmicronRepo::load_ignore_expiration(&log, &repo_path)?;
+                let repo = OmicronRepo::load_untrusted_ignore_expiration(
+                    &log, &repo_path,
+                )?;
                 let mut editor = repo.into_editor()?;
 
                 let new_artifact =
@@ -110,8 +111,9 @@ impl Args {
                     bail!("output path `{output_path}` must end with .zip");
                 }
 
-                let repo =
-                    OmicronRepo::load_ignore_expiration(&log, &repo_path)?;
+                let repo = OmicronRepo::load_untrusted_ignore_expiration(
+                    &log, &repo_path,
+                )?;
                 repo.archive(&output_path)?;
 
                 Ok(())
@@ -121,8 +123,8 @@ impl Args {
                 extractor.extract(&dest)?;
 
                 // Now load the repository and ensure it's valid.
-                let repo =
-                    OmicronRepo::load(&log, &dest).with_context(|| {
+                let repo = OmicronRepo::load_untrusted(&log, &dest)
+                    .with_context(|| {
                         format!(
                             "error loading extracted repository at `{dest}` \
                          (extracted files are still available)"

--- a/tufaceous/tests/integration-tests/command_tests.rs
+++ b/tufaceous/tests/integration-tests/command_tests.rs
@@ -54,7 +54,7 @@ fn test_init_and_add() -> Result<()> {
 
     // Now read the repository and ensure the list of expected artifacts.
     let repo_path: Utf8PathBuf = tempdir.path().join("repo").try_into()?;
-    let repo = OmicronRepo::load(&logctx.log, &repo_path)?;
+    let repo = OmicronRepo::load_untrusted(&logctx.log, &repo_path)?;
 
     let artifacts = repo.read_artifacts()?;
     assert_eq!(

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -209,8 +209,9 @@ impl ArtifactsWithPlan {
         //
         // XXX we aren't checking against a root of trust at this point --
         // anyone can sign the repositories and this code will accept that.
-        let repository = OmicronRepo::load_ignore_expiration(log, dir.path())
-            .map_err(RepositoryError::LoadRepository)?;
+        let repository =
+            OmicronRepo::load_untrusted_ignore_expiration(log, dir.path())
+                .map_err(RepositoryError::LoadRepository)?;
 
         let artifacts = repository
             .read_artifacts()


### PR DESCRIPTION
This renames the `load` family of functions in `tufaceous_lib::OmicronRepo` to `load_untrusted`, because these functions (out of necessity) trust any TUF repository regardless of the provenance of its keys.

This change makes it a little more obvious that these methods should never be used outside of rack bootstrapping or development tooling; namely, they should never show up in Nexus.

For the tufaceous binary, we may want to require the user pass a root.json or a `--untrusted` flag, as I can imagine us wanting to use that tool in automation in such a way that we trust a repository we're reading from. Other uses of these methods are appropriate.