### PR TITLE
[RSS] Provision more Crucible Pantries

### DIFF
--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -60,7 +60,7 @@ const CLICKHOUSE_COUNT: usize = 1;
 const MINIMUM_U2_ZPOOL_COUNT: usize = 3;
 // TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove.
 // when Nexus provisions the Pantry.
-const PANTRY_COUNT: usize = 1;
+const PANTRY_COUNT: usize = 3;
 
 /// Describes errors which may occur while generating a plan for services.
 #[derive(Error, Debug)]


### PR DESCRIPTION
More testing needs to be done to validate "are we able to contact these pantries correctly if one goes down".

Part of https://github.com/oxidecomputer/omicron/issues/3609 , need additional validation to confirm we can contact these pantries.