### PR TITLE
[sql] Batch together all DB creation/deletion ops, ~17x faster startup

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -22,6 +22,8 @@
  *    sparingly."
  */
 
+BEGIN;
+
 /*
  * We assume the database and user do not already exist so that we don't
  * inadvertently clobber what's there.  If they might exist, the user has to
@@ -2518,3 +2520,5 @@ INSERT INTO omicron.public.db_metadata (
 ) VALUES
     ( 'schema_version', '1.0.0' ),
     ( 'schema_time_created', CAST(NOW() AS STRING) );
+
+COMMIT;

--- a/common/src/sql/dbwipe.sql
+++ b/common/src/sql/dbwipe.sql
@@ -13,6 +13,9 @@
  * This is silly, but we throw an error if the user was already deleted.
  * Create the user so we can always delete it.
  */
+
+BEGIN;
+
 CREATE DATABASE IF NOT EXISTS omicron;
 CREATE USER IF NOT EXISTS omicron;
 
@@ -20,3 +23,5 @@ ALTER DEFAULT PRIVILEGES FOR ROLE root REVOKE ALL ON TABLES FROM omicron;
 
 DROP DATABASE IF EXISTS omicron;
 DROP USER IF EXISTS omicron;
+
+COMMIT;

--- a/dev-tools/src/bin/omicron-dev.rs
+++ b/dev-tools/src/bin/omicron-dev.rs
@@ -154,9 +154,16 @@ async fn cmd_db_run(args: &DbRunArgs) -> Result<(), anyhow::Error> {
 
     if args.populate {
         // Populate the database with our schema.
+        let start = tokio::time::Instant::now();
         println!("omicron-dev: populating database");
         db_instance.populate().await.context("populating database")?;
-        println!("omicron-dev: populated database");
+        let end = tokio::time::Instant::now();
+        let duration = end.duration_since(start);
+        println!(
+            "omicron-dev: populated database in {}.{} seconds",
+            duration.as_secs(),
+            duration.subsec_millis()
+        );
     }
 
     // Wait for either the child process to shut down on its own or for us to


### PR DESCRIPTION
I noticed that our performance for CRDB initialization was getting worse and worse. We create a "seed DB" under test, and we also have multiple tests that try to populate the DB. However, as we add more tables and more indices (because we're writing more software!) this has been getting progressively worse.

As a proxy for this operation, one can simply run `cargo run --bin omicron-dev db-run`, and see how long it takes to go from "populating database" to "populated database".

# Before This PR

```
omicron-dev: populated database in 39.470 seconds
```

With corresponding view of activity -- note the "Transaction time" -- in the console:

![image](https://github.com/oxidecomputer/omicron/assets/3258857/76b42f71-fa28-4388-a4af-b4b1ccd7498f)


# After this PR

```
omicron-dev: populated database in 2.366 seconds
```

![image](https://github.com/oxidecomputer/omicron/assets/3258857/b91e3db7-835b-460c-9d94-cb50efdfa60f)
