### PR TITLE
use deterministic MAC addresses in the test suite

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1905,6 +1905,14 @@ impl MacAddr {
         Self::from_i64(value)
     }
 
+    /// Iterate the MAC addresses in the system address range
+    /// (used as an allocator in contexts where collisions are not expected and
+    /// determinism is useful, like in the test suite)
+    pub fn iter_system() -> impl Iterator<Item = MacAddr> {
+        ((Self::MAX_SYSTEM_RESV + 1)..=Self::MAX_SYSTEM_ADDR)
+            .map(Self::from_i64)
+    }
+
     /// Is this a MAC in the Guest Addresses range
     pub fn is_guest(&self) -> bool {
         let value = self.to_i64();
@@ -3258,6 +3266,22 @@ mod test {
         let _ = MacAddr::from_str("g:g:g:g:g:g").unwrap_err();
         // Too many characters
         let _ = MacAddr::from_str("fff:ff:ff:ff:ff:ff").unwrap_err();
+    }
+
+    #[test]
+    fn test_mac_system_iterator() {
+        use super::MacAddr;
+
+        let mut count = 0;
+        for m in MacAddr::iter_system() {
+            assert!(m.is_system());
+            assert!(m.to_i64() > MacAddr::MAX_SYSTEM_RESV);
+            count += 1;
+        }
+        assert_eq!(
+            count,
+            MacAddr::MAX_SYSTEM_ADDR - MacAddr::MAX_SYSTEM_RESV
+        );
     }
 
     #[test]

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -3278,10 +3278,7 @@ mod test {
             assert!(m.to_i64() > MacAddr::MAX_SYSTEM_RESV);
             count += 1;
         }
-        assert_eq!(
-            count,
-            MacAddr::MAX_SYSTEM_ADDR - MacAddr::MAX_SYSTEM_RESV
-        );
+        assert_eq!(count, MacAddr::MAX_SYSTEM_ADDR - MacAddr::MAX_SYSTEM_RESV);
     }
 
     #[test]

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -913,6 +913,7 @@ mod test {
             .unwrap();
         let ntp2_id = Uuid::new_v4();
         let ntp3_id = Uuid::new_v4();
+        let mut macs = MacAddr::iter_system();
         let services = vec![
             internal_params::ServicePutRequest {
                 service_id: external_dns_id,
@@ -925,7 +926,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "external-dns".parse().unwrap(),
                         ip: external_dns_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -944,7 +945,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "ntp1".parse().unwrap(),
                         ip: ntp1_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -959,7 +960,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "nexus".parse().unwrap(),
                         ip: nexus_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -978,7 +979,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "ntp2".parse().unwrap(),
                         ip: ntp2_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -1159,6 +1160,7 @@ mod test {
         let nexus_pip2 = NEXUS_OPTE_IPV4_SUBNET
             .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES as u32 + 2)
             .unwrap();
+        let mut macs = MacAddr::iter_system();
         let mut services = vec![
             internal_params::ServicePutRequest {
                 service_id: nexus_id1,
@@ -1171,7 +1173,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "nexus1".parse().unwrap(),
                         ip: nexus_pip1.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -1186,7 +1188,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "nexus2".parse().unwrap(),
                         ip: nexus_pip2.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -1356,6 +1358,7 @@ mod test {
             .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES as u32 + 1)
             .unwrap();
         let nexus_id = Uuid::new_v4();
+        let mut macs = MacAddr::iter_system();
         let services = vec![internal_params::ServicePutRequest {
             service_id: nexus_id,
             sled_id: sled.id(),
@@ -1367,7 +1370,7 @@ mod test {
                     id: Uuid::new_v4(),
                     name: "nexus".parse().unwrap(),
                     ip: nexus_pip.into(),
-                    mac: MacAddr::random_system(),
+                    mac: macs.next().unwrap(),
                 },
             },
         }];
@@ -1412,6 +1415,7 @@ mod test {
         let nexus_pip = NEXUS_OPTE_IPV4_SUBNET
             .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES as u32 + 1)
             .unwrap();
+        let mut macs = MacAddr::iter_system();
 
         let services = vec![
             internal_params::ServicePutRequest {
@@ -1425,7 +1429,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "external-dns".parse().unwrap(),
                         ip: external_dns_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },
@@ -1440,7 +1444,7 @@ mod test {
                         id: Uuid::new_v4(),
                         name: "nexus".parse().unwrap(),
                         ip: nexus_pip.into(),
-                        mac: MacAddr::random_system(),
+                        mac: macs.next().unwrap(),
                     },
                 },
             },

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -330,6 +330,7 @@ pub async fn run_standalone_server(
     }];
 
     let mut internal_services_ip_pool_ranges = vec![];
+    let mut macs = MacAddr::iter_system();
     if let Some(nexus_external_addr) = rss_args.nexus_external_addr {
         let ip = nexus_external_addr.ip();
 
@@ -344,7 +345,7 @@ pub async fn run_standalone_server(
                         .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES as u32 + 1)
                         .unwrap()
                         .into(),
-                    mac: MacAddr::random_system(),
+                    mac: macs.next().unwrap(),
                 },
             },
             service_id: Uuid::new_v4(),
@@ -377,7 +378,7 @@ pub async fn run_standalone_server(
                         .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES as u32 + 1)
                         .unwrap()
                         .into(),
-                    mac: MacAddr::random_system(),
+                    mac: macs.next().unwrap(),
                 },
             },
             service_id: Uuid::new_v4(),


### PR DESCRIPTION
Hopefully fixes #3577.  I opted to use a sequential allocator from the same range of MAC addresses because it seemed easier to reuse in a bunch of places and it also makes the tests more deterministic.