### PR TITLE
Only update relevant ports when updating firewall rules on sled.

### DIFF
--- a/illumos-utils/src/opte/params.rs
+++ b/illumos-utils/src/opte/params.rs
@@ -13,6 +13,7 @@ use std::net::Ipv6Addr;
 /// Update firewall rules for a VPC
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct VpcFirewallRulesEnsureBody {
+    pub vni: external::Vni,
     pub rules: Vec<VpcFirewallRule>,
 }
 

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -13,6 +13,7 @@ use crate::opte::Gateway;
 use crate::opte::Port;
 use crate::opte::Vni;
 use ipnetwork::IpNetwork;
+use omicron_common::api::external;
 use omicron_common::api::internal::shared::NetworkInterface;
 use omicron_common::api::internal::shared::NetworkInterfaceKind;
 use omicron_common::api::internal::shared::SourceNatConfig;
@@ -383,6 +384,7 @@ impl PortManager {
     #[cfg(target_os = "illumos")]
     pub fn firewall_rules_ensure(
         &self,
+        vni: external::Vni,
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
         use opte_ioctl::OpteHdl;
@@ -390,11 +392,20 @@ impl PortManager {
         info!(
             self.inner.log,
             "Ensuring VPC firewall rules";
+            "vni" => ?vni,
             "rules" => ?&rules,
         );
 
         let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
-        for ((_, _), port) in self.inner.ports.lock().unwrap().iter() {
+
+        let ports = self.inner.ports.lock().unwrap();
+
+        // We update VPC rules as a set so grab only
+        // the relevant ports using the VPC's VNI.
+        let vpc_ports = ports
+            .iter()
+            .filter(|((_, _), port)| u32::from(vni) == u32::from(*port.vni()));
+        for ((_, _), port) in vpc_ports {
             let rules = opte_firewall_rules(rules, port.vni(), port.mac());
             let port_name = port.name().to_string();
             info!(
@@ -414,9 +425,15 @@ impl PortManager {
     #[cfg(not(target_os = "illumos"))]
     pub fn firewall_rules_ensure(
         &self,
+        vni: external::Vni,
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
-        info!(self.inner.log, "Ignoring {} firewall rules", rules.len());
+        info!(
+            self.inner.log,
+            "Ensuring VPC firewall rules (ignored)";
+            "vni" => ?vni,
+            "rules" => ?&rules,
+        );
         Ok(())
     }
 
@@ -450,9 +467,13 @@ impl PortManager {
     #[cfg(not(target_os = "illumos"))]
     pub fn set_virtual_nic_host(
         &self,
-        _mapping: &SetVirtualNetworkInterfaceHost,
+        mapping: &SetVirtualNetworkInterfaceHost,
     ) -> Result<(), Error> {
-        info!(self.inner.log, "Ignoring virtual NIC mapping");
+        info!(
+            self.inner.log,
+            "Mapping virtual NIC to physical host (ignored)";
+            "mapping" => ?&mapping,
+        );
         Ok(())
     }
 

--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -386,6 +386,13 @@ impl PortManager {
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
         use opte_ioctl::OpteHdl;
+
+        info!(
+            self.inner.log,
+            "Ensuring VPC firewall rules";
+            "rules" => ?&rules,
+        );
+
         let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
         for ((_, _), port) in self.inner.ports.lock().unwrap().iter() {
             let rules = opte_firewall_rules(rules, port.vni(), port.mac());
@@ -420,6 +427,11 @@ impl PortManager {
     ) -> Result<(), Error> {
         use opte_ioctl::OpteHdl;
 
+        info!(
+            self.inner.log,
+            "Mapping virtual NIC to physical host";
+            "mapping" => ?&mapping,
+        );
         let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
         hdl.set_v2p(&oxide_vpc::api::SetVirt2PhysReq {
             vip: mapping.virtual_ip.into(),

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -257,6 +257,7 @@ impl super::Nexus {
         debug!(self.log, "resolved {} rules for sleds", rules_for_sled.len());
         let sled_rules_request =
             sled_agent_client::types::VpcFirewallRulesEnsureBody {
+                vni: vpc.vni.0.into(),
                 rules: rules_for_sled,
             };
 

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2444,10 +2444,14 @@
             "items": {
               "$ref": "#/components/schemas/VpcFirewallRule"
             }
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
           }
         },
         "required": [
-          "rules"
+          "rules",
+          "vni"
         ]
       },
       "ZoneType": {

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -315,10 +315,10 @@ async fn vpc_firewall_rules_put(
     body: TypedBody<VpcFirewallRulesEnsureBody>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let sa = rqctx.context();
-    let vpc_id = path_params.into_inner().vpc_id;
+    let _vpc_id = path_params.into_inner().vpc_id;
     let body_args = body.into_inner();
 
-    sa.firewall_rules_ensure(vpc_id, &body_args.rules[..])
+    sa.firewall_rules_ensure(body_args.vni, &body_args.rules[..])
         .await
         .map_err(Error::from)?;
 

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -7,11 +7,10 @@
 use crate::nexus::LazyNexusClient;
 use crate::params::{
     InstanceHardware, InstanceMigrationSourceParams, InstancePutStateResponse,
-    InstanceStateRequested, InstanceUnregisterResponse, VpcFirewallRule,
+    InstanceStateRequested, InstanceUnregisterResponse,
 };
 use illumos_utils::dladm::Etherstub;
 use illumos_utils::link::VnicAllocator;
-use illumos_utils::opte::params::SetVirtualNetworkInterfaceHost;
 use illumos_utils::opte::PortManager;
 use illumos_utils::vmm_reservoir;
 use omicron_common::api::external::ByteCount;
@@ -319,45 +318,6 @@ impl InstanceManager {
             .issue_snapshot_request(disk_id, snapshot_id)
             .await
             .map_err(Error::from)
-    }
-
-    pub async fn firewall_rules_ensure(
-        &self,
-        rules: &[VpcFirewallRule],
-    ) -> Result<(), Error> {
-        info!(
-            &self.inner.log,
-            "Ensuring VPC firewall rules";
-            "rules" => ?&rules,
-        );
-        self.inner.port_manager.firewall_rules_ensure(rules)?;
-        Ok(())
-    }
-
-    pub async fn set_virtual_nic_host(
-        &self,
-        mapping: &SetVirtualNetworkInterfaceHost,
-    ) -> Result<(), Error> {
-        info!(
-            &self.inner.log,
-            "Mapping virtual NIC to physical host";
-            "mapping" => ?&mapping,
-        );
-        self.inner.port_manager.set_virtual_nic_host(mapping)?;
-        Ok(())
-    }
-
-    pub async fn unset_virtual_nic_host(
-        &self,
-        mapping: &SetVirtualNetworkInterfaceHost,
-    ) -> Result<(), Error> {
-        info!(
-            &self.inner.log,
-            "Unmapping virtual NIC to physical host";
-            "mapping" => ?&mapping,
-        );
-        self.inner.port_manager.unset_virtual_nic_host(mapping)?;
-        Ok(())
     }
 
     /// Generates an instance ticket associated with this instance manager. This

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -160,6 +160,9 @@ struct SledAgentInner {
     // Component of Sled Agent responsible for managing updates.
     updates: UpdateManager,
 
+    /// Component of Sled Agent responsible for managing OPTE ports.
+    port_manager: PortManager,
+
     // Other Oxide-controlled services running on this Sled.
     services: ServiceManager,
 
@@ -277,7 +280,7 @@ impl SledAgent {
         services
             .sled_agent_started(
                 svc_config,
-                port_manager,
+                port_manager.clone(),
                 *sled_address.ip(),
                 request.rack_id,
             )
@@ -291,6 +294,7 @@ impl SledAgent {
                 instances,
                 hardware,
                 updates,
+                port_manager,
                 services,
                 lazy_nexus_client,
 
@@ -682,9 +686,8 @@ impl SledAgent {
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
         self.inner
-            .instances
+            .port_manager
             .firewall_rules_ensure(rules)
-            .await
             .map_err(Error::from)
     }
 
@@ -693,9 +696,8 @@ impl SledAgent {
         mapping: &SetVirtualNetworkInterfaceHost,
     ) -> Result<(), Error> {
         self.inner
-            .instances
+            .port_manager
             .set_virtual_nic_host(mapping)
-            .await
             .map_err(Error::from)
     }
 
@@ -704,9 +706,8 @@ impl SledAgent {
         mapping: &SetVirtualNetworkInterfaceHost,
     ) -> Result<(), Error> {
         self.inner
-            .instances
+            .port_manager
             .unset_virtual_nic_host(mapping)
-            .await
             .map_err(Error::from)
     }
 

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -24,6 +24,7 @@ use illumos_utils::opte::PortManager;
 use omicron_common::address::{
     get_sled_address, get_switch_zone_address, Ipv6Subnet, SLED_PREFIX,
 };
+use omicron_common::api::external::Vni;
 use omicron_common::api::{
     internal::nexus::DiskRuntimeState, internal::nexus::InstanceRuntimeState,
     internal::nexus::UpdateArtifactId,
@@ -682,12 +683,12 @@ impl SledAgent {
 
     pub async fn firewall_rules_ensure(
         &self,
-        _vpc_id: Uuid,
+        vpc_vni: Vni,
         rules: &[VpcFirewallRule],
     ) -> Result<(), Error> {
         self.inner
             .port_manager
-            .firewall_rules_ensure(rules)
+            .firewall_rules_ensure(vpc_vni, rules)
             .map_err(Error::from)
     }
 


### PR DESCRIPTION
Firewall rules are always pushed per-VPC but we were previously attempting to apply said rules to every OPTE port on a sled. This would cause any ports not tied to the specific VPC to have their firewall rules cleared out. Filtering to just the relevant ports before attempting to apply the rules addresses this.

Fixes #3336