### PR TITLE
Remove `silo` path param from login endpoints

### DIFF
--- a/end-to-end-tests/src/helpers/ctx.rs
+++ b/end-to-end-tests/src/helpers/ctx.rs
@@ -196,8 +196,7 @@ pub async fn build_client() -> Result<oxide_client::Client> {
     let client_params = ClientParams::new()?;
     let config = &client_params.rss_config;
     let base_url = client_params.base_url();
-    let silo_name = config.recovery_silo.silo_name.as_str();
-    let login_url = format!("{}/v1/login/{}/local", base_url, silo_name);
+    let login_url = format!("{}/v1/login/local", base_url);
     let username: oxide_client::types::UserId =
         config.recovery_silo.user_name.as_str().parse().map_err(|s| {
             anyhow!("parsing configured recovery user name: {:?}", s)

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -687,11 +687,7 @@ impl SiloCert {
 
     /// Returns the full URL to the login endpoint for this Silo
     fn login_url(&self, port: u16) -> String {
-        format!(
-            "{}/v1/login/{}/local",
-            &self.base_url(port),
-            &self.silo_name.as_str()
-        )
+        format!("{}/v1/login/local", &self.base_url(port),)
     }
 
     /// Returns a new `ReqwestClientBuilder` that's configured to trust this

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -71,10 +71,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
         .expect_status(Some(StatusCode::FOUND))
         .expect_response_header(
             header::LOCATION,
-            &format!(
-                "/login/{}/local?redirect_uri=%2Fdevice%2Fverify",
-                cptestctx.silo_name
-            ),
+            "/login/local?redirect_uri=%2Fdevice%2Fverify",
         )
         .execute()
         .await

--- a/nexus/tests/integration_tests/rack.rs
+++ b/nexus/tests/integration_tests/rack.rs
@@ -59,10 +59,9 @@ async fn test_rack_initialization(cptestctx: &ControlPlaneTestContext) {
     // provide when setting up the rack (when setting up the
     // ControlPlaneTestContext).  We use the status code to verify a successful
     // login.
-    let login_url = format!("/v1/login/{}/local", cptestctx.silo_name);
     let username = cptestctx.user_name.clone();
     let password: params::Password = TEST_SUITE_PASSWORD.parse().unwrap();
-    let _ = RequestBuilder::new(&client, Method::POST, &login_url)
+    let _ = RequestBuilder::new(&client, Method::POST, "/v1/login/local")
         .body(Some(&params::UsernamePasswordCredentials { username, password }))
         .expect_status(Some(StatusCode::NO_CONTENT))
         .execute()

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -11,7 +11,7 @@ use omicron_nexus::authn::silos::{
     IdentityProviderType, SamlIdentityProvider, SamlLoginPost,
 };
 use omicron_nexus::external_api::console_api;
-use omicron_nexus::external_api::views::{self, Silo};
+use omicron_nexus::external_api::views;
 use omicron_nexus::external_api::{params, shared};
 use omicron_nexus::TestInterfaces;
 
@@ -38,16 +38,6 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     const SILO_NAME: &str = "saml-silo";
     create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
-    let silo: Silo = NexusRequest::object_get(
-        &client,
-        &format!("/v1/system/silos/{}", SILO_NAME,),
-    )
-    .authn_as(AuthnMode::PrivilegedUser)
-    .execute()
-    .await
-    .expect("failed to make request")
-    .parsed_body()
-    .unwrap();
 
     let saml_idp_descriptor = SAML_IDP_DESCRIPTOR;
 
@@ -128,10 +118,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!(
-                "/login/{}/saml/{}/redirect",
-                silo.identity.name, silo_saml_idp.identity.name
-            ),
+            &format!("/login/saml/{}/redirect", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )
@@ -332,10 +319,7 @@ async fn test_create_a_hidden_silo_saml_idp(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!(
-                "/login/hidden/saml/{}/redirect",
-                silo_saml_idp.identity.name
-            ),
+            &format!("/login/saml/{}/redirect", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )
@@ -998,10 +982,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!(
-                "/login/{}/saml/some-totally-real-saml-provider",
-                SILO_NAME
-            ),
+            "/login/saml/some-totally-real-saml-provider",
         )
         .raw_body(Some(
             serde_urlencoded::to_string(SamlLoginPost {
@@ -1129,10 +1110,7 @@ async fn test_post_saml_response_with_relay_state(
         RequestBuilder::new(
             client,
             Method::POST,
-            &format!(
-                "/login/{}/saml/some-totally-real-saml-provider",
-                SILO_NAME
-            ),
+            "/login/saml/some-totally-real-saml-provider",
         )
         .raw_body(Some(
             serde_urlencoded::to_string(SamlLoginPost {

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -549,10 +549,7 @@ async fn test_deleting_a_silo_deletes_the_idp(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!(
-                "/login/{}/saml/{}/redirect",
-                SILO_NAME, silo_saml_idp.identity.name
-            ),
+            &format!("/login/saml/{}/redirect", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::NOT_FOUND)),
     )
@@ -606,10 +603,7 @@ async fn test_saml_idp_metadata_data_valid(
         RequestBuilder::new(
             client,
             Method::GET,
-            &format!(
-                "/login/blahblah/saml/{}/redirect",
-                silo_saml_idp.identity.name
-            ),
+            &format!("/login/saml/{}/redirect", silo_saml_idp.identity.name),
         )
         .expect_status(Some(StatusCode::FOUND)),
     )
@@ -1936,7 +1930,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         client,
         StatusCode::NOT_FOUND,
         Method::GET,
-        "/login/fixed/saml/foo/redirect",
+        "/login/saml/foo/redirect",
     )
     .execute()
     .await
@@ -1948,7 +1942,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         client,
         StatusCode::NOT_FOUND,
         Method::POST,
-        "/login/fixed/saml/foo",
+        "/login/saml/foo",
     )
     .execute()
     .await

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -51,8 +51,8 @@ instance_view                            GET      /v1/instances/{instance}
 
 API operations found with tag "login"
 OPERATION ID                             METHOD   URL PATH
-login_local                              POST     /v1/login/{silo_name}/local
-login_saml                               POST     /login/{silo_name}/saml/{provider_name}
+login_local                              POST     /v1/login/local
+login_saml                               POST     /login/saml/{provider_name}
 
 API operations found with tag "policy"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -2,6 +2,6 @@ API endpoints with no coverage in authz tests:
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")
 device_access_token                      (post   "/device/token")
-login_saml                               (post   "/login/{silo_name}/saml/{provider_name}")
-login_local                              (post   "/v1/login/{silo_name}/local")
+login_saml                               (post   "/login/saml/{provider_name}")
+login_local                              (post   "/v1/login/local")
 logout                                   (post   "/v1/logout")

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -101,7 +101,7 @@
         }
       }
     },
-    "/login/{silo_name}/saml/{provider_name}": {
+    "/login/saml/{provider_name}": {
       "post": {
         "tags": [
           "login"
@@ -112,14 +112,6 @@
           {
             "in": "path",
             "name": "provider_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          },
-          {
-            "in": "path",
-            "name": "silo_name",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Name"
@@ -2124,23 +2116,13 @@
         }
       }
     },
-    "/v1/login/{silo_name}/local": {
+    "/v1/login/local": {
       "post": {
         "tags": [
           "login"
         ],
         "summary": "Authenticate a user via username and password",
         "operationId": "login_local",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "silo_name",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Name"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
We don't need silo in the paths now that we have it from DNS. This is on top of #3318, but it'll reset to being based on main once that's merged. The tests are doing surprisingly well on the first try, but there might need to be some tweaks to tests that work on multiple silos.