### PR TITLE
[wicketd] Update bootstrap peer addrs after RSS config is uploaded

### DIFF
--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -212,7 +212,7 @@ async fn get_rss_config(
     let inventory = inventory_or_unavail(&ctx.mgs_handle).await?;
 
     let mut config = ctx.rss_config.lock().unwrap();
-    config.populate_available_bootstrap_sleds_from_inventory(
+    config.update_with_inventory_and_bootstrap_peers(
         &inventory,
         &ctx.bootstrap_peers,
     );
@@ -239,7 +239,7 @@ async fn put_rss_config(
     let inventory = inventory_or_unavail(&ctx.mgs_handle).await?;
 
     let mut config = ctx.rss_config.lock().unwrap();
-    config.populate_available_bootstrap_sleds_from_inventory(
+    config.update_with_inventory_and_bootstrap_peers(
         &inventory,
         &ctx.bootstrap_peers,
     );


### PR DESCRIPTION
When the user calls `GET /rack-setup/config`, we were filling in the bootstrap addresses of the _inventory_ (i.e., all available sleds), but we were not filling them in of the chosen sleds if the user had already uploaded a config. We now fill in both.

Fixes #3440.