### PR TITLE
WIP: Start to integrate bootstore with sled-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,6 +4877,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.2",
  "bincode",
+ "bootstore",
  "bootstrap-agent-client",
  "bytes",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ base64 = "0.21.2"
 bb8 = "0.8.1"
 bcs = "0.1.5"
 bincode = "1.3.3"
+bootstore = { path = "bootstore" }
 bootstrap-agent-client = { path = "bootstrap-agent-client" }
 buf-list = { version = "1.0.3", features = ["tokio1"] }
 bytes = "1.4.0"

--- a/bootstore/src/schemes/v0/mod.rs
+++ b/bootstore/src/schemes/v0/mod.rs
@@ -23,9 +23,10 @@ pub use fsm::{ApiError, ApiOutput, Fsm, State};
 pub use messages::{
     Envelope, Msg, MsgError, Request, RequestType, Response, ResponseType,
 };
-pub use peer::{Node, NodeHandle, NodeRequestError, Status};
+pub use peer::{Config, Node, NodeHandle, NodeRequestError, Status};
 pub use request_manager::{RequestManager, TrackableRequest};
 pub use share_pkg::{create_pkgs, LearnedSharePkg, SharePkg, SharePkgCommon};
+pub use storage::NetworkConfig;
 
 /// The current version of supported messages within the v0 scheme
 ///

--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -26,14 +26,14 @@ use tokio::time::{interval, Instant, MissedTickBehavior};
 
 #[derive(Debug, Clone)]
 pub struct Config {
-    id: Baseboard,
-    addr: SocketAddrV6,
-    time_per_tick: Duration,
-    learn_timeout: Duration,
-    rack_init_timeout: Duration,
-    rack_secret_request_timeout: Duration,
-    fsm_state_ledger_paths: Vec<Utf8PathBuf>,
-    network_config_ledger_paths: Vec<Utf8PathBuf>,
+    pub id: Baseboard,
+    pub addr: SocketAddrV6,
+    pub time_per_tick: Duration,
+    pub learn_timeout: Duration,
+    pub rack_init_timeout: Duration,
+    pub rack_secret_request_timeout: Duration,
+    pub fsm_state_ledger_paths: Vec<Utf8PathBuf>,
+    pub network_config_ledger_paths: Vec<Utf8PathBuf>,
 }
 
 /// An error response from a `NodeApiRequest`
@@ -108,6 +108,7 @@ pub enum NodeApiRequest {
 }
 
 /// A handle for interacting with a `Node` task
+#[derive(Clone)]
 pub struct NodeHandle {
     tx: mpsc::Sender<NodeApiRequest>,
 }
