### PR TITLE
Disallow creating instances/disks with snapshots/images from another project

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -28,49 +28,6 @@ use sled_agent_client::Client as SledAgentClient;
 use std::sync::Arc;
 use uuid::Uuid;
 
-fn validate_disk_create_params(
-    params: &params::DiskCreate,
-    block_size: u64,
-) -> Result<(), Error> {
-    // Reject disks where the block size doesn't evenly divide the
-    // total size
-    if (params.size.to_bytes() % block_size) != 0 {
-        return Err(Error::InvalidValue {
-            label: String::from("size and block_size"),
-            message: format!(
-                "total size must be a multiple of block size {}",
-                block_size,
-            ),
-        });
-    }
-
-    // Reject disks where the size isn't at least
-    // MIN_DISK_SIZE_BYTES
-    if params.size.to_bytes() < params::MIN_DISK_SIZE_BYTES as u64 {
-        return Err(Error::InvalidValue {
-            label: String::from("size"),
-            message: format!(
-                "total size must be at least {}",
-                ByteCount::from(params::MIN_DISK_SIZE_BYTES)
-            ),
-        });
-    }
-
-    // Reject disks where the MIN_DISK_SIZE_BYTES doesn't evenly
-    // divide the size
-    if (params.size.to_bytes() % params::MIN_DISK_SIZE_BYTES as u64) != 0 {
-        return Err(Error::InvalidValue {
-            label: String::from("size"),
-            message: format!(
-                "total size must be a multiple of {}",
-                ByteCount::from(params::MIN_DISK_SIZE_BYTES)
-            ),
-        });
-    }
-
-    Ok(())
-}
-
 impl super::Nexus {
     // Disks
     pub fn disk_lookup<'a>(
@@ -105,30 +62,31 @@ impl super::Nexus {
         }
     }
 
-    pub async fn project_create_disk(
+    pub(super) async fn validate_disk_create_params(
         self: &Arc<Self>,
         opctx: &OpContext,
-        project_lookup: &lookup::Project<'_>,
+        authz_project: &authz::Project,
         params: &params::DiskCreate,
-    ) -> CreateResult<db::model::Disk> {
-        let (.., authz_project) =
-            project_lookup.lookup_for(authz::Action::CreateChild).await?;
-
-        match &params.disk_source {
-            params::DiskSource::Blank { block_size } => {
-                validate_disk_create_params(&params, (*block_size).into())?;
+    ) -> Result<(), Error> {
+        let block_size: u64 = match params.disk_source {
+            params::DiskSource::Blank { block_size }
+            | params::DiskSource::ImportingBlocks { block_size } => {
+                block_size.into()
             }
             params::DiskSource::Snapshot { snapshot_id } => {
                 let (.., db_snapshot) =
                     LookupPath::new(opctx, &self.db_datastore)
-                        .snapshot_id(*snapshot_id)
+                        .snapshot_id(snapshot_id)
                         .fetch()
                         .await?;
 
-                validate_disk_create_params(
-                    &params,
-                    db_snapshot.block_size.to_bytes().into(),
-                )?;
+                // Return an error if the snapshot does not belong to our
+                // project.
+                if db_snapshot.project_id != authz_project.id() {
+                    return Err(Error::invalid_request(
+                        "snapshot does not belong to this project",
+                    ));
+                }
 
                 // If the size of the snapshot is greater than the size of the
                 // disk, return an error.
@@ -141,17 +99,24 @@ impl super::Nexus {
                         ),
                     ));
                 }
+
+                db_snapshot.block_size.to_bytes().into()
             }
             params::DiskSource::Image { image_id } => {
                 let (.., db_image) = LookupPath::new(opctx, &self.db_datastore)
-                    .image_id(*image_id)
+                    .image_id(image_id)
                     .fetch()
                     .await?;
 
-                validate_disk_create_params(
-                    &params,
-                    db_image.block_size.to_bytes().into(),
-                )?;
+                // The image either needs to belong to our project or be
+                // promoted to our silo. If not, return an error.
+                if let Some(project) = db_image.project_id {
+                    if project != authz_project.id() {
+                        return Err(Error::invalid_request(
+                            "image does not belong to this project",
+                        ));
+                    }
+                }
 
                 // If the size of the image is greater than the size of the
                 // disk, return an error.
@@ -164,11 +129,59 @@ impl super::Nexus {
                         ),
                     ));
                 }
