### PR TITLE
ci/tuf-repo: Consistent artifact versions

### DIFF
--- a/.github/buildomat/jobs/ci-tools.sh
+++ b/.github/buildomat/jobs/ci-tools.sh
@@ -6,6 +6,7 @@
 #: rust_toolchain = "1.70.0"
 #: output_rules = [
 #:	"=/work/end-to-end-tests/*.gz",
+#:	"=/work/caboose-util.gz",
 #:	"=/work/tufaceous.gz",
 #: ]
 
@@ -36,6 +37,13 @@ for p in target/debug/bootstrap $(/opt/ooce/bin/jq -r 'select(.profile.test) | .
 	# shellcheck disable=SC2094
 	ptime -m gzip < "$p" > /work/end-to-end-tests/"$(basename "$p").gz"
 done
+
+########## caboose-util ##########
+
+banner caboose-util
+
+ptime -m cargo build --locked -p caboose-util --release
+ptime -m gzip < target/release/caboose-util > /work/caboose-util.gz
 
 ########## tufaceous ##########
 

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -44,14 +44,12 @@ set -o pipefail
 set -o xtrace
 
 TOP=$PWD
+VERSION=$(< /input/package/work/version.txt)
 
 source "$TOP/tools/dvt_dock_version"
 DVT_DOCK_COMMIT=$COMMIT
 source "$TOP/tools/hubris_version"
 HUBRIS_COMMIT=$COMMIT
-
-COMMIT=$(git rev-parse HEAD)
-VERSION="1.0.0-alpha+git${COMMIT:0:11}"
 
 ptime -m gunzip < /input/ci-tools/work/tufaceous.gz > /work/tufaceous
 chmod a+x /work/tufaceous

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -46,13 +46,10 @@ set -o xtrace
 TOP=$PWD
 VERSION=$(< /input/package/work/version.txt)
 
-source "$TOP/tools/dvt_dock_version"
-DVT_DOCK_COMMIT=$COMMIT
-source "$TOP/tools/hubris_version"
-HUBRIS_COMMIT=$COMMIT
-
-ptime -m gunzip < /input/ci-tools/work/tufaceous.gz > /work/tufaceous
-chmod a+x /work/tufaceous
+for bin in caboose-util tufaceous; do
+    ptime -m gunzip < /input/ci-tools/work/$bin.gz > /work/$bin
+    chmod a+x /work/$bin
+done
 
 #
 # We do two things here:
@@ -111,31 +108,41 @@ EOF
 done
 
 # Fetch signed ROT images from oxidecomputer/dvt-dock.
+source "$TOP/tools/dvt_dock_version"
 git clone https://github.com/oxidecomputer/dvt-dock.git /work/dvt-dock
-(cd /work/dvt-dock; git checkout "$DVT_DOCK_COMMIT")
-DVT_DOCK_VERSION="1.0.0-alpha+git${DVT_DOCK_COMMIT:0:11}"
+(cd /work/dvt-dock; git checkout "$COMMIT")
 
 for noun in gimlet psc sidecar; do
     tufaceous_kind=${noun//sidecar/switch}_rot
     hubris_kind=${noun}-rot
+    path_a="/work/dvt-dock/staging/build-$hubris_kind-image-a-cert-dev.zip"
+    path_b="/work/dvt-dock/staging/build-$hubris_kind-image-b-cert-dev.zip"
+    version_a=$(/work/caboose-util read-version "$path_a")
+    version_b=$(/work/caboose-util read-version "$path_b")
+    if [[ "$version_a" != "$version_b" ]]; then
+        echo "version mismatch:"
+        echo "  $path_a: $version_a"
+        echo "  $path_b: $version_b"
+        exit 1
+    fi
     cat >>/work/manifest.toml <<EOF
 [artifact.$tufaceous_kind]
 name = "$tufaceous_kind"
-version = "$DVT_DOCK_VERSION"
+version = "$version_a"
 [artifact.$tufaceous_kind.source]
 kind = "composite-rot"
 [artifact.$tufaceous_kind.source.archive_a]
 kind = "file"
-path = "/work/dvt-dock/staging/build-$hubris_kind-image-a-cert-dev.zip"
+path = "$path_a"
 [artifact.$tufaceous_kind.source.archive_b]
 kind = "file"
-path = "/work/dvt-dock/staging/build-$hubris_kind-image-b-cert-dev.zip"
+path = "$path_b"
 EOF
 done
 
 # Fetch SP images from oxidecomputer/hubris GHA artifacts.
-HUBRIS_VERSION="1.0.0-alpha+git${HUBRIS_COMMIT:0:11}"
-run_id=$(curl --netrc -fsS "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$HUBRIS_COMMIT" \
+source "$TOP/tools/hubris_version"
+run_id=$(curl --netrc -fsS "https://api.github.com/repos/oxidecomputer/hubris/actions/runs?head_sha=$COMMIT" \
     | /opt/ooce/bin/jq -r '.workflow_runs[] | select(.path == ".github/workflows/dist.yml") | .id')
 artifacts=$(curl --netrc -fsS "https://api.github.com/repos/oxidecomputer/hubris/actions/runs/$run_id/artifacts")
 for noun in gimlet-c psc-b sidecar-b; do
@@ -145,13 +152,15 @@ for noun in gimlet-c psc-b sidecar-b; do
     url=$(/opt/ooce/bin/jq --arg name "$job_name" -r '.artifacts[] | select(.name == $name) | .archive_download_url' <<<"$artifacts")
     curl --netrc -fsSL -o $job_name.zip "$url"
     unzip $job_name.zip
+    path="$PWD/build-$noun-image-default.zip"
+    version=$(/work/caboose-util read-version "$path")
     cat >>/work/manifest.toml <<EOF
 [artifact.$tufaceous_kind]
 name = "$tufaceous_kind"
-version = "$HUBRIS_VERSION"
+version = "$version"
 [artifact.$tufaceous_kind.source]
 kind = "file"
-path = "$PWD/build-$noun-image-default.zip"
+path = "$path"
 EOF
 done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,8 +767,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hubtools",
- "tlvc",
- "tlvc-text",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "caboose-util"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hubtools",
+ "tlvc",
+ "tlvc-text",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,8 +326,6 @@ termios = "0.3"
 textwrap = "0.16.0"
 test-strategy = "0.2.1"
 thiserror = "1.0"
-tlvc = { git = "https://github.com/oxidecomputer/tlvc.git" }
-tlvc-text = { git = "https://github.com/oxidecomputer/tlvc.git" }
 tofino = { git = "http://github.com/oxidecomputer/tofino", branch = "main" }
 tokio = "1.28"
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "api_identity",
     "bootstore",
     "bootstrap-agent-client",
+    "caboose-util",
     "certificates",
     "common",
     "ddm-admin-client",
@@ -63,6 +64,7 @@ members = [
 
 default-members = [
     "bootstrap-agent-client",
+    "caboose-util",
     "certificates",
     "common",
     "ddm-admin-client",
@@ -181,10 +183,11 @@ hex-literal = "0.3.4"
 hkdf = "0.12.3"
 http = "0.2.9"
 httptest = "0.15.4"
-hyper-rustls = "0.24.0"
-hyper = "0.14"
-hyper-staticfile = "0.9.5"
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git" }
 humantime = "2.1.0"
+hyper = "0.14"
+hyper-rustls = "0.24.0"
+hyper-staticfile = "0.9.5"
 illumos-utils = { path = "illumos-utils" }
 indexmap = "1.9.3"
 indicatif = { version = "0.17.5", features = ["rayon"] }
@@ -323,6 +326,8 @@ termios = "0.3"
 textwrap = "0.16.0"
 test-strategy = "0.2.1"
 thiserror = "1.0"
+tlvc = { git = "https://github.com/oxidecomputer/tlvc.git" }
+tlvc-text = { git = "https://github.com/oxidecomputer/tlvc.git" }
 tofino = { git = "http://github.com/oxidecomputer/tofino", branch = "main" }
 tokio = "1.28"
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }

--- a/caboose-util/Cargo.toml
+++ b/caboose-util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "caboose-util"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+anyhow.workspace = true
+hubtools.workspace = true
+tlvc.workspace = true
+tlvc-text.workspace = true

--- a/caboose-util/Cargo.toml
+++ b/caboose-util/Cargo.toml
@@ -7,5 +7,3 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 hubtools.workspace = true
-tlvc.workspace = true
-tlvc-text.workspace = true

--- a/caboose-util/src/main.rs
+++ b/caboose-util/src/main.rs
@@ -4,9 +4,8 @@
 
 // Copyright 2023 Oxide Computer Company
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use hubtools::RawHubrisArchive;
-use tlvc_text::{Piece, Tag};
 
 fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
@@ -16,22 +15,8 @@ fn main() -> Result<()> {
                 &args.next().context("path to hubris archive required")?,
             )?;
             let caboose = archive.read_caboose()?;
-            let reader = tlvc::TlvcReader::begin(caboose.as_slice())
-                .map_err(|e| anyhow!("tlvc error: {e:?}"))?;
-            let t = tlvc_text::dump(reader);
-            for piece in t {
-                if let Piece::Chunk(tag, data) = piece {
-                    if tag == Tag::new(*b"VERS") {
-                        for datum in data {
-                            if let Piece::String(version) = datum {
-                                println!("{}", version);
-                                return Ok(());
-                            }
-                        }
-                    }
-                }
-            }
-            bail!("no VERS string found");
+            println!("{}", std::str::from_utf8(caboose.version()?)?);
+            Ok(())
         }
         unknown => bail!("unknown command {}", unknown),
     }

--- a/caboose-util/src/main.rs
+++ b/caboose-util/src/main.rs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+use anyhow::{anyhow, bail, Context, Result};
+use hubtools::RawHubrisArchive;
+use tlvc_text::{Piece, Tag};
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    match args.next().context("subcommand required")?.as_str() {
+        "read-version" => {
+            let archive = RawHubrisArchive::load(
+                &args.next().context("path to hubris archive required")?,
+            )?;
+            let caboose = archive.read_caboose()?;
+            let reader = tlvc::TlvcReader::begin(caboose.as_slice())
+                .map_err(|e| anyhow!("tlvc error: {e:?}"))?;
+            let t = tlvc_text::dump(reader);
+            for piece in t {
+                if let Piece::Chunk(tag, data) = piece {
+                    if tag == Tag::new(*b"VERS") {
+                        for datum in data {
+                            if let Piece::String(version) = datum {
+                                println!("{}", version);
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+            bail!("no VERS string found");
+        }
+        unknown => bail!("unknown command {}", unknown),
+    }
+}


### PR DESCRIPTION
Fixes #3430. Changes:
- Changes the prerelease field in our version from `alpha` to `0.ci`, which comes before alpha, so that we can use `alpha` or other words found early in the dictionary and have them count as later than a CI build.
- Stamps a non-placeholder version into the global zone packages installed in the host and trampoline OS images.
- Adds `caboose-util`, loosely based on the small part of [https://github.com/oxidecomputer/hubtools](https://github.com/oxidecomputer/omicron/pull/hubedit) I needed, tweaked for usefulness to a shell script.
- Reads the version out of a Hubris archive's caboose and uses that for the TUF repository, instead of the control plane version we generate here.