### PR TITLE
[wicket] Replace SP inventory debug print with formatted lines

### DIFF
--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -119,6 +119,25 @@ impl Sp {
     pub fn state(&self) -> Option<&SpState> {
         self.state.as_ref()
     }
+
+    pub fn caboose_active(&self) -> Option<&SpComponentCaboose> {
+        self.caboose_active.as_ref()
+    }
+
+    pub fn caboose_inactive(&self) -> Option<&SpComponentCaboose> {
+        self.caboose_inactive.as_ref()
+    }
+
+    pub fn rot(&self) -> Option<&RotInventory> {
+        self.rot.as_ref()
+    }
+
+    pub fn components(&self) -> &[SpComponentInfo] {
+        match self.components.as_ref() {
+            Some(components) => components,
+            None => &[],
+        }
+    }
 }
 
 // XXX: Eventually a Sled will have a host component.

--- a/wicket/src/ui/defaults/style.rs
+++ b/wicket/src/ui/defaults/style.rs
@@ -120,3 +120,19 @@ pub fn bold() -> Style {
 pub fn faded_background() -> Style {
     Style::default().bg(TUI_BLACK).fg(TUI_GREY)
 }
+
+pub fn text_label() -> Style {
+    Style::default().fg(OX_OFF_WHITE)
+}
+
+pub fn text_success() -> Style {
+    Style::default().fg(OX_GREEN_LIGHT)
+}
+
+pub fn text_failure() -> Style {
+    Style::default().fg(OX_RED)
+}
+
+pub fn text_warning() -> Style {
+    Style::default().fg(OX_YELLOW)
+}

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -582,7 +582,7 @@ fn inventory_description(component: &Component) -> Text {
             power_state,
             revision,
             serial_number,
-            // We git the rot its own section below.
+            // We give the rot its own section below.
             rot: _,
         } = state;
         spans.push(label.into());

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -15,6 +15,7 @@ use crate::ui::defaults::style;
 use crate::ui::widgets::IgnitionPopup;
 use crate::ui::widgets::PopupScrollKind;
 use crate::ui::widgets::{BoxConnector, BoxConnectorKind, Rack};
+use crate::ui::wrap::wrap_text;
 use crate::{Action, Cmd, Frame, State};
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::Style;
@@ -241,6 +242,17 @@ impl InventoryView {
         }
     }
 