+
+                db_image.block_size.to_bytes().into()
             }
-            params::DiskSource::ImportingBlocks { block_size } => {
-                validate_disk_create_params(&params, (*block_size).into())?;
-            }
+        };
+
+        // Reject disks where the block size doesn't evenly divide the
+        // total size
+        if (params.size.to_bytes() % block_size) != 0 {
+            return Err(Error::InvalidValue {
+                label: String::from("size and block_size"),
+                message: format!(
+                    "total size must be a multiple of block size {}",
+                    block_size,
+                ),
+            });
         }
+
+        // Reject disks where the size isn't at least
+        // MIN_DISK_SIZE_BYTES
+        if params.size.to_bytes() < params::MIN_DISK_SIZE_BYTES as u64 {
+            return Err(Error::InvalidValue {
+                label: String::from("size"),
+                message: format!(
+                    "total size must be at least {}",
+                    ByteCount::from(params::MIN_DISK_SIZE_BYTES)
+                ),
+            });
+        }
+
+        // Reject disks where the MIN_DISK_SIZE_BYTES doesn't evenly
+        // divide the size
+        if (params.size.to_bytes() % params::MIN_DISK_SIZE_BYTES as u64) != 0 {
+            return Err(Error::InvalidValue {
+                label: String::from("size"),
+                message: format!(
+                    "total size must be a multiple of {}",
+                    ByteCount::from(params::MIN_DISK_SIZE_BYTES)
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    pub async fn project_create_disk(
+        self: &Arc<Self>,
+        opctx: &OpContext,
+        project_lookup: &lookup::Project<'_>,
+        params: &params::DiskCreate,
+    ) -> CreateResult<db::model::Disk> {
+        let (.., authz_project) =
+            project_lookup.lookup_for(authz::Action::CreateChild).await?;
+        self.validate_disk_create_params(opctx, &authz_project, params).await?;
 
         let saga_params = sagas::disk_create::Params {
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -219,6 +219,14 @@ impl super::Nexus {
                         .fetch()
                         .await?;
 
+                if let Some(authz_project) = &maybe_authz_project {
+                    if db_snapshot.project_id != authz_project.id() {
+                        return Err(Error::invalid_request(
+                            "snapshot does not belong to this project",
+                        ));
+                    }
+                }
+
                 // Copy the Volume data for this snapshot with randomized ids -
                 // this is safe because the snapshot is read-only, and even
                 // though volume_checkout will bump the gen numbers multiple

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -119,6 +119,12 @@ impl super::Nexus {
                 MAX_DISKS_PER_INSTANCE
             )));
         }
+        for disk in &params.disks {
+            if let params::InstanceDiskAttachment::Create(create) = disk {
+                self.validate_disk_create_params(opctx, &authz_project, create)
+                    .await?;
+            }
+        }
         if params.external_ips.len() > MAX_EXTERNAL_IPS_PER_INSTANCE {
             return Err(Error::invalid_request(&format!(
                 "An instance may not have more than {} external IP addresses",

--- a/nexus/tests/integration_tests/images.rs
+++ b/nexus/tests/integration_tests/images.rs
@@ -13,6 +13,7 @@ use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
+use omicron_common::api::external::Disk;
 
 use omicron_common::api::external::{ByteCount, IdentityMetadataCreateParams};
 use omicron_nexus::external_api::{params, views};
@@ -368,6 +369,65 @@ async fn test_make_disk_from_image(cptestctx: &ControlPlaneTestContext) {
 }
 
 #[nexus_test]
+async fn test_make_disk_from_other_project_image_fails(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    DiskTest::new(&cptestctx).await;
+
+    create_project(client, PROJECT_NAME).await;
+    let another_project = create_project(client, "another-proj").await;
+
+    let server = ServerBuilder::new().run().unwrap();
+    server.expect(
+        Expectation::matching(request::method_path("HEAD", "/image.raw"))
+            .times(1..)
+            .respond_with(
+                status_code(200).append_header(
+                    "Content-Length",
+                    format!("{}", 4096 * 1000),
+                ),
+            ),
+    );
+
+    let images_url = get_project_images_url(PROJECT_NAME);
+    let image_create_params = get_image_create(params::ImageSource::Url {
+        url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
+    });
+    let image =
+        NexusRequest::objects_post(client, &images_url, &image_create_params)
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute_and_parse_unwrap::<views::Image>()
+            .await;
+
+    let new_disk = params::DiskCreate {
+        identity: IdentityMetadataCreateParams {
+            name: "stolen-disk".parse().unwrap(),
+            description: String::from("yoink"),
+        },
+        disk_source: params::DiskSource::Image { image_id: image.identity.id },
+        size: ByteCount::from_gibibytes_u32(1),
+    };
+    let disks_url =
+        format!("/v1/disks?project={}", another_project.identity.name);
+    let error = NexusRequest::expect_failure_with_body(
+        client,
+        StatusCode::BAD_REQUEST,
+        Method::POST,
+        &disks_url,
+        &new_disk,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("expected 400")
+    .parsed_body::<dropshot::HttpErrorResponseBody>()
+    .unwrap();
+    assert_eq!(error.message, "image does not belong to this project");
+}
+
+#[nexus_test]
 async fn test_make_disk_from_image_too_small(
     cptestctx: &ControlPlaneTestContext,
 ) {
@@ -556,4 +616,96 @@ async fn test_image_promotion(cptestctx: &ControlPlaneTestContext) {
     .expect("unexpected success")
     .parsed_body::<dropshot::HttpErrorResponseBody>()
     .unwrap();
+}
+
+#[nexus_test]
+async fn test_image_from_other_project_snapshot_fails(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    DiskTest::new(&cptestctx).await;
+
+    let server = ServerBuilder::new().run().unwrap();
+    server.expect(
+        Expectation::matching(request::method_path("HEAD", "/image.raw"))
+            .times(1..)
+            .respond_with(
+                status_code(200).append_header(
+                    "Content-Length",
+                    format!("{}", 4096 * 1000),
+                ),
+            ),
+    );
+
+    create_project(client, PROJECT_NAME).await;
+    let images_url = get_project_images_url(PROJECT_NAME);
+    let disks_url = format!("/v1/disks?project={}", PROJECT_NAME);
+    let snapshots_url = format!("/v1/snapshots?project={}", PROJECT_NAME);
+
+    // Create an image
+    let image_create_params = get_image_create(params::ImageSource::Url {
+        url: server.url("/image.raw").to_string(),
+        block_size: BLOCK_SIZE,
+    });
+    let image: views::Image =
+        NexusRequest::objects_post(client, &images_url, &image_create_params)
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute_and_parse_unwrap()
+            .await;
+    // Create a disk from this image
+    let disk_create_params = params::DiskCreate {
+        identity: IdentityMetadataCreateParams {
+            name: "disk".parse().unwrap(),
+            description: "meow".into(),
+        },
+        disk_source: params::DiskSource::Image { image_id: image.identity.id },
+        size: ByteCount::from_gibibytes_u32(1),
+    };
+    let disk: Disk =
+        NexusRequest::objects_post(client, &disks_url, &disk_create_params)
+            .authn_as(AuthnMode::PrivilegedUser)
+            .execute()
+            .await
+            .unwrap()
+            .parsed_body()
+            .unwrap();
+    // Create a snapshot from this disk
+    let snapshot_create_params = params::SnapshotCreate {
+        identity: IdentityMetadataCreateParams {
+            name: "snapshot".parse().unwrap(),
+            description: "meow".into(),
+        },
+        disk: disk.identity.id.into(),
+    };
+    let snapshot: views::Snapshot = NexusRequest::objects_post(
+        client,
+        &snapshots_url,
+        &snapshot_create_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+
+    // Create a second project and ensure image creation fails
+    let another_project = create_project(client, "another-proj").await;
+    let images_url =
+        get_project_images_url(another_project.identity.name.as_str());
+    let image_create_params = get_image_create(params::ImageSource::Snapshot {
+        id: snapshot.identity.id,
+    });
+    let error = NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &images_url)
+            .body(Some(&image_create_params))
+            .expect_status(Some(StatusCode::BAD_REQUEST)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("unexpected success")
+    .parsed_body::<dropshot::HttpErrorResponseBody>()
+    .unwrap();
+    assert_eq!(error.message, "snapshot does not belong to this project");
 }

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -697,6 +697,89 @@ async fn test_reject_creating_disk_from_illegal_snapshot(
 }
 
 #[nexus_test]
+async fn test_reject_creating_disk_from_other_project_snapshot(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    let nexus = &cptestctx.server.apictx().nexus;
+    let datastore = nexus.datastore();
+
+    let project_id = create_org_and_project(&client).await;
+
+    let opctx =
+        OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
+
+    let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+        .project_id(project_id)
+        .lookup_for(authz::Action::CreateChild)
+        .await
+        .unwrap();
+
+    let snapshot = datastore
+        .project_ensure_snapshot(
+            &opctx,
+            &authz_project,
+            db::model::Snapshot {
+                identity: db::model::SnapshotIdentity {
+                    id: Uuid::new_v4(),
+                    name: external::Name::try_from("snapshot".to_string())
+                        .unwrap()
+                        .into(),
+                    description: "snapshot".into(),
+
+                    time_created: Utc::now(),
+                    time_modified: Utc::now(),
+                    time_deleted: None,
+                },
+
+                project_id,
+                disk_id: Uuid::new_v4(),
+                volume_id: Uuid::new_v4(),
+                destination_volume_id: Uuid::new_v4(),
+
+                gen: db::model::Generation::new(),
+                state: db::model::SnapshotState::Creating,
+                block_size: db::model::BlockSize::AdvancedFormat,
+
+                size: external::ByteCount::try_from(
+                    db::model::BlockSize::AdvancedFormat.to_bytes(),
+                )
+                .unwrap()
+                .into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let second_project = create_project(client, "moes-tavern").await;
+    let second_disks_url =
+        format!("/v1/disks?project={}", second_project.identity.name);
+    let error = NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &second_disks_url)
+            .body(Some(&params::DiskCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: "stolen-disk".parse().unwrap(),
+                    description: String::from("stolen disk"),
+                },
+
+                disk_source: params::DiskSource::Snapshot {
+                    snapshot_id: snapshot.id(),
+                },
+
+                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES).unwrap(),
+            }))
+            .expect_status(Some(StatusCode::BAD_REQUEST)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body::<dropshot::HttpErrorResponseBody>()
+    .unwrap();
+    assert_eq!(error.message, "snapshot does not belong to this project");
+}
+
+#[nexus_test]
 async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
     // Test that snapshots cannot be created if there is no space for the blocks
     let client = &cptestctx.external_client;


### PR DESCRIPTION
Fixes #3335 (@askfongjojo).

This adds these checks:
- in `project_create_disk`: ensure the snapshot belongs to the same project, or ensure the image belongs to the silo or the same project
- in `image_create`: ensure the snapshot belongs to the same project
- in `project_create_instance`: for created disks, implement the same checks as `project_create_disk`

This is a simple check to close off this kind of cross-project resource usage; we may want to enable this kind of thing in the future (perhaps with authz), but I think we will want to be more careful about the design, and it's easier to restrict it now and add functionality to permit this later.

(From when this was a check in the `create_disk` saga: ~~I don't know that where I added these checks is ideal, especially in a [asynchronous control plane operations](https://rfd.shared.oxide.computer/rfd/402) world. It does not seem common to put these checks in at the saga level, possibly for that reason, but I think at minimum having the checks here in addition to possibly adding them before the saga is created is a good idea, to prevent creating new API calls that start a `disk_create` saga without checking these preconditions.~~)