### PR TITLE
Allow snapshot create to take a disk by id

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -12,7 +12,6 @@ use crate::db::lookup;
 use crate::db::lookup::LookupPath;
 use crate::external_api::params;
 use nexus_db_queries::context::OpContext;
-use nexus_types::identity::Resource;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::CreateResult;
@@ -568,15 +567,14 @@ impl super::Nexus {
         disk_lookup: &lookup::Disk<'_>,
         finalize_params: &params::FinalizeDisk,
     ) -> UpdateResult<()> {
-        let (authz_silo, authz_proj, authz_disk, db_disk) =
-            disk_lookup.fetch_for(authz::Action::Modify).await?;
+        let (authz_silo, authz_proj, authz_disk) =
+            disk_lookup.lookup_for(authz::Action::Modify).await?;
 
         let saga_params = sagas::finalize_disk::Params {
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),
             silo_id: authz_silo.id(),
             project_id: authz_proj.id(),
             disk_id: authz_disk.id(),
-            disk_name: db_disk.name().clone(),
             snapshot_name: finalize_params.snapshot_name.clone(),
         };
 

--- a/nexus/src/app/sagas/finalize_disk.rs
+++ b/nexus/src/app/sagas/finalize_disk.rs
@@ -31,7 +31,6 @@ pub struct Params {
     pub serialized_authn: authn::saga::Serialized,
     pub silo_id: Uuid,
     pub project_id: Uuid,
-    pub disk_name: Name,
     pub disk_id: Uuid,
     pub snapshot_name: Option<Name>,
 }
@@ -86,10 +85,10 @@ impl NexusSaga for SagaFinalizeDisk {
                         name: snapshot_name.clone(),
                         description: format!(
                             "snapshot of finalized disk {}",
-                            params.disk_name
+                            params.disk_id
                         ),
                     },
-                    disk: params.disk_name.clone(),
+                    disk: params.disk_id.clone().into(),
                 },
             };
 

--- a/nexus/src/app/sagas/finalize_disk.rs
+++ b/nexus/src/app/sagas/finalize_disk.rs
@@ -88,7 +88,7 @@ impl NexusSaga for SagaFinalizeDisk {
                             params.disk_id
                         ),
                     },
-                    disk: params.disk_id.clone().into(),
+                    disk: params.disk_id.into(),
                 },
             };
 

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1586,6 +1586,7 @@ mod test {
     use omicron_common::api::external::Instance;
     use omicron_common::api::external::InstanceCpuCount;
     use omicron_common::api::external::Name;
+    use omicron_common::api::external::NameOrId;
     use sled_agent_client::types::CrucibleOpts;
     use sled_agent_client::TestInterfaces as SledAgentTestInterfaces;
     use std::net::Ipv4Addr;
@@ -1804,7 +1805,7 @@ mod test {
         silo_id: Uuid,
         project_id: Uuid,
         disk_id: Uuid,
-        disk: Name,
+        disk: NameOrId,
         use_the_pantry: bool,
     ) -> Params {
         Params {
@@ -1860,7 +1861,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             true,
         );
         let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
@@ -1970,7 +1971,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             use_the_pantry,
         );
         let mut dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
@@ -2028,7 +2029,7 @@ mod test {
                 silo_id,
                 project_id,
                 disk_id,
-                Name::from_str(DISK_NAME).unwrap(),
+                Name::from_str(DISK_NAME).unwrap().into(),
                 use_the_pantry,
             );
             dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
@@ -2067,7 +2068,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             // set use_the_pantry to true, disk is unattached at time of saga creation
             true,
         );
@@ -2131,7 +2132,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             // set use_the_pantry to true, disk is unattached at time of saga creation
             true,
         );
@@ -2176,7 +2177,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             // set use_the_pantry to true, disk is attached at time of saga creation
             false,
         );
@@ -2270,7 +2271,7 @@ mod test {
             silo_id,
             project_id,
             disk_id,
-            Name::from_str(DISK_NAME).unwrap(),
+            Name::from_str(DISK_NAME).unwrap().into(),
             // set use_the_pantry to false, disk is attached at time of saga creation
             false,
         );

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -486,7 +486,7 @@ lazy_static! {
                 name: DEMO_SNAPSHOT_NAME.clone(),
                 description: String::from(""),
             },
-            disk: DEMO_DISK_NAME.clone(),
+            disk: DEMO_DISK_NAME.clone().into(),
         };
 
     // SSH keys

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -18,9 +18,11 @@ use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
+use omicron_common::api::external::Name;
 use omicron_nexus::external_api::params;
 use omicron_nexus::external_api::views;
 use omicron_nexus::external_api::views::Project;
+use std::str::FromStr;
 
 type ControlPlaneTestContext =
     nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
@@ -297,7 +299,7 @@ async fn test_project_deletion_with_snapshot(
                 name: "my-snapshot".parse().unwrap(),
                 description: "not attached to instance".into(),
             },
-            disk: "my-disk".parse().unwrap(),
+            disk: Name::from_str("my-disk").unwrap().into(),
         },
     )
     .await;

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -165,7 +165,7 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
                 name: instance_name.parse().unwrap(),
                 description: format!("instance {:?}", instance_name),
             },
-            disk: base_disk_name,
+            disk: base_disk_name.into(),
         },
     )
     .await;
