### PR TITLE
Add support for attaching disk by id during instance creation

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -125,9 +125,23 @@ impl super::Nexus {
             )));
         }
         for disk in &params.disks {
-            if let params::InstanceDiskAttachment::Create(create) = disk {
-                self.validate_disk_create_params(opctx, &authz_project, create)
+            match disk {
+                params::InstanceDiskAttachment::Create(params) => {
+                    self.validate_disk_create_params(
+                        opctx,
+                        &authz_project,
+                        params,
+                    )
                     .await?;
+                }
+                params::InstanceDiskAttachment::Attach(params) => {
+                    self.validate_disk_attach_params(
+                        opctx,
+                        &authz_project,
+                        params,
+                    )
+                    .await?;
+                }
             }
         }
         if params.ncpus.0 > MAX_VCPU_PER_INSTANCE {

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -359,6 +359,7 @@ mod test {
     use nexus_test_utils::resource_helpers::DiskTest;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::identity::Resource;
+    use omicron_common::api::external::Name;
     use omicron_common::api::external::{
         ByteCount, IdentityMetadataCreateParams, InstanceCpuCount,
     };
@@ -419,7 +420,9 @@ mod test {
                 pool_name: None,
             }],
             disks: vec![params::InstanceDiskAttachment::Attach(
-                params::InstanceDiskAttach { name: DISK_NAME.parse().unwrap() },
+                params::InstanceDiskAttach {
+                    disk: DISK_NAME.parse::<Name>().unwrap().into(),
+                },
             )],
             start: false,
         }

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -2251,7 +2251,7 @@ mod test {
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::None,
                 disks: vec![params::InstanceDiskAttachment::Attach(
-                    params::InstanceDiskAttach { name: Name::from_str(DISK_NAME).unwrap() },
+                    params::InstanceDiskAttach { disk: DISK_NAME.parse::<Name>().unwrap().into() },
                 )],
                 external_ips: vec![],
                 start: true,

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -1505,7 +1505,9 @@ async fn create_instance_with_disk(client: &ClientTestContext) {
         INSTANCE_NAME,
         &params::InstanceNetworkInterfaceAttachment::Default,
         vec![params::InstanceDiskAttachment::Attach(
-            params::InstanceDiskAttach { name: DISK_NAME.parse().unwrap() },
+            params::InstanceDiskAttach {
+                disk: DISK_NAME.parse::<Name>().unwrap().into(),
+            },
         )],
         Vec::<params::ExternalIpCreate>::new(),
     )

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -2179,7 +2179,7 @@ async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
         external_ips: vec![],
         disks: vec![params::InstanceDiskAttachment::Attach(
             params::InstanceDiskAttach {
-                name: Name::try_from(String::from("probablydata")).unwrap(),
+                disk: "probablydata".parse::<Name>().unwrap().into(),
             },
         )],
         start: true,
@@ -2251,7 +2251,7 @@ async fn test_instance_create_attach_disks(
             }),
             params::InstanceDiskAttachment::Attach(
                 params::InstanceDiskAttach {
-                    name: attachable_disk.identity.name,
+                    disk: attachable_disk.identity.name.into(),
                 },
             ),
         ],
@@ -2344,10 +2344,14 @@ async fn test_instance_create_attach_disks_undo(
                 },
             }),
             params::InstanceDiskAttachment::Attach(
-                params::InstanceDiskAttach { name: regular_disk.identity.name },
+                params::InstanceDiskAttach {
+                    disk: regular_disk.identity.name.into(),
+                },
             ),
             params::InstanceDiskAttachment::Attach(
-                params::InstanceDiskAttach { name: faulted_disk.identity.name },
+                params::InstanceDiskAttach {
+                    disk: faulted_disk.identity.name.into(),
+                },
             ),
         ],
         start: true,
@@ -2420,8 +2424,10 @@ async fn test_attach_eight_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(format!("probablydata{}", i))
-                            .unwrap(),
+                        disk: format!("probablydata{}", i)
+                            .parse::<Name>()
+                            .unwrap()
+                            .into(),
                     },
                 )
             })
@@ -2500,8 +2506,10 @@ async fn test_cannot_attach_nine_disks_to_instance(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(format!("probablydata{}", i))
-                            .unwrap(),
+                        disk: format!("probablydata{}", i)
+                            .parse::<Name>()
+                            .unwrap()
+                            .into(),
                     },
                 )
             })
@@ -2594,8 +2602,10 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(format!("probablydata{}", i))
-                            .unwrap(),
+                        disk: format!("probablydata{}", i)
+                            .parse::<Name>()
+                            .unwrap()
+                            .into(),
                     },
                 )
             })
@@ -2677,8 +2687,10 @@ async fn test_disks_detached_when_instance_destroyed(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(format!("probablydata{}", i))
-                            .unwrap(),
+                        disk: format!("probablydata{}", i)
+                            .parse::<Name>()
+                            .unwrap()
+                            .into(),
                     },
                 )
             })
@@ -2761,8 +2773,10 @@ async fn test_disks_detached_when_instance_destroyed(
             .map(|i| {
                 params::InstanceDiskAttachment::Attach(
                     params::InstanceDiskAttach {
-                        name: Name::try_from(format!("probablydata{}", i))
-                            .unwrap(),
+                        disk: format!("probablydata{}", i)
+                            .parse::<Name>()
+                            .unwrap()
+                            .into(),
                     },
                 )
             })

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -143,7 +143,9 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::None,
             disks: vec![params::InstanceDiskAttachment::Attach(
-                params::InstanceDiskAttach { name: base_disk_name.clone() },
+                params::InstanceDiskAttach {
+                    disk: base_disk_name.clone().into(),
+                },
             )],
             external_ips: vec![],
             start: true,

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -795,8 +795,8 @@ pub enum InstanceDiskAttachment {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceDiskAttach {
-    /// A disk name to attach
-    pub name: Name,
+    /// A disk to attach
+    pub disk: NameOrId,
 }
 
 /// Parameters for creating an external IP address for instances.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9717,11 +9717,11 @@
             "description": "During instance creation, attach this disk",
             "type": "object",
             "properties": {
-              "name": {
-                "description": "A disk name to attach",
+              "disk": {
+                "description": "A disk to attach",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/Name"
+                    "$ref": "#/components/schemas/NameOrId"
                   }
                 ]
               },
@@ -9733,7 +9733,7 @@
               }
             },
             "required": [
-              "name",
+              "disk",
               "type"
             ]
           }


### PR DESCRIPTION
As I was reading through https://github.com/oxidecomputer/console/issues/1662 I realized that we couldn't attach a disk by ID from the instance creation payload. I've started the machinations required to be able to do that. Still need to add some integration tests. 

Note that this is a breaking change to the API. 