### PR TITLE
Allow VMM reservoir to be configured by sled-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#616e9fbda73ca90ee40dfea8283fe62437af99ff"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#61c035b1f70d7b2c2e2ee2481e850105bf15ff31"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#616e9fbda73ca90ee40dfea8283fe62437af99ff"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#61c035b1f70d7b2c2e2ee2481e850105bf15ff31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3168,6 +3168,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bhyve_api",
  "camino",
  "cfg-if 1.0.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df", features = [ "generated-migration" ] }
 propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df", default-features = false, features = ["mock-only"] }
 proptest = "1.1.0"

--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -84,6 +84,7 @@ CREATE TABLE omicron.public.sled (
     /* CPU & RAM summary for the sled */
     usable_hardware_threads INT8 CHECK (usable_hardware_threads BETWEEN 0 AND 4294967295) NOT NULL,
     usable_physical_ram INT8 NOT NULL,
+    reservoir_size INT8 CHECK (reservoir_size < usable_physical_ram) NOT NULL,
 
     /* The IP address and bound port of the sled agent server. */
     ip INET NOT NULL,

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+bhyve_api.workspace = true
 camino.workspace = true
 cfg-if.workspace = true
 futures.workspace = true

--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -15,6 +15,7 @@ pub mod link;
 pub mod opte;
 pub mod running_zone;
 pub mod svc;
+pub mod vmm_reservoir;
 pub mod zfs;
 pub mod zone;
 pub mod zpool;

--- a/illumos-utils/src/vmm_reservoir.rs
+++ b/illumos-utils/src/vmm_reservoir.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Wrappers around VMM Reservoir controls
+
+use omicron_common::api::external::ByteCount;
+
+#[allow(non_upper_case_globals)]
+const MiB: u64 = 1024 * 1024;
+#[allow(non_upper_case_globals)]
+const GiB: u64 = 1024 * 1024 * 1024;
+
+/// The control plane's required alignment for a reservoir size request.
+//
+// The ioctl interface for resizing the reservoir only requires rounding the
+// requested size to PAGESIZE. But we choose a larger value here of 2MiB to
+// better enable large pages for guests in the future: Currently, the reservoir
+// does not have support for large pages, but choosing a size that aligns with
+// the minimum large page size on x86 (2 MiB) will simplify things later.
+///
+pub const RESERVOIR_SZ_ALIGN: u64 = 2 * MiB;
+
+// Chunk size to request when resizing the reservoir. It's okay if this value is
+// greater than the requested size.
+const RESERVOIR_CHUNK_SZ: usize = GiB as usize;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Reservoir size must be aligned to 2 MiB: {0}")]
+    InvalidSize(ByteCount),
+
+    #[error("Failed to resize reservoir: {0}")]
+    ReservoirError(#[from] std::io::Error),
+}
+
+/// Controls the size of the memory reservoir
+pub struct ReservoirControl {}
+
+impl ReservoirControl {
+    /// Sets the reservoir to a particular size.
+    ///
+    /// The size must be aligned on RESERVOIR_SZ_ALIGN.
+    pub fn set(size: ByteCount) -> Result<(), Error> {
+        if !reservoir_size_is_aligned(size.to_bytes()) {
+            return Err(Error::InvalidSize(size));
+        }
+
+        let ctl = bhyve_api::VmmCtlFd::open()?;
+        ctl.reservoir_resize(
+            size.to_bytes().try_into().map_err(|_| Error::InvalidSize(size))?,
+            RESERVOIR_CHUNK_SZ,
+        )
+        .map_err(std::io::Error::from)?;
+
+        Ok(())
+    }
+}
+
+pub fn align_reservoir_size(size_bytes: u64) -> u64 {
+    size_bytes - (size_bytes % RESERVOIR_SZ_ALIGN)
+}
+
+pub fn reservoir_size_is_aligned(size_bytes: u64) -> bool {
+    (size_bytes % RESERVOIR_SZ_ALIGN) == 0
+}

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -680,6 +680,7 @@ table! {
 
         usable_hardware_threads -> Int8,
         usable_physical_ram -> Int8,
+        reservoir_size -> Int8,
 
         ip -> Inet,
         port -> Int4,

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -28,6 +28,9 @@ pub struct SledSystemHardware {
     pub is_scrimlet: bool,
     pub usable_hardware_threads: u32,
     pub usable_physical_ram: ByteCount,
+
+    // current VMM reservoir size
+    pub reservoir_size: ByteCount,
 }
 
 /// Database representation of a Sled.
@@ -46,8 +49,9 @@ pub struct Sled {
     part_number: String,
     revision: i64,
 
-    usable_hardware_threads: SqlU32,
-    usable_physical_ram: ByteCount,
+    pub usable_hardware_threads: SqlU32,
+    pub usable_physical_ram: ByteCount,
+    pub reservoir_size: ByteCount,
 
     // ServiceAddress (Sled Agent).
     pub ip: ipv6::Ipv6Addr,
@@ -83,6 +87,7 @@ impl Sled {
                 hardware.usable_hardware_threads,
             ),
             usable_physical_ram: hardware.usable_physical_ram,
+            reservoir_size: hardware.reservoir_size,
             ip: ipv6::Ipv6Addr::from(addr.ip()),
             port: addr.port().into(),
             last_used_address,

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -325,6 +325,8 @@ mod test {
             usable_hardware_threads: 4,
             usable_physical_ram: crate::db::model::ByteCount::try_from(1 << 40)
                 .unwrap(),
+            reservoir_size: crate::db::model::ByteCount::try_from(1 << 39)
+                .unwrap(),
         }
     }
 

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -63,6 +63,7 @@ impl super::Nexus {
                 is_scrimlet,
                 usable_hardware_threads: info.usable_hardware_threads,
                 usable_physical_ram: info.usable_physical_ram.into(),
+                reservoir_size: info.reservoir_size.into(),
             },
             self.rack_id,
         );

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -50,6 +50,8 @@ pub const PRODUCER_UUID: &str = "a6458b7d-87c3-4483-be96-854d814c20de";
 pub const TEST_HARDWARE_THREADS: u32 = 16;
 /// The reported amount of physical RAM for an emulated sled agent.
 pub const TEST_PHYSICAL_RAM: u64 = 32 * (1 << 30);
+/// The reported amount of VMM reservoir RAM for an emulated sled agent.
+pub const TEST_RESERVOIR_RAM: u64 = 16 * (1 << 30);
 
 /// Password for the user created by the test suite
 ///
@@ -402,6 +404,7 @@ pub async fn start_sled_agent(
         hardware: sim::ConfigHardware {
             hardware_threads: TEST_HARDWARE_THREADS,
             physical_ram: TEST_PHYSICAL_RAM,
+            reservoir_ram: TEST_RESERVOIR_RAM,
         },
     };
 

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -59,6 +59,11 @@ pub struct SledAgentStartupInfo {
 
     /// Amount of RAM which may be used by the Sled's OS
     pub usable_physical_ram: ByteCount,
+
+    /// Amount of RAM dedicated to the VMM reservoir
+    ///
+    /// Must be smaller than "usable_physical_ram"
+    pub reservoir_size: ByteCount,
 }
 
 /// Describes the type of physical disk.

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2894,6 +2894,14 @@
               }
             ]
           },