@@ -305,8 +306,9 @@ impl Node {
     pub async fn new(config: Config, log: &Logger) -> (Node, NodeHandle) {
         // We only expect one outstanding request at a time for `Init_` or
         // `LoadRackSecret` requests, We can have one of those requests in
-        // flight while allowing `PeerAddresses` updates.
-        let (tx, rx) = mpsc::channel(3);
+        // flight while allowing `PeerAddresses` updates. We also allow status
+        // requests in parallel. Just leave some room.
+        let (tx, rx) = mpsc::channel(10);
 
         // There are up to 31 sleds sending messages. These are mostly one at a
         // time for each sled, but we leave some extra room.

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bincode.workspace = true
+bootstore.workspace = true
 bootstrap-agent-client.workspace = true
 bytes.workspace = true
 camino.workspace = true

--- a/sled-agent/src/bootstrap/agent/rack_ops.rs
+++ b/sled-agent/src/bootstrap/agent/rack_ops.rs
@@ -331,6 +331,7 @@ async fn rack_initialize(
         request,
         agent.ip,
         agent.storage_resources.clone(),
+        agent.get_bootstore_node_handle(),
     )
     .await
 }

--- a/sled-agent/src/bootstrap/config.rs
+++ b/sled-agent/src/bootstrap/config.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 pub const BOOTSTRAP_AGENT_HTTP_PORT: u16 = 80;
 pub const BOOTSTRAP_AGENT_RACK_INIT_PORT: u16 = 12346;
+pub const BOOTSTORE_PORT: u16 = 12347;
 
 /// Configuration for a bootstrap agent
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/sled-agent/src/bootstrap/early_networking.rs
+++ b/sled-agent/src/bootstrap/early_networking.rs
@@ -1,0 +1,280 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Network setup required to bring up the control plane
+
+use bootstore::schemes::v0 as bootstore;
+use ddm_admin_client::{Client as DdmAdminClient, DdmError};
+use dpd_client::types::Ipv6Entry;
+use dpd_client::types::{
+    LinkCreate, LinkId, LinkSettings, PortId, PortSettings, RouteSettingsV4,
+};
+use dpd_client::Client as DpdClient;
+use dpd_client::Ipv4Cidr;
+use omicron_common::address::{Ipv6Subnet, AZ_PREFIX};
+use omicron_common::address::{DDMD_PORT, DENDRITE_PORT};
+use omicron_common::api::internal::shared::{
+    PortFec, PortSpeed, RackNetworkConfig, SwitchLocation, UplinkConfig,
+};
+use serde::{Deserialize, Serialize};
+use slog::Logger;
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
+use thiserror::Error;
+
+static BOUNDARY_SERVICES_ADDR: &str = "fd00:99::1";
+
+/// Errors that can occur during early network setup
+#[derive(Error, Debug)]
+pub enum EarlyNetworkSetupError {
+    #[error("Bad configuration for setting up rack: {0}")]
+    BadConfig(String),
+
+    #[error("Error contacting ddmd: {0}")]
+    DdmError(#[from] DdmError),
+
+    #[error("Error during request to Dendrite: {0}")]
+    Dendrite(String),
+
+    #[error("Error during DNS lookup: {0}")]
+    DnsResolver(#[from] internal_dns::resolver::ResolveError),
+}
+
+/// Code for configuring the necessary network bits to bring up the control
+/// plane
+pub struct EarlyNetworkSetup {
+    log: Logger,
+}
+
+impl EarlyNetworkSetup {
+    pub fn new(log: &Logger) -> Self {
+        EarlyNetworkSetup { log: log.clone() }
+    }
+
+    // Initialize the rack network and return the boundary switch addresses to
+    // be injected into zone requests
+    pub async fn init_rack_network(
+        &mut self,
+        rack_network_config: &RackNetworkConfig,
+        switch_mgmt_addrs: &HashMap<SwitchLocation, Ipv6Addr>,
+    ) -> Result<HashSet<Ipv6Addr>, EarlyNetworkSetupError> {
+        // Initialize rack network before NTP comes online, otherwise boundary
+        // services will not be available and NTP will fail to sync
+        info!(self.log, "Initializing Rack Network");
+        let dpd_clients = self.initialize_dpd_clients(&switch_mgmt_addrs);
+
+        // set of switches from uplinks, these are our targets for initial NAT configurations
+        let mut boundary_switch_addrs: HashSet<Ipv6Addr> = HashSet::new();
+
+        // configure uplink for each requested uplink in configuration
+        for uplink_config in &rack_network_config.uplinks {
+            // Configure the switch requested by the user
+            // Raise error if requested switch is not found
+            let dpd = dpd_clients
+                .get(&uplink_config.switch)
+                .ok_or_else(|| {
+                    EarlyNetworkSetupError::BadConfig(format!(
+                        "Switch requested by rack network config not found: {:#?}",
+                        uplink_config.switch
+                    ))
+                })?;
+
+            let zone_addr =
+                switch_mgmt_addrs.get(&uplink_config.switch).unwrap();
+
+            // This switch will have an uplink configured, so lets add it to our boundary_switch_addrs
+            boundary_switch_addrs.insert(*zone_addr);
+
+            let (ipv6_entry, dpd_port_settings, port_id) =
+                self.build_uplink_config(uplink_config)?;
+
+            self.wait_for_dendrite(dpd).await;
+
+            info!(self.log, "Configuring boundary services loopback address on switch"; "config" => #?ipv6_entry);
+            dpd.loopback_ipv6_create(&ipv6_entry).await.map_err(|e| {
+                EarlyNetworkSetupError::Dendrite(format!(
+                    "unable to create inital switch loopback address: {e}"
+                ))
+            })?;
+
+            info!(self.log, "Configuring default uplink on switch"; "config" => #?dpd_port_settings);
+            dpd.port_settings_apply(&port_id, &dpd_port_settings)
+                    .await
+                    .map_err(|e| {
+                        EarlyNetworkSetupError::Dendrite(format!("unable to apply initial uplink port configuration: {e}"))
+                    })?;
+
+            info!(self.log, "advertising boundary services loopback address");
+
+            let ddmd_addr = SocketAddrV6::new(*zone_addr, DDMD_PORT, 0, 0);
+            let ddmd_client = DdmAdminClient::new(&self.log, ddmd_addr)?;
+            ddmd_client.advertise_prefix(Ipv6Subnet::new(ipv6_entry.addr));
+        }
+        Ok(boundary_switch_addrs)
+    }
+
+    fn initialize_dpd_clients(
+        &self,
+        switch_mgmt_addrs: &HashMap<SwitchLocation, Ipv6Addr>,
+    ) -> HashMap<SwitchLocation, DpdClient> {
+        switch_mgmt_addrs
+            .iter()
+            .map(|(location, addr)| {
+                (
+                    location.clone(),
+                    DpdClient::new(
+                        &format!("http://[{}]:{}", addr, DENDRITE_PORT),
+                        dpd_client::ClientState {
+                            tag: "rss".to_string(),
+                            log: self.log.new(o!("component" => "DpdClient")),
+                        },
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn build_uplink_config(
+        &self,
+        uplink_config: &UplinkConfig,
+    ) -> Result<(Ipv6Entry, PortSettings, PortId), EarlyNetworkSetupError> {
+        info!(self.log, "Building Uplink Configuration");
+        let ipv6_entry = Ipv6Entry {
+            addr: BOUNDARY_SERVICES_ADDR.parse().map_err(|e| {
+                EarlyNetworkSetupError::BadConfig(format!(
+                "failed to parse `BOUNDARY_SERVICES_ADDR` as `Ipv6Addr`: {e}"
+            ))
+            })?,
+            tag: "rss".into(),
+        };
+        let mut dpd_port_settings = PortSettings {
+            tag: "rss".into(),
+            links: HashMap::new(),
+            v4_routes: HashMap::new(),
+            v6_routes: HashMap::new(),
+        };
+        let link_id = LinkId(0);
+        let addr = IpAddr::V4(uplink_config.uplink_ip);
+        let link_settings = LinkSettings {
+            // TODO Allow user to configure link properties
+            // https://github.com/oxidecomputer/omicron/issues/3061
+            params: LinkCreate {
+                autoneg: false,
+                kr: false,
+                fec: convert_fec(&uplink_config.uplink_port_fec),
+                speed: convert_speed(&uplink_config.uplink_port_speed),
+            },
+            addrs: vec![addr],
+        };
+        dpd_port_settings.links.insert(link_id.to_string(), link_settings);
+        let port_id: PortId = uplink_config
+            .uplink_port
+            .parse()
+            .map_err(|e| EarlyNetworkSetupError::BadConfig(
+            format!("could not use value provided to rack_network_config.uplink_port as PortID: {e}")))?;
+        let nexthop = Some(uplink_config.gateway_ip);
+        dpd_port_settings.v4_routes.insert(
+            Ipv4Cidr { prefix: "0.0.0.0".parse().unwrap(), prefix_len: 0 }
+                .to_string(),
+            RouteSettingsV4 {
+                link_id: link_id.0,
+                vid: uplink_config.uplink_vid,
+                nexthop,
+            },
+        );
+        Ok((ipv6_entry, dpd_port_settings, port_id))
+    }
+
+    async fn wait_for_dendrite(&self, dpd: &DpdClient) {
+        loop {
+            info!(self.log, "Checking dendrite uptime");
+            match dpd.dpd_uptime().await {
+                Ok(uptime) => {
+                    info!(self.log, "Dendrite online"; "uptime" => uptime.to_string());
+                    break;
+                }
+                Err(e) => {
+                    info!(self.log, "Unable to check Dendrite uptime"; "reason" => #?e);
+                }
+            }
+            info!(self.log, "Waiting for dendrite to come online");
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    }
+}
+
+/// Network configuration required to bring up the control plane
+///
+/// The fields in this structure are those from [`RackInitializeRequest`]
+/// necessary for use beyond RSS. This is just for the initial rack configuration
+/// and cold boot purposes. Updates will come from Nexus in the future.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EarlyNetworkConfig {
+    // The version of data. Always `1` when created from RSS.
+    pub generation: u64,
+
+    pub rack_subnet: Ipv6Addr,
+
+    /// The external NTP server addresses.
+    pub ntp_servers: Vec<String>,
+
+    /// A copy of the initial rack network configuration when we are in
+    /// generation `1`.
+    pub rack_network_config: RackNetworkConfig,
+}
+
+impl EarlyNetworkConfig {
+    pub fn az_subnet(&self) -> Ipv6Subnet<AZ_PREFIX> {
+        Ipv6Subnet::<AZ_PREFIX>::new(self.rack_subnet)
+    }
+}
+
+impl From<EarlyNetworkConfig> for bootstore::NetworkConfig {
+    fn from(value: EarlyNetworkConfig) -> Self {
+        // Can this ever actually fail?
+        // We literally just deserialized the same data in RSS
+        let blob = serde_json::to_vec(&value).unwrap();
+
+        // Yes this is duplicated, but that seems fine.
+        let generation = value.generation;
+
+        bootstore::NetworkConfig { generation, blob }
+    }
+}
+
+impl TryFrom<bootstore::NetworkConfig> for EarlyNetworkConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        value: bootstore::NetworkConfig,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(serde_json::from_slice(&value.blob)?)
+    }
+}
+
+// The following two conversion functions translate the speed and fec types used
+// in the internal API to the types used in the dpd-client API.  The conversion
+// is done here, rather than with "impl From" at the definition, to avoid a
+// circular dependency between omicron-common and dpd.
+fn convert_speed(speed: &PortSpeed) -> dpd_client::types::PortSpeed {
+    match speed {
+        PortSpeed::Speed0G => dpd_client::types::PortSpeed::Speed0G,
+        PortSpeed::Speed1G => dpd_client::types::PortSpeed::Speed1G,
+        PortSpeed::Speed10G => dpd_client::types::PortSpeed::Speed10G,
+        PortSpeed::Speed25G => dpd_client::types::PortSpeed::Speed25G,
+        PortSpeed::Speed40G => dpd_client::types::PortSpeed::Speed40G,
+        PortSpeed::Speed50G => dpd_client::types::PortSpeed::Speed50G,
+        PortSpeed::Speed100G => dpd_client::types::PortSpeed::Speed100G,
+        PortSpeed::Speed200G => dpd_client::types::PortSpeed::Speed200G,
+        PortSpeed::Speed400G => dpd_client::types::PortSpeed::Speed400G,
+    }
+}
+
+fn convert_fec(fec: &PortFec) -> dpd_client::types::PortFec {
+    match fec {
+        PortFec::Firecode => dpd_client::types::PortFec::Firecode,
+        PortFec::None => dpd_client::types::PortFec::None,
+        PortFec::Rs => dpd_client::types::PortFec::Rs,
+    }
+}

--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -7,6 +7,7 @@
 pub mod agent;
 pub mod client;
 pub mod config;
+pub mod early_networking;
 mod hardware;
 mod http_entrypoints;
 mod maghemite;

--- a/sled-agent/src/bootstrap/rss_handle.rs
+++ b/sled-agent/src/bootstrap/rss_handle.rs
@@ -11,6 +11,7 @@ use crate::rack_setup::service::RackSetupService;
 use crate::rack_setup::service::SetupServiceError;
 use crate::storage_manager::StorageResources;
 use ::bootstrap_agent_client::Client as BootstrapAgentClient;
+use bootstore::schemes::v0 as bootstore;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use omicron_common::backoff::retry_notify;
@@ -46,6 +47,7 @@ impl RssHandle {
         config: SetupServiceConfig,
         our_bootstrap_address: Ipv6Addr,
         storage_resources: StorageResources,
+        bootstore: bootstore::NodeHandle,
     ) -> Result<(), SetupServiceError> {
         let (tx, rx) = rss_channel(our_bootstrap_address);
 
@@ -54,6 +56,7 @@ impl RssHandle {
             config,
             storage_resources,
             tx,
+            bootstore,
         );
         let log = log.new(o!("component" => "BootstrapAgentRssHandler"));
         rx.await_local_rss_request(&log).await;

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -56,6 +56,9 @@
 
 use super::config::SetupServiceConfig as Config;
 use crate::bootstrap::config::BOOTSTRAP_AGENT_HTTP_PORT;
+use crate::bootstrap::early_networking::{
+    EarlyNetworkConfig, EarlyNetworkSetup, EarlyNetworkSetupError,
+};
 use crate::bootstrap::params::BootstrapAddressDiscovery;
 use crate::bootstrap::params::StartSledAgentRequest;
 use crate::bootstrap::rss_handle::BootstrapAgentHandle;
@@ -71,14 +74,9 @@ use crate::rack_setup::plan::sled::{
     Plan as SledPlan, PlanError as SledPlanError,
 };
 use crate::storage_manager::StorageResources;
+use bootstore::schemes::v0 as bootstore;
 use camino::Utf8PathBuf;
 use ddm_admin_client::{Client as DdmAdminClient, DdmError};
-use dpd_client::types::Ipv6Entry;
-use dpd_client::types::{
-    LinkCreate, LinkId, LinkSettings, PortId, PortSettings, RouteSettingsV4,
-};
-use dpd_client::Client as DpdClient;
-use dpd_client::Ipv4Cidr;
 use gateway_client::Client as MgsClient;
 use internal_dns::resolver::{DnsError, Resolver as DnsResolver};
 use internal_dns::ServiceName;
@@ -86,12 +84,9 @@ use nexus_client::{
     types as NexusTypes, Client as NexusClient, Error as NexusError,
 };
 use omicron_common::address::get_sled_address;
-use omicron_common::address::Ipv6Subnet;
-use omicron_common::address::{DDMD_PORT, DENDRITE_PORT, MGS_PORT};
+use omicron_common::address::MGS_PORT;
 use omicron_common::api::internal::shared::ExternalPortDiscovery;
 use omicron_common::api::internal::shared::SwitchLocation;
-use omicron_common::api::internal::shared::UplinkConfig;
-use omicron_common::api::internal::shared::{PortFec, PortSpeed};
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
 };
@@ -104,11 +99,8 @@ use sled_hardware::underlay::BootstrapInterface;
 use slog::Logger;
 use std::collections::{HashMap, HashSet};
 use std::iter;
-use std::net::IpAddr;
 use std::net::{Ipv6Addr, SocketAddrV6};
 use thiserror::Error;
-
-static BOUNDARY_SERVICES_ADDR: &str = "fd00:99::1";
 
 /// Describes errors which may occur while operating the setup service.
 #[derive(Error, Debug)]
@@ -161,6 +153,14 @@ pub enum SetupServiceError {
 
     #[error("Error during DNS lookup: {0}")]
     DnsResolver(#[from] internal_dns::resolver::ResolveError),
+
+    // We used transparent, because `EarlyNetworkSetupError` contains a subset
+    // of error variants already in this type
+    #[error(transparent)]
+    EarlyNetworkSetup(#[from] EarlyNetworkSetupError),
+
+    #[error("Failed to save early network config to bootstore")]
+    Bootstore(#[from] bootstore::NodeRequestError),
 }
 
 // The workload / information allocated to a single sled.
@@ -180,8 +180,7 @@ impl RackSetupService {
     /// Arguments:
     /// - `log`: The logger.
     /// - `config`: The config file, which is used to setup the rack.
-    /// - `peer_monitor`: The mechanism by which the setup service discovers
-    ///   bootstrap agents on nearby sleds.
+    /// - `storage_resources`: All the disks and zpools managed by this sled
     /// - `local_bootstrap_agent`: Communication channel by which we can send
     ///   commands to our local bootstrap-agent (e.g., to initialize sled
     ///   agents).
@@ -190,11 +189,17 @@ impl RackSetupService {
         config: Config,
         storage_resources: StorageResources,
         local_bootstrap_agent: BootstrapAgentHandle,
+        bootstore: bootstore::NodeHandle,
     ) -> Self {
         let handle = tokio::task::spawn(async move {
             let svc = ServiceInner::new(log.clone());
             if let Err(e) = svc
-                .run(&config, &storage_resources, local_bootstrap_agent)
+                .run(
+                    &config,
+                    &storage_resources,
+                    local_bootstrap_agent,
+                    bootstore,
+                )
                 .await
             {
                 warn!(log, "RSS injection failed: {}", e);
@@ -227,32 +232,6 @@ impl RackSetupService {
     /// Awaits the completion of the RSS service.
     pub async fn join(self) -> Result<(), SetupServiceError> {
         self.handle.await.expect("Rack Setup Service Task panicked")
-    }
-}
-
-// The following two conversion functions translate the speed and fec types used
-// in the internal API to the types used in the dpd-client API.  The conversion
-// is done here, rather than with "impl From" at the definition, to avoid a
-// circular dependency between omicron-common and dpd.
-fn convert_speed(speed: &PortSpeed) -> dpd_client::types::PortSpeed {
-    match speed {
-        PortSpeed::Speed0G => dpd_client::types::PortSpeed::Speed0G,
-        PortSpeed::Speed1G => dpd_client::types::PortSpeed::Speed1G,
-        PortSpeed::Speed10G => dpd_client::types::PortSpeed::Speed10G,
-        PortSpeed::Speed25G => dpd_client::types::PortSpeed::Speed25G,
-        PortSpeed::Speed40G => dpd_client::types::PortSpeed::Speed40G,
-        PortSpeed::Speed50G => dpd_client::types::PortSpeed::Speed50G,
-        PortSpeed::Speed100G => dpd_client::types::PortSpeed::Speed100G,
-        PortSpeed::Speed200G => dpd_client::types::PortSpeed::Speed200G,
-        PortSpeed::Speed400G => dpd_client::types::PortSpeed::Speed400G,
-    }
-}
-
-fn convert_fec(fec: &PortFec) -> dpd_client::types::PortFec {
-    match fec {
-        PortFec::Firecode => dpd_client::types::PortFec::Firecode,
-        PortFec::None => dpd_client::types::PortFec::None,
-        PortFec::Rs => dpd_client::types::PortFec::Rs,
     }
 }
 
@@ -754,6 +733,7 @@ impl ServiceInner {
         config: &Config,
         storage_resources: &StorageResources,
         local_bootstrap_agent: BootstrapAgentHandle,
+        bootstore: bootstore::NodeHandle,
     ) -> Result<(), SetupServiceError> {
         info!(self.log, "Injecting RSS configuration: {:#?}", config);
 
@@ -921,59 +901,22 @@ impl ServiceInner {
         // services will not be available and NTP will fail to sync
         info!(self.log, "Checking for Rack Network Configuration");
         if let Some(rack_network_config) = &config.rack_network_config {
-            info!(self.log, "Initializing Rack Network");
-            let dpd_clients = self.initialize_dpd_clients(&switch_mgmt_addrs);
+            let mut early_networking = EarlyNetworkSetup::new(&self.log);
+            let boundary_switch_addrs = early_networking
+                .init_rack_network(&rack_network_config, &switch_mgmt_addrs)
+                .await?;
 
-            // set of switches from uplinks, these are our targets for initial NAT configurations
-            let mut boundary_switch_addrs: HashSet<Ipv6Addr> = HashSet::new();
+            // Save the relevant network config in the bootstore
+            let early_network_config = EarlyNetworkConfig {
+                generation: 1,
+                rack_subnet: config.rack_subnet,
+                ntp_servers: config.ntp_servers.clone(),
+                rack_network_config: rack_network_config.clone(),
+            };
+            bootstore
+                .update_network_config(early_network_config.into())
+                .await?;
 
-            // configure uplink for each requested uplink in configuration
-            for uplink_config in &rack_network_config.uplinks {
-                // Configure the switch requested by the user
-                // Raise error if requested switch is not found
-                let dpd = dpd_clients
-                .get(&uplink_config.switch)
-                .ok_or_else(|| {
-                    SetupServiceError::BadConfig(format!(
-                        "Switch requested by rack network config not found: {:#?}",
-                        uplink_config.switch
-                    ))
-                })?;
-
-                let zone_addr =
-                    switch_mgmt_addrs.get(&uplink_config.switch).unwrap();
-
-                // This switch will have an uplink configured, so lets add it to our boundary_switch_addrs
-                boundary_switch_addrs.insert(*zone_addr);
-
-                let (ipv6_entry, dpd_port_settings, port_id) =
-                    self.build_uplink_config(uplink_config)?;
-
-                self.wait_for_dendrite(dpd).await;
-
-                info!(self.log, "Configuring boundary services loopback address on switch"; "config" => #?ipv6_entry);
-                dpd.loopback_ipv6_create(&ipv6_entry).await.map_err(|e| {
-                    SetupServiceError::Dendrite(format!(
-                        "unable to create inital switch loopback address: {e}"
-                    ))
-                })?;
-
-                info!(self.log, "Configuring default uplink on switch"; "config" => #?dpd_port_settings);
-                dpd.port_settings_apply(&port_id, &dpd_port_settings)
-                    .await
-                    .map_err(|e| {
-                        SetupServiceError::Dendrite(format!("unable to apply initial uplink port configuration: {e}"))
-                    })?;
-
-                info!(
-                    self.log,
-                    "advertising boundary services loopback address"
-                );
-
-                let ddmd_addr = SocketAddrV6::new(*zone_addr, DDMD_PORT, 0, 0);
-                let ddmd_client = DdmAdminClient::new(&self.log, ddmd_addr)?;
-                ddmd_client.advertise_prefix(Ipv6Subnet::new(ipv6_entry.addr));
-            }
             // Inject boundary_switch_addrs into ServiceZoneRequests
             // When the opte interface is created for the service,
             // nat entries will be created using the switches present here
@@ -1066,27 +1009,6 @@ impl ServiceInner {
         Ok(())
     }
 
-    fn initialize_dpd_clients(
-        &self,
-        switch_mgmt_addrs: &HashMap<SwitchLocation, Ipv6Addr>,
-    ) -> HashMap<SwitchLocation, DpdClient> {
-        switch_mgmt_addrs
-            .iter()
-            .map(|(location, addr)| {
-                (
-                    location.clone(),
-                    DpdClient::new(
-                        &format!("http://[{}]:{}", addr, DENDRITE_PORT),
-                        dpd_client::ClientState {
-                            tag: "rss".to_string(),
-                            log: self.log.new(o!("component" => "DpdClient")),
-                        },
-                    ),
-                )
-            })
-            .collect()
-    }
-
     // TODO: #3601 Audit switch location discovery logic for robustness in multi-rack deployments.
     // Query MGS servers in each switch zone to determine which switch slot they are managing.
     // This logic does not handle an event where there are multiple racks. Is that ok?
@@ -1140,73 +1062,5 @@ impl ServiceInner {
             };
         }
         switch_zone_addrs
-    }
-
-    fn build_uplink_config(
-        &self,
-        uplink_config: &UplinkConfig,
-    ) -> Result<(Ipv6Entry, PortSettings, PortId), SetupServiceError> {
-        info!(self.log, "Building Uplink Configuration");
-        let ipv6_entry = Ipv6Entry {
-            addr: BOUNDARY_SERVICES_ADDR.parse().map_err(|e| {
-                SetupServiceError::BadConfig(format!(
-                "failed to parse `BOUNDARY_SERVICES_ADDR` as `Ipv6Addr`: {e}"
-            ))
-            })?,
-            tag: "rss".into(),
-        };
-        let mut dpd_port_settings = PortSettings {
-            tag: "rss".into(),
-            links: HashMap::new(),
-            v4_routes: HashMap::new(),
-            v6_routes: HashMap::new(),
-        };
-        let link_id = LinkId(0);
-        let addr = IpAddr::V4(uplink_config.uplink_ip);
-        let link_settings = LinkSettings {
-            // TODO Allow user to configure link properties
-            // https://github.com/oxidecomputer/omicron/issues/3061
-            params: LinkCreate {
-                autoneg: false,
-                kr: false,
-                fec: convert_fec(&uplink_config.uplink_port_fec),
-                speed: convert_speed(&uplink_config.uplink_port_speed),
-            },
-            addrs: vec![addr],
-        };
-        dpd_port_settings.links.insert(link_id.to_string(), link_settings);
-        let port_id: PortId = uplink_config
-            .uplink_port
-            .parse()
-            .map_err(|e| SetupServiceError::BadConfig(
-            format!("could not use value provided to rack_network_config.uplink_port as PortID: {e}")))?;
-        let nexthop = Some(uplink_config.gateway_ip);
-        dpd_port_settings.v4_routes.insert(
-            Ipv4Cidr { prefix: "0.0.0.0".parse().unwrap(), prefix_len: 0 }
-                .to_string(),
-            RouteSettingsV4 {
-                link_id: link_id.0,
-                vid: uplink_config.uplink_vid,
-                nexthop,
-            },
-        );
-        Ok((ipv6_entry, dpd_port_settings, port_id))
-    }
-
-    async fn wait_for_dendrite(&self, dpd: &DpdClient) {
-        loop {
-            info!(self.log, "Checking dendrite uptime");
-            match dpd.dpd_uptime().await {
-                Ok(uptime) => {
-                    info!(self.log, "Dendrite online"; "uptime" => uptime.to_string());
-                    break;
-                }
-                Err(e) => {
-                    info!(self.log, "Unable to check Dendrite uptime"; "reason" => #?e);
-                }
-            }
-            info!(self.log, "Waiting for dendrite to come online");
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        }
     }
 }


### PR DESCRIPTION
This is the first part whose goal is saving early network config to the bootstore during RSS so that it can be used during cold boot to restore enough connectivity to bring up the control plane.