### PR TITLE
switch-zone: support user needs RBAC profile

### DIFF
--- a/smf/switch_zone_setup/switch_zone_setup
+++ b/smf/switch_zone_setup/switch_zone_setup
@@ -1,19 +1,32 @@
-#!/bin/bash
+#!/bin/ksh
+
 set -ex -o pipefail
 
 . /lib/svc/share/smf_include.sh
 
-# set up the users required for wicket.
-USERS=(wicket support)
+# set up the users required for wicket and support.
+USERS=(
+    (user=wicket group=wicket gecos='Wicket User')
+    (user=support group=support gecos='Oxide Support'
+        profiles=('Primary Administrator')
+    )
+)
 
-for user in ${USERS[@]}; do
-    if ! id -u $user >/dev/null 2>&1; then
-        # Add a new group for the user.
-        groupadd "$user"
-        # Add the user.
-        useradd -m -g "$user" "$user"
-        # Remove the password from the user to enable passwordless login.
-        passwd -d "$user"
+for i in "${!USERS[@]}"; do
+    nameref u=USERS[$i]
+
+    # Add a new group for the user.
+    getent group "${u.group}" >/dev/null 2>&1 || groupadd "${u.group}"
+    # Add the user.
+    getent passwd "${u.user}" >/dev/null 2>&1 \
+        || useradd -m -g "${u.group}" -c "${u.gecos}" "${u.user}"
+    # Remove the password from the user to enable passwordless login.
+    passwd -d "${u.user}"
+    # Assign or remove profiles
+    if [[ -n "${u.profiles}" ]]; then
+        usermod -P"$(printf '%s,' "${u.profiles[@]}")" "${u.user}"
+    else
+        usermod -P '' "${u.user}"
     fi
 done
 


### PR DESCRIPTION
Fixes #3195

Switch to `ksh` mostly for multi-dimensional associative arrays.

We might want to be more selective about the profiles, roles and authorisations that get assigned, but this is a start for PVT.