### PR TITLE
overhaul how-to-run docs

### DIFF
--- a/docs/boundary-services-a-to-z.adoc
+++ b/docs/boundary-services-a-to-z.adoc
@@ -1,49 +1,12 @@
 = Boundary Services A-Z
 
-This document describes how to run an environment with boundary services.
-It's a quick rundown and assumes knowledge of the basic setup described in the
-Running Omicron (Non-Simulated) document.
+NOTE: The instructions for _deploying_ SoftNPU with Omicron have been folded into xref:how-to-run.adoc[the main how-to-run docs].
 
-== 0. Download SoftNPU ASIC emulator machinery
-
-Grab the SoftNPU (ASIC simulator, scadm, P4 program, etc.) from CI:
-
-----
-./tools/ci_download_softnpu_machinery
-----
-
-(By default `install_runner_prerequisites.sh` will take care of running
-`ci_download_softnpu_machinery` for you.)
-
-== 1. Setup virtual hardware
-
-----
-PHYSICAL_LINK=<wan interface> pfexec ./tools/create_virtual_hardware.sh
-----
-Note that the `PHYSICAL_LINK` environment variable is optional. If not supplied,
-the first link in `dladm show-phys` will be used.
-
-The virtual hardware is a bit different than what has previously been used. What
-we now have looks like this.
+The virtual hardware making up SoftNPU is a bit different than what was previously used. What we now have looks like this.
 
 image::plumbing.png[]
 
-The `softnpu` zone will be configured and launched during the `create_virtual_hardware.sh`
-script.
-
-== 2. Build and install the control plane.
-
-----
-./tools/create_self_signed_cert.sh
-
-cargo build --release --bin omicron-package
-./target/release/omicron-package -t <target_name> target create -i standard -m non-gimlet -s softnpu
-./target/release/omicron-package package
-pfexec ./target/release/omicron-package install
-----
-
-The control plane is now starting, reference the Running Omicron (Non-Simulated)
-doc for more details on determining when things are ready to go.
+The `softnpu` zone will be configured and launched during the `create_virtual_hardware.sh` script.
 
 Once the control plane is running, `softnpu` can be configured via `dendrite`
 using the `swadm` binary located in the `oxz_switch` zone.
@@ -105,12 +68,10 @@ host                            mac                age
 fe80::aae1:deff:fe00:1          a8:e1:de:00:00:01  0s
 ----
 
-== 4. Populating the system
-
-Follow the
+While following
 https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run.adoc[how-to-run.adoc]
-to set up IPs, images, disks, instances etc. Things to pay particular attention
-to here are the following.
+to set up IPs, images, disks, instances etc, pay particular attention to the
+following.
 
 - The address range in the IP pool should be on a subnet in your local network that
   can NAT out to the Internet.
@@ -129,9 +90,7 @@ pfexec /opt/oxide/softnpu/stuff/scadm \
   $softnpu_mac
 ----
 
-== 5. Configuring scrimlet/sidecar
-
-A this point we have an instance up and running with external connectivity
+By the end, we have an instance up and running with external connectivity
 configured via boundary services:
 ----
 ry@korgano:~/omicron$ ~/propolis/target/release/propolis-cli --server fd00:1122:3344:101::c serial

--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -220,4 +220,4 @@ wrote private key to demo-key.pem
 $ curl -i --resolve test-suite-silo.sys.oxide-dev.test:12220:127.0.0.1 --cacert /path/to/your/certificate.pem https://test-suite-silo.sys.oxide-dev.test:12220
 ----
 +
-The Oxide CLI does not https://github.com/oxidecomputer/oxide.rs/issues/193[yet] support this so it's a little unwieldy to use a local TLS server this way.
+The Oxide CLI supports identical flags.

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -98,14 +98,14 @@ As an example, in this doc:
 * You can carve off 192.168.1.20 - 192.168.1.29 for externally-facing services provided by the system.
 * You can carve off 192.168.1.30 as the address used by SoftNPU on the external network.
 * You can carve off 192.168.1.31 - 192.168.1.40 as the addresses used for Instances that need some public IPs (even if just for NAT to the internet).
-2. Alternatively, you'll set up an "external" network that only exists on your test machine.  If you go this route, we'll choose 192.168.1.0/24 and all the same other details as in the case above, just for convenience.  In this mode, you'll need create your made-up network and give the global zone an IP address on it.  We'll use 192.168.1.19:
+2. Alternatively, you'll set up an "external" network that only exists on your test machine.  If you go this route, we'll choose 192.168.1.0/24 and all the same other details as in the case above, just for convenience.  In this mode, you'll need create your made-up network and give the global zone an IP address on it.  We'll use 192.168.1.199:
 +
 [source,text]
 ----
 # pfexec dladm create-etherstub -t fake_external_stub0
 $ pfexec dladm create-vnic -t -l fake_external_stub0 fake_external0
 $ pfexec ipadm create-if -t fake_external0
-$ pfexec ipadm create-addr -t -T static --address 192.168.1.19 fake_external0/external
+$ pfexec ipadm create-addr -t -T static --address 192.168.1.199 fake_external0/external
 ----
 
 Other network configurations are possible but beyond the scope of this doc.
@@ -355,7 +355,7 @@ If your external network is one you made up above, you'll need to override the g
 
 [source,console]
 ----
-$ GATEWAY_IP=192.168.1.19 ./tools/scrimlet/softnpu-init.sh
+$ GATEWAY_IP=192.168.1.199 ./tools/scrimlet/softnpu-init.sh
 ----
 
 You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -33,7 +33,7 @@ Here's a summary of the tradeoffs:
 
 |CockroachDB
 |Real implementation, 1-node cluster
-|Real implementation, multi-node cluster (coming soon)
+|Real implementation, multi-node cluster
 
 |Internal/External DNS
 |Real implementation
@@ -83,7 +83,7 @@ There are other configurations besides the ones mentioned here:
 
 * A real Oxide rack: real hardware with real implementations of all components.
 * A Gimlet in a real Oxide rack, deployed as a single system in isolation from the rest of the rack.
-* A Gimlet on a bench (i.e., not in a rack -- requires separate hardware to connect power and networking) connected a Sidecar (the Oxide switch, also on a bench)
+* A Gimlet on a bench (i.e., not in a rack -- requires separate hardware to connect power and networking) connected a Sidecar (the Oxide switch), also on a bench.
 * A Gimlet on a bench with no Sidecar.
 
 This document doesn't describe how to deploy these cases.

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -2,24 +2,131 @@
 :toc: left
 :icons: font
 
-= Running Omicron (Non-Simulated)
+= Running Omicron
 
-Omicron is the control plane for an Oxide rack. It expects to execute
-on Helios systems, and Sleds use Helios-specific interfaces to manage
-resources.
+Omicron is the control plane for the Oxide system.  There are a few different ways to run Omicron depending on what resources you have available and how much of the stack you want to run using real components vs. simulated ones.  Generally speaking, it's easier to get things going and automate testing with simulated components, but of course much of the system's functionality is missing or faked up when using simulated components.
 
-If you're interested in running the control plane on other platforms, including
-Linux and Mac, refer to the guide on xref:how-to-run-simulated.adoc[running
-simulated Omicron].
+The most common configurations are:
 
-== Installing Prerequisite Software
+1. Using one or more simulated Sled Agents.  There are no real VMs.  All components listen on localhost and talk to each other directly.  The automated tests in this repo generally use this kind of deployment.  This is the only mode that's supported on non-illumos systems (i.e., Linux and MacOS).
+2. Using one or more real Sled Agents (on separate physical machines) using SoftNPU-based Boundary Services.  You can provision real VMs this way.  Intra-"rack" networking and boundary Services (i.e., external connectivity) are fully functional using SoftNPU, a software-based simulation of the Tofino device that's normally responsible for these functions.
++
+Within this mode, you can run on real Oxide hardware ("Gimlets") or ordinary server PCs.
 
-A major prerequisite is to have a machine already running Helios. An easy way to
-do this is by using a https://github.com/oxidecomputer/helios-engvm[Helios VM].
-ISOs are also available for download https://pkg.oxide.computer/install[here].
+These are historically called "simulated" vs. "non-simulated", though they both involve simulation of some parts of a real Oxide system.
 
