### PR TITLE
[ci] tuf-repo: more curl flags fun

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -137,15 +137,15 @@ done
 
 # Fetch SP images from oxidecomputer/hubris GHA artifacts.
 HUBRIS_VERSION="1.0.0-alpha+git${HUBRIS_COMMIT:0:11}"
-run_id=$(curl --netrc "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$HUBRIS_COMMIT" \
+run_id=$(curl --netrc -fsS "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$HUBRIS_COMMIT" \
     | /opt/ooce/bin/jq -r '.workflow_runs[] | select(.path == ".github/workflows/dist.yml") | .id')
-artifacts=$(curl --netrc "https://api.github.com/repos/oxidecomputer/hubris/actions/runs/$run_id/artifacts")
+artifacts=$(curl --netrc -fsS "https://api.github.com/repos/oxidecomputer/hubris/actions/runs/$run_id/artifacts")
 for noun in gimlet-c psc-b sidecar-b; do
     tufaceous_kind=${noun%-?}
     tufaceous_kind=${tufaceous_kind//sidecar/switch}_sp
     job_name=dist-ubuntu-latest-$noun
     url=$(/opt/ooce/bin/jq --arg name "$job_name" -r '.artifacts[] | select(.name == $name) | .archive_download_url' <<<"$artifacts")
-    curl --netrc -L -o /work/$job_name.zip "$url"
+    curl --netrc -fsSL -o /work/$job_name.zip "$url"
     cat >>/work/manifest.toml <<EOF
 [artifact.$tufaceous_kind]
 name = "$tufaceous_kind"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -145,7 +145,7 @@ for noun in gimlet-c psc-b sidecar-b; do
     tufaceous_kind=${tufaceous_kind//sidecar/switch}_sp
     job_name=dist-ubuntu-latest-$noun
     url=$(/opt/ooce/bin/jq --arg name "$job_name" -r '.artifacts[] | select(.name == $name) | .archive_download_url' <<<"$artifacts")
-    curl -L -o /work/$job_name.zip "$url"
+    curl --netrc -L -o /work/$job_name.zip "$url"
     cat >>/work/manifest.toml <<EOF
 [artifact.$tufaceous_kind]
 name = "$tufaceous_kind"


### PR DESCRIPTION
Tried to do a mupdate over the weekend using the TUF repo outputed from the omicron CI job and ran into a failure while trying to update the scrimlet's SP. Peeking at the artifacts showed some suspicious file sizes:
```
      168  01-01-1980 00:00   repo/targets/78dee8daef1dcffd8138be2ca1faf0bf5557fe471cba10e7b8bc454269e67a4d.gimlet_sp-1.0.0-alpha+gitbf0963aa2a2.tar.gz
      168  01-01-1980 00:00   repo/targets/78dee8daef1dcffd8138be2ca1faf0bf5557fe471cba10e7b8bc454269e67a4d.psc_sp-1.0.0-alpha+gitbf0963aa2a2.tar.gz
      168  01-01-1980 00:00   repo/targets/78dee8daef1dcffd8138be2ca1faf0bf5557fe471cba10e7b8bc454269e67a4d.switch_sp-1.0.0-alpha+gitbf0963aa2a2.tar.gz
```

I know hubris builds can be small but 168 bytes seems a bit too small 😅. 

```console
$  file gimlet_sp.tar.gz
gimlet_sp.tar.gz:       ascii text

$  cat gimlet_sp.tar.gz
{
  "message": "You must have the actions scope to download artifacts.",
  "documentation_url": "https://docs.github.com/rest/reference/actions#download-an-artifact"
}
```

Hopefully `--netrc` is enough there; not sure what scopes are included in the API key buildomat plumbs. Also added some more useful flags for scripted curl.