### PR TITLE
[wicketd] Track trampoline images by hash instead of ID

### DIFF
--- a/gateway/examples/config.toml
+++ b/gateway/examples/config.toml
@@ -10,8 +10,8 @@ host_phase2_recovery_image_cache_max_images = 1
 
 [dropshot]
 # We want to allow uploads of host phase 2 recovery images, which may be
-# measured in the (small) hundreds of MiB. Set this to 512 MiB.
-request_body_max_bytes = 536870912
+# measured in the (small) hundreds of MiB. Set this to 1 GiB for testing.
+request_body_max_bytes = 1_073_741_824
 
 [switch]
 # Which interface is connected to our local sidecar SP (i.e., the SP that acts


### PR DESCRIPTION
If the user uploads a TUF repository with a different trampoline image but the same metadata (version, in particular), wicketd would _not_ treat that as a new trampoline image when checking whether it needed to be sent to MGS upon starting an update.

We now do this comparison by hash of the image instead of by metadata, ensuring a new image will always be sent to MGS even if the metadata is unchanged.

Fixes https://github.com/oxidecomputer/omicron/issues/3282.

TODO before merging:

- [ ] Test on `madrid` (basic testing locally shows this fixes the problem, but I can't do a full mupdate locally and want to confirm I didn't break something accidentally)