### PR TITLE
Implement a TTL of 1 month to each metric

### DIFF
--- a/oximeter/db/src/db-init.sql
+++ b/oximeter/db/src/db-init.sql
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
     datum UInt8
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
 (
@@ -18,7 +19,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
     datum Int64
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
 (
@@ -28,7 +30,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
     datum Float64
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string
 (
@@ -38,7 +41,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_string
     datum String
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
 (
@@ -48,7 +52,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
     datum Array(UInt8)
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, timestamp);
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
 (
@@ -59,7 +64,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
     datum Int64
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp);
+ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
 (
@@ -70,7 +76,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
     datum Float64
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp);
+ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
 (
@@ -82,7 +89,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp);
+ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
 (
@@ -94,7 +102,8 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
     counts Array(UInt64)
 )
 ENGINE = MergeTree()
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp);
+ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
+TTL timestamp + INTERVAL 1 MONTH;
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool
 (

--- a/oximeter/db/src/db-init.sql
+++ b/oximeter/db/src/db-init.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
 (
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_i64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
 (
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string
 (
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_string
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
 (
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
 (
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
 (
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
 (
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
 (
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL timestamp + INTERVAL 1 MONTH;
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool
 (


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/omicron/issues/3515

This 30 day long lifetime is arbitrary. It is only meant to keep the database from growing infinitely. If we receive feedback from our first customers that they have a specific data retention policy, we can modify.

In the future we will most likely allow our users to set their own metric TTL in accordance with their company data retention policies.

We will also implement [data rollup](https://clickhouse.com/docs/en/guides/developer/ttl#implementing-a-rollup) when deleting records. I initially meant to implement them as part of this PR, but we still don't know what type of aggregations will be most useful, so I decided to hold off on this. We need a TTL for FCS but TTL data rollup aggregations can wait until we have a better understanding of our customer's needs.