### PR TITLE
Enable anycast loopback addresseses

### DIFF
--- a/common/src/sql/dbinit.sql
+++ b/common/src/sql/dbinit.sql
@@ -2286,11 +2286,16 @@ CREATE TABLE omicron.public.address_lot_rsvd_block (
     id UUID PRIMARY KEY,
     address_lot_id UUID NOT NULL,
     first_address INET NOT NULL,
-    last_address INET NOT NULL
+    last_address INET NOT NULL,
+    anycast BOOL NOT NULL
 );
 
 CREATE INDEX ON omicron.public.address_lot_rsvd_block (
     address_lot_id
+);
+
+CREATE INDEX on omicron.public.address_lot_rsvd_block (
+    anycast
 );
 
 CREATE TABLE omicron.public.loopback_address (
@@ -2301,7 +2306,8 @@ CREATE TABLE omicron.public.loopback_address (
     rsvd_address_lot_block_id UUID NOT NULL,
     rack_id UUID NOT NULL,
     switch_location TEXT NOT NULL,
-    address INET NOT NULL
+    address INET NOT NULL,
+    anycast BOOL NOT NULL
 );
 
 /* TODO https://github.com/oxidecomputer/omicron/issues/3001 */

--- a/nexus/db-model/src/address_lot.rs
+++ b/nexus/db-model/src/address_lot.rs
@@ -149,4 +149,8 @@ pub struct AddressLotReservedBlock {
 
     /// The last address in the reservation (inclusive).
     pub last_address: IpNetwork,
+
+    /// Address is an anycast address.
+    /// This allows the address to be assigned to multiple locations simultaneously.
+    pub anycast: bool,
 }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -276,6 +276,7 @@ table! {
         address_lot_id -> Uuid,
         first_address -> Inet,
         last_address -> Inet,
+        anycast -> Bool,
     }
 }
 
@@ -289,6 +290,7 @@ table! {
         rack_id -> Uuid,
         switch_location -> Text,
         address -> Inet,
+        anycast -> Bool,
     }
 }
 

