### PR TITLE
[nexus] Avoid locking when accessing DNS resolver

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -27,7 +27,6 @@ use slog::Logger;
 use std::collections::HashMap;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
 // The implementation of Nexus is large, and split into a number of submodules
@@ -141,7 +140,7 @@ pub struct Nexus {
     // Nexus to not all fail.
     samael_max_issue_delay: std::sync::Mutex<Option<chrono::Duration>>,
 
-    resolver: Arc<Mutex<internal_dns::resolver::Resolver>>,
+    resolver: internal_dns::resolver::Resolver,
 
     /// Mapping of SwitchLocations to their respective Dendrite Clients
     dpd_clients: HashMap<SwitchLocation, Arc<dpd_client::Client>>,
@@ -156,7 +155,7 @@ impl Nexus {
     pub async fn new_with_id(
         rack_id: Uuid,
         log: Logger,
-        resolver: Arc<Mutex<internal_dns::resolver::Resolver>>,
+        resolver: internal_dns::resolver::Resolver,
         pool: db::Pool,
         producer_registry: &ProducerRegistry,
         config: &config::Config,
@@ -204,8 +203,6 @@ impl Nexus {
         if config.pkg.dendrite.is_empty() {
             loop {
                 let result = resolver
-                    .lock()
-                    .await
                     .lookup_all_ipv6(ServiceName::Dendrite)
                     .await
                     .map_err(|e| {
@@ -703,8 +700,7 @@ impl Nexus {
     }
 
     pub async fn resolver(&self) -> internal_dns::resolver::Resolver {
-        let resolver = self.resolver.lock().await;
-        resolver.clone()
+        self.resolver.clone()
     }
 }
 

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -197,7 +197,7 @@ impl ServerContext {
         let nexus = Nexus::new_with_id(
             rack_id,
             log.new(o!("component" => "nexus")),
-            Arc::new(tokio::sync::Mutex::new(resolver)),
+            resolver,
             pool,
             &producer_registry,
             config,


### PR DESCRIPTION
This was wrapped in a lock to allow it to be changed dynamically during tests, but test setup no longer requires this customization.

Remove the lock to undo any unnecessary serialization.