### PR TITLE
[bootstrap-agent] Make destructive endpoints cancel-safe and interlocked

### DIFF
--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -64,6 +64,28 @@
       }
     },
     "/rack-initialize": {
+      "get": {
+        "summary": "Get the current status of rack initialization (or reset).",
+        "operationId": "rack_initialization_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RackInitializationStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "post": {
         "summary": "Initializes the rack with the provided configuration.",
         "operationId": "rack_initialize",
@@ -106,6 +128,28 @@
       }
     },
     "/sled-initialize": {
+      "get": {
+        "summary": "Get the current status of rack initialization (or reset).",
+        "operationId": "sled_reset_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledResetStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "delete": {
         "summary": "Resets this particular sled to an unconfigured state.",
         "operationId": "sled_reset",
@@ -400,6 +444,116 @@
           "speed400_g"
         ]
       },
+      "RackInitializationStatus": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "not_running"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "initializing"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "initialized"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "initialization_failed"
+                ]
+              }
+            },
+            "required": [
+              "reason",
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "resetting"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "reset"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "reset_failed"
+                ]
+              }
+            },
+            "required": [
+              "reason",
+              "status"
+            ]
+          }
+        ]
+      },
       "RackInitializeRequest": {
         "description": "Configuration for the \"rack setup service\".\n\nThe Rack Setup Service should be responsible for one-time setup actions, such as CockroachDB placement and initialization.  Without operator intervention, however, these actions need a way to be automated in our deployment.",
         "type": "object",
@@ -557,6 +711,70 @@
       "SemverVersion": {
         "type": "string",
         "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+      },
+      "SledResetStatus": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "not_running"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "resetting"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "reset"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "reset_failed"
+                ]
+              }
+            },
+            "required": [
+              "reason",
+              "status"
+            ]
+          }
+        ]
       },
       "UserId": {
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -8,7 +8,6 @@ use super::config::{
     Config, BOOTSTRAP_AGENT_HTTP_PORT, BOOTSTRAP_AGENT_RACK_INIT_PORT,
 };
 use super::hardware::HardwareMonitor;
-use super::http_entrypoints::SledOperationInterlock;
 use super::params::RackInitializeRequest;
 use super::params::StartSledAgentRequest;
 use super::rss_handle::RssHandle;
@@ -178,10 +177,6 @@ pub struct Agent {
 
     /// Bootstrap network address.
     ip: Ipv6Addr,
-
-    /// Ensures that RSS (initialization or teardown) is not executed
-    /// concurrently.
-    pub(super) rss_interlock: SledOperationInterlock,
 
     sled_state: Mutex<SledAgentState>,
     storage_resources: StorageResources,
@@ -408,7 +403,6 @@ impl Agent {
             log: ba_log,
             parent_log: log,
             ip,
-            rss_interlock: SledOperationInterlock::new(),
             sled_state: Mutex::new(SledAgentState::Before(Some(
                 hardware_monitor,
             ))),

--- a/sled-agent/src/bootstrap/context.rs
+++ b/sled-agent/src/bootstrap/context.rs
@@ -1,0 +1,336 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::agent::Agent;
+use super::agent::BootstrapError;
+use super::http_entrypoints::RackInitializationStatus;
+use super::http_entrypoints::SledResetStatus;
+use super::params::RackInitializeRequest;
+use futures::Future;
+use std::fmt;
+use std::future;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::task::JoinError;
+use tokio::task::JoinHandle;
+
+pub(super) struct BootstrapContext {
+    pub(super) agent: Arc<Agent>,
+    pub(super) operation_interlock: SledOperationInterlock,
+}
+
+/// We expose some heavyweight, destructive operations in the bootstrap agent
+/// http server: rack initialization, rack reset, and sled reset. None of those
+/// operations should be allowed to run if another of them is still running. We
+/// use this interlock to provide a both exclusivity and current status for any
+/// of those operations.
+pub(super) struct SledOperationInterlock {
+    cmds_tx: mpsc::Sender<SledOperationInterlockCmd>,
+    inner_task: JoinHandle<()>,
+    rack_initialization_status_rx: watch::Receiver<RackInitializationStatus>,
+    sled_reset_status_rx: watch::Receiver<SledResetStatus>,
+}
+
+impl Drop for SledOperationInterlock {
+    fn drop(&mut self) {
+        self.inner_task.abort();
+    }
+}
+
+impl SledOperationInterlock {
+    pub(super) fn new() -> Self {
+        // Channel size is relatively arbitrary: we don't expect requests to sit
+        // in here long (only long enough to either return an error or spawn a
+        // task), so a small depth seems fine.
+        let (cmds_tx, cmds_rx) = mpsc::channel(4);
+
+        let (rack_initialization_status_tx, rack_initialization_status_rx) =
+            watch::channel(RackInitializationStatus::NotRunning);
+        let (sled_reset_status_tx, sled_reset_status_rx) =
+            watch::channel(SledResetStatus::NotRunning);
+
+        let inner = SledOperationInterlockInner {
+            cmds_rx,
+            running_task: None,
+            rack_initialization_status_tx,
+            sled_reset_status_tx,
+        };
+
+        let inner_task = tokio::spawn(inner.run());
+
+        Self {
+            cmds_tx,
+            inner_task,
+            rack_initialization_status_rx,
+            sled_reset_status_rx,
+        }
+    }
+
+    pub(crate) fn sled_reset_status(&self) -> SledResetStatus {
+        self.sled_reset_status_rx.borrow().clone()
+    }
+
+    pub(crate) fn rack_initialization_status(
+        &self,
+    ) -> RackInitializationStatus {
+        self.rack_initialization_status_rx.borrow().clone()
+    }
+
+    pub(crate) async fn rack_initialize(
+        &self,
+        agent: Arc<Agent>,
+        request: RackInitializeRequest,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+
+        // Our inner task is responsible for receiving this command and sending
+        // us a response once it does; unwrapping here can only panic if that
+        // task has itself panicked. Same applies to the other uses of `cmds_tx`
+        // below.
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::RackInitialize {
+                agent,
+                request,
+                response: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+
+    pub(crate) async fn rack_reset(
+        &self,
+        agent: Arc<Agent>,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::RackReset { agent, response: tx })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+
+    pub(crate) async fn sled_reset(
+        &self,
+        agent: Arc<Agent>,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::SledReset { agent, response: tx })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+enum SledOperationInterlockCmd {
+    RackInitialize {
+        agent: Arc<Agent>,
+        request: RackInitializeRequest,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+    RackReset {
+        agent: Arc<Agent>,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+    SledReset {
+        agent: Arc<Agent>,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+}
+
+// `Agent` doesn't impl `Debug`, so we'll manually impl Debug on ourself.
+impl fmt::Debug for SledOperationInterlockCmd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SledOperationInterlockCmd::RackInitialize { .. } => {
+                "SledOperationInterlockCmd::RackInitialize"
+            }
+            SledOperationInterlockCmd::RackReset { .. } => {
+                "SledOperationInterlockCmd::RackReset"
+            }
+            SledOperationInterlockCmd::SledReset { .. } => {
+                "SledOperationInterlockCmd::SledReset"
+            }
+        };
+        f.write_str(s)
+    }
+}
+
+type SledOperationTaskHandle = JoinHandle<Result<(), BootstrapError>>;
+type SledOperationTaskResult = Result<Result<(), BootstrapError>, JoinError>;
+
+enum SledOperationTask {
+    RackInitializing(SledOperationTaskHandle),
+    RackResetting(SledOperationTaskHandle),
+    SledResetting(SledOperationTaskHandle),
+}
+
+struct SledOperationInterlockInner {
+    cmds_rx: mpsc::Receiver<SledOperationInterlockCmd>,
+    running_task: Option<SledOperationTask>,
+    rack_initialization_status_tx: watch::Sender<RackInitializationStatus>,
+    sled_reset_status_tx: watch::Sender<SledResetStatus>,
+}
+
+impl SledOperationInterlockInner {
+    async fn run(mut self) {
+        loop {
+            // If we have a task running, we'll `select!` on its completion; if
+            // not, we use `pending()` which gives back a future that never
+            // completes.
+            let mut pending = future::pending();
+            let task_fut: &mut (dyn Future<Output = SledOperationTaskResult>
+                      + Send
+                      + Unpin) = match self.running_task.as_mut() {
+                Some(
+                    SledOperationTask::RackInitializing(t)
+                    | SledOperationTask::RackResetting(t)
+                    | SledOperationTask::SledResetting(t),
+                ) => t,
+                None => &mut pending,
+            };
+
+            tokio::select! {
+                result = task_fut => {
+                    self.handle_task_result(result);
+                }
+
+                Some(cmd) = self.cmds_rx.recv() => {
+                    self.handle_cmd(cmd);
+                }
+            }
+        }
+    }
+
+    fn handle_cmd(&mut self, cmd: SledOperationInterlockCmd) {
+        fn send_busy_response(
+            tx: oneshot::Sender<Result<(), BootstrapError>>,
+            task: &SledOperationTask,
+        ) {
+            let message = match task {
+                SledOperationTask::RackInitializing(_) => {
+                    "rack busy initializing"
+                }
+                SledOperationTask::RackResetting(_) => "rack busy resetting",
+                SledOperationTask::SledResetting(_) => "sled busy resetting",
+            };
+            _ = tx.send(Err(BootstrapError::ConcurrentSledOperationAccess {
+                message,
+            }));
+        }
+
+        match cmd {
+            SledOperationInterlockCmd::RackInitialize {
+                agent,
+                request,
+                response,
+            } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(
+                        SledOperationTask::RackInitializing(tokio::spawn(
+                            async move { agent.rack_initialize(request).await },
+                        )),
+                    );
+                }
+            }
+            SledOperationInterlockCmd::RackReset { agent, response } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(SledOperationTask::RackResetting(
+                        tokio::spawn(async move { agent.rack_reset().await }),
+                    ));
+                }
+            }
+            SledOperationInterlockCmd::SledReset { agent, response } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(SledOperationTask::SledResetting(
+                        tokio::spawn(async move { agent.sled_reset().await }),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn handle_task_result(&mut self, result: SledOperationTaskResult) {
+        // We are called from `run()` when our currently-running task is
+        // complete, which means there _must_ be a value in `self.running_task`
+        // (otherwise `run()` couldn't have gotten a result at all!).
+        let Some(running_task) = self.running_task.take() else {
+            panic!("handle_task_result called with no running task?!");
+        };
+
+        match running_task {
+            SledOperationTask::RackInitializing(_) => {
+                // Ignore send errors
+                _ = self.rack_initialization_status_tx.send(match result {
+                    Ok(Ok(())) => RackInitializationStatus::Initialized,
+                    Ok(Err(err)) => {
+                        RackInitializationStatus::InitializationFailed {
+                            reason: format!("{err:#}"),
+                        }
+                    }
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "initialization task panicked"
+                        } else if err.is_cancelled() {
+                            "initialization task unexpectedly cancelled"
+                        } else {
+                            "initialization task failed (reason unknown)"
+                        };
+                        RackInitializationStatus::InitializationFailed {
+                            reason: reason.into(),
+                        }
+                    }
+                });
+            }
+            SledOperationTask::RackResetting(_) => {
+                _ = self.rack_initialization_status_tx.send(match result {
+                    Ok(Ok(())) => RackInitializationStatus::Reset,
+                    Ok(Err(err)) => RackInitializationStatus::ResetFailed {
+                        reason: format!("{err:#}"),
+                    },
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "reset task panicked"
+                        } else if err.is_cancelled() {
+                            "reset task unexpectedly cancelled"
+                        } else {
+                            "reset task failed (reason unknown)"
+                        };
+                        RackInitializationStatus::ResetFailed {
+                            reason: reason.into(),
+                        }
+                    }
+                });
+            }
+            SledOperationTask::SledResetting(_) => {
+                _ = self.sled_reset_status_tx.send(match result {
+                    Ok(Ok(())) => SledResetStatus::Reset,
+                    Ok(Err(err)) => SledResetStatus::ResetFailed {
+                        reason: format!("{err:#}"),
+                    },
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "reset task panicked"
+                        } else if err.is_cancelled() {
+                            "reset task unexpectedly cancelled"
+                        } else {
+                            "reset task failed (reason unknown)"
+                        };
+                        SledResetStatus::ResetFailed { reason: reason.into() }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -14,9 +14,17 @@ use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk,
     HttpResponseUpdatedNoContent, RequestContext, TypedBody,
 };
+use futures::Future;
 use omicron_common::api::external::Error;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use sled_hardware::Baseboard;
 use std::sync::Arc;
+use std::{fmt, future};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::{JoinError, JoinHandle};
+
+use super::agent::BootstrapError;
 
 type BootstrapApiDescription = ApiDescription<Arc<Agent>>;
 
@@ -27,8 +35,10 @@ pub(crate) fn api() -> BootstrapApiDescription {
     ) -> Result<(), String> {
         api.register(baseboard_get)?;
         api.register(components_get)?;
+        api.register(rack_initialization_status)?;
         api.register(rack_initialize)?;
         api.register(rack_reset)?;
+        api.register(sled_reset_status)?;
         api.register(sled_reset)?;
         Ok(())
     }
@@ -68,6 +78,34 @@ async fn components_get(
     Ok(HttpResponseOk(components))
 }
 
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RackInitializationStatus {
+    NotRunning,
+    Initializing,
+    Initialized,
+    InitializationFailed { reason: String },
+    Resetting,
+    Reset,
+    ResetFailed { reason: String },
+}
+
+/// Get the current status of rack initialization (or reset).
+#[endpoint {
+    method = GET,
+    path = "/rack-initialize",
+}]
+async fn rack_initialization_status(
+    rqctx: RequestContext<Arc<Agent>>,
+) -> Result<HttpResponseOk<RackInitializationStatus>, HttpError> {
+    let ba = rqctx.context();
+    let status =
+        ba.rss_interlock.rack_initialization_status_rx.borrow().clone();
+    Ok(HttpResponseOk(status))
+}
+
 /// Initializes the rack with the provided configuration.
 #[endpoint {
     method = POST,
@@ -79,7 +117,10 @@ async fn rack_initialize(
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let ba = rqctx.context();
     let request = body.into_inner();
-    ba.rack_initialize(request).await.map_err(|e| Error::from(e))?;
+    ba.rss_interlock
+        .rack_initialize(Arc::clone(&ba), request)
+        .await
+        .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
 }
 
@@ -92,8 +133,35 @@ async fn rack_reset(
     rqctx: RequestContext<Arc<Agent>>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let ba = rqctx.context();
-    ba.rack_reset().await.map_err(|e| Error::from(e))?;
+    ba.rss_interlock
+        .rack_reset(Arc::clone(&ba))
+        .await
+        .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SledResetStatus {
+    NotRunning,
+    Resetting,
+    Reset,
+    ResetFailed { reason: String },
+}
+
+/// Get the current status of rack initialization (or reset).
+#[endpoint {
+    method = GET,
+    path = "/sled-initialize",
+}]
+async fn sled_reset_status(
+    rqctx: RequestContext<Arc<Agent>>,
+) -> Result<HttpResponseOk<SledResetStatus>, HttpError> {
+    let ba = rqctx.context();
+    let status = ba.rss_interlock.sled_reset_status_rx.borrow().clone();
+    Ok(HttpResponseOk(status))
 }
 
 /// Resets this particular sled to an unconfigured state.
@@ -105,6 +173,306 @@ async fn sled_reset(
     rqctx: RequestContext<Arc<Agent>>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let ba = rqctx.context();
-    ba.sled_reset().await.map_err(|e| Error::from(e))?;
+    ba.rss_interlock
+        .sled_reset(Arc::clone(&ba))
+        .await
+        .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
+}
+
+// We expose some heavyweight, destructive operations in this http server: rack
+// initialization, rack reset, and sled reset. None of those operations should
+// be allowed to run if another of them is still running. We use this struct to
+// provide a both exclusivity and status for any of those operations.
+pub(super) struct SledOperationInterlock {
+    cmds_tx: mpsc::Sender<SledOperationInterlockCmd>,
+    inner_task: JoinHandle<()>,
+    rack_initialization_status_rx: watch::Receiver<RackInitializationStatus>,
+    sled_reset_status_rx: watch::Receiver<SledResetStatus>,
+}
+
+impl Drop for SledOperationInterlock {
+    fn drop(&mut self) {
+        self.inner_task.abort();
+    }
+}
+
+impl SledOperationInterlock {
+    pub(super) fn new() -> Self {
+        // Channel size is relatively arbitrary: we don't expect requests to sit
+        // in here long (only long enough to either return an error or spawn a
+        // task), so a small depth seems fine.
+        let (cmds_tx, cmds_rx) = mpsc::channel(4);
+
+        let (rack_initialization_status_tx, rack_initialization_status_rx) =
+            watch::channel(RackInitializationStatus::NotRunning);
+        let (sled_reset_status_tx, sled_reset_status_rx) =
+            watch::channel(SledResetStatus::NotRunning);
+
+        let inner = SledOperationInterlockInner {
+            cmds_rx,
+            running_task: None,
+            rack_initialization_status_tx,
+            sled_reset_status_tx,
+        };
+
+        let inner_task = tokio::spawn(inner.run());
+
+        Self {
+            cmds_tx,
+            inner_task,
+            rack_initialization_status_rx,
+            sled_reset_status_rx,
+        }
+    }
+
+    async fn rack_initialize(
+        &self,
+        agent: Arc<Agent>,
+        request: RackInitializeRequest,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::RackInitialize {
+                agent,
+                request,
+                response: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+
+    async fn rack_reset(
+        &self,
+        agent: Arc<Agent>,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::RackReset { agent, response: tx })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+
+    async fn sled_reset(
+        &self,
+        agent: Arc<Agent>,
+    ) -> Result<(), BootstrapError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmds_tx
+            .send(SledOperationInterlockCmd::SledReset { agent, response: tx })
+            .await
+            .unwrap();
+        rx.await.unwrap()
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+enum SledOperationInterlockCmd {
+    RackInitialize {
+        agent: Arc<Agent>,
+        request: RackInitializeRequest,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+    RackReset {
+        agent: Arc<Agent>,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+    SledReset {
+        agent: Arc<Agent>,
+        response: oneshot::Sender<Result<(), BootstrapError>>,
+    },
+}
+
+// `Agent` doesn't impl `Debug`, so we'll manually impl Debug on ourself.
+impl fmt::Debug for SledOperationInterlockCmd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SledOperationInterlockCmd::RackInitialize { .. } => {
+                "SledOperationInterlockCmd::RackInitialize"
+            }
+            SledOperationInterlockCmd::RackReset { .. } => {
+                "SledOperationInterlockCmd::RackReset"
+            }
+            SledOperationInterlockCmd::SledReset { .. } => {
+                "SledOperationInterlockCmd::SledReset"
+            }
+        };
+        f.write_str(s)
+    }
+}
+
+type SledOperationTaskHandle = JoinHandle<Result<(), BootstrapError>>;
+type SledOperationTaskResult = Result<Result<(), BootstrapError>, JoinError>;
+
+enum SledOperationTask {
+    RackInitializing(SledOperationTaskHandle),
+    RackResetting(SledOperationTaskHandle),
+    SledResetting(SledOperationTaskHandle),
+}
+
+struct SledOperationInterlockInner {
+    cmds_rx: mpsc::Receiver<SledOperationInterlockCmd>,
+    running_task: Option<SledOperationTask>,
+    rack_initialization_status_tx: watch::Sender<RackInitializationStatus>,
+    sled_reset_status_tx: watch::Sender<SledResetStatus>,
+}
+
+impl SledOperationInterlockInner {
+    async fn run(mut self) {
+        loop {
+            // If we have a task running, we'll `select!` on its completion; if
+            // not, we use `pending()` which gives back a future that never
+            // completes.
+            let mut pending = future::pending();
+            let task_fut: &mut (dyn Future<Output = SledOperationTaskResult>
+                      + Send
+                      + Unpin) = match self.running_task.as_mut() {
+                Some(
+                    SledOperationTask::RackInitializing(t)
+                    | SledOperationTask::RackResetting(t)
+                    | SledOperationTask::SledResetting(t),
+                ) => t,
+                None => &mut pending,
+            };
+
+            tokio::select! {
+                result = task_fut => {
+                    self.handle_task_result(result);
+                }
+
+                Some(cmd) = self.cmds_rx.recv() => {
+                    self.handle_cmd(cmd);
+                }
+            }
+        }
+    }
+
+    fn handle_cmd(&mut self, cmd: SledOperationInterlockCmd) {
+        fn send_busy_response(
+            tx: oneshot::Sender<Result<(), BootstrapError>>,
+            task: &SledOperationTask,
+        ) {
+            let message = match task {
+                SledOperationTask::RackInitializing(_) => {
+                    "rack busy initializing"
+                }
+                SledOperationTask::RackResetting(_) => "rack busy resetting",
+                SledOperationTask::SledResetting(_) => "sled busy resetting",
+            };
+            _ = tx.send(Err(BootstrapError::ConcurrentSledOperationAccess {
+                message,
+            }));
+        }
+
+        match cmd {
+            SledOperationInterlockCmd::RackInitialize {
+                agent,
+                request,
+                response,
+            } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(
+                        SledOperationTask::RackInitializing(tokio::spawn(
+                            async move { agent.rack_initialize(request).await },
+                        )),
+                    );
+                }
+            }
+            SledOperationInterlockCmd::RackReset { agent, response } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(SledOperationTask::RackResetting(
+                        tokio::spawn(async move { agent.rack_reset().await }),
+                    ));
+                }
+            }
+            SledOperationInterlockCmd::SledReset { agent, response } => {
+                if let Some(task) = self.running_task.as_ref() {
+                    send_busy_response(response, task);
+                } else {
+                    self.running_task = Some(SledOperationTask::SledResetting(
+                        tokio::spawn(async move { agent.sled_reset().await }),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn handle_task_result(&mut self, result: SledOperationTaskResult) {
+        // We are called from `run()` when our currently-running task is
+        // complete, which means there _must_ be a value in `self.running_task`
+        // (otherwise `run()` couldn't have gotten a result at all!).
+        let Some(running_task) = self.running_task.take() else {
+            panic!("handle_task_result called with no running task?!");
+        };
+
+        match running_task {
+            SledOperationTask::RackInitializing(_) => {
+                // Ignore send errors
+                _ = self.rack_initialization_status_tx.send(match result {
+                    Ok(Ok(())) => RackInitializationStatus::Initialized,
+                    Ok(Err(err)) => {
+                        RackInitializationStatus::InitializationFailed {
+                            reason: format!("{err:#}"),
+                        }
+                    }
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "initialization task panicked"
+                        } else if err.is_cancelled() {
+                            "initialization task unexpectedly cancelled"
+                        } else {
+                            "initialization task failed (reason unknown)"
+                        };
+                        RackInitializationStatus::InitializationFailed {
+                            reason: reason.into(),
+                        }
+                    }
+                });
+            }
+            SledOperationTask::RackResetting(_) => {
+                _ = self.rack_initialization_status_tx.send(match result {
+                    Ok(Ok(())) => RackInitializationStatus::Reset,
+                    Ok(Err(err)) => RackInitializationStatus::ResetFailed {
+                        reason: format!("{err:#}"),
+                    },
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "reset task panicked"
+                        } else if err.is_cancelled() {
+                            "reset task unexpectedly cancelled"
+                        } else {
+                            "reset task failed (reason unknown)"
+                        };
+                        RackInitializationStatus::ResetFailed {
+                            reason: reason.into(),
+                        }
+                    }
+                });
+            }
+            SledOperationTask::SledResetting(_) => {
+                _ = self.sled_reset_status_tx.send(match result {
+                    Ok(Ok(())) => SledResetStatus::Reset,
+                    Ok(Err(err)) => SledResetStatus::ResetFailed {
+                        reason: format!("{err:#}"),
+                    },
+                    Err(err) => {
+                        let reason = if err.is_panic() {
+                            "reset task panicked"
+                        } else if err.is_cancelled() {
+                            "reset task unexpectedly cancelled"
+                        } else {
+                            "reset task failed (reason unknown)"
+                        };
+                        SledResetStatus::ResetFailed { reason: reason.into() }
+                    }
+                });
+            }
+        }
+    }
 }

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -7,29 +7,23 @@
 //! Note that the bootstrap agent also communicates over Sprockets,
 //! and has a separate interface for establishing the trust quorum.
 
-use crate::bootstrap::agent::Agent;
+use super::context::BootstrapContext;
 use crate::bootstrap::params::RackInitializeRequest;
 use crate::updates::Component;
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk,
     HttpResponseUpdatedNoContent, RequestContext, TypedBody,
 };
-use futures::Future;
 use omicron_common::api::external::Error;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_hardware::Baseboard;
 use std::sync::Arc;
-use std::{fmt, future};
-use tokio::sync::{mpsc, oneshot, watch};
-use tokio::task::{JoinError, JoinHandle};
 
-use super::agent::BootstrapError;
-
-type BootstrapApiDescription = ApiDescription<Arc<Agent>>;
+type BootstrapApiDescription = ApiDescription<BootstrapContext>;
 
 /// Returns a description of the bootstrap agent API
-pub(crate) fn api() -> BootstrapApiDescription {
+pub(super) fn api() -> BootstrapApiDescription {
     fn register_endpoints(
         api: &mut BootstrapApiDescription,
     ) -> Result<(), String> {
@@ -56,10 +50,10 @@ pub(crate) fn api() -> BootstrapApiDescription {
     path = "/baseboard",
 }]
 async fn baseboard_get(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseOk<Baseboard>, HttpError> {
-    let ba = rqctx.context();
-    Ok(HttpResponseOk(ba.baseboard().clone()))
+    let ctx = rqctx.context();
+    Ok(HttpResponseOk(ctx.agent.baseboard().clone()))
 }
 
 /// Provides a list of components known to the bootstrap agent.
@@ -71,10 +65,11 @@ async fn baseboard_get(
     path = "/components",
 }]
 async fn components_get(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseOk<Vec<Component>>, HttpError> {
-    let ba = rqctx.context();
-    let components = ba.components_get().await.map_err(|e| Error::from(e))?;
+    let ctx = rqctx.context();
+    let components =
+        ctx.agent.components_get().await.map_err(|e| Error::from(e))?;
     Ok(HttpResponseOk(components))
 }
 
@@ -98,11 +93,10 @@ pub enum RackInitializationStatus {
     path = "/rack-initialize",
 }]
 async fn rack_initialization_status(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseOk<RackInitializationStatus>, HttpError> {
-    let ba = rqctx.context();
-    let status =
-        ba.rss_interlock.rack_initialization_status_rx.borrow().clone();
+    let ctx = rqctx.context();
+    let status = ctx.operation_interlock.rack_initialization_status();
     Ok(HttpResponseOk(status))
 }
 
@@ -112,13 +106,13 @@ async fn rack_initialization_status(
     path = "/rack-initialize",
 }]
 async fn rack_initialize(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
     body: TypedBody<RackInitializeRequest>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let ba = rqctx.context();
+    let ctx = rqctx.context();
     let request = body.into_inner();
-    ba.rss_interlock
-        .rack_initialize(Arc::clone(&ba), request)
+    ctx.operation_interlock
+        .rack_initialize(Arc::clone(&ctx.agent), request)
         .await
         .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
@@ -130,11 +124,11 @@ async fn rack_initialize(
     path = "/rack-initialize",
 }]
 async fn rack_reset(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let ba = rqctx.context();
-    ba.rss_interlock
-        .rack_reset(Arc::clone(&ba))
+    let ctx = rqctx.context();
+    ctx.operation_interlock
+        .rack_reset(Arc::clone(&ctx.agent))
         .await
         .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
@@ -157,10 +151,10 @@ pub enum SledResetStatus {
     path = "/sled-initialize",
 }]
 async fn sled_reset_status(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseOk<SledResetStatus>, HttpError> {
-    let ba = rqctx.context();
-    let status = ba.rss_interlock.sled_reset_status_rx.borrow().clone();
+    let ctx = rqctx.context();
+    let status = ctx.operation_interlock.sled_reset_status();
     Ok(HttpResponseOk(status))
 }
 
@@ -170,309 +164,12 @@ async fn sled_reset_status(
     path = "/sled-initialize",
 }]
 async fn sled_reset(
-    rqctx: RequestContext<Arc<Agent>>,
+    rqctx: RequestContext<BootstrapContext>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let ba = rqctx.context();
-    ba.rss_interlock
-        .sled_reset(Arc::clone(&ba))
+    let ctx = rqctx.context();
+    ctx.operation_interlock
+        .sled_reset(Arc::clone(&ctx.agent))
         .await
         .map_err(|e| Error::from(e))?;
     Ok(HttpResponseUpdatedNoContent())
-}
-
-// We expose some heavyweight, destructive operations in this http server: rack
-// initialization, rack reset, and sled reset. None of those operations should
-// be allowed to run if another of them is still running. We use this struct to
-// provide a both exclusivity and status for any of those operations.
-pub(super) struct SledOperationInterlock {
-    cmds_tx: mpsc::Sender<SledOperationInterlockCmd>,
-    inner_task: JoinHandle<()>,
-    rack_initialization_status_rx: watch::Receiver<RackInitializationStatus>,
-    sled_reset_status_rx: watch::Receiver<SledResetStatus>,
-}
-
-impl Drop for SledOperationInterlock {
-    fn drop(&mut self) {
-        self.inner_task.abort();
-    }
-}
-
-impl SledOperationInterlock {
-    pub(super) fn new() -> Self {
-        // Channel size is relatively arbitrary: we don't expect requests to sit
-        // in here long (only long enough to either return an error or spawn a
-        // task), so a small depth seems fine.
-        let (cmds_tx, cmds_rx) = mpsc::channel(4);
-
-        let (rack_initialization_status_tx, rack_initialization_status_rx) =
-            watch::channel(RackInitializationStatus::NotRunning);
-        let (sled_reset_status_tx, sled_reset_status_rx) =
-            watch::channel(SledResetStatus::NotRunning);
-
-        let inner = SledOperationInterlockInner {
-            cmds_rx,
-            running_task: None,
-            rack_initialization_status_tx,
-            sled_reset_status_tx,
-        };
-
-        let inner_task = tokio::spawn(inner.run());
-
-        Self {
-            cmds_tx,
-            inner_task,
-            rack_initialization_status_rx,
-            sled_reset_status_rx,
-        }
-    }
-
-    async fn rack_initialize(
-        &self,
-        agent: Arc<Agent>,
-        request: RackInitializeRequest,
-    ) -> Result<(), BootstrapError> {
-        let (tx, rx) = oneshot::channel();
-        self.cmds_tx
-            .send(SledOperationInterlockCmd::RackInitialize {
-                agent,
-                request,
-                response: tx,
-            })
-            .await
-            .unwrap();
-        rx.await.unwrap()
-    }
-
-    async fn rack_reset(
-        &self,
-        agent: Arc<Agent>,
-    ) -> Result<(), BootstrapError> {
-        let (tx, rx) = oneshot::channel();
-        self.cmds_tx
-            .send(SledOperationInterlockCmd::RackReset { agent, response: tx })
-            .await
-            .unwrap();
-        rx.await.unwrap()
-    }
-
-    async fn sled_reset(
-        &self,
-        agent: Arc<Agent>,
-    ) -> Result<(), BootstrapError> {
-        let (tx, rx) = oneshot::channel();
-        self.cmds_tx
-            .send(SledOperationInterlockCmd::SledReset { agent, response: tx })
-            .await
-            .unwrap();
-        rx.await.unwrap()
-    }
-}
-
-#[allow(clippy::large_enum_variant)]
-enum SledOperationInterlockCmd {
-    RackInitialize {
-        agent: Arc<Agent>,
-        request: RackInitializeRequest,
-        response: oneshot::Sender<Result<(), BootstrapError>>,
-    },
-    RackReset {
-        agent: Arc<Agent>,
-        response: oneshot::Sender<Result<(), BootstrapError>>,
-    },
-    SledReset {
-        agent: Arc<Agent>,
-        response: oneshot::Sender<Result<(), BootstrapError>>,
-    },
-}
-
-// `Agent` doesn't impl `Debug`, so we'll manually impl Debug on ourself.
-impl fmt::Debug for SledOperationInterlockCmd {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            SledOperationInterlockCmd::RackInitialize { .. } => {
-                "SledOperationInterlockCmd::RackInitialize"
-            }
-            SledOperationInterlockCmd::RackReset { .. } => {
-                "SledOperationInterlockCmd::RackReset"
-            }
-            SledOperationInterlockCmd::SledReset { .. } => {
-                "SledOperationInterlockCmd::SledReset"
-            }
-        };
-        f.write_str(s)
-    }
-}
-
-type SledOperationTaskHandle = JoinHandle<Result<(), BootstrapError>>;
-type SledOperationTaskResult = Result<Result<(), BootstrapError>, JoinError>;
-
-enum SledOperationTask {
-    RackInitializing(SledOperationTaskHandle),
-    RackResetting(SledOperationTaskHandle),
-    SledResetting(SledOperationTaskHandle),
-}
-
-struct SledOperationInterlockInner {
-    cmds_rx: mpsc::Receiver<SledOperationInterlockCmd>,
-    running_task: Option<SledOperationTask>,
-    rack_initialization_status_tx: watch::Sender<RackInitializationStatus>,
-    sled_reset_status_tx: watch::Sender<SledResetStatus>,
-}
-
-impl SledOperationInterlockInner {
-    async fn run(mut self) {
-        loop {
-            // If we have a task running, we'll `select!` on its completion; if
-            // not, we use `pending()` which gives back a future that never
-            // completes.
-            let mut pending = future::pending();
-            let task_fut: &mut (dyn Future<Output = SledOperationTaskResult>
-                      + Send
-                      + Unpin) = match self.running_task.as_mut() {
-                Some(
-                    SledOperationTask::RackInitializing(t)
-                    | SledOperationTask::RackResetting(t)
-                    | SledOperationTask::SledResetting(t),
-                ) => t,
-                None => &mut pending,
-            };
-
-            tokio::select! {
-                result = task_fut => {
-                    self.handle_task_result(result);
-                }
-
-                Some(cmd) = self.cmds_rx.recv() => {
-                    self.handle_cmd(cmd);
-                }
-            }
-        }
-    }
-
-    fn handle_cmd(&mut self, cmd: SledOperationInterlockCmd) {
-        fn send_busy_response(
-            tx: oneshot::Sender<Result<(), BootstrapError>>,
-            task: &SledOperationTask,
-        ) {
-            let message = match task {
-                SledOperationTask::RackInitializing(_) => {
-                    "rack busy initializing"
-                }
-                SledOperationTask::RackResetting(_) => "rack busy resetting",
-                SledOperationTask::SledResetting(_) => "sled busy resetting",
-            };
-            _ = tx.send(Err(BootstrapError::ConcurrentSledOperationAccess {
-                message,
-            }));
-        }
-
-        match cmd {
-            SledOperationInterlockCmd::RackInitialize {
-                agent,
-                request,
-                response,
-            } => {
-                if let Some(task) = self.running_task.as_ref() {
-                    send_busy_response(response, task);
-                } else {
-                    self.running_task = Some(
-                        SledOperationTask::RackInitializing(tokio::spawn(
-                            async move { agent.rack_initialize(request).await },
-                        )),
-                    );
-                }
-            }
-            SledOperationInterlockCmd::RackReset { agent, response } => {
-                if let Some(task) = self.running_task.as_ref() {
-                    send_busy_response(response, task);
-                } else {
-                    self.running_task = Some(SledOperationTask::RackResetting(
-                        tokio::spawn(async move { agent.rack_reset().await }),
-                    ));
-                }
-            }
-            SledOperationInterlockCmd::SledReset { agent, response } => {
-                if let Some(task) = self.running_task.as_ref() {
-                    send_busy_response(response, task);
-                } else {
-                    self.running_task = Some(SledOperationTask::SledResetting(
-                        tokio::spawn(async move { agent.sled_reset().await }),
-                    ));
-                }
-            }
-        }
-    }
-
-    fn handle_task_result(&mut self, result: SledOperationTaskResult) {
-        // We are called from `run()` when our currently-running task is
-        // complete, which means there _must_ be a value in `self.running_task`
-        // (otherwise `run()` couldn't have gotten a result at all!).
-        let Some(running_task) = self.running_task.take() else {
-            panic!("handle_task_result called with no running task?!");
-        };
-
-        match running_task {
-            SledOperationTask::RackInitializing(_) => {
-                // Ignore send errors
-                _ = self.rack_initialization_status_tx.send(match result {
-                    Ok(Ok(())) => RackInitializationStatus::Initialized,
-                    Ok(Err(err)) => {
-                        RackInitializationStatus::InitializationFailed {
-                            reason: format!("{err:#}"),
-                        }
-                    }
-                    Err(err) => {
-                        let reason = if err.is_panic() {
-                            "initialization task panicked"
-                        } else if err.is_cancelled() {
-                            "initialization task unexpectedly cancelled"
-                        } else {
-                            "initialization task failed (reason unknown)"
-                        };
-                        RackInitializationStatus::InitializationFailed {
-                            reason: reason.into(),
-                        }
-                    }
-                });
-            }
-            SledOperationTask::RackResetting(_) => {
-                _ = self.rack_initialization_status_tx.send(match result {
-                    Ok(Ok(())) => RackInitializationStatus::Reset,
-                    Ok(Err(err)) => RackInitializationStatus::ResetFailed {
-                        reason: format!("{err:#}"),
-                    },
-                    Err(err) => {
-                        let reason = if err.is_panic() {
-                            "reset task panicked"
-                        } else if err.is_cancelled() {
-                            "reset task unexpectedly cancelled"
-                        } else {
-                            "reset task failed (reason unknown)"
-                        };
-                        RackInitializationStatus::ResetFailed {
-                            reason: reason.into(),
-                        }
-                    }
-                });
-            }
-            SledOperationTask::SledResetting(_) => {
-                _ = self.sled_reset_status_tx.send(match result {
-                    Ok(Ok(())) => SledResetStatus::Reset,
-                    Ok(Err(err)) => SledResetStatus::ResetFailed {
-                        reason: format!("{err:#}"),
-                    },
-                    Err(err) => {
-                        let reason = if err.is_panic() {
-                            "reset task panicked"
-                        } else if err.is_cancelled() {
-                            "reset task unexpectedly cancelled"
-                        } else {
-                            "reset task failed (reason unknown)"
-                        };
-                        SledResetStatus::ResetFailed { reason: reason.into() }
-                    }
-                });
-            }
-        }
-    }
 }

--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -7,6 +7,7 @@
 pub mod agent;
 pub mod client;
 pub mod config;
+mod context;
 mod hardware;
 mod http_entrypoints;
 mod maghemite;


### PR DESCRIPTION
After this change, the three bootstrap-agent endpoints:

* `POST /sled-initialize`
* `DELETE /sled-initialize`
* `POST /sled-reset`

are safe in the face of future cancellation due to client disconnects: all three will `tokio::spawn()` a task to do their relevant work and then return to the client, leaving the actual work running. Previously, the two `sled-initialize` endpoints used a `tokio::Mutex` to guard against their being called concurrently; now all three are mutually exclusive, and any request to any of the three will fail if a _prior_ request to any of the three is still running.

We also add two new endpoints:

* `GET /sled-initialize`
* `GET /sled-reset`

that allow a client to get the (very basic, no details provided except on failure) status of a prior request.

TODO before merging:

- [ ] test on `madrid`