@@ -265,7 +265,7 @@ async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
                 name: "not-attached".parse().unwrap(),
                 description: "not attached to instance".into(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -342,7 +342,7 @@ async fn test_delete_snapshot(cptestctx: &ControlPlaneTestContext) {
                 name: "not-attached".parse().unwrap(),
                 description: "not attached to instance".into(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -741,7 +741,7 @@ async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
                     name: "not-attached".parse().unwrap(),
                     description: "not attached to instance".into(),
                 },
-                disk: base_disk_name,
+                disk: base_disk_name.into(),
             }))
             .expect_status(Some(StatusCode::SERVICE_UNAVAILABLE)),
     )
@@ -841,7 +841,7 @@ async fn test_snapshot_unwind(cptestctx: &ControlPlaneTestContext) {
                 name: "snapshot".parse().unwrap(),
                 description: String::from("a snapshot"),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -157,7 +157,7 @@ async fn test_snapshot_then_delete_disk(cptestctx: &ControlPlaneTestContext) {
                 name: "a-snapshot".parse().unwrap(),
                 description: "a snapshot!".to_string(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -218,7 +218,7 @@ async fn test_delete_snapshot_then_disk(cptestctx: &ControlPlaneTestContext) {
                 name: "a-snapshot".parse().unwrap(),
                 description: "a snapshot!".to_string(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -279,7 +279,7 @@ async fn test_multiple_snapshots(cptestctx: &ControlPlaneTestContext) {
                     name: format!("a-snapshot-{}", i).parse().unwrap(),
                     description: "a snapshot!".to_string(),
                 },
-                disk: base_disk_name.clone(),
+                disk: base_disk_name.clone().into(),
             },
         )
         .await;
@@ -341,7 +341,7 @@ async fn test_snapshot_prevents_other_disk(
                 name: "a-snapshot".parse().unwrap(),
                 description: "a snapshot!".to_string(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -465,7 +465,7 @@ async fn test_multiple_disks_multiple_snapshots_order_1(
                 name: "first-snapshot".parse().unwrap(),
                 description: "first snapshot!".to_string(),
             },
-            disk: first_disk_name.clone(),
+            disk: first_disk_name.clone().into(),
         },
     )
     .await;
@@ -507,7 +507,7 @@ async fn test_multiple_disks_multiple_snapshots_order_1(
                 name: "second-snapshot".parse().unwrap(),
                 description: "second snapshot!".to_string(),
             },
-            disk: second_disk_name.clone(),
+            disk: second_disk_name.clone().into(),
         },
     )
     .await;
@@ -601,7 +601,7 @@ async fn test_multiple_disks_multiple_snapshots_order_2(
                 name: "first-snapshot".parse().unwrap(),
                 description: "first snapshot!".to_string(),
             },
-            disk: first_disk_name.clone(),
+            disk: first_disk_name.clone().into(),
         },
     )
     .await;
@@ -643,7 +643,7 @@ async fn test_multiple_disks_multiple_snapshots_order_2(
                 name: "second-snapshot".parse().unwrap(),
                 description: "second snapshot!".to_string(),
             },
-            disk: second_disk_name.clone(),
+            disk: second_disk_name.clone().into(),
         },
     )
     .await;
@@ -731,7 +731,7 @@ async fn prepare_for_test_multiple_layers_of_snapshots(
                 name: "layer-1-snapshot".parse().unwrap(),
                 description: "layer 1 snapshot!".to_string(),
             },
-            disk: layer_1_disk_name.clone(),
+            disk: layer_1_disk_name.clone().into(),
         },
     )
     .await;
@@ -773,7 +773,7 @@ async fn prepare_for_test_multiple_layers_of_snapshots(
                 name: "layer-2-snapshot".parse().unwrap(),
                 description: "layer 2 snapshot!".to_string(),
             },
-            disk: layer_2_disk_name.clone(),
+            disk: layer_2_disk_name.clone().into(),
         },
     )
     .await;
@@ -815,7 +815,7 @@ async fn prepare_for_test_multiple_layers_of_snapshots(
                 name: "layer-3-snapshot".parse().unwrap(),
                 description: "layer 3 snapshot!".to_string(),
             },
-            disk: layer_3_disk_name.clone(),
+            disk: layer_3_disk_name.clone().into(),
         },
     )
     .await;
@@ -995,7 +995,7 @@ async fn test_create_image_from_snapshot(cptestctx: &ControlPlaneTestContext) {
                 name: "a-snapshot".parse().unwrap(),
                 description: "a snapshot!".to_string(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;
@@ -1055,7 +1055,7 @@ async fn test_create_image_from_snapshot_delete(
                 name: "a-snapshot".parse().unwrap(),
                 description: "a snapshot!".to_string(),
             },
-            disk: base_disk_name.clone(),
+            disk: base_disk_name.clone().into(),
         },
     )
     .await;

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1605,7 +1605,7 @@ pub struct SnapshotCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
 
-    /// The name of the disk to be snapshotted
+    /// The disk to be snapshotted
     pub disk: NameOrId,
 }
 

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1606,7 +1606,7 @@ pub struct SnapshotCreate {
     pub identity: IdentityMetadataCreateParams,
 
     /// The name of the disk to be snapshotted
-    pub disk: Name,
+    pub disk: NameOrId,
 }
 
 // USERS AND GROUPS

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12319,7 +12319,7 @@
             "description": "The name of the disk to be snapshotted",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Name"
+                "$ref": "#/components/schemas/NameOrId"
               }
             ]
           },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12316,7 +12316,7 @@
             "type": "string"
           },
           "disk": {
-            "description": "The name of the disk to be snapshotted",
+            "description": "The disk to be snapshotted",
             "allOf": [
               {
                 "$ref": "#/components/schemas/NameOrId"


### PR DESCRIPTION
Fixes #3457 

Updates the create snapshot endpoint to allow specifying a disk by name or ID