### PR TITLE
[RSS] Remove rack_secret_threshold param

### DIFF
--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -491,12 +491,6 @@
               }
             ]
           },
-          "rack_secret_threshold": {
-            "description": "The minimum number of sleds required to unlock the rack secret.\n\nIf this value is less than 2, no rack secret will be created on startup; this is the typical case for single-server test/development.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
           "rack_subnet": {
             "type": "string",
             "format": "ipv6"
@@ -518,7 +512,6 @@
           "external_dns_zone_name",
           "internal_services_ip_pool_ranges",
           "ntp_servers",
-          "rack_secret_threshold",
           "rack_subnet",
           "recovery_silo"
         ]

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -29,7 +29,6 @@ pub enum BootstrapAddressDiscovery {
 struct UnvalidatedRackInitializeRequest {
     rack_subnet: Ipv6Addr,
     bootstrap_discovery: BootstrapAddressDiscovery,
-    rack_secret_threshold: usize,
     ntp_servers: Vec<String>,
     dns_servers: Vec<String>,
     internal_services_ip_pool_ranges: Vec<address::IpRange>,
@@ -53,12 +52,6 @@ pub struct RackInitializeRequest {
 
     /// Describes how bootstrap addresses should be collected during RSS.
     pub bootstrap_discovery: BootstrapAddressDiscovery,
-
-    /// The minimum number of sleds required to unlock the rack secret.
-    ///
-    /// If this value is less than 2, no rack secret will be created on startup;
-    /// this is the typical case for single-server test/development.
-    pub rack_secret_threshold: usize,
 
     /// The external NTP server addresses.
     pub ntp_servers: Vec<String>,
@@ -116,7 +109,6 @@ impl TryFrom<UnvalidatedRackInitializeRequest> for RackInitializeRequest {
         Ok(RackInitializeRequest {
             rack_subnet: value.rack_subnet,
             bootstrap_discovery: value.bootstrap_discovery,
-            rack_secret_threshold: value.rack_secret_threshold,
             ntp_servers: value.ntp_servers,
             dns_servers: value.dns_servers,
             internal_services_ip_pool_ranges: value
@@ -212,7 +204,6 @@ mod tests {
         let config = r#"
             rack_subnet = "fd00:1122:3344:0100::"
             bootstrap_discovery.type = "only_ours"
-            rack_secret_threshold = 1
             ntp_servers = [ "ntp.eng.oxide.computer" ]
             dns_servers = [ "1.1.1.1", "9.9.9.9" ]
             external_dns_zone_name = "oxide.test"
@@ -264,7 +255,6 @@ mod tests {
         let mut config = UnvalidatedRackInitializeRequest {
             rack_subnet: Ipv6Addr::LOCALHOST,
             bootstrap_discovery: BootstrapAddressDiscovery::OnlyOurs,
-            rack_secret_threshold: 0,
             ntp_servers: Vec::new(),
             dns_servers: Vec::new(),
             internal_services_ip_pool_ranges: Vec::new(),

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -99,7 +99,6 @@ mod test {
         let cfg = SetupServiceConfig {
             rack_subnet: "fd00:1122:3344:0100::".parse().unwrap(),
             bootstrap_discovery: BootstrapAddressDiscovery::OnlyOurs,
-            rack_secret_threshold: 0,
             ntp_servers: vec![String::from("test.pool.example.com")],
             dns_servers: vec![String::from("1.1.1.1")],
             external_dns_zone_name: String::from("oxide.test"),

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -1042,7 +1042,6 @@ mod tests {
         let config = Config {
             rack_subnet: Ipv6Addr::LOCALHOST,
             bootstrap_discovery: BootstrapAddressDiscovery::OnlyOurs,
-            rack_secret_threshold: 0,
             ntp_servers: Vec::new(),
             dns_servers: Vec::new(),
             internal_services_ip_pool_ranges: ip_pools

--- a/smf/sled-agent/gimlet-standalone/config-rss.toml
+++ b/smf/sled-agent/gimlet-standalone/config-rss.toml
@@ -15,11 +15,6 @@ rack_subnet = "fd00:1122:3344:0100::"
 # Only include "our own sled" in the bootstrap network
 bootstrap_discovery.type = "only_ours"
 
-# The number of sleds required to unlock the rack secret.
-#
-# For values less than 2, no rack secret will be generated.
-rack_secret_threshold = 1
-
 ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -15,11 +15,6 @@ rack_subnet = "fd00:1122:3344:0100::"
 # Only include "our own sled" in the bootstrap network
 bootstrap_discovery.type = "only_ours"
 
-# The number of sleds required to unlock the rack secret.
-#
-# For values less than 2, no rack secret will be generated.
-rack_secret_threshold = 1
-
 ntp_servers = [ "ntp.eng.oxide.computer" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -193,7 +193,6 @@ impl CurrentRssConfig {
             bootstrap_discovery: BootstrapAddressDiscovery::OnlyThese(
                 bootstrap_ips,
             ),
-            rack_secret_threshold: 1, // TODO REMOVE?
             ntp_servers: self.ntp_servers.clone(),
             dns_servers: self.dns_servers.clone(),
             internal_services_ip_pool_ranges,


### PR DESCRIPTION
#3204 removed most of the old placeholder trust quorum code; this removes the now-vestigial `rack_secret_threshold` RSS parameter.