### PR TITLE
[sled-agent] Add /baseboard bootstrap server endpoint

### DIFF
--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -10,6 +10,30 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/baseboard": {
+      "get": {
+        "summary": "Return the baseboard identity of this sled.",
+        "operationId": "baseboard_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Baseboard"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/components": {
       "get": {
         "summary": "Provides a list of components known to the bootstrap agent.",
@@ -113,6 +137,74 @@
       }
     },
     "schemas": {
+      "Baseboard": {
+        "description": "Describes properties that should uniquely identify a Gimlet.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gimlet"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "revision",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pc"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "type"
+            ]
+          }
+        ]
+      },
       "BootstrapAddressDiscovery": {
         "oneOf": [
           {

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -34,7 +34,7 @@ use omicron_common::address::Ipv6Subnet;
 use omicron_common::api::external::Error as ExternalError;
 use serde::{Deserialize, Serialize};
 use sled_hardware::underlay::BootstrapInterface;
-use sled_hardware::HardwareManager;
+use sled_hardware::{Baseboard, HardwareManager};
 use slog::Logger;
 use std::borrow::Cow;
 use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
@@ -186,6 +186,9 @@ pub struct Agent {
     ddmd_client: DdmAdminClient,
 
     global_zone_bootstrap_link_local_address: Ipv6Addr,
+
+    /// Our sled's baseboard identity.
+    baseboard: Baseboard,
 }
 
 const SLED_AGENT_REQUEST_FILE: &str = "sled-agent-request.toml";
@@ -358,6 +361,7 @@ impl Agent {
         .await?;
 
         let storage_resources = hardware_monitor.storage().clone();
+        let baseboard = hardware_monitor.baseboard().clone();
 
         let agent = Agent {
             log: ba_log,
@@ -372,6 +376,7 @@ impl Agent {
             sled_config,
             ddmd_client,
             global_zone_bootstrap_link_local_address,
+            baseboard,
         };
 
         // Wait for at least the M.2 we booted from to show up.
@@ -402,6 +407,10 @@ impl Agent {
         }
 
         Ok(agent)
+    }
+
+    pub fn baseboard(&self) -> &Baseboard {
+        &self.baseboard
     }
 
     async fn start_hardware_monitor(

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -15,6 +15,7 @@ use dropshot::{
     HttpResponseUpdatedNoContent, RequestContext, TypedBody,
 };
 use omicron_common::api::external::Error;
+use sled_hardware::Baseboard;
 use std::sync::Arc;
 
 type BootstrapApiDescription = ApiDescription<Arc<Agent>>;
@@ -24,6 +25,7 @@ pub(crate) fn api() -> BootstrapApiDescription {
     fn register_endpoints(
         api: &mut BootstrapApiDescription,
     ) -> Result<(), String> {
+        api.register(baseboard_get)?;
         api.register(components_get)?;
         api.register(rack_initialize)?;
         api.register(rack_reset)?;
@@ -36,6 +38,18 @@ pub(crate) fn api() -> BootstrapApiDescription {
         panic!("failed to register entrypoints: {}", err);
     }
     api
+}
+
+/// Return the baseboard identity of this sled.
+#[endpoint {
+    method = GET,
+    path = "/baseboard",
+}]
+async fn baseboard_get(
+    rqctx: RequestContext<Arc<Agent>>,
+) -> Result<HttpResponseOk<Baseboard>, HttpError> {
+    let ba = rqctx.context();
+    Ok(HttpResponseOk(ba.baseboard().clone()))
 }
 
 /// Provides a list of components known to the bootstrap agent.


### PR DESCRIPTION
This is a precursor to wicketd being able to initiate RSS: we need to be able to pair baseboards (i.e., the identifying triple wicketd gets from all the SPs in the rack) to bootstrap addresses. An easy way to do that is hitting a `/baseboard` endpoint (added by this PR) on every peer mg-ddm finds on the bootstrap network.

Running this on the madrid scrimlet:

```
BRM44220001 # curl http://[fdb0:a840:2504:355::1]/baseboard
{"type":"gimlet","identifier":"BRM44220001","model":"913-0000019","revision":6}
```