### PR TITLE
Update to latest dropshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,7 +1738,7 @@ dependencies = [
  "diesel",
  "serde",
  "usdt",
- "uuid 0.8.2",
+ "uuid 1.3.3",
  "version_check",
 ]
 
@@ -1978,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#c719b41bc4ba46e3e9e5d85f6efffab694e0f0ff"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fc0ffd522a78f9296f855bdf4c2703f900dfe99e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1986,6 +1992,7 @@ dependencies = [
  "bytes",
  "camino",
  "chrono",
+ "debug-ignore",
  "dropshot_endpoint",
  "form_urlencoded",
  "futures",
@@ -2016,12 +2023,13 @@ dependencies = [
  "usdt",
  "uuid 1.3.3",
  "version_check",
+ "waitgroup",
 ]
 
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#c719b41bc4ba46e3e9e5d85f6efffab694e0f0ff"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fc0ffd522a78f9296f855bdf4c2703f900dfe99e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8836,10 +8844,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.8",
- "serde",
-]
 
 [[package]]
 name = "uuid"
@@ -8931,6 +8935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
 ]
 
 [[package]]

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -7,7 +7,7 @@ use dns_service_client::{
     types::{DnsConfigParams, DnsConfigZone, DnsRecord, Srv},
     Client,
 };
-use dropshot::test_util::LogContext;
+use dropshot::{test_util::LogContext, HandlerTaskMode};
 use omicron_test_utils::dev::test_setup_log;
 use slog::o;
 use std::{collections::HashMap, net::Ipv4Addr, net::Ipv6Addr};
