### PR TITLE
Fix `error[E0308]: mismatched types` – expected `u32`, found `u16`

### DIFF
--- a/dev-tools/src/bin/omicron-dev.rs
+++ b/dev-tools/src/bin/omicron-dev.rs
@@ -435,6 +435,7 @@ async fn cmd_cert_create(args: &CertCreateArgs) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[cfg_attr(not(mac), allow(clippy::useless_conversion))]
 fn write_private_file(
     path: &Utf8Path,
     contents: &[u8],
@@ -444,7 +445,7 @@ fn write_private_file(
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .mode(perms.into())
+        .mode(perms.into()) // into() needed on mac only
         .open(path)
         .with_context(|| format!("open {:?} for writing", path))?;
     file.write_all(contents).with_context(|| format!("write to {:?}", path))

--- a/dev-tools/src/bin/omicron-dev.rs
+++ b/dev-tools/src/bin/omicron-dev.rs
@@ -444,7 +444,7 @@ fn write_private_file(
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .mode(perms)
+        .mode(perms.into())
         .open(path)
         .with_context(|| format!("open {:?} for writing", path))?;
     file.write_all(contents).with_context(|| format!("write to {:?}", path))


### PR DESCRIPTION
Fix for the following error:

```
   Compiling omicron-dev-tools v0.1.0 (/Users/leonard/Desktop/Development/omicron/dev-tools)
   Compiling omicron-nexus v0.1.0 (/Users/leonard/Desktop/Development/omicron/nexus)
error[E0308]: mismatched types
   --> dev-tools/src/bin/omicron-dev.rs:447:15
    |
447 |         .mode(perms)
    |          ---- ^^^^^ expected `u32`, found `u16`
    |          |
    |          arguments to this method are incorrect
    |
note: associated function defined here
   --> /Users/leonard/.rustup/toolchains/1.68.2-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/os/unix/fs.rs:327:8
    |
327 |     fn mode(&mut self, mode: u32) -> &mut Self;
    |        ^^^^
help: you can convert a `u16` to a `u32`
    |
447 |         .mode(perms.into())
    |                    +++++++
```