-The steps below will install several executables that will need to be in your
-`PATH`.  You can set that up first using:
+Here's a summary of the tradeoffs:
+
+[cols="1h,1,1", options="header"]
+|===
+|
+|"Simulated" deployment
+|"Non-simulated" deployment
+
+|Works on
+|illumos, Linux, MacOS
+|illumos only
+
+|Nexus
+|Real implementation
+|Real implementation
+
+|CockroachDB
+|Real implementation, 1-node cluster
+|Real implementation, multi-node cluster (coming soon)
+
+|Internal/External DNS
+|Real implementation
+|Real implementation
+
+|Crucible Pantry
+|Real implementation
+|Real implementation
+
+|Sled Agent
+|Simulated, multiple okay
+|Real implementation, requires separate machines for each
+
+|Propolis
+|Missing (VMs are faked-up by simulated Sled Agent)
+|Real implementation
+
+|Dendrite
+|Stub implementation
+|Simulated implementation
+
+|Management Gateway Service (MGS)
+|Missing
+|Real implementation
+
+|Internal ("rack") networking
+|Localhost
+|Real implementation on-sled, simulated implementation across sleds (SoftNPU)
+
+|Boundary services (external connectivity)
+|Localhost
+|Simulated implementation (SoftNPU)
+
+|Wicket
+|Missing
+|Not used
+
+|Management network
+|Missing
+|Not used
+
+|===
+
+To run the simulated control plane, refer to the guide on xref:how-to-run-simulated.adoc[running simulated Omicron].  The rest of this document describes how to run a single-Sled Omicron with a real Sled Agent and SoftNPU-based Boundary Services.
+
+== Prerequisites
+
+=== Bare-metal operating system
+
+This guide assumes that you have a system running https://github.com/oxidecomputer/helios[Helios] on a bare-metal system.footnote:[You can in principle use a VM, but you wouldn't be able to provision Instances because nested virtualization is not supported.]
+
+=== External networking
+
+Two modes of external networking are described here:
+
+1. You'll be plugging your Omicron system into an existing IPv4 network (e.g., a home network or a lab network) from which you can allocate a few IP addresses that won't be used elsewhere on the network.  The existing network will be used as the "external" network for the system, meaning that externally-facing services (like the API and console) will use IPs on this network.  If you want to be able to reach the the internet from Instances, there must be a gateway on this network that provides access to the internet.
++
+As an example, in this doc:
++
+* The network is 192.168.1.0/24.
+* The network's gateway is 192.168.1.199.
+* You can carve off 192.168.1.20 - 192.168.1.29 for externally-facing services provided by the system.
+* You can carve off 192.168.1.30 as the address used by SoftNPU on the external network.
+* You can carve off 192.168.1.31 - 192.168.1.40 as the addresses used for Instances that need some public IPs (even if just for NAT to the internet).
+2. Alternatively, you'll set up an "external" network that only exists on your test machine.  If you go this route, we'll choose 192.168.1.0/24 and all the same other details as in the case above, just for convenience.  In this mode, you'll need create your made-up network and give the global zone an IP address on it.  We'll use 192.168.1.19:
++
+[source,text]
+----
+# pfexec dladm create-etherstub -t fake_external_stub0
+$ pfexec dladm create-vnic -t -l fake_external_stub0 fake_external0
+$ pfexec ipadm create-if -t fake_external0
+$ pfexec ipadm create-addr -t -T static --address 192.168.1.19 fake_external0/external
+----
+
+Other network configurations are possible but beyond the scope of this doc.
+
+When making this choice, note that **in order to use the system once it's set up, you will need to be able to access it from a web browser.**  If you go with option 2 here, you may need to use an ssh tunnel or the like to do this.
+
+=== Picking a "machine" type
+
+Omicron packages (discussed in more detail below) are associated with a particular _machine_ type, which is one of:
+
+* `gimlet` (real Oxide hardware deployed in a real Oxide rack)
+* `gimlet-standalone` (real Oxide server hardware running as a single-machine "rack")
+* `non-gimlet` (some kind of PC running as a single-machine "rack")
+
+The main difference are the configuration files used for the Sled Agent and Rak Setup Service (RSS).
+
+This guide is for `gimlet-standalone` and `non-gimlet`.  In the rest of this guide, `$MACHINE` refers to one of these two values.
+
+=== Prerequisite software
+
+The steps below will install several executables that will need to be in your `PATH`.  You can set that up first using:
 
 [source,text]
 ----
@@ -37,9 +144,7 @@ $ pfexec ./tools/install_prerequisites.sh
 
 You need to do this step once per workspace and potentially again each time you fetch new changes.  If the script reports any PATH problems, you'll need to correct those before proceeding.
 
-This script expects that you are both attempting to compile code and execute
-it on the same machine. If you'd like to have a different machine for a "builder"
-and a "runner", you can use the two more fine-grained scripts:
+This script expects that you are both attempting to compile code and execute it on the same machine. If you'd like to have a different machine for a "builder" and a "runner", you can use the two more fine-grained scripts:
 
 [source,text]
 ----
@@ -51,60 +156,112 @@ $ ./tools/install_runner_prerequisites.sh
 
 Again, if these scripts report any PATH problems, you'll need to correct those before proceeding.
 
-=== Make (or unmake) me a Gimlet!
+The rest of these instructions assume that you're building and running Omicron on the same machine.
 
-The sled agent expects to manage a real Gimlet. However, until those are built,
-developers generally make do with something else, usually a commodity machine.
-To make your machine "look" like a Gimlet, the
-`pfexec ./tools/create_virtual_hardware.sh` script can be used. This creates a few
-file-based ZFS vdevs and ZFS zpools on top of those, and a couple of VNICs. The
-vdevs model the actual U.2s that will be in a Gimlet, and the VNICs model the
-two Chelsio NIC ports.
+== Build and deploy Omicron
 
-To access the outside world or other gimlets, we also set up a virtual sidecar
-device for those network paths.
+=== Set up virtual hardware
 
-Optionally, the `PHYSICAL_LINK` environment variable can be set to override the
-default logic used to automatically determine the physical network connection
-used for external communication. For example:
+The Sled Agent supports operation on both:
+
+* a Gimlet (i.e., real Oxide hardware), and
+* an ordinary PC that's been set up to look like a Gimlet using the `./tools_create_virtual_hardware.sh` script.
+
+This script also sets up a "softnpu" zone to implement Boundary Services.  SoftNPU simulates the Tofino device that's used in real systems.  Just like Tofino, it can implement sled-to-sled networking, but that's beyond the scope of this doc.
+
+If you're running on a PC and using an existing network as your external network, you can usually just run:
 
 ----
-$ PHYSICAL_LINK=ixgbe0 pfexec ./tools/create_virtual_hardware.sh
+$ pfexec ./tools/create_virtual_hardware.sh
 ----
 
-You can clean up these resources with `pfexec ./tools/destroy_virtual_hardware.sh`.
-This script requires Omicron be uninstalled, e.g., with `pfexec
-./target/release/omicron-package uninstall`, and a warning will be printed if
-that is not the case. The script will then remove the file-based vdevs and the
-VNICs created by `create_virtual_hardware.sh`.
+If above you made up a new "external" network only accessible within the Sled, then you'll want to override PHYSICAL_LINK:
 
-=== Make me a certificate!
+----
+$ PHYSICAL_LINK=fake_external_stub0 pfexec ./tools/create_virtual_hardware.sh
+----
 
-Nexus's external interface will typically be served using public-facing x.509
-certificate. While we are still configuring the mechanism to integrate this real
-certificate into the package system, `./tools/create_self_signed_cert.sh` can be
-used to generate an equivalent self-signed certificate.
+You can also use this override if you find that the script chose the wrong datalink to use for external connectivity for whatever reason.
 
-== Deploying Omicron
+If you're running on a Gimlet, you don't need (or want) most of what `create_virtual_hardware.sh` does, but you do still need SoftNPU.  You'll have to look at the script and run that part by hand.
 
-The control plane repository contains a packaging tool which bundles binaries
-and SMF manifests. After building the expected binaries, they can be packaged
-in a format which lets them be transferred to a Helios machine.
+Later, you can clean up the resources created by `create_virtual_hardware.sh` with:
 
-This tool acts on a `package-manifest.toml` file which describes the packages
-to be bundled in the build.
+----
+$ pfexec ./tools/destroy_virtual_hardware.sh
+----
 
-Configuration files are used to select IP addresses, and to manage Zpools
-utilized by the Sled Agent. These configuration files are located within
-`smf/`, and likely need to be modified to use addresses and zpools which match
-your hardware. Much of this configuration will be automated in the future
-(e.g., IP addresses will be inferred and posted to a DNS system, Zpools will
-automatically be detected on discovered disks), but for now it remains
-hard-coded.
+If you've done all this before and Omicron is still running, these resources will be in use and this script will fail.  Uninstall Omicron (see below) before running this script.
 
