### PR TITLE
update async-bb8-diesel for error message update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?ref=dap/error-message?branch=dap/error-message#03bbad7159643a0e2f5084a2605a4e30723b9833"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?ref=dap/error-message?branch=dap/error-message#03bbad7159643a0e2f5084a2605a4e30723b9833"
+source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001#be3d9bce50051d8c0e0c06078e8066cc27db3001"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,6 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=7944dafc8a36dc6e20a1405eca59d04662de2bb7#7944dafc8a36dc6e20a1405eca59d04662de2bb7"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ anyhow = "1.0"
 api_identity = { path = "api_identity" }
 assert_matches = "1.5.0"
 assert_cmd = "2.0.11"
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "7944dafc8a36dc6e20a1405eca59d04662de2bb7" }
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "be3d9bce50051d8c0e0c06078e8066cc27db3001" }
 async-trait = "0.1.68"
 authz-macros = { path = "nexus/authz-macros" }
 backoff = { version = "0.4.0", features = [ "tokio" ] }
@@ -380,9 +380,6 @@ panic = "abort"
 #
 #[patch."https://github.com/oxidecomputer/dropshot"]
 #dropshot = { path = "../dropshot/dropshot" }
-[patch."https://github.com/oxidecomputer/async-bb8-diesel".async-bb8-diesel]
-git = 'https://github.com:443/oxidecomputer/async-bb8-diesel?ref=dap/error-message'
-branch = "dap/error-message"
 #[patch.crates-io]
 #steno = { path = "../steno" }
 #[patch."https://github.com/oxidecomputer/propolis"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,6 +380,9 @@ panic = "abort"
 #
 #[patch."https://github.com/oxidecomputer/dropshot"]
 #dropshot = { path = "../dropshot/dropshot" }
+[patch."https://github.com/oxidecomputer/async-bb8-diesel".async-bb8-diesel]
+git = 'https://github.com:443/oxidecomputer/async-bb8-diesel?ref=dap/error-message'
+branch = "dap/error-message"
 #[patch.crates-io]
 #steno = { path = "../steno" }
 #[patch."https://github.com/oxidecomputer/propolis"]

--- a/nexus/db-queries/src/db/error.rs
+++ b/nexus/db-queries/src/db/error.rs
@@ -168,10 +168,9 @@ where
 {
     match error {
         PoolError::Connection(error) => match error {
-            ConnectionError::Checkout(error) => PublicError::unavail(&format!(
-                "Failed to access connection pool: {}",
-                error
-            )),
+            ConnectionError::Connection(error) => PublicError::unavail(
+                &format!("Failed to access connection pool: {}", error),
+            ),
             ConnectionError::Query(error) => make_query_error(error),
         },
         PoolError::Timeout => {


### PR DESCRIPTION
See oxidecomputer/async-bb8-diesel#43.

After this change _and_ #3232, when I start up Nexus without Cockroach running, I see this log message:

```
[2023-05-25T20:18:38.178755567-07:00] ERROR: e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c/ServerContext/2542 on ivanova: database connection error
    database_url: postgresql://root@127.0.0.1:32221/omicron?sslmode=disable
    --  
    error_message: Connection error: could not connect to server: Connection refused
        Is the server running on host "127.0.0.1" and accepting
        TCP/IP connections on port 32221?
```

When I have both Nexus and CockroachDB running and then shut down CockroachDB, I see this:

```
[2023-05-25T20:21:45.242147357-07:00] ERROR: e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c/ServerContext/2610 on ivanova: database connection error (error_message="Connection error: server is shutting down")
    database_url: postgresql://root@127.0.0.1:32221/omicron?sslmode=disable
```

Before, these said something about failing to checkout a connection, which wasn't true.

Leaving as draft because I need to fix up Cargo.toml before landing it.  But this is ready for review.