### PR TITLE
Fix SAML login redirect

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -179,16 +179,33 @@ impl RelayState {
     }
 }
 
-/// Prompt user login
-///
-/// Either display a page asking a user for their credentials, or redirect them
-/// to their identity provider.
+/// SAML login console page (just a link to the IdP)
 #[endpoint {
    method = GET,
    path = "/login/{silo_name}/saml/{provider_name}",
    tags = ["login"],
+   unpublished = true,
 }]
 pub async fn login_saml_begin(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    _path_params: Path<LoginToProviderPathParam>,
+    _query_params: Query<LoginUrlQuery>,
+) -> Result<Response<Body>, HttpError> {
+    serve_console_index(rqctx.context()).await
+}
+
+/// Get a redirect straight to the IdP
+///
+/// Console uses this to avoid having to ask the API anything about the IdP. It
+/// already knows the IdP name from the path, so it can just link to this path
+/// and rely on Nexus to redirect to the actual IdP.
+#[endpoint {
+   method = GET,
+   path = "/login/{silo_name}/saml/{provider_name}/redirect",
+   tags = ["login"],
+   unpublished = true,
+}]
+pub async fn login_saml_redirect(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<LoginToProviderPathParam>,
     query_params: Query<LoginUrlQuery>,

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -71,8 +71,8 @@ use std::{collections::HashSet, ffi::OsString, path::PathBuf, sync::Arc};
 // a page with a link to /login/{silo}/saml/{provider}/redirect?redirect_uri={}
 // (note the /redirect), which redirects to the IdP  with `redirect_uri` encoded
 // in a RelayState query param). On successful login in the IdP, the IdP will
-// POST /login/{silo}/saml/{} with a body including that redirect_uri, so that
-// on success, we can redirect to the original target page.
+// POST /login/{silo}/saml/{provider} with a body including that redirect_uri,
+// so that on success, we can redirect to the original target page.
 
 // -------------------------------
 // Detailed overview of SAML login

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -292,6 +292,7 @@ pub fn external_api() -> NexusApiDescription {
         api.register(console_api::login_local_begin)?;
         api.register(console_api::login_local)?;
         api.register(console_api::login_saml_begin)?;
+        api.register(console_api::login_saml_redirect)?;
         api.register(console_api::login_saml)?;
         api.register(console_api::logout)?;
 

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -479,9 +479,6 @@ async fn test_login_redirect_simple(cptestctx: &ControlPlaneTestContext) {
         &format!("{}?redirect_uri=%2Fabc%2Fdef", expected),
     )
     .await;
-
-    // empty state param gets dropped
-    // expect_redirect(testctx, "/login?redirect_uri=", &expected).await;
 }
 
 // reject anything that's not a relative URI

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -189,7 +189,7 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
         testctx,
         "/projects/irrelevant-path",
         &format!(
-            "/login/{}/local?state=%2Fprojects%2Firrelevant-path",
+            "/login/{}/local?redirect_uri=%2Fprojects%2Firrelevant-path",
             cptestctx.silo_name
         ),
     )
@@ -467,21 +467,21 @@ async fn test_login_redirect_simple(cptestctx: &ControlPlaneTestContext) {
     // encoded path is /abc/def
     expect_redirect(
         testctx,
-        "/login?state=%2Fabc%2Fdef",
-        &format!("{}?state=%2Fabc%2Fdef", expected),
+        "/login?redirect_uri=%2Fabc%2Fdef",
+        &format!("{}?redirect_uri=%2Fabc%2Fdef", expected),
     )
     .await;
 
     // if state param comes in not URL encoded, we should still URL encode it
     expect_redirect(
         testctx,
-        "/login?state=/abc/def",
-        &format!("{}?state=%2Fabc%2Fdef", expected),
+        "/login?redirect_uri=/abc/def",
+        &format!("{}?redirect_uri=%2Fabc%2Fdef", expected),
     )
     .await;
 
     // empty state param gets dropped
-    expect_redirect(testctx, "/login?state=", &expected).await;
+    expect_redirect(testctx, "/login?redirect_uri=", &expected).await;
 }
 
 #[nexus_test]
