### PR TITLE
time out CI jobs instead of waiting for buildomat timeout

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -60,9 +60,13 @@ ptime -m cargo build --locked --all-targets --verbose
 # We also don't use `--workspace` here because we're not prepared to run tests
 # from end-to-end-tests.
 #
-
+# Hopefully temporary: we've been seeing hangs in these tests lately.  When this
+# happens, buildomat aborts the job after several hours and we're left with
+# little data with which to debug it (buildomat#8).  For now, implement our own
+# timeout that kills the job first.  On explicit failure like this, buildomat
+# will save the files left around.
 banner test
-RUST_BACKTRACE=1 ptime -m cargo test --locked --verbose --no-fail-fast
+RUST_BACKTRACE=1 ptime -m timeout 1h cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way


### PR DESCRIPTION
This is to help debug #3580 and the various test hangs seen lately in the Ubuntu test runner.