### PR TITLE
[mgs/wicketd/wicket] Plumb RoT and SP caboose information up through wicket

### DIFF
--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -27,7 +27,6 @@ use dropshot::UntypedBody;
 use dropshot::WebsocketEndpointResult;
 use dropshot::WebsocketUpgrade;
 use futures::TryFutureExt;
-use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_sp_comms::error::CommunicationError;
 use gateway_sp_comms::HostPhase2Provider;
@@ -58,7 +57,6 @@ pub struct SpState {
     pub revision: u32,
     pub hubris_archive_id: String,
     pub base_mac_address: [u8; 6],
-    pub version: ImageVersion,
     pub power_state: PowerState,
     pub rot: RotState,
 }
@@ -76,13 +74,13 @@ pub struct SpState {
 )]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum RotState {
-    // TODO gateway_messages's RotState includes a couple nested structures that
-    // I've flattened here because they only contain one field each. When those
-    // structures grow we'll need to expand/change this.
     Enabled {
         active: RotSlot,
-        slot_a: Option<RotImageDetails>,
-        slot_b: Option<RotImageDetails>,
+        persistent_boot_preference: RotSlot,
+        pending_persistent_boot_preference: Option<RotSlot>,
+        transient_boot_preference: Option<RotSlot>,
+        slot_a_sha3_256_digest: Option<String>,
+        slot_b_sha3_256_digest: Option<String>,
     },
     CommunicationFailed {
         message: String,
@@ -619,6 +617,7 @@ async fn sp_component_get(
 async fn sp_component_caboose_get(
     rqctx: RequestContext<Arc<ServerContext>>,
     path: Path<PathSpComponent>,
+    query_params: Query<ComponentCabooseSlot>,
 ) -> Result<HttpResponseOk<SpComponentCaboose>, HttpError> {
     const CABOOSE_KEY_GIT_COMMIT: [u8; 4] = *b"GITC";
     const CABOOSE_KEY_BOARD: [u8; 4] = *b"BORD";
@@ -628,18 +627,8 @@ async fn sp_component_caboose_get(
     let apictx = rqctx.context();
     let PathSpComponent { sp, component } = path.into_inner();
     let sp = apictx.mgmt_switch.sp(sp.into())?;
-
-    // At the moment this endpoint only works if the requested component
-    // is the SP itself; we have no way (yet!) of asking the SP for (e.g.) RoT
-    // caboose values.
+    let ComponentCabooseSlot { firmware_slot } = query_params.into_inner();
     let component = component_from_str(&component)?;
-    if component != SpComponent::SP_ITSELF {
-        return Err(HttpError::from(SpCommsError::from(
-            CommunicationError::SpError(
-                SpError::RequestUnsupportedForComponent,
-            ),
-        )));
-    }
 
     let from_utf8 = |key: &[u8], bytes| {
         // This helper closure is only called with the ascii-printable [u8; 4]
@@ -655,18 +644,25 @@ async fn sp_component_caboose_get(
     };
 
     let git_commit = sp
-        .get_caboose_value(CABOOSE_KEY_GIT_COMMIT)
+        .read_component_caboose(
+            component,
+            firmware_slot,
+            CABOOSE_KEY_GIT_COMMIT,
+        )
         .await
         .map_err(SpCommsError::from)?;
     let board = sp
-        .get_caboose_value(CABOOSE_KEY_BOARD)
+        .read_component_caboose(component, firmware_slot, CABOOSE_KEY_BOARD)
         .await
         .map_err(SpCommsError::from)?;
     let name = sp
-        .get_caboose_value(CABOOSE_KEY_NAME)
+        .read_component_caboose(component, firmware_slot, CABOOSE_KEY_NAME)
         .await
         .map_err(SpCommsError::from)?;
-    let version = match sp.get_caboose_value(CABOOSE_KEY_VERSION).await {
+    let version = match sp
+        .read_component_caboose(component, firmware_slot, CABOOSE_KEY_VERSION)
+        .await
+    {
         Ok(value) => Some(from_utf8(&CABOOSE_KEY_VERSION, value)?),
         Err(CommunicationError::SpError(SpError::NoSuchCabooseKey(_))) => None,
         Err(err) => return Err(SpCommsError::from(err).into()),
@@ -835,6 +831,12 @@ pub struct ComponentUpdateIdSlot {
     pub id: Uuid,
     /// The update slot to apply this image to. Supply 0 if the component only
     /// has one update slot.
+    pub firmware_slot: u16,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ComponentCabooseSlot {
+    /// The firmware slot to for which we want to request caboose information.
     pub firmware_slot: u16,
 }
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -518,6 +518,17 @@
             "schema": {
               "$ref": "#/components/schemas/SpType"
             }
+          },
+          {
+            "in": "query",
+            "name": "firmware_slot",
+            "description": "The firmware slot to for which we want to request caboose information.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0
+            }
           }
         ],
         "responses": {
@@ -1423,25 +1434,6 @@
           "verbose"
         ]
       },
-      "ImageVersion": {
-        "type": "object",
-        "properties": {
-          "epoch": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "version": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "epoch",
-          "version"
-        ]
-      },
       "InstallinatorImageId": {
         "type": "object",
         "properties": {
@@ -2079,21 +2071,6 @@
           "A2"
         ]
       },
-      "RotImageDetails": {
-        "type": "object",
-        "properties": {
-          "digest": {
-            "type": "string"
-          },
-          "version": {
-            "$ref": "#/components/schemas/ImageVersion"
-          }
-        },
-        "required": [
-          "digest",
-          "version"
-        ]
-      },
       "RotSlot": {
         "oneOf": [
           {
@@ -2134,31 +2111,43 @@
               "active": {
                 "$ref": "#/components/schemas/RotSlot"
               },
-              "slot_a": {
+              "pending_persistent_boot_preference": {
                 "nullable": true,
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/RotImageDetails"
+                    "$ref": "#/components/schemas/RotSlot"
                   }
                 ]
               },
-              "slot_b": {
+              "persistent_boot_preference": {
+                "$ref": "#/components/schemas/RotSlot"
+              },
+              "slot_a_sha3_256_digest": {
                 "nullable": true,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/RotImageDetails"
-                  }
-                ]
+                "type": "string"
+              },
+              "slot_b_sha3_256_digest": {
+                "nullable": true,
+                "type": "string"
               },
               "state": {
                 "type": "string",
                 "enum": [
                   "enabled"
                 ]
+              },
+              "transient_boot_preference": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RotSlot"
+                  }
+                ]
               }
             },
             "required": [
               "active",
+              "persistent_boot_preference",
               "state"
             ]
           },
@@ -2642,9 +2631,6 @@
           },
           "serial_number": {
             "type": "string"
-          },
-          "version": {
-            "$ref": "#/components/schemas/ImageVersion"
           }
         },
         "required": [
@@ -2654,8 +2640,7 @@
           "power_state",
           "revision",
           "rot",
-          "serial_number",
-          "version"
+          "serial_number"
         ]
       },
       "SpType": {

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -616,25 +616,6 @@
           }
         ]
       },
