### PR TITLE
[sled-agent] Delay nexus hw notifications

### DIFF
--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -333,7 +333,20 @@ impl StorageWorker {
 
     // Adds a "notification to nexus" to `nexus_notifications`,
     // informing it about the addition of `pool_id` to this sled.
-    fn add_zpool_notify(&mut self, pool: &Pool, size: ByteCount) {
+    async fn add_zpool_notify(&mut self, pool: &Pool, size: ByteCount) {
+        // The underlay network is setup once at sled-agent startup. Before
+        // there is an underlay we want to avoid sending notifications to nexus for
+        // two reasons:
+        //  1. They can't possibly succeed
+        //  2. They increase the backoff time exponentially, so that once
+        //   sled-agent does start  it may take mucyh longer to notify nexus
+        //   than it would if we avoid this. This goes especially so for rack
+        //   setup, when bootstrap agent is waiting an aribtrary time for RSS
+        //   initialization.
+        if self.underlay.lock().await.is_none() {
+            return;
+        }
+
         let pool_id = pool.name.id();
         let DiskIdentity { vendor, serial, model } = pool.parent.clone();
         let underlay = self.underlay.clone();
@@ -540,7 +553,8 @@ impl StorageWorker {
         self.physical_disk_notify(NotifyDiskRequest::Add {
             identity: disk.identity(),
             variant: disk.variant(),
-        });
+        })
+        .await;
         self.upsert_zpool(&resources, disk.identity(), disk.zpool_name())
             .await?;
 
@@ -574,14 +588,70 @@ impl StorageWorker {
     ) -> Result<(), Error> {
         if let Some(parsed_disk) = disks.remove(key) {
             resources.pools.lock().await.remove(&parsed_disk.zpool_name().id());
-            self.physical_disk_notify(NotifyDiskRequest::Remove(key.clone()));
+            self.physical_disk_notify(NotifyDiskRequest::Remove(key.clone()))
+                .await;
         }
         Ok(())
     }
 
+    /// When the underlay becomes available, we need to notify nexus about any
+    /// discovered disks and pools, since we don't attempt to notify until there
+    /// is an underlay available.
+    async fn notify_nexus_about_existing_resources(
+        &mut self,
+        resources: &StorageResources,
+    ) -> Result<(), Error> {
+        let disks = resources.disks.lock().await;
+        for disk in disks.values() {
+            self.physical_disk_notify(NotifyDiskRequest::Add {
+                identity: disk.identity(),
+                variant: disk.variant(),
+            })
+            .await;
+        }
+
+        // We may encounter errors while processing any of the pools; keep track of
+        // any errors that occur and return any of them if something goes wrong.
+        //
+        // That being said, we should not prevent notification to nexus of the
+        // other pools if only one failure occurs.
+        let mut err: Option<Error> = None;
+
+        let pools = resources.pools.lock().await;
+        for pool in pools.values() {
+            match ByteCount::try_from(pool.info.size()).map_err(|err| {
+                Error::BadPoolSize { name: pool.name.to_string(), err }
+            }) {
+                Ok(size) => self.add_zpool_notify(pool, size).await,
+                Err(e) => {
+                    warn!(self.log, "Failed to notify nexus about pool: {e}");
+                    err = Some(e)
+                }
+            }
+        }
+
+        if let Some(err) = err {
+            Err(err)
+        } else {
+            Ok(())
+        }
+    }
+
     // Adds a "notification to nexus" to `self.nexus_notifications`, informing it
     // about the addition/removal of a physical disk to this sled.
-    fn physical_disk_notify(&mut self, disk: NotifyDiskRequest) {
+    async fn physical_disk_notify(&mut self, disk: NotifyDiskRequest) {
+        // The underlay network is setup once at sled-agent startup. Before
+        // there is an underlay we want to avoid sending notifications to nexus for
+        // two reasons:
+        //  1. They can't possibly succeed
+        //  2. They increase the backoff time exponentially, so that once
+        //   sled-agent does start  it may take mucyh longer to notify nexus
+        //   than it would if we avoid this. This goes especially so for rack
+        //   setup, when bootstrap agent is waiting an aribtrary time for RSS
+        //   initialization.
+        if self.underlay.lock().await.is_none() {
+            return;
+        }
         let underlay = self.underlay.clone();
         let disk2 = disk.clone();
         let notify_nexus = move || {
@@ -676,7 +746,7 @@ impl StorageWorker {
             Error::BadPoolSize { name: pool_name.to_string(), err }
         })?;
         // Notify Nexus of the zpool.
-        self.add_zpool_notify(&pool, size);
+        self.add_zpool_notify(&pool, size).await;
         Ok(())
     }
 
@@ -750,7 +820,16 @@ impl StorageWorker {
                             self.ensure_using_exactly_these_disks(&resources, disks).await?;
                         },
                         SetupUnderlayAccess(UnderlayRequest { underlay, responder }) => {
-                            self.underlay.lock().await.replace(underlay);
+                            // If this is the first time establishing an
+                            // underlay we should notify nexus of all existing
+                            // disks and zpools.
+                            //
+                            // Instead of individual notifications, we should
+                            // send a bulk notification as described in https://
+                            // github.com/oxidecomputer/omicron/issues/1917
+                            if self.underlay.lock().await.replace(underlay).is_none() {
+                                self.notify_nexus_about_existing_resources(&resources).await?;
+                            }
                             let _ = responder.send(Ok(()));
                         }
                     }

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -339,7 +339,7 @@ impl StorageWorker {
         // two reasons:
         //  1. They can't possibly succeed
         //  2. They increase the backoff time exponentially, so that once
-        //   sled-agent does start  it may take mucyh longer to notify nexus
+        //   sled-agent does start it may take much longer to notify nexus
         //   than it would if we avoid this. This goes especially so for rack
         //   setup, when bootstrap agent is waiting an aribtrary time for RSS
         //   initialization.
@@ -645,7 +645,7 @@ impl StorageWorker {
         // two reasons:
         //  1. They can't possibly succeed
         //  2. They increase the backoff time exponentially, so that once
-        //   sled-agent does start  it may take mucyh longer to notify nexus
+        //   sled-agent does start it may take much longer to notify nexus
         //   than it would if we avoid this. This goes especially so for rack
         //   setup, when bootstrap agent is waiting an aribtrary time for RSS
         //   initialization.


### PR DESCRIPTION
Before underlay access has been allocated to the `StorageWorker`, there is no chance of successfully talking to nexus. Delay any notifications until after underlay access is available. This occurs when sled-agent starts, after disks and zpools may have already been allocated/recorded locally.

By waiting we reduce unnecessary backoff timer increases that are not due to any actual faults, and delay normal sled startup. This is especially important during rack setup since those backoff timers wait indefinitely until RSS is run.

This is a partial fix to dependency order, but just a small one. We  should take a more systematic approach ala https://github.com/ oxidecomputer/omicron/issues/1917 in the future.