-Packages also have a notion of "build targets", which are used to select
-between different variants of certain components. A build target is composed
-of an image type, a machine type, and a switch type:
+=== Create a TLS certificate for the external API
+
+You can skip this step.  In that case, the externally-facing services (API and console) will run on insecure HTTP.
+
+You can generate a self-signed TLS certificate chain with:
+
+----
+$ cargo run --bin=omicron-dev -- cert-create ./smf/sled-agent/$MACHINE/initial-tls- '*.sys.oxide.test'
+----
+
+=== Rack setup configuration
+
+The relevant configuration files are in `./smf/sled-agent/$MACHINE`.  Start with `config-rss.toml` in one of those directories.  There are only a few parts you need to review:
+
+[source,toml]
+----
+[[internal_services_ip_pool_ranges]]
+first = "192.168.1.20"
+last = "192.168.1.29"
+----
+
+This is a range of IP addresses on your external network that Omicron can assign to externally-facing services (like DNS and the API).  You'll need to change these if you've picked different addresses for your external network.  See <<_external_networking>> above for more on this.
+
+[source,toml]
+----
+# Configuration to bring up boundary services and make Nexus reachable from the
+# outside.  This block assumes that you're following option (2) above: putting
+# your Oxide system on an existing network that you control.
+[rack_network_config]
+# The gateway for the external network
+gateway_ip = "192.168.1.199"
+# A range of IP addresses used by Boundary Services on the network.  In a real
+# system, these would be addresses of the uplink ports on the Sidecar.  With
+# softnpu, only one address is used.
+infra_ip_first = "192.168.1.30"
+infra_ip_last = "192.168.1.30"
+# Name of the port.  This should always be "qsfp0" when using softnpu.
+uplink_port = "qsfp0"
+uplink_port_speed = "40G"
+uplink_port_fec="none"
+# For softnpu, an address within the "infra" block above that will be used for
+# the softnpu uplink port.  You can just pick the first address in that pool.
+uplink_ip = "192.168.1.30"
+----
+
+Update your `smf/sled-agent/$MACHINE/config.toml` if necessary:
+
+TODO how does one know if this is necessary and if so, what to put here?
+
+----
+# An optional data link from which we extract a MAC address.
+# This is used as a unique identifier for the bootstrap address.
+#
+# If empty, this will be equivalent to the first result from:
+# $ dladm show-phys -p -o LINK
+# data_link = "igb0"           <--- update if necessary
+
+# If testing on non-gimlet hardware, fill this in with the name of links that
+# should be mapped into the switch zone and used for transit mode maghemite
+# there. On gimlets, this is not required as tfportd will create links in the
+# switch zone when it boots, and maghemite is configured to use those.
+# switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"] <--- update if necessary
+----
+
+=== Build Omicron packages
+
+The `omicron-package` tool builds Omicron and bundles all required files into _packages_ that can be copied to another system (if necessary) and installed there.  This tool acts on `package-manifest.toml`, which describes the contents of the packages.
+
+Packages have a notion of "build targets", which are used to select between different variants of certain components.  A build target is composed of an image type, a machine type, and a switch type:
 
 [source,console]
 ----
@@ -123,8 +280,7 @@ Options:
 
 ----
 
-To setup a build target for a non-Gimlet machine with external networking, you
-would run:
+To setup a build target for a non-Gimlet machine with simulated (but fully functional) external networking, you would run:
 
 [source,console]
 ----
@@ -134,83 +290,24 @@ $ cargo run --release --bin omicron-package -- -t default target create -i stand
 Created new build target 'default' and set it as active
 ----
 
-NOTE: The `target create` command will set the new target as active and thus let you
-omit the `-t` flag in subsequent commands.
+NOTE: The `target create` command will set the new target as active and thus let you omit the `-t` flag in subsequent commands.
 
-Initial TLS certificates for the externally-facing endpoints are also part of
-the runtime configuration that would normally come from the customer during
-initial setup.  In development, by default, a deployed Omicron system will have
-no TLS certificates.  You can deploy a system with TLS certificates by putting
-a PEM-format certificate chain and private key into files called
-"initial-tls-cert.pem" and "initial-tls-key.pem" in the same directory as the
-"config-rss.toml" file that you're using.  This must happen before packaging up
-the sled agent (which is the next step below).
-
-If you don't specify initial certificates in this way, you can always load
-certificates later via the API.  This assumes you have a way to reach the API
-that doesn't require a valid TLS certificate.  Today, Nexus always starts an
-HTTP server that you can use for this.  This may be removed in the future.
-
-=== Configuration
-
-Update your `smf/seld-agent/$MACHINE/config-rss.toml` with the appropriate network information:
-
-----
-[[internal_services_ip_pool_ranges]]
-first = "192.168.1.20"          <--- first address of pool used for internal services (like Nexus)
-last = "192.168.1.22"           <--- last address of pool used for internal services
-
-# Configuration to bring up boundary services and make nexus reachable from the outside
-[rack_network_config]
-gateway_ip = "192.168.1.199"    <--- ip address of your default gateway / router
-infra_ip_first = "192.168.1.30" <--- first address of pool used for rack networking
-infra_ip_last = "192.168.1.50"  <--- last address of pool used for rack networking
-uplink_port = "qsfp0"           <--- for "softnpu" environments, this will always be "qsfp0"
-uplink_port_speed = "40G"       <--- uplink interface speed
-uplink_ip = "192.168.1.32"      <--- address to assign to the uplink port
-----
-
-Update your `smf/sled-agent/$MACHINE/config.toml` if necessary:
-----
-# An optional data link from which we extract a MAC address.
-# This is used as a unique identifier for the bootstrap address.
-#
-# If empty, this will be equivalent to the first result from:
-# $ dladm show-phys -p -o LINK
-# data_link = "igb0"           <--- update if necessary
-
-# If testing on non-gimlet hardware, fill this in with the name of links that
-# should be mapped into the switch zone and used for transit mode maghemite
-# there. On gimlets, this is not required as tfportd will create links in the
-# switch zone when it boots, and maghemite is configured to use those.
-# switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"] <--- update if necessary
-----
-
-=== Building
-
-To actually kick off the build and package everything, you can run:
+To kick off the build and package everything up, you can run:
 
 [source,console]
 ----
-cargo run --release --bin omicron-package -- package
+$ cargo run --release --bin omicron-package -- package
 ----
 
-This will take all the packages defined in the manifest and further selected
-by the active build target and either build them (if local) or download them
-before packaging them into tarballs. The final artifacts will be placed in
-a target directory of your choice (by default, `out/`) ready to be unpacked
-as services.
+This will package up all the packages defined in the manifest that are selected by the active build target.  Packing involves building software from this repo, downloading prebuilt pieces from elsewhere, and assembling the results into tarballs. The final artifacts will be placed in a target directory of your choice (by default, `out/`) ready to be unpacked as services.
 
-NOTE: Running in `release` mode isn't strictly required, but improves
-the performance of the packaging tools significantly.
+NOTE: Running in `release` mode isn't strictly required, but improves the performance of the packaging tools significantly.
 
-NOTE: Instead of `package` you can also use the `check` subcommand to just
-essentially run `cargo check` without building or creating packages.
+NOTE: Instead of `package` you can also use the `check` subcommand to essentially run `cargo check` without building or creating packages.
 
 === Installing
 
-To install the services on a target machine, the following command
-may be executed:
+To install the services on a target machine:
 
 [source,console]
 ----
@@ -218,32 +315,23 @@ $ cargo build --release --bin omicron-package
 $ pfexec ./target/release/omicron-package install
 ----
 
-[NOTE]
+[WARNING]
 ====
 **Do not use `pfexec cargo run` directly**; it will cause files in `~/.cargo` and `target/` to be owned by root, which will cause problems down the road.
 
 If you've done this already, and you wish to recover, run from the root of this repository `pfexec chown -R $USER:$(id -ng $USER) target ${CARGO_HOME:-~/.cargo}`.
 ====
 
-This command installs a bootstrap service called
-`svc:/oxide/sled-agent:default`, which itself loads other requested
-services. The bootstrap service is currently the only service which is
-"persistent" across reboots - although it will initialize other services as part
-of its setup sequence anyway.
-
-The first time the bootstrap service runs, it will take a while to initialize
-the Omicron zones:
+This command installs an SMF service called `svc:/oxide/sled-agent:default`, which itself starts the other required services.  This will take a few minutes.  You can watch the progress by looking at the Sled Agent log:
 
 [source,console]
 ----
-# List all services:
-$ svcs
-
-# View logs for sled-agent:
 $ tail -F $(svcs -L sled-agent)
 ----
 
