### PR TITLE
actually tell buildomat to publish the TUF repo

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -23,17 +23,17 @@
 #: [[publish]]
 #: series = "tuf-repo"
 #: name = "repo.zip.parta"
-#: from_output = "/out/repo.zip.parta"
+#: from_output = "/work/repo.zip.parta"
 #:
 #: [[publish]]
 #: series = "tuf-repo"
 #: name = "repo.zip.partb"
-#: from_output = "/out/repo.zip.partb"
+#: from_output = "/work/repo.zip.partb"
 #:
 #: [[publish]]
 #: series = "tuf-repo"
 #: name = "repo.zip.sha256.txt"
-#: from_output = "/out/repo.zip.sha256.txt"
+#: from_output = "/work/repo.zip.sha256.txt"
 #:
 
 set -o errexit


### PR DESCRIPTION
Corrects a glaring error in #3146.

I merged despite the URL not working because I thought it might only work on main. It wasn't until shortly after I reached out for @jclulow for help that I noticed the error.