@@ -397,6 +397,7 @@ fn test_config(
     let config_dropshot = dropshot::ConfigDropshot {
         bind_address: "[::1]:0".to_string().parse().unwrap(),
         request_body_max_bytes: 1024,
+        default_handler_task_mode: HandlerTaskMode::Detached,
     };
 
     Ok((tmp_dir, config_storage, config_dropshot, logctx))

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -27,6 +27,7 @@ pub use management_switch::SwitchPortConfig;
 pub use management_switch::SwitchPortDescription;
 
 use dropshot::ConfigDropshot;
+use dropshot::HandlerTaskMode;
 use slog::debug;
 use slog::error;
 use slog::info;
@@ -93,6 +94,7 @@ fn start_dropshot_server(
     let dropshot = ConfigDropshot {
         bind_address: SocketAddr::V6(addr),
         request_body_max_bytes,
+        default_handler_task_mode: HandlerTaskMode::Detached,
     };
     let http_server_starter = dropshot::HttpServerStarter::new(
         &dropshot,

--- a/installinator-artifactd/src/server.rs
+++ b/installinator-artifactd/src/server.rs
@@ -9,7 +9,7 @@
 use std::net::SocketAddrV6;
 
 use anyhow::{anyhow, Result};
-use dropshot::HttpServer;
+use dropshot::{HandlerTaskMode, HttpServer};
 
 use crate::{
     context::ServerContext,
@@ -54,6 +54,7 @@ impl ArtifactServer {
             // https://github.com/oxidecomputer/dropshot/pull/618 lands and is
             // available in omicron.
             request_body_max_bytes: 4 * 1024 * 1024,
+            default_handler_task_mode: HandlerTaskMode::Detached,
         };
 
         let api = crate::http_entrypoints::api();

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -180,6 +180,7 @@ mod test {
     use anyhow::Context;
     use assert_matches::assert_matches;
     use dns_service_client::types::DnsConfigParams;
+    use dropshot::HandlerTaskMode;
     use omicron_test_utils::dev::test_setup_log;
     use slog::{o, Logger};
     use std::collections::HashMap;
@@ -232,6 +233,7 @@ mod test {
                 &dropshot::ConfigDropshot {
                     bind_address: "[::1]:0".parse().unwrap(),
                     request_body_max_bytes: 8 * 1024,
+                    default_handler_task_mode: HandlerTaskMode::Detached,
                 },
             )
             .await

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -154,6 +154,7 @@ pub mod test {
     use crate::db::TransactionError;
     use async_bb8_diesel::AsyncConnection;
     use async_bb8_diesel::AsyncRunQueryDsl;
+    use dropshot::HandlerTaskMode;
     use nexus_db_model::DnsGroup;
     use nexus_db_model::Generation;
     use nexus_db_queries::context::OpContext;
@@ -248,6 +249,7 @@ pub mod test {
             &dropshot::ConfigDropshot {
                 bind_address: "[::1]:0".parse().unwrap(),
                 request_body_max_bytes: 8 * 1024,
+                default_handler_task_mode: HandlerTaskMode::Detached,
             },
         )
         .await

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -11,6 +11,7 @@ use dropshot::test_util::LogContext;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
+use dropshot::HandlerTaskMode;
 use nexus_test_interface::NexusServer;
 use nexus_types::external_api::params::UserId;
 use nexus_types::internal_api::params::Certificate;
@@ -393,6 +394,7 @@ pub async fn start_sled_agent(
         dropshot: ConfigDropshot {
             bind_address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0),
             request_body_max_bytes: 1024 * 1024,
+            default_handler_task_mode: HandlerTaskMode::Detached,
         },
         // TODO-cleanup this is unused
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Debug },
@@ -576,6 +578,7 @@ pub async fn start_dns_server(
         &dropshot::ConfigDropshot {
             bind_address: "[::1]:0".parse().unwrap(),
             request_body_max_bytes: 8 * 1024,
+            default_handler_task_mode: HandlerTaskMode::Detached,
         },
     )
     .await

--- a/oximeter/producer/examples/producer.rs
+++ b/oximeter/producer/examples/producer.rs
@@ -11,6 +11,7 @@ use chrono::Utc;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
+use dropshot::HandlerTaskMode;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use oximeter::types::Cumulative;
 use oximeter::types::Sample;
@@ -94,8 +95,11 @@ impl Producer for CpuBusyProducer {
 #[tokio::main]
 async fn main() {
     let address = "[::1]:0".parse().unwrap();
-    let dropshot =
-        ConfigDropshot { bind_address: address, request_body_max_bytes: 2048 };
+    let dropshot = ConfigDropshot {
+        bind_address: address,
+        request_body_max_bytes: 2048,
+        default_handler_task_mode: HandlerTaskMode::Detached,
+    };
     let log = LogConfig::Config(ConfigLogging::StderrTerminal {
         level: ConfigLoggingLevel::Debug,
     });

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
+use dropshot::HandlerTaskMode;
 use nexus_client::types as NexusTypes;
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
@@ -98,6 +99,7 @@ async fn do_run() -> Result<(), CmdError> {
         dropshot: ConfigDropshot {
             bind_address: args.sled_agent_addr.into(),
             request_body_max_bytes: 1024 * 1024,
+            default_handler_task_mode: HandlerTaskMode::Detached,
         },
         log: ConfigLogging::StderrTerminal { level: ConfigLoggingLevel::Info },
         storage: ConfigStorage {

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -38,6 +38,7 @@ use crate::storage_manager::StorageManager;
 use camino::{Utf8Path, Utf8PathBuf};
 use ddm_admin_client::{Client as DdmAdminClient, DdmError};
 use dpd_client::{types as DpdTypes, Client as DpdClient, Error as DpdError};
+use dropshot::HandlerTaskMode;
 use illumos_utils::addrobj::AddrObject;
 use illumos_utils::addrobj::IPV6_LINK_LOCAL_NAME;
 use illumos_utils::dladm::{Dladm, Etherstub, EtherstubVnic, PhysicalLink};
@@ -1327,6 +1328,8 @@ impl ServiceManager {
                                 // This has to be large enough to support:
                                 // - bulk writes to disks
                                 request_body_max_bytes: 8192 * 1024,
+                                default_handler_task_mode:
+                                    HandlerTaskMode::Detached,
                             },
                         },
                         dropshot_internal: dropshot::ConfigDropshot {
@@ -1339,6 +1342,8 @@ impl ServiceManager {
                             // certificates provided by the customer during rack
                             // setup.
                             request_body_max_bytes: 10 * 1024 * 1024,
+                            default_handler_task_mode:
+                                HandlerTaskMode::Detached,
                         },
                         subnet: Ipv6Subnet::<RACK_PREFIX>::new(
                             sled_info.underlay_address,

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -17,6 +17,7 @@ use crucible_agent_client::types::{
     CreateRegion, Region, RegionId, RunningSnapshot, Snapshot, State,
 };
 use crucible_client_types::VolumeConstructionRequest;
+use dropshot::HandlerTaskMode;
 use dropshot::HttpError;
 use futures::lock::Mutex;
 use nexus_client::types::{
@@ -800,6 +801,7 @@ impl PantryServer {
                 // This has to be large enough to support:
                 // - bulk writes into disks
                 request_body_max_bytes: 8192 * 1024,
+                default_handler_task_mode: HandlerTaskMode::Detached,
             },
             super::http_entrypoints_pantry::api(),
             pantry.clone(),

--- a/wicketd/src/lib.rs
+++ b/wicketd/src/lib.rs
@@ -21,7 +21,7 @@ use mgs::make_mgs_client;
 pub(crate) use mgs::{MgsHandle, MgsManager};
 use sled_hardware::Baseboard;
 
-use dropshot::{ConfigDropshot, HttpServer};
+use dropshot::{ConfigDropshot, HandlerTaskMode, HttpServer};
 use slog::{debug, error, o, Drain};
 use std::{
     net::{SocketAddr, SocketAddrV6},
@@ -76,6 +76,7 @@ impl Server {
             // The maximum request size is set to 4 GB -- artifacts can be large and there's currently
             // no way to set a larger request size for some endpoints.
             request_body_max_bytes: 4 << 30,
+            default_handler_task_mode: HandlerTaskMode::Detached,
         };
 
         let mgs_manager = MgsManager::new(&log, args.mgs_address);


### PR DESCRIPTION
Picks up the change to add a `default_handler_task_mode` to detach spawned tasks and avoid cancellation woes.

For any `ConfigDropshot` where we were listing all args explicitly, I added the explicit task handler mode. (Maybe this was wrong I  should have added `..Default::default()`? It's easy to change if you think that would be better.) For any `ConfigDropshot` that we were already using `Default` (or for which we're reading the config from a toml file), we will pick up the dropshot default of `Detached`.