+          "reservoir_size": {
+            "description": "Amount of RAM dedicated to the VMM reservoir\n\nMust be smaller than \"usable_physical_ram\"",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
           "role": {
             "description": "Describes the responsibilities of the sled",
             "allOf": [
@@ -2923,6 +2931,7 @@
         },
         "required": [
           "baseboard",
+          "reservoir_size",
           "role",
           "sa_address",
           "usable_hardware_threads",

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -95,6 +95,7 @@ async fn do_run() -> Result<(), CmdError> {
         hardware: ConfigHardware {
             hardware_threads: 32,
             physical_ram: 64 * (1 << 30),
+            reservoir_ram: 32 * (1 << 30),
         },
     };
 

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -41,6 +41,7 @@ pub struct SoftPortConfig {
 
 /// Configuration for a sled agent
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Configuration for the sled agent debug log
     pub log: ConfigLogging,
@@ -48,6 +49,8 @@ pub struct Config {
     pub sled_mode: SledMode,
     // TODO: Remove once this can be auto-detected.
     pub sidecar_revision: SidecarRevision,
+    /// Optional percentage of DRAM to reserve for guest memory
+    pub vmm_reservoir_percentage: Option<u8>,
     /// Optional VLAN ID to be used for tagging guest VNICs.
     pub vlan: Option<VlanID>,
     /// Optional list of zpools to be used as "discovered disks".

--- a/sled-agent/src/sim/config.rs
+++ b/sled-agent/src/sim/config.rs
@@ -46,6 +46,7 @@ pub struct ConfigStorage {
 pub struct ConfigHardware {
     pub hardware_threads: u32,
     pub physical_ram: u64,
+    pub reservoir_ram: u64,
 }
 
 /// Configuration for a sled agent

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -110,6 +110,10 @@ impl Server {
                             config.hardware.physical_ram,
                         )
                         .unwrap(),
+                        reservoir_size: NexusTypes::ByteCount::try_from(
+                            config.hardware.reservoir_ram,
+                        )
+                        .unwrap(),
                     },
                 )
                 .await)

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -239,6 +239,9 @@ impl SledAgent {
             })
             .await?;
 
+        let hardware = HardwareManager::new(&parent_log, services.sled_mode())
+            .map_err(|e| Error::Hardware(e))?;
+
         let instances = InstanceManager::new(
             parent_log.clone(),
             lazy_nexus_client.clone(),
@@ -246,8 +249,23 @@ impl SledAgent {
             port_manager.clone(),
         )?;
 
-        let hardware = HardwareManager::new(&parent_log, services.sled_mode())
-            .map_err(|e| Error::Hardware(e))?;
+        match config.vmm_reservoir_percentage {
+            Some(sz) if sz > 0 && sz < 100 => {
+                instances.set_reservoir_size(&hardware, sz).map_err(|e| {
+                    warn!(log, "Failed to set VMM reservoir size: {e}");
+                    e
+                })?;
+            }
+            Some(sz) if sz == 0 => {
+                warn!(log, "Not using VMM reservoir (size 0 bytes requested)");
+            }
+            None => {
+                warn!(log, "Not using VMM reservoir");
+            }
+            Some(sz) => {
+                panic!("invalid requested VMM reservoir percentage: {}", sz);
+            }
+        }
 
         let update_config = ConfigUpdates {
             zone_artifact_path: Utf8PathBuf::from("/opt/oxide"),
@@ -408,6 +426,7 @@ impl SledAgent {
             self.inner.hardware.online_processor_count();
         let usable_physical_ram =
             self.inner.hardware.usable_physical_ram_bytes();
+        let reservoir_size = self.inner.instances.reservoir_size();
 
         let log = log.clone();
         let fut = async move {
@@ -444,6 +463,9 @@ impl SledAgent {
                             usable_hardware_threads,
                             usable_physical_ram: nexus_client::types::ByteCount(
                                 usable_physical_ram,
+                            ),
+                            reservoir_size: nexus_client::types::ByteCount(
+                                reservoir_size.to_bytes(),
                             ),
                         },
                     )

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -18,6 +18,10 @@ sidecar_revision.physical = "b"
 # in-sync, rather than querying its NTP zone.
 skip_timesync = true
 
+# Percentage of usable physical DRAM to use for the VMM reservoir, which
+# guest memory is pulled from.
+vmm_reservoir_percentage = 0
+
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -21,6 +21,10 @@ sidecar_revision.physical = "b"
 # $ dladm show-phys -p -o LINK
 data_link = "cxgbe0"
 
+# Percentage of usable physical DRAM to use for the VMM reservoir, which
+# guest memory is pulled from.
+vmm_reservoir_percentage = 0
+
 [log]
 level = "info"
 mode = "file"

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -32,6 +32,10 @@ zpools = [
   "oxp_f4b4dc87-ab46-49fb-a4b4-d361ae214c03",
 ]
 
+# Percentage of usable physical DRAM to use for the VMM reservoir, which
+# guest memory is pulled from.
+vmm_reservoir_percentage = 0
+
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #


### PR DESCRIPTION
Builds on top of #2684, with some slight changes, and with the addition of allowing the reservoir size to be configured as a percentage of sled DRAM, via sled-agent's config.toml.

Summary:
- adds support in sled-agent to configure the bhyve VMM reservoir
- the reservoir size is configured as a percentage of DRAM, rounded down to the nearest 2MiB (this is to make support of large pages easier later)
-  the percentage is an optional value in sled-agent's config.toml (`/opt/oxide/sled-agent/package/config.toml`)
- sled-agent reports the last set reservoir size back to Nexus after startup
- currently the default percentage for all config.toml files shipped in the repo (gimlet, standalone gimlet, non-gimlet) is 0, **so with this change, the reservoir is by default not used without manual intervention**

Allowing the size to be configured in this way is intentional; we know that we can't use the reservoir without swap devices configured, and there are potentially other issues to sort out there too. A PR for having sled-agent set up a swap device is in progress. But having the reservoir bits in main is valuable for testing; we can configure swap devices manually and test use of the reservoir without sled-agent knowing how to set those up yet.

To change the reservoir configured by sled-agent, modify this field in /opt/oxide/sled-agent/pkg/config.toml:

```
vmm_reservoir_percentage = 0
```

Then restart sled-agent: `$ svcadm restart sled-agent`
**Note that sled-agent currently tears down existing zones on startup; restarting sled-agent is thus destructive to existing instances on the sled.**

An illegal value (< 0 or > 100) will cause sled-agent to panic.

Note that the config.toml is in the ramdisk, so changes here are not persisted across reboot.