### PR TITLE
[wicketd] Respect installinator's report of which disks were written

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1296,14 +1296,6 @@
           }
         ]
       },
-      "SpComponentUpdateStage": {
-        "type": "string",
-        "enum": [
-          "sending",
-          "preparing",
-          "writing"
-        ]
-      },
       "SpIdentifier": {
         "type": "object",
         "properties": {
@@ -2986,14 +2978,10 @@
                 "enum": [
                   "sp_component_update"
                 ]
-              },
-              "stage": {
-                "$ref": "#/components/schemas/SpComponentUpdateStage"
               }
             },
             "required": [
-              "id",
-              "stage"
+              "id"
             ]
           },
           {

--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -43,7 +43,7 @@ pub enum UpdateStepId {
     InterrogateRot,
     ResetRot,
     ResetSp,
-    SpComponentUpdate { stage: SpComponentUpdateStage },
+    SpComponentUpdate,
     SettingInstallinatorImageId,
     ClearingInstallinatorImageId,
     SettingHostStartupOptions,
@@ -63,6 +63,27 @@ impl StepSpec for WicketdEngineSpec {
 }
 
 update_engine::define_update_engine!(pub WicketdEngineSpec);
+
+#[derive(JsonSchema)]
+pub enum SpComponentUpdateSpec {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "id", rename_all = "snake_case")]
+pub enum SpComponentUpdateStepId {
+    Sending,
+    Preparing,
+    Writing,
+}
+
+impl StepSpec for SpComponentUpdateSpec {
+    type Component = UpdateComponent;
+    type StepId = SpComponentUpdateStepId;
+    type StepMetadata = serde_json::Value;
+    type ProgressMetadata = serde_json::Value;
+    type CompletionMetadata = serde_json::Value;
+    type SkippedMetadata = serde_json::Value;
+    type Error = UpdateTerminalError;
+}
 
 #[derive(Debug, Error)]
 pub enum UpdateTerminalError {

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -56,8 +56,6 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use update_engine::events::StepEventKind;
-use update_engine::events::StepOutcome;
 use update_engine::StepSpec;
 use uuid::Uuid;
 use wicket_common::update_events::ComponentRegistrar;

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1102,27 +1102,14 @@ impl UpdateContext {
             if write_output.is_none() {
                 for event in &report.step_events {
                     // We only care about the outcome of completion events.
-                    let outcome = match &event.kind {
-                        StepEventKind::StepCompleted { outcome, .. }
-                        | StepEventKind::ExecutionCompleted {
-                            last_outcome: outcome,
-                            ..
-                        } => outcome,
-                        StepEventKind::NoStepsDefined
-                        | StepEventKind::ExecutionStarted { .. }
-                        | StepEventKind::ProgressReset { .. }
-                        | StepEventKind::AttemptRetry { .. }
-                        | StepEventKind::ExecutionFailed { .. }
-                        | StepEventKind::Nested { .. }
-                        | StepEventKind::Unknown => continue,
+                    let Some(outcome) = event.kind.step_outcome() else {
+                        continue;
                     };
 
                     // We only care about successful (including "success with
                     // warning") outcomes.
-                    let metadata = match outcome {
-                        StepOutcome::Success { metadata }
-                        | StepOutcome::Warning { metadata, .. } => metadata,
-                        StepOutcome::Skipped { .. } => continue,
+                    let Some(metadata) = outcome.completion_metadata() else {
+                        continue;
                     };
 
                     match metadata {


### PR DESCRIPTION
We use this in two (new) ways:

1. We write the corresponding host boot flash slots (previously we only and always wrote slot 0)
2. Set the host to boot off of "the first disk successfully written" (previously we didn't set this at all, and left the host booting off of slot 0 as a side effect of trampoline delivery)

A big chunk of the diff is shifting engine steps to deliver an update to a component via the SP into a new nested engine, making it easier to loop over the disks returned by installinator (which are only available to us inside a running step).