### PR TITLE
Flatten out the physical disk kind enum

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1122,7 +1122,7 @@ impl JsonSchema for BlockSize {
 #[derive(
     Debug, Serialize, Deserialize, JsonSchema, Clone, Copy, PartialEq, Eq,
 )]
-#[serde(rename_all = "snake_case", tag = "type", content = "content")]
+#[serde(rename_all = "snake_case")]
 pub enum PhysicalDiskKind {
     M2,
     U2,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2219,35 +2219,10 @@
       },
       "PhysicalDiskKind": {
         "description": "Describes the form factor of physical disks.",
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "m2"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "u2"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
+        "type": "string",
+        "enum": [
+          "m2",
+          "u2"
         ]
       },
       "PhysicalDiskPutRequest": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10625,35 +10625,10 @@
       },
       "PhysicalDiskKind": {
         "description": "Describes the form factor of physical disks.",
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "m2"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "u2"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
+        "type": "string",
+        "enum": [
+          "m2",
+          "u2"
         ]
       },
       "PhysicalDiskResultsPage": {


### PR DESCRIPTION
@david-crespo noticed the output structure of this enum was off. I removed the explicit tags to flatten it out and make it more ergonomic. 