### PR TITLE
Retry progenitor client calls in sagas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,6 +4599,7 @@ dependencies = [
  "pem",
  "petgraph",
  "pq-sys",
+ "progenitor-client",
  "propolis-client",
  "rand 0.8.5",
  "rcgen",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -51,6 +51,7 @@ parse-display.workspace = true
 paste.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
+progenitor-client.workspace = true
 propolis-client.workspace = true
 rand.workspace = true
 ref-cast.workspace = true

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -330,10 +330,7 @@ pub async fn call_pantry_attach_for_disk(
         client.attach(&disk_id.to_string(), &attach_request)
     })
     .map_err(|e| {
-        ActionError::action_failed(format!(
-            "pantry attach failed with {:?}",
-            e
-        ))
+        ActionError::action_failed(format!("pantry attach failed with {:?}", e))
     })?;
 
     Ok(())

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -10,6 +10,7 @@ use crate::authz;
 use crate::db;
 use crate::db::identity::Asset;
 use crate::db::lookup::LookupPath;
+use crate::retry_until_known_result;
 use crate::Nexus;
 use anyhow::anyhow;
 use crucible_agent_client::{
@@ -281,73 +282,6 @@ pub async fn get_pantry_address(
 
 // Common Pantry operations
 
-#[macro_export]
-macro_rules! retry_until_known_result {
-    ( $log:ident, $func:block ) => {{
-        use omicron_common::backoff;
-
-        #[derive(Debug, thiserror::Error)]
-        enum InnerError {
-            #[error("Reqwest error: {0}")]
-            Reqwest(#[from] reqwest::Error),
-
-            #[error("Pantry client error: {0}")]
-            PantryClient(
-                #[from]
-                crucible_pantry_client::Error<
-                    crucible_pantry_client::types::Error,
-                >,
-            ),
-        }
-
-        backoff::retry_notify(
-            backoff::retry_policy_internal_service(),
-            || async {
-                match ($func).await {
-                    Err(crucible_pantry_client::Error::CommunicationError(
-                        e,
-                    )) => {
-                        warn!(
-                            $log,
-                            "saw transient communication error {}, retrying...",
-                            e,
-                        );
-
-                        Err(backoff::BackoffError::<InnerError>::transient(
-                            e.into(),
-                        ))
-                    }
-
-                    Err(e) => {
-                        warn!($log, "saw permanent error {}, aborting", e,);
-
-                        Err(backoff::BackoffError::<InnerError>::Permanent(
-                            e.into(),
-                        ))
-                    }
-
-                    Ok(v) => Ok(v),
-                }
-            },
-            |error: InnerError, delay| {
-                warn!(
-                    $log,
-                    "failed external call ({:?}), will retry in {:?}",
-                    error,
-                    delay,
-                );
-            },
-        )
-        .await
-        .map_err(|e| {
-            ActionError::action_failed(format!(
-                "gave up on external call due to {:?}",
-                e
-            ))
-        })
-    }};
-}
-
 pub async fn call_pantry_attach_for_disk(
     log: &slog::Logger,
     opctx: &OpContext,
@@ -394,6 +328,12 @@ pub async fn call_pantry_attach_for_disk(
 
     retry_until_known_result!(log, {
         client.attach(&disk_id.to_string(), &attach_request)
+    })
+    .map_err(|e| {
+        ActionError::action_failed(format!(
+            "pantry attach failed with {:?}",
+            e
+        ))
     })?;
 
     Ok(())
@@ -410,7 +350,13 @@ pub async fn call_pantry_detach_for_disk(
 
     let client = crucible_pantry_client::Client::new(&endpoint);
 
-    retry_until_known_result!(log, { client.detach(&disk_id.to_string()) })?;
+    retry_until_known_result!(log, { client.detach(&disk_id.to_string()) })
+        .map_err(|e| {
+            ActionError::action_failed(format!(
+                "pantry detach failed with {:?}",
+                e
+            ))
+        })?;
 
     Ok(())
 }

--- a/nexus/src/app/sagas/finalize_disk.rs
+++ b/nexus/src/app/sagas/finalize_disk.rs
@@ -10,10 +10,10 @@ use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
 use super::SagaInitError;
+use crate::app::sagas::common_storage::call_pantry_detach_for_disk;
 use crate::app::sagas::snapshot_create;
 use crate::db::lookup::LookupPath;
 use crate::external_api::params;
-use crate::retry_until_known_result;
 use crate::{authn, authz};
 use nexus_db_model::Generation;
 use omicron_common::api::external;
@@ -284,24 +284,9 @@ async fn sfd_call_pantry_detach_for_disk(
 ) -> Result<(), ActionError> {
     let log = sagactx.user_data().log();
     let params = sagactx.saga_params::<Params>()?;
-
     let pantry_address = sagactx.lookup::<SocketAddrV6>("pantry_address")?;
-    let endpoint = format!("http://{}", pantry_address);
 
-    info!(
-        log,
-        "sending detach request for disk {} to pantry endpoint {}",
-        params.disk_id,
-        endpoint,
-    );
-
-    let disk_id = params.disk_id.to_string();
-
-    let client = crucible_pantry_client::Client::new(&endpoint);
-
-    retry_until_known_result!(log, { client.detach(&disk_id) })?;
-
-    Ok(())
+    call_pantry_detach_for_disk(&log, params.disk_id, pantry_address).await
 }
 
 async fn sfd_clear_pantry_address(

--- a/nexus/src/app/sagas/import_blocks_from_url.rs
+++ b/nexus/src/app/sagas/import_blocks_from_url.rs
@@ -10,8 +10,8 @@ use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
 use super::SagaInitError;
+use crate::app::sagas::retry_until_known_result;
 use crate::db::lookup::LookupPath;
-use crate::retry_until_known_result;
 use crate::{authn, authz};
 use nexus_db_model::Generation;
 use nexus_types::external_api::params;
@@ -272,9 +272,10 @@ async fn sibfu_call_pantry_import_from_url_for_disk(
         },
     };
 
-    let response = retry_until_known_result!(log, {
-        client.import_from_url(&disk_id, &request)
+    let response = retry_until_known_result(log, || async {
+        client.import_from_url(&disk_id, &request).await
     })
+    .await
     .map_err(|e| {
         ActionError::action_failed(format!(
             "import from url failed with {:?}",
@@ -308,14 +309,16 @@ async fn sibfu_wait_for_import_from_url(
     );
 
     loop {
-        let result =
-            retry_until_known_result!(log, { client.is_job_finished(&job_id) })
-                .map_err(|e| {
-                    ActionError::action_failed(format!(
-                        "is_job_finished failed with {:?}",
-                        e
-                    ))
-                })?;
+        let result = retry_until_known_result(log, || async {
+            client.is_job_finished(&job_id).await
+        })
+        .await
+        .map_err(|e| {
+            ActionError::action_failed(format!(
+                "is_job_finished failed with {:?}",
+                e
+            ))
+        })?;
 
         if result.job_is_finished {
             break;
@@ -332,14 +335,13 @@ async fn sibfu_wait_for_import_from_url(
         endpoint,
     );
 
-    let response =
-        retry_until_known_result!(log, { client.job_result_ok(&job_id) })
-            .map_err(|e| {
-                ActionError::action_failed(format!(
-                    "job_result_ok failed with {:?}",
-                    e
-                ))
-            })?;
+    let response = retry_until_known_result(log, || async {
+        client.job_result_ok(&job_id).await
+    })
+    .await
+    .map_err(|e| {
+        ActionError::action_failed(format!("job_result_ok failed with {:?}", e))
+    })?;
 
     if !response.job_result_ok {
         return Err(ActionError::action_failed(format!("Job {job_id} failed")));

--- a/nexus/src/app/sagas/loopback_address_delete.rs
+++ b/nexus/src/app/sagas/loopback_address_delete.rs
@@ -177,15 +177,8 @@ async fn slc_loopback_address_delete(
     let dpd_client: Arc<dpd_client::Client> =
         Arc::clone(&osagactx.nexus().dpd_client);
 
-    match &params.address {
-        IpNet::V4(a) => retry_until_known_result!(log, {
-            dpd_client.loopback_ipv4_delete(&a.ip())
-        }),
-        IpNet::V6(a) => retry_until_known_result!(log, {
-            dpd_client.loopback_ipv6_delete(&a.ip())
-        }),
-    }
-    .map_err(|e| ActionError::action_failed(e.to_string()))?;
-
-    Ok(())
+    retry_until_known_result!(log, {
+        dpd_client.ensure_loopback_deleted(log, params.address.ip())
+    })
+    .map_err(|e| ActionError::action_failed(e.to_string()))
 }

--- a/nexus/src/app/sagas/switch_port_settings_apply.rs
+++ b/nexus/src/app/sagas/switch_port_settings_apply.rs
@@ -7,6 +7,7 @@ use crate::app::sagas::{
     declare_saga_actions, ActionRegistry, NexusSaga, SagaInitError,
 };
 use crate::db::datastore::UpdatePrecondition;
+use crate::retry_until_known_result;
 use crate::{authn, db};
 use anyhow::Error;
 use db::datastore::SwitchPortSettingsCombinedResult;
@@ -200,6 +201,7 @@ async fn spa_ensure_switch_port_settings(
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
+    let log = sagactx.user_data().log();
 
     let settings = sagactx
         .lookup::<SwitchPortSettingsCombinedResult>("switch_port_settings")?;
@@ -213,10 +215,10 @@ async fn spa_ensure_switch_port_settings(
     let dpd_port_settings = api_to_dpd_port_settings(&settings)
         .map_err(ActionError::action_failed)?;
 
-    dpd_client
-        .port_settings_apply(&port_id, &dpd_port_settings)
-        .await
-        .map_err(|e| ActionError::action_failed(e.to_string()))?;
+    retry_until_known_result!(log, {
+        dpd_client.port_settings_apply(&port_id, &dpd_port_settings)
+    })
+    .map_err(|e| ActionError::action_failed(e.to_string()))?;
 
     Ok(())
 }
@@ -231,6 +233,7 @@ async fn spa_undo_ensure_switch_port_settings(
         &sagactx,
         &params.serialized_authn,
     );
+    let log = sagactx.user_data().log();
 
     let port_id: PortId = PortId::from_str(&params.switch_port_name)
         .map_err(|e| external::Error::internal_error(e))?;
@@ -245,10 +248,10 @@ async fn spa_undo_ensure_switch_port_settings(
     let id = match orig_port_settings_id {
         Some(id) => id,
         None => {
-            dpd_client
-                .port_settings_clear(&port_id)
-                .await
-                .map_err(|e| external::Error::internal_error(&e.to_string()))?;
+            retry_until_known_result!(log, {
+                dpd_client.port_settings_clear(&port_id)
+            })
+            .map_err(|e| external::Error::internal_error(&e.to_string()))?;
 
             return Ok(());
         }
@@ -262,10 +265,10 @@ async fn spa_undo_ensure_switch_port_settings(
     let dpd_port_settings = api_to_dpd_port_settings(&settings)
         .map_err(ActionError::action_failed)?;
 
-    dpd_client
-        .port_settings_apply(&port_id, &dpd_port_settings)
-        .await
-        .map_err(|e| external::Error::internal_error(&e.to_string()))?;
+    retry_until_known_result!(log, {
+        dpd_client.port_settings_apply(&port_id, &dpd_port_settings)
+    })
+    .map_err(|e| external::Error::internal_error(&e.to_string()))?;
 
     Ok(())
 }

--- a/nexus/src/app/sagas/switch_port_settings_clear.rs
+++ b/nexus/src/app/sagas/switch_port_settings_clear.rs
@@ -9,6 +9,7 @@ use crate::app::sagas::{
 };
 use crate::authn;
 use crate::db::datastore::UpdatePrecondition;
+use crate::retry_until_known_result;
 use anyhow::Error;
 use dpd_client::types::PortId;
 use omicron_common::api::external::{self, NameOrId};
@@ -123,6 +124,7 @@ async fn spa_clear_switch_port_settings(
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
+    let log = sagactx.user_data().log();
 
     let port_id: PortId = PortId::from_str(&params.port_name)
         .map_err(|e| ActionError::action_failed(e.to_string()))?;
@@ -130,10 +132,10 @@ async fn spa_clear_switch_port_settings(
     let dpd_client: Arc<dpd_client::Client> =
         Arc::clone(&osagactx.nexus().dpd_client);
 
-    dpd_client
-        .port_settings_clear(&port_id)
-        .await
-        .map_err(|e| ActionError::action_failed(e.to_string()))?;
+    retry_until_known_result!(log, {
+        dpd_client.port_settings_clear(&port_id)
+    })
+    .map_err(|e| ActionError::action_failed(e.to_string()))?;
 
     Ok(())
 }
@@ -148,6 +150,7 @@ async fn spa_undo_clear_switch_port_settings(
         &sagactx,
         &params.serialized_authn,
     );
+    let log = sagactx.user_data().log();
 
     let port_id: PortId = PortId::from_str(&params.port_name)
         .map_err(|e| external::Error::internal_error(e))?;
@@ -172,10 +175,10 @@ async fn spa_undo_clear_switch_port_settings(
     let dpd_port_settings = api_to_dpd_port_settings(&settings)
         .map_err(ActionError::action_failed)?;
 
-    dpd_client
-        .port_settings_apply(&port_id, &dpd_port_settings)
-        .await
-        .map_err(|e| external::Error::internal_error(&e.to_string()))?;
+    retry_until_known_result!(log, {
+        dpd_client.port_settings_apply(&port_id, &dpd_port_settings)
+    })
+    .map_err(|e| external::Error::internal_error(&e.to_string()))?;
 
     Ok(())
 }


### PR DESCRIPTION
Generalize the retry_until_known_result macro, and wrap progenitor client calls from saga nodes. This will retry in the face of transient errors, and reduce

1) the times that sagas fail due to network weather, and 2) the times that saga unwinds fail for the same reason.