### PR TITLE
[nexus, minor] Use helper for disk create params validation in one more spot

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -149,19 +149,10 @@ impl super::Nexus {
                     .fetch()
                     .await?;
 
-                // Reject disks where the block size doesn't evenly divide the
-                // total size
-                if (params.size.to_bytes()
-                    % db_image.block_size.to_bytes() as u64)
-                    != 0
-                {
-                    return Err(Error::InvalidValue {
-                        label: String::from("size and block_size"),
-                        message: String::from(
-                            "total size must be a multiple of global image's block size",
-                        ),
-                    });
-                }
+                validate_disk_create_params(
+                    &params,
+                    db_image.block_size.to_bytes().into(),
+                )?;
 
                 // If the size of the image is greater than the size of the
                 // disk, return an error.
@@ -173,32 +164,6 @@ impl super::Nexus {
                             db_image.size.to_bytes(),
                         ),
                     ));
-                }
-
-                // Reject disks where the size isn't at least
-                // MIN_DISK_SIZE_BYTES
-                if params.size.to_bytes() < params::MIN_DISK_SIZE_BYTES as u64 {
-                    return Err(Error::InvalidValue {
-                        label: String::from("size"),
-                        message: format!(
-                            "total size must be at least {}",
-                            ByteCount::from(params::MIN_DISK_SIZE_BYTES)
-                        ),
-                    });
-                }
-
-                // Reject disks where the MIN_DISK_SIZE_BYTES doesn't evenly
-                // divide the size
-                if (params.size.to_bytes() % params::MIN_DISK_SIZE_BYTES as u64)
-                    != 0
-                {
-                    return Err(Error::InvalidValue {
-                        label: String::from("size"),
-                        message: format!(
-                            "total size must be a multiple of {}",
-                            ByteCount::from(params::MIN_DISK_SIZE_BYTES)
-                        ),
-                    });
                 }
             }
             params::DiskSource::ImportingBlocks { block_size } => {


### PR DESCRIPTION
I noticed we were doing some manual checks in the create from image case that are covered by `validate_disk_create_params`.