### PR TITLE
ci/tuf-repo: unpack hubris zip from GHA zip

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -145,14 +145,15 @@ for noun in gimlet-c psc-b sidecar-b; do
     tufaceous_kind=${tufaceous_kind//sidecar/switch}_sp
     job_name=dist-ubuntu-latest-$noun
     url=$(/opt/ooce/bin/jq --arg name "$job_name" -r '.artifacts[] | select(.name == $name) | .archive_download_url' <<<"$artifacts")
-    curl --netrc -fsSL -o /work/$job_name.zip "$url"
+    curl --netrc -fsSL -o $job_name.zip "$url"
+    unzip $job_name.zip
     cat >>/work/manifest.toml <<EOF
 [artifact.$tufaceous_kind]
 name = "$tufaceous_kind"
 version = "$HUBRIS_VERSION"
 [artifact.$tufaceous_kind.source]
 kind = "file"
-path = "/work/$job_name.zip"
+path = "$PWD/build-$noun-image-default.zip"
 EOF
 done
 


### PR DESCRIPTION
Actions jobs can upload multiple artifacts, but GitHub combines them into a single zip, even if there's only one artifact for the job. This unpacks the zip we download from the GitHub API so that the SP images are actually SP images, and not nested zips.

This is the last fix I'm aware of before mupdate from a CI-generated repo should work, at least until we find the next problem.