-      "ImageVersion": {
-        "type": "object",
-        "properties": {
-          "epoch": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "version": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "epoch",
-          "version"
-        ]
-      },
       "PowerState": {
         "description": "See RFD 81.\n\nThis enum only lists power states the SP is able to control; higher power states are controlled by ignition.",
         "type": "string",
@@ -1123,26 +1104,22 @@
           "sps"
         ]
       },
-      "RotImageDetails": {
-        "type": "object",
-        "properties": {
-          "digest": {
-            "type": "string"
-          },
-          "version": {
-            "$ref": "#/components/schemas/ImageVersion"
-          }
-        },
-        "required": [
-          "digest",
-          "version"
-        ]
-      },
       "RotInventory": {
         "description": "RoT-related data that isn't already supplied in [`SpState`].",
         "type": "object",
         "properties": {
-          "caboose": {
+          "active": {
+            "$ref": "#/components/schemas/RotSlot"
+          },
+          "caboose_a": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpComponentCaboose"
+              }
+            ]
+          },
+          "caboose_b": {
             "nullable": true,
             "allOf": [
               {
@@ -1150,7 +1127,10 @@
               }
             ]
           }
-        }
+        },
+        "required": [
+          "active"
+        ]
       },
       "RotSlot": {
         "oneOf": [
@@ -1192,31 +1172,43 @@
               "active": {
                 "$ref": "#/components/schemas/RotSlot"
               },
-              "slot_a": {
+              "pending_persistent_boot_preference": {
                 "nullable": true,
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/RotImageDetails"
+                    "$ref": "#/components/schemas/RotSlot"
                   }
                 ]
               },
-              "slot_b": {
+              "persistent_boot_preference": {
+                "$ref": "#/components/schemas/RotSlot"
+              },
+              "slot_a_sha3_256_digest": {
                 "nullable": true,
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/RotImageDetails"
-                  }
-                ]
+                "type": "string"
+              },
+              "slot_b_sha3_256_digest": {
+                "nullable": true,
+                "type": "string"
               },
               "state": {
                 "type": "string",
                 "enum": [
                   "enabled"
                 ]
+              },
+              "transient_boot_preference": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RotSlot"
+                  }
+                ]
               }
             },
             "required": [
               "active",
+              "persistent_boot_preference",
               "state"
             ]
           },
