### PR TITLE
CertificateCreate cert/key Vec<u8> -> String

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -39,7 +39,7 @@ _exit_trap() {
 	pfexec netstat -rncva
 	pfexec netstat -anu
 	pfexec arp -an
-	pfexec RUST_BACKTRACE=1 ./out/softnpu/scadm \
+	pfexec ./out/softnpu/scadm \
 		--server /opt/oxide/softnpu/stuff/server \
 		--client /opt/oxide/softnpu/stuff/client \
 		standalone \

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -39,7 +39,7 @@ _exit_trap() {
 	pfexec netstat -rncva
 	pfexec netstat -anu
 	pfexec arp -an
-	pfexec ./out/softnpu/scadm \
+	pfexec RUST_BACKTRACE=1 ./out/softnpu/scadm \
 		--server /opt/oxide/softnpu/stuff/server \
 		--client /opt/oxide/softnpu/stuff/client \
 		standalone \

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -47,7 +47,7 @@ impl Certificate {
         params: params::CertificateCreate,
     ) -> Result<Self, CertificateError> {
         let validator = CertificateValidator::default();
-        validator.validate(&params.cert, &params.key)?;
+        validator.validate(params.cert.as_bytes(), params.key.as_bytes())?;
 
         Ok(Self::new_unvalidated(silo_id, id, service, params))
     }
@@ -64,8 +64,8 @@ impl Certificate {
             identity: CertificateIdentity::new(id, params.identity),
             silo_id,
             service,
-            cert: params.cert,
-            key: params.key,
+            cert: params.cert.into_bytes(),
+            key: params.key.into_bytes(),
         }
     }
 }

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -859,8 +859,8 @@ mod test {
                 name: namestr.parse().unwrap(),
                 description: String::new(),
             },
