### PR TITLE
ci_download_softnpu_machinery: don't skip just because file exists locally

### DIFF
--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -7,34 +7,45 @@
 #   - the sidecar-lite precompiled P4 program
 #
 
+set -euo pipefail
 
-# This is the softnpu ASIC emulator
-if [[ ! -f out/softnpu/softnpu ]]; then
-    echo "fetching softnpu"
-    # This comes from a separate repo from the below artifacts,
-    SOFTNPU_COMMIT="88f5f1334364e5580fe778c44ac0746a35927351"
-    COMMIT_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/softnpu/image/$SOFTNPU_COMMIT"
-    curl -OL "$COMMIT_URL/softnpu"
-    chmod +x softnpu
-    mkdir -p out/softnpu
-    mv softnpu out/softnpu/
-fi
+TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Commit and base URL that's pinned for softnpu tools
-SIDECAR_LITE_COMMIT="3fff53ae549ab1348b680845693e66b224bb5d2f"
-COMMIT_URL="https://buildomat.eng.oxide.computer/public/file/oxidecomputer/sidecar-lite/release/$SIDECAR_LITE_COMMIT"
+OUT_DIR="out/softnpu"
+
+# Pinned commit for softnpu ASIC simulator
+SOFTNPU_REPO="softnpu"
+SOFTNPU_COMMIT="88f5f1334364e5580fe778c44ac0746a35927351"
+
+# Pinned commit for softnpu tools
+SIDECAR_LITE_REPO="sidecar-lite"
+SIDECAR_LITE_COMMIT="56abef043a9e2ba0363fea82528d7a9e86d3c0b0"
+
+# This is the softnpu ASIC simulator
+echo "fetching softnpu"
+mkdir -p out/softnpu
+$TOOLS_DIR/ensure_buildomat_artifact.sh \
+    -O $OUT_DIR \
+    "softnpu" \
+    "$SOFTNPU_REPO" \
+    "$SOFTNPU_COMMIT"
+chmod +x $OUT_DIR/softnpu
 
 # This is an ASIC administration program.
-if [[ ! -f out/softnpu/scadm ]]; then
-    echo "fetching scadm"
-    curl -OL "$COMMIT_URL/scadm"
-    chmod +x scadm
-    mv scadm out/softnpu/
-fi
+echo "fetching scadm"
+$TOOLS_DIR/ensure_buildomat_artifact.sh \
+    -O $OUT_DIR \
+    -s "release" \
+    "scadm" \
+    "$SIDECAR_LITE_REPO" \
+    "$SIDECAR_LITE_COMMIT"
+chmod +x $OUT_DIR/scadm
 
 # Fetch the pre-compiled sidecar_lite p4 program
-if [[ ! -f out/softnpu/libsidecar_lite.so ]]; then
-    echo "fetching libsidecar_lite.so"
-    curl -OL "$COMMIT_URL/libsidecar_lite.so"
-    mv libsidecar_lite.so out/softnpu/
-fi
+echo "fetching libsidecar_lite.so"
+$TOOLS_DIR/ensure_buildomat_artifact.sh \
+    -O $OUT_DIR \
+    -s "release" \
+    "libsidecar_lite.so" \
+    "$SIDECAR_LITE_REPO" \
+    "$SIDECAR_LITE_COMMIT"

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -19,6 +19,7 @@ SOFTNPU_COMMIT="88f5f1334364e5580fe778c44ac0746a35927351"
 
 # Pinned commit for softnpu tools
 SIDECAR_LITE_REPO="sidecar-lite"
+SIDECAR_LITE_SERIES="release"
 SIDECAR_LITE_COMMIT="56abef043a9e2ba0363fea82528d7a9e86d3c0b0"
 
 # This is the softnpu ASIC simulator
@@ -35,7 +36,7 @@ chmod +x $OUT_DIR/softnpu
 echo "fetching scadm"
 $TOOLS_DIR/ensure_buildomat_artifact.sh \
     -O $OUT_DIR \
-    -s "release" \
+    -s "$SIDECAR_LITE_SERIES" \
     "scadm" \
     "$SIDECAR_LITE_REPO" \
     "$SIDECAR_LITE_COMMIT"
@@ -45,7 +46,7 @@ chmod +x $OUT_DIR/scadm
 echo "fetching libsidecar_lite.so"
 $TOOLS_DIR/ensure_buildomat_artifact.sh \
     -O $OUT_DIR \
-    -s "release" \
+    -s "$SIDECAR_LITE_SERIES" \
     "libsidecar_lite.so" \
     "$SIDECAR_LITE_REPO" \
     "$SIDECAR_LITE_COMMIT"

