### PR TITLE
tell buildomat to publish the TUF repo

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -5,7 +5,7 @@
 #: target = "helios-latest"
 #: output_rules = [
 #:	"=/work/manifest.toml",
-#:	"=/work/repo.zip.part*",
+#:	"=/work/repo.zip*",
 #: ]
 #:
 #: [dependencies.ci-tools]
@@ -19,6 +19,21 @@
 #:
 #: [dependencies.trampoline]
 #: job = "helios / build trampoline OS image"
+#:
+#: [[publish]]
+#: series = "tuf-repo"
+#: name = "repo.zip.parta"
+#: from_output = "/out/repo.zip.parta"
+#:
+#: [[publish]]
+#: series = "tuf-repo"
+#: name = "repo.zip.partb"
+#: from_output = "/out/repo.zip.partb"
+#:
+#: [[publish]]
+#: series = "tuf-repo"
+#: name = "repo.zip.sha256.txt"
+#: from_output = "/out/repo.zip.sha256.txt"
 #:
 
 set -o errexit
@@ -84,9 +99,13 @@ EOF
 done
 
 /work/tufaceous assemble --no-generate-key --skip-all-present /work/manifest.toml /work/repo.zip
+digest -a sha256 /work/repo.zip > /work/repo.zip.sha256.txt
 
 #
 # XXX: Buildomat currently does not support uploads greater than 1 GiB. This is
 # an awful temporary hack which we need to strip out the moment it does.
 #
 split -a 1 -b 1024m /work/repo.zip /work/repo.zip.part
+rm /work/repo.zip
+# Ensure the build doesn't fail if the repo gets smaller than 1 GiB.
+touch /work/repo.zip.partb


### PR DESCRIPTION
I'm working on a separate repo which will combine this job's output and Hubris artifacts into a full TUF repository.

I was holding off from adding this because the `split` thing felt like an enormous hack, but an even worse hack would be to use a Markdown parser on the GitHub check output to find the URLs to the uploaded artifacts.[^1]

[^1]: Which I have already written. Oops.