@@ -584,7 +584,8 @@ async fn test_login_redirect_multiple_silos(
         port: u16,
         state: Option<&str>,
     ) -> Redirect {
-        let query = state.map_or("".to_string(), |s| format!("?state={}", s));
+        let query =
+            state.map_or("".to_string(), |s| format!("?redirect_uri={}", s));
         let url = format!(
             "http://{}.sys.{}:{}/login{}",
             silo_name, DNS_ZONE_EXTERNAL_TESTING, port, query
@@ -684,7 +685,7 @@ async fn test_login_redirect_multiple_silos(
         )
         .await,
         Redirect::Location(format!(
-            "/login/{}/local?state=%2Fabc%2Fdef",
+            "/login/{}/local?redirect_uri=%2Fabc%2Fdef",
             &cptestctx.silo_name,
         )),
     );
@@ -726,7 +727,7 @@ async fn test_login_redirect_multiple_silos(
         )
         .await,
         Redirect::Location(format!(
-            "/login/{}/saml/idp0?state=%2Fabc%2Fdef",
+            "/login/{}/saml/idp0?redirect_uri=%2Fabc%2Fdef",
             silo_saml1.identity.name.as_str()
         )),
     );

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -220,7 +220,8 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
 async fn test_unauthed_console_pages(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
-    let unauthed_console_paths = &["/login/irrelevant-silo/local"];
+    let unauthed_console_paths =
+        &["/login/irrelevant-silo/local", "/login/irrelevant-silo/saml/my-idp"];
 
     for path in unauthed_console_paths {
         expect_console_page(testctx, path, None).await;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -584,7 +584,7 @@ async fn test_login_redirect_multiple_silos(
         port: u16,
     ) -> Redirect {
         let url = format!(
-            "http://{}.sys.{}:{}/login",
+            "http://{}.sys.{}:{}/login?state=%2Fabc%2Fdef",
             silo_name, DNS_ZONE_EXTERNAL_TESTING, port,
         );
         let response = client
@@ -668,7 +668,10 @@ async fn test_login_redirect_multiple_silos(
     // Recovery silo: redirect for local username/password login
     assert_eq!(
         make_request(&reqwest_client, cptestctx.silo_name.as_str(), port).await,
-        Redirect::Location(format!("/login/{}/local", &cptestctx.silo_name,)),
+        Redirect::Location(format!(
+            "/login/{}/local?state=%2Fabc%2Fdef",
+            &cptestctx.silo_name,
+        )),
     );
     // SAML with no idps: no redirect possible
     assert_eq!(
@@ -683,7 +686,7 @@ async fn test_login_redirect_multiple_silos(
         make_request(&reqwest_client, silo_saml1.identity.name.as_str(), port)
             .await,
         Redirect::Location(format!(
-            "/login/{}/saml/idp0",
+            "/login/{}/saml/idp0?state=%2Fabc%2Fdef",
             silo_saml1.identity.name.as_str()
         )),
     );
@@ -694,7 +697,7 @@ async fn test_login_redirect_multiple_silos(
         make_request(&reqwest_client, silo_saml2.identity.name.as_str(), port)
             .await,
         Redirect::Location(format!(
-            "/login/{}/saml/idp0",
+            "/login/{}/saml/idp0?state=%2Fabc%2Fdef",
             silo_saml2.identity.name.as_str()
         )),
     );

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -72,7 +72,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
         .expect_response_header(
             header::LOCATION,
             &format!(
-                "/login/{}/local?state=%2Fdevice%2Fverify",
+                "/login/{}/local?redirect_uri=%2Fdevice%2Fverify",
                 cptestctx.silo_name
             ),
         )

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -1141,7 +1141,7 @@ async fn test_post_saml_response_with_relay_state(
                 relay_state: Some(
                     console_api::RelayState {
                         redirect_uri: Some(
-                            "/some/actual/nexus/url".to_string(),
+                            "/some/actual/nexus/url".parse().unwrap(),
                         ),
                     }
                     .to_encoded()

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -1137,7 +1137,9 @@ async fn test_post_saml_response_with_relay_state(
                     .encode(SAML_RESPONSE),
                 relay_state: Some(
                     console_api::RelayState {
-                        referer: Some("/some/actual/nexus/url".to_string()),
+                        redirect_uri: Some(
+                            "/some/actual/nexus/url".to_string(),
+                        ),
                     }
                     .to_encoded()
                     .unwrap(),

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -129,7 +129,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
             client,
             Method::GET,
             &format!(
-                "/login/{}/saml/{}",
+                "/login/{}/saml/{}/redirect",
                 silo.identity.name, silo_saml_idp.identity.name
             ),
         )
@@ -332,7 +332,10 @@ async fn test_create_a_hidden_silo_saml_idp(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!("/login/hidden/saml/{}", silo_saml_idp.identity.name),
+            &format!(
+                "/login/hidden/saml/{}/redirect",
+                silo_saml_idp.identity.name
+            ),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -550,7 +550,7 @@ async fn test_deleting_a_silo_deletes_the_idp(
             client,
             Method::GET,
             &format!(
-                "/login/{}/saml/{}",
+                "/login/{}/saml/{}/redirect",
                 SILO_NAME, silo_saml_idp.identity.name
             ),
         )
@@ -1936,7 +1936,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         client,
         StatusCode::NOT_FOUND,
         Method::GET,
-        "/login/fixed/saml/foo",
+        "/login/fixed/saml/foo/redirect",
     )
     .execute()
     .await

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -606,7 +606,10 @@ async fn test_saml_idp_metadata_data_valid(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!("/login/blahblah/saml/{}", silo_saml_idp.identity.name),
+            &format!(
+                "/login/blahblah/saml/{}/redirect",
+                silo_saml_idp.identity.name
+            ),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -53,7 +53,6 @@ API operations found with tag "login"
 OPERATION ID                             METHOD   URL PATH
 login_local                              POST     /v1/login/{silo_name}/local
 login_saml                               POST     /login/{silo_name}/saml/{provider_name}
-login_saml_begin                         GET      /login/{silo_name}/saml/{provider_name}
 
 API operations found with tag "policy"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,5 +1,4 @@
 API endpoints with no coverage in authz tests:
-login_saml_begin                         (get    "/login/{silo_name}/saml/{provider_name}")
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")
 device_access_token                      (post   "/device/token")

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -125,6 +125,14 @@
             "schema": {
               "$ref": "#/components/schemas/Name"
             }
+          },
+          {
+            "in": "query",
+            "name": "redirect_uri",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -102,61 +102,6 @@
       }
     },
     "/login/{silo_name}/saml/{provider_name}": {
-      "get": {
-        "tags": [
-          "login"
-        ],
-        "summary": "Prompt user login",
-        "description": "Either display a page asking a user for their credentials, or redirect them to their identity provider.",
-        "operationId": "login_saml_begin",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "provider_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          },
-          {
-            "in": "path",
-            "name": "silo_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          },
-          {
-            "in": "query",
-            "name": "redirect_uri",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "302": {
-            "description": "redirect (found)",
-            "headers": {
-              "location": {
-                "description": "HTTP \"Location\" header",
-                "style": "simple",
-                "required": true,
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
       "post": {
         "tags": [
           "login"


### PR DESCRIPTION
When you get logged out in the console or get linked to a page while not logged in (like `/device/verify` for authenticating in the CLI), we want to send you somewhere you can log in and, after you succeed, we want to send you back where you were trying to go. In order to do that, we need to keep track of the original target page and hold onto it through the login process. 

With local login, this is easy: in the case of a server-side 401, we take the current path, and redirect to `/login/{silo}/local?redirect_uri={path}`, which loads a console page that handles username/password login through a background API call. When the login POST comes back successful, we pull the target path from the `state` query param and nav to it client-side ([console source](https://github.com/oxidecomputer/console/blob/d52e87d69877e9dd63254dfa44ef8c284a2d3518/app/pages/LoginPage.tsx#L29-L36)). (We need to make sure you can't link someone to `oxide-rack.com/login/{silo}/local?redirect_uri=https://evil.com/virus` — see to-do list below.) A client-side 401 is almost the same, except there's one more step at the beginning where we nav to `/login?redirect_uri={current_path}`, and then that handler sends you to local or SAML login as appropriate, making sure to pass along the `state` param (very important!).

With SAML login it's slightly more complicated because we need to send the target URL over to the IdP using SAML's `RelayState` concept and they will send it back with the login POST. Most of that is already in place, so the main thing this change does is pull the target URL from the `state` query param server side instead of the `referer` header and stick it in the `RelayState` we get back from the IdP on login.

### What's in here

- [x] Move existing redirect to IdP logic from `/login/{silo}/saml/{provider}` to `/login/{silo}/saml/{provider}/redirect`, `/login/{silo}/saml/{provider}` now serves console landing page
- [x] Get post-login redirect URL from `state` query param instead of `referer` header
- [x] Rename `state` param to `redirect_uri` and use that in both the query params and the RelayState object
- [x] Validate that `redirect_uri` is a relative path to prevent someone being given a login link with an arbitrary URL 45e2fbe93bef09a1c04ecc8ccee79b221ef3d5ed
- [x] Better tests, probably
-  ~~Change state param from path to full URL per this comment~~ Relative URIs are valid in a 302 response Location header ([RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2)). I wrote that comment because I thought the IdP would be returning a redirect to Nexus, but it seems they post to Nexus from the browser, and browsers resolve a relative Location against the request URI
    https://github.com/oxidecomputer/omicron/blob/8a1fbdfb8244d232274ee03d82a47b3186b89cf4/nexus/src/external_api/console_api.rs#L593-L599

### Why not the `referer` header

`referer` certainly does sound like the natural choice, but browser behavior around it is inconsistent, especially in the case of multiple redirects. When you run into a 401 client-side (like if your session expired), the console uses `window.location.assign` to send the user to `/login` on Nexus, which will return a redirect to either `/login/{silo}/local` or `/login/{silo}/saml/{idp}` depending on the silo.

https://github.com/oxidecomputer/omicron/blob/8a1fbdfb8244d232274ee03d82a47b3186b89cf4/nexus/src/external_api/console_api.rs#L559-L577

In theory the original `referer` should be passed through those redirects and accessible on the final page, but I don't see it when I test it manually. I might do more testing, but overall I don't trust it. It's browser-specific, who knows what could happen. For now I think it's more reliable to use a query param we fully control.
