### PR TITLE
Update create image API to only take `block_size` for url uploads

### DIFF
--- a/end-to-end-tests/src/instance_launch.rs
+++ b/end-to-end-tests/src/instance_launch.rs
@@ -45,13 +45,13 @@ async fn instance_launch() -> Result<()> {
         .body(ImageCreate {
             name: generate_name("debian")?,
             description: String::new(),
-            block_size: 512.try_into().map_err(anyhow::Error::msg)?,
             os: "debian".try_into().map_err(anyhow::Error::msg)?,
             version: "propolis-blob".into(),
             source: ImageSource::Url {
                 url:
                     "http://[fd00:1122:3344:101::1]:54321/debian-11-genericcloud-amd64.raw"
                         .into(),
+                block_size: 512.try_into().map_err(anyhow::Error::msg)?,
             },
         })
         .send()

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -94,14 +94,12 @@ impl super::Nexus {
             }
         };
         let new_image = match &params.source {
-            params::ImageSource::Url { url } => {
-                let db_block_size = db::model::BlockSize::try_from(
-                    params.block_size,
-                )
-                .map_err(|e| Error::InvalidValue {
-                    label: String::from("block_size"),
-                    message: format!("block_size is invalid: {}", e),
-                })?;
+            params::ImageSource::Url { url, block_size } => {
+                let db_block_size = db::model::BlockSize::try_from(*block_size)
+                    .map_err(|e| Error::InvalidValue {
+                        label: String::from("block_size"),
+                        message: format!("block_size is invalid: {}", e),
+                    })?;
 
                 let image_id = Uuid::new_v4();
 
@@ -177,7 +175,7 @@ impl super::Nexus {
                 )?;
 
                 // validate total size is divisible by block size
-                let block_size: u64 = params.block_size.into();
+                let block_size: u64 = (*block_size).into();
                 if (size.to_bytes() % block_size) != 0 {
                     return Err(Error::InvalidValue {
                         label: String::from("size"),

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -434,8 +434,10 @@ lazy_static! {
                 name: DEMO_IMAGE_NAME.clone(),
                 description: String::from(""),
             },
-            source: params::ImageSource::Url { url: HTTP_SERVER.url("/image.raw").to_string() },
-            block_size: params::BlockSize::try_from(4096).unwrap(),
+            source: params::ImageSource::Url {
+                url: HTTP_SERVER.url("/image.raw").to_string(),
+                block_size: params::BlockSize::try_from(4096).unwrap(),
+            },
             os: "fake-os".to_string(),
             version: "1.0".to_string()
         };

--- a/nexus/tests/integration_tests/images.rs
+++ b/nexus/tests/integration_tests/images.rs
@@ -26,6 +26,8 @@ const PROJECT_NAME: &str = "myproj";
 
 const PROJECT_NAME_2: &str = "myproj2";
 
+const BLOCK_SIZE: params::BlockSize = params::BlockSize(512);
+
 fn get_project_images_url(project_name: &str) -> String {
     format!("/v1/images?project={}", project_name)
 }
@@ -44,7 +46,6 @@ fn get_image_create(source: params::ImageSource) -> params::ImageCreate {
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
         source,
     }
 }
@@ -96,6 +97,7 @@ async fn test_image_create(cptestctx: &ControlPlaneTestContext) {
     // Create an image in the project
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     NexusRequest::objects_post(client, &images_url, &image_create_params)
@@ -225,6 +227,7 @@ async fn test_silo_image_create(cptestctx: &ControlPlaneTestContext) {
     // Create an image in the project
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     // Create image
@@ -260,6 +263,7 @@ async fn test_image_create_url_404(cptestctx: &ControlPlaneTestContext) {
 
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -291,6 +295,7 @@ async fn test_image_create_bad_url(cptestctx: &ControlPlaneTestContext) {
 
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: "not_a_url".to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -333,6 +338,7 @@ async fn test_image_create_bad_content_length(
 
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -374,6 +380,7 @@ async fn test_image_create_bad_image_size(cptestctx: &ControlPlaneTestContext) {
 
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -418,6 +425,7 @@ async fn test_make_disk_from_image(cptestctx: &ControlPlaneTestContext) {
     // Create an image in the project
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/alpine/edge.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -469,6 +477,7 @@ async fn test_make_disk_from_image_too_small(
     // Create an image in the project
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/alpine/edge.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -543,6 +552,7 @@ async fn test_image_access(cptestctx: &ControlPlaneTestContext) {
 
     let image_create_params = get_image_create(params::ImageSource::Url {
         url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
     });
 
     NexusRequest::objects_post(client, &images_url, &image_create_params)

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -230,7 +230,6 @@ async fn test_project_deletion_with_image(cptestctx: &ControlPlaneTestContext) {
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
         source: params::ImageSource::YouCanBootAnythingAsLongAsItsAlpine,
     };
 

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -84,10 +84,10 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
         },
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
+            block_size: params::BlockSize::try_from(512).unwrap(),
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let images_url = format!("/v1/images?project={}", PROJECT_NAME);
@@ -204,10 +204,10 @@ async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
         },
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
+            block_size: params::BlockSize::try_from(512).unwrap(),
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let images_url = format!("/v1/images?project={}", PROJECT_NAME);
@@ -781,10 +781,10 @@ async fn test_snapshot_unwind(cptestctx: &ControlPlaneTestContext) {
         },
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
+            block_size: params::BlockSize::try_from(512).unwrap(),
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let images_url = format!("/v1/images?project={}", PROJECT_NAME);

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -83,10 +83,10 @@ async fn create_image(client: &ClientTestContext) -> views::Image {
         },
         source: params::ImageSource::Url {
             url: server.url("/image.raw").to_string(),
+            block_size: params::BlockSize::try_from(512).unwrap(),
         },
         os: "alpine".to_string(),
         version: "edge".to_string(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let images_url = format!("/v1/images?project={}", PROJECT_NAME);
@@ -1009,7 +1009,6 @@ async fn test_create_image_from_snapshot(cptestctx: &ControlPlaneTestContext) {
         source: params::ImageSource::Snapshot { id: snapshot.identity.id },
         os: "debian".parse().unwrap(),
         version: "11".into(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let _image: views::Image =
@@ -1069,7 +1068,6 @@ async fn test_create_image_from_snapshot_delete(
         source: params::ImageSource::Snapshot { id: snapshot.identity.id },
         os: "debian".parse().unwrap(),
         version: "11".into(),
-        block_size: params::BlockSize::try_from(512).unwrap(),
     };
 
     let _image: views::Image =

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1557,6 +1557,9 @@ pub struct SwitchPortApplySettings {
 pub enum ImageSource {
     Url {
         url: String,
+
+        /// The block size in bytes
+        block_size: BlockSize,
     },
     Snapshot {
         id: Uuid,
@@ -1588,9 +1591,6 @@ pub struct ImageCreate {
 
     /// The version of the operating system (e.g. 18.04, 20.04, etc.)
     pub version: String,
-
-    /// block size in bytes
-    pub block_size: BlockSize,
 
     /// The source of the image's contents.
     pub source: ImageSource,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9370,14 +9370,6 @@
         "description": "Create-time parameters for an `Image`",
         "type": "object",
         "properties": {
-          "block_size": {
-            "description": "block size in bytes",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BlockSize"
-              }
-            ]
-          },
           "description": {
             "type": "string"
           },
@@ -9402,7 +9394,6 @@
           }
         },
         "required": [
-          "block_size",
           "description",
           "name",
           "os",
@@ -9437,6 +9428,14 @@
           {
             "type": "object",
             "properties": {
+              "block_size": {
+                "description": "The block size in bytes",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BlockSize"
+                  }
+                ]
+              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -9448,6 +9447,7 @@
               }
             },
             "required": [
+              "block_size",
               "type",
               "url"
             ]


### PR DESCRIPTION
Fixes #3497 

We were only using the block size provided via the API when doing a URL upload. This updates the API so that `block_size` is now part of `ImageSource` and used only in the arm where it's needed. See the linked issue for more details. 

Note that this is a breaking change.