### PR TITLE
[sled-agent] MGS listen addrs: use addpropvalue() over setprop()

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2280,7 +2280,7 @@ impl ServiceManager {
                             )?;
 
                             // Add the underlay address.
-                            smfh.setprop(
+                            smfh.addpropvalue(
                                 "config/address",
                                 &format!("[{address}]:{MGS_PORT}"),
                             )?;


### PR DESCRIPTION
When reconfiguring the switch zone, we attempted to tell MGS to listen on both localhost and the underlay network. However, the second `config/address` value (the underlay network) was using `setprop`, which overwrites existing values; this PR changes it to `addpropvalue()` so we'll still listen on localhost as intended.