### PR TITLE
stop logging private key during RSS init

### DIFF
--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -25,7 +25,7 @@ pub enum BootstrapAddressDiscovery {
 
 // "Shadow" copy of `RackInitializeRequest` that does no validation on its
 // fields.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 struct UnvalidatedRackInitializeRequest {
     rack_subnet: Ipv6Addr,
     bootstrap_discovery: BootstrapAddressDiscovery,
@@ -45,7 +45,7 @@ struct UnvalidatedRackInitializeRequest {
 /// such as CockroachDB placement and initialization.  Without operator
 /// intervention, however, these actions need a way to be automated in our
 /// deployment.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, JsonSchema)]
 #[serde(try_from = "UnvalidatedRackInitializeRequest")]
 pub struct RackInitializeRequest {
     pub rack_subnet: Ipv6Addr,
@@ -80,6 +80,42 @@ pub struct RackInitializeRequest {
 
     /// Initial rack network configuration
     pub rack_network_config: Option<RackNetworkConfig>,
+}
+
+// This custom debug implementation hides the private keys.
+impl std::fmt::Debug for RackInitializeRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // If you find a compiler error here, and you just added a field to this
+        // struct, be sure to add it to the Debug impl below!
+        let RackInitializeRequest {
+            rack_subnet,
+            bootstrap_discovery,
+            ntp_servers,
+            dns_servers,
+            internal_services_ip_pool_ranges,
+            external_dns_ips,
+            external_dns_zone_name,
+            external_certificates: _,
+            recovery_silo,
+            rack_network_config,
+        } = &self;
+
+        f.debug_struct("RackInitializeRequest")
+            .field("rack_subnet", rack_subnet)
+            .field("bootstrap_discovery", bootstrap_discovery)
+            .field("ntp_servers", ntp_servers)
+            .field("dns_servers", dns_servers)
+            .field(
+                "internal_services_ip_pool_ranges",
+                internal_services_ip_pool_ranges,
+            )
+            .field("external_dns_ips", external_dns_ips)
+            .field("external_dns_zone_name", external_dns_zone_name)
+            .field("external_certificates", &"<redacted>")
+            .field("recovery_silo", recovery_silo)
+            .field("rack_network_config", rack_network_config)
+            .finish()
+    }
 }
 
 impl TryFrom<UnvalidatedRackInitializeRequest> for RackInitializeRequest {


### PR DESCRIPTION
@jgallagher noticed that during RSS initialization we print the private TLS key.  This stops doing that.

I looked for other instances in the sled agent and Nexus logs by looking for both `BEGIN` and `45,.*45.,*45` (three hyphens, as ASCII in decimal).  I saw both of these in the`Injecting RSS configuration` log message.  I didn't find any others.  (This wasn't the most exhaustive search.)

We could do better here (e.g., use a type or some other metadata to tell Progenitor that this type should impl a dummy Debug?) but urgency is a factor here.