### PR TITLE
[installinator] Report progress on a background task

### DIFF
--- a/installinator/src/reporter.rs
+++ b/installinator/src/reporter.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use display_error_chain::DisplayErrorChain;
 use futures::{Future, StreamExt};
 use installinator_common::{Event, EventBuffer};
-use tokio::{sync::mpsc, time};
+use tokio::{sync::mpsc, task::JoinHandle, time};
 use uuid::Uuid;
 
 use crate::{errors::DiscoverPeersError, peers::Peers};
@@ -23,11 +23,12 @@ pub(crate) struct ProgressReporter<F> {
     event_receiver: mpsc::Receiver<Event>,
     buffer: EventBuffer,
     last_reported: Option<usize>,
+    on_tick_task: Option<JoinHandle<Option<Option<usize>>>>,
 }
 
 impl<F, Fut> ProgressReporter<F>
 where
-    F: 'static + Send + FnMut() -> Fut,
+    F: 'static + Clone + Send + FnMut() -> Fut,
     Fut: Future<Output = Result<Peers, DiscoverPeersError>> + Send,
 {
     pub(crate) fn new(
@@ -47,6 +48,7 @@ where
             // cause a payload that's too large.
             buffer: EventBuffer::new(8),
             last_reported: None,
+            on_tick_task: None,
         };
         (ret, event_sender)
     }
@@ -88,35 +90,63 @@ where
         })
     }
 
-    async fn on_tick(&mut self) {
+    fn spawn_on_tick_task(&self) -> JoinHandle<Option<Option<usize>>> {
         let report = self.buffer.generate_report();
+        let mut discover_fn = self.discover_fn.clone();
+        let update_id = self.update_id;
+        let log = self.log.clone();
 
-        let peers = match (self.discover_fn)().await {
-            Ok(peers) => peers,
-            Err(error) => {
-                // Ignore DiscoverPeersError::Abort here because the
-                // installinator must keep retrying.
-                slog::warn!(
-                    self.log,
-                    "failed to discover peers: {}",
-                    DisplayErrorChain::new(&error),
-                );
+        tokio::spawn(async move {
+            let peers = match (discover_fn)().await {
+                Ok(peers) => peers,
+                Err(error) => {
+                    // Ignore DiscoverPeersError::Abort here because the
+                    // installinator must keep retrying.
+                    slog::warn!(
+                        log,
+                        "failed to discover peers: {}",
+                        DisplayErrorChain::new(&error),
+                    );
+                    return None;
+                }
+            };
+
+            // We could use StreamExt::any() here, but we're choosing to avoid
+            // short-circuiting for now in favor of reaching out to all peers.
+            //
+            // TODO: is this correct? If a peer takes too long this might end up
+            // stalling updates for everyone -- feels wrong. The tradeoff is
+            // that if two servers both say, only one of them will
+            // deterministically get the update. Need to decide post-PVT1.
+            let last_reported = report.last_seen;
+            let results: Vec<_> =
+                peers.broadcast_report(update_id, report).collect().await;
+            if results.iter().any(|res| res.is_ok()) {
+                Some(last_reported)
+            } else {
+                None
+            }
+        })
+    }
+
+    async fn on_tick(&mut self) {
+        if let Some(task) = self.on_tick_task.take() {
+            // If the task we spawned on a previous tick is still running, just
+            // put it back; we'll wait for the next tick.
+            if !task.is_finished() {
+                self.on_tick_task = Some(task);
                 return;
             }
-        };
 
-        // We could use StreamExt::any() here, but we're choosing to avoid
-        // short-circuiting for now in favor of reaching out to all peers.
-        //
-        // TODO: is this correct? If a peer takes too long this might end up
-        // stalling updates for everyone -- feels wrong. The tradeoff is that if
-        // two servers both say, only one of them will deterministically get the
-        // update. Need to decide post-PVT1.
-        let last_reported = report.last_seen;
-        let results: Vec<_> =
-            peers.broadcast_report(self.update_id, report).collect().await;
-        if results.iter().any(|res| res.is_ok()) {
-            self.last_reported = last_reported;
+            // Our last `on_tick` task is done; get its result, and possibly
+            // update `self.last_reported` (if we successfully reported
+            // progress to a peer).
+            if let Some(last_reported) = task.await.unwrap() {
+                self.last_reported = last_reported;
+            }
         }
+
+        // Spawn a task to do the actual work, which may take considerable time.
+        self.on_tick_task = Some(self.spawn_on_tick_task());
     }
 }


### PR DESCRIPTION
Both last week and this week when trying to mupdate dogfood, we would see the first sled or two work, but then future sled mupdates would hang with installinator timing out trying to download artifacts from wicketd (even though it was able to send progress reports). With a lot of help from @rcgoodfellow I think I tracked this down to a channel block between tasks: our downloading task gets blocked [trying to send progress reports](https://github.com/oxidecomputer/omicron/blob/5280a10fcb529b5e54ae8b7fd37737d53d66b57b/installinator/src/peers.rs#L319-L324) because the UpdateEngine is blocked [trying to send events to the progress reporter](https://github.com/oxidecomputer/omicron/blob/5280a10fcb529b5e54ae8b7fd37737d53d66b57b/update-engine/src/engine.rs#L655-L765) because the progress reporter is [waiting to send reports to all peers](https://github.com/oxidecomputer/omicron/blob/5280a10fcb529b5e54ae8b7fd37737d53d66b57b/installinator/src/reporter.rs#L116-L117).

This PR changes the progress reporter to send reports to all peers on a background task, allowing it to still receive events from the UpdateEngine promptly. I tested this on `BRM42220057` in dogfood, and it does appear to fix the problem. I am not sure this is the best fix though - open to suggestions!