-Once the zones are initialized, they'll show up in `zoneadm`:
+(You may want to pipe that to https://github.com/oxidecomputer/looker[looker] for better readability.)
+
+You can also list the zones that have been created so far:
 
 [source,console]
 ----
@@ -254,95 +342,27 @@ $ zoneadm list -cnv
 $ pfexec tail -f $(pfexec svcs -z oxz_nexus -L nexus)
 ----
 
-=== Uninstalling
+=== Finish configuring external networking
 
-To uninstall all Omicron services from a machine, the following may be
-executed:
-
-[source,console]
-----
-$ cargo build --release --bin omicron-package
-$ pfexec ./target/release/omicron-package uninstall
-----
-
-Once all the omicron services are uninstalled, you can also remove the
-previously created virtual hardware as mentioned above:
-
-[source,console]
-----
-$ pfexec ./tools/destroy_virtual_hardware.sh
-----
-
-==== Switch Zone
-
-In a real rack, two of the Gimlets (referred to as Scrimlets) will be connected
-directly to the switch (Sidecar). Those sleds will thus be configured with a switch
-zone (`oxz_switch`) used to manage the switch. The `sled_mode` option in Sled Agent's
-config will indicate whether the sled its running on is potentially a Scrimlet or Gimlet.
-
-The relevant config will be in `smf/sled-agent/$MACHINE/config.toml`, where `$MACHINE`
-is the machine type (e.g. `gimlet`, `gimlet-standalone`, `non-gimlet`) as specified
-in the build target.
-
-[source,text]
-----
-# Identifies whether sled agent treats itself as a scrimlet or a gimlet.
-#
-# If this is set to "scrimlet", the sled agent treats itself as a scrimlet.
-# If this is set to "gimlet", the sled agent treats itself as a gimlet.
-# If this is set to "auto":
-# - On illumos, the sled automatically detects whether or not it is a scrimlet.
-# - On all other platforms, the sled assumes it is a gimlet.
-sled_mode = "scrimlet"
-----
-
-Once Sled Agent has been configured to run as a Scrimlet (whether explicitly or
-implicitly), it will attempt to create and start the switch zone. This will
-depend on the switch type that was specified in the build target:
-
-1. `asic` implies we're running on a real Gimlet and are directly attached to the
-Tofino ASIC.
-2. `stub` provides a stubbed out switch implementation that doesn't
-require any hardware.
-3. `softnpu` provides a simulated switch implementation that
-runs the same P4 program as the ASIC, but in software.
-
-For the purposes of local development, the `softnpu` switch provides is used.
-Unfortunately, Omicron does not currently automatically configure the switch
-with respect to external networking, so you'll need to manually do so.
-
-After installing omicron with `omicron-package install`, you can run the
-`softnpu-init.sh` script to configure SoftNPU. By default, it'll attempt to
-automatically detect your local network's gateway IP and MAC but those can
-be overridden by setting the `GATEWAY_IP` and `GATEWAY_MAC` environment
-variables, respectively.
+After installing omicron with `omicron-package install`, you can run the `softnpu-init.sh` script to configure SoftNPU.  If your external network is the one that your global zone is already on (i.e., an existing network), then you can likely just run:
 
 [source,console]
 ----
 $ ./tools/scrimlet/softnpu-init.sh
 ----
 
-=== Test Environment
+If your external network is one you made up above, you'll need to override the gateway IP to be the address of the global zone on your made-up network.  In our example:
 
-When we deploy, we're effectively creating a number of different zones
-for all the components that make up Omicron (Nexus, Clickhouse, Crucible, etc).
-Since all these services run in different zones they cannot communicate with
-each other (and Sled Agent in the global zone) via `localhost`. In practice,
-we'll assign addresses as per RFD 63 as well as incorporating DNS based
-service discovery.
+[source,console]
+----
+$ GATEWAY_IP=192.168.1.19 ./tools/scrimlet/softnpu-init.sh
+----
 
-For the purposes of local development today, we specify some hardcoded IPv6
-unique local addresses in the subnet of the first Sled Agent: `fd00:1122:3344:1::/64`.
+You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.
 
-If you'd like to modify these values to suit your local network, you can modify
-them within the https://github.com/oxidecomputer/omicron/tree/main/smf[`smf/` subdirectory].
-Notably, Nexus is being served from IPv4 address, which may be configured to be
-external. By default, it uses a private IPv4 address but may be configured to use
-a public-facing IP address.
+Services that require external connectivity (e.g. Nexus, Boundary NTP, External DNS) do so via OPTE using addresses from the services IP pool.  When using SoftNPU, we'll need to configure Proxy ARP for those addresses.
 
-NOTE: Internal services that require external connectivity (e.g. Nexus, Boundary NTP,
-External DNS) do so via OPTE. When using SoftNPU we'll need to configure Proxy ARP for
-the services IP Pool.
+In this snippet, `$SERVICE_IP_POOL_START` and `$SERVICE_IP_POOL_END` are the addresses you put into `config-rss.toml` above for `internal_services_ip_pool_ranges`:
 
 [source,console]
 ----
@@ -357,6 +377,237 @@ $ pfexec /opt/oxide/softnpu/stuff/scadm \
   $SERVICE_IP_POOL_END \
   $SOFTNPU_MAC
 ----
+
+== Using Omicron
+
+At this point, the system should be up and running!  You should be able to reach the external API and web console from your external network.  But how?  The URL for the API and console will be:
+
+* `http://` / `https://` (depending on whether you provided TLS certificates in the steps above)
+* `recovery` (assuming you did not change the default recovery Silo name)
+* `.sys.`
+* `oxide.test` (assuming you did not change the delegated DNS domain).
+
+This won't be in public DNS, though.  You'd need to be using the deployed system's external DNS servers as your DNS server for things to "just work".footnote:[If you did this, everything _else_ would be broken because the Omicron-provided DNS servers do not serve any domains except the ones operated by Omicron.]  You can query them directly:
+
+[source,console]
+----
+$ dig recovery.sys.oxide.test @192.168.1.20 +short
+192.168.1.21
+----
+
+Where did 192.168.1.20 come from?  That's the external address of the external DNS server.  We knew that only because it's the first address in the "internal services" IP pool in config-rss.toml.
+
+Having looked this up, the easiest thing will be to use `http://192.168.1.21` for your URL (replacing with `https` if you used a certificate, and replacing that IP if needed).  If you've set up networking right, you should be able to reach this from your web browser.  You may have to instruct the browser to accept a self-signed TLS certificate.  See also <<_connecting_securely_with_tls_using_the_cli>>.
+
+=== Using the CLI
+
+Follow the instructions to set up the https://github.com/oxidecomputer/oxide.rs[Oxide CLI].  See the previous section to find the URL for the API.  Then you can log in with:
+
+[source,console]
+----
+oxide auth login --host http://192.168.1.21
+----
+
+=== Create an IP pool
+
+An IP pool is needed to provide external connectivity to Instances.  The addresses you use here should be addresses you've reserved from the external network (see <<_external_networking>>).
+
+[source,console]
+----
+$ oxide api /v1/system/ip-pools/default/ranges/add --method POST --input - <<EOF
+{
+  "first": "192.168.1.31",
+  "last": "192.168.1.40"
+}
+EOF
+----
+
+With SoftNPU you will generally also need to configure Proxy ARP.  Below, `IP_POOL_START` and `IP_POOL_END` are the first and last addresses you used in the previous command:
+
+[source,console]
+----
+# dladm won't return leading zeroes but `scadm` expects them
+$ SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | gsed 's/\b\(\w\)\b/0\1/g')
+$ pfexec /opt/oxide/softnpu/stuff/scadm \
+  --server /opt/oxide/softnpu/stuff/server \
+  --client /opt/oxide/softnpu/stuff/client \
+  standalone \
+  add-proxy-arp \
+  $IP_POOL_START \
+  $IP_POOL_END \
+  $SOFTNPU_MAC
+----
+
+=== Create a Project and Image
+
+First, create a Project:
+
+[source,console]
+----
+$ oxide project create myproj
+----
+
+Create a Project Image that will be used as initial disk contents.
+
+This can be the alpine.iso image that ships with propolis:
+
+[source,console]
+----
+$ oxide api /v1/images?project=<proj> --method POST --input - <<EOF
+{
+  "name": "alpine",
+  "description": "boot from propolis zone blob!",
+  "block_size": 512,
+  "distribution": {
+    "name": "alpine",
+    "version": "propolis-blob"
+  },
+  "source": {
+    "type": "you_can_boot_anything_as_long_as_its_alpine"
+  }
+}
+EOF
+----
+
+Or an ISO / raw disk image / etc hosted at a URL:
+
+[source,console]
+----
+$ oxide api /v1/images --method POST --input - <<EOF
+{
+  "name": "crucible-tester-sparse",
+  "description": "boot from a url!",
+  "block_size": 512,
+  "distribution": {
+    "name": "debian",
+    "version": "9"
+  },
+  "source": {
+    "type": "url",
+    "url": "http://[fd00:1122:3344:101::15]/crucible-tester-sparse.img"
+  }
+}
+EOF
+----
+
+=== Provision an instance using the CLI
+
+You'll need the id `$IMAGE_ID` of the image you just created.
+
+Now, create a Disk from that Image.  The disk size must be a multiple of 1 GiB and at least as large as the image size.  The example below creates a disk using the image made from the alpine ISO that ships with propolis, and sets the size to the next 1GiB multiple of the original alpine source:
+
+[source,console]
+----
+$ oxide api /v1/disks?project=myproj --method POST --input - <<EOF
+{
+  "name": "alpine",
+  "description": "alpine.iso blob",
+  "block_size": 512,
+  "size": 1073741824,
+  "disk_source": {
+      "type": "image",
+      "image_id": "$IMAGE_ID"
+  }
+}
+EOF
+----
+
+Now we're ready to create an Instance, attaching the alpine disk created above:
+
+[source,console]
+----
+$ oxide api /v1/instances?project=myproj --method POST --input - <<EOF
+{
+  "name": "myinst",
+  "description": "my inst",
+  "hostname": "myinst",
+  "memory": 1073741824,
+  "ncpus": 2,
+  "disks": [
+    {
+      "type": "attach",
+      "name": "alpine"
+    }
+  ],
+  "external_ips": [{"type": "ephemeral"}]
+}
+EOF
+----
+
+=== Attach to the serial console
+
+You can attach to the proxied propolis server serial console:
+
+[source,console]
+----
+$ oxide instance serial --interactive -p myproj myinst
+----
+
+== Cleaning up
+
+To uninstall all Omicron services from a machine:
+
+[source,console]
+----
+$ cargo build --release --bin omicron-package
+$ pfexec ./target/release/omicron-package uninstall
+----
+
+Once all the Omicron services are uninstalled, you can also remove the previously created virtual hardware as mentioned above:
+
+[source,console]
+----
+$ pfexec ./tools/destroy_virtual_hardware.sh
+----
+
+== More information
+
+=== Connecting securely with TLS using the CLI
+
+If you provided TLS certificates during setup, you can connect securely to the API.  But you'll need to be accessing it via its DNS name.  That's usually hard because in development, you're not using a real top-level domain that's in public DNS.  Both curl(1) and the Oxide CLI provide (identical) flags that can help here:
+
+[source,console]
+----
+$ curl -i --resolve recovery.sys.oxide.test:443:192.168.1.21 --cacert ./smf/sled-agent/$MACHINE/initial-tls-key.pem https://recovery.sys.oxide.test
+----
+
+[source,console]
+----
+$ oxide --resolve recovery.sys.oxide.test:443:192.168.1.21 --cacert ./smf/sled-agent/$MACHINE/initial-tls-key.pem auth login --host https://recovery.sys.oxide.test
+----
+
+=== Switch Zone
+
+In a real rack, two of the Gimlets (referred to as Scrimlets) will be connected directly to the switch (Sidecar). Those sleds will thus be configured with a switch zone (`oxz_switch`) used to manage the switch. The `sled_mode` option in Sled Agent's config will indicate whether the sled its running on is potentially a Scrimlet or Gimlet.
+
+The relevant config will be in `smf/sled-agent/$MACHINE/config.toml`.
+
+[source,text]
+----
+# Identifies whether sled agent treats itself as a scrimlet or a gimlet.
+#
+# If this is set to "scrimlet", the sled agent treats itself as a scrimlet.
+# If this is set to "gimlet", the sled agent treats itself as a gimlet.
+# If this is set to "auto":
+# - On illumos, the sled automatically detects whether or not it is a scrimlet.
+# - On all other platforms, the sled assumes it is a gimlet.
+sled_mode = "scrimlet"
+----
+
+Once Sled Agent has been configured to run as a Scrimlet (whether explicitly or implicitly), it will attempt to create and start the switch zone. This will depend on the switch type that was specified in the build target:
+
+1. `asic` implies we're running on a real Gimlet and are directly attached to the
+Tofino ASIC.
+2. `stub` provides a stubbed out switch implementation that doesn't
+require any hardware.
+3. `softnpu` provides a simulated switch implementation that
+runs the same P4 program as the ASIC, but in software.
+
+For the purposes of local development, the `softnpu` switch is used.  Unfortunately, Omicron does not currently automatically configure the switch with respect to external networking, so you'll need to manually do so.
+
+=== Test Environment
+
+The components of Omicron are deployed into separate zones that act as separate hosts on the network, each with their own address.  Since this network is private to the deployment, we can use the same IPv6 prefix in all development deployments and even hardcode the IPv6 addresses of each component.  If you'd like to modify these values to suit your local network, you can modify them within the https://github.com/oxidecomputer/omicron/tree/main/smf[`smf/` subdirectory].
 
 [options="header"]
 |===================================================================================================
