### PR TITLE
Add `external_dns_ips` RSS parameter

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -338,6 +338,20 @@ impl From<IpAddr> for IpRange {
     }
 }
 
+impl TryFrom<(IpAddr, IpAddr)> for IpRange {
+    type Error = String;
+
+    fn try_from(pair: (IpAddr, IpAddr)) -> Result<Self, Self::Error> {
+        match (pair.0, pair.1) {
+            (IpAddr::V4(a), IpAddr::V4(b)) => Self::try_from((a, b)),
+            (IpAddr::V6(a), IpAddr::V6(b)) => Self::try_from((a, b)),
+            (IpAddr::V4(_), IpAddr::V6(_)) | (IpAddr::V6(_), IpAddr::V4(_)) => {
+                Err("IP address ranges cannot mix IPv4 and IPv6".to_string())
+            }
+        }
+    }
+}
+
 impl TryFrom<(Ipv4Addr, Ipv4Addr)> for IpRange {
     type Error = String;
 

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -298,6 +298,15 @@ impl JsonSchema for IpRange {
 }
 
 impl IpRange {
+    pub fn contains(&self, addr: IpAddr) -> bool {
+        match (self, addr) {
+            (IpRange::V4(r), IpAddr::V4(addr)) => r.contains(addr),
+            (IpRange::V6(r), IpAddr::V6(addr)) => r.contains(addr),
+            (IpRange::V6(_), IpAddr::V4(_))
+            | (IpRange::V4(_), IpAddr::V6(_)) => false,
+        }
+    }
+
     pub fn first_address(&self) -> IpAddr {
         match self {
             IpRange::V4(inner) => IpAddr::from(inner.first),
@@ -364,6 +373,10 @@ impl Ipv4Range {
         }
     }
 
+    pub fn contains(&self, addr: Ipv4Addr) -> bool {
+        self.first <= addr && addr <= self.last
+    }
+
     pub fn first_address(&self) -> Ipv4Addr {
         self.first
     }
@@ -414,6 +427,10 @@ impl Ipv6Range {
         } else {
             Err(String::from("IP address ranges must be non-decreasing"))
         }
+    }
+
+    pub fn contains(&self, addr: Ipv6Addr) -> bool {
+        self.first <= addr && addr <= self.last
     }
 
     pub fn first_address(&self) -> Ipv6Addr {

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -456,6 +456,14 @@
               "$ref": "#/components/schemas/Certificate"
             }
           },
+          "external_dns_ips": {
+            "description": "Service IP addresses on which we run external DNS servers.\n\nEach address must be present in `internal_services_ip_pool_ranges`.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
           "external_dns_zone_name": {
             "description": "DNS name for the DNS zone delegated to the rack for external DNS",
             "type": "string"
@@ -506,6 +514,7 @@
           "bootstrap_discovery",
           "dns_servers",
           "external_certificates",
+          "external_dns_ips",
           "external_dns_zone_name",
           "internal_services_ip_pool_ranges",
           "ntp_servers",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -904,6 +904,13 @@
               "type": "string"
             }
           },
+          "external_dns_ips": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
           "external_dns_zone_name": {
             "type": "string"
           },
@@ -931,6 +938,7 @@
         "required": [
           "bootstrap_sleds",
           "dns_servers",
+          "external_dns_ips",
           "external_dns_zone_name",
           "internal_services_ip_pool_ranges",
           "ntp_servers"
@@ -1733,6 +1741,13 @@
               "type": "string"
             }
           },
+          "external_dns_ips": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
           "external_dns_zone_name": {
             "type": "string"
           },
