### PR TITLE
`ZPOOL_NAME_REGEX` fails to match some uuids

### DIFF
--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -290,7 +290,8 @@ pub struct ZpoolName {
     kind: ZpoolKind,
 }
 
-const ZPOOL_NAME_REGEX: &str = r"^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
+const ZPOOL_NAME_REGEX: &str =
+    r"^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
 /// Custom JsonSchema implementation to encode the constraints on Name.
 impl JsonSchema for ZpoolName {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2685,7 +2685,7 @@
         "title": "The name of a Zpool",
         "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
         "type": "string",
-        "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
       }
     }
   }


### PR DESCRIPTION
Currently ZPOOL_NAME_REGEX's middle section:

    4[0-9a-f]{3}-[89ab][0-9a-f]{3}

fails to match against randomly generated UUIDs that don't have those specific expected numbers. This commit generalizes it to match all UUIDs.