### PR TITLE
Revert deploy log snapshot, don't collect propolis logs as CI artifacts.

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -7,6 +7,7 @@
 #:  "%/var/svc/log/oxide-sled-agent:default.log",
 #:  "%/zone/oxz_*/root/var/svc/log/oxide-*.log",
 #:  "%/zone/oxz_*/root/var/svc/log/system-illumos-*.log",
+#:  "!/zone/oxz_propolis-server_*/root/var/svc/log/*.log"
 #: ]
 #: skip_clone = true
 #:

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -4,7 +4,9 @@
 #: variety = "basic"
 #: target = "lab-opte-0.23"
 #: output_rules = [
-#:  "%/snapshot/*.log",
+#:  "%/var/svc/log/oxide-sled-agent:default.log",
+#:  "%/zone/oxz_*/root/var/svc/log/oxide-*.log",
+#:  "%/zone/oxz_*/root/var/svc/log/system-illumos-*.log",
 #: ]
 #: skip_clone = true
 #:
@@ -22,15 +24,6 @@ set -o xtrace
 # If we fail, try to collect some debugging information
 #
 _exit_trap() {
-    # Take a snapshot of logs. If these disappear or change while buildomat is
-    # collecting them, the CI job will fail.
-    pfexec mkdir /snapshot
-    pfexec cp /var/svc/log/oxide-sled-agent:default.log /snapshot/
-    pfexec find /zone/oxz_* -name proc -prune -o -name oxide-*.log -exec cp "{}" /snapshot/ \;
-    pfexec find /zone/oxz_* -name proc -prune -o -name system-illumos-*.log -exec cp "{}" /snapshot/ \;
-    pfexec zlogin softnpu cat /softnpu.log > /tmp/softnpu.log
-    pfexec cp /tmp/softnpu.log /snapshot/
-
 	local status=$?
 	[[ $status -eq 0 ]] && exit 0
 
@@ -51,10 +44,10 @@ _exit_trap() {
 		standalone \
 		dump-state
 	pfexec /opt/oxide/opte/bin/opteadm list-ports
-    z_swadm link ls
-    z_swadm addr list
-    z_swadm route list
-    z_swadm arp list
+	z_swadm link ls
+	z_swadm addr list
+	z_swadm route list
+	z_swadm arp list
 
 	PORTS=$(pfexec /opt/oxide/opte/bin/opteadm list-ports | tail +2 | awk '{ print $1; }')
 	for p in $PORTS; do
@@ -79,14 +72,14 @@ _exit_trap() {
 		pfexec zlogin "$z" arp -an
 	done
 
-    pfexec zlogin softnpu cat /softnpu.log
+	pfexec zlogin softnpu cat /softnpu.log
 
 	exit $status
 }
 trap _exit_trap EXIT
 
 z_swadm () {
-    pfexec zlogin oxz_switch /opt/oxide/dendrite/bin/swadm $@
+	pfexec zlogin oxz_switch /opt/oxide/dendrite/bin/swadm $@
 }
 
 #


### PR DESCRIPTION
In #3241 I was running into an [issue](https://github.com/oxidecomputer/omicron/runs/13807983531) with the deploy job, where artifact collection would fail because propolis logs were being deleted during collection. In that PR i attempted to create a snapshot before collection, only to have the snapshot fail  for the same reason. This commit does two things.

1. Reverts the misguided snapshot mechanism.
2. Adds an output rule to prevent propolis logs from being collected as artifacts.

The output rule added here was originally in the buildomat job. It was removed in #1902 to get better visibility of propolis logs on CI output. However, to do that without risk of failing collection we need to stash the logs somewhere safe before deleting instances as a part of the e2e tests.
