### PR TITLE
Idempotently delete volumes during disk delete

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -304,10 +304,16 @@ impl super::Nexus {
         let (.., project, authz_disk) =
             disk_lookup.lookup_for(authz::Action::Delete).await?;
 
+        let (.., db_disk) = LookupPath::new(opctx, &self.db_datastore)
+            .disk_id(authz_disk.id())
+            .fetch()
+            .await?;
+
         let saga_params = sagas::disk_delete::Params {
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),
             project_id: project.id(),
             disk_id: authz_disk.id(),
+            volume_id: db_disk.volume_id,
         };
         self.execute_saga::<sagas::disk_delete::SagaDiskDelete>(saga_params)
             .await?;

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -6,11 +6,14 @@ use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
 use crate::app::sagas::declare_saga_actions;
+use crate::app::sagas::volume_delete;
+use crate::app::sagas::SagaInitError;
 use crate::authn;
 use crate::db;
 use serde::Deserialize;
 use serde::Serialize;
 use steno::ActionError;
+use steno::Node;
 use uuid::Uuid;
 
 // disk delete saga: input parameters
@@ -20,6 +23,7 @@ pub struct Params {
     pub serialized_authn: authn::saga::Serialized,
     pub project_id: Uuid,
     pub disk_id: Uuid,
+    pub volume_id: Uuid,
 }
 
 // disk delete saga: actions
@@ -36,9 +40,6 @@ declare_saga_actions! {
         + sdd_account_space
         - sdd_account_space_undo
     }
-    DELETE_VOLUME -> "no_result2" {
-        + sdd_delete_volume
-    }
 }
 
 // disk delete saga: definition
@@ -54,12 +55,44 @@ impl NexusSaga for SagaDiskDelete {
     }
 
     fn make_saga_dag(
-        _params: &Self::Params,
+        params: &Self::Params,
         mut builder: steno::DagBuilder,
     ) -> Result<steno::Dag, super::SagaInitError> {
         builder.append(delete_disk_record_action());
         builder.append(space_account_action());
-        builder.append(delete_volume_action());
+
+        let subsaga_params = volume_delete::Params {
+            serialized_authn: params.serialized_authn.clone(),
+            volume_id: params.volume_id,
+        };
+
+        let subsaga_dag = {
+            let subsaga_builder =
+                steno::DagBuilder::new(steno::SagaName::new(
+                    volume_delete::SagaVolumeDelete::NAME,
+                ));
+            volume_delete::SagaVolumeDelete::make_saga_dag(
+                &subsaga_params,
+                subsaga_builder,
+            )?
+        };
+
+        builder.append(Node::constant(
+            "params_for_volume_delete_subsaga",
+            serde_json::to_value(&subsaga_params).map_err(|e| {
+                SagaInitError::SerializeError(
+                    "params_for_volume_delete_subsaga".to_string(),
+                    e,
+                )
+            })?,
+        ));
+
+        builder.append(Node::subsaga(
+            "volume_delete_subsaga_no_result",
+            subsaga_dag,
+            "params_for_volume_delete_subsaga",
+        ));
+
         Ok(builder.build()?)
     }
 }
@@ -128,25 +161,6 @@ async fn sdd_account_space_undo(
     Ok(())
 }
 
-async fn sdd_delete_volume(
-    sagactx: NexusActionContext,
-) -> Result<(), ActionError> {
-    let osagactx = sagactx.user_data();
-    let params = sagactx.saga_params::<Params>()?;
-    let opctx = crate::context::op_context_for_saga_action(
-        &sagactx,
-        &params.serialized_authn,
-    );
-    let volume_id =
-        sagactx.lookup::<db::model::Disk>("deleted_disk")?.volume_id;
-    osagactx
-        .nexus()
-        .volume_delete(&opctx, volume_id)
-        .await
-        .map_err(ActionError::action_failed)?;
-    Ok(())
-}
-
 #[cfg(test)]
 pub(crate) mod test {
     use crate::{
@@ -155,6 +169,7 @@ pub(crate) mod test {
     };
     use dropshot::test_util::ClientTestContext;
     use nexus_db_queries::context::OpContext;
+    use nexus_db_model::Disk;
     use nexus_test_utils::resource_helpers::create_ip_pool;
     use nexus_test_utils::resource_helpers::create_project;
     use nexus_test_utils::resource_helpers::DiskTest;
@@ -182,7 +197,7 @@ pub(crate) mod test {
         )
     }
 
-    async fn create_disk(cptestctx: &ControlPlaneTestContext) -> Uuid {
+    async fn create_disk(cptestctx: &ControlPlaneTestContext) -> Disk {
         let nexus = &cptestctx.server.apictx.nexus;
         let opctx = test_opctx(&cptestctx);
 
@@ -200,7 +215,6 @@ pub(crate) mod test {
             )
             .await
             .expect("Failed to create disk")
-            .id()
     }
 
     #[nexus_test(server = crate::Server)]
@@ -212,14 +226,15 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx.nexus;
         let project_id = create_org_and_project(&client).await;
-        let disk_id = create_disk(&cptestctx).await;
+        let disk = create_disk(&cptestctx).await;
 
         // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(&cptestctx);
         let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             project_id,
-            disk_id,
+            disk_id: disk.id(),
+            volume_id: disk.volume_id,
         };
         let dag = create_saga_dag::<SagaDiskDelete>(params).unwrap();
         let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
@@ -237,14 +252,15 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx.nexus;
         let project_id = create_org_and_project(&client).await;
-        let disk_id = create_disk(&cptestctx).await;
+        let disk = create_disk(&cptestctx).await;
 
         // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(&cptestctx);
         let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             project_id,
-            disk_id,
+            disk_id: disk.id(),
+            volume_id: disk.volume_id,
         };
         let dag = create_saga_dag::<SagaDiskDelete>(params).unwrap();
 

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -67,10 +67,9 @@ impl NexusSaga for SagaDiskDelete {
         };
 
         let subsaga_dag = {
-            let subsaga_builder =
-                steno::DagBuilder::new(steno::SagaName::new(
-                    volume_delete::SagaVolumeDelete::NAME,
-                ));
+            let subsaga_builder = steno::DagBuilder::new(steno::SagaName::new(
+                volume_delete::SagaVolumeDelete::NAME,
+            ));
             volume_delete::SagaVolumeDelete::make_saga_dag(
                 &subsaga_params,
                 subsaga_builder,
@@ -168,8 +167,8 @@ pub(crate) mod test {
         app::sagas::disk_delete::SagaDiskDelete, authn::saga::Serialized,
     };
     use dropshot::test_util::ClientTestContext;
-    use nexus_db_queries::context::OpContext;
     use nexus_db_model::Disk;
+    use nexus_db_queries::context::OpContext;
     use nexus_test_utils::resource_helpers::create_ip_pool;
     use nexus_test_utils::resource_helpers::create_project;
     use nexus_test_utils::resource_helpers::DiskTest;


### PR DESCRIPTION
Previous to this commit, deleting a volume during the disk delete saga was done by starting the execution of the `volume_delete` saga, but this is not idempotent. Embed a `volume_delete` subsaga instead.

There's two other sagas where `Nexus::volume_delete` is called: during the disk creation saga and the snapshot creation saga, both when unwinding the saga. Unfortunately, embedding a subsaga cannot be done as part of the *rollback* of a saga, because there's no way to create an undo node that itself is a subsaga. This commit retains the previous behaviour during unwind: kick off the `volume_delete` saga. If there's a failure, then the saga will be parked as "Stuck" anyway.

Fixes #3305