### PR TITLE
Extract omicron-certificates from nexus-db-model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,10 +3963,10 @@ dependencies = [
  "newtype_derive",
  "nexus-defaults",
  "nexus-types",
+ "omicron-certificates",
  "omicron-common 0.1.0",
  "omicron-passwords",
  "omicron-rpaths",
- "openssl",
  "parse-display",
  "pq-sys",
  "rand 0.8.5",
@@ -4357,6 +4357,15 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-normalization",
+]
+
+[[package]]
+name = "omicron-certificates"
+version = "0.1.0"
+dependencies = [
+ "omicron-common 0.1.0",
+ "openssl",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "api_identity",
     "bootstore",
     "bootstrap-agent-client",
+    "certificates",
     "common",
     "ddm-admin-client",
     "dpd-client",
@@ -201,6 +202,7 @@ nexus-client = { path = "nexus-client" }
 nexus-db-model = { path = "nexus/db-model" }
 nexus-db-queries = { path = "nexus/db-queries" }
 nexus-defaults = { path = "nexus/defaults" }
+omicron-certificates = { path = "certificates" }
 omicron-passwords = { path = "passwords" }
 nexus-test-interface = { path = "nexus/test-interface" }
 nexus-test-utils-macros = { path = "nexus/test-utils-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
 
 default-members = [
     "bootstrap-agent-client",
+    "certificates",
     "common",
     "ddm-admin-client",
     "dpd-client",

--- a/certificates/Cargo.toml
+++ b/certificates/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "omicron-certificates"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+openssl.workspace = true
+thiserror.workspace = true
+
+omicron-common.workspace = true

--- a/certificates/src/lib.rs
+++ b/certificates/src/lib.rs
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Utilities for validating X509 certificates, used by both nexus and wicketd.
+
+use omicron_common::api::external::Error;
+use openssl::asn1::Asn1Time;
+use openssl::pkey::PKey;
+use openssl::x509::X509;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CertificateError {
+    #[error("Failed to parse certificate: {0}")]
+    BadCertificate(openssl::error::ErrorStack),
+
+    #[error("Certificate exists, but is empty")]
+    CertificateEmpty,
+
+    #[error("Certificate exists, but is expired")]
+    CertificateExpired,
+
+    #[error("Failed to parse private key")]
+    BadPrivateKey(openssl::error::ErrorStack),
+
+    #[error("Certificate and private key do not match")]
+    Mismatch,
+
+    #[error("Unexpected error: {0}")]
+    Unexpected(openssl::error::ErrorStack),
+}
+
+impl From<CertificateError> for Error {
+    fn from(error: CertificateError) -> Self {
+        use CertificateError::*;
+        match error {
+            BadCertificate(_) | CertificateEmpty | CertificateExpired
+            | Mismatch => Error::InvalidValue {
+                label: String::from("certificate"),
+                message: error.to_string(),
+            },
+            BadPrivateKey(_) => Error::InvalidValue {
+                label: String::from("private-key"),
+                message: error.to_string(),
+            },
+            Unexpected(_) => {
+                Error::InternalError { internal_message: error.to_string() }
+            }
+        }
+    }
+}
+
+pub struct CertificateValidator {
+    validate_expiration: bool,
+}
+
+impl Default for CertificateValidator {
+    fn default() -> Self {
+        Self { validate_expiration: true }
+    }
+}
+
+impl CertificateValidator {
+    /// Disable validation of certificate expiration dates.
+    ///
+    /// This exists to support basic certificate validation even before time is
+    /// available (e.g., before the rack has been initialized and NTP has
+    /// started).
+    pub fn danger_disable_expiration_validation(&mut self) {
+        self.validate_expiration = false;
+    }
+
+    /// Validate that we can parse the cert chain, that the key matches, and
+    /// that the certs in the chain are not expired (unless we have disabled
+    /// expiration validation).
+    //
+    // TODO-completeness: Can we take an optional hostname and validate that
+    // this cert will work for it? (This might be a paramter to this method, or
+    // could be an additional property on `Self`.)
+    pub fn validate(
+        &self,
+        certs: &[u8],
+        key: &[u8],
+    ) -> Result<(), CertificateError> {
+        // Checks on the certs themselves.
+        let mut certs = X509::stack_from_pem(certs)
+            .map_err(CertificateError::BadCertificate)?;
+        if certs.is_empty() {
+            return Err(CertificateError::CertificateEmpty);
+        }
+
+        if self.validate_expiration {
+            let now = Asn1Time::days_from_now(0)
+                .map_err(CertificateError::Unexpected)?;
+            for cert in &certs {
+                if cert.not_after() < now {
+                    return Err(CertificateError::CertificateExpired);
+                }
+            }
+        }
+
+        // Extract the first certificate in the chain (the leaf certificate)
+        // to use with verifying the private key.
+        let cert = certs.swap_remove(0);
+
+        // Checks on the private key.
+        let key = PKey::private_key_from_pem(key)
+            .map_err(CertificateError::BadPrivateKey)?;
+
+        // Verify the public key corresponding to this private key
+        // matches the public key in the certificate.
+        if !cert
+            .public_key()
+            .map_err(CertificateError::BadCertificate)?
+            .public_eq(&key)
+        {
+            return Err(CertificateError::Mismatch);
+        }
+
+        Ok(())
+    }
+}

--- a/certificates/src/lib.rs
+++ b/certificates/src/lib.rs
@@ -73,6 +73,11 @@ impl CertificateValidator {
     /// Validate that we can parse the cert chain, that the key matches, and
     /// that the certs in the chain are not expired (unless we have disabled
     /// expiration validation).
+    ///
+    /// `certs` is expected to be a certificate chain in PEM format.
+    ///
+    /// `key` is expected to be the private key for the leaf certificate of
+    /// `certs` in PEM format.
     //
     // TODO-completeness: Can we take an optional hostname and validate that
     // this cert will work for it? (This might be a parameter to this method, or

--- a/certificates/src/lib.rs
+++ b/certificates/src/lib.rs
@@ -75,7 +75,7 @@ impl CertificateValidator {
     /// expiration validation).
     //
     // TODO-completeness: Can we take an optional hostname and validate that
-    // this cert will work for it? (This might be a paramter to this method, or
+    // this cert will work for it? (This might be a parameter to this method, or
     // could be an additional property on `Self`.)
     pub fn validate(
         &self,

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -16,7 +16,6 @@ hex.workspace = true
 ipnetwork.workspace = true
 macaddr.workspace = true
 newtype_derive.workspace = true
-openssl.workspace = true
 parse-display.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
@@ -31,6 +30,7 @@ steno.workspace = true
 uuid.workspace = true
 
 db-macros.workspace = true
+omicron-certificates.workspace = true
 omicron-common.workspace = true
 nexus-defaults.workspace = true
 nexus-types.workspace = true

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -8,90 +8,11 @@ use db_macros::Resource;
 use nexus_types::external_api::params;
 use nexus_types::external_api::views;
 use nexus_types::identity::Resource;
+use omicron_certificates::CertificateValidator;
 use omicron_common::api::external::Error;
-use openssl::asn1::Asn1Time;
-use openssl::pkey::PKey;
-use openssl::x509::X509;
 use uuid::Uuid;
 
-#[derive(Debug, thiserror::Error)]
-pub enum CertificateError {
-    #[error("Failed to parse certificate: {0}")]
-    BadCertificate(openssl::error::ErrorStack),
-
-    #[error("Certificate exists, but is empty")]
-    CertificateEmpty,
-
-    #[error("Certificate exists, but is expired")]
-    CertificateExpired,
-
-    #[error("Failed to parse private key")]
-    BadPrivateKey(openssl::error::ErrorStack),
-
-    #[error("Certificate and private key do not match")]
-    Mismatch,
-
-    #[error("Unexpected error: {0}")]
-    Unexpected(openssl::error::ErrorStack),
-}
-
-impl From<CertificateError> for Error {
-    fn from(error: CertificateError) -> Self {
-        use CertificateError::*;
-        match error {
-            BadCertificate(_) | CertificateEmpty | CertificateExpired
-            | Mismatch => Error::InvalidValue {
-                label: String::from("certificate"),
-                message: error.to_string(),
-            },
-            BadPrivateKey(_) => Error::InvalidValue {
-                label: String::from("private-key"),
-                message: error.to_string(),
-            },
-            Unexpected(_) => {
-                Error::InternalError { internal_message: error.to_string() }
-            }
-        }
-    }
-}
-
-fn validate_certs(input: &[u8]) -> Result<X509, CertificateError> {
-    let mut certs = X509::stack_from_pem(input)
-        .map_err(CertificateError::BadCertificate)?;
-    if certs.is_empty() {
-        return Err(CertificateError::CertificateEmpty);
-    }
-    let now =
-        Asn1Time::days_from_now(0).map_err(CertificateError::Unexpected)?;
-    for cert in &certs {
-        if cert.not_after() < now {
-            return Err(CertificateError::CertificateExpired);
-        }
-    }
-    // Return the first certificate in the chain (the leaf certificate)
-    // to use with verifying the private key.
-    Ok(certs.swap_remove(0))
-}
-
-fn validate_private_key(
-    cert: X509,
-    key: &[u8],
-) -> Result<(), CertificateError> {
-    let key = PKey::private_key_from_pem(key)
-        .map_err(CertificateError::BadPrivateKey)?;
-
-    // Verify the public key corresponding to this private key
-    // matches the public key in the certificate.
-    if !cert
-        .public_key()
-        .map_err(CertificateError::BadCertificate)?
-        .public_eq(&key)
-    {
-        return Err(CertificateError::Mismatch);
-    }
-
-    Ok(())
-}
+pub use omicron_certificates::CertificateError;
 
 /// Representation of x509 certificates used by services.
 #[derive(Queryable, Insertable, Clone, Selectable, Resource)]
@@ -125,8 +46,8 @@ impl Certificate {
         service: ServiceKind,
         params: params::CertificateCreate,
     ) -> Result<Self, CertificateError> {
-        let cert = validate_certs(&params.cert)?;
-        validate_private_key(cert, &params.key)?;
+        let validator = CertificateValidator::default();
+        validator.validate(&params.cert, &params.key)?;
 
         Ok(Self::new_unvalidated(silo_id, id, service, params))
     }

--- a/passwords/src/lib.rs
+++ b/passwords/src/lib.rs
@@ -240,7 +240,7 @@ impl<R: CryptoRng + RngCore> Hasher<R> {
 /// Parses the given PHC-format password hash string and returns it only if it
 /// meets some basic requirements (which match the way we generate password
 /// hashes).
-pub fn parse_phc_hash(s: &str) -> Result<PasswordHashString, String> {
+fn parse_phc_hash(s: &str) -> Result<PasswordHashString, String> {
     let hash = PasswordHashString::new(s)
         .map_err(|e| format!("password hash: {}", e))?;
     verify_strength(&hash)?;


### PR DESCRIPTION
This will allow wicketd to share certificate validation for user-provided certs during rack setup.