--- a/tools/ensure_buildomat_artifact.sh
+++ b/tools/ensure_buildomat_artifact.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Ensure a buildomat artifact is downloaded and available locally.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Published buildomat artifacts are available at a predictable URL:
+# https://buildomat.eng.oxide.computer/public/file/ORG/REPO/SERIES/HASH/ARTIFACT
+BUILDOMAT_BASE_URL="https://buildomat.eng.oxide.computer/public/file"
+
+# Default value for optional flags
+ORG="oxidecomputer"
+SERIES="image"
+CHECK_HASH=true
+OUTDIR="$PWD"
+
+function usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS] <ARTIFACT> <REPO> <COMMIT>
+
+    REPO:     The repository that published the artifact.
+    ARTIFACT: The name of the artifact.
+    COMMIT:   The commit the artifact was published from.
+
+Options:
+    -o <ORG>    Org containing the repository. [default: $ORG]
+    -s <SERIES> The series artifact was published to. [default: $SERIES]
+    -n          Disable artifact validation.
+    -O <OUTDIR> Directory to output artifact to. [default: $OUTDIR]
+    -h          Print help and exit
+
+By default, this script expects a SHA256 hash to be published alongside
+the artifact with the same name but with a '.sha256.txt' suffix. This hash
+is used to validate the downloaded artifact as well as to check if we can
+skip downloading the artifact if it already exists locally. To disable this
+behavior, pass the -n flag.
+
+Note that if hash validation is disabled, we'll always download the artifact
+even if it already exists locally.
+EOF
+}
+
+function validate_file_hash() {
+    local file="$1"
+    local hash="$2"
+    echo "$hash  $file" | shasum -a 256 --check --status
+}
+
+function main() {
+    # Parse flags
+    local opt
+    while getopts "o:s:nO:h" opt; do
+        case $opt in
+            o) ORG="$OPTARG" ;;
+            s) SERIES="$OPTARG" ;;
+            n) CHECK_HASH=false ;;
+            O) OUTDIR="$OPTARG" ;;
+
+            h)
+                usage
+                exit 0
+                ;;
+            *)
+                usage
+                exit 1
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    # Grab required arguments
+    if [[ $# -ne 3 ]]; then
+        usage
+        exit 1
+    fi
+
+    ARTIFACT="$1"
+    REPO="$2"
+    COMMIT="$3"
+
+    ARTIFACT_URL="$BUILDOMAT_BASE_URL/$ORG/$REPO/$SERIES/$COMMIT/$ARTIFACT"
+    ARTIFACT_OUT="$OUTDIR/$ARTIFACT"
+
+    echo "Ensuring $ORG/$REPO/$SERIES/$ARTIFACT in $OUTDIR"
+    echo "  (commit: $COMMIT)"
+
+    local hash=""
+    # If hash checking is enabled, grab the expected hash
+    if $CHECK_HASH; then
+        local hash_url="$ARTIFACT_URL.sha256.txt"
+        echo "Getting hash for $ARTIFACT"
+        hash="$(curl --silent --show-error --fail --location "$hash_url")"
+        echo "  (hash: $hash)"
+    fi
+
+    # Check if the artifact already exists
+    if [[ -f "$ARTIFACT_OUT" ]]; then
+        if $CHECK_HASH; then
+            # If the artifact exists and has the correct hash, we're done.
+            if validate_file_hash "$ARTIFACT_OUT" "$hash"; then
+                echo "$ARTIFACT already exists with correct hash"
+                exit 0
+            else
+                echo "$ARTIFACT already exists but has incorrect hash, re-downloading"
+            fi
+        else
+            echo "$ARTIFACT already exists but hash validation disabled, re-downloading"
+        fi
+    fi
+
+    # Either the artifact doesn't exist or it has the wrong hash. Download it.
+    mkdir -p "$OUTDIR"
+    curl --silent --show-error --fail --location --output "$ARTIFACT_OUT" "$ARTIFACT_URL"
+
+    # If hash checking is enabled, validate the downloaded artifact.
+    if $CHECK_HASH; then
+        if ! validate_file_hash "$ARTIFACT_OUT" "$hash"; then
+            echo "Downloaded artifact failed verification"
+            exit 1
+        fi
+    fi
+
+    echo "$ARTIFACT downloaded successfully"
+
+}
+
+main "$@"

--- a/tools/ensure_buildomat_artifact.sh
+++ b/tools/ensure_buildomat_artifact.sh
@@ -28,7 +28,7 @@ Usage: $0 [OPTIONS] <ARTIFACT> <REPO> <COMMIT>
 Options:
     -o <ORG>    Org containing the repository. [default: $ORG]
     -s <SERIES> The series artifact was published to. [default: $SERIES]
-    -n          Disable artifact validation.
+    -f          Disable artifact validation.
     -O <OUTDIR> Directory to output artifact to. [default: $OUTDIR]
     -h          Print help and exit
 
@@ -36,7 +36,7 @@ By default, this script expects a SHA256 hash to be published alongside
 the artifact with the same name but with a '.sha256.txt' suffix. This hash
 is used to validate the downloaded artifact as well as to check if we can
 skip downloading the artifact if it already exists locally. To disable this
-behavior, pass the -n flag.
+behavior, pass the -f flag.
 
 Note that if hash validation is disabled, we'll always download the artifact
 even if it already exists locally.
@@ -52,11 +52,11 @@ function validate_file_hash() {
 function main() {
     # Parse flags
     local opt
-    while getopts "o:s:nO:h" opt; do
+    while getopts "o:s:fO:h" opt; do
         case $opt in
             o) ORG="$OPTARG" ;;
             s) SERIES="$OPTARG" ;;
-            n) CHECK_HASH=false ;;
+            f) CHECK_HASH=false ;;
             O) OUTDIR="$OPTARG" ;;
 
             h)


### PR DESCRIPTION
Ran into this fun issue again where `ci_download_softnpu_machinery` would skip updating the softnpu binaries if it found them in `out/softnpu` already. That's all well and good until the pinned commit actually gets updated and you've run `install_runner_prerequisites.sh` thinking that's enough.

To anyone who's softnpu deploy doesn't seem to be working and `/softnpu.log` in the `softnpu` zone is spamming:
```
Dec 28 10:34:48.723 WARN got sidecar egress port of 0
Dec 28 10:34:48.723 WARN this is probably a p4 program bug
Dec 28 10:34:48.723 WARN dropping packet
```
You're running an old copy of `softnpu` is why.

Fix that by using the published sha256 hashes to verify any local copy that exists.