-            cert: cert_pem.into_bytes(),
-            key: key_pem.into_bytes(),
+            cert: cert_pem,
+            key: key_pem,
             service: shared::ServiceUsingCertificate::ExternalApi,
         }
     }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -149,8 +149,8 @@ pub async fn create_ip_pool(
 pub async fn create_certificate(
     client: &ClientTestContext,
     cert_name: &str,
-    cert: Vec<u8>,
-    key: Vec<u8>,
+    cert: String,
+    key: String,
 ) -> Certificate {
     let url = "/v1/certificates".to_string();
     object_create(

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -735,10 +735,10 @@ pub struct CertificateCreate {
     /// common identifying metadata
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    /// PEM file containing public certificate chain
-    pub cert: Vec<u8>,
-    /// PEM file containing private key
-    pub key: Vec<u8>,
+    /// PEM-formatted string containing public certificate chain
+    pub cert: String,
+    /// PEM-formatted string containing private key
+    pub key: String,
     /// The service using this certificate
     pub service: shared::ServiceUsingCertificate,
 }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -239,8 +239,8 @@ pub struct DatasetCreateRequest {
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Certificate {
-    pub cert: Vec<u8>,
-    pub key: Vec<u8>,
+    pub cert: String,
+    pub key: String,
 }
 
 impl std::fmt::Debug for Certificate {

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -288,20 +288,10 @@
         "type": "object",
         "properties": {
           "cert": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "type": "string"
           },
           "key": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "type": "string"
           }
         },
         "required": [

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -847,20 +847,10 @@
         "type": "object",
         "properties": {
           "cert": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "type": "string"
           },
           "key": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "type": "string"
           }
         },
         "required": [

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8385,25 +8385,15 @@
         "type": "object",
         "properties": {
           "cert": {
-            "description": "PEM file containing public certificate chain",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "description": "PEM-formatted string containing public certificate chain",
+            "type": "string"
           },
           "description": {
             "type": "string"
           },
           "key": {
-            "description": "PEM file containing private key",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
+            "description": "PEM-formatted string containing private key",
+            "type": "string"
           },
           "name": {
             "$ref": "#/components/schemas/Name"

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -364,13 +364,8 @@
           "content": {
             "application/json": {
               "schema": {
-                "title": "Array_of_uint8",
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0
-                }
+                "title": "String",
+                "type": "string"
               }
             }
           },
@@ -405,13 +400,8 @@
           "content": {
             "application/json": {
               "schema": {
-                "title": "Array_of_uint8",
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0
-                }
+                "title": "String",
+                "type": "string"
               }
             }
           },

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -118,10 +118,10 @@ async fn do_run() -> Result<(), CmdError> {
     let tls_certificate = match (args.rss_tls_cert, args.rss_tls_key) {
         (None, None) => None,
         (Some(cert_path), Some(key_path)) => {
-            let cert_bytes = std::fs::read(&cert_path)
+            let cert_bytes = std::fs::read_to_string(&cert_path)
                 .with_context(|| format!("read {:?}", &cert_path))
                 .map_err(|e| CmdError::Failure(e.to_string()))?;
-            let key_bytes = std::fs::read(&key_path)
+            let key_bytes = std::fs::read_to_string(&key_path)
                 .with_context(|| format!("read {:?}", &key_path))
                 .map_err(|e| CmdError::Failure(e.to_string()))?;
             Some(NexusTypes::Certificate { cert: cert_bytes, key: key_bytes })

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -33,8 +33,8 @@ impl SetupServiceConfig {
         if let Some(parent) = path.parent() {
             let cert_path = parent.join("initial-tls-cert.pem");
             let key_path = parent.join("initial-tls-key.pem");
-            let cert_bytes = std::fs::read(&cert_path);
-            let key_bytes = std::fs::read(&key_path);
+            let cert_bytes = std::fs::read_to_string(&cert_path);
+            let key_bytes = std::fs::read_to_string(&key_path);
             match (cert_bytes, key_bytes) {
                 (Ok(cert), Ok(key)) => {
                     raw_config
@@ -222,9 +222,7 @@ mod test {
             .expect("failed to read generated config with certificate");
         assert_eq!(read_cfg.external_certificates.len(), 1);
         let cert = read_cfg.external_certificates.iter().next().unwrap();
-        let key_pem = std::str::from_utf8(&cert.key)
-            .expect("generated PEM was not UTF-8");
-        let _ = rcgen::KeyPair::from_pem(&key_pem)
+        let _ = rcgen::KeyPair::from_pem(&cert.key)
             .expect("generated PEM did not parse as KeyPair");
     }
 }

--- a/wicket/src/rack_setup.rs
+++ b/wicket/src/rack_setup.rs
@@ -136,9 +136,9 @@ impl SetupArgs {
             }
             SetupArgs::UploadCert => {
                 slog::info!(log, "reading cert from stdin...");
-                let mut cert = Vec::new();
+                let mut cert = String::new();
                 io::stdin()
-                    .read_to_end(&mut cert)
+                    .read_to_string(&mut cert)
                     .context("failed to read certificate from stdin")?;
 
                 slog::info!(log, "uploading cert to wicketd...");
@@ -180,9 +180,9 @@ impl SetupArgs {
             }
             SetupArgs::UploadKey => {
                 slog::info!(log, "reading key from stdin...");
-                let mut key = Zeroizing::new(Vec::new());
+                let mut key = Zeroizing::new(String::new());
                 io::stdin()
-                    .read_to_end(&mut key)
+                    .read_to_string(&mut key)
                     .context("failed to read key from stdin")?;
 
                 slog::info!(log, "uploading key to wicketd...");

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -269,7 +269,7 @@ pub enum CertificateUploadResponse {
 }]
 async fn post_rss_config_cert(
     rqctx: RequestContext<ServerContext>,
-    body: TypedBody<Vec<u8>>,
+    body: TypedBody<String>,
 ) -> Result<HttpResponseOk<CertificateUploadResponse>, HttpError> {
     let ctx = rqctx.context();
 
@@ -291,7 +291,7 @@ async fn post_rss_config_cert(
 }]
 async fn post_rss_config_key(
     rqctx: RequestContext<ServerContext>,
-    body: TypedBody<Vec<u8>>,
+    body: TypedBody<String>,
 ) -> Result<HttpResponseOk<CertificateUploadResponse>, HttpError> {
     let ctx = rqctx.context();
 

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -22,8 +22,8 @@ use wicket_common::rack_setup::PutRssUserConfigInsensitive;
 
 #[derive(Default)]
 struct PartialCertificate {
-    cert: Option<Vec<u8>>,
-    key: Option<Vec<u8>>,
+    cert: Option<String>,
+    key: Option<String>,
 }
 
 /// An analogue to `RackInitializeRequest`, but with optional fields to allow
@@ -88,7 +88,7 @@ impl CurrentRssConfig {
 
     pub(crate) fn push_cert(
         &mut self,
-        cert: Vec<u8>,
+        cert: String,
     ) -> Result<CertificateUploadResponse, String> {
         self.partial_external_certificate.cert = Some(cert);
         self.maybe_promote_external_certificate()
@@ -96,7 +96,7 @@ impl CurrentRssConfig {
 
     pub(crate) fn push_key(
         &mut self,
-        key: Vec<u8>,
+        key: String,
     ) -> Result<CertificateUploadResponse, String> {
         self.partial_external_certificate.key = Some(key);
         self.maybe_promote_external_certificate()
@@ -129,7 +129,9 @@ impl CurrentRssConfig {
         // will have to do that.
         validator.danger_disable_expiration_validation();
 
-        validator.validate(cert, key).map_err(|err| err.to_string())?;
+        validator
+            .validate(cert.as_bytes(), key.as_bytes())
+            .map_err(|err| err.to_string())?;
 
         // Cert and key appear to be valid; steal them out of
         // `partial_external_certificate` and promote them to


### PR DESCRIPTION
This is intended to address: https://github.com/oxidecomputer/oxide.rs/issues/161

In short: the API current calls for the key and cert to be specified as a `Vec<u8>`. While progenitor **could**, say, infer that a `Vec<u8>` should be some file that we load from disk, in fact the inputs here are PEM-formatted strings. I think therefore that a `String` is a better way to model these parameters.

This might not be the right approach; input welcome.