### PR TITLE
Remove tools/helios_version

### DIFF
--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -42,13 +42,11 @@ rustc --version
 
 TOP=$PWD
 
-source "$TOP/tools/helios_version"
 source "$TOP/tools/include/force-git-over-https.sh"
 
 # Checkout helios at a pinned commit into /work/helios
 git clone https://github.com/oxidecomputer/helios.git /work/helios
 cd /work/helios
-git checkout "$COMMIT"
 
 # TODO: Consider importing zones here too?
 

--- a/.github/buildomat/jobs/trampoline-image.sh
+++ b/.github/buildomat/jobs/trampoline-image.sh
@@ -42,13 +42,11 @@ rustc --version
 
 TOP=$PWD
 
-source "$TOP/tools/helios_version"
 source "$TOP/tools/include/force-git-over-https.sh"
 
 # Checkout helios at a pinned commit into /work/helios
 git clone https://github.com/oxidecomputer/helios.git /work/helios
 cd /work/helios
-git checkout "$COMMIT"
 
 cd "$TOP"
 ./tools/build-host-image.sh -R \

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -513,11 +513,8 @@ $ ./.github/buildomat/jobs/package.sh
 
 This will create a `/work` directory with a few tarballs in it. Building a host
 image requires a checkout of
-https://github.com/oxidecomputer/helios-engvm[helios]; the instructions below
-use `$HELIOS_PATH` for the path to this repository. To match CI builds, you
-should check out the commit specified in `./tools/helios_version`. (The script
-will check your current commit hash and will refuse to run if it doesn't match
-unless you pass `-f`.)
+https://github.com/oxidecomputer/helios[helios]; the instructions below
+use `$HELIOS_PATH` for the path to this repository.
 
 To build a standard host image:
 

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -60,9 +60,7 @@ function main
     HELIOS_PATH=$1
     GLOBAL_ZONE_TARBALL_PATH=$2
 
-    # Read expected helios commit into $COMMIT
     TOOLS_DIR="$(pwd)/$(dirname $0)"
-    source "$TOOLS_DIR/helios_version"
 
     # Grab the opte version
     OPTE_VER=$(cat "$TOOLS_DIR/opte_version")
@@ -87,21 +85,6 @@ function main
 
     # Move to the helios checkout
     cd $HELIOS_PATH
-
-    # Unless the user passed -f, check that the helios commit matches the one we
-    # have specified in `tools/helios_version`
-    if [ "x$FORCE" == "x" ]; then
-        CURRENT_COMMIT=$(git rev-parse HEAD)
-        if [ "x$COMMIT" != "x$CURRENT_COMMIT" ]; then
-            echo "WARNING: omicron/tools/helios_version specifies helios commit"
-            echo "  $COMMIT"
-            echo "but you have"
-            echo "  $CURRENT_COMMIT"
-            echo "Either check out the expected commit or pass -f to this"
-            echo "script to disable this check."
-            exit 1
-        fi
-    fi
 
     # Create the "./helios-build" command, which lets us build images
     gmake setup

--- a/tools/helios_version
+++ b/tools/helios_version
@@ -1,1 +1,0 @@
-COMMIT=c99d8ff5df1fdfb30fb943353abf8b5ed95ae79a


### PR DESCRIPTION
This is motivated by a commit in stlouis that requires the latest helios commit. https://pkg.oxide.computer/helios-netdev is updated whenever stlouis is, so images that are built here before helios_version is updated will be wrong. Unpin the helios version so that this does not occur.