### PR TITLE
Improve "services PUT" API: Execute in parallel and allow zone teardown

### DIFF
--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -625,7 +625,10 @@ impl SledAgent {
                 .await?;
         }
 
-        self.inner.services.ensure_all_services(requested_services).await?;
+        self.inner
+            .services
+            .ensure_all_services_persistent(requested_services)
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
This should reduce the execution time of both RSS and sled boot a fair bit.

Comparing the moment of "omicron-package install" to "Nexus Handoff Complete", indicating that RSS has fully executed, on a 24 core, 64 GiB workstation running Helios:

Without this change: 9m8.171s
With this change: 3m58.622s 

## Before this PR

- The `/services` PUT API was purely additive. Removing anything from the set of zones to-be-run was unsupported
- Zone initialization was performed serially.

## With this PR

- The `/services` PUT API can now both add and remove zones.
- Zone initialization is concurrent, within a `try_for_each_concurrent` invocation.

Fixes https://github.com/oxidecomputer/omicron/issues/726