### PR TITLE
Enable VMM reservoir usage on gimlets

### DIFF
--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -23,7 +23,7 @@ data_link = "cxgbe0"
 
 # Percentage of usable physical DRAM to use for the VMM reservoir, which
 # guest memory is pulled from.
-vmm_reservoir_percentage = 0
+vmm_reservoir_percentage = 80
 
 # Swap device size for the system.
 # We pick 256 GiB somewhat arbitrarily, since the device is sparsely allocated.


### PR DESCRIPTION
With #3200, sled-agent is capable of provisioning the VMM reservoir on startup. It's configured as a percentage of DRAM via sled-agent's config.toml.

This PR toggles this value to 80% for gimlets. I haven't gotten to test this as much as I had hoped due to unrelated issues with my dev setup. But per the hypervisor huddle today, we would like to enable this in the dogfood cluster as soon as we can, and we want this for FCS. So we decided to land this as is.

Fixes #3223