+    /// Returns the wrap options that should be used in most cases for popups.
+    fn default_wrap_options(width: usize) -> crate::ui::wrap::Options<'static> {
+        crate::ui::wrap::Options {
+            width,
+            // The indent here is to add 1 character of padding.
+            initial_indent: Span::raw(" "),
+            subsequent_indent: Span::raw(" "),
+            break_words: true,
+        }
+    }
+
     pub fn draw_ignition_popup(
         &mut self,
         state: &State,
@@ -346,6 +358,13 @@ impl Control for InventoryView {
             Some(inventory) => inventory_description(inventory),
             None => Text::styled("Inventory Unavailable", inventory_style),
         };
+        let text = wrap_text(
+            &text,
+            // -2 each for borders and padding
+            Self::default_wrap_options(
+                chunks[1].width.saturating_sub(4).into(),
+            ),
+        );
 
         let scroll_offset = self.scroll_offsets.get_mut(&component_id).unwrap();
         let y_offset = ComputedScrollOffset::new(

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -551,35 +551,6 @@ fn inventory_description(component: &Component) -> Text {
     // blank line separator
     spans.push(Spans::default());
 
-    // Helper closure for appending caboose details (used for both SP and RoT
-    // below).
-    let append_caboose =
-        |spans: &mut Vec<Spans>, caboose: &SpComponentCaboose| {
-            spans.push(
-                vec![
-                    nest_bullet(),
-                    Span::styled("Git Commit: ", label_style),
-                    Span::styled(caboose.git_commit.clone(), ok_style),
-                ]
-                .into(),
-            );
-            spans.push(
-                vec![
-                    nest_bullet(),
-                    Span::styled("Board: ", label_style),
-                    Span::styled(caboose.board.clone(), ok_style),
-                ]
-                .into(),
-            );
-            let mut version =
-                vec![nest_bullet(), Span::styled("Version: ", label_style)];
-            if let Some(v) = caboose.version.as_ref() {
-                version.push(Span::styled(v.clone(), ok_style));
-            } else {
-                version.push(Span::styled("Unknown", bad_style));
-            }
-        };
-
     // Describe the SP.
     let mut label = vec![Span::styled("Service Processor: ", label_style)];
     if let Some(state) = sp.state() {
@@ -649,7 +620,7 @@ fn inventory_description(component: &Component) -> Text {
         );
 
         if let Some(caboose) = sp.caboose_active() {
-            append_caboose(&mut spans, caboose);
+            append_caboose(&mut spans, nest_bullet(), caboose);
         } else {
             spans.push(
                 vec![
@@ -664,7 +635,7 @@ fn inventory_description(component: &Component) -> Text {
             vec![bullet(), Span::styled("Inactive Slot:", label_style)].into(),
         );
         if let Some(caboose) = sp.caboose_inactive() {
-            append_caboose(&mut spans, caboose);
+            append_caboose(&mut spans, nest_bullet(), caboose);
         } else {
             spans.push(
                 vec![nest_bullet(), Span::styled("No information", warn_style)]
@@ -767,7 +738,7 @@ fn inventory_description(component: &Component) -> Text {
                 if let Some(caboose) =
                     sp.rot().and_then(|r| r.caboose_a.as_ref())
                 {
-                    append_caboose(&mut spans, caboose);
+                    append_caboose(&mut spans, nest_bullet(), caboose);
                 } else {
                     spans.push(
                         vec![
@@ -796,7 +767,7 @@ fn inventory_description(component: &Component) -> Text {
                 if let Some(caboose) =
                     sp.rot().and_then(|r| r.caboose_b.as_ref())
                 {
-                    append_caboose(&mut spans, caboose);
+                    append_caboose(&mut spans, nest_bullet(), caboose);
                 } else {
                     spans.push(
                         vec![
@@ -868,4 +839,40 @@ fn inventory_description(component: &Component) -> Text {
     }
 
     Text::from(spans)
+}
+
+// Helper function for appending caboose details to a section of the
+// inventory (used for both SP and RoT above).
+fn append_caboose(
+    spans: &mut Vec<Spans>,
+    prefix: Span<'static>,
+    caboose: &SpComponentCaboose,
+) {
+    let label_style = style::text_label();
+    let ok_style = style::text_success();
+    let bad_style = style::text_failure();
+
+    spans.push(
+        vec![
+            prefix.clone(),
+            Span::styled("Git Commit: ", label_style),
+            Span::styled(caboose.git_commit.clone(), ok_style),
+        ]
+        .into(),
+    );
+    spans.push(
+        vec![
+            prefix.clone(),
+            Span::styled("Board: ", label_style),
+            Span::styled(caboose.board.clone(), ok_style),
+        ]
+        .into(),
+    );
+    let mut version =
+        vec![prefix.clone(), Span::styled("Version: ", label_style)];
+    if let Some(v) = caboose.version.as_ref() {
+        version.push(Span::styled(v.clone(), ok_style));
+    } else {
+        version.push(Span::styled("Unknown", bad_style));
+    }
 }

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -10,7 +10,6 @@ use super::ComputedScrollOffset;
 use super::Control;
 use crate::state::Component;
 use crate::state::{ComponentId, ALL_COMPONENT_IDS};
-use crate::ui::defaults::colors;
 use crate::ui::defaults::colors::*;
 use crate::ui::defaults::style;
 use crate::ui::widgets::IgnitionPopup;
@@ -448,10 +447,10 @@ impl Control for InventoryView {
 fn inventory_description(component: &Component) -> Text {
     let sp = component.sp();
 
-    let label_style = Style::default().fg(colors::OX_OFF_WHITE);
-    let ok_style = Style::default().fg(colors::OX_GREEN_LIGHT);
-    let bad_style = Style::default().fg(colors::OX_RED);
-    let warn_style = Style::default().fg(colors::OX_YELLOW);
+    let label_style = style::text_label();
+    let ok_style = style::text_success();
+    let bad_style = style::text_failure();
+    let warn_style = style::text_warning();
     let dyn_style = |ok| if ok { ok_style } else { bad_style };
     let yes_no = |val| if val { "Yes" } else { "No" };
     let bullet = || Span::styled("  • ", label_style);

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -6,7 +6,6 @@ use super::help_text;
 use super::push_text_lines;
 use super::ComputedScrollOffset;
 use crate::keymap::ShowPopupCmd;
-use crate::ui::defaults::colors;
 use crate::ui::defaults::style;
 use crate::ui::widgets::BoxConnector;
 use crate::ui::widgets::BoxConnectorKind;
@@ -23,7 +22,6 @@ use tui::layout::Constraint;
 use tui::layout::Direction;
 use tui::layout::Layout;
 use tui::layout::Rect;
-use tui::style::Style;
 use tui::text::Span;
 use tui::text::Spans;
 use tui::text::Text;
@@ -628,8 +626,8 @@ fn rss_config_text<'a>(
         ok_contents: impl Into<Cow<'a, str>>,
         bad_contents: &'static str,
     ) -> Span<'a> {
-        let ok_style = Style::default().fg(colors::OX_GREEN_LIGHT);
-        let bad_style = Style::default().fg(colors::OX_RED);
+        let ok_style = style::text_success();
+        let bad_style = style::text_failure();
         if ok {
             Span::styled(ok_contents, ok_style)
         } else {
@@ -637,10 +635,10 @@ fn rss_config_text<'a>(
         }
     }
 
-    let label_style = Style::default().fg(colors::OX_OFF_WHITE);
-    let ok_style = Style::default().fg(colors::OX_GREEN_LIGHT);
-    let bad_style = Style::default().fg(colors::OX_RED);
-    let warn_style = Style::default().fg(colors::OX_YELLOW);
+    let label_style = style::text_label();
+    let ok_style = style::text_success();
+    let bad_style = style::text_failure();
+    let warn_style = style::text_warning();
     let dyn_style = |ok| if ok { ok_style } else { bad_style };
 
     let setup_description = match setup_state {

--- a/wicket/src/ui/widgets/rack.rs
+++ b/wicket/src/ui/widgets/rack.rs
@@ -4,7 +4,7 @@
 
 //! A rendering of the Oxide rack
 
-use crate::state::{Component, Inventory};
+use crate::state::Inventory;
 use crate::state::{ComponentId, KnightRiderMode, RackState};
 use std::collections::BTreeMap;
 use tui::buffer::Buffer;
@@ -179,11 +179,7 @@ enum ComponentPresence {
 impl ComponentPresence {
     fn for_component(inventory: &Inventory, component: &ComponentId) -> Self {
         let sp = match inventory.get_inventory(component) {
-            Some(
-                Component::Sled(sp)
-                | Component::Switch(sp)
-                | Component::Psc(sp),
-            ) => sp,
+            Some(component) => component.sp(),
             None => return Self::NotPresent,
         };
 


### PR DESCRIPTION
Replaces our debug print screen:

![inventory-old](https://github.com/oxidecomputer/omicron/assets/1435635/e885e5df-9ef2-46c1-9544-9beb46f93f32)

with formatted output:

![inventory-new](https://github.com/oxidecomputer/omicron/assets/1435635/d332693e-d506-449e-bf4b-7568bda65978)

This will be more tedious to update with future changes to the information available here, and is already a little tedious in places where related data is split across different elements (e.g., the caboose data is separate from the state, and the rot state is contained within the SP state), but is _so much_ easier to read I think it's definitely worth it.