### PR TITLE
[installinator] Stop calling diskinfo spuriously

### DIFF
--- a/installinator/src/hardware.rs
+++ b/installinator/src/hardware.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::process::Command;
-
 use anyhow::anyhow;
 use anyhow::ensure;
 use anyhow::Context;
@@ -15,8 +13,6 @@ use sled_hardware::SledMode;
 use slog::info;
 use slog::Logger;
 
-const DISKINFO_PATH: &str = "/usr/bin/diskinfo";
-
 pub struct Hardware {
     m2_disks: Vec<Disk>,
 }
@@ -26,15 +22,6 @@ impl Hardware {
         let is_gimlet = sled_hardware::is_gimlet()
             .context("failed to detect whether host is a gimlet")?;
         ensure!(is_gimlet, "hardware scan only supported on gimlets");
-
-        // Workaround https://github.com/oxidecomputer/stlouis/issues/395:
-        // `Disk::new()` below expects the `...:wd,raw` whole disk minor node to
-        // exist, but it doesn't always; running `diskinfo` ahead of time forces
-        // it to show up.
-        let status = Command::new(DISKINFO_PATH)
-            .status()
-            .with_context(|| format!("failed to run `{DISKINFO_PATH}`"))?;
-        ensure!(status.success(), "{DISKINFO_PATH} failed: {status}");
 
         let hardware =
             HardwareManager::new(log, SledMode::Auto).map_err(|err| {


### PR DESCRIPTION
We did this to work around https://github.com/oxidecomputer/stlouis/issues/395, which has since been fixed.