### PR TITLE
Use the service zone request UUID for zone names

### DIFF
--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -347,7 +347,7 @@ You can also list the zones that have been created so far:
 $ zoneadm list -cnv
 
 # View logs for a service:
-$ pfexec tail -f $(pfexec svcs -z oxz_nexus -L nexus)
+$ pfexec tail -f $(pfexec svcs -z oxz_nexus_<UUID> -L nexus)
 ----
 
 === SoftNPU Configuration

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -19,6 +19,7 @@ use slog::o;
 use slog::warn;
 use slog::Logger;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use uuid::Uuid;
 
 #[cfg(any(test, feature = "testing"))]
 use crate::zone::MockZones as Zones;
@@ -968,11 +969,11 @@ impl InstalledZone {
     /// The zone name is based on:
     /// - A unique Oxide prefix ("oxz_")
     /// - The name of the zone type being hosted (e.g., "nexus")
-    /// - An optional, zone-unique identifier (typically a UUID).
+    /// - An optional, zone-unique UUID
     ///
     /// This results in a zone name which is distinct across different zpools,
     /// but stable and predictable across reboots.
-    pub fn get_zone_name(zone_type: &str, unique_name: Option<&str>) -> String {
+    pub fn get_zone_name(zone_type: &str, unique_name: Option<Uuid>) -> String {
         let mut zone_name = format!("{}{}", ZONE_PREFIX, zone_type);
         if let Some(suffix) = unique_name {
             zone_name.push_str(&format!("_{}", suffix));
@@ -1001,7 +1002,7 @@ impl InstalledZone {
         zone_root_path: &Utf8Path,
         zone_image_paths: &[Utf8PathBuf],
         zone_type: &str,
-        unique_name: Option<&str>,
+        unique_name: Option<Uuid>,
         datasets: &[zone::Dataset],
         filesystems: &[zone::Fs],
         devices: &[zone::Device],

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -863,7 +863,7 @@ impl Instance {
             &root,
             &["/opt/oxide".into()],
             "propolis-server",
-            Some(&inner.propolis_id().to_string()),
+            Some(*inner.propolis_id()),
             // dataset=
             &[],
             // filesystems=

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -544,33 +544,26 @@ impl ServiceZoneRequest {
     pub fn zone_name(&self) -> String {
         illumos_utils::running_zone::InstalledZone::get_zone_name(
             &self.zone_type.to_string(),
-            self.zone_name_unique_identifier().as_deref(),
+            self.zone_name_unique_identifier(),
         )
     }
 
     // The name of a unique identifier for the zone, if one is necessary.
-    pub fn zone_name_unique_identifier(&self) -> Option<String> {
-        self.dataset.as_ref().map(|d| d.name.pool().to_string()).or_else(|| {
-            match &self.zone_type {
-                // The switch zone is necessarily a singleton.
-                ZoneType::Switch => None,
-
-                // We should never get here for the following zones because they
-                // have a dataset.
-                ZoneType::Clickhouse
-                | ZoneType::CockroachDb
-                | ZoneType::Crucible
-                | ZoneType::ExternalDns
-                | ZoneType::InternalDns => None,
-
-                // Other zones should be able to have multiple instances on the
-                // same Sled.  Not all have been tested yet.
-                ZoneType::Nexus => Some(self.id.to_string()),
-                ZoneType::CruciblePantry
-                | ZoneType::Ntp
-                | ZoneType::Oximeter => None,
-            }
-        })
+    pub fn zone_name_unique_identifier(&self) -> Option<Uuid> {
+        match &self.zone_type {
+            // The switch zone is necessarily a singleton.
+            ZoneType::Switch => None,
+            // All other zones should be identified by their zone UUID.
+            ZoneType::Clickhouse
+            | ZoneType::CockroachDb
+            | ZoneType::Crucible
+            | ZoneType::ExternalDns
+            | ZoneType::InternalDns
+            | ZoneType::Nexus
+            | ZoneType::CruciblePantry
+            | ZoneType::Ntp
+            | ZoneType::Oximeter => Some(self.id),
+        }
     }
 }
 

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1006,7 +1006,7 @@ impl ServiceManager {
             &request.root,
             zone_image_paths.as_slice(),
             &request.zone.zone_type.to_string(),
-            unique_name.as_deref(),
+            unique_name,
             datasets.as_slice(),
             &filesystems,
             &devices,
@@ -2980,7 +2980,7 @@ mod test {
     const GLOBAL_ZONE_BOOTSTRAP_IP: Ipv6Addr = Ipv6Addr::LOCALHOST;
     const SWITCH_ZONE_BOOTSTRAP_IP: Ipv6Addr = Ipv6Addr::LOCALHOST;
 
-    const EXPECTED_ZONE_NAME: &str = "oxz_oximeter";
+    const EXPECTED_ZONE_NAME_PREFIX: &str = "oxz_oximeter";
 
     // Returns the expectations for a new service to be created.
     fn expect_new_service() -> Vec<Box<dyn std::any::Any>> {
@@ -2995,14 +2995,14 @@ mod test {
         // Install the Omicron Zone
         let install_ctx = MockZones::install_omicron_zone_context();
         install_ctx.expect().return_once(|_, _, name, _, _, _, _, _, _| {
-            assert_eq!(name, EXPECTED_ZONE_NAME);
+            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
             Ok(())
         });
 
         // Boot the zone.
         let boot_ctx = MockZones::boot_context();
         boot_ctx.expect().return_once(|name| {
-            assert_eq!(name, EXPECTED_ZONE_NAME);
+            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
             Ok(())
         });
 
@@ -3011,7 +3011,7 @@ mod test {
         // `MockZone::id` to find the zone and get its ID.
         let id_ctx = MockZones::id_context();
         id_ctx.expect().return_once(|name| {
-            assert_eq!(name, EXPECTED_ZONE_NAME);
+            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
             Ok(Some(1))
         });
 
@@ -3095,7 +3095,7 @@ mod test {
     fn drop_service_manager(mgr: ServiceManager) {
         let halt_ctx = MockZones::halt_and_remove_logged_context();
         halt_ctx.expect().returning(|_, name| {
-            assert_eq!(name, EXPECTED_ZONE_NAME);
+            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
             Ok(())
         });
         let delete_vnic_ctx = MockDladm::delete_vnic_context();

--- a/tools/populate/populate-alpine.sh
+++ b/tools/populate/populate-alpine.sh
@@ -24,6 +24,6 @@ EOF
 if [[ $? -ne 0 ]]; then
         echo "There was a problem installing the alpine image"
     echo "Please check Nexus logs for possible clues"
-    echo "pfexec zlogin oxz_nexus \"tail \\\$(svcs -L nexus)\""
+    echo "pfexec zlogin oxz_nexus_<UUID> \"tail \\\$(svcs -L nexus)\""
     exit 1
 fi


### PR DESCRIPTION
Generalizes the change in https://github.com/oxidecomputer/omicron/pull/3564 to all zones except the switch zone.

Tested on a single-node non-gimlet (w/SoftNPU) deployment. Nexus initialized, and I was able to provision an instance. The set of zones looks like the following:

```
global
softnpu
oxz_internal_dns_5886b7ea-0565-4ec2-b6e0-fc877d0ead86
oxz_switch
oxz_ntp_7e6e0b34-6a51-430f-8d7a-ed9a94d96848
oxz_cockroachdb_ae1e676a-c0ba-4509-9358-73c258b8019c
oxz_cockroachdb_ce14ca6a-aebc-4f3a-9fe8-fb3ce52bef1d
oxz_cockroachdb_832a3950-8879-415d-ab6e-38d72d352cf8
oxz_cockroachdb_f34d3e3b-7ed2-4f3a-a692-1778956f04c6
oxz_cockroachdb_1bff100c-9f65-479d-9ff8-c667d14ba854
oxz_nexus_6f8ffe1d-8f7b-43b5-a406-8f972797fe2b
oxz_nexus_81c9fc90-3d55-46fb-a9d9-5893663a17ed
oxz_oximeter_0ea77cec-8fdb-46b6-98c1-40af612d68be
oxz_crucible_f48d0786-180c-45d5-866b-03cad6c001bd
oxz_external_dns_144f4824-275d-45a7-b1eb-bee8dfc59c52
oxz_nexus_ff6d675a-7e20-4207-8861-a666be58604a
oxz_clickhouse_9e3ab892-7722-43c2-b5a7-6cd47fa0ce16
oxz_crucible_pantry_7e54406e-98a0-44d3-83e9-103bca0ad714
oxz_crucible_71b9b25b-3e11-49fc-bfaf-167ae9491059
oxz_crucible_06614a2c-dd41-47c2-9edc-91645fc89b6f
oxz_crucible_fe3057a2-472a-4444-8eb9-f89311f7da46
oxz_crucible_dee5527c-a948-4b7c-b7db-d022367ec4aa
oxz_propolis-server_f567e4a8-52b1-4c70-8b12-f077ef2f2a28
```