### PR TITLE
sled agent: propagate Propolis error statuses to Nexus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
  "chrono",
  "clap 4.3.3",
  "crucible-agent-client",
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d)",
  "ddm-admin-client",
  "dns-server",
  "dns-service-client 0.1.0",
@@ -5946,7 +5946,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=96ba33d2629b93bfb9cdb806327c16113bcf0cf3#96ba33d2629b93bfb9cdb806327c16113bcf0cf3"
 dependencies = [
  "base64 0.21.2",
- "crucible-client-types",
+ "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805)",
  "futures",
  "progenitor",
  "propolis_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,7 +4751,7 @@ dependencies = [
  "chrono",
  "clap 4.3.3",
  "crucible-agent-client",
- "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d)",
+ "crucible-client-types",
  "ddm-admin-client",
  "dns-server",
  "dns-service-client 0.1.0",
@@ -5946,7 +5946,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=96ba33d2629b93bfb9cdb806327c16113bcf0cf3#96ba33d2629b93bfb9cdb806327c16113bcf0cf3"
 dependencies = [
  "base64 0.21.2",
- "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805)",
+ "crucible-client-types",
  "futures",
  "progenitor",
  "propolis_types",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -27,6 +27,7 @@ dpd-client.workspace = true
 dropshot.workspace = true
 flate2.workspace = true
 futures.workspace = true
+http.workspace = true
 illumos-utils.workspace = true
 internal-dns.workspace = true
 ipnetwork.workspace = true

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -149,9 +149,7 @@ async fn instance_register(
     let instance_id = path_params.into_inner().instance_id;
     let body_args = body.into_inner();
     Ok(HttpResponseOk(
-        sa.instance_ensure_registered(instance_id, body_args.initial)
-            .await
-            .map_err(Error::from)?,
+        sa.instance_ensure_registered(instance_id, body_args.initial).await?,
     ))
 }
 
@@ -165,11 +163,7 @@ async fn instance_unregister(
 ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
     let sa = rqctx.context();
     let instance_id = path_params.into_inner().instance_id;
-    Ok(HttpResponseOk(
-        sa.instance_ensure_unregistered(instance_id)
-            .await
-            .map_err(Error::from)?,
-    ))
+    Ok(HttpResponseOk(sa.instance_ensure_unregistered(instance_id).await?))
 }
 
 #[endpoint {
@@ -185,9 +179,7 @@ async fn instance_put_state(
     let instance_id = path_params.into_inner().instance_id;
     let body_args = body.into_inner();
     Ok(HttpResponseOk(
-        sa.instance_ensure_state(instance_id, body_args.state)
-            .await
-            .map_err(Error::from)?,
+        sa.instance_ensure_state(instance_id, body_args.state).await?,
     ))
 }
 
@@ -209,8 +201,7 @@ async fn instance_put_migration_ids(
             &body_args.old_runtime,
             &body_args.migration_params,
         )
-        .await
-        .map_err(Error::from)?,
+        .await?,
     ))
 }
 


### PR DESCRIPTION
Fix instance-related HTTP entrypoints so that they invoke the correct `From` impl to convert Propolis errors to Dropshot `HttpError`s. Update sled agent's conversion routine to work around dropshot#693 (can't use `for_status` to re- wrap server errors).

Without this fix, all Propolis errors get converted into 500 Internal Server Error on egress from sled agent, which can cause Nexus to conclude incorrectly that instances have failed.

Tested with ad hoc Omicron testing and stress testing.