### PR TITLE
stop building twice for tests

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -47,26 +47,17 @@ ptime -m bash ./tools/install_builder_prerequisites.sh -y
 #   run.  Building with `--locked` ensures that the checked-in Cargo.lock
 #   is up to date.
 #
-banner build
+# We don't use `--workspace` here because we're not prepared to run tests
+# from end-to-end-tests.
+#
+# We apply our own timeout to ensure that we get a normal failure on timeout
+# rather than a buildomat timeout.  See oxidecomputer/buildomat#8.
+banner test
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo build --locked --all-targets --verbose
-
-#
-# NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
-# having to rebuild here.
-#
-# We also don't use `--workspace` here because we're not prepared to run tests
-# from end-to-end-tests.
-#
-# Hopefully temporary: we've been seeing hangs in these tests lately.  When this
-# happens, buildomat aborts the job after several hours and we're left with
-# little data with which to debug it (buildomat#8).  For now, implement our own
-# timeout that kills the job first.  On explicit failure like this, buildomat
-# will save the files left around.
-banner test
-RUST_BACKTRACE=1 ptime -m timeout 1h cargo test --locked --verbose --no-fail-fast
+export RUST_BACKTRACE=1
+ptime -m timeout 2h cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -47,22 +47,17 @@ ptime -m bash ./tools/install_builder_prerequisites.sh -y
 #   run.  Building with `--locked` ensures that the checked-in Cargo.lock
 #   is up to date.
 #
-banner build
+# We don't use `--workspace` here because we're not prepared to run tests
+# from end-to-end-tests.
+#
+# We apply our own timeout to ensure that we get a normal failure on timeout
+# rather than a buildomat timeout.  See oxidecomputer/buildomat#8.
+banner test
 export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
-ptime -m cargo build --locked --all-targets --verbose
-
-#
-# NOTE: We're using using the same RUSTFLAGS and RUSTDOCFLAGS as above to avoid
-# having to rebuild here.
-#
-# We also don't use `--workspace` here because we're not prepared to run tests
-# from end-to-end-tests.
-#
-
-banner test
-RUST_BACKTRACE=1 ptime -m cargo test --locked --verbose --no-fail-fast
+export RUST_BACKTRACE=1
+ptime -m timeout 2h cargo test --locked --verbose --no-fail-fast
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -8,6 +8,9 @@
 
 # Run clippy on illumos (not just other systems) because a bunch of our code
 # (that we want to check) is conditionally-compiled on illumos only.
+#
+# Note that `cargo clippy` includes `cargo check, so this ends up checking all
+# of our code.
 
 set -o errexit
 set -o pipefail

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,8 @@ jobs:
     - name: Check build of deployed Omicron packages
       run: cargo run --bin omicron-package -- -t default check
 
+  # Note that `cargo clippy` includes `cargo check, so this ends up checking all
+  # of our code.
   clippy-lint:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This change replaces the separate `cargo build` + `cargo test` steps in CI with just one `cargo test`.  On my test machine this brings total time from 50 minutes to 30 minutes.  What do we lose by doing this?  Well, we're already building all Omicron packages in other jobs.  We're also running `cargo clippy` over everything, which [runs `cargo check`](https://stackoverflow.com/questions/57449356/is-cargo-clippy-a-superset-of-cargo-check).  So I think we're still checking everything, building the binaries we actually need, and testing everything that we were testing before.

(this is not urgent if we need to free up CI slots.)