### PR TITLE
Expose the physical disk form factor

### DIFF
--- a/nexus/db-model/src/physical_disk.rs
+++ b/nexus/db-model/src/physical_disk.rs
@@ -74,6 +74,7 @@ impl From<PhysicalDisk> for views::PhysicalDisk {
             vendor: disk.vendor,
             serial: disk.serial,
             model: disk.model,
+            form_factor: disk.variant.into(),
         }
     }
 }

--- a/nexus/db-model/src/physical_disk_kind.rs
+++ b/nexus/db-model/src/physical_disk_kind.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::impl_enum_type;
-use nexus_types::internal_api;
+use nexus_types::external_api;
 use serde::{Deserialize, Serialize};
 
 impl_enum_type!(
@@ -20,11 +20,20 @@ impl_enum_type!(
     U2 => b"u2"
 );
 
-impl From<internal_api::params::PhysicalDiskKind> for PhysicalDiskKind {
-    fn from(k: internal_api::params::PhysicalDiskKind) -> Self {
+impl From<external_api::params::PhysicalDiskKind> for PhysicalDiskKind {
+    fn from(k: external_api::params::PhysicalDiskKind) -> Self {
         match k {
-            internal_api::params::PhysicalDiskKind::M2 => PhysicalDiskKind::M2,
-            internal_api::params::PhysicalDiskKind::U2 => PhysicalDiskKind::U2,
+            external_api::params::PhysicalDiskKind::M2 => PhysicalDiskKind::M2,
+            external_api::params::PhysicalDiskKind::U2 => PhysicalDiskKind::U2,
+        }
+    }
+}
+
+impl From<PhysicalDiskKind> for external_api::params::PhysicalDiskKind {
+    fn from(value: PhysicalDiskKind) -> Self {
+        match value {
+            PhysicalDiskKind::M2 => external_api::params::PhysicalDiskKind::M2,
+            PhysicalDiskKind::U2 => external_api::params::PhysicalDiskKind::U2,
         }
     }
 }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -14,6 +14,7 @@ use dropshot::Method;
 use http::StatusCode;
 use nexus_test_interface::NexusServer;
 use nexus_types::external_api::params;
+use nexus_types::external_api::params::PhysicalDiskKind;
 use nexus_types::external_api::params::UserId;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::shared::IdentityType;
@@ -201,7 +202,7 @@ pub async fn create_physical_disk(
     vendor: &str,
     serial: &str,
     model: &str,
-    variant: internal_params::PhysicalDiskKind,
+    variant: PhysicalDiskKind,
     sled_id: Uuid,
 ) -> internal_params::PhysicalDiskPutResponse {
     object_put(

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -16,6 +16,7 @@ use nexus_test_utils::resource_helpers::populate_ip_pool;
 use nexus_test_utils::start_sled_agent;
 use nexus_test_utils::SLED_AGENT_UUID;
 use nexus_test_utils_macros::nexus_test;
+use omicron_nexus::external_api::params::PhysicalDiskKind;
 use omicron_nexus::external_api::views::SledInstance;
 use omicron_nexus::external_api::views::{PhysicalDisk, Sled};
 use omicron_nexus::internal_api::params as internal_params;
@@ -113,7 +114,7 @@ async fn test_physical_disk_create_list_delete(
         "v",
         "s",
         "m",
-        internal_params::PhysicalDiskKind::U2,
+        PhysicalDiskKind::U2,
         sled_id,
     )
     .await;

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -19,7 +19,6 @@ use nexus_test_utils_macros::nexus_test;
 use omicron_nexus::external_api::params::PhysicalDiskKind;
 use omicron_nexus::external_api::views::SledInstance;
 use omicron_nexus::external_api::views::{PhysicalDisk, Sled};
-use omicron_nexus::internal_api::params as internal_params;
 use omicron_sled_agent::sim;
 use std::str::FromStr;
 use uuid::Uuid;

--- a/nexus/tests/integration_tests/zpools.rs
+++ b/nexus/tests/integration_tests/zpools.rs
@@ -6,7 +6,7 @@ use dropshot::test_util::ClientTestContext;
 use http::method::Method;
 use http::StatusCode;
 use omicron_common::api::external::ByteCount;
-use omicron_nexus::internal_api::params::PhysicalDiskKind;
+use omicron_nexus::external_api::params::PhysicalDiskKind;
 use omicron_nexus::internal_api::params::PhysicalDiskPutRequest;
 use omicron_nexus::internal_api::params::ZpoolPutRequest;
 use uuid::Uuid;

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1118,6 +1118,16 @@ impl JsonSchema for BlockSize {
     }
 }
 
+/// Describes the form factor of physical disks.
+#[derive(
+    Debug, Serialize, Deserialize, JsonSchema, Clone, Copy, PartialEq, Eq,
+)]
+#[serde(rename_all = "snake_case", tag = "type", content = "content")]
+pub enum PhysicalDiskKind {
+    M2,
+    U2,
+}
+
 /// Different sources for a disk
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -22,6 +22,8 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 use uuid::Uuid;
 
+use super::params::PhysicalDiskKind;
+
 // SILOS
 
 /// View of a Silo
@@ -340,6 +342,8 @@ pub struct PhysicalDisk {
     pub vendor: String,
     pub serial: String,
     pub model: String,
+
+    pub form_factor: PhysicalDiskKind,
 }
 
 // SILO USERS

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -4,6 +4,7 @@
 
 //! Params define the request bodies of API endpoints for creating or updating resources.
 
+use crate::external_api::params::PhysicalDiskKind;
 use crate::external_api::params::UserId;
 use crate::external_api::shared::IpRange;
 use omicron_common::api::external::ByteCount;
@@ -64,16 +65,6 @@ pub struct SledAgentStartupInfo {
     ///
     /// Must be smaller than "usable_physical_ram"
     pub reservoir_size: ByteCount,
-}
-
-/// Describes the type of physical disk.
-#[derive(
-    Debug, Serialize, Deserialize, JsonSchema, Clone, Copy, PartialEq, Eq,
-)]
-#[serde(rename_all = "snake_case", tag = "type", content = "content")]
-pub enum PhysicalDiskKind {
-    M2,
-    U2,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2218,7 +2218,7 @@
         ]
       },
       "PhysicalDiskKind": {
-        "description": "Describes the type of physical disk.",
+        "description": "Describes the form factor of physical disks.",
         "oneOf": [
           {
             "type": "object",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10579,6 +10579,9 @@
         "description": "View of a Physical Disk\n\nPhysical disks reside in a particular sled and are used to store both Instance Disk data as well as internal metadata.",
         "type": "object",
         "properties": {
+          "form_factor": {
+            "$ref": "#/components/schemas/PhysicalDiskKind"
+          },
           "id": {
             "description": "unique, immutable, system-controlled identifier for each resource",
             "type": "string",
@@ -10611,12 +10614,46 @@
           }
         },
         "required": [
+          "form_factor",
           "id",
           "model",
           "serial",
           "time_created",
           "time_modified",
           "vendor"
+        ]
+      },
+      "PhysicalDiskKind": {
+        "description": "Describes the form factor of physical disks.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "m2"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u2"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
         ]
       },
       "PhysicalDiskResultsPage": {


### PR DESCRIPTION
As a follow up to #3496 @smklein, @rmustacc, and I chatted in a few context about still needing to be able to differentiate the disk types. It was agreed that the raw form factor is at least a fact that's not context dependent that we can use as a discriminate for now. 

I've done the plumbing to pipe that through the view layer. One note was that `PhysicalDiskKind` was part of the internal api so I moved it to the external API. 