### PR TITLE
[wicket] Support multiple uplink config entries

### DIFF
--- a/wicket/src/rack_setup/config_template.toml
+++ b/wicket/src/rack_setup/config_template.toml
@@ -30,4 +30,12 @@ bootstrap_sleds = []
 [rack_network_config]
 infra_ip_first = ""
 infra_ip_last = ""
-uplinks = []
+
+[[rack_network_config.uplinks]]
+switch = ""
+gateway_ip = ""
+uplink_port = ""
+uplink_port_speed = ""
+uplink_port_fec = ""
+uplink_ip = ""
+uplink_vid = 1234 # optional - remove if no VLAN id is needed


### PR DESCRIPTION
Fleshes out the `wicket` bits for #3262:

1. The empty template returned by `setup get-config` now includes a sample uplink table:

```toml
# ... rest of config

[rack_network_config]
infra_ip_first = ""
infra_ip_last = ""

[[rack_network_config.uplinks]]
switch = ""
gateway_ip = ""
uplink_port = ""
uplink_port_speed = ""
uplink_port_fec = ""
uplink_ip = ""
uplink_vid = 1234 # optional - remove if no VLAN id is needed
```

2. The populated template returned by `setup get-config` is filled in with data:

```toml
# ... rest of config

[rack_network_config]
infra_ip_first = "172.20.26.1"
infra_ip_last = "172.20.26.5"

[[rack_network_config.uplinks]]
switch = "switch0"
gateway_ip = "1.2.3.4"
uplink_port = "foo"
uplink_port_speed = "speed10_g"
uplink_port_fec = "none"
uplink_ip = "2.3.4.5"
# uplink_vid =

[[rack_network_config.uplinks]]
switch = "switch1"
gateway_ip = "4.5.6.7"
uplink_port = "bar"
uplink_port_speed = "speed40_g"
uplink_port_fec = "none"
uplink_ip = "5.6.7.8"
uplink_vid = 100
```

3. Multiple uplink configs can be displayed in the UI:

![multiple-uplinks](https://github.com/oxidecomputer/omicron/assets/1435635/6fb31ee6-03e0-46ca-a65f-1708d1517d84)
