### PR TITLE
document repo structure and goals a bit better

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,7 +51,7 @@ You can **run the https://github.com/rust-lang/rust-clippy[Clippy linter]** usin
 
 == Working in Omicron
 
-Omicron is a pretty large repo containing a bunch of related components.  If you just build the whole thing with `cargo build` or `cargo test`, it can take a while, even for incremental builds.  Since most people are only working on a few of these components at a time, it's helpful to be know about Cargo's tools for working with individual packages in a workspace.
+Omicron is a pretty large repo containing a bunch of related components.  (Why?  See xref:docs/repo.adoc[].)  If you just build the whole thing with `cargo build` or `cargo test`, it can take a while, even for incremental builds.  Since most people are only working on a few of these components at a time, it's helpful to be know about Cargo's tools for working with individual packages in a workspace.
 
 NOTE: This section assumes you're already familiar with the prerequisites and environment setup needed to do _any_ work on Omicron.  See xref:docs/how-to-run-simulated.adoc[] or xref:docs/how-to-run.adoc[] for more on that.
 
@@ -239,88 +239,6 @@ Both of these will cause Cargo to make many more changes (relative to "main") th
 
 You can also resolve conflicts by hand.  It's tedious and error-prone.
 
-
-== Configuration reference
-
-`nexus` requires a TOML configuration file.  There's an example in
-xref:nexus/examples/config.toml[].
-
-Supported config properties include:
-
-[cols="1,1,1,3",options="header"]
-|===
-|Name
-|Example
-|Required?
-|Description
-
-|`database.url`
-|`"postgresql://root@127.0.0.1:32221/omicron?sslmode=disable"`
-|Yes
-|URL identifying the CockroachDB instance(s) to connect to.  CockroachDB is used for all persistent data.
-
-|`dropshot_external`
-|
-|Yes
-|Dropshot configuration for the external server (i.e., the one that operators and developers using the Oxide rack will use).  Specific properties are documented below, but see the Dropshot README for details. Note that this is an array of external address configurations; multiple may be supplied.
-
-|`dropshot_external.bind_address`
-|`"127.0.0.1:12220"`
-|Yes
-|Specifies that the server should bind to the given IP address and TCP port for the **external** API (i.e., the one that operators and developers using the Oxide rack will use).  In general, servers can bind to more than one IP address and port, but this is not (yet?) supported.
-
-|`dropshot_external.request_body_max_bytes`
-|`1000`
-|Yes
-|Specifies the maximum request body size for the **external** API.
-
-|`dropshot_internal`
-|
-|Yes
-|Dropshot configuration for the internal server (i.e., the one used by the sled agent).  Specific properties are documented below, but see the Dropshot README for details.
-
-|`dropshot_internal.bind_address`
-|`"127.0.0.1:12220"`
-|Yes
-|Specifies that the server should bind to the given IP address and TCP port for the **internal** API (i.e., the one used by the sled agent).  In general, servers can bind to more than one IP address and port, but this is not (yet?) supported.
-
-|`dropshot_internal.request_body_max_bytes`
-|`1000`
-|Yes
-|Specifies the maximum request body size for the **internal** API.
-
-|`id`
-|`"e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"`
-|Yes
-|Unique identifier for this Nexus instance
-
-|`log`
-|
-|Yes
-|Logging configuration.  Specific properties are documented below, but see the Dropshot README for details.
-
-|`log.mode`
-|`"file"`
-|Yes
-|Controls where server logging will go.  Valid modes are `"stderr-terminal"` and `"file".  If the mode is `"stderr-terminal"`, human-readable output, with colors and other terminal formatting if possible, will be sent to stderr.  If the mode is `"file"`, Bunyan-format output will be sent to the filesystem path given by `log.path`.  See also `log.if_exists`, which controls the behavior if the destination path already exists.
-
-|`log.level`
-|`"info"`
-|Yes
-|Specifies what severity of log messages should be included in the log.  Valid values include `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, and `"critical"`, which are increasing order of severity.  Log messages at the specified level and more severe levels will be included in the log.
-
-|`log.path`
-|`"logs/server.log"`
-|Only if `log.mode = "file"`
-|If `log.mode` is `"file"`, this property determines the path to the log file.
-See also `log.if_exists`.
-
-|`log.if_exists`
-|`"append"`
-|Only if `log.mode = "file"`
-|If `log.mode` is `"file"`, this property specifies what to do if the destination log file already exists.  Valid values include `"append"` (which appends to the existing file), `"truncate"` (which truncates the existing file and then uses it as though it had just been created), and `"fail"` (which causes the server to exit immediately with an error).
-
-|===
 
 === Configuring ClickHouse
 

