### PR TITLE
ci: --netrc + [[publish]] in tuf-repo.sh

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -25,18 +25,18 @@
 #:
 #: [[publish]]
 #: series = "tuf-repo"
-#: name = "repo.zip.parta"
-#: from_output = "/work/repo.zip.parta"
+#: name = "repo-dogfood.zip.parta"
+#: from_output = "/work/repo-dogfood.zip.parta"
 #:
 #: [[publish]]
 #: series = "tuf-repo"
-#: name = "repo.zip.partb"
-#: from_output = "/work/repo.zip.partb"
+#: name = "repo-dogfood.zip.partb"
+#: from_output = "/work/repo-dogfood.zip.partb"
 #:
 #: [[publish]]
 #: series = "tuf-repo"
-#: name = "repo.zip.sha256.txt"
-#: from_output = "/work/repo.zip.sha256.txt"
+#: name = "repo-dogfood.zip.sha256.txt"
+#: from_output = "/work/repo-dogfood.zip.sha256.txt"
 #:
 
 set -o errexit

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -137,9 +137,9 @@ done
 
 # Fetch SP images from oxidecomputer/hubris GHA artifacts.
 HUBRIS_VERSION="1.0.0-alpha+git${HUBRIS_COMMIT:0:11}"
-run_id=$(curl "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$HUBRIS_COMMIT" \
+run_id=$(curl --netrc "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$HUBRIS_COMMIT" \
     | /opt/ooce/bin/jq -r '.workflow_runs[] | select(.path == ".github/workflows/dist.yml") | .id')
-artifacts=$(curl "https://api.github.com/repos/oxidecomputer/hubris/actions/runs/$run_id/artifacts")
+artifacts=$(curl --netrc "https://api.github.com/repos/oxidecomputer/hubris/actions/runs/$run_id/artifacts")
 for noun in gimlet-c psc-b sidecar-b; do
     tufaceous_kind=${noun%-?}
     tufaceous_kind=${tufaceous_kind//sidecar/switch}_sp


### PR DESCRIPTION
This, hopefully, fixes two issues:

- e7b9526: I didn't update the `[[publish]]` keys to refer to the new paths.
- e87169a: The curl binary does not enable ~/.netrc support by default; [Buildomat drops in a ~/.netrc file with a GitHub token](https://github.com/oxidecomputer/buildomat/blob/f7683e113f0d5b1745ded9b9ba83ca02a3431f64/github/server/src/variety/basic.rs#L739-L777) so jobs can clone private repos. Most EC2 public IPs are constantly exceeding anonymous rate limits, so it was sheer luck that it worked in the job for #3363.