### PR TITLE
[console] Local (username/password) login page

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -253,6 +253,7 @@ pub fn external_api() -> NexusApiDescription {
 
         // Console API operations
         api.register(console_api::login_begin)?;
+        api.register(console_api::login)?;
         api.register(console_api::login_local_begin)?;
         api.register(console_api::login_local)?;
         api.register(console_api::login_saml_begin)?;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -253,9 +253,8 @@ pub fn external_api() -> NexusApiDescription {
 
         // Console API operations
         api.register(console_api::login_begin)?;
+        api.register(console_api::login_local_begin)?;
         api.register(console_api::login_local)?;
-        api.register(console_api::login_spoof_begin)?;
-        api.register(console_api::login_spoof)?;
         api.register(console_api::login_saml_begin)?;
         api.register(console_api::login_saml)?;
         api.register(console_api::logout)?;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -433,19 +433,15 @@ fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {
 }
 
 async fn log_in_and_extract_token(testctx: &ClientTestContext) -> String {
-    let login = RequestBuilder::new(
-        &testctx,
-        Method::POST,
-        "/login/test-suite-silo/local",
-    )
-    .body(Some(&UsernamePasswordCredentials {
-        username: "test-privileged".parse().unwrap(),
-        password: "oxide".parse().unwrap(),
-    }))
-    .expect_status(Some(StatusCode::SEE_OTHER))
-    .execute()
-    .await
-    .expect("failed to log in");
+    let login = RequestBuilder::new(&testctx, Method::POST, "/login")
+        .body(Some(&UsernamePasswordCredentials {
+            username: "test-privileged".parse().unwrap(),
+            password: "oxide".parse().unwrap(),
+        }))
+        .expect_status(Some(StatusCode::SEE_OTHER))
+        .execute()
+        .await
+        .expect("failed to log in");
 
     let session_cookie = get_header_value(login, header::SET_COOKIE);
     let (session_token, rest) = session_cookie.split_once("; ").unwrap();

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -71,7 +71,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
         .expect_status(Some(StatusCode::FOUND))
         .expect_response_header(
             header::LOCATION,
-            "/spoof_login?state=%2Fdevice%2Fverify",
+            "/login?state=%2Fdevice%2Fverify",
         )
         .execute()
         .await

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -51,8 +51,9 @@ instance_view                            GET      /v1/instances/{instance}
 
 API operations found with tag "login"
 OPERATION ID                             METHOD   URL PATH
+login                                    POST     /v1/login
 login_local                              POST     /login/{silo_name}/local
-login_saml                               POST     /login/{silo_name}/saml/{provider_name}
+login_saml                               POST     /v1/login/{silo_name}/saml/{provider_name}
 login_saml_begin                         GET      /login/{silo_name}/saml/{provider_name}
 
 API operations found with tag "policy"

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -16,7 +16,6 @@ OPERATION ID                             METHOD   URL PATH
 device_access_token                      POST     /device/token
 device_auth_confirm                      POST     /device/confirm
 device_auth_request                      POST     /device/auth
-login_spoof                              POST     /login
 logout                                   POST     /logout
 
 API operations found with tag "images"

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -101,35 +101,6 @@
         }
       }
     },
-    "/login": {
-      "post": {
-        "tags": [
-          "hidden"
-        ],
-        "operationId": "login_spoof",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SpoofLoginBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/login/{silo_name}/local": {
       "post": {
         "tags": [
@@ -291,6 +262,7 @@
         "tags": [
           "hidden"
         ],
+        "summary": "Log user out by deleting session on client and server",
         "operationId": "logout",
         "responses": {
           "204": {
@@ -11016,17 +10988,6 @@
           "ready",
           "faulted",
           "destroyed"
-        ]
-      },
-      "SpoofLoginBody": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "username"
         ]
       },
       "SshKey": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -198,63 +198,6 @@
             "$ref": "#/components/responses/Error"
           }
         }
-      },
-      "post": {
-        "tags": [
-          "login"
-        ],
-        "summary": "Authenticate a user via SAML",
-        "operationId": "login_saml",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "provider_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          },
-          {
-            "in": "path",
-            "name": "silo_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/octet-stream": {
-              "schema": {
-                "type": "string",
-                "format": "binary"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "303": {
-            "description": "redirect (see other)",
-            "headers": {
-              "location": {
-                "description": "HTTP \"Location\" header",
-                "style": "simple",
-                "required": true,
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
       }
     },
     "/logout": {
@@ -2105,6 +2048,106 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/login": {
+      "post": {
+        "tags": [
+          "login"
+        ],
+        "summary": "Generic login post endpoint. Designed to work the same way as",
+        "description": "`/login/{silo_name}/local`, but pulling the silo name from the host.",
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UsernamePasswordCredentials"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "303": {
+            "description": "redirect (see other)",
+            "headers": {
+              "location": {
+                "description": "HTTP \"Location\" header",
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/login/{silo_name}/saml/{provider_name}": {
+      "post": {
+        "tags": [
+          "login"
+        ],
+        "summary": "Authenticate a user via SAML",
+        "operationId": "login_saml",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            }
+          },
+          {
+            "in": "path",
+            "name": "silo_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "303": {
+            "description": "redirect (see other)",
+            "headers": {
+              "location": {
+                "description": "HTTP \"Location\" header",
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
- [x] Delete `/spoof_login` and redirects to it
  - Note this was misleadingly named and has nothing to do with the header-based spoof login scheme (which is still in place) other than relying on the same fake privileged and unprivileged users
- [ ] When we don't know the current silo from the subdomain (because silo name in subdomain isn't done yet) `/login` should redirect to `/login/{silo_name}/local` with the first silo it finds
- [ ] TBD

