### PR TITLE
[wicketd] make installinator_progress cancel safe

### DIFF
--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -104,7 +104,7 @@ impl ArtifactGetter for WicketdArtifactServer {
         update_id: Uuid,
         report: installinator_common::EventReport,
     ) -> Result<EventReportStatus, HttpError> {
-        Ok(self.ipr_artifact.report_progress(update_id, report).await)
+        Ok(self.ipr_artifact.report_progress(update_id, report))
     }
 }
 

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1287,7 +1287,9 @@ impl UpdateContext {
     async fn process_installinator_reports<'engine>(
         &self,
         cx: &StepContext,
-        mut ipr_receiver: mpsc::Receiver<EventReport<InstallinatorSpec>>,
+        mut ipr_receiver: mpsc::UnboundedReceiver<
+            EventReport<InstallinatorSpec>,
+        >,
     ) -> anyhow::Result<WriteOutput> {
         let mut write_output = None;
 

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -202,7 +202,7 @@ impl UpdateTracker {
 
             let event_buffer = Arc::new(StdMutex::new(EventBuffer::new(16)));
             let ipr_start_receiver =
-                self.ipr_update_tracker.register(update_id).await;
+                self.ipr_update_tracker.register(update_id);
 
             let update_cx = UpdateContext {
                 update_id,

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1404,7 +1404,8 @@ impl UpdateContext {
         cx: &StepContext,
         mut ipr_start_receiver: IprStartReceiver,
         image_id: HostPhase2RecoveryImageId,
-    ) -> anyhow::Result<mpsc::Receiver<EventReport<InstallinatorSpec>>> {
+    ) -> anyhow::Result<mpsc::UnboundedReceiver<EventReport<InstallinatorSpec>>>
+    {
         const MGS_PROGRESS_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
         // Waiting for the installinator to start is a little strange. It can't

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -220,7 +220,7 @@ async fn test_installinator_fetch() {
     // Create a new update ID and register it. This is required to ensure the
     // installinator reaches completion.
     let update_id = Uuid::new_v4();
-    wicketd_testctx.server.ipr_update_tracker.register(update_id).await;
+    wicketd_testctx.server.ipr_update_tracker.register(update_id);
 
     let update_id_str = update_id.to_string();
     let dest_path = temp_dir.path().join("installinator-out");
@@ -245,7 +245,7 @@ async fn test_installinator_fetch() {
 
     // Check that the update status is marked as closed.
     assert_eq!(
-        wicketd_testctx.server.ipr_update_tracker.update_state(update_id).await,
+        wicketd_testctx.server.ipr_update_tracker.update_state(update_id),
         Some(RunningUpdateState::Closed),
         "update should be marked as closed at the end of the run"
     );


### PR DESCRIPTION
This code currently uses a Tokio mutex and is currently not cancel-safe
(`RunningUpdate` can be invalid across an await point). Make it
cancel-safe by using an unbounded receiver.

This means that we can replace Tokio's mutex with `std::sync::Mutex`, and make these methods synchronous.