### PR TITLE
ci/deploy: use lab machine disks for zpools

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -135,7 +135,8 @@ for p in /input/ci-tools/work/end-to-end-tests/*.gz; do
 	chmod a+x "tests/$(basename "${p%.gz}")"
 done
 
-ptime -m pfexec ./tools/create_virtual_hardware.sh
+pfexec zpool create -f scratch c1t1d0 c2t1d0
+ZPOOL_VDEV_DIR=/scratch ptime -m pfexec ./tools/create_virtual_hardware.sh
 
 #
 # Generate a self-signed certificate to use as the initial TLS certificate for

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -45,13 +45,9 @@ function ensure_zpools {
             )
         for ZPOOL in "${ZPOOLS[@]}"; do
             echo "Zpool: [$ZPOOL]"
-            VDEV_PATH="$OMICRON_TOP/$ZPOOL.vdev"
+            VDEV_PATH="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
             if ! [[ -f "$VDEV_PATH" ]]; then
-                if [[ $ZPOOL == oxp_* ]]; then
-                    dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=8G
-                else
-                    dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=6G
-                fi
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=10G
             fi
             success "ZFS vdev $VDEV_PATH exists"
             if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -106,7 +106,7 @@ function try_destroy_zpools {
     for ZPOOL_TYPE in "${ZPOOL_TYPES[@]}"; do
         readarray -t ZPOOLS < <(zfs list -d 0 -o name | grep "^$ZPOOL_TYPE")
         for ZPOOL in "${ZPOOLS[@]}"; do
-            VDEV_FILE="$OMICRON_TOP/$ZPOOL.vdev"
+            VDEV_FILE="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
             zfs destroy -r "$ZPOOL" && \
                     zfs unmount "$ZPOOL" && \
                     zpool destroy "$ZPOOL" && \


### PR DESCRIPTION
This is a temporary hack to deal with the fact that we are now running /opt/oxide (which we mount as swap) out of space. This script could use some more robustness work, as we're just slightly widening our margin for CI success.