### PR TITLE
Remove "from_start" parameter from serial stream.

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1396,7 +1396,7 @@ impl super::Nexus {
         &self,
         conn: dropshot::WebsocketConnection,
         instance_lookup: &lookup::Instance<'_>,
-        params: &params::InstanceSerialConsoleRequest,
+        params: &params::InstanceSerialConsoleStreamRequest,
     ) -> Result<(), Error> {
         let client = self
             .propolis_client_for_instance(
@@ -1405,9 +1405,7 @@ impl super::Nexus {
             )
             .await?;
         let mut req = client.instance_serial();
-        if let Some(from_start) = params.from_start {
-            req = req.from_start(from_start);
-        } else if let Some(most_recent) = params.most_recent {
+        if let Some(most_recent) = params.most_recent {
             req = req.most_recent(most_recent);
         }
         let propolis_upgraded = req

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1992,7 +1992,7 @@ async fn instance_serial_console(
 async fn instance_serial_console_stream(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<params::InstancePath>,
-    query_params: Query<params::InstanceSerialConsoleRequest>,
+    query_params: Query<params::InstanceSerialConsoleStreamRequest>,
     conn: WebsocketConnection,
 ) -> WebsocketChannelResult {
     let apictx = rqctx.context();

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -973,9 +973,17 @@ pub struct InstanceSerialConsoleRequest {
     /// Maximum number of bytes of buffered serial console contents to return. If the requested
     /// range runs to the end of the available buffer, the data returned will be shorter than
     /// `max_bytes`.
-    /// This parameter is only useful for the non-streaming GET request for serial console data,
-    /// and *ignored* by the streaming websocket endpoint.
     pub max_bytes: Option<u64>,
+}
+
+/// Forwarded to a propolis server to request the contents of an Instance's serial console.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleStreamRequest {
+    /// Name or ID of the project, only required if `instance` is provided as a `Name`
+    pub project: Option<NameOrId>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance.
+    pub most_recent: Option<u64>,
 }
 
 /// Contents of an Instance's serial console buffer.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1956,7 +1956,7 @@
           {
             "in": "query",
             "name": "max_bytes",
-            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`. This parameter is only useful for the non-streaming GET request for serial console data, and *ignored* by the streaming websocket endpoint.",
+            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`.",
             "schema": {
               "nullable": true,
               "type": "integer",
@@ -2023,30 +2023,8 @@
           },
           {
             "in": "query",
-            "name": "from_start",
-            "description": "Character index in the serial buffer from which to read, counting the bytes output since instance start. If this is not provided, `most_recent` must be provided, and if this *is* provided, `most_recent` must *not* be provided.",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0
-            }
-          },
-          {
-            "in": "query",
-            "name": "max_bytes",
-            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`. This parameter is only useful for the non-streaming GET request for serial console data, and *ignored* by the streaming websocket endpoint.",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0
-            }
-          },
-          {
-            "in": "query",
             "name": "most_recent",
-            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance. (See note on `from_start` about mutual exclusivity)",
+            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance.",
             "schema": {
               "nullable": true,
               "type": "integer",


### PR DESCRIPTION
Removal of an API footgun, as this parameter really only makes sense for the history-retrieval GET endpoint, not the continuous websocket connection.

Eventually over an instance's lifespan, it makes less sense for a client connecting to try asking for bytes starting from the beginning of time, as we don't buffer everything forever and this eventually becomes impossible to satisfy.

(further explanation in this comment https://github.com/oxidecomputer/propolis/issues/409#issuecomment-1552351154 - a bug encountered while investigating what is likely an unrelated issue.)