### PR TITLE
Remove hardware constraints given possible manufacture defects

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -98,12 +98,6 @@ CREATE TABLE omicron.public.sled (
 
     /* The last address allocated to an Oxide service on this sled. */
     last_used_address INET NOT NULL,
-
-    -- This constraint should be upheld, even for deleted disks
-    -- in the fleet.
-    CONSTRAINT serial_part_revision_unique UNIQUE (
-      serial_number, part_number, revision
-    )
 );
 
 /* Add an index which lets us look up sleds on a rack */
@@ -255,12 +249,6 @@ CREATE TABLE omicron.public.physical_disk (
 
     -- FK into the Sled table
     sled_id UUID NOT NULL,
-
-    -- This constraint should be upheld, even for deleted disks
-    -- in the fleet.
-    CONSTRAINT vendor_serial_model_unique UNIQUE (
-      vendor, serial, model
-    )
 );
 
 CREATE INDEX ON omicron.public.physical_disk (


### PR DESCRIPTION
Back in May several of us got together to talk about uniquely identifying hardware. You can find the recording [here](https://drive.google.com/file/d/1LPygwvjaBAVeDo-1XitPKpw6lOAg_1s5/view). The TL;DR is that part, serial, and revision numbers aren't inherently reliable and don't carry the guarantee of always being unique. @smklein had done some work to add db constraints around serial, part, and revision numbers in a few places. Given our limited window for making db changes I think it's a good time to go ahead and figure out if we need to remove these constraints.

@jclulow, @smklein I'd like both of your input on this. I'm fine with closing the PR if that's the consensus, just given the timing I wanted to make sure we had an explicit decision about it. 