### PR TITLE
Update crucible and propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "libc",
  "num_enum",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=df7e274edf0a1df287770e9567b27676f3ae4cc5#df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=df7e274edf0a1df287770e9567b27676f3ae4cc5#df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=df7e274edf0a1df287770e9567b27676f3ae4cc5#df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=df7e274edf0a1df287770e9567b27676f3ae4cc5#df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "libc",
  "num-derive",
@@ -1865,7 +1865,7 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 [[package]]
 name = "dladm"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "libc",
  "num_enum",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "propolis"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "anyhow",
  "bhyve_api",
@@ -6036,7 +6036,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -6060,7 +6060,7 @@ dependencies = [
 [[package]]
 name = "propolis-server"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6112,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "propolis-server-config"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6123,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "schemars",
  "serde",
@@ -8976,7 +8976,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viona_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "libc",
  "num_enum",
@@ -8986,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "viona_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=04a275736e9f3316de6bf2a4077d03acfa4e2cdf#04a275736e9f3316de6bf2a4077d03acfa4e2cdf"
+source = "git+https://github.com/oxidecomputer/propolis?rev=25111a88832a6bbca48880f16e731c9ba5f519a7#25111a88832a6bbca48880f16e731c9ba5f519a7"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,10 +151,10 @@ cookie = "0.16"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.26.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "df7e274edf0a1df287770e9567b27676f3ae4cc5" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "df7e274edf0a1df287770e9567b27676f3ae4cc5" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "df7e274edf0a1df287770e9567b27676f3ae4cc5" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "df7e274edf0a1df287770e9567b27676f3ae4cc5" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
 curve25519-dalek = "3"
 datatest-stable = "0.1.3"
 display-error-chain = "0.1.1"
@@ -264,9 +264,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "04a275736e9f3316de6bf2a4077d03acfa4e2cdf" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "04a275736e9f3316de6bf2a4077d03acfa4e2cdf", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "04a275736e9f3316de6bf2a4077d03acfa4e2cdf", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "25111a88832a6bbca48880f16e731c9ba5f519a7" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "25111a88832a6bbca48880f16e731c9ba5f519a7", features = [ "generated-migration" ] }
+propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "25111a88832a6bbca48880f16e731c9ba5f519a7", default-features = false, features = ["mock-only"] }
 #propolis-server = { path = "../propolis/bin/propolis-server" }
 proptest = "1.2.0"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -241,10 +241,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source.commit = "f78832dc7ca48bce53f23de00d557bc9320a933f"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "c1a7996dfdded9476d5a595f16fcd07e902bb02f2ec0858bb3625f9b2195a919"
+source.sha256 = "ea537309d457d2ef8175074c6872859fb7ec1e1f974fd755da4c4753bc79713a"
 output.type = "zone"
 
 [package.crucible-pantry]
@@ -252,10 +252,10 @@ service_name = "crucible_pantry"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "df7e274edf0a1df287770e9567b27676f3ae4cc5"
+source.commit = "f78832dc7ca48bce53f23de00d557bc9320a933f"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "23611f3770a797b829c340e6dba25a4898678ece79db8534e06f76e438214e4c"
+source.sha256 = "9edd38fab9951dcbf8f52e89388862de247b901e59995d4dbd9259ad2829307a"
 output.type = "zone"
 
 # Refer to
@@ -266,10 +266,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "21ac8a9f5005f96caa384e3de0bd38283fc0188f"
+source.commit = "25111a88832a6bbca48880f16e731c9ba5f519a7"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "2a7b4bfa6d2b13714f68ec0095419218257ab584e763faac1d34baf38c8b09de"
+source.sha256 = "4cdb1a33c7ad98e71acc0ca580bff34d729452d4b29ccf2775f8b955edd38f51"
 output.type = "zone"
 
 [package.maghemite]


### PR DESCRIPTION
Bump crucible rev to pick up:

- fix build break caused by merging omicon/crucible#801
- Issue extent flushes in parallel
- Add Logger Option to Volume construct method
- Update Rust crate libc to 0.2.147
- Update Rust crate percent-encoding to 2.3
- Retry jobs until they succeed
- Reorder select arms so pings can't be starved out
- Treat a skipped IO like an error IO for ACK results.
- Retry pantry requests
- Remove panics and asserts in dummy tests
- Update Rust crate csv to 1.2.2
- Update Rust crate reedline to 0.21.0
- Set open file resource limit to the max
- Update Rust crate ringbuffer to 0.14
- DTrace meet cmon
- Widen assert values to u128 to deal with u64::MAX
- Change size_to_validate from usize to u64
- Turn on live-repair test in CI
- Increase flush_timeout for some tests, collect cores
- Update to latest dropshot

Bump propolis rev to pick up:

- Bump crucible rev to latest
- Make the propolis zone self-assembling
- Flesh out more PIIX3-PM to suppress log gripes
- Bump crucible rev to latest
- Restructure PM-timer under PIIX3 device
- Fix inventory handling for nested child entities
- Centralize vmm-data interface into bhyve_api
- Clean up PCI device classes
- Update openssl dep to 0.10.55
- Allow propolis-standalone to use VMM reservoir
- only allow one request to reboot to be enqueued at a time

Note that #3456 bumped package-manifest, but this commit bumps both that and Cargo.toml. All Propolis commits between 04a27573 and 25111a88 are listed above.