### PR TITLE
[wicket] use key chords rather than Ctrl-Alt shortcuts

### DIFF
--- a/wicket/src/keymap.rs
+++ b/wicket/src/keymap.rs
@@ -154,6 +154,7 @@ pub enum ShowPopupCmd {
 #[allow(non_camel_case_types)]
 enum MultiKeySeqStart {
     g,
+    CtrlR,
 }
 
 /// A Key Handler maintains any state that is needed across key presses,
@@ -185,6 +186,33 @@ impl KeyHandler {
                     }
                     _ => (),
                 },
+                MultiKeySeqStart::CtrlR => match event.code {
+                    KeyCode::Char('a')
+                        if event.modifiers == KeyModifiers::CONTROL =>
+                    {
+                        self.seq = None;
+                        return Some(Cmd::AbortUpdate);
+                    }
+                    KeyCode::Char('r')
+                        if event.modifiers == KeyModifiers::CONTROL =>
+                    {
+                        self.seq = None;
+                        return Some(Cmd::ResetState);
+                    }
+                    KeyCode::Char('s')
+                        if event.modifiers == KeyModifiers::CONTROL =>
+                    {
+                        self.seq = None;
+                        return Some(Cmd::DumpSnapshot);
+                    }
+                    KeyCode::Char('t')
+                        if event.modifiers == KeyModifiers::CONTROL =>
+                    {
+                        self.seq = None;
+                        return Some(Cmd::KnightRiderMode);
+                    }
+                    _ => (),
+                },
             }
         }
 
@@ -208,43 +236,16 @@ impl KeyHandler {
             KeyCode::Char('u') if event.modifiers == KeyModifiers::CONTROL => {
                 Cmd::StartUpdate
             }
-            // The CONTROL+ALT shortcuts are a bit harder to define because some
-            // terminals interpret them as well. However, as a heuristic we can
-            // rely on the fact that common Emacs shortcuts with the same
-            // modifiers (C-M-<char>) will not be interpreted by the terminal.
-            //
-            // C-M-a is "move to next function".
-            KeyCode::Char('a')
-                if event.modifiers
-                    == KeyModifiers::CONTROL | KeyModifiers::ALT =>
-            {
-                Cmd::AbortUpdate
+            KeyCode::Char('r') if event.modifiers == KeyModifiers::CONTROL => {
+                self.seq = Some(MultiKeySeqStart::CtrlR);
+                return None;
             }
-            // C-M-r is "reverse regular expression search".
-            KeyCode::Char('r')
-                if event.modifiers
-                    == KeyModifiers::CONTROL | KeyModifiers::ALT =>
-            {
-                Cmd::ResetState
-            }
-            // C-M-k is "kill sexp forward". (This was previously C-M-s, which
-            // is "regular expression search", but that is bound to other
-            // commands by default in both KDE Konsole and urxvt.)
-            KeyCode::Char('k')
-                if event.modifiers
-                    == KeyModifiers::CONTROL | KeyModifiers::ALT =>
-            {
+            KeyCode::Char('k') if event.modifiers == KeyModifiers::CONTROL => {
                 Cmd::StartRackSetup
             }
             KeyCode::Char('n') => Cmd::No,
-            KeyCode::Char('k') if event.modifiers == KeyModifiers::CONTROL => {
-                Cmd::KnightRiderMode
-            }
             KeyCode::Tab => Cmd::NextPane,
             KeyCode::BackTab => Cmd::PrevPane,
-            KeyCode::Char('r') if event.modifiers == KeyModifiers::CONTROL => {
-                Cmd::DumpSnapshot
-            }
 
             // Vim navigation
             KeyCode::Char('k') => Cmd::Up,

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -120,12 +120,12 @@ impl Default for RackSetupPane {
             rack_uninitialized_help: vec![
                 ("Scroll", "<UP/DOWN>"),
                 ("Current Status Details", "<D>"),
-                ("Start Rack Setup", "<Ctrl-Alt-K>"),
+                ("Start Rack Setup", "<Ctrl-K>"),
             ],
             rack_initialized_help: vec![
                 ("Scroll", "<UP/DOWN>"),
                 ("Current Status Details", "<D>"),
-                ("Start Rack Reset", "<Ctrl-Alt-R>"),
+                ("Start Rack Reset", "<Ctrl-R Ctrl-R>"),
             ],
             scroll_offset: 0,
             popup: None,

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -183,8 +183,8 @@ impl UpdatePane {
                 ("Update", "<Enter>"),
             ],
             not_started_help: vec![("Start", "<Ctrl-U>")],
-            running_help: vec![("Abort", "<Ctrl-Alt-A>")],
-            completed_help: vec![("Clear", "<Ctrl-Alt-R>")],
+            running_help: vec![("Abort", "<Ctrl-R Ctrl-A>")],
+            completed_help: vec![("Clear", "<Ctrl-R Ctrl-R>")],
             component_state: ALL_COMPONENT_IDS
                 .iter()
                 .map(|id| (*id, ComponentUpdateListState::default()))


### PR DESCRIPTION
Ctrl-Alt is sadly just too unreliable, particularly on Mac where Alt (Option) by
default is mapped to Unicode rather than the meta key.

Use Emacs-like key chords instead. Change these shortcuts:

* Abort update: Ctrl-R Ctrl-A
* Reset state: Ctrl-R Ctrl-R
* Setup rack: Ctrl-K (I don't think this needs a key chord?)

I also changed some of the other shortcuts since they collided with
these new ones:

* Knight rider mode is now Ctrl-R Ctrl-T
* Dumping snapshots is now Ctrl-R Ctrl-S
