### PR TITLE
[internal-dns] Access DNS servers concurrently

### DIFF
--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -69,7 +69,10 @@ impl Resolver {
                 bind_addr: None,
             });
         }
-        let resolver = TokioAsyncResolver::tokio(rc, ResolverOpts::default())?;
+        let mut opts = ResolverOpts::default();
+        opts.use_hosts_file = false;
+        opts.num_concurrent_reqs = dns_addrs.len();
+        let resolver = TokioAsyncResolver::tokio(rc, opts)?;
 
         Ok(Self { log, resolver })
     }

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -60,6 +60,7 @@ impl Resolver {
         info!(log, "new DNS resolver"; "addresses" => ?dns_addrs);
 
         let mut rc = ResolverConfig::new();
+        let dns_server_count = dns_addrs.len();
         for socket_addr in dns_addrs.into_iter() {
             rc.add_name_server(NameServerConfig {
                 socket_addr,
@@ -71,7 +72,7 @@ impl Resolver {
         }
         let mut opts = ResolverOpts::default();
         opts.use_hosts_file = false;
-        opts.num_concurrent_reqs = dns_addrs.len();
+        opts.num_concurrent_reqs = dns_server_count;
         let resolver = TokioAsyncResolver::tokio(rc, opts)?;
 
         Ok(Self { log, resolver })


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/3620

We should probably consider continuing to tweak these `ResolverOpts` more, but **without** this concurrency, I've been able to consistently reproduce significant timeouts while accessing a mixed set of offline/online DNS servers from Nexus. 

With these setting on my local config, if **any** DNS servers are up, we should be able to resolve the necessary addresses immediately.