@@ -376,133 +627,11 @@ $ pfexec /opt/oxide/softnpu/stuff/scadm \
 | Nexus: External API        | `192.168.1.21:80`
 |===================================================================================================
 
-Note that Sled Agent runs in the global zone and is the one responsible for bringing up all the other
-other services and allocating them with vNICs and IPv6 addresses.
-
-=== How to provision an instance using the CLI
-
-Here are the current steps to provision an instance using the https://github.com/oxidecomputer/cli[oxide]
-command line interface.  Note that the `jq` command is required. In addition, the examples build on each other, so a previous name (or org, or project) are used in later steps.
-
-1. Create a project that the resources will live under:
-
-    oxide project create myproj
-
-2. Create an IP Pool, for providing external connectivity to the instance later.
-We need to create an IP Pool itself, and a range of IP addresses in that pool.
-**Important:** The addresses used here are appropriate for the Oxide lab
-environment, but not for an arbitrary environment. The actual IP range must
-currently be something that matches the physical network that the host is
-running in, at least if you'd like to be able to SSH into the guest. This is
-most often a private address range, like `10.0.0.0/8` or `192.168.0.0/16`, but
-the exact addresses that are available depends on the environment.
-+
-[source,console]
-----
-$ oxide api /v1/system/ip-pools/default/ranges/add --method POST --input - <<EOF
-{
-  "first": "172.20.15.227",
-  "last": "172.20.15.239"
-}
-EOF
-----
-+
-Additionally, if you're using SoftNPU and your chosen IP range is on the same
-L2 network as the router or other non-oxide hosts, you'll need to configure
-Proxy ARP:
-+
-[source,console]
-----
-# dladm won't return leading zeroes but `scadm` expects them
-$ SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | gsed 's/\b\(\w\)\b/0\1/g')
-$ pfexec /opt/oxide/softnpu/stuff/scadm \
-  --server /opt/oxide/softnpu/stuff/server \
-  --client /opt/oxide/softnpu/stuff/client \
-  standalone \
-  add-proxy-arp \
-  $IP_POOL_START \
-  $IP_POOL_END \
-  $SOFTNPU_MAC
-----
-
-3. Define a project image that will be used as initial disk contents.
-
- a. This can be the alpine.iso image that ships with propolis:
-
-    oxide api /v1/images?project=<proj> --method POST --input - <<EOF
-    {
-      "name": "alpine",
-      "description": "boot from propolis zone blob!",
-      "block_size": 512,
-      "distribution": {
-        "name": "alpine",
-        "version": "propolis-blob"
-      },
-      "source": {
-        "type": "you_can_boot_anything_as_long_as_its_alpine"
-      }
-    }
-    EOF
-
- b. Or an ISO / raw disk image / etc hosted at a URL:
-
-    oxide api /v1/images --method POST --input - <<EOF
-    {
-      "name": "crucible-tester-sparse",
-      "description": "boot from a url!",
-      "block_size": 512,
-      "distribution": {
-        "name": "debian",
-        "version": "9"
-      },
-      "source": {
-        "type": "url",
-        "url": "http://[fd00:1122:3344:101::15]/crucible-tester-sparse.img"
-      }
-    }
-    EOF
-
-4. Create a disk from that image (note that disk size must be greater than or equal to image size and a 1GiB multiple!). The example below creates a disk using the image made from the alpine ISO that ships with propolis, and sets the size to the next 1GiB multiple of the original alpine source:
-
-    oxide api /v1/disks?project=myproj --method POST --input - <<EOF
-    {
-      "name": "alpine",
-      "description": "alpine.iso blob",
-      "block_size": 512,
-      "size": 1073741824,
-      "disk_source": {
-          "type": "image",
-          "image_id": "$(oxide api /v1/images/alpine | jq -r .id)"
-      }
-    }
-    EOF
-
-5. Create an instance, attaching the alpine disk created above:
-
-    oxide api /v1/instances?project=myproj --method POST --input - <<EOF
-    {
-      "name": "myinst",
-      "description": "my inst",
-      "hostname": "myinst",
-      "memory": 1073741824,
-      "ncpus": 2,
-      "disks": [
-        {
-          "type": "attach",
-          "name": "alpine"
-        }
-      ],
-      "external_ips": [{"type": "ephemeral"}]
-    }
-    EOF
-
-6. Optionally, attach to the proxied propolis server serial console (this requires https://github.com/oxidecomputer/cli/commit/adab246142270778db7208126fb03724f5d35858[this commit] or newer of the CLI.)
-
-    oxide instance serial --interactive -p myproj -o myorg myinst
+Note that Sled Agent runs in the global zone and is the one responsible for bringing up all the other other services and allocating them with VNICs and IPv6 addresses.
 
 == Building host images
 
-Host images for both the standard omicron install and the trampoline/recovery
+Host images for both the standard Omicron install and the trampoline/recovery
 install are built as a part of CI. To build them locally, first run the CI
 script:
 

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -6,7 +6,7 @@
 
 Omicron is the control plane for the Oxide system.  There are a few different ways to run Omicron depending on what resources you have available and how much of the stack you want to run using real components vs. simulated ones.  Generally speaking, it's easier to get things going and automate testing with simulated components, but of course much of the system's functionality is missing or faked up when using simulated components.
 
-The most common configurations are:
+The most common development configurations are:
 
 1. Using one or more simulated Sled Agents.  There are no real VMs.  All components listen on localhost and talk to each other directly.  The automated tests in this repo generally use this kind of deployment.  This is the only mode that's supported on non-illumos systems (i.e., Linux and MacOS).
 2. Using one or more real Sled Agents (on separate physical machines) using SoftNPU-based Boundary Services.  You can provision real VMs this way.  Intra-"rack" networking and boundary Services (i.e., external connectivity) are fully functional using SoftNPU, a software-based simulation of the Tofino device that's normally responsible for these functions.
@@ -64,7 +64,7 @@ Here's a summary of the tradeoffs:
 |Real implementation on-sled, simulated implementation across sleds (SoftNPU)
 
 |Boundary services (external connectivity)
-|Localhost
+|Missing.  Externally-facing Oxide services listen directly on localhost.  The VMs are fake, so external connectivity is moot.
 |Simulated implementation (SoftNPU)
 
 |Wicket
@@ -77,7 +77,16 @@ Here's a summary of the tradeoffs:
 
 |===
 
-To run the simulated control plane, refer to the guide on xref:how-to-run-simulated.adoc[running simulated Omicron].  The rest of this document describes how to run a single-Sled Omicron with a real Sled Agent and SoftNPU-based Boundary Services.
+**To run the simulated control plane, refer to the guide on xref:how-to-run-simulated.adoc[running simulated Omicron].**  The rest of this document describes how to run a single-Sled Omicron with a real Sled Agent and SoftNPU-based Boundary Services.
+
+There are other configurations besides the ones mentioned here:
+
+* A real Oxide rack: real hardware with real implementations of all components.
+* A Gimlet in a real Oxide rack, deployed as a single system in isolation from the rest of the rack.
+* A Gimlet on a bench (i.e., not in a rack -- requires separate hardware to connect power and networking) connected a Sidecar (the Oxide switch, also on a bench)
+* A Gimlet on a bench with no Sidecar.
+
+This document doesn't describe how to deploy these cases.
 
 == Prerequisites
 
@@ -116,13 +125,11 @@ When making this choice, note that **in order to use the system once it's set up
 
 Omicron packages (discussed in more detail below) are associated with a particular _machine_ type, which is one of:
 
-* `gimlet` (real Oxide hardware deployed in a real Oxide rack)
-* `gimlet-standalone` (real Oxide server hardware running as a single-machine "rack")
-* `non-gimlet` (some kind of PC running as a single-machine "rack")
+* `gimlet` (real Oxide hardware deployed in a real Oxide rack with a bunch of other Gimlets that together form a multi-sled system)
+* `gimlet-standalone` (real Oxide server hardware deployed in a real Oxide rack, but running as a separate single-node system)
+* `non-gimlet` (some kind of PC running as a single-machine "rack"; can potentially also be used for Gimlet running on the bench?)
 
-The main difference are the configuration files used for the Sled Agent and Rak Setup Service (RSS).
-
-This guide is for `gimlet-standalone` and `non-gimlet`.  In the rest of this guide, `$MACHINE` refers to one of these two values.
+The main difference are the configuration files used for the Sled Agent and Rack Setup Service (RSS).
 
 === Prerequisite software
 
@@ -238,9 +245,7 @@ uplink_port_fec="none"
 uplink_ip = "192.168.1.30"
 ----
 
-Update your `smf/sled-agent/$MACHINE/config.toml` if necessary:
-
-TODO how does one know if this is necessary and if so, what to put here?
+In some configurations (not the one described here), it may be necessary to update `smf/sled-agent/$MACHINE/config.toml`:
 
 ----
 # An optional data link from which we extract a MAC address.
@@ -248,13 +253,16 @@ TODO how does one know if this is necessary and if so, what to put here?
 #
 # If empty, this will be equivalent to the first result from:
 # $ dladm show-phys -p -o LINK
-# data_link = "igb0"           <--- update if necessary
+# data_link = "igb0"
 
-# If testing on non-gimlet hardware, fill this in with the name of links that
-# should be mapped into the switch zone and used for transit mode maghemite
-# there. On gimlets, this is not required as tfportd will create links in the
-# switch zone when it boots, and maghemite is configured to use those.
-# switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"] <--- update if necessary
+# On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
+# to configure routes between sleds.  This runs over the Sidecar's rear ports
+# (whether simulated with SoftNPU or not).  On a Gimlet deployed in a rack,
+# tfportd will create the necessary links and Maghemite will be configured to
+# use those.  But on non-Gimlet systems, you need to specify physical links to
+# be passed into the `oxz_switch` zone for this purpose.  You can skip this if
+# you're deploying a single-sled system.
+# switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"]
 ----
 
 === Build Omicron packages
@@ -342,7 +350,7 @@ $ zoneadm list -cnv
 $ pfexec tail -f $(pfexec svcs -z oxz_nexus -L nexus)
 ----
 
-=== Finish configuring external networking
+=== SoftNPU Configuration
 
 After installing omicron with `omicron-package install`, you can run the `softnpu-init.sh` script to configure SoftNPU.  If your external network is the one that your global zone is already on (i.e., an existing network), then you can likely just run:
 
@@ -351,14 +359,18 @@ After installing omicron with `omicron-package install`, you can run the `softnp
 $ ./tools/scrimlet/softnpu-init.sh
 ----
 
-If your external network is one you made up above, you'll need to override the gateway IP to be the address of the global zone on your made-up network.  In our example:
+In this case, `softnpu-init.sh` determines a network gateway by looking at your system's default gateway.  Again, the assumption for this use case is that your rack gets external connectivity the same way your system does because it's part of the same network.
+
+If your external network is one you made up above that's local to your own system, this won't be right.  In that case, you'll want to override the gateway IP to be the address of the global zone on your made-up network.  In our example:
 
 [source,console]
 ----
 $ GATEWAY_IP=192.168.1.199 ./tools/scrimlet/softnpu-init.sh
 ----
 
-You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.
+In other configurations, you might use a different GATEWAY_IP.  You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.
+
+=== SoftNPU Proxy ARP Setup
 
 Services that require external connectivity (e.g. Nexus, Boundary NTP, External DNS) do so via OPTE using addresses from the services IP pool.  When using SoftNPU, we'll need to configure Proxy ARP for those addresses.
 

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -444,7 +444,7 @@ First, create a Project:
 
 [source,console]
 ----
-$ oxide project create myproj
+$ oxide project create --name=myproj --description demo
 ----
 
 Create a Project Image that will be used as initial disk contents.
@@ -453,7 +453,7 @@ This can be the alpine.iso image that ships with propolis:
 
 [source,console]
 ----
-$ oxide api /v1/images?project=<proj> --method POST --input - <<EOF
+$ oxide api /v1/images?project=myproj --method POST --input - <<EOF
 {
   "name": "alpine",
   "description": "boot from propolis zone blob!",
@@ -462,6 +462,8 @@ $ oxide api /v1/images?project=<proj> --method POST --input - <<EOF
     "name": "alpine",
     "version": "propolis-blob"
   },
+  "os": "linux",
+  "version": "1",
   "source": {
     "type": "you_can_boot_anything_as_long_as_its_alpine"
   }
@@ -536,11 +538,11 @@ EOF
 
 === Attach to the serial console
 
-You can attach to the proxied propolis server serial console:
+You can attach to the proxied propolis server serial console.  You'll need the id returned from the previous command, which we'll call $INSTANCE_ID:
 
 [source,console]
 ----
-$ oxide instance serial --interactive -p myproj myinst
+$ oxide instance serial console --instance $INSTANCE_ID
 ----
 
 == Cleaning up

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -4,8 +4,9 @@
 # Agent API.  See the `RackInitializeRequest` type in bootstrap-agent or its
 # OpenAPI spec (in openapi/bootstrap-agent.json in the root of this workspace).
 
-# The /56 subnet for the rack.
-# Also implies the /48 AZ subnet.
+# The /56 subnet for this rack.  This subnet is internal to the rack and fully
+# managed by Omicron, so you can pick anything you want.  The rack-specific /56
+# subnet also implies the parent /48 AZ subnet.
 #              |............|    <- This /48 is the AZ Subnet
 #              |...............| <- This /56 is the Rack Subnet
 rack_subnet = "fd00:1122:3344:0100::"
@@ -22,25 +23,82 @@ ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 
 # Delegated external DNS zone name
+#
+# The rack provides separate external API and console endpoints for each Silo.
+# These are named `$silo_name.sys.$external_dns_zone_name`.  For a Silo called
+# "eng" with delegated domain "oxide.example", the API would be accessible at
+# "eng.sys.oxide.example".  The rack runs external DNS servers that serve A/AAAA
+# records for these DNS names.
+#
+# In a real deployment, the operator would own this DNS domain and delegate it
+# to the rack.  That means adding glue records in their DNS servers for the
+# parent domain that point to the rack's external DNS servers.
+#
+# In development, we usually use a fake domain here and configure clients to use
+# the rack's external DNS server as their normal DNS server.  Programmatically,
+# we do this with a custom reqwest Resolver.  Using curl or the Oxide CLI, you
+# can do this with the `--resolve` option.  In practice, people often skip DNS
+# altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
+
+# The IP ranges configured as part of the "internal services" IP Pool
+#
+# This is a range of *external* IP addresses that will be assigned to the
+# External DNS server(s) and Nexus instances.  These are the IPs that users
+# *outside* the rack will use to reach these services.  These will also be used
+# by services like NTP as their externally-facing address for NAT.
+#
+# For more on this and what to put here, see docs/how-to-run.adoc.
+[[internal_services_ip_pool_ranges]]
+first = "192.168.1.20"
+last = "192.168.1.29"
+
+# TODO - this configuration is subject to change going forward. Ultimately these
+# parameters should be provided to the control plane via wicket, but we need to
+# put these parameters somewhere in the meantime so that the Nexus API will be
+# reachable upon Rack startup.
+
+# Configuration to bring up Boundary Services and make Nexus reachable from the
+# outside.  See docs/how-to-run.adoc for more on what to put here.
+[rack_network_config]
+# The gateway IP for the rack's external network
+gateway_ip = "192.168.1.199"
+# A range of IP addresses used by Boundary Services on the external network.  In
+# a real system, these would be addresses of the uplink ports on the Sidecar.
+# With softnpu, only one address is used.
+infra_ip_first = "192.168.1.30"
+infra_ip_last = "192.168.1.30"
+# Name of the uplink port.  This should always be "qsfp0" when using softnpu.
+uplink_port = "qsfp0"
+uplink_port_speed = "40G"
+uplink_port_fec="none"
+# For softnpu, an address within the "infra" block above that will be used for
+# the softnpu uplink port.  You can just pick the first address in that pool.
+uplink_ip = "192.168.1.30"
 
 # Initial TLS certificates for the external API
 #
+# Each entry here is really a TLS certificate chain.  You typically only need
+# one entry here.  Multiple are supported primarily for rotating them.
+#
+# The certificates provided here will be used for the "recovery" Silo that's
+# created during initial setup with Wicket.  Immediately after that setup, users
+# will go to https://recovery.sys.$external_dns_zone_name to reach the console
+# to finish initial setup.  The rack will serve one of these TLS certificates at
+# that time.  Once in the console, the user would generally create another Silo
+# with its own certificate(s).
+#
 # For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it can be unwieldy to put them here.  You can also
-# specify a certificate by including the certificate chain and private key in
-# PEM-format files called "initial-tls-cert.pem" and "initial-tls-key.pem",
-# respectively, in the same place as this configuration file.
+# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
+# you can specify a certificate by including the certificate chain and private
+# key in PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.
 external_certificates = []
 
-# The IP ranges configured as part of the services IP Pool.
-# e.g., Nexus will be configured to use an address from this
-# pool as its external IP.
-[[internal_services_ip_pool_ranges]]
-first = "192.168.1.20"
-last = "192.168.1.22"
-
 # Configuration for the initial Silo, user, and password.
+#
+# You don't need to change the silo or user names.
 [recovery_silo]
 silo_name = "recovery"
 user_name = "recovery"

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -41,6 +41,26 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
 
+# Initial TLS certificates for the external API
+#
+# Each entry here is really a TLS certificate chain.  You typically only need
+# one entry here.  Multiple are supported primarily for rotating them.
+#
+# The certificates provided here will be used for the "recovery" Silo that's
+# created during initial setup with Wicket.  Immediately after that setup, users
+# will go to https://recovery.sys.$external_dns_zone_name to reach the console
+# to finish initial setup.  The rack will serve one of these TLS certificates at
+# that time.  Once in the console, the user would generally create another Silo
+# with its own certificate(s).
+#
+# For the structure of these certificates, see `Certificate` in the Nexus
+# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
+# you can specify a certificate by including the certificate chain and private
+# key in PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.
+external_certificates = []
+
 # The IP ranges configured as part of the "internal services" IP Pool
 #
 # This is a range of *external* IP addresses that will be assigned to the
@@ -75,26 +95,6 @@ uplink_port_fec="none"
 # For softnpu, an address within the "infra" block above that will be used for
 # the softnpu uplink port.  You can just pick the first address in that pool.
 uplink_ip = "192.168.1.30"
-
-# Initial TLS certificates for the external API
-#
-# Each entry here is really a TLS certificate chain.  You typically only need
-# one entry here.  Multiple are supported primarily for rotating them.
-#
-# The certificates provided here will be used for the "recovery" Silo that's
-# created during initial setup with Wicket.  Immediately after that setup, users
-# will go to https://recovery.sys.$external_dns_zone_name to reach the console
-# to finish initial setup.  The rack will serve one of these TLS certificates at
-# that time.  Once in the console, the user would generally create another Silo
-# with its own certificate(s).
-#
-# For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
-# you can specify a certificate by including the certificate chain and private
-# key in PEM-format files called "initial-tls-cert.pem" and
-# "initial-tls-key.pem", respectively, in the same place as this configuration
-# file.
-external_certificates = []
 
 # Configuration for the initial Silo, user, and password.
 #

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -5,8 +5,9 @@
 # OpenAPI spec (in openapi/bootstrap-agent.json in the root of this workspace).
 
 # The /56 subnet for this rack.  This subnet is internal to the rack and fully
-# managed by Omicron, so you can pick anything you want.  The rack-specific /56
-# subnet also implies the parent /48 AZ subnet.
+# managed by Omicron, so you can pick anything you want within the IPv6 Unique
+# Local Address (ULA) range.  The rack-specific /56 subnet also implies the
+# parent /48 AZ subnet.
 #              |............|    <- This /48 is the AZ Subnet
 #              |...............| <- This /56 is the Rack Subnet
 rack_subnet = "fd00:1122:3344:0100::"
@@ -43,22 +44,27 @@ external_dns_zone_name = "oxide.test"
 
 # Initial TLS certificates for the external API
 #
-# Each entry here is really a TLS certificate chain.  You typically only need
-# one entry here.  Multiple are supported primarily for rotating them.
+# You should probably leave this field empty even if you want to configure TLS.
+# If you want to configure TLS, the easier approach is to put the certificate
+# chain and private key into PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.  They will be loaded and inserted into this array as part of loading
+# this file.  If for some reason you must put the contents inline here, see the
+# API documentation for the structure of these objects.
 #
-# The certificates provided here will be used for the "recovery" Silo that's
-# created during initial setup with Wicket.  Immediately after that setup, users
-# will go to https://recovery.sys.$external_dns_zone_name to reach the console
-# to finish initial setup.  The rack will serve one of these TLS certificates at
+# However you provide the initial certificates, these will become associated
+# with the "recovery" Silo that's created during initial setup (i.e., with
+# Wicket, in a real system).  Immediately after that setup, users will go to
+# https://recovery.sys.$external_dns_zone_name to reach the web console to
+# finish initial setup.  The rack will serve one of these TLS certificates at
 # that time.  Once in the console, the user would generally create another Silo
 # with its own certificate(s).
 #
-# For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
-# you can specify a certificate by including the certificate chain and private
-# key in PEM-format files called "initial-tls-cert.pem" and
-# "initial-tls-key.pem", respectively, in the same place as this configuration
-# file.
+# When configuring TLS, you typically only need one entry here.  Each entry is
+# more accurately called a TLS certificate _chain_.
+#
+# If no initial TLS certificates are provided, then your external API will be
+# configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
 
 # The IP ranges configured as part of the "internal services" IP Pool

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -41,6 +41,26 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
 
+# Initial TLS certificates for the external API
+#
+# Each entry here is really a TLS certificate chain.  You typically only need
+# one entry here.  Multiple are supported primarily for rotating them.
+#
+# The certificates provided here will be used for the "recovery" Silo that's
+# created during initial setup with Wicket.  Immediately after that setup, users
+# will go to https://recovery.sys.$external_dns_zone_name to reach the console
+# to finish initial setup.  The rack will serve one of these TLS certificates at
+# that time.  Once in the console, the user would generally create another Silo
+# with its own certificate(s).
+#
+# For the structure of these certificates, see `Certificate` in the Nexus
+# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
+# you can specify a certificate by including the certificate chain and private
+# key in PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.
+external_certificates = []
+
 # The IP ranges configured as part of the "internal services" IP Pool
 #
 # This is a range of *external* IP addresses that will be assigned to the
@@ -75,26 +95,6 @@ uplink_port_fec="none"
 # For softnpu, an address within the "infra" block above that will be used for
 # the softnpu uplink port.  You can just pick the first address in that pool.
 uplink_ip = "192.168.1.30"
-
-# Initial TLS certificates for the external API
-#
-# Each entry here is really a TLS certificate chain.  You typically only need
-# one entry here.  Multiple are supported primarily for rotating them.
-#
-# The certificates provided here will be used for the "recovery" Silo that's
-# created during initial setup with Wicket.  Immediately after that setup, users
-# will go to https://recovery.sys.$external_dns_zone_name to reach the console
-# to finish initial setup.  The rack will serve one of these TLS certificates at
-# that time.  Once in the console, the user would generally create another Silo
-# with its own certificate(s).
-#
-# For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
-# you can specify a certificate by including the certificate chain and private
-# key in PEM-format files called "initial-tls-cert.pem" and
-# "initial-tls-key.pem", respectively, in the same place as this configuration
-# file.
-external_certificates = []
 
 # Configuration for the initial Silo, user, and password.
 #

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -5,8 +5,9 @@
 # OpenAPI spec (in openapi/bootstrap-agent.json in the root of this workspace).
 
 # The /56 subnet for this rack.  This subnet is internal to the rack and fully
-# managed by Omicron, so you can pick anything you want.  The rack-specific /56
-# subnet also implies the parent /48 AZ subnet.
+# managed by Omicron, so you can pick anything you want within the IPv6 Unique
+# Local Address (ULA) range.  The rack-specific /56 subnet also implies the
+# parent /48 AZ subnet.
 #              |............|    <- This /48 is the AZ Subnet
 #              |...............| <- This /56 is the Rack Subnet
 rack_subnet = "fd00:1122:3344:0100::"
@@ -43,22 +44,27 @@ external_dns_zone_name = "oxide.test"
 
 # Initial TLS certificates for the external API
 #
-# Each entry here is really a TLS certificate chain.  You typically only need
-# one entry here.  Multiple are supported primarily for rotating them.
+# You should probably leave this field empty even if you want to configure TLS.
+# If you want to configure TLS, the easier approach is to put the certificate
+# chain and private key into PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.  They will be loaded and inserted into this array as part of loading
+# this file.  If for some reason you must put the contents inline here, see the
+# API documentation for the structure of these objects.
 #
-# The certificates provided here will be used for the "recovery" Silo that's
-# created during initial setup with Wicket.  Immediately after that setup, users
-# will go to https://recovery.sys.$external_dns_zone_name to reach the console
-# to finish initial setup.  The rack will serve one of these TLS certificates at
+# However you provide the initial certificates, these will become associated
+# with the "recovery" Silo that's created during initial setup (i.e., with
+# Wicket, in a real system).  Immediately after that setup, users will go to
+# https://recovery.sys.$external_dns_zone_name to reach the web console to
+# finish initial setup.  The rack will serve one of these TLS certificates at
 # that time.  Once in the console, the user would generally create another Silo
 # with its own certificate(s).
 #
-# For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
-# you can specify a certificate by including the certificate chain and private
-# key in PEM-format files called "initial-tls-cert.pem" and
-# "initial-tls-key.pem", respectively, in the same place as this configuration
-# file.
+# When configuring TLS, you typically only need one entry here.  Each entry is
+# more accurately called a TLS certificate _chain_.
+#
+# If no initial TLS certificates are provided, then your external API will be
+# configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
 
 # The IP ranges configured as part of the "internal services" IP Pool

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -4,8 +4,9 @@
 # Agent API.  See the `RackInitializeRequest` type in bootstrap-agent or its
 # OpenAPI spec (in openapi/bootstrap-agent.json in the root of this workspace).
 
-# The /56 subnet for the rack.
-# Also implies the /48 AZ subnet.
+# The /56 subnet for this rack.  This subnet is internal to the rack and fully
+# managed by Omicron, so you can pick anything you want.  The rack-specific /56
+# subnet also implies the parent /48 AZ subnet.
 #              |............|    <- This /48 is the AZ Subnet
 #              |...............| <- This /56 is the Rack Subnet
 rack_subnet = "fd00:1122:3344:0100::"
@@ -22,25 +23,82 @@ ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 
 # Delegated external DNS zone name
+#
+# The rack provides separate external API and console endpoints for each Silo.
+# These are named `$silo_name.sys.$external_dns_zone_name`.  For a Silo called
+# "eng" with delegated domain "oxide.example", the API would be accessible at
+# "eng.sys.oxide.example".  The rack runs external DNS servers that serve A/AAAA
+# records for these DNS names.
+#
+# In a real deployment, the operator would own this DNS domain and delegate it
+# to the rack.  That means adding glue records in their DNS servers for the
+# parent domain that point to the rack's external DNS servers.
+#
+# In development, we usually use a fake domain here and configure clients to use
+# the rack's external DNS server as their normal DNS server.  Programmatically,
+# we do this with a custom reqwest Resolver.  Using curl or the Oxide CLI, you
+# can do this with the `--resolve` option.  In practice, people often skip DNS
+# altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
+
+# The IP ranges configured as part of the "internal services" IP Pool
+#
+# This is a range of *external* IP addresses that will be assigned to the
+# External DNS server(s) and Nexus instances.  These are the IPs that users
+# *outside* the rack will use to reach these services.  These will also be used
+# by services like NTP as their externally-facing address for NAT.
+#
+# For more on this and what to put here, see docs/how-to-run.adoc.
+[[internal_services_ip_pool_ranges]]
+first = "192.168.1.20"
+last = "192.168.1.29"
+
+# TODO - this configuration is subject to change going forward. Ultimately these
+# parameters should be provided to the control plane via wicket, but we need to
+# put these parameters somewhere in the meantime so that the Nexus API will be
+# reachable upon Rack startup.
+
+# Configuration to bring up Boundary Services and make Nexus reachable from the
+# outside.  See docs/how-to-run.adoc for more on what to put here.
+[rack_network_config]
+# The gateway IP for the rack's external network
+gateway_ip = "192.168.1.199"
+# A range of IP addresses used by Boundary Services on the external network.  In
+# a real system, these would be addresses of the uplink ports on the Sidecar.
+# With softnpu, only one address is used.
+infra_ip_first = "192.168.1.30"
+infra_ip_last = "192.168.1.30"
+# Name of the uplink port.  This should always be "qsfp0" when using softnpu.
+uplink_port = "qsfp0"
+uplink_port_speed = "40G"
+uplink_port_fec="none"
+# For softnpu, an address within the "infra" block above that will be used for
+# the softnpu uplink port.  You can just pick the first address in that pool.
+uplink_ip = "192.168.1.30"
 
 # Initial TLS certificates for the external API
 #
+# Each entry here is really a TLS certificate chain.  You typically only need
+# one entry here.  Multiple are supported primarily for rotating them.
+#
+# The certificates provided here will be used for the "recovery" Silo that's
+# created during initial setup with Wicket.  Immediately after that setup, users
+# will go to https://recovery.sys.$external_dns_zone_name to reach the console
+# to finish initial setup.  The rack will serve one of these TLS certificates at
+# that time.  Once in the console, the user would generally create another Silo
+# with its own certificate(s).
+#
 # For the structure of these certificates, see `Certificate` in the Nexus
-# internal API.  In practice, it can be unwieldy to put them here.  You can also
-# specify a certificate by including the certificate chain and private key in
-# PEM-format files called "initial-tls-cert.pem" and "initial-tls-key.pem",
-# respectively, in the same place as this configuration file.
+# internal API.  In practice, it's unwieldy to put them in this file.  Instead,
+# you can specify a certificate by including the certificate chain and private
+# key in PEM-format files called "initial-tls-cert.pem" and
+# "initial-tls-key.pem", respectively, in the same place as this configuration
+# file.
 external_certificates = []
 
-# The IP ranges configured as part of the services IP Pool.
-# e.g., Nexus will be configured to use an address from this
-# pool as its external IP.
-[[internal_services_ip_pool_ranges]]
-first = "192.168.1.20"
-last = "192.168.1.22"
-
 # Configuration for the initial Silo, user, and password.
+#
+# You don't need to change the silo or user names.
 [recovery_silo]
 silo_name = "recovery"
 user_name = "recovery"
@@ -52,17 +110,3 @@ user_name = "recovery"
 # more on what's supported, see the API docs for this type and the specific
 # constraints in the omicron-passwords crate.
 user_password_hash = "$argon2id$v=19$m=98304,t=13,p=1$RUlWc0ZxaHo0WFdrN0N6ZQ$S8p52j85GPvMhR/ek3GL0el/oProgTwWpHJZ8lsQQoY"
-
-# TODO - this configuration is subject to change going forward. Ultimately these parameters
-# should be provided to the control plane via wicket, but we need to put these parameters
-# somewhere in the meantime so that the Nexus API will be reachable upon Rack startup.
-
-# Configuration to bring up boundary services and make nexus reachable from the outside
-[rack_network_config]
-gateway_ip = "192.168.1.199"
-infra_ip_first = "192.168.1.30"
-infra_ip_last = "192.168.1.50"
-uplink_port = "qsfp0"
-uplink_port_speed = "40G"
-uplink_port_fec="none"
-uplink_ip = "192.168.1.32"

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -43,10 +43,13 @@ vmm_reservoir_percentage = 0
 # $ dladm show-phys -p -o LINK
 # data_link = "igb0"
 
-# If testing on non-gimlet hardware, fill this in with the name of links that
-# should be mapped into the switch zone and used for transit mode maghemite
-# there. On gimlets, this is not required as tfportd will create links in the
-# switch zone when it boots, and maghemite is configured to use those.
+# On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
+# to configure routes between sleds.  This runs over the Sidecar's rear ports
+# (whether simulated with SoftNPU or not).  On a Gimlet deployed in a rack,
+# tfportd will create the necessary links and Maghemite will be configured to
+# use those.  But on non-Gimlet systems, you need to specify physical links to
+# be passed into the `oxz_switch` zone for this purpose.  You can skip this if
+# you're deploying a single-sled system.
 #switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"]
 
 [log]


### PR DESCRIPTION
While going through the how-to-run instructions to set up Omicron on a lab machine, I found a lot of cases where the docs were incomplete, self-inconsistent, outdated, or otherwise misleading.  Mostly I felt it would benefit from a lot more context (especially around external networking) and a concrete example that's carried the whole way through.  So:

- I basically overhauled the whole structure of the how-to-run doc.
- The boundary-services-a-to-z doc was mostly (but not entirely) redundant with what was/is now in how-to-run, so I trimmed all that out but left some detail that seemed useful.
- I added a lot more comments to the config-rss.toml files, which I also notice are identical, yet diverged in ways that seem likely wrong.  I suspect nobody has used `gimlet-standalone` in quite a while and I wonder if we should remove it altogether.  Even the proposed instructions in #3410 seem not to use it?

I hope this is at least a good direction.  (If not, that'd be useful feedback.)  There's a lot more to be improved here and a lot that's still out of date.  For example, these instructions make direct calls the API where I imagine we could do these things with the CLI at this point.  I'd welcome any contributions to this PR -- feel free to push directly to it!