@@ -1511,7 +1503,15 @@
         "description": "SP-related data",
         "type": "object",
         "properties": {
-          "caboose": {
+          "caboose_active": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpComponentCaboose"
+              }
+            ]
+          },
+          "caboose_inactive": {
             "nullable": true,
             "allOf": [
               {
@@ -1538,7 +1538,12 @@
             ]
           },
           "rot": {
-            "$ref": "#/components/schemas/RotInventory"
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RotInventory"
+              }
+            ]
           },
           "state": {
             "nullable": true,
@@ -1550,8 +1555,7 @@
           }
         },
         "required": [
-          "id",
-          "rot"
+          "id"
         ]
       },
       "SpState": {
@@ -1586,9 +1590,6 @@
           },
           "serial_number": {
             "type": "string"
-          },
-          "version": {
-            "$ref": "#/components/schemas/ImageVersion"
           }
         },
         "required": [
@@ -1598,8 +1599,7 @@
           "power_state",
           "revision",
           "rot",
-          "serial_number",
-          "version"
+          "serial_number"
         ]
       },
       "SpType": {

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -1059,7 +1059,7 @@ impl UpdatePane {
                 Span::styled("STATUS", header_style),
             ],
         ))
-        .block(block.clone());
+        .block(block.clone().title("OVERVIEW (* = active)"));
         frame.render_widget(headers, self.table_headers_rect);
 
         // Need to refresh the items, as their versions/state may have changed
@@ -1126,7 +1126,7 @@ impl UpdatePane {
                     .style(header_style),
             )
             .widths(&width_constraints)
-            .block(block.clone().title("OVERVIEW"));
+            .block(block.clone().title("OVERVIEW (* = active)"));
         frame.render_widget(header_table, self.table_headers_rect);
 
         // For the selected item, draw the version table.