@@ -1755,6 +1770,7 @@
         "required": [
           "bootstrap_sleds",
           "dns_servers",
+          "external_dns_ips",
           "external_dns_zone_name",
           "internal_services_ip_pool_ranges",
           "ntp_servers",

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -135,9 +135,6 @@ async fn rack_initialize(
 ) -> Result<HttpResponseOk<RackInitId>, HttpError> {
     let ba = rqctx.context();
     let request = body.into_inner();
-    request
-        .validate()
-        .map_err(|err| HttpError::for_bad_request(None, err.to_string()))?;
     let id = ba
         .start_rack_initialize(request)
         .map_err(|err| HttpError::for_bad_request(None, err.to_string()))?;

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -135,6 +135,9 @@ async fn rack_initialize(
 ) -> Result<HttpResponseOk<RackInitId>, HttpError> {
     let ba = rqctx.context();
     let request = body.into_inner();
+    request
+        .validate()
+        .map_err(|err| HttpError::for_bad_request(None, err.to_string()))?;
     let id = ba
         .start_rack_initialize(request)
         .map_err(|err| HttpError::for_bad_request(None, err.to_string()))?;

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -106,6 +106,7 @@ mod test {
             internal_services_ip_pool_ranges: vec![IpRange::from(IpAddr::V4(
                 Ipv4Addr::new(129, 168, 1, 20),
             ))],
+            external_dns_ips: vec![],
             external_certificates: vec![],
             recovery_silo: RecoverySiloConfig {
                 silo_name: "test-silo".parse().unwrap(),

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -42,6 +42,12 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
 
+# IP addresses for authoritative external DNS servers operated by the rack for
+# the DNS domain delegated to the rack by the customer. Each of these addresses
+# must be contained in one of the "internal services" IP Pool ranges listed
+# below.
+external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
+
 # Initial TLS certificates for the external API
 #
 # You should probably leave this field empty even if you want to configure TLS.
@@ -66,10 +72,6 @@ external_dns_zone_name = "oxide.test"
 # If no initial TLS certificates are provided, then your external API will be
 # configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
-
-# IP addresses for external DNS servers. Each of these addresses must be
-# contained in one of the "internal services" IP Pool ranges listed below.
-external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
 
 # The IP ranges configured as part of the "internal services" IP Pool
 #

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -67,6 +67,10 @@ external_dns_zone_name = "oxide.test"
 # configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
 
+# IP addresses for external DNS servers. Each of these addresses must be
+# contained in one of the "internal services" IP Pool ranges listed below.
+external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
+
 # The IP ranges configured as part of the "internal services" IP Pool
 #
 # This is a range of *external* IP addresses that will be assigned to the

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -42,6 +42,12 @@ dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 # altogether (which also means skipping TLS).
 external_dns_zone_name = "oxide.test"
 
+# IP addresses for authoritative external DNS servers operated by the rack for
+# the DNS domain delegated to the rack by the customer. Each of these addresses
+# must be contained in one of the "internal services" IP Pool ranges listed
+# below.
+external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
+
 # Initial TLS certificates for the external API
 #
 # You should probably leave this field empty even if you want to configure TLS.
@@ -66,10 +72,6 @@ external_dns_zone_name = "oxide.test"
 # If no initial TLS certificates are provided, then your external API will be
 # configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
-
-# IP addresses for external DNS servers. Each of these addresses must be
-# contained in one of the "internal services" IP Pool ranges listed below.
-external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
 
 # The IP ranges configured as part of the "internal services" IP Pool
 #

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -67,6 +67,10 @@ external_dns_zone_name = "oxide.test"
 # configured to listen only for plaintext HTTP on port 80.
 external_certificates = []
 
+# IP addresses for external DNS servers. Each of these addresses must be
+# contained in one of the "internal services" IP Pool ranges listed below.
+external_dns_ips = [ "192.168.1.20", "192.168.1.21" ]
+
 # The IP ranges configured as part of the "internal services" IP Pool
 #
 # This is a range of *external* IP addresses that will be assigned to the

--- a/wicket-common/src/rack_setup.rs
+++ b/wicket-common/src/rack_setup.rs
@@ -10,6 +10,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeSet;
+use std::net::IpAddr;
 
 // The portion of `CurrentRssUserConfig` that can be posted in one shot; it is
 // provided by the wicket user uploading a TOML file, currently.
@@ -24,6 +25,7 @@ pub struct PutRssUserConfigInsensitive {
     pub ntp_servers: Vec<String>,
     pub dns_servers: Vec<String>,
     pub internal_services_ip_pool_ranges: Vec<address::IpRange>,
+    pub external_dns_ips: Vec<IpAddr>,
     pub external_dns_zone_name: String,
     pub rack_network_config: RackNetworkConfig,
 }

--- a/wicket/src/rack_setup/config_template.toml
+++ b/wicket/src/rack_setup/config_template.toml
@@ -1,7 +1,19 @@
 # TODO Explanatory block comment
 
-# DNS name for the DNS zone delegated to the rack for external DNS.
+# Delegated external DNS zone name
+#
+# The rack provides separate external API and console endpoints for each Silo.
+# These are named `$silo_name.sys.$external_dns_zone_name`.  For a Silo called
+# "eng" with delegated domain "oxide.example", the API would be accessible at
+# "eng.sys.oxide.example".  The rack runs external DNS servers that serve A/AAAA
+# records for these DNS names.
 external_dns_zone_name = ""
+
+# IP addresses for authoritative external DNS servers operated by the rack for
+# the DNS domain delegated to the rack by the customer. Each of these addresses
+# must be contained in one of the "internal services" IP Pool ranges listed
+# below.
+external_dns_ips = []
 
 # External NTP servers; e.g., "ntp.eng.oxide.computer".
 ntp_servers = [
@@ -20,10 +32,6 @@ dns_servers = []
 #
 #    { first = "172.20.26.1", last = "172.20.26.10" }
 internal_services_ip_pool_ranges = []
-
-# IP addresses on which the rack runs DNS servers. Each of these IP addresses
-# must be contained in one of the internal services IP pool ranges listed above.
-external_dns_ips = []
 
 # List of sleds to initialize.
 #

--- a/wicket/src/rack_setup/config_template.toml
+++ b/wicket/src/rack_setup/config_template.toml
@@ -21,6 +21,10 @@ dns_servers = []
 #    { first = "172.20.26.1", last = "172.20.26.10" }
 internal_services_ip_pool_ranges = []
 
+# IP addresses on which the rack runs DNS servers. Each of these IP addresses
+# must be contained in one of the internal services IP pool ranges listed above.
+external_dns_ips = []
+
 # List of sleds to initialize.
 #
 # Confirm this list contains all expected sleds before continuing!

--- a/wicket/src/rack_setup/config_toml.rs
+++ b/wicket/src/rack_setup/config_toml.rs
@@ -71,9 +71,19 @@ impl TomlTemplate {
             })
             .collect();
 
-        for array in
-            ["ntp_servers", "dns_servers", "internal_services_ip_pool_ranges"]
-        {
+        *doc.get_mut("external_dns_ips").unwrap().as_array_mut().unwrap() =
+            config
+                .external_dns_ips
+                .iter()
+                .map(|s| Value::String(Formatted::new(s.to_string())))
+                .collect();
+
+        for array in [
+            "ntp_servers",
+            "dns_servers",
+            "internal_services_ip_pool_ranges",
+            "external_dns_ips",
+        ] {
             format_multiline_array(
                 doc.get_mut(array).unwrap().as_array_mut().unwrap(),
             );
@@ -240,6 +250,7 @@ mod tests {
                     }
                 })
                 .collect(),
+            external_dns_ips: value.external_dns_ips,
             ntp_servers: value.ntp_servers,
             rack_network_config: InternalRackNetworkConfig {
                 gateway_ip: rnc.gateway_ip,
@@ -299,6 +310,7 @@ mod tests {
                     last: "10.0.0.5".parse().unwrap(),
                 },
             )],
+            external_dns_ips: vec!["10.0.0.1".parse().unwrap()],
             ntp_servers: vec!["ntp1.com".into(), "ntp2.com".into()],
             rack_network_config: Some(RackNetworkConfig {
                 gateway_ip: Ipv4Addr::new(1, 2, 3, 4),

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -787,6 +787,16 @@ fn rss_config_text<'a>(
     );
     append_list(
         &mut spans,
+        "External DNS IPs: ",
+        insensitive
+            .external_dns_ips
+            .iter()
+            .cloned()
+            .map(|ip| plain_list_item(ip.to_string()))
+            .collect(),
+    );
+    append_list(
+        &mut spans,
         "Sleds: ",
         insensitive
             .bootstrap_sleds

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -35,6 +35,7 @@ use serde::Serialize;
 use sled_hardware::Baseboard;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::time::Duration;
 use uuid::Uuid;
@@ -157,6 +158,7 @@ pub struct CurrentRssUserConfigInsensitive {
     pub ntp_servers: Vec<String>,
     pub dns_servers: Vec<String>,
     pub internal_services_ip_pool_ranges: Vec<address::IpRange>,
+    pub external_dns_ips: Vec<IpAddr>,
     pub external_dns_zone_name: String,
     pub rack_network_config: Option<RackNetworkConfig>,
 }

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -28,6 +28,7 @@ use omicron_common::api::internal::shared::RackNetworkConfig;
 use sled_hardware::Baseboard;
 use std::collections::BTreeSet;
 use std::mem;
+use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use wicket_common::rack_setup::PutRssUserConfigInsensitive;
 
@@ -56,6 +57,7 @@ pub(crate) struct CurrentRssConfig {
     ntp_servers: Vec<String>,
     dns_servers: Vec<String>,
     internal_services_ip_pool_ranges: Vec<address::IpRange>,
+    external_dns_ips: Vec<IpAddr>,
     external_dns_zone_name: String,
     external_certificates: Vec<Certificate>,
     recovery_silo_password_hash: Option<omicron_passwords::NewPasswordHash>,
@@ -128,6 +130,9 @@ impl CurrentRssConfig {
         if self.internal_services_ip_pool_ranges.is_empty() {
             bail!("at least one internal services IP pool range is required");
         }
+        if self.external_dns_ips.is_empty() {
+            bail!("at least one external DNS IP address is required");
+        }
         if self.external_dns_zone_name.is_empty() {
             bail!("external dns zone name is required");
         }
@@ -192,6 +197,7 @@ impl CurrentRssConfig {
             ntp_servers: self.ntp_servers.clone(),
             dns_servers: self.dns_servers.clone(),
             internal_services_ip_pool_ranges,
+            external_dns_ips: self.external_dns_ips.clone(),
             external_dns_zone_name: self.external_dns_zone_name.clone(),
             external_certificates: self.external_certificates.clone(),
             recovery_silo: RecoverySiloConfig {
@@ -332,6 +338,7 @@ impl CurrentRssConfig {
         self.dns_servers = value.dns_servers;
         self.internal_services_ip_pool_ranges =
             value.internal_services_ip_pool_ranges;
+        self.external_dns_ips = value.external_dns_ips;
         self.external_dns_zone_name = value.external_dns_zone_name;
         self.rack_network_config = Some(value.rack_network_config);
 
@@ -363,6 +370,7 @@ impl From<&'_ CurrentRssConfig> for CurrentRssUserConfig {
                 internal_services_ip_pool_ranges: rss
                     .internal_services_ip_pool_ranges
                     .clone(),
+                external_dns_ips: rss.external_dns_ips.clone(),
                 external_dns_zone_name: rss.external_dns_zone_name.clone(),
                 rack_network_config: rss.rack_network_config.clone(),
             },


### PR DESCRIPTION
Every external DNS IP must be contained in one of the `internal_services_ip_pool_ranges`, which we validate when we receive the RSS request in bootstrap agent.

This puts the number of external DNS servers in the control of the user requesting rack setup; we require at least one but do not put a cap on it. Should we?

Fixes #3280.