### PR TITLE
Clarify the CTE around region allocation

### DIFF
--- a/nexus/db-queries/src/db/queries/region_allocation.rs
+++ b/nexus/db-queries/src/db/queries/region_allocation.rs
@@ -74,6 +74,11 @@ impl OldRegions {
 }
 
 /// A subquery to find datasets which could be used for provisioning regions.
+///
+/// We only consider datasets which are already allocated as "Crucible".
+/// This implicitly distinguishes between "M.2s" and "U.2s" -- Nexus need
+/// to determine during dataset provisioning which devices should be considered
+/// for usage as Crucible storage.
 #[derive(Subquery, QueryId)]
 #[subquery(name = candidate_datasets)]
 struct CandidateDatasets {
@@ -214,13 +219,14 @@ struct OldPoolUsage {
 }
 
 impl OldPoolUsage {
-    fn new() -> Self {
+    fn new(candidate_zpools: &CandidateZpools) -> Self {
         use crate::db::schema::dataset::dsl as dataset_dsl;
         Self {
             query: Box::new(
                 dataset_dsl::dataset
                     .inner_join(
-                        candidate_zpools::dsl::candidate_zpools
+                        candidate_zpools
+                            .query_source()
                             .on(dataset_dsl::pool_id
                                 .eq(candidate_zpools::dsl::id)),
                     )
@@ -473,7 +479,7 @@ impl RegionAllocate {
             extent_count,
         );
         let proposed_changes = ProposedChanges::new(&candidate_regions);
-        let old_pool_usage = OldPoolUsage::new();
+        let old_pool_usage = OldPoolUsage::new(&candidate_zpools);
         let zpool_size_delta = ZpoolSizeDelta::new(&proposed_changes);
         let proposed_datasets_fit =
             ProposedDatasetsFit::new(&old_pool_usage, &zpool_size_delta);

--- a/nexus/db-queries/src/db/queries/region_allocation.rs
+++ b/nexus/db-queries/src/db/queries/region_allocation.rs
@@ -76,9 +76,9 @@ impl OldRegions {
 /// A subquery to find datasets which could be used for provisioning regions.
 ///
 /// We only consider datasets which are already allocated as "Crucible".
-/// This implicitly distinguishes between "M.2s" and "U.2s" -- Nexus need
-/// to determine during dataset provisioning which devices should be considered
-/// for usage as Crucible storage.
+/// This implicitly distinguishes between "M.2s" and "U.2s" -- Nexus needs to
+/// determine during dataset provisioning which devices should be considered for
+/// usage as Crucible storage.
 #[derive(Subquery, QueryId)]
 #[subquery(name = candidate_datasets)]
 struct CandidateDatasets {


### PR DESCRIPTION
Some minor docs improvements, as I dug through this codebase recently:

- I wanted to clarify, "Does this CTE only provision Crucible datasets to U.2s, and not M.2s?". The answer to this question is: "yes, but implicitly decided when we provision the datasets themselves". Added a comment to clarify this during region selection.
- Additionally, when referencing a virtual table from an earlier `WITH candidate_zpools AS ...` arm of the CTE, make that reference explicit. This is a no-op change, but it clarifies the dependencies within the CTE. 