### PR TITLE
[wicket] Allow user to force RoT/SP upgrade

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1559,6 +1559,14 @@
       "StartUpdateOptions": {
         "type": "object",
         "properties": {
+          "skip_rot_version_check": {
+            "description": "If true, skip the check on the current RoT version and always update it regardless of whether the update appears to be neeeded.",
+            "type": "boolean"
+          },
+          "skip_sp_version_check": {
+            "description": "If true, skip the check on the current SP version and always update it regardless of whether the update appears to be neeeded.",
+            "type": "boolean"
+          },
           "test_error": {
             "nullable": true,
             "description": "If passed in, fails the update with a simulated error.",
@@ -1575,7 +1583,11 @@
             "format": "uint64",
             "minimum": 0
           }
-        }
+        },
+        "required": [
+          "skip_rot_version_check",
+          "skip_sp_version_check"
+        ]
       },
       "StepComponentSummaryForGenericSpec": {
         "type": "object",

--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -25,6 +25,9 @@ pub enum Cmd {
     /// Exit the current context
     Exit,
 
+    /// Toggle the currently-selected item (e.g., checkbox).
+    Toggle,
+
     /// Expand the current tree context
     Expand,
 
@@ -162,6 +165,7 @@ impl KeyHandler {
         let cmd = match event.code {
             KeyCode::Enter => Cmd::Enter,
             KeyCode::Esc => Cmd::Exit,
+            KeyCode::Char(' ') => Cmd::Toggle,
             KeyCode::Char('e') => Cmd::Expand,
             KeyCode::Char('c') => Cmd::Collapse,
             KeyCode::Char('d') => Cmd::Details,

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -222,8 +222,12 @@ impl RunnerCore {
                                 )
                             });
 
-                    let options =
-                        StartUpdateOptions { test_error, test_step_seconds };
+                    let options = StartUpdateOptions {
+                        test_error,
+                        test_step_seconds,
+                        skip_rot_version_check: false,
+                        skip_sp_version_check: false,
+                    };
                     wicketd.tx.blocking_send(
                         wicketd::Request::StartUpdate { component_id, options },
                     )?;

--- a/wicket/src/runner.rs
+++ b/wicket/src/runner.rs
@@ -225,8 +225,14 @@ impl RunnerCore {
                     let options = StartUpdateOptions {
                         test_error,
                         test_step_seconds,
-                        skip_rot_version_check: false,
-                        skip_sp_version_check: false,
+                        skip_rot_version_check: self
+                            .state
+                            .force_update_state
+                            .force_update_rot,
+                        skip_sp_version_check: self
+                            .state
+                            .force_update_state
+                            .force_update_sp,
                     };
                     wicketd.tx.blocking_send(
                         wicketd::Request::StartUpdate { component_id, options },

--- a/wicket/src/state/force_update.rs
+++ b/wicket/src/state/force_update.rs
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde::{Deserialize, Serialize};
+use wicket_common::update_events::UpdateComponent;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ForceUpdateState {
+    pub force_update_rot: bool,
+    pub force_update_sp: bool,
+    selected_component: UpdateComponent,
+}
+
+impl Default for ForceUpdateState {
+    fn default() -> Self {
+        Self {
+            force_update_rot: false,
+            force_update_sp: false,
+            selected_component: UpdateComponent::Rot,
+        }
+    }
+}
+
+impl ForceUpdateState {
+    pub fn selected_component(&self) -> UpdateComponent {
+        self.selected_component
+    }
+
+    pub fn next_component(&mut self) {
+        if self.selected_component == UpdateComponent::Rot {
+            self.selected_component = UpdateComponent::Sp;
+        } else {
+            self.selected_component = UpdateComponent::Rot;
+        }
+    }
+
+    pub fn prev_component(&mut self) {
+        // We only have 2 components; next/prev are both toggles.
+        self.next_component();
+    }
+
+    pub fn toggle(&mut self, component: UpdateComponent) {
+        match component {
+            UpdateComponent::Rot => {
+                self.force_update_rot = !self.force_update_rot;
+            }
+            UpdateComponent::Sp => {
+                self.force_update_sp = !self.force_update_sp;
+            }
+            UpdateComponent::Host => (),
+        }
+    }
+}

--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -4,11 +4,13 @@
 
 //! The global state manipulated by wicket.
 
+mod force_update;
 mod inventory;
 mod rack;
 mod status;
 mod update;
 
+pub use force_update::ForceUpdateState;
 pub use inventory::{
     Component, ComponentId, Inventory, ParsableComponentId, PowerState, Sp,
     ALL_COMPONENT_IDS,
@@ -34,6 +36,7 @@ pub struct State {
     pub rack_state: RackState,
     pub service_status: ServiceStatus,
     pub update_state: RackUpdateState,
+    pub force_update_state: ForceUpdateState,
 }
 
 impl State {
@@ -45,6 +48,7 @@ impl State {
             rack_state: RackState::new(),
             service_status: ServiceStatus::new(),
             update_state: RackUpdateState::new(),
+            force_update_state: ForceUpdateState::default(),
         }
     }
 }

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -289,6 +289,10 @@ impl UpdateItem {
         }
     }
 
+    pub fn components(&self) -> &[UpdateComponent] {
+        &self.components
+    }
+
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = (UpdateComponent, UpdateState)> + '_ {

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -1165,8 +1165,10 @@ impl ForceUpdateSelectionState {
     fn help_text(&self) -> Vec<(&'static str, &'static str)> {
         match self.num_spans() {
             0 => vec![],
-            1 => vec![("Toggle", "Space")],
-            _ => vec![("Toggle", "Space"), ("Up", "Up"), ("Down", "Down")],
+            1 => vec![("Toggle", "<Space>")],
+            _ => {
+                vec![("Toggle", "<Space>"), ("Up", "<Up>"), ("Down", "<Down>")]
+            }
         }
     }
 

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -151,6 +151,16 @@ pub(crate) struct StartUpdateOptions {
     ///
     /// This is used for testing.
     pub(crate) test_step_seconds: Option<u64>,
+
+    /// If true, skip the check on the current RoT version and always update it
+    /// regardless of whether the update appears to be neeeded.
+    #[allow(dead_code)] // TODO actually use this
+    pub(crate) skip_rot_version_check: bool,
+
+    /// If true, skip the check on the current SP version and always update it
+    /// regardless of whether the update appears to be neeeded.
+    #[allow(dead_code)] // TODO actually use this
+    pub(crate) skip_sp_version_check: bool,
 }
 
 #[derive(Copy, Clone, Debug, JsonSchema, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
When showing the start update pane, if the current RoT and SP versions are both different from the version in the uploaded TUF repo, the screen looks basically the same (but now left-justified, for reasons that will become clearer below):

![force-none](https://github.com/oxidecomputer/omicron/assets/1435635/827c54d2-e80f-455b-82bf-ba06e9e59aa6)

If one of the two (the SP in this example) has a version that exactly matches the TUF repo, we now display a toggle-able line for the user to force an upgrade (also note the `Toggle` help):

![force-sp](https://github.com/oxidecomputer/omicron/assets/1435635/c3e2eb2f-9a00-4362-b5f2-781920900847)

If both the RoT and SP have a version that exactly mathes the TUF repo, we display two lines with extra help for up/down (the RoT version in this screenshot doesn't actually match; I hacked up the check to display the line anyway to get this screenshot):

![force-both](https://github.com/oxidecomputer/omicron/assets/1435635/96d7afa3-0486-46ed-9404-3e497d0f1a6a)

A couple notes:

* There is only one `ForceInstallState`, not one per SP. I think (?) this is right because if one is updating multiple sleds, one will presumably want the same setting for all of them?
* The wicketd side of this accepts the new bools, but doesn't do anything with them. That work will come in a followup PR.

Builds on #3143