### PR TITLE
fix loopback address lookup in rack init

### DIFF
--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -350,7 +350,14 @@ impl super::Nexus {
                     &opctx,
                     rack_id,
                     switch_location.into(),
-                    first_address.into(),
+                    ipnetwork::IpNetwork::new(
+                        loopback_address_params.address,
+                        loopback_address_params.mask,
+                    )
+                    .map_err(|_| {
+                        Error::invalid_request("invalid loopback address")
+                    })?
+                    .into(),
                 )?
                 .lookup_for(authz::Action::Read)
                 .await


### PR DESCRIPTION
We ran the networking bits of rack initialize today on Rack 2. The overall initialize call did not succeed and had to be called several times by the sled agent. This wound up going sideways with address lot allocation failures. This was curious as I had seen this in a local dev environment and thought I had fixed the issue by conditioning calls that reserve address lot blocks on lookups that see if they are already there. However, one of my lookups was bad.

I was relying on `into` conversion from an IP address to an `IpNet` object. That results in a subnet mask of zero. However, in this case, the prefix length was not zero and the lookup failed. This has been corrected by explicitly creating an `IpNetwork` object for the loopback address lookup, mask and all.