### PR TITLE
Update crucible and propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd0
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -661,7 +661,7 @@ dependencies = [
  "ipnetwork",
  "omicron-common 0.1.0",
  "progenitor",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "serde",
  "slog",
@@ -1993,7 +1993,7 @@ dependencies = [
  "progenitor-client",
  "quote",
  "rand 0.8.5",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "rustfmt-wrapper",
  "schemars",
@@ -3311,7 +3311,7 @@ version = "0.1.0"
 dependencies = [
  "installinator-common",
  "progenitor",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "schemars",
  "serde",
@@ -3956,9 +3956,9 @@ dependencies = [
  "chrono",
  "futures",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "progenitor",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "schemars",
  "serde",
@@ -3973,13 +3973,10 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd02dac075669cb2ece41d1cc1ddf2"
 dependencies = [
  "chrono",
- "futures",
  "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-passwords 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "progenitor",
- "regress",
+ "regress 0.5.0",
  "reqwest",
- "schemars",
  "serde",
  "serde_json",
  "slog",
@@ -4003,7 +4000,7 @@ dependencies = [
  "nexus-types",
  "omicron-certificates",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "omicron-rpaths",
  "parse-display",
  "pq-sys",
@@ -4014,7 +4011,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled-agent-client",
- "steno",
+ "steno 0.4.0",
  "thiserror",
  "uuid",
 ]
@@ -4056,7 +4053,7 @@ dependencies = [
  "nexus-types",
  "num-integer",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -4087,7 +4084,7 @@ dependencies = [
  "serde_with",
  "sled-agent-client",
  "slog",
- "steno",
+ "steno 0.4.0",
  "strum",
  "subprocess",
  "tempfile",
@@ -4144,7 +4141,7 @@ dependencies = [
  "nexus-test-interface",
  "nexus-types",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "omicron-sled-agent",
  "omicron-test-utils",
  "oximeter 0.1.0",
@@ -4184,14 +4181,14 @@ dependencies = [
  "futures",
  "newtype_derive",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "openssl",
  "openssl-probe",
  "openssl-sys",
  "schemars",
  "serde",
  "serde_json",
- "steno",
+ "steno 0.4.0",
  "uuid",
 ]
 
@@ -4428,7 +4425,7 @@ dependencies = [
  "progenitor",
  "proptest",
  "rand 0.8.5",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "ring",
  "schemars",
@@ -4440,7 +4437,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_with",
  "slog",
- "steno",
+ "steno 0.4.0",
  "strum",
  "test-strategy",
  "thiserror",
@@ -4465,7 +4462,6 @@ dependencies = [
  "http",
  "hyper",
  "ipnetwork",
- "lazy_static",
  "macaddr",
  "parse-display",
  "progenitor",
@@ -4480,7 +4476,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "slog",
- "steno",
+ "steno 0.3.1",
  "strum",
  "thiserror",
  "tokio",
@@ -4630,7 +4626,7 @@ dependencies = [
  "nexus-types",
  "num-integer",
  "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -4669,7 +4665,7 @@ dependencies = [
  "sled-agent-client",
  "slog",
  "slog-dtrace",
- "steno",
+ "steno 0.4.0",
  "strum",
  "subprocess",
  "tempfile",
@@ -4727,19 +4723,6 @@ dependencies = [
  "criterion",
  "rand 0.8.5",
  "rust-argon2",
- "schemars",
- "serde",
- "serde_with",
- "thiserror",
-]
-
-[[package]]
-name = "omicron-passwords"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
-dependencies = [
- "argon2",
- "rand 0.8.5",
  "schemars",
  "serde",
  "serde_with",
@@ -5058,7 +5041,7 @@ dependencies = [
  "hyper",
  "progenitor",
  "rand 0.8.5",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -5208,7 +5191,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd0
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6402,6 +6385,16 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "regress"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d995d590bd8ec096d1893f414bf3f5e8b0ee4c9eed9a5642b9766ef2c8e2e8e9"
+dependencies = [
+ "hashbrown 0.13.2",
+ "memchr",
+]
+
+[[package]]
+name = "regress"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a9ecfa0cb04d0b04dddb99b8ccf4f66bc8dfd23df694b398570bd8ae3a50fb"
@@ -7388,7 +7381,7 @@ dependencies = [
  "ipnetwork",
  "omicron-common 0.1.0",
  "progenitor",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "serde",
  "slog",
@@ -7750,6 +7743,28 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "steno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee007f34597a281684e1ab95e5c62d4c330db52644ad81dbaa53204f1ff7ba9f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "lazy_static",
+ "newtype_derive",
+ "petgraph",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "steno"
@@ -8690,7 +8705,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "regress",
+ "regress 0.6.0",
  "schemars",
  "serde_json",
  "syn 2.0.16",
@@ -9332,7 +9347,7 @@ dependencies = [
  "chrono",
  "installinator-common",
  "progenitor",
- "regress",
+ "regress 0.6.0",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd0
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "libc",
  "num_enum",
@@ -661,7 +661,7 @@ dependencies = [
  "ipnetwork",
  "omicron-common 0.1.0",
  "progenitor",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "serde",
  "slog",
@@ -1345,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
 dependencies = [
  "libc",
  "num-derive",
@@ -1869,7 +1869,7 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 [[package]]
 name = "dladm"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "libc",
  "num_enum",
@@ -1896,7 +1896,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap 4.3.0",
- "dns-service-client",
+ "dns-service-client 0.1.0",
  "dropshot",
  "expectorate",
  "http",
@@ -1927,6 +1927,23 @@ dependencies = [
 [[package]]
 name = "dns-service-client"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures",
+ "http",
+ "progenitor",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "uuid",
+]
+
+[[package]]
+name = "dns-service-client"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
 dependencies = [
  "chrono",
  "futures",
@@ -1976,7 +1993,7 @@ dependencies = [
  "progenitor-client",
  "quote",
  "rand 0.8.5",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "rustfmt-wrapper",
  "schemars",
@@ -3294,7 +3311,7 @@ version = "0.1.0"
 dependencies = [
  "installinator-common",
  "progenitor",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "schemars",
  "serde",
@@ -3362,7 +3379,7 @@ dependencies = [
  "assert_matches",
  "chrono",
  "dns-server",
- "dns-service-client",
+ "dns-service-client 0.1.0",
  "dropshot",
  "expectorate",
  "futures",
@@ -3374,6 +3391,24 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "trust-dns-proto",
+ "trust-dns-resolver",
+ "uuid",
+]
+
+[[package]]
+name = "internal-dns"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "chrono",
+ "dns-service-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "futures",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "slog",
+ "thiserror",
  "trust-dns-proto",
  "trust-dns-resolver",
  "uuid",
@@ -3921,9 +3956,9 @@ dependencies = [
  "chrono",
  "futures",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "progenitor",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "schemars",
  "serde",
@@ -3938,10 +3973,13 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd02dac075669cb2ece41d1cc1ddf2"
 dependencies = [
  "chrono",
+ "futures",
  "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "omicron-passwords 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "progenitor",
- "regress 0.5.0",
+ "regress",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "slog",
@@ -3957,7 +3995,7 @@ dependencies = [
  "db-macros",
  "diesel",
  "hex",
- "internal-dns",
+ "internal-dns 0.1.0",
  "ipnetwork",
  "macaddr",
  "newtype_derive",
@@ -3965,7 +4003,7 @@ dependencies = [
  "nexus-types",
  "omicron-certificates",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "omicron-rpaths",
  "parse-display",
  "pq-sys",
@@ -3976,7 +4014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled-agent-client",
- "steno 0.4.0",
+ "steno",
  "thiserror",
  "uuid",
 ]
@@ -4005,7 +4043,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
- "internal-dns",
+ "internal-dns 0.1.0",
  "ipnetwork",
  "itertools",
  "lazy_static",
@@ -4018,7 +4056,7 @@ dependencies = [
  "nexus-types",
  "num-integer",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -4049,7 +4087,7 @@ dependencies = [
  "serde_with",
  "sled-agent-client",
  "slog",
- "steno 0.4.0",
+ "steno",
  "strum",
  "subprocess",
  "tempfile",
@@ -4079,7 +4117,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "dropshot",
- "internal-dns",
+ "internal-dns 0.1.0",
  "nexus-types",
  "omicron-common 0.1.0",
  "slog",
@@ -4101,12 +4139,12 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "internal-dns",
+ "internal-dns 0.1.0",
  "nexus-db-queries",
  "nexus-test-interface",
  "nexus-types",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "omicron-sled-agent",
  "omicron-test-utils",
  "oximeter 0.1.0",
@@ -4142,18 +4180,18 @@ dependencies = [
  "api_identity 0.1.0",
  "base64 0.21.2",
  "chrono",
- "dns-service-client",
+ "dns-service-client 0.1.0",
  "futures",
  "newtype_derive",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "openssl",
  "openssl-probe",
  "openssl-sys",
  "schemars",
  "serde",
  "serde_json",
- "steno 0.4.0",
+ "steno",
  "uuid",
 ]
 
@@ -4390,7 +4428,7 @@ dependencies = [
  "progenitor",
  "proptest",
  "rand 0.8.5",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "ring",
  "schemars",
@@ -4402,7 +4440,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_with",
  "slog",
- "steno 0.4.0",
+ "steno",
  "strum",
  "test-strategy",
  "thiserror",
@@ -4427,6 +4465,7 @@ dependencies = [
  "http",
  "hyper",
  "ipnetwork",
+ "lazy_static",
  "macaddr",
  "parse-display",
  "progenitor",
@@ -4441,7 +4480,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "slog",
- "steno 0.3.1",
+ "steno",
  "strum",
  "thiserror",
  "tokio",
@@ -4563,7 +4602,7 @@ dependencies = [
  "diesel",
  "diesel-dtrace",
  "dns-server",
- "dns-service-client",
+ "dns-service-client 0.1.0",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -4575,7 +4614,7 @@ dependencies = [
  "httptest",
  "hyper",
  "hyper-rustls",
- "internal-dns",
+ "internal-dns 0.1.0",
  "ipnetwork",
  "itertools",
  "lazy_static",
@@ -4591,7 +4630,7 @@ dependencies = [
  "nexus-types",
  "num-integer",
  "omicron-common 0.1.0",
- "omicron-passwords",
+ "omicron-passwords 0.1.0",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -4630,7 +4669,7 @@ dependencies = [
  "sled-agent-client",
  "slog",
  "slog-dtrace",
- "steno 0.4.0",
+ "steno",
  "strum",
  "subprocess",
  "tempfile",
@@ -4695,6 +4734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-passwords"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+dependencies = [
+ "argon2",
+ "rand 0.8.5",
+ "schemars",
+ "serde",
+ "serde_with",
+ "thiserror",
+]
+
+[[package]]
 name = "omicron-rpaths"
 version = "0.1.0"
 
@@ -4718,7 +4770,7 @@ dependencies = [
  "crucible-client-types",
  "ddm-admin-client",
  "dns-server",
- "dns-service-client",
+ "dns-service-client 0.1.0",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -4726,7 +4778,7 @@ dependencies = [
  "futures",
  "http",
  "illumos-utils",
- "internal-dns",
+ "internal-dns 0.1.0",
  "ipnetwork",
  "itertools",
  "key-manager",
@@ -5006,7 +5058,7 @@ dependencies = [
  "hyper",
  "progenitor",
  "rand 0.8.5",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "serde",
  "serde_json",
@@ -5080,7 +5132,7 @@ dependencies = [
  "dropshot",
  "expectorate",
  "futures",
- "internal-dns",
+ "internal-dns 0.1.0",
  "nexus-client 0.1.0",
  "omicron-common 0.1.0",
  "omicron-test-utils",
@@ -5156,7 +5208,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#7f772b32a0cd0
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -5906,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "propolis"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "anyhow",
  "bhyve_api",
@@ -5936,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "base64 0.21.2",
  "crucible-client-types",
@@ -5959,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "propolis-server"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5977,7 +6029,9 @@ dependencies = [
  "erased-serde",
  "futures",
  "hyper",
+ "internal-dns 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "lazy_static",
+ "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "num_enum",
  "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
@@ -6008,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "propolis-server-config"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6019,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "schemars",
  "serde",
@@ -6345,16 +6399,6 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "regress"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995d590bd8ec096d1893f414bf3f5e8b0ee4c9eed9a5642b9766ef2c8e2e8e9"
-dependencies = [
- "hashbrown 0.13.2",
- "memchr",
-]
 
 [[package]]
 name = "regress"
@@ -7344,7 +7388,7 @@ dependencies = [
  "ipnetwork",
  "omicron-common 0.1.0",
  "progenitor",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "serde",
  "slog",
@@ -7706,28 +7750,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "steno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee007f34597a281684e1ab95e5c62d4c330db52644ad81dbaa53204f1ff7ba9f"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "futures",
- "lazy_static",
- "newtype_derive",
- "petgraph",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "thiserror",
- "tokio",
- "uuid",
-]
 
 [[package]]
 name = "steno"
@@ -8668,7 +8690,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "regress 0.6.0",
+ "regress",
  "schemars",
  "serde_json",
  "syn 2.0.16",
@@ -8946,7 +8968,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viona_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "libc",
  "num_enum",
@@ -8956,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "viona_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5f694f4833a4368e05764a3b4b0fcaa6feed54df#5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source = "git+https://github.com/oxidecomputer/propolis?rev=78314ae5f74f951c03b0cb97b06f9bc28446bdb5#78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 dependencies = [
  "libc",
 ]
@@ -9310,7 +9332,7 @@ dependencies = [
  "chrono",
  "installinator-common",
  "progenitor",
- "regress 0.6.0",
+ "regress",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,10 +145,10 @@ cookie = "0.16"
 criterion = { version = "0.4", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.26.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
 datatest-stable = "0.1.3"
 display-error-chain = "0.1.1"
 ddm-admin-client = { path = "ddm-admin-client" }
@@ -254,9 +254,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "5f694f4833a4368e05764a3b4b0fcaa6feed54df", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "78314ae5f74f951c03b0cb97b06f9bc28446bdb5" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "78314ae5f74f951c03b0cb97b06f9bc28446bdb5", features = [ "generated-migration" ] }
+propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "78314ae5f74f951c03b0cb97b06f9bc28446bdb5", default-features = false, features = ["mock-only"] }
 proptest = "1.2.0"
 quote = "1.0"
 rand = "0.8.5"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -223,10 +223,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source.commit = "8757b3fb55a1763382ad7111144bc60ec72af23d"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "80b3f88136dbac7d4d03cc775b89a0ac907a3bdac7e2a4f78dfc15dd39aba384"
+source.sha256 = "3593bf2eccc3dbdb5a3a5a6053f06d4768895a7a9063715fdce5c2bfe9ee1dc0"
 output.type = "zone"
 
 [package.crucible-pantry]
@@ -234,10 +234,10 @@ service_name = "crucible_pantry"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"
+source.commit = "8757b3fb55a1763382ad7111144bc60ec72af23d"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "a9face1851993c5bc7542e4a057f5e24a283702a2ea5e9c49cb2e3140437a310"
+source.sha256 = "3a83266bbd70c00fd725a0a5c9264baa7d77c66997b178b292256c05208a0c85"
 output.type = "zone"
 
 # Refer to
@@ -248,10 +248,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "5f694f4833a4368e05764a3b4b0fcaa6feed54df"
+source.commit = "78314ae5f74f951c03b0cb97b06f9bc28446bdb5"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "22e553aa69d25ea85eb40e718deae0d2ab4d11b8ef29950acf1fb9b92a60a46f"
+source.sha256 = "c77c597b6ce111e14a10052d35641857581e158be58f9131f56fa1baeeac2b30"
 output.type = "zone"
 
 [package.maghemite]


### PR DESCRIPTION
Bump crucible rev to pick up:

* Eliminate some scans + store jobs in BTree
* Add the first part of downstairs replacement
* Add a clippy run to Rust workflows
* Update Rust crate clap to 4.3
* Update Rust crate reqwest to 0.11.18
* Update Rust crate num_enum to 0.6
* Update Rust crate tokio to v1.28.1
* Update Terraform aws to v5
* Replace cargo test with nextest for github actions
* Live Repair
* remove std::panic::set_hook in upstairs test
* Add dummy downstairs tests
* up_main take a log option, Block on logging by default
* Elide duplicate unencrypted contexts
* Make agent and pantry use bunyan format for logs

Bump propolis rev to pick up:

* Bump Crucible rev to latest
* Reorganize and update cargo dependencies
* Raise arbitrary MMIO physmem limit
* Crucible tell Nexus when a scrub is done