### PR TITLE
[sled agent] Fixes to enable the reboot after RSS initialization

### DIFF
--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -9,7 +9,8 @@ use clap::{Parser, Subcommand};
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
 use omicron_sled_agent::bootstrap::{
-    config::Config as BootstrapConfig, server as bootstrap_server,
+    agent as bootstrap_agent, config::Config as BootstrapConfig,
+    server as bootstrap_server,
 };
 use omicron_sled_agent::rack_setup::config::SetupServiceConfig as RssConfig;
 use omicron_sled_agent::{config::Config as SledConfig, server as sled_server};
@@ -117,10 +118,17 @@ async fn do_run() -> Result<(), CmdError> {
             // This should remain equivalent to the HTTP request which can
             // be invoked by Wicket.
             if let Some(rss_config) = rss_config {
-                server
-                    .agent()
-                    .start_rack_initialize(rss_config)
-                    .map_err(|e| CmdError::Failure(e.to_string()))?;
+                match server.agent().start_rack_initialize(rss_config) {
+                    // If the rack has already been initialized, we shouldn't
+                    // abandon the server.
+                    Ok(_)
+                    | Err(
+                        bootstrap_agent::RssAccessError::AlreadyInitialized,
+                    ) => {}
+                    Err(e) => {
+                        return Err(CmdError::Failure(e.to_string()));
+                    }
+                }
             }
 
             server.wait_for_finish().await.map_err(CmdError::Failure)?;

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -73,6 +73,7 @@ impl Server {
             Agent::new(log.clone(), config.clone(), sled_config)
                 .await
                 .map_err(|e| e.to_string())?;
+        info!(log, "bootstrap agent finished initialization successfully");
         let bootstrap_agent = Arc::new(bootstrap_agent);
 
         let mut dropshot_config = dropshot::ConfigDropshot::default();

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -590,8 +590,9 @@ impl ServiceManager {
         Ok(())
     }
 
-    /// Loads services from the services manager, and returns once all requested
-    /// services have been started.
+    /// Sets up "Sled Agent" information, including underlay info.
+    ///
+    /// Any subsequent calls after the first invocation return an error.
     pub async fn sled_agent_started(
         &self,
         config: Config,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -506,6 +506,10 @@ impl ServiceManager {
             .collect()
     }
 
+    // TODO(https://github.com/oxidecomputer/omicron/issues/2973):
+    // These will fail if the disks aren't attached.
+    // Should we have a retry loop here? Kinda like we have with the switch
+    // / NTP zone?
     pub async fn load_services(&self) -> Result<(), Error> {
         let log = &self.inner.log;
         let ledger_paths = self.all_service_ledgers().await;
@@ -610,15 +614,6 @@ impl ServiceManager {
             })
             .map_err(|_| "already set".to_string())
             .expect("Sled Agent should only start once");
-
-        // TODO(https://github.com/oxidecomputer/omicron/issues/2973):
-        // These will fail if the disks aren't attached.
-        // Should we have a retry loop here? Kinda like we have with the switch
-        // / NTP zone?
-        self.load_services().await.map_err(|e| {
-            error!(self.inner.log, "failed to launch services"; "error" => e.to_string());
-            e
-        })?;
 
         Ok(())
     }
@@ -1305,13 +1300,39 @@ impl ServiceManager {
             // can be supplied - now that we're actively using it, we
             // aren't really handling the "many GZ addresses" case, and it
             // doesn't seem necessary now.
+            info!(self.inner.log, "Zone using its own GZ address as gateway");
             Some(request.zone.gz_addresses[0])
         } else if let Some(info) = self.inner.sled_info.get() {
-            // If the service has not supplied a GZ address, simply add
-            // a route to the sled's underlay address.
-            Some(info.underlay_address)
+            // Only consider a route to the sled's underlay address if the
+            // underlay is up.
+            let sled_underlay_subnet =
+                Ipv6Subnet::<SLED_PREFIX>::new(info.underlay_address);
+
+            if request
+                .zone
+                .addresses
+                .iter()
+                .any(|ip| sled_underlay_subnet.net().contains(*ip))
+            {
+                // If the underlay is up, provide a route to it through an
+                // existing address in the Zone on the same subnet.
+                info!(self.inner.log, "Zone using sled underlay as gateway");
+                Some(info.underlay_address)
+            } else {
+                // If no such address exists in the sled's subnet, don't route
+                // to anything.
+                info!(
+                    self.inner.log,
+                    "Zone not using gateway (even though underlay is up)"
+                );
+                None
+            }
         } else {
             // If the underlay doesn't exist, no routing occurs.
+            info!(
+                self.inner.log,
+                "Zone not using gateway (underlay is not up)"
+            );
             None
         };
 

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -339,6 +339,11 @@ impl SledAgent {
             sa.hardware_monitor_task(log).await;
         });
 
+        // Finally, load services for which we're already responsible.
+        //
+        // Do this *after* monitoring for harware, to enable the switch zone to
+        // establish an underlay address before proceeding.
+        sled_agent.inner.services.load_services().await?;
         Ok(sled_agent)
     }
 


### PR DESCRIPTION
This PR consists of changes to the Sled Agent to allow internal services to re-launch successfully after a reboot.

This was tested with the following script, on an initialized system running with SoftNPU:

```bash
# Emulate a "sled shutdown"
svcadm disable sled-agent

# Kill and restart softnpu, to "empty out switch state"
zlogin softnpu pkill softnpu
zlogin softnpu pgrep softnpu || {
    zlogin softnpu 'RUST_LOG=debug /stuff/softnpu /stuff/softnpu.toml &> /softnpu.log &'
}

# Restart the sled agent. Observe that it still tears down all running zones on boot,
# but it successfully re-initializes all sleds which are described by:
# /pool/int/<UUID>/config/services.toml
svcadm enable sled-agent

```

## Before this PR

- Sled Agent was capable of booting and initializing via RSS
- However, after a reboot, the Sled Agent did not successfully re-initialize all zones that had been running before reboot. It attempted to bring up the switch zone, failed, and would not be able to continue initializing other services

## This PR

- Fixes the routing issue described by #3461: Zone initialization only attempts to add a route to the "sled agent underlay address" as a gateway iff (1) the underlay is up, and (2) the zone-being-launched has an address on the same subnet. 
- Delays launching all "Sled Agent services" until after the sled agent has an underlay address. This makes it more likely for services dependent on external connectivity (e.g., NTP, external DNS, Nexus) to initialize correctly.
- The bootstrap agent, which may send a `start_rack_initialize` request if and RSS configuration file is included, no longer throws an error if RSS has already been initialized.

Fixes https://github.com/oxidecomputer/omicron/issues/3461
Fixes https://github.com/oxidecomputer/omicron/issues/3106
Part of https://github.com/oxidecomputer/omicron/issues/725