### PR TITLE
Add order argument to get metrics in desc order

### DIFF
--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -7,7 +7,6 @@
 use crate::authz;
 use crate::external_api::http_entrypoints::SystemMetricName;
 use crate::external_api::http_entrypoints::SystemMetricParams;
-use dropshot::PaginationOrder;
 use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::Error;
 use oximeter_db::Measurement;
@@ -20,7 +19,6 @@ impl super::Nexus {
         metric_name: SystemMetricName,
         query: SystemMetricParams,
         limit: NonZeroU32,
-        order: PaginationOrder,
     ) -> Result<dropshot::ResultsPage<Measurement>, Error> {
         let timeseries = match metric_name {
             SystemMetricName::VirtualDiskSpaceProvisioned
@@ -35,7 +33,6 @@ impl super::Nexus {
             &[&format!("id=={}", query.id)],
             query.pagination,
             limit,
-            order,
         )
         .await
     }

--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -7,6 +7,7 @@
 use crate::authz;
 use crate::external_api::http_entrypoints::SystemMetricName;
 use crate::external_api::http_entrypoints::SystemMetricParams;
+use dropshot::PaginationOrder;
 use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::Error;
 use oximeter_db::Measurement;
@@ -19,6 +20,7 @@ impl super::Nexus {
         metric_name: SystemMetricName,
         query: SystemMetricParams,
         limit: NonZeroU32,
+        order: PaginationOrder,
     ) -> Result<dropshot::ResultsPage<Measurement>, Error> {
         let timeseries = match metric_name {
             SystemMetricName::VirtualDiskSpaceProvisioned
@@ -33,6 +35,7 @@ impl super::Nexus {
             &[&format!("id=={}", query.id)],
             query.pagination,
             limit,
+            order,
         )
         .await
     }

--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -6,18 +6,21 @@
 
 use crate::authz;
 use crate::external_api::http_entrypoints::SystemMetricName;
-use crate::external_api::http_entrypoints::SystemMetricParams;
+use crate::external_api::params::ResourceMetrics;
+use dropshot::PaginationParams;
 use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::Error;
 use oximeter_db::Measurement;
 use std::num::NonZeroU32;
+use uuid::Uuid;
 
 impl super::Nexus {
     pub async fn system_metric_lookup(
         &self,
         opctx: &OpContext,
         metric_name: SystemMetricName,
-        query: SystemMetricParams,
+        resource_id: Uuid,
+        pagination: PaginationParams<ResourceMetrics, ResourceMetrics>,
         limit: NonZeroU32,
     ) -> Result<dropshot::ResultsPage<Measurement>, Error> {
         let timeseries = match metric_name {
@@ -30,8 +33,8 @@ impl super::Nexus {
         };
         self.select_timeseries(
             &timeseries,
-            &[&format!("id=={}", query.id)],
-            query.pagination,
+            &[&format!("id=={}", resource_id)],
+            pagination,
             limit,
         )
         .await

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -218,6 +218,7 @@ impl super::Nexus {
         criteria: &[&str],
         query_params: PaginationParams<ResourceMetrics, ResourceMetrics>,
         limit: NonZeroU32,
+        order: PaginationOrder,
     ) -> Result<dropshot::ResultsPage<Measurement>, Error> {
         #[inline]
         fn no_results() -> dropshot::ResultsPage<Measurement> {
@@ -263,6 +264,7 @@ impl super::Nexus {
                 Some(start_time),
                 Some(end_time),
                 Some(limit),
+                Some(order),
             )
             .await
             .or_else(|err| {
@@ -299,6 +301,7 @@ impl super::Nexus {
                 ResourceMetrics {
                     start_time: last_measurement.timestamp(),
                     end_time: query.end_time,
+                    order: None,
                 }
             },
         )

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -4293,12 +4293,6 @@ async fn sled_physical_disk_list(
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SystemMetricParams {
-    #[serde(flatten)]
-    pub pagination: dropshot::PaginationParams<
-        params::ResourceMetrics,
-        params::ResourceMetrics,
-    >,
-
     /// The UUID of the container being queried
     // TODO: I might want to force the caller to specify type here?
     pub id: Uuid,
@@ -4327,19 +4321,28 @@ struct SystemMetricsPathParam {
 async fn system_metric(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<SystemMetricsPathParam>,
-    query_params: Query<SystemMetricParams>,
+    pag_params: Query<
+        PaginationParams<params::ResourceMetrics, params::ResourceMetrics>,
+    >,
+    other_params: Query<SystemMetricParams>,
 ) -> Result<HttpResponseOk<ResultsPage<oximeter_db::Measurement>>, HttpError> {
     let apictx = rqctx.context();
-    let nexus = &apictx.nexus;
-    let metric_name = path_params.into_inner().metric_name;
-
-    let query = query_params.into_inner();
-    let limit = rqctx.page_limit(&query.pagination)?;
-
     let handler = async {
+        let nexus = &apictx.nexus;
+        let metric_name = path_params.into_inner().metric_name;
+        let resource_id = other_params.into_inner().id;
+        let pagination = pag_params.into_inner();
+        let limit = rqctx.page_limit(&pagination)?;
+
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         let result = nexus
-            .system_metric_lookup(&opctx, metric_name, query, limit)
+            .system_metric_lookup(
+                &opctx,
+                metric_name,
+                resource_id,
+                pagination,
+                limit,
+            )
             .await?;
 
         Ok(HttpResponseOk(result))

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1573,6 +1573,7 @@ async fn disk_metrics_list(
                 &[&format!("upstairs_uuid=={}", authz_disk.id())],
                 query,
                 limit,
+                PaginationOrder::Ascending,
             )
             .await?;
 
@@ -4335,11 +4336,12 @@ async fn system_metric(
 
     let query = query_params.into_inner();
     let limit = rqctx.page_limit(&query.pagination)?;
+    let direction = PaginationOrder::Ascending;
 
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         let result = nexus
-            .system_metric_lookup(&opctx, metric_name, query, limit)
+            .system_metric_lookup(&opctx, metric_name, query, limit, direction)
             .await?;
 
         Ok(HttpResponseOk(result))

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1573,7 +1573,6 @@ async fn disk_metrics_list(
                 &[&format!("upstairs_uuid=={}", authz_disk.id())],
                 query,
                 limit,
-                PaginationOrder::Ascending,
             )
             .await?;
 
@@ -4336,12 +4335,11 @@ async fn system_metric(
 
     let query = query_params.into_inner();
     let limit = rqctx.page_limit(&query.pagination)?;
-    let direction = PaginationOrder::Ascending;
 
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         let result = nexus
-            .system_metric_lookup(&opctx, metric_name, query, limit, direction)
+            .system_metric_lookup(&opctx, metric_name, query, limit)
             .await?;
 
         Ok(HttpResponseOk(result))

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -1392,7 +1392,7 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
     // Check the utilization info for the whole project too.
     let utilization_url = |id: Uuid| {
         format!(
-            "/v1/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={:?}",
+            "/v1/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={:?}&order=descending",
             cptestctx.start_time,
             Utc::now(),
             id,

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -4,7 +4,7 @@
 
 //! Tests basic disk support in the API
 
-use super::metrics::{query_for_latest_metric, query_for_metrics};
+use super::metrics::{get_latest_system_metric, query_for_metrics};
 
 use chrono::Utc;
 use crucible_agent_client::types::State as RegionState;
@@ -1389,15 +1389,6 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
             PROJECT_NAME,
         )
     };
-    // Check the utilization info for the whole project too.
-    let utilization_url = |id: Uuid| {
-        format!(
-            "/v1/system/metrics/virtual_disk_space_provisioned?start_time={:?}&end_time={:?}&id={:?}&order=descending",
-            cptestctx.start_time,
-            Utc::now(),
-            id,
-        )
-    };
 
     // Try accessing metrics before we attach the disk to an instance.
     //
@@ -1409,7 +1400,12 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
     assert!(measurements.items.is_empty());
 
     assert_eq!(
-        query_for_latest_metric(client, &utilization_url(project_id)).await,
+        get_latest_system_metric(
+            cptestctx,
+            "virtual_disk_space_provisioned",
+            project_id,
+        )
+        .await,
         i64::from(disk.size)
     );
 
@@ -1432,7 +1428,12 @@ async fn test_disk_metrics(cptestctx: &ControlPlaneTestContext) {
 
     // Check the utilization info for the whole project too.
     assert_eq!(
-        query_for_latest_metric(client, &utilization_url(project_id)).await,
+        get_latest_system_metric(
+            cptestctx,
+            "virtual_disk_space_provisioned",
+            project_id,
+        )
+        .await,
         i64::from(disk.size)
     );
 }

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -745,7 +745,7 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     // Query the view of these metrics stored within Clickhouse
     let metric_url = |metric_type: &str, id: Uuid| {
         format!(
-            "/v1/system/metrics/{metric_type}?start_time={:?}&end_time={:?}&id={id}",
+            "/v1/system/metrics/{metric_type}?start_time={:?}&end_time={:?}&id={id}&order=descending",
             cptestctx.start_time,
             Utc::now(),
         )

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4,10 +4,9 @@
 
 //! Tests basic instance support in the API
 
-use super::metrics::query_for_latest_metric;
+use super::metrics::get_latest_system_metric;
 
 use camino::Utf8Path;
-use chrono::Utc;
 use http::method::Method;
 use http::StatusCode;
 use nexus_db_queries::context::OpContext;
@@ -742,38 +741,23 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(virtual_provisioning_collection.cpus_provisioned, 0);
     assert_eq!(virtual_provisioning_collection.ram_provisioned.to_bytes(), 0);
 
-    // Query the view of these metrics stored within Clickhouse
-    let metric_url = |metric_type: &str, id: Uuid| {
-        format!(
-            "/v1/system/metrics/{metric_type}?start_time={:?}&end_time={:?}&id={id}&order=descending",
-            cptestctx.start_time,
-            Utc::now(),
-        )
-    };
     oximeter.force_collect().await;
     for id in &[*SILO_ID, project_id] {
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("virtual_disk_space_provisioned", *id),
+            get_latest_system_metric(
+                cptestctx,
+                "virtual_disk_space_provisioned",
+                *id,
             )
             .await,
             0
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("cpus_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "cpus_provisioned", *id).await,
             0
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("ram_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "ram_provisioned", *id).await,
             0
         );
     }
@@ -820,27 +804,20 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     oximeter.force_collect().await;
     for id in &[*SILO_ID, project_id] {
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("virtual_disk_space_provisioned", *id),
+            get_latest_system_metric(
+                cptestctx,
+                "virtual_disk_space_provisioned",
+                *id,
             )
             .await,
             0
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("cpus_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "cpus_provisioned", *id).await,
             expected_cpus
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("ram_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "ram_provisioned", *id).await,
             expected_ram
         );
     }
@@ -861,27 +838,20 @@ async fn test_instance_metrics(cptestctx: &ControlPlaneTestContext) {
     oximeter.force_collect().await;
     for id in &[*SILO_ID, project_id] {
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("virtual_disk_space_provisioned", *id),
+            get_latest_system_metric(
+                cptestctx,
+                "virtual_disk_space_provisioned",
+                *id,
             )
             .await,
             0
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("cpus_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "cpus_provisioned", *id).await,
             0
         );
         assert_eq!(
-            query_for_latest_metric(
-                client,
-                &metric_url("ram_provisioned", *id),
-            )
-            .await,
+            get_latest_system_metric(cptestctx, "ram_provisioned", *id).await,
             0
         );
     }

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -28,7 +28,7 @@ pub async fn get_latest_system_metric(
 ) -> i64 {
     let client = &cptestctx.external_client;
     let url = format!(
-        "/v1/system/metrics/{metric_name}?start_time={:?}&end_time={:?}&id={:?}&order=descending", 
+        "/v1/system/metrics/{metric_name}?start_time={:?}&end_time={:?}&id={:?}&order=descending&limit=1", 
         cptestctx.start_time,
         Utc::now(),
         resource_id,
@@ -37,7 +37,7 @@ pub async fn get_latest_system_metric(
         objects_list_page_authz(client, &url).await;
 
     // prevent more confusing error on next line
-    assert!(measurements.items.len() > 0, "Expected at least one measurement");
+    assert!(measurements.items.len() == 1, "Expected exactly one measurement");
 
     let item = &measurements.items[0];
     let datum = match item.datum() {

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -28,7 +28,7 @@ pub async fn query_for_latest_metric(
     // prevent more confusing 'attempt to subtract with overflow' on next line
     assert!(measurements.items.len() > 0, "Expected at least one measurement");
 
-    let item = &measurements.items[measurements.items.len() - 1];
+    let item = &measurements.items[0];
     let datum = match item.datum() {
         Datum::I64(c) => c,
         _ => panic!("Unexpected datum type {:?}", item.datum()),

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -116,7 +116,14 @@ async fn test_oximeter_reregistration() {
     let timeseries_name = "integration_target:integration_metric";
     let retrieve_timeseries = || async {
         match client
-            .select_timeseries_with(timeseries_name, &[], None, None, None)
+            .select_timeseries_with(
+                timeseries_name,
+                &[],
+                None,
+                None,
+                None,
+                None,
+            )
             .await
         {
             Ok(maybe_series) => {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -11,7 +11,8 @@ use chrono::{DateTime, Utc};
 use omicron_common::api::external::{
     AddressLotKind, ByteCount, IdentityMetadataCreateParams,
     IdentityMetadataUpdateParams, InstanceCpuCount, IpNet, Ipv4Net, Ipv6Net,
-    Name, NameOrId, RouteDestination, RouteTarget, SemverVersion,
+    Name, NameOrId, PaginationOrder, RouteDestination, RouteTarget,
+    SemverVersion,
 };
 use schemars::JsonSchema;
 use serde::{
@@ -1639,6 +1640,8 @@ pub struct ResourceMetrics {
     pub start_time: DateTime<Utc>,
     /// An exclusive end time of metrics.
     pub end_time: DateTime<Utc>,
+    /// Query result order
+    pub order: Option<PaginationOrder>,
 }
 
 // SYSTEM UPDATE

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4747,16 +4747,6 @@
           },
           {
             "in": "query",
-            "name": "id",
-            "description": "The UUID of the container being queried",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "in": "query",
             "name": "limit",
             "description": "Maximum number of items returned by a single call",
             "schema": {
@@ -4790,6 +4780,16 @@
             "schema": {
               "type": "string",
               "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "description": "The UUID of the container being queried",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -870,6 +870,14 @@
           },
           {
             "in": "query",
+            "name": "order",
+            "description": "Query result order",
+            "schema": {
+              "$ref": "#/components/schemas/PaginationOrder"
+            }
+          },
+          {
+            "in": "query",
             "name": "page_token",
             "description": "Token returned by previous call to retrieve the subsequent page",
             "schema": {
@@ -4756,6 +4764,14 @@
               "type": "integer",
               "format": "uint32",
               "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "description": "Query result order",
+            "schema": {
+              "$ref": "#/components/schemas/PaginationOrder"
             }
           },
           {
@@ -14293,6 +14309,14 @@
           "read_bytes",
           "write",
           "write_bytes"
+        ]
+      },
+      "PaginationOrder": {
+        "description": "The order in which the client wants to page through the requested collection",
+        "type": "string",
+        "enum": [
+          "ascending",
+          "descending"
         ]
       },
       "IdSortMode": {

--- a/oximeter/db/src/bin/oxdb.rs
+++ b/oximeter/db/src/bin/oxdb.rs
@@ -288,6 +288,7 @@ async fn query(
             start,
             end,
             None,
+            None,
         )
         .await?;
     println!("{}", serde_json::to_string(&timeseries).unwrap());

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -79,6 +79,9 @@ pub enum Error {
 
     #[error("Invalid timeseries name")]
     InvalidTimeseriesName,
+
+    #[error("Query must resolve to a single timeseries if limit is specified")]
+    InvalidLimitQuery,
 }
 
 /// A timeseries name.

--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -262,12 +262,7 @@ impl SelectQueryBuilder {
             time_range: self.time_range,
             limit: self.limit,
             offset: self.offset,
-            order: match self.order {
-                Some(PaginationOrder::Descending) => {
-                    PaginationOrder::Descending
-                }
-                _ => PaginationOrder::Ascending,
-            },
+            order: self.order.unwrap_or(PaginationOrder::Ascending),
         }
     }
 }

--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -10,6 +10,7 @@ use crate::{
     DATABASE_NAME, DATABASE_SELECT_FORMAT,
 };
 use chrono::{DateTime, Utc};
+use dropshot::PaginationOrder;
 use oximeter::types::{DatumType, FieldType, FieldValue};
 use oximeter::{Metric, Target};
 use regex::Regex;
@@ -37,6 +38,7 @@ pub struct SelectQueryBuilder {
     time_range: TimeRange,
     limit: Option<NonZeroU32>,
     offset: Option<u32>,
+    order: Option<PaginationOrder>,
 }
 
 impl SelectQueryBuilder {
@@ -48,6 +50,7 @@ impl SelectQueryBuilder {
             time_range: TimeRange { start: None, end: None },
             limit: None,
             offset: None,
+            order: None,
         }
     }
 
@@ -72,6 +75,12 @@ impl SelectQueryBuilder {
     /// Set the number of rows to skip in the result set.
     pub fn offset(mut self, offset: u32) -> Self {
         self.offset.replace(offset);
+        self
+    }
+
+    /// Set the order direction for the query
+    pub fn order(mut self, order: PaginationOrder) -> Self {
+        self.order.replace(order);
         self
     }
 
@@ -253,6 +262,12 @@ impl SelectQueryBuilder {
             time_range: self.time_range,
             limit: self.limit,
             offset: self.offset,
+            order: match self.order {
+                Some(PaginationOrder::Descending) => {
+                    PaginationOrder::Descending
+                }
+                _ => PaginationOrder::Ascending,
+            },
         }
     }
 }
@@ -479,6 +494,7 @@ pub struct SelectQuery {
     time_range: TimeRange,
     limit: Option<NonZeroU32>,
     offset: Option<u32>,
+    order: PaginationOrder,
 }
 
 fn create_join_on_condition(columns: &[&str], current: usize) -> String {
@@ -620,6 +636,10 @@ impl SelectQuery {
             };
             clause
         };
+        let order_dir = match self.order {
+            PaginationOrder::Descending => "DESC ",
+            PaginationOrder::Ascending => "",
+        };
         format!(
             concat!(
                 "SELECT * ",
@@ -628,7 +648,7 @@ impl SelectQuery {
                 "timeseries_name = '{timeseries_name}'",
                 "{key_clause}",
                 "{timestamp_clause}",
-                "ORDER BY (timeseries_name, timeseries_key, timestamp) ",
+                "ORDER BY (timeseries_name, timeseries_key, timestamp) {order_dir}",
                 "{pagination_clause}",
                 "FORMAT {fmt};",
             ),
@@ -639,6 +659,7 @@ impl SelectQuery {
             key_clause = key_clause,
             timestamp_clause = self.time_range.as_query(),
             pagination_clause = pagination_clause,
+            order_dir = order_dir,
             fmt = DATABASE_SELECT_FORMAT,
         )
     }


### PR DESCRIPTION
This is a pretty sad PR, a band-aid on an API we want to rework. In the console we want to be able to pull the single most recent measurement on a given metric to show it as the "current" value, so we need to be able to do `ORDER DESC LIMIT 1` in the Clickhouse query.

- [x] Plumb through order arg in oximeter
- [x] Figure out how to represent order in the Nexus endpoint query params (~~@ahl I feel like I should be using something from Dropshot here~~ it was there already?)
- [x] Existing integration tests use `order=desc` to get the latest metric
- [x] Dedicated tests for the order and limit params
- [x] Fix issue with limit param parse due to serde flatten
- [x] Error if query is made with a limit param that returns data from multiple timeseries, which would produce weird results