### PR TITLE
deploy multiple Nexus zones

### DIFF
--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -550,7 +550,27 @@ impl ServiceZoneRequest {
 
     // The name of a unique identifier for the zone, if one is necessary.
     pub fn zone_name_unique_identifier(&self) -> Option<String> {
-        self.dataset.as_ref().map(|d| d.name.pool().to_string())
+        self.dataset.as_ref().map(|d| d.name.pool().to_string()).or_else(|| {
+            match &self.zone_type {
+                // The switch zone is necessarily a singleton.
+                ZoneType::Switch => None,
+
+                // We should never get here for the following zones because they
+                // have a dataset.
+                ZoneType::Clickhouse
+                | ZoneType::CockroachDb
+                | ZoneType::Crucible
+                | ZoneType::ExternalDns
+                | ZoneType::InternalDns => None,
+
+                // Other zones should be able to have multiple instances on the
+                // same Sled.  Not all have been tested yet.
+                ZoneType::Nexus => Some(self.id.to_string()),
+                ZoneType::CruciblePantry
+                | ZoneType::Ntp
+                | ZoneType::Oximeter => None,
+            }
+        })
     }
 }
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -44,7 +44,7 @@ use uuid::Uuid;
 const BOUNDARY_NTP_COUNT: usize = 2;
 
 // The number of Nexus instances to create from RSS.
-const NEXUS_COUNT: usize = 1;
+const NEXUS_COUNT: usize = 3;
 
 // The number of CRDB instances to create from RSS.
 const CRDB_COUNT: usize = 5;


### PR DESCRIPTION
This required two changes:

- In RSS, deploying 3 zones instead of 1.  I chose three because it's the minimum required to survive a double failure.  More zones should be possible, but take more resources for testing and are also more annoying to work with.
- In Sled Agent, putting the service id into the zone name.  Otherwise, the zonename for the Nexus zone is the same for every zone on the box, and that results in Sled Agent only provisioning one of them.  (When it goes to provision the other two, it thinks it's already done it.)