### PR TITLE
[installinator] also support v4 addresses passed in via list:

### DIFF
--- a/installinator-common/src/progress.rs
+++ b/installinator-common/src/progress.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{collections::BTreeSet, fmt, net::SocketAddrV6};
+use std::{collections::BTreeSet, fmt, net::SocketAddr};
 
 use anyhow::bail;
 use camino::Utf8PathBuf;
@@ -104,7 +104,7 @@ pub enum InstallinatorProgressMetadata {
         /// The peer being downloaded from.
         ///
         /// Available with downlad events.
-        peer: SocketAddrV6,
+        peer: SocketAddr,
     },
 
     /// Future variants that might be unknown.
@@ -127,7 +127,7 @@ pub enum InstallinatorCompletionMetadata {
 
     Download {
         /// The address the artifact was downloaded from.
-        address: SocketAddrV6,
+        address: SocketAddr,
     },
     Write {
         /// The output of the write operation.

--- a/installinator/src/artifact.rs
+++ b/installinator/src/artifact.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::net::SocketAddrV6;
+use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 use clap::Args;
@@ -67,8 +67,17 @@ pub(crate) struct ArtifactClient {
 }
 
 impl ArtifactClient {
-    pub(crate) fn new(addr: SocketAddrV6, log: &slog::Logger) -> Self {
-        let endpoint = format!("http://[{}]:{}", addr.ip(), addr.port());
+    pub(crate) fn new(addr: SocketAddr, log: &slog::Logger) -> Self {
+        // NOTE: the production code path is always IPv6. IPv4 is supported for
+        // testing only.
+        let endpoint = match addr {
+            SocketAddr::V4(addr) => {
+                format!("http://{}:{}", addr.ip(), addr.port())
+            }
+            SocketAddr::V6(addr) => {
+                format!("http://[{}]:{}", addr.ip(), addr.port())
+            }
+        };
         let log = log.new(
             slog::o!("component" => "ArtifactClient", "peer" => addr.to_string()),
         );

--- a/installinator/src/errors.rs
+++ b/installinator/src/errors.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{net::SocketAddrV6, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 
 use installinator_artifact_client::ClientError;
 use thiserror::Error;
@@ -11,13 +11,13 @@ use thiserror::Error;
 pub(crate) enum ArtifactFetchError {
     #[error("peer {peer} returned an HTTP error")]
     HttpError {
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         #[source]
         error: HttpError,
     },
 
     #[error("peer {peer} timed out ({timeout:?}) after returning {bytes_fetched} bytes")]
-    Timeout { peer: SocketAddrV6, timeout: Duration, bytes_fetched: usize },
+    Timeout { peer: SocketAddr, timeout: Duration, bytes_fetched: usize },
 
     #[error("artifact size in Content-Length header ({artifact_size}) did not match downloaded size ({downloaded_bytes})")]
     SizeMismatch { artifact_size: u64, downloaded_bytes: u64 },

--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::BTreeMap,
     fmt,
-    net::{Ipv6Addr, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -28,7 +28,7 @@ use crate::{
 
 struct MockPeersUniverse {
     artifact: Bytes,
-    peers: BTreeMap<SocketAddrV6, MockPeer>,
+    peers: BTreeMap<SocketAddr, MockPeer>,
     attempt_bitmaps: Vec<AttemptBitmap>,
 }
 
@@ -45,7 +45,7 @@ impl fmt::Debug for MockPeersUniverse {
 impl MockPeersUniverse {
     fn new(
         artifact: Bytes,
-        peers: BTreeMap<SocketAddrV6, MockPeer>,
+        peers: BTreeMap<SocketAddr, MockPeer>,
         attempt_bitmaps: Vec<AttemptBitmap>,
     ) -> Self {
         assert!(peers.len() <= 32, "this test only supports up to 32 peers");
@@ -66,7 +66,7 @@ impl MockPeersUniverse {
         // being unique identifiers. This means that this code can use a BTreeMap rather than a
         // fancier structure like an IndexMap.
         let peers_strategy = prop::collection::btree_map(
-            any::<SocketAddrV6>(),
+            any::<SocketAddr>(),
             any::<MockResponse_>(),
             0..max_peer_count,
         );
@@ -78,7 +78,7 @@ impl MockPeersUniverse {
         (artifact_strategy, peers_strategy, attempt_bitmaps_strategy).prop_map(
             |(artifact, peers, attempt_bitmaps): (
                 Vec<u8>,
-                BTreeMap<SocketAddrV6, MockResponse_>,
+                BTreeMap<SocketAddr, MockResponse_>,
                 Vec<AttemptBitmap>,
             )| {
                 let artifact = Bytes::from(artifact);
@@ -103,7 +103,7 @@ impl MockPeersUniverse {
     fn expected_result(
         &self,
         timeout: Duration,
-    ) -> Result<(usize, SocketAddrV6), usize> {
+    ) -> Result<(usize, SocketAddr), usize> {
         self.attempts()
             .enumerate()
             .filter_map(|(attempt, peers)| {
@@ -170,20 +170,20 @@ enum AttemptBitmap {
 struct MockPeers {
     artifact: Bytes,
     // Peers within the universe that have been selected
-    selected_peers: BTreeMap<SocketAddrV6, MockPeer>,
+    selected_peers: BTreeMap<SocketAddr, MockPeer>,
 }
 
 impl MockPeers {
-    fn get(&self, addr: SocketAddrV6) -> Option<&MockPeer> {
+    fn get(&self, addr: SocketAddr) -> Option<&MockPeer> {
         self.selected_peers.get(&addr)
     }
 
-    fn peers(&self) -> impl Iterator<Item = (&SocketAddrV6, &MockPeer)> + '_ {
+    fn peers(&self) -> impl Iterator<Item = (&SocketAddr, &MockPeer)> + '_ {
         self.selected_peers.iter()
     }
 
     /// Returns the peer that can return the entire dataset within the timeout.
-    fn successful_peer(&self, timeout: Duration) -> Option<SocketAddrV6> {
+    fn successful_peer(&self, timeout: Duration) -> Option<SocketAddr> {
         self.peers()
             .filter_map(|(addr, peer)| {
                 if peer.artifact != self.artifact {
@@ -229,7 +229,7 @@ impl MockPeers {
 
 #[async_trait]
 impl PeersImpl for MockPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddrV6> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
         Box::new(self.selected_peers.keys().copied())
     }
 
@@ -239,7 +239,7 @@ impl PeersImpl for MockPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         // We don't (yet) use the artifact ID in MockPeers
         _artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
@@ -257,7 +257,7 @@ impl PeersImpl for MockPeers {
 
     async fn report_progress_impl(
         &self,
-        _peer: SocketAddrV6,
+        _peer: SocketAddr,
         _update_id: Uuid,
         _report: EventReport,
     ) -> Result<(), ClientError> {
@@ -464,17 +464,17 @@ struct MockReportPeers {
 }
 
 impl MockReportPeers {
-    // SocketAddrV6::new is not a const fn in stable Rust as of this writing
-    fn valid_peer() -> SocketAddrV6 {
-        SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 2000, 0, 0)
+    // SocketAddr::new is not a const fn in stable Rust as of this writing
+    fn valid_peer() -> SocketAddr {
+        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 2000)
     }
 
-    fn invalid_peer() -> SocketAddrV6 {
-        SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2), 2000, 0, 0)
+    fn invalid_peer() -> SocketAddr {
+        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2), 2000)
     }
 
-    fn unresponsive_peer() -> SocketAddrV6 {
-        SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3), 2000, 0, 0)
+    fn unresponsive_peer() -> SocketAddr {
+        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3), 2000)
     }
 
     fn new(update_id: Uuid, report_sender: mpsc::Sender<EventReport>) -> Self {
@@ -484,7 +484,7 @@ impl MockReportPeers {
 
 #[async_trait]
 impl PeersImpl for MockReportPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddrV6> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
         Box::new(
             [
                 Self::valid_peer(),
@@ -501,7 +501,7 @@ impl PeersImpl for MockReportPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        _peer: SocketAddrV6,
+        _peer: SocketAddr,
         _artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
         unimplemented!(
@@ -512,7 +512,7 @@ impl PeersImpl for MockReportPeers {
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError> {
@@ -708,7 +708,7 @@ mod tests {
 
     fn assert_reports(
         reports: &[EventReport],
-        expected_result: Result<(usize, SocketAddrV6), usize>,
+        expected_result: Result<(usize, SocketAddr), usize>,
     ) {
         let all_step_events: Vec<_> =
             reports.iter().flat_map(|report| &report.step_events).collect();
@@ -732,7 +732,7 @@ mod tests {
     fn assert_success_events(
         all_step_events: Vec<&StepEvent>,
         expected_attempt: usize,
-        expected_addr: SocketAddrV6,
+        expected_addr: SocketAddr,
     ) {
         let mut saw_success = false;
 

--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::BTreeMap,
     fmt,
-    net::{Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -466,15 +466,15 @@ struct MockReportPeers {
 impl MockReportPeers {
     // SocketAddr::new is not a const fn in stable Rust as of this writing
     fn valid_peer() -> SocketAddr {
-        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 2000)
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 2000)
     }
 
     fn invalid_peer() -> SocketAddr {
-        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2), 2000)
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), 2000)
     }
 
     fn unresponsive_peer() -> SocketAddr {
-        SocketAddr::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3), 2000)
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3)), 2000)
     }
 
     fn new(update_id: Uuid, report_sender: mpsc::Sender<EventReport>) -> Self {

--- a/installinator/src/peers.rs
+++ b/installinator/src/peers.rs
@@ -3,7 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    fmt, future::Future, net::SocketAddrV6, str::FromStr, time::Duration,
+    fmt,
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+    time::Duration,
 };
 
 use anyhow::{bail, Result};
@@ -38,7 +42,7 @@ pub(crate) enum DiscoveryMechanism {
     Bootstrap,
 
     /// A list of peers is manually specified.
-    List(Vec<SocketAddrV6>),
+    List(Vec<SocketAddr>),
 }
 
 impl DiscoveryMechanism {
@@ -68,7 +72,10 @@ impl DiscoveryMechanism {
                     })?;
                 addrs
                     .map(|addr| {
-                        SocketAddrV6::new(addr, BOOTSTRAP_ARTIFACT_PORT, 0, 0)
+                        SocketAddr::new(
+                            IpAddr::V6(addr),
+                            BOOTSTRAP_ARTIFACT_PORT,
+                        )
                     })
                     .collect()
             }
@@ -111,7 +118,7 @@ impl FromStr for DiscoveryMechanism {
 /// A fetched artifact.
 pub(crate) struct FetchedArtifact {
     pub(crate) attempt: usize,
-    pub(crate) addr: SocketAddrV6,
+    pub(crate) addr: SocketAddr,
     pub(crate) artifact: BufList,
 }
 
@@ -222,7 +229,7 @@ impl Peers {
         &self,
         cx: &StepContext,
         artifact_hash_id: &ArtifactHashId,
-    ) -> Option<(SocketAddrV6, BufList)> {
+    ) -> Option<(SocketAddr, BufList)> {
         // TODO: do we want a check phase that happens before the download?
         let peers = self.peers();
         let mut remaining_peers = self.peer_count();
@@ -267,7 +274,7 @@ impl Peers {
         None
     }
 
-    pub(crate) fn peers(&self) -> impl Iterator<Item = SocketAddrV6> + '_ {
+    pub(crate) fn peers(&self) -> impl Iterator<Item = SocketAddr> + '_ {
         self.imp.peers()
     }
 
@@ -282,7 +289,7 @@ impl Peers {
     async fn fetch_from_peer(
         &self,
         cx: &StepContext,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         artifact_hash_id: &ArtifactHashId,
     ) -> Result<BufList, ArtifactFetchError> {
         let log = self.log.new(slog::o!("peer" => peer.to_string()));
@@ -413,19 +420,19 @@ impl Peers {
 
 #[async_trait]
 pub(crate) trait PeersImpl: fmt::Debug + Send + Sync {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddrV6> + Send + '_>;
+    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_>;
     fn peer_count(&self) -> usize;
 
     /// Returns (size, receiver) on success, and an error on failure.
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError>;
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError>;
@@ -438,11 +445,11 @@ pub(crate) type FetchReceiver = mpsc::Receiver<Result<Bytes, ClientError>>;
 #[derive(Clone, Debug)]
 pub(crate) struct HttpPeers {
     log: slog::Logger,
-    peers: Vec<SocketAddrV6>,
+    peers: Vec<SocketAddr>,
 }
 
 impl HttpPeers {
-    pub(crate) fn new(log: &slog::Logger, peers: Vec<SocketAddrV6>) -> Self {
+    pub(crate) fn new(log: &slog::Logger, peers: Vec<SocketAddr>) -> Self {
         let log = log.new(slog::o!("component" => "HttpPeers"));
         Self { log, peers }
     }
@@ -450,7 +457,7 @@ impl HttpPeers {
 
 #[async_trait]
 impl PeersImpl for HttpPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddrV6> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
         Box::new(self.peers.iter().copied())
     }
 
@@ -460,7 +467,7 @@ impl PeersImpl for HttpPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
         // TODO: be able to fetch from sled-agent clients as well
@@ -470,7 +477,7 @@ impl PeersImpl for HttpPeers {
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddrV6,
+        peer: SocketAddr,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError> {


### PR DESCRIPTION
This is useful for local testing situations where v6 routes aren't set
up yet (as I have with helios hitting a Linux box).

Production will always be v6-only.

Note that this changes the wire format slightly. This is backwards-compatible with older wicketd because the [serde serialization impl](https://docs.rs/serde/1.0.171/src/serde/ser/impls.rs.html#841-845) is backwards compatible (`serde_json` is a human-readable format).