### PR TITLE
Constrain backoff to a 3 minute max interval

### DIFF
--- a/common/src/backoff.rs
+++ b/common/src/backoff.rs
@@ -65,7 +65,7 @@ where
 pub fn retry_policy_internal_service() -> ::backoff::ExponentialBackoff {
     backoff_builder()
         .with_initial_interval(Duration::from_millis(250))
-        .with_max_interval(Duration::from_secs(60 * 60))
+        .with_max_interval(Duration::from_secs(60 * 3))
         .build()
 }
 
@@ -82,7 +82,7 @@ pub fn retry_policy_internal_service_aggressive(
     backoff_builder()
         .with_initial_interval(Duration::from_millis(100))
         .with_multiplier(1.2)
-        .with_max_interval(Duration::from_secs(60 * 60))
+        .with_max_interval(Duration::from_secs(60 * 3))
         .build()
 }
 


### PR DESCRIPTION
### Addresses
- #3082 
- #3165 

### See also
- #3201 

### Notes
Because of how the underlying backoff crate works, this change creates an effective maximum backoff value of 4.5 minutes (`3 + 3*0.5`).