--- a/nexus/db-model/src/switch_interface.rs
+++ b/nexus/db-model/src/switch_interface.rs
@@ -106,6 +106,7 @@ pub struct LoopbackAddress {
     pub rack_id: Uuid,
     pub switch_location: String,
     pub address: IpNetwork,
+    pub anycast: bool,
 }
 
 impl LoopbackAddress {
@@ -116,6 +117,7 @@ impl LoopbackAddress {
         rack_id: Uuid,
         switch_location: String,
         address: IpNetwork,
+        anycast: bool,
     ) -> Self {
         Self {
             identity: LoopbackAddressIdentity::new(
@@ -126,6 +128,7 @@ impl LoopbackAddress {
             rack_id,
             switch_location,
             address,
+            anycast,
         }
     }
 }

--- a/nexus/db-queries/src/db/datastore/switch_interface.rs
+++ b/nexus/db-queries/src/db/datastore/switch_interface.rs
@@ -57,6 +57,7 @@ impl DataStore {
                 crate::db::datastore::address_lot::try_reserve_block(
                     lot_id,
                     inet.ip().into(),
+                    params.anycast,
                     &conn,
                 )
                 .await
@@ -78,6 +79,7 @@ impl DataStore {
                 params.rack_id,
                 params.switch_location.to_string(),
                 inet,
+                params.anycast,
             );
 
             let db_addr: LoopbackAddress =

--- a/nexus/db-queries/src/db/datastore/switch_port.rs
+++ b/nexus/db-queries/src/db/datastore/switch_port.rs
@@ -359,6 +359,9 @@ impl DataStore {
                         crate::db::datastore::address_lot::try_reserve_block(
                             address_lot_id,
                             address.address.ip().into(),
+                            // TODO: Should we allow anycast addresses for switch_ports?
+                            // anycast
+                            false,
                             &conn
                         )
                         .await

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -405,6 +405,7 @@ impl super::Nexus {
                     switch_location: switch_location.clone(),
                     address: first_address,
                     mask: 64,
+                    anycast: true,
                 };
 
                 if self

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -174,7 +174,7 @@ impl NexusSaga for SagaInstanceCreate {
 
         // Helper function for appending subsagas to our parent saga.
         fn subsaga_append<S: Serialize>(
-            node_basename: &'static str,
+            node_basename: String,
             subsaga_dag: steno::Dag,
             parent_builder: &mut steno::DagBuilder,
             params: S,
@@ -238,7 +238,7 @@ impl NexusSaga for SagaInstanceCreate {
                 CREATE_NETWORK_INTERFACE.as_ref(),
             ));
             subsaga_append(
-                "network_interface",
+                "network_interface".into(),
                 subsaga_builder.build()?,
                 &mut builder,
                 repeat_params,
@@ -272,7 +272,7 @@ impl NexusSaga for SagaInstanceCreate {
                 CREATE_EXTERNAL_IP.as_ref(),
             ));
             subsaga_append(
-                "external_ip",
+                "external_ip".into(),
                 subsaga_builder.build()?,
                 &mut builder,
                 repeat_params,
@@ -292,7 +292,7 @@ impl NexusSaga for SagaInstanceCreate {
                     create_params: create_disk.clone(),
                 };
                 subsaga_append(
-                    "create_disk",
+                    "create_disk".into(),
                     SagaDiskCreate::make_saga_dag(&params, subsaga_builder)?,
                     &mut builder,
                     params,
@@ -319,7 +319,7 @@ impl NexusSaga for SagaInstanceCreate {
                 attach_params: disk_attach.clone(),
             };
             subsaga_append(
-                "attach_disk",
+                "attach_disk".into(),
                 subsaga_builder.build()?,
                 &mut builder,
                 params,
@@ -335,9 +335,11 @@ impl NexusSaga for SagaInstanceCreate {
                     "instance-configure-nat-{i}-{switch_location}"
                 ));
                 let mut subsaga_builder = DagBuilder::new(subsaga_name);
+
+                let basename = format!("ConfigureAsic-{i}-{switch_location}");
                 subsaga_builder.append(Node::action(
                     "configure_asic",
-                    format!("ConfigureAsic-{i}-{switch_location}").as_str(),
+                    &basename,
                     CONFIGURE_ASIC.as_ref(),
                 ));
                 let net_params = NetworkConfigParams {
@@ -347,7 +349,7 @@ impl NexusSaga for SagaInstanceCreate {
                     switch_location: switch_location.clone(),
                 };
                 subsaga_append(
-                    "configure_asic",
+                    basename,
                     subsaga_builder.build()?,
                     &mut builder,
                     net_params,

--- a/nexus/src/app/sagas/loopback_address_delete.rs
+++ b/nexus/src/app/sagas/loopback_address_delete.rs
@@ -129,6 +129,7 @@ async fn slc_loopback_address_undelete_record(
             .map_err(|e| anyhow!("bad switch location name: {}", e))?,
         address: value.address.ip(),
         mask: value.address.prefix(),
+        anycast: value.anycast,
     };
 
     let address_lot_lookup = nexus

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -37,6 +37,7 @@ use oximeter_collector::Oximeter;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
 use slog::{debug, o, Logger};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::time::Duration;
@@ -83,8 +84,7 @@ pub struct ControlPlaneTestContext<N> {
     pub sled_agent: sim::Server,
     pub oximeter: Oximeter,
     pub producer: ProducerServer,
-    pub dendrite: dev::dendrite::DendriteInstance,
-
+    pub dendrite: HashMap<SwitchLocation, dev::dendrite::DendriteInstance>,
     pub external_dns_zone_name: String,
     pub external_dns: dns_server::TransientServer,
     pub internal_dns: dns_server::TransientServer,
@@ -100,7 +100,9 @@ impl<N: NexusServer> ControlPlaneTestContext<N> {
         self.sled_agent.http_server.close().await.unwrap();
         self.oximeter.close().await.unwrap();
         self.producer.close().await.unwrap();
-        self.dendrite.cleanup().await.unwrap();
+        for (_, mut dendrite) in self.dendrite {
+            dendrite.cleanup().await.unwrap();
+        }
         self.logctx.cleanup_successful();
     }
 }
@@ -229,7 +231,7 @@ pub struct ControlPlaneTestContextBuilder<'a, N: NexusServer> {
     pub sled_agent: Option<sim::Server>,
     pub oximeter: Option<Oximeter>,
     pub producer: Option<ProducerServer>,
-    pub dendrite: Option<dev::dendrite::DendriteInstance>,
+    pub dendrite: HashMap<SwitchLocation, dev::dendrite::DendriteInstance>,
 
     // NOTE: Only exists after starting Nexus, until external Nexus is
     // initialized.
@@ -266,7 +268,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             sled_agent: None,
             oximeter: None,
             producer: None,
-            dendrite: None,
+            dendrite: HashMap::new(),
             nexus_internal: None,
             nexus_internal_addr: None,
             external_dns_zone_name: None,
@@ -341,17 +343,16 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             .set_port(port);
     }
 
-    pub async fn start_dendrite(&mut self) {
+    pub async fn start_dendrite(&mut self, switch_location: SwitchLocation) {
         let log = &self.logctx.log;
-        debug!(log, "Starting Dendrite");
+        debug!(log, "Starting Dendrite for {switch_location}");
 
         // Set up a stub instance of dendrite
         let dendrite = dev::dendrite::DendriteInstance::start(0).await.unwrap();
         let port = dendrite.port;
-        self.dendrite = Some(dendrite);
+        self.dendrite.insert(switch_location.clone(), dendrite);
 
         let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
-        let switch_location = SwitchLocation::Switch0;
 
         // Update the configuration options for Nexus, if it's launched later.
         //
@@ -712,7 +713,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             oximeter: self.oximeter.unwrap(),
             producer: self.producer.unwrap(),
             logctx: self.logctx,
-            dendrite: self.dendrite.unwrap(),
+            dendrite: self.dendrite,
             external_dns_zone_name: self.external_dns_zone_name.unwrap(),
             external_dns: self.external_dns.unwrap(),
             internal_dns: self.internal_dns.unwrap(),
@@ -740,7 +741,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         if let Some(producer) = self.producer {
             producer.close().await.unwrap();
         }
-        if let Some(mut dendrite) = self.dendrite {
+        for (_, mut dendrite) in self.dendrite {
             dendrite.cleanup().await.unwrap();
         }
         self.logctx.cleanup_successful();
@@ -758,7 +759,8 @@ pub async fn test_setup_with_config<N: NexusServer>(
 
     builder.start_crdb().await;
     builder.start_clickhouse().await;
-    builder.start_dendrite().await;
+    builder.start_dendrite(SwitchLocation::Switch0).await;
+    builder.start_dendrite(SwitchLocation::Switch1).await;
     builder.start_internal_dns().await;
     builder.start_external_dns().await;
     builder.start_nexus_internal().await;

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -380,6 +380,7 @@ lazy_static! {
             switch_location: "switch0".parse().unwrap(),
             address: "203.0.113.99".parse().unwrap(),
             mask: 24,
+            anycast: false,
         };
 }
 

--- a/nexus/tests/integration_tests/initialization.rs
+++ b/nexus/tests/integration_tests/initialization.rs
@@ -10,6 +10,7 @@ use gateway_test_utils::setup as mgs_setup;
 use nexus_test_interface::NexusServer;
 use nexus_test_utils::{load_test_config, ControlPlaneTestContextBuilder};
 use omicron_common::address::MGS_PORT;
+use omicron_common::api::internal::shared::SwitchLocation;
 use tokio::time::sleep;
 use tokio::time::timeout;
 use tokio::time::Duration;
@@ -26,7 +27,8 @@ async fn test_nexus_boots_before_cockroach() {
 
     let log = builder.logctx.log.new(o!("component" => "test"));
 
-    builder.start_dendrite().await;
+    builder.start_dendrite(SwitchLocation::Switch0).await;
+    builder.start_dendrite(SwitchLocation::Switch1).await;
     builder.start_internal_dns().await;
     builder.start_external_dns().await;
 
@@ -136,7 +138,8 @@ async fn test_nexus_boots_before_dendrite() {
     //
     // This is necessary for the prior call to "start Nexus" to succeed.
     info!(log, "Starting Dendrite");
-    builder.start_dendrite().await;
+    builder.start_dendrite(SwitchLocation::Switch0).await;
+    builder.start_dendrite(SwitchLocation::Switch1).await;
     info!(log, "Started Dendrite");
 
     info!(log, "Populating internal DNS records");
@@ -158,7 +161,8 @@ async fn nexus_schema_test_setup(
     builder.start_crdb().await;
     builder.start_internal_dns().await;
     builder.start_external_dns().await;
-    builder.start_dendrite().await;
+    builder.start_dendrite(SwitchLocation::Switch0).await;
+    builder.start_dendrite(SwitchLocation::Switch1).await;
     builder.populate_internal_dns().await;
 }
 

--- a/nexus/tests/integration_tests/loopback_address.rs
+++ b/nexus/tests/integration_tests/loopback_address.rs
@@ -76,6 +76,7 @@ async fn test_loopback_address_basic_crud(ctx: &ControlPlaneTestContext) {
         switch_location: "switch0".parse().unwrap(),
         address: "203.0.113.99".parse().unwrap(),
         mask: 24,
+        anycast: false,
     };
     let addr: LoopbackAddress = NexusRequest::objects_post(
         client,
@@ -205,4 +206,184 @@ async fn test_loopback_address_basic_crud(ctx: &ControlPlaneTestContext) {
     .unwrap()
     .parsed_body()
     .unwrap();
+}
+
+#[nexus_test]
+async fn test_anycast_loopback_address_basic_crud(
+    ctx: &ControlPlaneTestContext,
+) {
+    let client = &ctx.external_client;
+
+    // Create a lot
+    let lot_params = AddressLotCreate {
+        identity: IdentityMetadataCreateParams {
+            name: "parkinglot".parse().unwrap(),
+            description: "an address parking lot".into(),
+        },
+        kind: AddressLotKind::Infra,
+        blocks: vec![AddressLotBlockCreate {
+            first_address: "203.0.113.10".parse().unwrap(),
+            last_address: "203.0.113.100".parse().unwrap(),
+        }],
+    };
+
+    NexusRequest::objects_post(
+        client,
+        "/v1/system/networking/address-lot",
+        &lot_params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
+
+    // Verify there are no loopback addresses
+    let addrs = NexusRequest::iter_collection_authn::<LoopbackAddress>(
+        client,
+        "/v1/system/networking/loopback-address",
+        "",
+        None,
+    )
+    .await
+    .expect("Failed to list loopback addresses")
+    .all_items;
+
+    assert_eq!(addrs.len(), 0, "Expected no loopback addresses");
+
+    let racks_url = "/v1/system/hardware/racks";
+    let racks: Vec<Rack> =
+        NexusRequest::iter_collection_authn(client, racks_url, "", None)
+            .await
+            .expect("failed to list racks")
+            .all_items;
+
+    let rack_id = racks[0].identity.id;
+
+    // Create an anycast loopback address
+    let params = LoopbackAddressCreate {
+        address_lot: NameOrId::Name("parkinglot".parse().unwrap()),
+        rack_id,
+        switch_location: "switch0".parse().unwrap(),
+        address: "203.0.113.99".parse().unwrap(),
+        mask: 24,
+        anycast: true,
+    };
+    let addr: LoopbackAddress = NexusRequest::objects_post(
+        client,
+        "/v1/system/networking/loopback-address",
+        &params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+
+    assert_eq!(addr.address.ip(), params.address);
+    assert_eq!(addr.address.prefix(), params.mask);
+    assert_eq!(addr.rack_id, params.rack_id);
+    assert_eq!(addr.switch_location, params.switch_location.to_string());
+
+    // Create a second anycast record for another switch
+    let params = LoopbackAddressCreate {
+        address_lot: NameOrId::Name("parkinglot".parse().unwrap()),
+        rack_id,
+        switch_location: "switch1".parse().unwrap(),
+        address: "203.0.113.99".parse().unwrap(),
+        mask: 24,
+        anycast: true,
+    };
+    let addr: LoopbackAddress = NexusRequest::objects_post(
+        client,
+        "/v1/system/networking/loopback-address",
+        &params,
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+
+    assert_eq!(addr.address.ip(), params.address);
+    assert_eq!(addr.address.prefix(), params.mask);
+    assert_eq!(addr.rack_id, params.rack_id);
+    assert_eq!(addr.switch_location, params.switch_location.to_string());
+
+    // Verify there are two anycast loopback addresses
+    let addrs = NexusRequest::iter_collection_authn::<LoopbackAddress>(
+        client,
+        "/v1/system/networking/loopback-address",
+        "",
+        None,
+    )
+    .await
+    .expect("Failed to list loopback addresses")
+    .all_items;
+
+    assert_eq!(addrs.len(), 2, "Expected 2 loopback addresses");
+    assert_eq!(addrs[0].address.ip(), params.address);
+    assert_eq!(addrs[0].address.prefix(), params.mask);
+
+    // Delete anycast loopback addresses
+    NexusRequest::object_delete(
+        client,
+        &format!(
+            "{}/{}/{}/{}/{}",
+            "/v1/system/networking/loopback-address",
+            rack_id,
+            "switch0",
+            "203.0.113.99",
+            24,
+        ),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
+
+    // Verify there is only one anycast loopback address
+    let addrs = NexusRequest::iter_collection_authn::<LoopbackAddress>(
+        client,
+        "/v1/system/networking/loopback-address",
+        "",
+        None,
+    )
+    .await
+    .expect("Failed to list loopback addresses")
+    .all_items;
+
+    assert_eq!(addrs.len(), 1, "Expected 1 loopback address");
+    assert_eq!(addrs[0].address.ip(), params.address);
+    assert_eq!(addrs[0].address.prefix(), params.mask);
+
+    NexusRequest::object_delete(
+        client,
+        &format!(
+            "{}/{}/{}/{}/{}",
+            "/v1/system/networking/loopback-address",
+            rack_id,
+            "switch1",
+            "203.0.113.99",
+            24,
+        ),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
+
+    // Verify there are no addresses
+    let addrs = NexusRequest::iter_collection_authn::<LoopbackAddress>(
+        client,
+        "/v1/system/networking/loopback-address",
+        "",
+        None,
+    )
+    .await
+    .expect("Failed to list loopback addresses")
+    .all_items;
+
+    assert_eq!(addrs.len(), 0, "Expected no loopback addresses after delete");
 }

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1238,6 +1238,10 @@ pub struct LoopbackAddressCreate {
 
     /// The subnet mask to use for the address.
     pub mask: u8,
+
+    /// Address is an anycast address.
+    /// This allows the address to be assigned to multiple locations simultaneously.
+    pub anycast: bool,
 }
 
 /// Parameters for creating a port settings group.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10444,6 +10444,10 @@
               }
             ]
           },
+          "anycast": {
+            "description": "Address is an anycast address. This allows the address to be assigned to multiple locations simultaneously.",
+            "type": "boolean"
+          },
           "mask": {
             "description": "The subnet mask to use for the address.",
             "type": "integer",
@@ -10467,6 +10471,7 @@
         "required": [
           "address",
           "address_lot",
+          "anycast",
           "mask",
           "rack_id",
           "switch_location"


### PR DESCRIPTION
For our boundary services, we use an anycast ipv6 address. Our existing address allocation and assignment logic did not permit the same address to be assigned multiple times.

* Add an `anycast` column / field for `LoopbackAddress` and reservations
* Update `TestContext` to allow initialization of multiple `Dendrite` instances to simulate multi-switch environments

Another boundary services issue was encountered when launching instances while uplinks are configured on more than one switch. The subsaga nodes would end up generating the same names when generating the subsaga nodes for configuring nat on additional boundary switches.

* Generate a unique name using the index of the NAT entry in combination with the `SwitchLocation`