--- a/docs/repo.adoc
+++ b/docs/repo.adoc
@@ -1,0 +1,104 @@
+:showtitle:
+:numbered:
+:toc: left
+
+= Omicron repository
+
+The Omicron git repo is a _consolidation_ of several different components that work together but are deployed separately.  Developers new to Omicron can get tripped up by the size and complexity of the repo.  The README contains a bunch of tips for working in Omicron, including how to iterate more quickly by only building parts of it.  This document explains more about why the repo is structured the way it is.
+
+== History
+
+(from @davepacheco's perspective)
+
+Many of the early decisions around Omicron's repo came directly from my experience working on Joyent's https://github.com/TritonDataCenter/manta[Manta], a distributed object store.  I'll describe this in some detail to illustrate the problems I was hoping to avoid.  Of course, none of this is intended as criticism of the people that worked on Manta.
+
+Architecturally, Manta wasfootnote:[Manta is still maintained today.  I use the past tense here since I'm describing my experience years ago.] made up of https://github.com/TritonDataCenter/manta#repositories[10] - https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/architecture.md#manta-components-at-a-glance[20] major top-level components, each housed in its own git repo.  Most of these were Node.js network services, mostly HTTP.  Between these top-level components and the smaller components shared across services, there were https://github.com/TritonDataCenter/manta/blob/master/tools/jr-manifest.json[over 100 git repos] that made up the whole system.  We can mostly focus on the 10-20 top-level components.  The important thing is that every deployed component had its own repo.
+
+Since we had so many repos, we had a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md[guide] that described, among other things, uniform patterns for structuring repos and providing style and lint checks (via `make check`) and standard ways to run tests (`make test`).  Much latitude was given to repo owners about exactly how to implement this, but we created a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md#writing-makefiles[library of Makefiles] that could be dropped into each repo to minimize boilerplate and ensure the standard stuff worked (e.g., `make check`, `make test`, etc.).
+
+In the early years, about a dozen people worked heavily on Manta.  Most people worked only on a couple of different repos at that time.  After its launch and several years went by, for various reasons, Manta became less important to the company and the team shrunk to just one person.  I spent 1-2 years keeping the lights on, during which I wound up making changes in virtually every part of the system.  Then suddenly, interest in Manta surged rather quickly: within a year or two, the team was spun up to a few dozen people, together working all over the system.
+
+By this point, I really started to appreciate that it was _hard_ and _slow_ to work on Manta.  I knew a big part of that was the lack of test infrastructure.  But it was much more than that.  When someone walked up to a repo that they hadn't seen before:
+
+* It was often unclear how to set up a development environment to work on the repo.  Even though in principle you could walk up to any repo and run `make`, that would depend on your environment having been set up properly.  That might include having installed various commands, native libraries, etc. or environment variables to be set.
+** It was different across repos.
+** It was often not documented.
+** The failure mode was often baffling (e.g., `node` reporting a syntax error because the repo assumed a different version of Node than was found on your PATH).
+* It was often unclear how to run tests.  Again, in principle it was just `make test`, but in practice, you had all the problems above about setting up a development environment, plus a bunch of runtime dependencies like "you must set SOME_DEP_NAME=localhost:12345 in the environment to point at a running instance of a dependency".
+** Again, the specific steps would differ across repos and were often undocumented.
+** The failure modes could be baffling.
+** To give an example of the inconsistency, some repos might use DEP_HOST as a hostname [and port] of some dependency, and another repo might use the same environment variable but expected it to be a full HTTP URL.  When you got it wrong, you might just see an error about being unable to resolve a host.
+** **This problem is recursive:** once you learn you need to run a copy of $dependency, you have all the same challenges associated with getting that thing to run.
+* Even once you knew what you were doing, it was still annoying to run the tests.  As mentioned, you often had to set up your own running version of various dependencies.  There were a bunch of manual steps here that were easy to get wrong.  (Forgot to update the local clone of $dependency that you had lying around?  Oops!  You tested the wrong thing.)
+* It was also annoying to write new tests.
+** If you were building something new, you would typically establish your own requirements around environment variables, etc. for talking to dependencies.  Hopefully you'd document them to avoid the problems above.
+** Since the tests often assumed the service was already running and some environment variable was pointing at it, you'd always run the risk that the service had state left over from other tests, or that other tests would interfere with your test.
+** For the same reason, there wasn't a great way to write tests that involved crashing or restarting the service.
+* We had okay documentation about setting up and testing the system as a whole.  But since each component was in its own repo, the overall documentation didn't make sense to live in any one of those.  Instead, it wound up in a separate repo -- one that active developers would almost never need to reference.  It would often get out of date.
+* We had virtually no automated tests for the whole system, and none that involved setting up a whole system.  It wasn't clear where these tests would go.  It seems they'd have to go in a separate repo, which would make it even more annoying to write new tests and keep them updated.
+
+Note that all this is _despite_ having written standards around this stuff and even provided shareable implementations!  These didn't work because:
+
+* There was ambiguity about what "`make test` should run all the tests" means.  Are those unit tests or integration tests?  What do they assume about their environment?  Who is responsible for setting up and tearing down the thing being tested?
+* The Makefile library was useful, but initially people copied them into repos.  They would rarely get updated when things were fixed or new features added upstream.  Sometimes people would make local changes, making it harder to update them from upstream later.
+
+I didn't appreciate it at the time, but I (and many others, I'm sure) were downright _afraid_ to touch anything.  It was hard to know how to get started and even harder to know that you weren't breaking anything.  No wonder it took forever to make even simple changes to the system.footnote:[As an aside, a lot could be said here about how to proceed in these situations.  It's so tempting to try to change the smallest possible thing and get out of there.  But that only makes the problem worse.  The most satisfying work I did during these periods involved immersing myself in these gnarly areas, understanding them completely, and either documenting them or (more often) replacing them.]  This fear-based feedback loop (which kills motivation as well as progress) is bad enough, but there were other problems, too:
+
+* Particularly after most of the initial team left, the common state was that most repos would be idle for many months or even years at a time.  Often when you needed to update it, you'd find that:
+** It used a Node version from two unsupported LTS releases ago and Node had made many breaking changes since then.
+** It used ancient versions of various packages.  You might find some bug was already fixed in some dependency.  But between JavaScript's looseness at compile-time, incorrect use of semver among npm packages at large, general lack of documentation among npm packages about breaking changes, and our own mediocre test coverage, it could be _very_ challenging to update just one dependency.  With so many interconnected dependencies, it was easy to wind up in a situation where you had to move Node and dozens of packages across _years_ worth of breaking changes just to pull in some fix.
+** Again, you usually found yourself here because you were trying to make one change to a component that had otherwise remained unchanged (and working!) for _years_.  It felt like losing a game of hot potato.
+* If we needed to update some component (even just those Makefiles), we'd need to make the change in literally dozens of places.  Probably the best example is when we built Cueball, a sophisticated library for service discovery and connection management.  A component in the frontend web server might need to use this in a half dozen different places, some of them several layers of dependency deep.  Across the stack, even when making a fully compatible change, we might have to update the dependency in dozens of repos.
+
+== Trying to do things differently
+
+We did a bunch of things differently to try to avoid these problems in Omicron.  Here are some design goals:
+
+* We should have clear instructions for setting up a development environment.  To the extent possible, we should make sure these get tested regularly.
+* The test suite should do everything possible to automate setup and teardown.  That includes spinning up and spinning down transient instances of any services that it depends on.  You don't set up any environment variables or configuration files to point your repo at some already-running service.
+* Individual tests should not need to worry about interference from other tests.  That includes things like TCP ports in use or stale state in dependent services.
+* A new developer cloning the repo and running Omicron should get the same software as any other developer and the CI environment.  (i.e., if tests pass for one developer on the tip of "main", it should pass for other developers as well as CI).
+* We should regularly keep dependencies (including Rust itself) up to date so that we don't suddenly find we need to make big leaps in these.
+* Where we have stable interfaces, we should make changelogs that describe for each breaking change how to know if you're affected and what you have to do to move past it.
+
+Towards these ends, here are some of the things we've done:
+
+
+* The dev environment setup process is https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#installing-prerequisites[documented and mostly automated].  That automation is tested regularly because CI uses the same script to go from a bare environment to one that build and tests Omicron.
+* We're using Rust, so quite a lot more is verifiable by just compiling the software.  (By comparison with JavaScript, it's _much_ less likely for a breaking change of a dependency to slip through CI.)
+* We use dependabot and Renovate to keep dependencies updated, including Rust itself.
+* We use rust-toolchain and Cargo.lock to ensure that developers are getting a consistent toolchain and packages as each other and CI.
+* Omicron houses many related components in one repo.
+** This gives us a clear place to put overall system documentation (README, ./docs at the root).
+** There's no issue of different dev environment steps for different repos since it's just one repo.  (There are _not_ specific steps for testing individual components within Omicron, either.)
+** The test suites for various components can depend on other components in the repo so that they can spin up transient instances of them for testing.  We've also invested in automation to spin up transient instances of most services: a standard `ControlPlaneTestContext` in the Nexus test suite spins up real instances of CockroachDB, Clickhouse, Nexus, and internal/external DNS; plus Sled Agent and parts of Crucible (mock servers).  All of this makes it very easy to write a new integration test that uses a great deal of the real stack.  This is also exposed through a command, `omicron-dev run-all`, so that you can spin all this up and play with interactively with just a few commands.
+** When we want to update a dependency used in many places, we can often just make one (git) change to update it everywhere.  (This doesn't solve the problem of _deploying_ all those changes, of course.)
+* Because we automated spin-up/spin-down of transient instances of most things, every Nexus integration test gets its own copy of everything (including the database), which means we don't have to worry about stomping on each other.  All server sockets use the pattern of binding to port 0 in the test suite (letting the OS pick the port), also so they don't stomp on each other or any other running software.
+* We do create https://github.com/oxidecomputer/dropshot/blob/main/CHANGELOG.adoc#090-released-2023-01-20[changelogs] that describe for each breaking change how to know if you're affected and what you have to do to move past it.
+
+These are all related: using dependabot for keeping dependencies up to date is only tenable _because_ Rust is so well statically-checked (so the build usually breaks when a dependency makes a breaking change) and we have good test coverage so that it's generally fair to say that if CI passes, the change didn't break Omicron.  This is hard to know, but I strongly believe we have good test coverage in large part _because_ it's relatively easy to write tests.  It's easy to write tests in part because they're in the same repo as the software, they operate on their own isolated copies of the stack, etc.
+
+== Has it worked?
+
+It's apples-and-oranges to compare Manta with Omicron because they're two totally different systems built largely by separately people years apart in two very different environments.  But it's still a meaningful data point.  For _most_ of Omicron: I'm not afraid to wade into it.  (You might think that's because I'm familiar with all of Omicron already.  That's not the case!)  We have quite a few people regularly doing a lot of work in Omicron.  We update dozens of dependencies per week (and keep everything up to date).
+
+It's not all roses.  Much of the system can be worked on and tested very thoroughly using the automated tests, but not all of it.  Sled Agent by nature takes over whatever system it's managing, and the resources it manages are not themselves virtualized, so it's not possible to fully test it outside of, say, giving it a whole VM.  (That said, I've made many changes to Sled Agent that I knew would be correct by virtue of them compiling.  That's _not_ saying "if it compiles, it works" in general, but there are many mundane refactoring-type changes for which that is true.)  Networking is another area where it seems hard to automate testing in the way we've described above without a much richer virtualized environment.
+
+There are downsides of this approach.  Mainly: a large repo can be hard to work with:
+
+* It can be hard to find the stuff you need.
+* If you try to build the whole thing, it can take a while.  There are tools for building parts of it.  People don't always know about these.  And they have their own pitfalls, like the way workspace feature unification works.  (See "Working with Omicron" in the README.)
+* All things being equal, a larger repo repo means more developers in the same repo, meaning more more conflicts.
+* All things being equal, a full CI run takes longer, since it tests more.  (This can likely be mitigated with a merge queue, but we haven't tried that yet.)
+* Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're all set.  That's not true.  We need to consider when a newer client is deployed against an older server or vice versa.
+
+It's not clear that most of these would be better with separate repos, though:
+
+* With separate repos, it can be hard to find which _repo_ you need.
+* The problem with workspace feature unification is that when you change what package you're building, you might find Cargo unexpectedly rebuilding some common dependency.  If we used separate repos, Cargo would _always_ rebuild that dependency when you switched repos.
+* If components are truly unrelated, merge conflicts should be automatically resolved.
+* Given that we need to create tooling to ensure that we manage both sides of stable APIs, we don't _also_ need to make it harder to _make_ such API changes by requiring coordinated pushes to two separate repos.
+
+There are other annoying things about working on Omicron:
+
+* Dependabot is incredibly noisy and annoying to work with for various reasons.  These are mostly implementation issues, and we could probably improve it considerably if we want to invest time in setting it up better (e.g., having it merge into a separate branch and merge _that_ branch into main once a week or so).

--- a/docs/repo.adoc
+++ b/docs/repo.adoc
@@ -1,80 +1,67 @@
 :showtitle:
 :numbered:
-:toc: left
 
 = Omicron repository
 
 The Omicron git repo is a consolidation of several different components that work together but are deployed separately.  Developers new to Omicron can get tripped up by the size and complexity of the repo.  The README contains tips for working in Omicron, including how to iterate more quickly by only building parts of it.  This document explains more about why the repo is structured the way it is.  This largely comes from experience with previous systems that were similarly complicated but structured differently.
 
-== Design goals
+Overall, we want to make it easy and fast for people to iterate on Omicron, reflecting Oxide's values of teamwork, rigor, and urgency.  A lot of what we've done here seeks to cut out common causes of paper cuts and make it easy to write and run comprehensive tests so that we can quickly have high confidence in any software changes.
+
+Where we've fallen down, **please** let someone know by filing an issue!  It's easy for active developers to get used to various speed bumps or learn to work around them.  But we'd rather fix them to improve the experience for everyone.
+
+== Operating goals
 
 To help the development process, we seek:
 
-* to have clear, up-to-date, and regularly tested instructions for setting up a development environment from scratch.
+* to have clear and up-to-date https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#installing-prerequisites[instructions] for setting up a development environment from scratch.  Most of this is automated.  CI uses the same automation to go from a bare environment to one that builds and tests Omicron, so this automation is tested regularly with the rest of the repo.
 * to have clear instructions for basic activities like formatting code, running clippy, running tests, etc.  These should be consistent across components and across local development vs. CI.
-* to prioritize debugging and fixing flaky tests so that developers can always expect the tests to pass.
-* to ensure that a fresh clone and build of the repo should produce equivalent software to any other clone, including the CI environment.  If tests pass for one developer on the tip of "main", they should pass for other developers as well as CI.
+* to prioritize debugging and fixing flaky tests so that developers can always expect the tests to pass.  Failures don't necessarily need to be reproducible to debug them.  The test suite preserves trace-level log files and database contents from failed test runs.  You can inspect the database contents using `omicron-dev db-run` to spin up a transient database instance pointed at the saved database contents.
+* to ensure that a fresh clone and build of the repo should produce equivalent software to any other clone, including the CI environment.  If tests pass for one developer on the tip of "main", they should pass for other developers as well as CI.  We use rust-toolchain and Cargo.lock to ensure that developers are getting a consistent toolchain and packages as each other and CI.
 
-To make it easy to run tests, the test suite automates setup and teardown of the service under test _and_ other services that it depends on (rather than relying on error-prone manual steps to set these up).
+Omicron houses many related components in one repo:
+
+* There's a clear place to put overall system documentation, including how to set up one's dev environment.  This lives with the repo that people are regularly using (as opposed to a separate meta-repo).
+* There's a single set of steps for setting up your dev environment, formatting code, running clippy, and running tests, no matter which component(s) you're working on.  (To move faster, you can still operate on individual components rather than the whole repo.)
+* Various component test suites depend on other components in the repo so that they can spin up transient instances of them for testing.
+* When we want to update a dependency used in many places, we can often just make one (git) change to update it everywhere.  (This doesn't solve the problem of _deploying_ all those changes, of course.)
+
+To make it easy to run tests, the test suite automates setup and teardown of the service under test _and_ other services that it depends on (rather than relying on error-prone manual steps to set these up).  A standard `ControlPlaneTestContext` in the Nexus test suite spins up real instances of CockroachDB, Clickhouse, Nexus, and internal/external DNS; plus mock versions of Sled Agent and optionally parts of Crucible.  All of this makes it very easy to write a new integration test that uses a great deal of the real stack.  You can also spin all this up and poke around interactively using the `omicron-dev run-all` command.
 
 To make it easy to write comprehensive, reliable tests:
 
-* Individual tests generally don't need to worry about interference from other tests.  That includes things like TCP ports in use or stale state in dependent services.
+* Individual tests generally don't need to worry about interference from other tests.  Because spin-up/spin-down of these services is automated, every Nexus integration test gets its own copy of everything (including the database).  Server sockets use the pattern of binding to port 0 in the test suite (letting the OS pick a free port) so they don't collide with each other or any other running software.
 * With the above infrastructure for standing up transient instances of dependencies, it's possible to write end-to-end integration tests that exercise multiple components together with minimal boilerplate.
 
-We regularly keep dependencies (including Rust itself) up to date so that we don't suddenly find we need to make big leaps in these.
+We use automation (dependabot and Renovate) to keep dependencies (including Rust itself) up to date so that we don't suddenly find we need to make big leaps in these.
 
-Where we have stable interfaces, we seek to keep changelogs that describe for each breaking change how to know if you're affected and what you have to do to move past it.  These are written for maintainers of consumers, who might not be very familiar with a library's other recent changes or internal details.
-
----
-
-Here are some of things we've done towards these goals:
-
-* The dev environment setup process is https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#installing-prerequisites[documented and mostly automated].  CI uses this script to go from a bare environment to one that builds and tests Omicron, so this automation is tested regularly with the rest of the repo.
-* Omicron houses many related components in one repo.
-** There's a clear place to put overall system documentation, including how to set up one's dev environment.
-** There's a single set of steps for setting up your dev environment, formatting code, running clippy, and running tests, no matter which component(s) you're working on.  (You can still do any of this on individual components rather than the whole repo at once.)
-** Various component test suites depend on other components in the repo so that they can spin up transient instances of them for testing.
-** When we want to update a dependency used in many places, we can often just make one (git) change to update it everywhere.  (This doesn't solve the problem of _deploying_ all those changes, of course.)
-* We've automated the process to spin up transient instances of most services: a standard `ControlPlaneTestContext` in the Nexus test suite spins up real instances of CockroachDB, Clickhouse, Nexus, and internal/external DNS; plus mock versions of Sled Agent and parts of Crucible.  All of this makes it very easy to write a new integration test that uses a great deal of the real stack.  You can also spin all this up and poke around interactively using the `omicron-dev run-all` command.
-* Because spin-up/spin-down of these services is automated, every Nexus integration test gets its own copy of everything (including the database).  They don't have to worry about stomping on each other.  All server sockets use the pattern of binding to port 0 in the test suite (letting the OS pick the port), also so they don't stomp on each other or any other running software.
-* To help stamp out build flakes, we keep around debugging information for failed tests (e.g., trace-level log files, database contents, etc.).  There are tools for spinning up a transient database instance atop an existing database storage directory so that you can easily inspect the contents after a failed test.
-* We use dependabot and Renovate to keep dependencies updated, including Rust itself.
-* We use rust-toolchain and Cargo.lock to ensure that developers are getting a consistent toolchain and packages as each other and CI.
-* For many components used by Omicron, we create https://github.com/oxidecomputer/dropshot/blob/main/CHANGELOG.adoc#090-released-2023-01-20[changelogs] that describe for each breaking change how to know if you're affected and what you have to do to move past it.  (We don't yet do this for the tightly coupled components within Omicron.)
+For many components used by Omicron, we create https://github.com/oxidecomputer/dropshot/blob/main/CHANGELOG.adoc#090-released-2023-01-20[changelogs] that describe for each breaking change how to know if you're affected and what you have to do to move past it.  These are written for maintainers of consumers, who might not be very familiar with a library's other recent changes or internal details.  (We don't yet do this for the tightly coupled components within Omicron.)
 
 These are all related: using dependabot for keeping dependencies up to date is only tenable _because_ Rust is so well statically-checked (so the build usually breaks when a dependency makes a breaking change) and we have good test coverage so that it's generally fair to say that if CI passes, the change didn't break Omicron.  We have good test coverage in large part _because_ it's relatively easy to write reliable tests.  It's easy to write tests in part because they're in the same repo as the software, they operate on their own isolated copies of the stack, etc.
 
 == Caveats, downsides, alternatives
 
 Above we talk up the value of easy-to-run, easy-to-write, comprehensive automated tests.
-This doesn't work for everything.  Sled Agent by nature takes over whatever system it's managing, and the resources it manages are not themselves virtualized, so it's not possible to fully test it outside of, say, giving it a whole VM.  (That said, thanks to Rust, it _is_ possible to have confidence in many mundane refactoring-type changes just by virtue of them compiling.)  Networking is another area where it's hard to automate testing in the way we've described above without a much richer virtualized environment.
+This doesn't work for everything.  Sled Agent by nature takes over whatever system it's managing, and the resources it manages are not themselves virtualized, so it's not possible to fully test it outside of, say, giving it a whole VM.  (On the plus side, thanks to Rust, it _is_ possible to have confidence in many mundane refactoring-type changes just by virtue of them compiling.)  Networking is another area where it's hard to automate testing in the way we've described above without a much richer virtualized environment.
 
-A large, consolidated repo like Omicron has its downsides:
+A large, consolidated repo like Omicron has its downsides, though using separate repos doesn't address most of these problems:
 
-* It can be hard to find the stuff you need.
-* If you try to build the whole thing, it can take a while.  There are tools for building parts of it.  People don't always know about these.  And they have their own pitfalls, like the way workspace feature unification works.  (See "Working with Omicron" in the README.)
-* All things being equal, a larger repo repo means more developers in the same repo, meaning more merge conflicts.
-* All things being equal, a full CI run takes longer, since it tests more.  (This can likely be mitigated with a merge queue, but we haven't tried that yet.)
-* Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're all set.  That's not true.  We need to consider when a newer client is deployed against an older server and vice versa.
-
-The obvious alternative would be to use separate repos.  It's not clear this would address most of the above problems, though:
-
-* With separate repos, it can be hard to find which _repo_ you need.
-* The problem with workspace feature unification is that when you change what package you're building, you might find Cargo unexpectedly rebuilding some common dependency.  If we used separate repos, Cargo would _always_ rebuild that dependency when you switched repos.
-* Merge conflicts for truly unrelated changes should be automatically resolved.
-* Given that we need to create tooling to ensure that we manage both sides of stable APIs, we don't _also_ need to make it harder to _make_ such API changes by requiring coordinated pushes to two separate repos.
-
-Some of us have worked on large systems that used separate repos for deployed components, particularly Joyent's https://github.com/TritonDataCenter/manta[Manta].  In that specific case, we had a bunch of challenges that led to the design goals above:
-
-* There were https://github.com/TritonDataCenter/manta#repositories[10] - https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/architecture.md#manta-components-at-a-glance[20] major top-level components, and https://github.com/TritonDataCenter/manta/blob/master/tools/jr-manifest.json[over 100 git repos] in all.  We eventually built a meta-repo with documentation about the whole system.  But since the active developers never needed this, it was often out of date.
-* Each repo had its own process for setting up a development environment.  They would assume various tools on your PATH, but often not say where to get them or what version was required.  Even though almost all components used Node, they were bound to specific versions (due to fairly frequent breaking changes in Node), so you had to have the right version of Node on your path _for this repo_.
-* Updating a common dependency (including Node) across the board involved separately updating it in each repo.  This was harder in Node than in Rust because breaking API changes only fail at runtime.  Plus, test coverage wasn't great (for all the reasons mentioned here), so this cost was even higher.
-* Each repo had its own infrastructure for checking style and lint, running tests, etc.  Even though we had https://github.com/TritonDataCenter/eng/blob/master/docs/index.md[standardized on things like how to run these checks], and even provided a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md#writing-makefiles[library of Makefiles] to make it easy to stick to this interface, in practice, every repo assumed different things about its environment.  These assumptions were not always documented.  When things failed, they often did so in baffling ways.
-* Repo test suites generally assumed the developer had already started a copy of the service under test and any of its dependencies and had set some environment variables to point at it.
-
----
+* It can be hard to find the stuff you need.  With separate repos, it can be hard to find which _repo_ you need.
+* If you try to build the whole thing, it can take a while.  But you generally don't need to do this.  You can easily build subsets of it, though people don't always know about the Cargo options for doing that.  These have their own pitfalls, like the way workspace feature unification works.  (See "Working with Omicron" in the README.)  To run with that example: the problem with workspace feature unification is that when you change what package you're building, you might find Cargo unexpectedly rebuilding some common dependency.  If we used separate repos, Cargo would _always_ rebuild that dependency when you switched repos.
+* All things being equal, a larger repo means more developers in the same repo, meaning more merge conflicts.  But merge conflicts for unrelated changes should be automatically resolved.
+* All things being equal, a full CI run takes longer, since it tests more.  (This can likely be mitigated with a merge queue.  We haven't tried that yet.)
+* Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're done.  That's not true.  We need to consider when a newer client is deployed against an older server and vice versa.  But given that we need to do that, we don't _also_ need to make it harder to mechanically _make_ such API changes by requiring coordinated pushes to separate repos.
 
 There are other annoying things about working on Omicron:
 
 * Dependabot is incredibly noisy and annoying to work with for various reasons.  These are mostly implementation issues, and we could probably improve it considerably if we want to invest time in setting it up better (e.g., having it merge into a separate branch and merge _that_ branch into main once a week or so).
+
+Some of us have worked on large systems that used separate repos for deployed components, particularly Joyent's https://github.com/TritonDataCenter/manta[Manta].  We ran into many challenges with this.  Some of these are implementation details, and not all of these have to do with using separate repos, but many were exacerbated by that pattern:
+
+* There were https://github.com/TritonDataCenter/manta#repositories[10] - https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/architecture.md#manta-components-at-a-glance[20] major top-level components, and https://github.com/TritonDataCenter/manta/blob/master/tools/jr-manifest.json[over 100 git repos] in all.  We eventually built a meta-repo with documentation about the whole system.  But since the active developers rarely needed this, it was often out of date.
+* There were no system-level automated tests, in part because there was no place to put them.  We could have put them in the above meta-repo.  That would mean inventing a mechanism to bind it to specific versions of all the different components.  It would also mean the tests would live separately from all the components being tested.  Any change that also updated the system test suite (presumably most of them) would have to coordinate commits to multiple repos.
+* Each repo had its own bespoke process for setting up a development environment.  They would assume various tools on your PATH, but often not say where to get them or what version was required.  Things would fail bafflingly.  For example, although they all used Node, they depended on different versions.  Having the wrong Node on your PATH might cause a syntax error when running the service.
+* Each repo had its own infrastructure for checking style and lint, running tests, etc.  Even though we had https://github.com/TritonDataCenter/eng/blob/master/docs/index.md[standardized on things like how to run these checks], and even provided a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md#writing-makefiles[library of Makefiles] to make it easy to stick to this interface, in practice, every repo assumed different things about its environment.  These assumptions were not always documented.  When things failed, they often did so in baffling ways.
+* Each repo had its own idea about what `make test` means.  Most them assumed that you had started the service under test already.  That in turn means you had also started its dependencies, which means cloning all those repos, figuring out _their_ dev environment setup steps, etc.  This approach also made it impossible to write tests that would stop or start the service under test, since that was outside the control of the test suite.
+* Updating a common dependency (including Node) across the board involved separately updating it in each repo.  This was harder in Node than in Rust because breaking API changes only fail at runtime.  Plus, test coverage wasn't great (for all the reasons mentioned here), so this cost was even higher.
+
+The net result was that Manta became _very_ slow to iterate on, even for experienced developers.

--- a/docs/repo.adoc
+++ b/docs/repo.adoc
@@ -4,100 +4,76 @@
 
 = Omicron repository
 
-The Omicron git repo is a _consolidation_ of several different components that work together but are deployed separately.  Developers new to Omicron can get tripped up by the size and complexity of the repo.  The README contains a bunch of tips for working in Omicron, including how to iterate more quickly by only building parts of it.  This document explains more about why the repo is structured the way it is.
+The Omicron git repo is a consolidation of several different components that work together but are deployed separately.  Developers new to Omicron can get tripped up by the size and complexity of the repo.  The README contains tips for working in Omicron, including how to iterate more quickly by only building parts of it.  This document explains more about why the repo is structured the way it is.  This largely comes from experience with previous systems that were similarly complicated but structured differently.
 
-== History
+== Design goals
 
-(from @davepacheco's perspective)
+To help the development process, we seek:
 
-Many of the early decisions around Omicron's repo came directly from my experience working on Joyent's https://github.com/TritonDataCenter/manta[Manta], a distributed object store.  I'll describe this in some detail to illustrate the problems I was hoping to avoid.  Of course, none of this is intended as criticism of the people that worked on Manta.
+* to have clear, up-to-date, and regularly tested instructions for setting up a development environment from scratch.
+* to have clear instructions for basic activities like formatting code, running clippy, running tests, etc.  These should be consistent across components and across local development vs. CI.
+* to prioritize debugging and fixing flaky tests so that developers can always expect the tests to pass.
+* to ensure that a fresh clone and build of the repo should produce equivalent software to any other clone, including the CI environment.  If tests pass for one developer on the tip of "main", they should pass for other developers as well as CI.
 
-Architecturally, Manta wasfootnote:[Manta is still maintained today.  I use the past tense here since I'm describing my experience years ago.] made up of https://github.com/TritonDataCenter/manta#repositories[10] - https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/architecture.md#manta-components-at-a-glance[20] major top-level components, each housed in its own git repo.  Most of these were Node.js network services, mostly HTTP.  Between these top-level components and the smaller components shared across services, there were https://github.com/TritonDataCenter/manta/blob/master/tools/jr-manifest.json[over 100 git repos] that made up the whole system.  We can mostly focus on the 10-20 top-level components.  The important thing is that every deployed component had its own repo.
+To make it easy to run tests, the test suite automates setup and teardown of the service under test _and_ other services that it depends on (rather than relying on error-prone manual steps to set these up).
 
-Since we had so many repos, we had a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md[guide] that described, among other things, uniform patterns for structuring repos and providing style and lint checks (via `make check`) and standard ways to run tests (`make test`).  Much latitude was given to repo owners about exactly how to implement this, but we created a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md#writing-makefiles[library of Makefiles] that could be dropped into each repo to minimize boilerplate and ensure the standard stuff worked (e.g., `make check`, `make test`, etc.).
+To make it easy to write comprehensive, reliable tests:
 
-In the early years, about a dozen people worked heavily on Manta.  Most people worked only on a couple of different repos at that time.  After its launch and several years went by, for various reasons, Manta became less important to the company and the team shrunk to just one person.  I spent 1-2 years keeping the lights on, during which I wound up making changes in virtually every part of the system.  Then suddenly, interest in Manta surged rather quickly: within a year or two, the team was spun up to a few dozen people, together working all over the system.
+* Individual tests generally don't need to worry about interference from other tests.  That includes things like TCP ports in use or stale state in dependent services.
+* With the above infrastructure for standing up transient instances of dependencies, it's possible to write end-to-end integration tests that exercise multiple components together with minimal boilerplate.
 
-By this point, I really started to appreciate that it was _hard_ and _slow_ to work on Manta.  I knew a big part of that was the lack of test infrastructure.  But it was much more than that.  When someone walked up to a repo that they hadn't seen before:
+We regularly keep dependencies (including Rust itself) up to date so that we don't suddenly find we need to make big leaps in these.
 
-* It was often unclear how to set up a development environment to work on the repo.  Even though in principle you could walk up to any repo and run `make`, that would depend on your environment having been set up properly.  That might include having installed various commands, native libraries, etc. or environment variables to be set.
-** It was different across repos.
-** It was often not documented.
-** The failure mode was often baffling (e.g., `node` reporting a syntax error because the repo assumed a different version of Node than was found on your PATH).
-* It was often unclear how to run tests.  Again, in principle it was just `make test`, but in practice, you had all the problems above about setting up a development environment, plus a bunch of runtime dependencies like "you must set SOME_DEP_NAME=localhost:12345 in the environment to point at a running instance of a dependency".
-** Again, the specific steps would differ across repos and were often undocumented.
-** The failure modes could be baffling.
-** To give an example of the inconsistency, some repos might use DEP_HOST as a hostname [and port] of some dependency, and another repo might use the same environment variable but expected it to be a full HTTP URL.  When you got it wrong, you might just see an error about being unable to resolve a host.
-** **This problem is recursive:** once you learn you need to run a copy of $dependency, you have all the same challenges associated with getting that thing to run.
-* Even once you knew what you were doing, it was still annoying to run the tests.  As mentioned, you often had to set up your own running version of various dependencies.  There were a bunch of manual steps here that were easy to get wrong.  (Forgot to update the local clone of $dependency that you had lying around?  Oops!  You tested the wrong thing.)
-* It was also annoying to write new tests.
-** If you were building something new, you would typically establish your own requirements around environment variables, etc. for talking to dependencies.  Hopefully you'd document them to avoid the problems above.
-** Since the tests often assumed the service was already running and some environment variable was pointing at it, you'd always run the risk that the service had state left over from other tests, or that other tests would interfere with your test.
-** For the same reason, there wasn't a great way to write tests that involved crashing or restarting the service.
-* We had okay documentation about setting up and testing the system as a whole.  But since each component was in its own repo, the overall documentation didn't make sense to live in any one of those.  Instead, it wound up in a separate repo -- one that active developers would almost never need to reference.  It would often get out of date.
-* We had virtually no automated tests for the whole system, and none that involved setting up a whole system.  It wasn't clear where these tests would go.  It seems they'd have to go in a separate repo, which would make it even more annoying to write new tests and keep them updated.
+Where we have stable interfaces, we seek to keep changelogs that describe for each breaking change how to know if you're affected and what you have to do to move past it.  These are written for maintainers of consumers, who might not be very familiar with a library's other recent changes or internal details.
 
-Note that all this is _despite_ having written standards around this stuff and even provided shareable implementations!  These didn't work because:
+---
 
-* There was ambiguity about what "`make test` should run all the tests" means.  Are those unit tests or integration tests?  What do they assume about their environment?  Who is responsible for setting up and tearing down the thing being tested?
-* The Makefile library was useful, but initially people copied them into repos.  They would rarely get updated when things were fixed or new features added upstream.  Sometimes people would make local changes, making it harder to update them from upstream later.
+Here are some of things we've done towards these goals:
 
-I didn't appreciate it at the time, but I (and many others, I'm sure) were downright _afraid_ to touch anything.  It was hard to know how to get started and even harder to know that you weren't breaking anything.  No wonder it took forever to make even simple changes to the system.footnote:[As an aside, a lot could be said here about how to proceed in these situations.  It's so tempting to try to change the smallest possible thing and get out of there.  But that only makes the problem worse.  The most satisfying work I did during these periods involved immersing myself in these gnarly areas, understanding them completely, and either documenting them or (more often) replacing them.]  This fear-based feedback loop (which kills motivation as well as progress) is bad enough, but there were other problems, too:
-
-* Particularly after most of the initial team left, the common state was that most repos would be idle for many months or even years at a time.  Often when you needed to update it, you'd find that:
-** It used a Node version from two unsupported LTS releases ago and Node had made many breaking changes since then.
-** It used ancient versions of various packages.  You might find some bug was already fixed in some dependency.  But between JavaScript's looseness at compile-time, incorrect use of semver among npm packages at large, general lack of documentation among npm packages about breaking changes, and our own mediocre test coverage, it could be _very_ challenging to update just one dependency.  With so many interconnected dependencies, it was easy to wind up in a situation where you had to move Node and dozens of packages across _years_ worth of breaking changes just to pull in some fix.
-** Again, you usually found yourself here because you were trying to make one change to a component that had otherwise remained unchanged (and working!) for _years_.  It felt like losing a game of hot potato.
-* If we needed to update some component (even just those Makefiles), we'd need to make the change in literally dozens of places.  Probably the best example is when we built Cueball, a sophisticated library for service discovery and connection management.  A component in the frontend web server might need to use this in a half dozen different places, some of them several layers of dependency deep.  Across the stack, even when making a fully compatible change, we might have to update the dependency in dozens of repos.
-
-== Trying to do things differently
-
-We did a bunch of things differently to try to avoid these problems in Omicron.  Here are some design goals:
-
-* We should have clear instructions for setting up a development environment.  To the extent possible, we should make sure these get tested regularly.
-* The test suite should do everything possible to automate setup and teardown.  That includes spinning up and spinning down transient instances of any services that it depends on.  You don't set up any environment variables or configuration files to point your repo at some already-running service.
-* Individual tests should not need to worry about interference from other tests.  That includes things like TCP ports in use or stale state in dependent services.
-* A new developer cloning the repo and running Omicron should get the same software as any other developer and the CI environment.  (i.e., if tests pass for one developer on the tip of "main", it should pass for other developers as well as CI).
-* We should regularly keep dependencies (including Rust itself) up to date so that we don't suddenly find we need to make big leaps in these.
-* Where we have stable interfaces, we should make changelogs that describe for each breaking change how to know if you're affected and what you have to do to move past it.
-
-Towards these ends, here are some of the things we've done:
-
-
-* The dev environment setup process is https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#installing-prerequisites[documented and mostly automated].  That automation is tested regularly because CI uses the same script to go from a bare environment to one that build and tests Omicron.
-* We're using Rust, so quite a lot more is verifiable by just compiling the software.  (By comparison with JavaScript, it's _much_ less likely for a breaking change of a dependency to slip through CI.)
+* The dev environment setup process is https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#installing-prerequisites[documented and mostly automated].  CI uses this script to go from a bare environment to one that builds and tests Omicron, so this automation is tested regularly with the rest of the repo.
+* Omicron houses many related components in one repo.
+** There's a clear place to put overall system documentation, including how to set up one's dev environment.
+** There's a single set of steps for setting up your dev environment, formatting code, running clippy, and running tests, no matter which component(s) you're working on.  (You can still do any of this on individual components rather than the whole repo at once.)
+** Various component test suites depend on other components in the repo so that they can spin up transient instances of them for testing.
+** When we want to update a dependency used in many places, we can often just make one (git) change to update it everywhere.  (This doesn't solve the problem of _deploying_ all those changes, of course.)
+* We've automated the process to spin up transient instances of most services: a standard `ControlPlaneTestContext` in the Nexus test suite spins up real instances of CockroachDB, Clickhouse, Nexus, and internal/external DNS; plus mock versions of Sled Agent and parts of Crucible.  All of this makes it very easy to write a new integration test that uses a great deal of the real stack.  You can also spin all this up and poke around interactively using the `omicron-dev run-all` command.
+* Because spin-up/spin-down of these services is automated, every Nexus integration test gets its own copy of everything (including the database).  They don't have to worry about stomping on each other.  All server sockets use the pattern of binding to port 0 in the test suite (letting the OS pick the port), also so they don't stomp on each other or any other running software.
+* To help stamp out build flakes, we keep around debugging information for failed tests (e.g., trace-level log files, database contents, etc.).  There are tools for spinning up a transient database instance atop an existing database storage directory so that you can easily inspect the contents after a failed test.
 * We use dependabot and Renovate to keep dependencies updated, including Rust itself.
 * We use rust-toolchain and Cargo.lock to ensure that developers are getting a consistent toolchain and packages as each other and CI.
-* Omicron houses many related components in one repo.
-** This gives us a clear place to put overall system documentation (README, ./docs at the root).
-** There's no issue of different dev environment steps for different repos since it's just one repo.  (There are _not_ specific steps for testing individual components within Omicron, either.)
-** The test suites for various components can depend on other components in the repo so that they can spin up transient instances of them for testing.  We've also invested in automation to spin up transient instances of most services: a standard `ControlPlaneTestContext` in the Nexus test suite spins up real instances of CockroachDB, Clickhouse, Nexus, and internal/external DNS; plus Sled Agent and parts of Crucible (mock servers).  All of this makes it very easy to write a new integration test that uses a great deal of the real stack.  This is also exposed through a command, `omicron-dev run-all`, so that you can spin all this up and play with interactively with just a few commands.
-** When we want to update a dependency used in many places, we can often just make one (git) change to update it everywhere.  (This doesn't solve the problem of _deploying_ all those changes, of course.)
-* Because we automated spin-up/spin-down of transient instances of most things, every Nexus integration test gets its own copy of everything (including the database), which means we don't have to worry about stomping on each other.  All server sockets use the pattern of binding to port 0 in the test suite (letting the OS pick the port), also so they don't stomp on each other or any other running software.
-* We do create https://github.com/oxidecomputer/dropshot/blob/main/CHANGELOG.adoc#090-released-2023-01-20[changelogs] that describe for each breaking change how to know if you're affected and what you have to do to move past it.
+* For many components used by Omicron, we create https://github.com/oxidecomputer/dropshot/blob/main/CHANGELOG.adoc#090-released-2023-01-20[changelogs] that describe for each breaking change how to know if you're affected and what you have to do to move past it.  (We don't yet do this for the tightly coupled components within Omicron.)
 
-These are all related: using dependabot for keeping dependencies up to date is only tenable _because_ Rust is so well statically-checked (so the build usually breaks when a dependency makes a breaking change) and we have good test coverage so that it's generally fair to say that if CI passes, the change didn't break Omicron.  This is hard to know, but I strongly believe we have good test coverage in large part _because_ it's relatively easy to write tests.  It's easy to write tests in part because they're in the same repo as the software, they operate on their own isolated copies of the stack, etc.
+These are all related: using dependabot for keeping dependencies up to date is only tenable _because_ Rust is so well statically-checked (so the build usually breaks when a dependency makes a breaking change) and we have good test coverage so that it's generally fair to say that if CI passes, the change didn't break Omicron.  We have good test coverage in large part _because_ it's relatively easy to write reliable tests.  It's easy to write tests in part because they're in the same repo as the software, they operate on their own isolated copies of the stack, etc.
 
-== Has it worked?
+== Caveats, downsides, alternatives
 
-It's apples-and-oranges to compare Manta with Omicron because they're two totally different systems built largely by separately people years apart in two very different environments.  But it's still a meaningful data point.  For _most_ of Omicron: I'm not afraid to wade into it.  (You might think that's because I'm familiar with all of Omicron already.  That's not the case!)  We have quite a few people regularly doing a lot of work in Omicron.  We update dozens of dependencies per week (and keep everything up to date).
+Above we talk up the value of easy-to-run, easy-to-write, comprehensive automated tests.
+This doesn't work for everything.  Sled Agent by nature takes over whatever system it's managing, and the resources it manages are not themselves virtualized, so it's not possible to fully test it outside of, say, giving it a whole VM.  (That said, thanks to Rust, it _is_ possible to have confidence in many mundane refactoring-type changes just by virtue of them compiling.)  Networking is another area where it's hard to automate testing in the way we've described above without a much richer virtualized environment.
 
-It's not all roses.  Much of the system can be worked on and tested very thoroughly using the automated tests, but not all of it.  Sled Agent by nature takes over whatever system it's managing, and the resources it manages are not themselves virtualized, so it's not possible to fully test it outside of, say, giving it a whole VM.  (That said, I've made many changes to Sled Agent that I knew would be correct by virtue of them compiling.  That's _not_ saying "if it compiles, it works" in general, but there are many mundane refactoring-type changes for which that is true.)  Networking is another area where it seems hard to automate testing in the way we've described above without a much richer virtualized environment.
-
-There are downsides of this approach.  Mainly: a large repo can be hard to work with:
+A large, consolidated repo like Omicron has its downsides:
 
 * It can be hard to find the stuff you need.
 * If you try to build the whole thing, it can take a while.  There are tools for building parts of it.  People don't always know about these.  And they have their own pitfalls, like the way workspace feature unification works.  (See "Working with Omicron" in the README.)
-* All things being equal, a larger repo repo means more developers in the same repo, meaning more more conflicts.
+* All things being equal, a larger repo repo means more developers in the same repo, meaning more merge conflicts.
 * All things being equal, a full CI run takes longer, since it tests more.  (This can likely be mitigated with a merge queue, but we haven't tried that yet.)
-* Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're all set.  That's not true.  We need to consider when a newer client is deployed against an older server or vice versa.
+* Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're all set.  That's not true.  We need to consider when a newer client is deployed against an older server and vice versa.
 
-It's not clear that most of these would be better with separate repos, though:
+The obvious alternative would be to use separate repos.  It's not clear this would address most of the above problems, though:
 
 * With separate repos, it can be hard to find which _repo_ you need.
 * The problem with workspace feature unification is that when you change what package you're building, you might find Cargo unexpectedly rebuilding some common dependency.  If we used separate repos, Cargo would _always_ rebuild that dependency when you switched repos.
-* If components are truly unrelated, merge conflicts should be automatically resolved.
+* Merge conflicts for truly unrelated changes should be automatically resolved.
 * Given that we need to create tooling to ensure that we manage both sides of stable APIs, we don't _also_ need to make it harder to _make_ such API changes by requiring coordinated pushes to two separate repos.
+
+Some of us have worked on large systems that used separate repos for deployed components, particularly Joyent's https://github.com/TritonDataCenter/manta[Manta].  In that specific case, we had a bunch of challenges that led to the design goals above:
+
+* There were https://github.com/TritonDataCenter/manta#repositories[10] - https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/architecture.md#manta-components-at-a-glance[20] major top-level components, and https://github.com/TritonDataCenter/manta/blob/master/tools/jr-manifest.json[over 100 git repos] in all.  We eventually built a meta-repo with documentation about the whole system.  But since the active developers never needed this, it was often out of date.
+* Each repo had its own process for setting up a development environment.  They would assume various tools on your PATH, but often not say where to get them or what version was required.  Even though almost all components used Node, they were bound to specific versions (due to fairly frequent breaking changes in Node), so you had to have the right version of Node on your path _for this repo_.
+* Updating a common dependency (including Node) across the board involved separately updating it in each repo.  This was harder in Node than in Rust because breaking API changes only fail at runtime.  Plus, test coverage wasn't great (for all the reasons mentioned here), so this cost was even higher.
+* Each repo had its own infrastructure for checking style and lint, running tests, etc.  Even though we had https://github.com/TritonDataCenter/eng/blob/master/docs/index.md[standardized on things like how to run these checks], and even provided a https://github.com/TritonDataCenter/eng/blob/master/docs/index.md#writing-makefiles[library of Makefiles] to make it easy to stick to this interface, in practice, every repo assumed different things about its environment.  These assumptions were not always documented.  When things failed, they often did so in baffling ways.
+* Repo test suites generally assumed the developer had already started a copy of the service under test and any of its dependencies and had set some environment variables to point at it.
+
+---
 
 There are other annoying things about working on Omicron:
 

--- a/docs/repo.adoc
+++ b/docs/repo.adoc
@@ -50,10 +50,8 @@ A large, consolidated repo like Omicron has its downsides, though using separate
 * All things being equal, a larger repo means more developers in the same repo, meaning more merge conflicts.  But merge conflicts for unrelated changes should be automatically resolved.
 * All things being equal, a full CI run takes longer, since it tests more.  (This can likely be mitigated with a merge queue.  We haven't tried that yet.)
 * Putting a bunch of components into one repo can create the illusion that if you update both sides of a client/server interface, you're done.  That's not true.  We need to consider when a newer client is deployed against an older server and vice versa.  But given that we need to do that, we don't _also_ need to make it harder to mechanically _make_ such API changes by requiring coordinated pushes to separate repos.
-
-There are other annoying things about working on Omicron:
-
-* Dependabot is incredibly noisy and annoying to work with for various reasons.  These are mostly implementation issues, and we could probably improve it considerably if we want to invest time in setting it up better (e.g., having it merge into a separate branch and merge _that_ branch into main once a week or so).
+* It takes a lot of compute resources (CPU, memory, and disk space) on one's development machine to build the whole repo.
+* Dependabot is incredibly noisy and annoying to work with for various reasons.  These are mostly implementation issues, and we could probably improve it considerably if we want to invest time in setting it up better (e.g., having it merge into a separate branch and merge _that_ branch into main once a week or so).  With separate repos that _also_ used dependabot, the noise would presumably be much larger since many dependencies would be updated separately in each repo.
 
 Some of us have worked on large systems that used separate repos for deployed components, particularly Joyent's https://github.com/TritonDataCenter/manta[Manta].  We ran into many challenges with this.  Some of these are implementation details, and not all of these have to do with using separate repos, but many were exacerbated by that pattern:
 


### PR DESCRIPTION
Recent discussions made me realize that there are a lot of goals we've adopted but never wrote down, nor the rationale for why we've done things this way.  Here's a first cut.

Edit: I'm also updating the README to link to this doc.  I also removed the "Configuration Reference".  This doesn't really make sense here.  There are a bunch of config files in Omicron now.  This one is not particularly special.  In general these are probably best documented in either the rustdoc for the config structs or else the example files.