### PR TITLE
`create-if` may fail

### DIFF
--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -251,13 +251,7 @@ impl RunningZone {
         ];
 
         for args in &commands {
-            if let Err(e) = running_zone.run_cmd(args) {
-                // `create-if` may fail if the vnic already has an interface.
-                // eat that error and continue.
-                if args[1] != "create-if" {
-                    return Err(e.into());
-                }
-            }
+            running_zone.run_cmd(args)?;
         }
 
         Ok(running_zone)

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -225,6 +225,22 @@ impl RunningZone {
             ];
 
             running_zone.run_cmd(args)?;
+        } else {
+            // If the zone is self-assembling, then it's possible that the IP
+            // interface does not exist yet because it has not been brought up
+            // by the software in the zone. Run `create-if` here, but eat the
+            // error if there is one: this is safe unless the software that's
+            // part of self-assembly inside the zone is also trying to run
+            // `create-if` (instead of `create-addr`), and required for the
+            // `set-ifprop` commands below to pass.
+            let args = vec![
+                IPADM.to_string(),
+                "create-if".to_string(),
+                "-t".to_string(),
+                vnic.clone(),
+            ];
+
+            let _result = running_zone.run_cmd(args);
         }
 
         let commands = vec![

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -234,7 +234,13 @@ impl RunningZone {
         ];
 
         for args in &commands {
-            running_zone.run_cmd(args)?;
+            if let Err(e) = running_zone.run_cmd(args) {
+                // `create-if` may fail if the vnic already has an interface.
+                // eat that error and continue.
+                if args[1] != "create-if" {
+                    return Err(e.into());
+                }
+            }
         }
 
         Ok(running_zone)

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -199,18 +199,35 @@ impl RunningZone {
             }
         })?;
 
+        let site_profile_xml_exists =
+            std::path::Path::new(&zone.site_profile_xml_path()).exists();
+
         let running_zone = RunningZone { running: true, inner: zone };
 
         // Make sure the control vnic has an IP MTU of 9000 inside the zone
         const CONTROL_VNIC_MTU: usize = 9000;
         let vnic = running_zone.inner.control_vnic.name().to_string();
-        let commands = vec![
-            vec![
+
+        // If the zone is self-assembling, then SMF service(s) inside the zone
+        // will be creating the listen address for the zone's service(s). This
+        // will create IP interfaces, and means that `create-if` here will fail
+        // due to the interface already existing. Checking the output of
+        // `show-if` is also problematic due to TOCTOU. Use the check for the
+        // existence of site.xml, which means the zone is performing this
+        // self-assembly, and skip create-if if so.
+
+        if !site_profile_xml_exists {
+            let args = vec![
                 IPADM.to_string(),
                 "create-if".to_string(),
                 "-t".to_string(),
                 vnic.clone(),
-            ],
+            ];
+
+            running_zone.run_cmd(args)?;
+        }
+
+        let commands = vec![
             vec![
                 IPADM.to_string(),
                 "set-ifprop".to_string(),
@@ -752,5 +769,11 @@ impl InstalledZone {
             opte_ports,
             links,
         })
+    }
+
+    pub fn site_profile_xml_path(&self) -> Utf8PathBuf {
+        let mut path: Utf8PathBuf = self.zonepath().into();
+        path.push("root/var/svc/profile/site.xml");
+        path
     }
 }

--- a/sled-agent/src/profile.rs
+++ b/sled-agent/src/profile.rs
@@ -30,10 +30,7 @@ impl ProfileBuilder {
     ) -> Result<(), std::io::Error> {
         info!(log, "Profile for {}:\n{}", installed_zone.name(), self);
 
-        let profile_path = format!(
-            "{zonepath}/root/var/svc/profile/site.xml",
-            zonepath = installed_zone.zonepath()
-        );
+        let profile_path = installed_zone.site_profile_xml_path();
 
         tokio::fs::write(&profile_path, format!("{self}").as_bytes()).await?;
         Ok(())


### PR DESCRIPTION
`create-if` may fail if the vnic being used inside a zone already has an interface in that zone. We saw this when bringing up dogfood, but I didn't see this in my original testing.

In `RunningZone::boot`, eat errors if the ipadm command is `create-if`