### PR TITLE
[wicketd] Add periodic check for sled agent bootstrap addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9217,6 +9217,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "clap 4.3.4",
+ "ddm-admin-client",
  "debug-ignore",
  "display-error-chain",
  "dropshot",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -107,6 +107,30 @@
         }
       }
     },
+    "/bootstrap-sleds": {
+      "get": {
+        "summary": "Get wicketd's current view of all sleds visible on the bootstrap network.",
+        "operationId": "get_bootstrap_sleds",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstrapSledIps"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/clear-update-state/{type}/{slot}": {
       "post": {
         "summary": "Resets update state for a sled.",
@@ -664,26 +688,52 @@
       "BootstrapSledDescription": {
         "type": "object",
         "properties": {
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          },
+          "bootstrap_ip": {
+            "nullable": true,
+            "description": "The sled's bootstrap address, if the host is on and we've discovered it on the bootstrap network.",
+            "type": "string",
+            "format": "ipv6"
+          },
           "id": {
             "$ref": "#/components/schemas/SpIdentifier"
-          },
-          "model": {
-            "type": "string"
-          },
-          "revision": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "serial_number": {
-            "type": "string"
           }
         },
         "required": [
-          "id",
-          "model",
-          "revision",
-          "serial_number"
+          "baseboard",
+          "id"
+        ]
+      },
+      "BootstrapSledIp": {
+        "type": "object",
+        "properties": {
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          },
+          "ip": {
+            "type": "string",
+            "format": "ipv6"
+          }
+        },
+        "required": [
+          "baseboard",
+          "ip"
+        ]
+      },
+      "BootstrapSledIps": {
+        "type": "object",
+        "properties": {
+          "sleds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BootstrapSledIp"
+            }
+          }
+        },
+        "required": [
+          "sleds"
         ]
       },
       "CertificateUploadResponse": {

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -74,7 +74,16 @@ pub enum SledMode {
 
 /// Describes properties that should uniquely identify a Gimlet.
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+    Clone,
+    Debug,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    JsonSchema,
 )]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Baseboard {

--- a/wicketd-client/src/lib.rs
+++ b/wicketd-client/src/lib.rs
@@ -37,6 +37,7 @@ progenitor::generate_api!(
         Ipv4Range = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
         Ipv6Range = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
         IpRange = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
+        Baseboard = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
         BootstrapSledDescription = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
         RackNetworkConfig = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },
         CurrentRssUserConfigInsensitive = { derives = [ PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize ] },

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -36,6 +36,7 @@ toml.workspace = true
 uuid.workspace = true
 
 bootstrap-agent-client.workspace = true
+ddm-admin-client.workspace = true
 gateway-client.workspace = true
 installinator-artifactd.workspace = true
 installinator-common.workspace = true

--- a/wicketd/src/bootstrap_addrs.rs
+++ b/wicketd/src/bootstrap_addrs.rs
@@ -1,0 +1,175 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ddm_admin_client::Client as DdmAdminClient;
+use futures::stream::FuturesUnordered;
+use sled_hardware::underlay::BootstrapInterface;
+use sled_hardware::Baseboard;
+use slog::warn;
+use slog::Logger;
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
+
+pub(crate) struct BootstrapPeers {
+    // We use a standard mutex here, not a tokio mutex, even though this is
+    // shared with a tokio task. We only keep it locked long enough to insert a
+    // new entry or clone it.
+    sleds: Arc<Mutex<BTreeMap<Baseboard, Ipv6Addr>>>,
+    inner_task: JoinHandle<()>,
+}
+
+impl Drop for BootstrapPeers {
+    fn drop(&mut self) {
+        self.inner_task.abort();
+    }
+}
+
+#[allow(dead_code)] // TODO REMOVE
+impl BootstrapPeers {
+    pub(crate) fn new(log: &Logger) -> Self {
+        let log = log.new(slog::o!("component" => "BootstrapPeers"));
+        let sleds = Arc::default();
+        let inner_task = tokio::spawn(scan_for_peers(Arc::clone(&sleds), log));
+        Self { sleds, inner_task }
+    }
+
+    pub(crate) fn sleds(&self) -> BTreeMap<Baseboard, Ipv6Addr> {
+        self.sleds.lock().unwrap().clone()
+    }
+}
+
+async fn scan_for_peers(
+    sleds: Arc<Mutex<BTreeMap<Baseboard, Ipv6Addr>>>,
+    log: Logger,
+) {
+    // How frequently do we attempt to refresh the set of peers? This does not
+    // count the time it takes to do each refresh, which is potentially
+    // significant if any prefixes reported by DDM are not running responsive
+    // sled-agents, since we'll wait for them to time out.
+    const SLEEP_BETWEEN_REFRESH: Duration = Duration::from_secs(30);
+
+    let ddm_client = make_ddm_admin_client(&log).await;
+
+    // We only share `sleds` with the `BootstrapPeers` that created us, and it
+    // only ever reads the current value: we are the only one that changes it.
+    // We keep the previous version we set it to so if the set of addresses
+    // remains unchanged (which we expect nearly all the time), we don't bother
+    // locking and copying the new set in.
+    let mut prev_sleds = None;
+    loop {
+        // Ask mg-ddm for a list of bootstrap address prefixes.
+        let addrs = possible_sled_agent_addrs(&ddm_client, &log).await;
+
+        // Query the sled-agent on each prefix for its baseboard, dropping any
+        // addresses that fail to return.
+        let mut addrs_to_sleds = addrs
+            .map(|ip| {
+                let log = &log;
+                async move {
+                    let client = bootstrap_agent_client::Client::new(
+                        &format!("http://[{ip}]"),
+                        log.clone(),
+                    );
+                    let result = client.baseboard_get().await;
+
+                    (ip, result)
+                }
+            })
+            .collect::<FuturesUnordered<_>>();
+
+        let mut all_sleds = BTreeMap::new();
+        while let Some((ip, result)) = addrs_to_sleds.next().await {
+            match result {
+                Ok(baseboard) => {
+                    // Convert from progenitor type back to `sled-hardware`
+                    // type.
+                    let baseboard = match baseboard.into_inner() {
+                        bootstrap_agent_client::types::Baseboard::Gimlet {
+                            identifier,
+                            model,
+                            revision,
+                        } => Baseboard::new_gimlet(identifier, model, revision),
+                        bootstrap_agent_client::types::Baseboard::Unknown => {
+                            Baseboard::unknown()
+                        }
+                        bootstrap_agent_client::types::Baseboard::Pc {
+                            identifier,
+                            model,
+                        } => Baseboard::new_pc(identifier, model),
+                    };
+
+                    all_sleds.insert(baseboard, ip);
+                }
+                Err(err) => {
+                    warn!(
+                        log, "Failed to get baseboard for {ip}";
+                        "err" => #%err,
+                    );
+                }
+            }
+        }
+
+        // Did our set of peers change? If so, update both `sleds` (shared with
+        // our parent `BootstrapPeers`) and `prev_sleds` (our local cache).
+        if Some(&all_sleds) != prev_sleds.as_ref() {
+            *sleds.lock().unwrap() = all_sleds.clone();
+            prev_sleds = Some(all_sleds);
+        }
+
+        tokio::time::sleep(SLEEP_BETWEEN_REFRESH).await;
+    }
+}
+
+async fn possible_sled_agent_addrs(
+    ddm_client: &DdmAdminClient,
+    log: &Logger,
+) -> impl Iterator<Item = Ipv6Addr> {
+    // TODO: Should we use `backoff` here instead of a loop/sleep? We're talking
+    // to a service's admin interface on localhost within our own switch zone,
+    // and we're only asking for its current state. Backoff should be
+    // unnecessary, I think?
+    const RETRY: Duration = Duration::from_secs(5);
+
+    loop {
+        match ddm_client
+            .derive_bootstrap_addrs_from_prefixes(&[
+                BootstrapInterface::GlobalZone,
+            ])
+            .await
+        {
+            Ok(addrs) => return addrs,
+            Err(err) => {
+                warn!(
+                    log, "Failed to get prefixes from ddm";
+                    "err" => #%err,
+                );
+                tokio::time::sleep(RETRY).await;
+            }
+        }
+    }
+}
+
+async fn make_ddm_admin_client(log: &Logger) -> DdmAdminClient {
+    const DDM_CONSTRUCT_RETRY: Duration = Duration::from_secs(1);
+
+    // We don't really expect this to fail ever, so just keep retrying
+    // indefinitely if it does.
+    loop {
+        match DdmAdminClient::localhost(log) {
+            Ok(client) => return client,
+            Err(err) => {
+                warn!(
+                    log, "Failed to construct DdmAdminClient";
+                    "err" => #%err,
+                );
+                tokio::time::sleep(DDM_CONSTRUCT_RETRY).await;
+            }
+        }
+    }
+}

--- a/wicketd/src/context.rs
+++ b/wicketd/src/context.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::bootstrap_addrs::BootstrapPeers;
 use crate::rss_config::CurrentRssConfig;
 use crate::update_tracker::UpdateTracker;
 use crate::MgsHandle;
@@ -16,6 +17,7 @@ use sled_hardware::Baseboard;
 pub struct ServerContext {
     pub mgs_handle: MgsHandle,
     pub mgs_client: gateway_client::Client,
+    pub(crate) bootstrap_peers: BootstrapPeers,
     pub(crate) update_tracker: Arc<UpdateTracker>,
     pub(crate) baseboard: Option<Baseboard>,
     pub(crate) rss_config: Mutex<CurrentRssConfig>,

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod artifacts;
+mod bootstrap_addrs;
 mod config;
 mod context;
 mod http_entrypoints;
@@ -14,6 +15,7 @@ mod update_tracker;
 
 use anyhow::{anyhow, Result};
 use artifacts::{WicketdArtifactServer, WicketdArtifactStore};
+use bootstrap_addrs::BootstrapPeers;
 pub use config::Config;
 pub(crate) use context::ServerContext;
 pub use installinator_progress::{IprUpdateTracker, RunningUpdateState};
@@ -97,6 +99,8 @@ impl Server {
             ipr_update_tracker.clone(),
         ));
 
+        let bootstrap_peers = BootstrapPeers::new(&log);
+
         let wicketd_server = {
             let log = log.new(o!("component" => "dropshot (wicketd)"));
             let mgs_client = make_mgs_client(log.clone(), args.mgs_address);
@@ -106,6 +110,7 @@ impl Server {
                 ServerContext {
                     mgs_handle,
                     mgs_client,
+                    bootstrap_peers,
                     update_tracker: update_tracker.clone(),
                     baseboard: args.baseboard,
                     rss_config: Default::default(),


### PR DESCRIPTION
RSS wants to know the bootstrap addresses of the sleds to include; this PR teaches wicketd how to find them. It also updates the wicket TOML config introduced in #3326 to include the sled's bootstrap address (if known) in a comment in the sled list; I'm unsure if this is something we'll want to keep once customers are running RSS, but it seems handy for debugging for now.

Builds on #3326.