### PR TITLE
ci/deploy: fix?

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -5,9 +5,9 @@
 #: target = "lab-2.0-opte-0.23"
 #: output_rules = [
 #:  "%/var/svc/log/oxide-sled-agent:default.log",
-#:  "%/zone/oxz_*/root/var/svc/log/oxide-*.log",
-#:  "%/zone/oxz_*/root/var/svc/log/system-illumos-*.log",
-#:  "!/zone/oxz_propolis-server_*/root/var/svc/log/*.log"
+#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log",
+#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log",
+#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log"
 #: ]
 #: skip_clone = true
 #:

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -47,7 +47,7 @@ function ensure_zpools {
             echo "Zpool: [$ZPOOL]"
             VDEV_PATH="$OMICRON_TOP/$ZPOOL.vdev"
             if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=6G
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=10G
             fi
             success "ZFS vdev $VDEV_PATH exists"
             if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -47,7 +47,11 @@ function ensure_zpools {
             echo "Zpool: [$ZPOOL]"
             VDEV_PATH="$OMICRON_TOP/$ZPOOL.vdev"
             if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=10G
+                if [[ $ZPOOL == oxp_* ]]; then
+                    dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=8G
+                else
+                    dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=6G
+                fi
             fi
             success "ZFS vdev $VDEV_PATH exists"
             if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then


### PR DESCRIPTION
1. Moving the zones onto the U.2 devices (#3557), real or synthetic, results in the paths of all the zones changing, which results in the paths of all their logs changing. Updated the deploy.sh job to look in the new spot for logs, so that we can find:
2. The end-to-end test is failing[^1] because Nexus is returning a 500 on disk creation, because [Nexus cannot contact the Crucible downstairs](https://buildomat.eng.oxide.computer/wg/0/artefact/01H5ED4P9ZPW22RMY4BEDV0X6Q/VZmMOazlZARWMoMr6qgqt59i4NHEwei5lZ4Ds8d5TJLKdbd2/01H5ED53S5T9XSX4PXS7K6GZ1S/01H5EGRG8XW9GWBQ6ZQXP93WPD/oxide-nexus:default.log?format=x-bunyan#L3759), because [the Crucible agent is repeatedly panicking because it cannot create a dataset, because the zpool is out of space](https://buildomat.eng.oxide.computer/wg/0/artefact/01H5ED4P9ZPW22RMY4BEDV0X6Q/VZmMOazlZARWMoMr6qgqt59i4NHEwei5lZ4Ds8d5TJLKdbd2/01H5ED53S5T9XSX4PXS7K6GZ1S/01H5EGRF4V6N2XS8TXN2B6CK15/oxide-crucible-agent:default.log?format=x-bunyan#L93). We attempt to rectify the issue by increasing the size of the synthetic drives in create_virtual_hardware.sh.
3. It is possible that we are hitting this limit for the first time because Crucible as of #3646 reserves more space.

(We should also switch the deploy job to using real disks, instead of tmpfs, for these datasets. But that will not be part of this PR.)

[^1]: Not always; some commits are evidently lucky.