@@ -1806,11 +1806,11 @@ fn all_installed_versions(
             |component| {
                 vec![
                     InstalledVersion {
-                        title: format!("{base_title} (active)").into(),
+                        title: format!("{base_title}/0 *").into(),
                         version: component.sp_version_active().into(),
                     },
                     InstalledVersion {
-                        title: format!("{base_title} (inactive)").into(),
+                        title: format!("{base_title}/1").into(),
                         version: component.sp_version_inactive().into(),
                     },
                 ]
@@ -1831,16 +1831,16 @@ fn all_installed_versions(
                     }];
                 };
                 let (active_a, active_b) = match active {
-                    RotSlot::A => ("active", "inactive"),
-                    RotSlot::B => ("inactive", "active"),
+                    RotSlot::A => (" *", ""),
+                    RotSlot::B => ("", " *"),
                 };
                 vec![
                     InstalledVersion {
-                        title: format!("{base_title}/A ({active_a})").into(),
+                        title: format!("{base_title}/A{active_a}").into(),
                         version: component.rot_version_a().into(),
                     },
                     InstalledVersion {
-                        title: format!("{base_title}/B ({active_b})").into(),
+                        title: format!("{base_title}/B{active_b}").into(),
                         version: component.rot_version_b().into(),
                     },
                 ]

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use super::{align_by, help_text, push_text_lines, Control};
@@ -31,7 +32,7 @@ use update_engine::{ExecutionStatus, StepKey};
 use wicket_common::update_events::{
     EventBuffer, EventReport, StepOutcome, StepStatus, UpdateComponent,
 };
-use wicketd_client::types::SemverVersion;
+use wicketd_client::types::{RotSlot, SemverVersion};
 
 const MAX_COLUMN_WIDTH: u16 = 25;
 
