### PR TITLE
Zero touch switch config for dev environments

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -135,15 +135,14 @@ for p in /input/ci-tools/work/end-to-end-tests/*.gz; do
 	chmod a+x "tests/$(basename "${p%.gz}")"
 done
 
-pfexec zpool create -f scratch c1t1d0 c2t1d0
-ZPOOL_VDEV_DIR=/scratch ptime -m pfexec ./tools/create_virtual_hardware.sh
-
 # Lab gateway ip
 export GATEWAY_IP=192.168.1.199
 # Proxy arp settings.
 export PXA_START="192.168.1.50"
 export PXA_END="192.168.1.90"
-ptime -m pfexec ./tools/create_virtual_hardware.sh
+
+pfexec zpool create -f scratch c1t1d0 c2t1d0
+ZPOOL_VDEV_DIR=/scratch ptime -m pfexec ./tools/create_virtual_hardware.sh
 
 #
 # Generate a self-signed certificate to use as the initial TLS certificate for

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -55,11 +55,12 @@ ptime -m cargo run --locked --release --bin omicron-package -- \
 files=(
 	out/*.tar
 	out/target/test
-	out/softnpu/*
+	out/npuzone/*
 	package-manifest.toml
 	smf/sled-agent/non-gimlet/config.toml
 	target/release/omicron-package
 	tools/create_virtual_hardware.sh
+    tools/virtual_hardware.sh
 	tools/scrimlet/*
 )
 

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -176,13 +176,19 @@ The Sled Agent supports operation on both:
 
 This script also sets up a "softnpu" zone to implement Boundary Services.  SoftNPU simulates the Tofino device that's used in real systems.  Just like Tofino, it can implement sled-to-sled networking, but that's beyond the scope of this doc.
 
-If you're running on a PC and using an existing network as your external network, you can usually just run:
+If you're running on a PC and using an existing network as your external network, you can usually just run this script with a few environment vaiables set. These environment varaibles tell softnpu about your local network. 
 
+[source,bash]
 ----
+export PHYSICAL_LINK=igb0           # The physical link for your local network.
+export GATEWAY_IP=192.168.1.199     # The gateway IP address for your local network.
+export PXA_START=192.168.1.2        # The first IP address your Oxide cluster can use.
+export PXA_END=192.168.1.100        # The last IP address your Oxide cluster can use.
+
 $ pfexec ./tools/create_virtual_hardware.sh
 ----
 
-If above you made up a new "external" network only accessible within the Sled, then you'll want to override PHYSICAL_LINK:
+If above you made up a new "external" network only accessible within the Sled, then you'll want to override PHYSICAL_LINK as follows:
 
 ----
 $ PHYSICAL_LINK=fake_external_stub0 pfexec ./tools/create_virtual_hardware.sh
@@ -369,26 +375,6 @@ $ GATEWAY_IP=192.168.1.199 ./tools/scrimlet/softnpu-init.sh
 ----
 
 In other configurations, you might use a different GATEWAY_IP.  You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.
-
-=== SoftNPU Proxy ARP Setup
-
-Services that require external connectivity (e.g. Nexus, Boundary NTP, External DNS) do so via OPTE using addresses from the services IP pool.  When using SoftNPU, we'll need to configure Proxy ARP for those addresses.
-
-In this snippet, `$SERVICE_IP_POOL_START` and `$SERVICE_IP_POOL_END` are the addresses you put into `config-rss.toml` above for `internal_services_ip_pool_ranges`:
-
-[source,console]
-----
-# dladm won't return leading zeroes but `scadm` expects them
-$ SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | gsed 's/\b\(\w\)\b/0\1/g')
-$ pfexec /opt/oxide/softnpu/stuff/scadm \
-  --server /opt/oxide/softnpu/stuff/server \
-  --client /opt/oxide/softnpu/stuff/client \
-  standalone \
-  add-proxy-arp \
-  $SERVICE_IP_POOL_START \
-  $SERVICE_IP_POOL_END \
-  $SOFTNPU_MAC
-----
 
 == Using Omicron
 

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -176,7 +176,7 @@ The Sled Agent supports operation on both:
 
 This script also sets up a "softnpu" zone to implement Boundary Services.  SoftNPU simulates the Tofino device that's used in real systems.  Just like Tofino, it can implement sled-to-sled networking, but that's beyond the scope of this doc.
 
-If you're running on a PC and using an existing network as your external network, you can usually just run this script with a few environment vaiables set. These environment varaibles tell softnpu about your local network. 
+If you're running on a PC and using an existing network as your external network, you can usually just run this script with a few environment vaiables set. These environment varaibles tell SoftNPU about your local network. You'll need to carve out part of your network for the Oxide platform, making sure that the range you specify below is not occupied by other hosts on your network.
 
 [source,bash]
 ----
@@ -356,26 +356,6 @@ $ zoneadm list -cnv
 $ pfexec tail -f $(pfexec svcs -z oxz_nexus_<UUID> -L nexus)
 ----
 
-=== SoftNPU Configuration
-
-After installing omicron with `omicron-package install`, you can run the `softnpu-init.sh` script to configure SoftNPU.  If your external network is the one that your global zone is already on (i.e., an existing network), then you can likely just run:
-
-[source,console]
-----
-$ ./tools/scrimlet/softnpu-init.sh
-----
-
-In this case, `softnpu-init.sh` determines a network gateway by looking at your system's default gateway.  Again, the assumption for this use case is that your rack gets external connectivity the same way your system does because it's part of the same network.
-
-If your external network is one you made up above that's local to your own system, this won't be right.  In that case, you'll want to override the gateway IP to be the address of the global zone on your made-up network.  In our example:
-
-[source,console]
-----
-$ GATEWAY_IP=192.168.1.199 ./tools/scrimlet/softnpu-init.sh
-----
-
-In other configurations, you might use a different GATEWAY_IP.  You can also override GATEWAY_MAC if needed, but that shouldn't be necessary for the configurations described here.
-
 == Using Omicron
 
 At this point, the system should be up and running!  You should be able to reach the external API and web console from your external network.  But how?  The URL for the API and console will be:
@@ -426,9 +406,9 @@ With SoftNPU you will generally also need to configure Proxy ARP.  Below, `IP_PO
 ----
 # dladm won't return leading zeroes but `scadm` expects them
 $ SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | gsed 's/\b\(\w\)\b/0\1/g')
-$ pfexec /opt/oxide/softnpu/stuff/scadm \
-  --server /opt/oxide/softnpu/stuff/server \
-  --client /opt/oxide/softnpu/stuff/client \
+$ pfexec zlogin sidecar_softnpu /softnpu/scadm \
+  --server /softnpu/server \
+  --client /softnpu/client \
   standalone \
   add-proxy-arp \
   $IP_POOL_START \

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -1104,6 +1104,7 @@ impl InstalledZone {
         unique_name: Option<Uuid>,
         datasets: &[zone::Dataset],
         filesystems: &[zone::Fs],
+        data_links: &[String],
         devices: &[zone::Device],
         opte_ports: Vec<(Port, PortTicket)>,
         bootstrap_vnic: Option<Link>,
@@ -1140,13 +1141,20 @@ impl InstalledZone {
                     .collect(),
             })?;
 
-        let net_device_names: Vec<String> = opte_ports
+        let mut net_device_names: Vec<String> = opte_ports
             .iter()
             .map(|(port, _)| port.vnic_name().to_string())
             .chain(std::iter::once(control_vnic.name().to_string()))
             .chain(bootstrap_vnic.as_ref().map(|vnic| vnic.name().to_string()))
             .chain(links.iter().map(|nic| nic.name().to_string()))
+            .chain(data_links.iter().map(|x| x.to_string()))
             .collect();
+
+        // There are many sources for device names. In some cases they can
+        // overlap, depending on the contents of user defined config files. This
+        // can cause zones to fail to start if duplicate data links are given.
+        net_device_names.sort();
+        net_device_names.dedup();
 
         Zones::install_omicron_zone(
             log,

--- a/installinator/src/bootstrap.rs
+++ b/installinator/src/bootstrap.rs
@@ -26,9 +26,12 @@ const MG_DDM_MANIFEST_PATH: &str = "/opt/oxide/mg-ddm/pkg/ddm/manifest.xml";
 // TODO-cleanup The implementation of this function is heavily derived from
 // `sled_agent::bootstrap::server::Server::start()`; consider whether we could
 // find a way for them to share it.
-pub(crate) async fn bootstrap_sled(log: Logger) -> Result<()> {
+pub(crate) async fn bootstrap_sled(
+    data_links: &[String; 2],
+    log: Logger,
+) -> Result<()> {
     // Find address objects to pass to maghemite.
-    let links = underlay::find_chelsio_links()
+    let links = underlay::find_chelsio_links(data_links)
         .context("failed to find chelsio links")?;
     ensure!(
         !links.is_empty(),

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -151,14 +151,16 @@ struct InstallOpts {
     #[clap(long)]
     install_on_gimlet: bool,
 
-    //TODO(ry) how to get this parameter set?
+    //TODO(ry) this probably needs to get plumbed somewhere instead of relying
+    //on a default.
     /// The first gimlet data link to use.
-    #[clap(long)]
+    #[clap(long, default_value = "cxgbe0")]
     data_link0: String,
 
-    //TODO(ry) how to get this parameter set?
+    //TODO(ry) this probably needs to get plumbed somewhere instead of relying
+    //on a default.
     /// The second gimlet data link to use.
-    #[clap(long)]
+    #[clap(long, default_value = "cxgbe1")]
     data_link1: String,
 
     // TODO: checksum?

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -151,6 +151,16 @@ struct InstallOpts {
     #[clap(long)]
     install_on_gimlet: bool,
 
+    //TODO(ry) how to get this parameter set?
+    /// The first gimlet data link to use.
+    #[clap(long)]
+    data_link0: String,
+
+    //TODO(ry) how to get this parameter set?
+    /// The second gimlet data link to use.
+    #[clap(long)]
+    data_link1: String,
+
     // TODO: checksum?
 
     // The destination to write to.
@@ -164,7 +174,8 @@ struct InstallOpts {
 impl InstallOpts {
     async fn exec(self, log: &slog::Logger) -> Result<()> {
         if self.bootstrap_sled {
-            crate::bootstrap::bootstrap_sled(log.clone()).await?;
+            let data_links = [self.data_link0.clone(), self.data_link1.clone()];
+            crate::bootstrap::bootstrap_sled(&data_links, log.clone()).await?;
         }
 
         let image_id = self.artifact_ids.resolve()?;

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -76,6 +76,7 @@ impl Resolver {
         // The underlay is IPv6 only, so this helps avoid needless lookups of
         // the IPv4 variant.
         opts.ip_strategy = LookupIpStrategy::Ipv6Only;
+        opts.negative_max_ttl = Some(std::time::Duration::from_secs(15));
         let resolver = TokioAsyncResolver::tokio(rc, opts)?;
 
         Ok(Self { log, resolver })

--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -122,9 +122,9 @@ async fn do_run() -> Result<(), CmdError> {
                     // If the rack has already been initialized, we shouldn't
                     // abandon the server.
                     Ok(_)
-                        | Err(
-                            bootstrap_agent::RssAccessError::AlreadyInitialized,
-                        ) => {}
+                    | Err(
+                        bootstrap_agent::RssAccessError::AlreadyInitialized,
+                    ) => {}
                     Err(e) => {
                         return Err(CmdError::Failure(e.to_string()));
                     }

--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -105,6 +105,8 @@ async fn do_run() -> Result<(), CmdError> {
                 updates: config.updates.clone(),
             };
 
+            let rss_initiator = config.rss_initiator;
+
             // TODO: It's a little silly to pass the config this way - namely,
             // that we construct the bootstrap config from `config`, but then
             // pass it separately just so the sled agent can ingest it later on.
@@ -117,16 +119,18 @@ async fn do_run() -> Result<(), CmdError> {
             //
             // This should remain equivalent to the HTTP request which can
             // be invoked by Wicket.
-            if let Some(rss_config) = rss_config {
-                match server.agent().start_rack_initialize(rss_config) {
-                    // If the rack has already been initialized, we shouldn't
-                    // abandon the server.
-                    Ok(_)
-                    | Err(
-                        bootstrap_agent::RssAccessError::AlreadyInitialized,
-                    ) => {}
-                    Err(e) => {
-                        return Err(CmdError::Failure(e.to_string()));
+            if rss_initiator {
+                if let Some(rss_config) = rss_config {
+                    match server.agent().start_rack_initialize(rss_config) {
+                        // If the rack has already been initialized, we shouldn't
+                        // abandon the server.
+                        Ok(_)
+                        | Err(
+                            bootstrap_agent::RssAccessError::AlreadyInitialized,
+                        ) => {}
+                        Err(e) => {
+                            return Err(CmdError::Failure(e.to_string()));
+                        }
                     }
                 }
             }

--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -105,8 +105,6 @@ async fn do_run() -> Result<(), CmdError> {
                 updates: config.updates.clone(),
             };
 
-            let rss_initiator = config.rss_initiator;
-
             // TODO: It's a little silly to pass the config this way - namely,
             // that we construct the bootstrap config from `config`, but then
             // pass it separately just so the sled agent can ingest it later on.
@@ -119,18 +117,16 @@ async fn do_run() -> Result<(), CmdError> {
             //
             // This should remain equivalent to the HTTP request which can
             // be invoked by Wicket.
-            if rss_initiator {
-                if let Some(rss_config) = rss_config {
-                    match server.agent().start_rack_initialize(rss_config) {
-                        // If the rack has already been initialized, we shouldn't
-                        // abandon the server.
-                        Ok(_)
+            if let Some(rss_config) = rss_config {
+                match server.agent().start_rack_initialize(rss_config) {
+                    // If the rack has already been initialized, we shouldn't
+                    // abandon the server.
+                    Ok(_)
                         | Err(
                             bootstrap_agent::RssAccessError::AlreadyInitialized,
                         ) => {}
-                        Err(e) => {
-                            return Err(CmdError::Failure(e.to_string()));
-                        }
+                    Err(e) => {
+                        return Err(CmdError::Failure(e.to_string()));
                     }
                 }
             }

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -55,9 +55,10 @@ impl Server {
         }
 
         // Find address objects to pass to maghemite.
-        let mg_addr_objs = underlay::find_nics().map_err(|err| {
-            format!("Failed to find address objects for maghemite: {err}")
-        })?;
+        let mg_addr_objs = underlay::find_nics(&sled_config.data_links)
+            .map_err(|err| {
+                format!("Failed to find address objects for maghemite: {err}")
+            })?;
         if mg_addr_objs.is_empty() {
             return Err(
                 "underlay::find_nics() returned 0 address objects".to_string()

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -71,6 +71,10 @@ pub struct Config {
     /// systems.
     pub data_link: Option<PhysicalLink>,
 
+    /// The data links that sled-agent will treat as a real gimlet cxgbe0/cxgbe1
+    /// links.
+    pub data_links: [String; 2],
+
     #[serde(default)]
     pub updates: ConfigUpdates,
 
@@ -83,6 +87,10 @@ pub struct Config {
     /// mode maghemite there.
     #[serde(default)]
     pub switch_zone_maghemite_links: Vec<PhysicalLink>,
+
+    /// Set to true if the sled-agent should look for an RSS config file and
+    /// automatically initiate RSS.
+    pub rss_initiator: bool,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -87,10 +87,6 @@ pub struct Config {
     /// mode maghemite there.
     #[serde(default)]
     pub switch_zone_maghemite_links: Vec<PhysicalLink>,
-
-    /// Set to true if the sled-agent should look for an RSS config file and
-    /// automatically initiate RSS.
-    pub rss_initiator: bool,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -846,6 +846,8 @@ impl Instance {
             &[],
             // filesystems=
             &[],
+            // data_links=
+            &[],
             &[
                 zone::Device { name: "/dev/vmm/*".to_string() },
                 zone::Device { name: "/dev/vmmctl".to_string() },

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2046,6 +2046,8 @@ impl ServiceManager {
                     request,
                     // filesystems=
                     &[],
+                    // data_links=
+                    &[],
                 )
                 .await
                 .map_err(|error| (request.zone.zone_name(), error))

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -292,7 +292,7 @@ impl SledAgent {
         .map_err(|err| Error::SledSubnet { err })?;
 
         // Initialize the xde kernel driver with the underlay devices.
-        let underlay_nics = underlay::find_nics()?;
+        let underlay_nics = underlay::find_nics(&config.data_links)?;
         illumos_utils::opte::initialize_xde_driver(&log, &underlay_nics)?;
 
         // Create the PortManager to manage all the OPTE ports on the sled.

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -29,6 +29,10 @@ vmm_reservoir_percentage = 0
 # $ dladm show-phys -p -o LINK
 # data_link = "igb0"
 
+data_links = ["net0", "net1"]
+
+rss_initiator = true
+
 [log]
 level = "info"
 mode = "file"

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -31,8 +31,6 @@ vmm_reservoir_percentage = 0
 
 data_links = ["net0", "net1"]
 
-rss_initiator = true
-
 [log]
 level = "info"
 mode = "file"

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -31,6 +31,9 @@ vmm_reservoir_percentage = 80
 # for non-gimlets will configure a swap device via /etc/vfstab.
 swap_device_size_gb = 256
 
+data_links = ["cxgbe0", "cxgbe1"]
+rss_initiator = true
+
 [log]
 level = "info"
 mode = "file"

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -32,7 +32,6 @@ vmm_reservoir_percentage = 80
 swap_device_size_gb = 256
 
 data_links = ["cxgbe0", "cxgbe1"]
-rss_initiator = true
 
 [log]
 level = "info"

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -60,8 +60,6 @@ switch_zone_maghemite_links = ["tfportrear0_0"]
 
 data_links = ["net0", "net1"]
 
-rss_initiator = true
-
 [log]
 level = "info"
 mode = "file"

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -54,8 +54,13 @@ vmm_reservoir_percentage = 0
 # tfportd will create the necessary links and Maghemite will be configured to
 # use those.  But on non-Gimlet systems, you need to specify physical links to
 # be passed into the `oxz_switch` zone for this purpose.  You can skip this if
-# you're deploying a single-sled system.
-#switch_zone_maghemite_links = ["ixgbe0", "ixgbe1"]
+# you're deploying a single-sled system and just leave the single tfportrear
+# as-is.
+switch_zone_maghemite_links = ["tfportrear0_0"]
+
+data_links = ["net0", "net1"]
+
+rss_initiator = true
 
 [log]
 level = "info"

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -11,42 +11,18 @@ set -euo pipefail
 
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-OUT_DIR="out/softnpu"
+OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="88f5f1334364e5580fe778c44ac0746a35927351"
-
-# Pinned commit for softnpu tools
-SIDECAR_LITE_REPO="sidecar-lite"
-SIDECAR_LITE_SERIES="release"
-SIDECAR_LITE_COMMIT="56abef043a9e2ba0363fea82528d7a9e86d3c0b0"
+SOFTNPU_COMMIT="cf26bc25e67f10e5ec836cffae814a3cb1a5b747"
 
 # This is the softnpu ASIC simulator
-echo "fetching softnpu"
-mkdir -p out/softnpu
+echo "fetching npuzone"
+mkdir -p $OUT_DIR
 $TOOLS_DIR/ensure_buildomat_artifact.sh \
     -O $OUT_DIR \
-    "softnpu" \
+    "npuzone" \
     "$SOFTNPU_REPO" \
     "$SOFTNPU_COMMIT"
-chmod +x $OUT_DIR/softnpu
-
-# This is an ASIC administration program.
-echo "fetching scadm"
-$TOOLS_DIR/ensure_buildomat_artifact.sh \
-    -O $OUT_DIR \
-    -s "$SIDECAR_LITE_SERIES" \
-    "scadm" \
-    "$SIDECAR_LITE_REPO" \
-    "$SIDECAR_LITE_COMMIT"
-chmod +x $OUT_DIR/scadm
-
-# Fetch the pre-compiled sidecar_lite p4 program
-echo "fetching libsidecar_lite.so"
-$TOOLS_DIR/ensure_buildomat_artifact.sh \
-    -O $OUT_DIR \
-    -s "$SIDECAR_LITE_SERIES" \
-    "libsidecar_lite.so" \
-    "$SIDECAR_LITE_REPO" \
-    "$SIDECAR_LITE_COMMIT"
+chmod +x $OUT_DIR/npuzone

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -15,7 +15,7 @@ OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="cf26bc25e67f10e5ec836cffae814a3cb1a5b747"
+SOFTNPU_COMMIT="b51dc127dd170186d9013e5e2548436942bdf252"
 
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -15,7 +15,7 @@ OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="ef25703e330ebfd5ee7b9827f8f10b5a98abd802"
+SOFTNPU_COMMIT="64beaff129b7f63a04a53dd5ed0ec09f012f5756"
 
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -15,7 +15,7 @@ OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="b51dc127dd170186d9013e5e2548436942bdf252"
+SOFTNPU_COMMIT="ef25703e330ebfd5ee7b9827f8f10b5a98abd802"
 
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"

--- a/tools/create_gimlet_virtual_hardware.sh
+++ b/tools/create_gimlet_virtual_hardware.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Make me a Gimlet!
+#
+# The entire control plane stack is designed to run and operate on the Oxide
+# rack, on each Gimlet. However, Gimlets are not always available for
+# development. This script can be used to create a few pieces of virtual
+# hardware that _simulate_ a Gimlet, allowing us to develop software that
+# approximates operation on Oxide hardware.
+#
+# This script is specific to gimlet virtual hardware setup. If you only need a
+# gimlet, use create_gimlet_virtual_hardware.sh.
+#
+# See `docs/how-to-run.adoc` section "Set up virtual hardware" for more details.
+
+set -e
+set -u
+set -x
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OMICRON_TOP="$SOURCE_DIR/.."
+
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
+function success {
+    set +x
+    echo -e "\e[1;36m$1\e[0m"
+    set -x
+}
+
+# Create the ZFS zpools required for the sled agent, backed by file-based vdevs.
+function ensure_zpools {
+    # Find the list of zpools the sled agent expects, from its configuration
+    # file.
+    ZPOOL_TYPES=('oxp_' 'oxi_')
+    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
+        readarray -t ZPOOLS < <( \
+                grep "\"$ZPOOL_TYPE" "$OMICRON_TOP/smf/sled-agent/non-gimlet/config.toml" | \
+                sed 's/[ ",]//g' \
+            )
+        for ZPOOL in "${ZPOOLS[@]}"; do
+            echo "Zpool: [$ZPOOL]"
+            VDEV_PATH="$OMICRON_TOP/$ZPOOL.vdev"
+            if ! [[ -f "$VDEV_PATH" ]]; then
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=6G
+            fi
+            success "ZFS vdev $VDEV_PATH exists"
+            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
+                zpool create -f "$ZPOOL" "$VDEV_PATH"
+            fi
+            success "ZFS zpool $ZPOOL exists"
+        done
+    done
+}
+
+function ensure_run_as_root {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "This script must be run as root"
+        exit 1
+    fi
+}
+
+
+ensure_run_as_root
+ensure_zpools

--- a/tools/create_gimlet_virtual_hardware.sh
+++ b/tools/create_gimlet_virtual_hardware.sh
@@ -20,50 +20,13 @@ set -x
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 OMICRON_TOP="$SOURCE_DIR/.."
 
+. "$SOURCE_DIR/virtual_hardware.sh"
+
 MARKER=/etc/opt/oxide/NO_INSTALL
 if [[ -f "$MARKER" ]]; then
     echo "This system has the marker file $MARKER, aborting." >&2
     exit 1
 fi
-
-function success {
-    set +x
-    echo -e "\e[1;36m$1\e[0m"
-    set -x
-}
-
-# Create the ZFS zpools required for the sled agent, backed by file-based vdevs.
-function ensure_zpools {
-    # Find the list of zpools the sled agent expects, from its configuration
-    # file.
-    ZPOOL_TYPES=('oxp_' 'oxi_')
-    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
-        readarray -t ZPOOLS < <( \
-                grep "\"$ZPOOL_TYPE" "$OMICRON_TOP/smf/sled-agent/non-gimlet/config.toml" | \
-                sed 's/[ ",]//g' \
-            )
-        for ZPOOL in "${ZPOOLS[@]}"; do
-            echo "Zpool: [$ZPOOL]"
-            VDEV_PATH="$OMICRON_TOP/$ZPOOL.vdev"
-            if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=6G
-            fi
-            success "ZFS vdev $VDEV_PATH exists"
-            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
-                zpool create -f "$ZPOOL" "$VDEV_PATH"
-            fi
-            success "ZFS zpool $ZPOOL exists"
-        done
-    done
-}
-
-function ensure_run_as_root {
-    if [[ "$(id -u)" -ne 0 ]]; then
-        echo "This script must be run as root"
-        exit 1
-    fi
-}
-
 
 ensure_run_as_root
 ensure_zpools

--- a/tools/create_scrimlet_virtual_hardware.sh
+++ b/tools/create_scrimlet_virtual_hardware.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Make me a Scrimlet!
+#
+# The entire control plane stack is designed to run and operate on the Oxide
+# rack, on each Gimlet. However, Gimlets are not always available for
+# development. This script can be used to create a few pieces of virtual
+# hardware that _simulate_ a Gimlet, allowing us to develop software that
+# approximates operation on Oxide hardware.
+#
+# This script is specific to scrimlet virtual hardware setup. If you only need a
+# gimlet, use create_gimlet_virtual_hardware.sh.
+#
+# See `docs/how-to-run.adoc` section "Set up virtual hardware" for more details.
+
+set -e
+set -u
+set -x
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OMICRON_TOP="$SOURCE_DIR/.."
+
+. "$SOURCE_DIR/virtual_hardware.sh"
+
+TFP0=${TFP0:-igb0}
+TFP1=${TFP1:-igb2}
+TFP2=${TFP2:-cxgbe0}
+TFP3=${TFP3:-cxgbe1}
+
+# Select the physical uplink softnpu will use as an emulated sidecar uplink
+# port.
+PHYSICAL_LINK=${PHYSICAL_LINK:=$(dladm show-phys -p -o LINK | head -1)}
+echo "Using $PHYSICAL_LINK as physical link"
+
+# Create virtual links to represent the Chelsio physical links
+#
+# Arguments:
+#   $1: Optional name of the physical link to use. If not provided, use the
+#   first physical link available on the machine.
+function ensure_uplink_vnic {
+    local PHYSICAL_LINK="$1"
+    if [[ -z "$(get_vnic_name_if_exists "up0")" ]]; then
+        dladm create-vnic -t "up0" -l $PHYSICAL_LINK -m a8:e1:de:01:70:1d
+    fi
+    success "Vnic up0 exists"
+}
+
+function ensure_softnpu_zone {
+    zoneadm list | grep -q sidecar_softnpu || {
+        out/softnpu/npuzone create sidecar \
+            --ports $TFP0,tfportrear0_0 \
+            --ports $TFP1,tfportrear1_0 \
+            --ports $TFP2,tfportrear2_0 \
+            --ports $TFP3,tfportrear3_0 \
+            --ports up0,tfportqsfp0_0
+    }
+    success "softnpu zone exists"
+}
+
+ensure_run_as_root
+ensure_zpools
+ensure_uplink_vnic "$PHYSICAL_LINK"
+ensure_softnpu_zone

--- a/tools/create_scrimlet_virtual_hardware.sh
+++ b/tools/create_scrimlet_virtual_hardware.sh
@@ -47,7 +47,7 @@ function ensure_uplink_vnic {
 
 function ensure_softnpu_zone {
     zoneadm list | grep -q sidecar_softnpu || {
-        out/softnpu/npuzone create sidecar \
+        out/npuzone/npuzone create sidecar \
             --omicron-zone \
             --ports $TFP0,tfportrear0_0 \
             --ports $TFP1,tfportrear1_0 \
@@ -55,6 +55,7 @@ function ensure_softnpu_zone {
             --ports $TFP3,tfportrear3_0 \
             --ports up0,tfportqsfp0_0
     }
+    $SOURCE_DIR/scrimlet/softnpu-init.sh
     success "softnpu zone exists"
 }
 

--- a/tools/create_scrimlet_virtual_hardware.sh
+++ b/tools/create_scrimlet_virtual_hardware.sh
@@ -48,6 +48,7 @@ function ensure_uplink_vnic {
 function ensure_softnpu_zone {
     zoneadm list | grep -q sidecar_softnpu || {
         out/softnpu/npuzone create sidecar \
+            --omicron-zone \
             --ports $TFP0,tfportrear0_0 \
             --ports $TFP1,tfportrear1_0 \
             --ports $TFP2,tfportrear2_0 \

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -51,6 +51,7 @@ function ensure_simulated_links {
 function ensure_softnpu_zone {
     zoneadm list | grep -q sidecar_softnpu || {
         out/npuzone/npuzone create sidecar \
+            --softnpu-branch npuzone-tool \
             --omicron-zone \
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -51,7 +51,6 @@ function ensure_simulated_links {
 function ensure_softnpu_zone {
     zoneadm list | grep -q sidecar_softnpu || {
         out/npuzone/npuzone create sidecar \
-            --softnpu-branch npuzone-tool \
             --omicron-zone \
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -51,6 +51,7 @@ function ensure_simulated_links {
 function ensure_softnpu_zone {
     zoneadm list | grep -q sidecar_softnpu || {
         out/npuzone/npuzone create sidecar \
+            --omicron-zone \
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0
     }

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -17,65 +17,18 @@ set -x
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 OMICRON_TOP="$SOURCE_DIR/.."
 
-MARKER=/etc/opt/oxide/NO_INSTALL
-if [[ -f "$MARKER" ]]; then
-    echo "This system has the marker file $MARKER, aborting." >&2
-    exit 1
-fi
+. "$SOURCE_DIR/virtual_hardware.sh"
 
 # Select the physical link over which to simulate the Chelsio links
 PHYSICAL_LINK=${PHYSICAL_LINK:=$(dladm show-phys -p -o LINK | head -1)}
 echo "Using $PHYSICAL_LINK as physical link"
 
-function success {
-    set +x
-    echo -e "\e[1;36m$1\e[0m"
-    set -x
-}
-
-# Create the ZFS zpools required for the sled agent, backed by file-based vdevs.
-function ensure_zpools {
-    # Find the list of zpools the sled agent expects, from its configuration
-    # file.
-    ZPOOL_TYPES=('oxp_' 'oxi_')
-    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
-        readarray -t ZPOOLS < <( \
-                grep "\"$ZPOOL_TYPE" "$OMICRON_TOP/smf/sled-agent/non-gimlet/config.toml" | \
-                sed 's/[ ",]//g' \
-            )
-        for ZPOOL in "${ZPOOLS[@]}"; do
-            echo "Zpool: [$ZPOOL]"
-            VDEV_PATH="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
-            if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=15G
-            fi
-            success "ZFS vdev $VDEV_PATH exists"
-            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
-                zpool create -f "$ZPOOL" "$VDEV_PATH"
-            fi
-            success "ZFS zpool $ZPOOL exists"
-        done
-    done
-}
-
-# Return the name of a VNIC link if it exists, or the empty string if not.
+# Create virtual links
 #
 # Arguments:
-#   $1: The name of the VNIC to look for
-function get_vnic_name_if_exists {
-    dladm show-vnic -p -o LINK "$1" 2> /dev/null || echo ""
-}
-
-function get_simnet_name_if_exists {
-    dladm show-simnet -p -o LINK "$1" 2> /dev/null || echo ""
-}
-
-# Create virtual links to represent the Chelsio physical links
-#
-# Arguments:
-#   $1: Optional name of the physical link to use. If not provided, use the
+#   $1: Optional name of the physical uplink to use. If not provided, use the
 #   first physical link available on the machine.
-function ensure_simulated_chelsios {
+function ensure_simulated_links {
     local PHYSICAL_LINK="$1"
     INDICES=("0" "1")
     for I in "${INDICES[@]}"; do
@@ -85,13 +38,8 @@ function ensure_simulated_chelsios {
             dladm create-simnet -t "sc${I}_0"
             dladm modify-simnet -t -p "net$I" "sc${I}_0"
             dladm set-linkprop -p mtu=1600 "sc${I}_0" # encap headroom
-
-            # corresponding scrimlet ports
-            dladm create-simnet -t "sr0_$I"
-            dladm create-simnet -t "scr0_$I"
-            dladm modify-simnet -t -p "sr0_$I" "scr0_$I"
         fi
-        success "Simnet net$I/sc${I}_0/sr0_$I/scr0_$I exists"
+        success "Simnet net$I/sc${I}_0 exists"
     done
 
     if [[ -z "$(get_vnic_name_if_exists "sc0_1")" ]]; then
@@ -100,45 +48,17 @@ function ensure_simulated_chelsios {
     success "Vnic sc0_1 exists"
 }
 
-function ensure_run_as_root {
-    if [[ "$(id -u)" -ne 0 ]]; then
-        echo "This script must be run as root"
-        exit 1
-    fi
-}
-
 function ensure_softnpu_zone {
-    zoneadm list | grep -q softnpu || {
-        mkdir -p /softnpu-zone
-        mkdir -p /opt/oxide/softnpu/stuff
-        cp tools/scrimlet/softnpu.toml /opt/oxide/softnpu/stuff/
-        cp tools/scrimlet/softnpu-init.sh /opt/oxide/softnpu/stuff/
-        cp out/softnpu/libsidecar_lite.so /opt/oxide/softnpu/stuff/
-        cp out/softnpu/softnpu /opt/oxide/softnpu/stuff/
-        cp out/softnpu/scadm /opt/oxide/softnpu/stuff/
-
-        zfs create -p -o mountpoint=/softnpu-zone rpool/softnpu-zone
-
-        zonecfg -z softnpu -f tools/scrimlet/softnpu-zone.txt
-        zoneadm -z softnpu install
-        zoneadm -z softnpu boot
+    zoneadm list | grep -q sidecar_softnpu || {
+        out/npuzone/npuzone create sidecar \
+            --ports sc0_0,tfportrear0_0 \
+            --ports sc0_1,tfportqsfp0_0
     }
+    $SOURCE_DIR/scrimlet/softnpu-init.sh
     success "softnpu zone exists"
-}
-
-function enable_softnpu {
-    zlogin softnpu uname -a || {
-        echo "softnpu zone not ready"
-        exit 1
-    }
-    zlogin softnpu pgrep softnpu || {
-        zlogin softnpu 'RUST_LOG=debug /stuff/softnpu /stuff/softnpu.toml &> /softnpu.log &'
-    }
-    success "softnpu started"
 }
 
 ensure_run_as_root
 ensure_zpools
-ensure_simulated_chelsios "$PHYSICAL_LINK"
+ensure_simulated_links "$PHYSICAL_LINK"
 ensure_softnpu_zone
-enable_softnpu

--- a/tools/destroy_gimlet_virtual_hardware.sh
+++ b/tools/destroy_gimlet_virtual_hardware.sh
@@ -14,6 +14,8 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."
 OMICRON_TOP="$PWD"
 
+. "$SOURCE_DIR/virtual_hardware.sh"
+
 MARKER=/etc/opt/oxide/NO_INSTALL
 if [[ -f "$MARKER" ]]; then
     echo "This system has the marker file $MARKER, aborting." >&2
@@ -25,63 +27,8 @@ if [[ "$(id -u)" -ne 0 ]]; then
     exit 1
 fi
 
-function warn {
-    set +x
-    echo -e "\e[1;31m$1\e[0m"
-    set -x
-}
-
-function success {
-    set +x
-    echo -e "\e[1;36m$1\e[0m"
-    set -x
-}
-
-function fail {
-    warn "$1"
-    exit 1
-}
-
-function verify_omicron_uninstalled {
-    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
-        fail "Omicron is still installed, please run \`omicron-package uninstall\`, and then re-run this script"
-}
-
-function unload_xde_driver {
-    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
-    if [[ "$ID" ]]; then
-        modunload -i "$ID" || fail "Failed to unload xde driver"
-    fi
-    success "Verified the xde kernel driver is unloaded"
-}
-
-function try_remove_address {
-    local ADDRESS="$1"
-    if [[ "$(ipadm show-addr -p -o addr "$ADDRESS")" ]]; then
-        ipadm delete-addr "$ADDRESS" || warn "Failed to delete address $ADDRESS"
-    fi
-    success "Verified address $ADDRESS does not exist"
-}
-
 function try_remove_addrs {
     try_remove_address "lo0/underlay"
-}
-
-function try_destroy_zpools {
-    ZPOOL_TYPES=('oxp_' 'oxi_')
-    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
-        readarray -t ZPOOLS < <(zfs list -d 0 -o name | grep "^$ZPOOL_TYPE")
-        for ZPOOL in "${ZPOOLS[@]}"; do
-            VDEV_FILE="$OMICRON_TOP/$ZPOOL.vdev"
-            zfs destroy -r "$ZPOOL" && \
-                    zfs unmount "$ZPOOL" && \
-                    zpool destroy "$ZPOOL" && \
-                    rm -f "$VDEV_FILE" || \
-                    warn "Failed to remove ZFS pool and vdev: $ZPOOL"
-
-            success "Verified ZFS pool and vdev $ZPOOL does not exist"
-        done
-    done
 }
 
 verify_omicron_uninstalled

--- a/tools/destroy_gimlet_virtual_hardware.sh
+++ b/tools/destroy_gimlet_virtual_hardware.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Unmake me a Gimlet!
+#
+# This tool undoes the operations of # `create_gimlet_virtual_hardware.sh`,
+# destroying VNICs and ZFS zpools, to the extent possible. Note that if an
+# operation fails, for example because a VNIC link is busy, a warning is
+# printed. The user is responsible for deleting these entirely.
+
+set -u
+set -x
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SOURCE_DIR}/.."
+OMICRON_TOP="$PWD"
+
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "This must be run as root"
+    exit 1
+fi
+
+function warn {
+    set +x
+    echo -e "\e[1;31m$1\e[0m"
+    set -x
+}
+
+function success {
+    set +x
+    echo -e "\e[1;36m$1\e[0m"
+    set -x
+}
+
+function fail {
+    warn "$1"
+    exit 1
+}
+
+function verify_omicron_uninstalled {
+    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
+        fail "Omicron is still installed, please run \`omicron-package uninstall\`, and then re-run this script"
+}
+
+function unload_xde_driver {
+    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
+    if [[ "$ID" ]]; then
+        modunload -i "$ID" || fail "Failed to unload xde driver"
+    fi
+    success "Verified the xde kernel driver is unloaded"
+}
+
+function try_remove_address {
+    local ADDRESS="$1"
+    if [[ "$(ipadm show-addr -p -o addr "$ADDRESS")" ]]; then
+        ipadm delete-addr "$ADDRESS" || warn "Failed to delete address $ADDRESS"
+    fi
+    success "Verified address $ADDRESS does not exist"
+}
+
+function try_remove_addrs {
+    try_remove_address "lo0/underlay"
+}
+
+function try_destroy_zpools {
+    ZPOOL_TYPES=('oxp_' 'oxi_')
+    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
+        readarray -t ZPOOLS < <(zfs list -d 0 -o name | grep "^$ZPOOL_TYPE")
+        for ZPOOL in "${ZPOOLS[@]}"; do
+            VDEV_FILE="$OMICRON_TOP/$ZPOOL.vdev"
+            zfs destroy -r "$ZPOOL" && \
+                    zfs unmount "$ZPOOL" && \
+                    zpool destroy "$ZPOOL" && \
+                    rm -f "$VDEV_FILE" || \
+                    warn "Failed to remove ZFS pool and vdev: $ZPOOL"
+
+            success "Verified ZFS pool and vdev $ZPOOL does not exist"
+        done
+    done
+}
+
+verify_omicron_uninstalled
+unload_xde_driver
+try_remove_addrs
+try_destroy_zpools

--- a/tools/destroy_scrimlet_virtual_hardware.sh
+++ b/tools/destroy_scrimlet_virtual_hardware.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Unmake me a Scrimlet!
+#
+# This tool undoes the operations of # `create_scrimlet_virtual_hardware.sh`,
+# destroying VNICs and ZFS zpools, to the extent possible. Note that if an
+# operation fails, for example because a VNIC link is busy, a warning is
+# printed. The user is responsible for deleting these entirely.
+
+set -u
+set -x
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SOURCE_DIR}/.."
+OMICRON_TOP="$PWD"
+
+. "$SOURCE_DIR/virtual_hardware.sh"
+
+TFP0=${TFP0:-igb0}
+TFP1=${TFP1:-igb2}
+TFP2=${TFP2:-cxgbe0}
+TFP3=${TFP3:-cxgbe1}
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "This must be run as root"
+    exit 1
+fi
+
+function try_remove_vnics {
+    try_remove_address "lo0/underlay"
+    try_remove_vnic up0
+}
+
+function remove_softnpu_zone {
+    out/softnpu/npuzone destroy sidecar \
+        --ports $TFP0,tfportrear0_0 \
+        --ports $TFP1,tfportrear1_0 \
+        --ports $TFP2,tfportrear2_0 \
+        --ports $TFP3,tfportrear3_0 \
+        --ports up0,tfportqsfp0_0
+}
+
+verify_omicron_uninstalled
+unload_xde_driver
+remove_softnpu_zone
+try_remove_vnics
+try_destroy_zpools

--- a/tools/destroy_scrimlet_virtual_hardware.sh
+++ b/tools/destroy_scrimlet_virtual_hardware.sh
@@ -8,7 +8,6 @@
 # printed. The user is responsible for deleting these entirely.
 
 set -u
-set -x
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."
@@ -32,7 +31,7 @@ function try_remove_vnics {
 }
 
 function remove_softnpu_zone {
-    out/softnpu/npuzone destroy sidecar \
+    out/npuzone/npuzone destroy sidecar \
         --omicron-zone \
         --ports $TFP0,tfportrear0_0 \
         --ports $TFP1,tfportrear1_0 \

--- a/tools/destroy_scrimlet_virtual_hardware.sh
+++ b/tools/destroy_scrimlet_virtual_hardware.sh
@@ -33,6 +33,7 @@ function try_remove_vnics {
 
 function remove_softnpu_zone {
     out/softnpu/npuzone destroy sidecar \
+        --omicron-zone \
         --ports $TFP0,tfportrear0_0 \
         --ports $TFP1,tfportrear1_0 \
         --ports $TFP2,tfportrear2_0 \

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -51,6 +51,7 @@ function try_remove_vnics {
 
 function remove_softnpu_zone {
     out/npuzone/npuzone destroy sidecar \
+        --omicron-zone \
         --ports sc0_0,tfportrear0_0 \
         --ports sc0_1,tfportqsfp0_0
 }

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -14,54 +14,12 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."
 OMICRON_TOP="$PWD"
 
-MARKER=/etc/opt/oxide/NO_INSTALL
-if [[ -f "$MARKER" ]]; then
-    echo "This system has the marker file $MARKER, aborting." >&2
-    exit 1
-fi
+. "$SOURCE_DIR/virtual_hardware.sh"
 
 if [[ "$(id -u)" -ne 0 ]]; then
     echo "This must be run as root"
     exit 1
 fi
-
-function warn {
-    set +x
-    echo -e "\e[1;31m$1\e[0m"
-    set -x
-}
-
-function success {
-    set +x
-    echo -e "\e[1;36m$1\e[0m"
-    set -x
-}
-
-function fail {
-    warn "$1"
-    exit 1
-}
-
-function verify_omicron_uninstalled {
-    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
-        fail "Omicron is still installed, please run \`omicron-package uninstall\`, and then re-run this script"
-}
-
-function unload_xde_driver {
-    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
-    if [[ "$ID" ]]; then
-        modunload -i "$ID" || fail "Failed to unload xde driver"
-    fi
-    success "Verified the xde kernel driver is unloaded"
-}
-
-function try_remove_address {
-    local ADDRESS="$1"
-    if [[ "$(ipadm show-addr -p -o addr "$ADDRESS")" ]]; then
-        ipadm delete-addr "$ADDRESS" || warn "Failed to delete address $ADDRESS"
-    fi
-    success "Verified address $ADDRESS does not exist"
-}
 
 function try_remove_interface {
     local IFACE="$1"
@@ -69,14 +27,6 @@ function try_remove_interface {
         ipadm delete-if "$IFACE" || warn "Failed to delete interface $IFACE"
     fi
     success "Verified IP interface $IFACE does not exist"
-}
-
-function try_remove_vnic {
-    local LINK="$1"
-    if [[ "$(dladm show-vnic -p -o LINK "$LINK")" ]]; then
-        dladm delete-vnic "$LINK" || warn "Failed to delete VNIC link $LINK"
-    fi
-    success "Verified VNIC link $LINK does not exist"
 }
 
 function try_remove_simnet {
@@ -96,36 +46,13 @@ function try_remove_vnics {
         try_remove_interface "net$I"
         try_remove_simnet "net$I"
         try_remove_simnet "sc${I}_0"
-        try_remove_simnet "sr0_$I"
-        try_remove_simnet "scr0_$I"
-    done
-}
-
-function try_destroy_zpools {
-    ZPOOL_TYPES=('oxp_' 'oxi_')
-    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
-        readarray -t ZPOOLS < <(zfs list -d 0 -o name | grep "^$ZPOOL_TYPE")
-        for ZPOOL in "${ZPOOLS[@]}"; do
-            VDEV_FILE="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
-            zfs destroy -r "$ZPOOL" && \
-                    (zfs unmount "$ZPOOL" || true) && \
-                    zpool destroy "$ZPOOL" && \
-                    rm -f "$VDEV_FILE" || \
-                    warn "Failed to remove ZFS pool and vdev: $ZPOOL"
-
-            success "Verified ZFS pool and vdev $ZPOOL does not exist"
-        done
     done
 }
 
 function remove_softnpu_zone {
-    zoneadm -z softnpu halt
-    zoneadm -z softnpu uninstall -F
-    zonecfg -z softnpu delete -F
-
-    rm -rf /opt/oxide/softnpu/stuff
-    zfs destroy rpool/softnpu-zone
-    rm -rf /softnpu-zone
+    out/npuzone/npuzone destroy sidecar \
+        --ports sc0_0,tfportrear0_0 \
+        --ports sc0_1,tfportqsfp0_0
 }
 
 verify_omicron_uninstalled

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -104,7 +104,6 @@ function install_packages {
       'library/postgresql-13'
       'pkg-config'
       'brand/omicron1/tools'
-      'brand/sparse'
       'library/libxmlsec1'
     )
 

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -104,6 +104,7 @@ function install_packages {
       'library/postgresql-13'
       'pkg-config'
       'brand/omicron1/tools'
+      'brand/sparse'
       'library/libxmlsec1'
     )
 

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -8,14 +8,16 @@ set -x
 GATEWAY_IP=${GATEWAY_IP:=$(netstat -rn -f inet | grep default | awk -F ' ' '{print $2}')}
 echo "Using $GATEWAY_IP as gateway ip"
 
-ping $GATEWAY_IP
-sleep 1
-ping $GATEWAY_IP
-sleep 1
-ping $GATEWAY_IP
-sleep 1
-ping $GATEWAY_IP
-sleep 1
+if [[ ! -v GATEWAY_MAC ]]; then
+    ping $GATEWAY_IP
+    sleep 1
+    ping $GATEWAY_IP
+    sleep 1
+    ping $GATEWAY_IP
+    sleep 1
+    ping $GATEWAY_IP
+    sleep 1
+fi
 
 # Gateway mac is determined automatically by inspecting the arp table on the development machine
 # Can be overridden by setting GATEWAY_MAC

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -19,9 +19,15 @@ if [[ ! -v GATEWAY_MAC ]]; then
     sleep 1
 fi
 
-# Gateway mac is determined automatically by inspecting the arp table on the development machine
-# Can be overridden by setting GATEWAY_MAC
-GATEWAY_MAC=${GATEWAY_MAC:=$(arp "$GATEWAY_IP" | awk -F ' ' '{print $4}')}
+# Gateway mac is determined automatically by inspecting the arp table on the
+# development machine. Can be overridden by setting GATEWAY_MAC
+# TODO arp without -a seems broken on illumos
+#   $ arp 192.168.21.1
+#   192.168.21.1 (192.168.21.1) -- no entry
+
+#   $ arp -a | grep 192.168.21.1
+#   e1000g1 192.168.21.1         255.255.255.255          90:ec:77:2e:70:27
+GATEWAY_MAC=${GATEWAY_MAC:=$(arp -a | grep "$GATEWAY_IP" | awk -F ' ' '{print $4}')}
 echo "Using $GATEWAY_MAC as gateway mac"
 
 z_scadm () {

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -27,7 +27,7 @@ fi
 
 #   $ arp -a | grep 192.168.21.1
 #   e1000g1 192.168.21.1         255.255.255.255          90:ec:77:2e:70:27
-GATEWAY_MAC=${GATEWAY_MAC:=$(arp -a | grep "$GATEWAY_IP" | awk -F ' ' '{print $4}')}
+GATEWAY_MAC=${GATEWAY_MAC:=$(arp -a | grep "$GATEWAY_IP" | awk -F ' ' '{print $NF}')}
 echo "Using $GATEWAY_MAC as gateway mac"
 
 z_scadm () {

--- a/tools/virtual_hardware.sh
+++ b/tools/virtual_hardware.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+MARKER=/etc/opt/oxide/NO_INSTALL
+if [[ -f "$MARKER" ]]; then
+    echo "This system has the marker file $MARKER, aborting." >&2
+    exit 1
+fi
+
+function success {
+    set +x
+    echo -e "\e[1;36m$1\e[0m"
+    set -x
+}
+
+function warn {
+    set +x
+    echo -e "\e[1;31m$1\e[0m"
+    set -x
+}
+
+function fail {
+    warn "$1"
+    exit 1
+}
+
+# Create the ZFS zpools required for the sled agent, backed by file-based vdevs.
+function ensure_zpools {
+    # Find the list of zpools the sled agent expects, from its configuration
+    # file.
+    ZPOOL_TYPES=('oxp_' 'oxi_')
+    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
+        readarray -t ZPOOLS < <( \
+                grep "\"$ZPOOL_TYPE" "$OMICRON_TOP/smf/sled-agent/non-gimlet/config.toml" | \
+                sed 's/[ ",]//g' \
+            )
+        for ZPOOL in "${ZPOOLS[@]}"; do
+            echo "Zpool: [$ZPOOL]"
+            VDEV_PATH="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
+            if ! [[ -f "$VDEV_PATH" ]]; then
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=15G
+            fi
+            success "ZFS vdev $VDEV_PATH exists"
+            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
+                zpool create -f "$ZPOOL" "$VDEV_PATH"
+            fi
+            success "ZFS zpool $ZPOOL exists"
+        done
+    done
+}
+
+function try_destroy_zpools {
+    ZPOOL_TYPES=('oxp_' 'oxi_')
+    for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
+        readarray -t ZPOOLS < <(zfs list -d 0 -o name | grep "^$ZPOOL_TYPE")
+        for ZPOOL in "${ZPOOLS[@]}"; do
+            VDEV_FILE="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
+            zfs destroy -r "$ZPOOL" && \
+                    (zfs unmount "$ZPOOL" || true) && \
+                    zpool destroy "$ZPOOL" && \
+                    rm -f "$VDEV_FILE" || \
+                    warn "Failed to remove ZFS pool and vdev: $ZPOOL"
+
+            success "Verified ZFS pool and vdev $ZPOOL does not exist"
+        done
+    done
+}
+
+# Return the name of a VNIC link if it exists, or the empty string if not.
+#
+# Arguments:
+#   $1: The name of the VNIC to look for
+function get_vnic_name_if_exists {
+    dladm show-vnic -p -o LINK "$1" 2> /dev/null || echo ""
+}
+
+function get_simnet_name_if_exists {
+    dladm show-simnet -p -o LINK "$1" 2> /dev/null || echo ""
+}
+
+function ensure_run_as_root {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "This script must be run as root"
+        exit 1
+    fi
+}
+
+function verify_omicron_uninstalled {
+    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
+        fail "Omicron is still installed, please run \`omicron-package uninstall\`, and then re-run this script"
+}
+
+function unload_xde_driver {
+    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
+    if [[ "$ID" ]]; then
+        modunload -i "$ID" || fail "Failed to unload xde driver"
+    fi
+    success "Verified the xde kernel driver is unloaded"
+}
+
+function try_remove_vnic {
+    local LINK="$1"
+    if [[ "$(dladm show-vnic -p -o LINK "$LINK")" ]]; then
+        dladm delete-vnic "$LINK" || warn "Failed to delete VNIC link $LINK"
+    fi
+    success "Verified VNIC link $LINK does not exist"
+}
+
+function try_remove_address {
+    local ADDRESS="$1"
+    if [[ "$(ipadm show-addr -p -o addr "$ADDRESS")" ]]; then
+        ipadm delete-addr "$ADDRESS" || warn "Failed to delete address $ADDRESS"
+    fi
+    success "Verified address $ADDRESS does not exist"
+}

--- a/tools/virtual_hardware.sh
+++ b/tools/virtual_hardware.sh
@@ -37,7 +37,7 @@ function ensure_zpools {
             echo "Zpool: [$ZPOOL]"
             VDEV_PATH="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
             if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=15G
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=20G
             fi
             success "ZFS vdev $VDEV_PATH exists"
             if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -236,6 +236,10 @@ async fn test_installinator_fetch() {
         "--control-plane",
         control_plane_hash.as_str(),
         dest_path.as_str(),
+        "--data-link0",
+        "cxgbe0",
+        "--data-link1",
+        "cxgbe1",
     ])
     .expect("installinator args parsed successfully");
 


### PR DESCRIPTION
The primary changes here are for supporting tfportd and other bits of automation for virtual environments that make multi-node setups more automated. You can now launch an omicron development environment without manual switch configuration.

There are also some general robustness fixes in omicron itself that I came across and attempted to fix.