### PR TITLE
Cap disk allocation via the API at 1 TiB

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -28,6 +28,9 @@ use sled_agent_client::Client as SledAgentClient;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use super::MAX_DISK_SIZE_BYTES;
+use super::MIN_DISK_SIZE_BYTES;
+
 impl super::Nexus {
     // Disks
     pub fn disk_lookup<'a>(
@@ -148,24 +151,35 @@ impl super::Nexus {
 
         // Reject disks where the size isn't at least
         // MIN_DISK_SIZE_BYTES
-        if params.size.to_bytes() < params::MIN_DISK_SIZE_BYTES as u64 {
+        if params.size.to_bytes() < MIN_DISK_SIZE_BYTES as u64 {
             return Err(Error::InvalidValue {
                 label: String::from("size"),
                 message: format!(
                     "total size must be at least {}",
-                    ByteCount::from(params::MIN_DISK_SIZE_BYTES)
+                    ByteCount::from(MIN_DISK_SIZE_BYTES)
                 ),
             });
         }
 
         // Reject disks where the MIN_DISK_SIZE_BYTES doesn't evenly
         // divide the size
-        if (params.size.to_bytes() % params::MIN_DISK_SIZE_BYTES as u64) != 0 {
+        if (params.size.to_bytes() % MIN_DISK_SIZE_BYTES as u64) != 0 {
             return Err(Error::InvalidValue {
                 label: String::from("size"),
                 message: format!(
                     "total size must be a multiple of {}",
-                    ByteCount::from(params::MIN_DISK_SIZE_BYTES)
+                    ByteCount::from(MIN_DISK_SIZE_BYTES)
+                ),
+            });
+        }
+
+        // Reject disks where the size is greated than MAX_DISK_SIZE_BYTES
+        if params.size.to_bytes() > MAX_DISK_SIZE_BYTES {
+            return Err(Error::InvalidValue {
+                label: String::from("size"),
+                message: format!(
+                    "total size must be less than {}",
+                    ByteCount::try_from(MAX_DISK_SIZE_BYTES).unwrap()
                 ),
             });
         }

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -83,6 +83,9 @@ pub const MAX_VCPU_PER_INSTANCE: u16 = 32;
 pub const MIN_MEMORY_BYTES_PER_INSTANCE: u32 = 1 << 30; // 1 GiB
 pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 64 * (1 << 30); // 64 GiB
 
+pub const MIN_DISK_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
+pub const MAX_DISK_SIZE_BYTES: u64 = 1 << 40; // 1 TiB
+
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {
     /// uuid for this nexus instance.

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -26,6 +26,7 @@ use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
 use omicron_common::api::external::Name;
+use omicron_nexus::app::MIN_DISK_SIZE_BYTES;
 use omicron_nexus::authz;
 use omicron_nexus::db;
 use omicron_nexus::db::identity::Resource;
@@ -490,11 +491,9 @@ async fn test_reject_creating_disk_from_snapshot(
                 state: db::model::SnapshotState::Creating,
                 block_size: db::model::BlockSize::AdvancedFormat,
 
-                size: external::ByteCount::try_from(
-                    2 * params::MIN_DISK_SIZE_BYTES,
-                )
-                .unwrap()
-                .into(),
+                size: external::ByteCount::try_from(2 * MIN_DISK_SIZE_BYTES)
+                    .unwrap()
+                    .into(),
             },
         )
         .await
@@ -516,7 +515,7 @@ async fn test_reject_creating_disk_from_snapshot(
                 },
 
                 size: ByteCount::try_from(
-                    2 * params::MIN_DISK_SIZE_BYTES
+                    2 * MIN_DISK_SIZE_BYTES
                         + db::model::BlockSize::Traditional.to_bytes(),
                 )
                 .unwrap(),
@@ -547,7 +546,7 @@ async fn test_reject_creating_disk_from_snapshot(
                     snapshot_id: snapshot.id(),
                 },
 
-                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES).unwrap(),
+                size: ByteCount::try_from(MIN_DISK_SIZE_BYTES).unwrap(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -561,8 +560,8 @@ async fn test_reject_creating_disk_from_snapshot(
         error.message,
         format!(
             "disk size {} must be greater than or equal to snapshot size {}",
-            params::MIN_DISK_SIZE_BYTES,
-            2 * params::MIN_DISK_SIZE_BYTES,
+            MIN_DISK_SIZE_BYTES,
+            2 * MIN_DISK_SIZE_BYTES,
         )
     );
 
@@ -581,7 +580,7 @@ async fn test_reject_creating_disk_from_snapshot(
                 },
 
                 size: ByteCount::try_from(
-                    2 * params::MIN_DISK_SIZE_BYTES
+                    2 * MIN_DISK_SIZE_BYTES
                         + db::model::BlockSize::AdvancedFormat.to_bytes(),
                 )
                 .unwrap(),
@@ -766,7 +765,7 @@ async fn test_reject_creating_disk_from_other_project_snapshot(
                     snapshot_id: snapshot.id(),
                 },
 
-                size: ByteCount::try_from(params::MIN_DISK_SIZE_BYTES).unwrap(),
+                size: ByteCount::try_from(MIN_DISK_SIZE_BYTES).unwrap(),
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1062,8 +1062,6 @@ pub struct RouterRouteUpdate {
 
 // DISKS
 
-pub const MIN_DISK_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
-
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "u32")] // invoke the try_from validation routine below
 pub struct BlockSize(pub u32);


### PR DESCRIPTION
Introduces a 1 TiB limit to disk allocations via the API. As with the instance caps, this is check is only through the entrypoint in the app layer and thus _isn't_ checked deeper in control plane operations like if disks are created by unrelated sagas. 