@@ -623,29 +624,29 @@ impl UpdatePane {
             .map(|(id, states)| {
                 let children: Vec<_> = states
                     .iter()
-                    .map(|(component, s)| {
+                    .flat_map(|(component, s)| {
                         let target_version =
                             artifact_version(id, component, &versions);
-                        let installed_version =
-                            installed_version(id, component, inventory);
-                        let spans = vec![
-                            Span::styled(
-                                update_component_title(component),
-                                style::selected(),
-                            ),
-                            Span::styled(
-                                installed_version,
-                                style::selected_line(),
-                            ),
-                            Span::styled(target_version, style::selected()),
-                            Span::styled(s.to_string(), s.style()),
-                        ];
-                        TreeItem::new_leaf(align_by(
-                            0,
-                            MAX_COLUMN_WIDTH,
-                            self.contents_rect,
-                            spans,
-                        ))
+                        let installed_versions =
+                            all_installed_versions(id, component, inventory);
+                        let contents_rect = self.contents_rect;
+                        installed_versions.into_iter().map(move |v| {
+                            let spans = vec![
+                                Span::styled(v.title, style::selected()),
+                                Span::styled(v.version, style::selected_line()),
+                                Span::styled(
+                                    target_version.clone(),
+                                    style::selected(),
+                                ),
+                                Span::styled(s.to_string(), s.style()),
+                            ];
+                            TreeItem::new_leaf(align_by(
+                                0,
+                                MAX_COLUMN_WIDTH,
+                                contents_rect,
+                                spans,
+                            ))
+                        })
                     })
                     .collect();
                 TreeItem::new(*id, children)
@@ -1133,26 +1134,28 @@ impl UpdatePane {
         let item_state = &state.update_state.items[&selected];
 
         let version_rows =
-            item_state.iter().map(|(component, update_state)| {
+            item_state.iter().flat_map(|(component, update_state)| {
                 let target_version = artifact_version(
                     &state.rack_state.selected,
                     component,
                     versions,
                 );
-                let installed_version = installed_version(
+                let installed_versions = all_installed_versions(
                     &state.rack_state.selected,
                     component,
                     inventory,
                 );
 
-                Row::new(vec![
-                    Cell::from(update_component_title(component))
-                        .style(style::selected()),
-                    Cell::from(installed_version).style(style::selected_line()),
-                    Cell::from(target_version).style(style::selected()),
-                    Cell::from(update_state.to_string())
-                        .style(update_state.style()),
-                ])
+                installed_versions.into_iter().map(move |v| {
+                    Row::new(vec![
+                        Cell::from(v.title).style(style::selected()),
+                        Cell::from(v.version).style(style::selected_line()),
+                        Cell::from(target_version.clone())
+                            .style(style::selected()),
+                        Cell::from(update_state.to_string())
+                            .style(update_state.style()),
+                    ])
+                })
             });
         let version_table =
             Table::new(version_rows).widths(&width_constraints).block(
@@ -1339,7 +1342,7 @@ impl From<&'_ State> for ForceUpdateSelectionState {
             let artifact_version =
                 artifact_version(&component_id, component, versions);
             let installed_version =
-                installed_version(&component_id, component, inventory);
+                active_installed_version(&component_id, component, inventory);
             match component {
                 UpdateComponent::Rot => {
                     assert!(
@@ -1753,7 +1756,7 @@ enum ComponentUpdateShowHelp {
     Completed,
 }
 
-fn installed_version(
+fn active_installed_version(
     id: &ComponentId,
     update_component: UpdateComponent,
     inventory: &Inventory,
@@ -1762,16 +1765,94 @@ fn installed_version(
     match update_component {
         UpdateComponent::Sp => component.map_or_else(
             || "UNKNOWN".to_string(),
-            |component| component.sp_version(),
+            |component| component.sp_version_active(),
         ),
         UpdateComponent::Rot => component.map_or_else(
             || "UNKNOWN".to_string(),
-            |component| component.rot_version(),
+            |component| match component.rot_active_slot() {
+                Some(RotSlot::A) => component.rot_version_a(),
+                Some(RotSlot::B) => component.rot_version_b(),
+                None => return "UNKNOWN".to_string(),
+            },
         ),
         UpdateComponent::Host => {
             // We currently have no way to tell what version of host software is
             // installed.
             "-----".to_string()
+        }
+    }
+}
+
+struct InstalledVersion {
+    title: Cow<'static, str>,
+    version: Cow<'static, str>,
+}
+
+fn all_installed_versions(
+    id: &ComponentId,
+    update_component: UpdateComponent,
+    inventory: &Inventory,
+) -> Vec<InstalledVersion> {
+    let base_title = update_component_title(update_component);
+    let component = inventory.get_inventory(id);
+    match update_component {
+        UpdateComponent::Sp => component.map_or_else(
+            || {
+                vec![InstalledVersion {
+                    title: base_title.into(),
+                    version: "UNKNOWN".into(),
+                }]
+            },
+            |component| {
+                vec![
+                    InstalledVersion {
+                        title: format!("{base_title} (active)").into(),
+                        version: component.sp_version_active().into(),
+                    },
+                    InstalledVersion {
+                        title: format!("{base_title} (inactive)").into(),
+                        version: component.sp_version_inactive().into(),
+                    },
+                ]
+            },
+        ),
+        UpdateComponent::Rot => component.map_or_else(
+            || {
+                vec![InstalledVersion {
+                    title: base_title.into(),
+                    version: "UNKNOWN".into(),
+                }]
+            },
+            |component| {
+                let Some(active) = component.rot_active_slot() else {
+                    return vec![InstalledVersion {
+                        title: base_title.into(),
+                        version: "UNKNOWN".into(),
+                    }];
+                };
+                let (active_a, active_b) = match active {
+                    RotSlot::A => ("active", "inactive"),
+                    RotSlot::B => ("inactive", "active"),
+                };
+                vec![
+                    InstalledVersion {
+                        title: format!("{base_title}/A ({active_a})").into(),
+                        version: component.rot_version_a().into(),
+                    },
+                    InstalledVersion {
+                        title: format!("{base_title}/B ({active_b})").into(),
+                        version: component.rot_version_b().into(),
+                    },
+                ]
+            },
+        ),
+        UpdateComponent::Host => {
+            // We currently have no way to tell what version of host software is
+            // installed.
+            vec![InstalledVersion {
+                title: base_title.into(),
+                version: "-----".into(),
+            }]
         }
     }
 }
@@ -1844,7 +1925,7 @@ impl Control for UpdatePane {
                 [
                     Constraint::Length(3),
                     Constraint::Length(3),
-                    Constraint::Length(4),
+                    Constraint::Length(6),
                     Constraint::Min(0),
                     Constraint::Length(3),
                 ]

--- a/wicketd/src/inventory.rs
+++ b/wicketd/src/inventory.rs
@@ -5,7 +5,8 @@
 //! Rack inventory for display by wicket
 
 use gateway_client::types::{
-    SpComponentCaboose, SpComponentInfo, SpIdentifier, SpIgnition, SpState,
+    RotSlot, SpComponentCaboose, SpComponentInfo, SpIdentifier, SpIgnition,
+    SpState,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -18,8 +19,9 @@ pub struct SpInventory {
     pub ignition: Option<SpIgnition>,
     pub state: Option<SpState>,
     pub components: Option<Vec<SpComponentInfo>>,
-    pub caboose: Option<SpComponentCaboose>,
-    pub rot: RotInventory,
+    pub caboose_active: Option<SpComponentCaboose>,
+    pub caboose_inactive: Option<SpComponentCaboose>,
+    pub rot: Option<RotInventory>,
 }
 
 impl SpInventory {
@@ -32,17 +34,20 @@ impl SpInventory {
             ignition: None,
             state: None,
             components: None,
-            caboose: None,
-            rot: RotInventory::default(),
+            caboose_active: None,
+            caboose_inactive: None,
+            rot: None,
         }
     }
 }
 
 /// RoT-related data that isn't already supplied in [`SpState`].
-#[derive(Default, Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(tag = "sp_inventory", rename_all = "snake_case")]
 pub struct RotInventory {
-    pub caboose: Option<SpComponentCaboose>,
+    pub active: RotSlot,
+    pub caboose_a: Option<SpComponentCaboose>,
+    pub caboose_b: Option<SpComponentCaboose>,
 }
 
 /// The current state of the v1 Rack as known to wicketd

--- a/wicketd/src/mgs.rs
+++ b/wicketd/src/mgs.rs
@@ -368,7 +368,8 @@ impl MgsManager {
             .or_insert_with(|| SpInventory::new(sp.id));
         entry.state = Some(sp.state);
         entry.components = sp.components;
-        entry.caboose = sp.caboose;
+        entry.caboose_active = sp.caboose_active;
+        entry.caboose_inactive = sp.caboose_inactive;
         entry.rot = sp.rot;
 
         // Scan any pending waiters and remove this SP from their list; if that

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -640,6 +640,11 @@ impl UpdateDriver {
 
         let sp_registrar = engine.for_component(UpdateComponent::Sp);
 
+        // The SP only has one updateable firmware slot ("the inactive bank").
+        // We want to ask about slot 0 (the active slot)'s current version, and
+        // we are supposed to always pass 0 when updating.
+        let sp_firmware_slot = 0;
+
         let sp_current_version = sp_registrar
             .new_step(
                 UpdateStepId::InterrogateSp,
@@ -651,6 +656,7 @@ impl UpdateDriver {
                             update_cx.sp.type_,
                             update_cx.sp.slot,
                             SpComponent::SP_ITSELF.const_as_str(),
+                            sp_firmware_slot,
                         )
                         .await
                         .map_err(|error| {
@@ -706,9 +712,6 @@ impl UpdateDriver {
                         .into();
                     }
 
-                    // The SP only has one updateable firmware slot ("the
-                    // inactive bank") - we always pass 0.
-                    let sp_firmware_slot = 0;
                     cx.with_nested_engine(|engine| {
                         inner_cx.register_steps(
                             engine,


### PR DESCRIPTION
This addresses some lingering TODOs from the quick fixes in #3185: we now relay the modern RoT state information, and wicket now displays versions for both RoT slots and both SP slots, if available; e.g.,

![pane](https://github.com/oxidecomputer/omicron/assets/1435635/74668c65-445c-401d-9bbd-6b74316e3964)

This is a precursor to supporting "skip updating the RoT if it already has the version we want to update to".