### PR TITLE
Add API cap to instance vCPUs and memory

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -131,7 +131,7 @@ impl super::Nexus {
         if params.ncpus.0 > MAX_VCPU_PER_INSTANCE {
             return Err(Error::invalid_request(&format!(
                 "cannot have more than {} vCPUs per instance",
-                MAX_DISKS_PER_INSTANCE
+                MAX_VCPU_PER_INSTANCE
             )));
         }
         if params.external_ips.len() > MAX_EXTERNAL_IPS_PER_INSTANCE {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -7,6 +7,7 @@
 use super::MAX_DISKS_PER_INSTANCE;
 use super::MAX_EXTERNAL_IPS_PER_INSTANCE;
 use super::MAX_NICS_PER_INSTANCE;
+use super::MAX_VCPU_PER_INSTANCE;
 use crate::app::sagas;
 use crate::app::sagas::retry_until_known_result;
 use crate::authn;
@@ -115,7 +116,7 @@ impl super::Nexus {
         // Validate parameters
         if params.disks.len() > MAX_DISKS_PER_INSTANCE as usize {
             return Err(Error::invalid_request(&format!(
-                "cannot attach more than {} disks to instance!",
+                "cannot attach more than {} disks to instance",
                 MAX_DISKS_PER_INSTANCE
             )));
         }
@@ -124,6 +125,12 @@ impl super::Nexus {
                 self.validate_disk_create_params(opctx, &authz_project, create)
                     .await?;
             }
+        }
+        if params.ncpus.0 > MAX_VCPU_PER_INSTANCE {
+            return Err(Error::invalid_request(&format!(
+                "cannot have more than {} vCPUs per instance",
+                MAX_DISKS_PER_INSTANCE
+            )));
         }
         if params.external_ips.len() > MAX_EXTERNAL_IPS_PER_INSTANCE {
             return Err(Error::invalid_request(&format!(

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -6,8 +6,10 @@
 
 use super::MAX_DISKS_PER_INSTANCE;
 use super::MAX_EXTERNAL_IPS_PER_INSTANCE;
+use super::MAX_MEMORY_BYTES_PER_INSTANCE;
 use super::MAX_NICS_PER_INSTANCE;
 use super::MAX_VCPU_PER_INSTANCE;
+use super::MIN_MEMORY_BYTES_PER_INSTANCE;
 use crate::app::sagas;
 use crate::app::sagas::retry_until_known_result;
 use crate::authn;
@@ -165,27 +167,38 @@ impl super::Nexus {
         }
 
         // Reject instances where the memory is not at least
-        // MIN_MEMORY_SIZE_BYTES
-        if params.memory.to_bytes() < params::MIN_MEMORY_SIZE_BYTES as u64 {
+        // MIN_MEMORY_BYTES_PER_INSTANCE
+        if params.memory.to_bytes() < MIN_MEMORY_BYTES_PER_INSTANCE as u64 {
             return Err(Error::InvalidValue {
                 label: String::from("size"),
                 message: format!(
                     "memory must be at least {}",
-                    ByteCount::from(params::MIN_MEMORY_SIZE_BYTES)
+                    ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE)
                 ),
             });
         }
 
         // Reject instances where the memory is not divisible by
-        // MIN_MEMORY_SIZE_BYTES
-        if (params.memory.to_bytes() % params::MIN_MEMORY_SIZE_BYTES as u64)
+        // MIN_MEMORY_BYTES_PER_INSTANCE
+        if (params.memory.to_bytes() % MIN_MEMORY_BYTES_PER_INSTANCE as u64)
             != 0
         {
             return Err(Error::InvalidValue {
                 label: String::from("size"),
                 message: format!(
                     "memory must be divisible by {}",
-                    ByteCount::from(params::MIN_MEMORY_SIZE_BYTES)
+                    ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE)
+                ),
+            });
+        }
+
+        // Reject instances where the memory is greated than the limit
+        if params.memory.to_bytes() > MAX_MEMORY_BYTES_PER_INSTANCE {
+            return Err(Error::InvalidValue {
+                label: String::from("size"),
+                message: format!(
+                    "memory must be less than or equal to {}",
+                    ByteCount::try_from(MAX_MEMORY_BYTES_PER_INSTANCE).unwrap()
                 ),
             });
         }

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -73,6 +73,8 @@ pub(crate) const MAX_NICS_PER_INSTANCE: usize = 8;
 // TODO-completeness: Support multiple external IPs
 pub(crate) const MAX_EXTERNAL_IPS_PER_INSTANCE: usize = 1;
 
+pub(crate) const MAX_VCPU_PER_INSTANCE: u16 = 32;
+
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {
     /// uuid for this nexus instance.

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -73,7 +73,7 @@ pub(crate) const MAX_NICS_PER_INSTANCE: usize = 8;
 // TODO-completeness: Support multiple external IPs
 pub(crate) const MAX_EXTERNAL_IPS_PER_INSTANCE: usize = 1;
 
-pub(crate) const MAX_VCPU_PER_INSTANCE: u16 = 32;
+pub const MAX_VCPU_PER_INSTANCE: u16 = 32;
 
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -75,6 +75,9 @@ pub(crate) const MAX_EXTERNAL_IPS_PER_INSTANCE: usize = 1;
 
 pub const MAX_VCPU_PER_INSTANCE: u16 = 32;
 
+pub const MIN_MEMORY_BYTES_PER_INSTANCE: u32 = 1 << 30; // 1 GiB
+pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 64 * (1 << 30); // 64 GiB
+
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {
     /// uuid for this nexus instance.

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -36,7 +36,9 @@ use omicron_common::api::external::InstanceState;
 use omicron_common::api::external::Ipv4Net;
 use omicron_common::api::external::Name;
 use omicron_common::api::external::Vni;
+use omicron_nexus::app::MAX_MEMORY_BYTES_PER_INSTANCE;
 use omicron_nexus::app::MAX_VCPU_PER_INSTANCE;
+use omicron_nexus::app::MIN_MEMORY_BYTES_PER_INSTANCE;
 use omicron_nexus::db::fixed_data::silo::SILO_ID;
 use omicron_nexus::db::lookup::LookupPath;
 use omicron_nexus::external_api::shared::IpKind;
@@ -2793,7 +2795,7 @@ async fn test_disks_detached_when_instance_destroyed(
 }
 
 // Tests that an instance is rejected if the memory is less than
-// MIN_MEMORY_SIZE_BYTES
+// MIN_MEMORY_BYTES_PER_INSTANCE
 #[nexus_test]
 async fn test_instances_memory_rejected_less_than_min_memory_size(
     cptestctx: &ControlPlaneTestContext,
@@ -2809,7 +2811,7 @@ async fn test_instances_memory_rejected_less_than_min_memory_size(
             description: format!("instance {:?}", &instance_name),
         },
         ncpus: InstanceCpuCount(1),
-        memory: ByteCount::from(params::MIN_MEMORY_SIZE_BYTES / 2),
+        memory: ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE / 2),
         hostname: String::from("inst"),
         user_data:
             b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
@@ -2836,7 +2838,7 @@ async fn test_instances_memory_rejected_less_than_min_memory_size(
         error.message,
         format!(
             "unsupported value for \"size\": memory must be at least {}",
-            ByteCount::from(params::MIN_MEMORY_SIZE_BYTES)
+            ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE)
         ),
     );
 }
@@ -2885,9 +2887,52 @@ async fn test_instances_memory_not_divisible_by_min_memory_size(
         error.message,
         format!(
             "unsupported value for \"size\": memory must be divisible by {}",
-            ByteCount::from(params::MIN_MEMORY_SIZE_BYTES)
+            ByteCount::from(MIN_MEMORY_BYTES_PER_INSTANCE)
         ),
     );
+}
+
+// Test that an instance is rejected if memory is above cap
+#[nexus_test]
+async fn test_instances_memory_greater_than_max_size(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+    create_org_and_project(client).await;
+
+    // Attempt to create the instance, observe a server error.
+    let instance_name = "just-rainsticks";
+    let instance = params::InstanceCreate {
+        identity: IdentityMetadataCreateParams {
+            name: instance_name.parse().unwrap(),
+            description: format!("instance {:?}", &instance_name),
+        },
+        ncpus: InstanceCpuCount(1),
+        memory: ByteCount::try_from(MAX_MEMORY_BYTES_PER_INSTANCE + (1 << 30))
+            .unwrap(),
+        hostname: String::from("inst"),
+        user_data:
+            b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
+                .to_vec(),
+        network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
+        external_ips: vec![],
+        disks: vec![],
+        start: true,
+    };
+
+    let error = NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &get_instances_url())
+            .body(Some(&instance))
+            .expect_status(Some(StatusCode::BAD_REQUEST)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body::<dropshot::HttpErrorResponseBody>()
+    .unwrap();
+
+    assert!(error.message.contains("memory must be less than"));
 }
 
 async fn expect_instance_creation_fail_unavailable(
@@ -3048,7 +3093,7 @@ async fn test_cannot_provision_instance_beyond_ram_capacity(
 
     let too_much_ram = ByteCount::try_from(
         nexus_test_utils::TEST_PHYSICAL_RAM
-            + u64::from(params::MIN_MEMORY_SIZE_BYTES),
+            + u64::from(MIN_MEMORY_BYTES_PER_INSTANCE),
     )
     .unwrap();
     let enough_ram =

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -742,8 +742,6 @@ pub struct IpPoolUpdate {
 
 // INSTANCES
 
-pub const MIN_MEMORY_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
-
 /// Describes an attachment of an `InstanceNetworkInterface` to an `Instance`,
 /// at the time the instance is created.
 // NOTE: VPC's are an organizing concept for networking resources, not for


### PR DESCRIPTION
Mitigates #3212

This a first stab at adding validation to the API to cap the number of vCPUs to 32 until the bhyve limit can be upped. We also added a 64 GiB cap on instance memory. I'm still working out exactly where the validation checks need to happen. #3212 mentions that it should happen in sled agent but for now I've located it with the other instance creation validation logic. 