### PR TITLE
Use zfs compression (and 100G quota) on U.2 debug volume

### DIFF
--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -368,16 +368,14 @@ impl StorageWorker {
         let fs_name = &dataset_name.full();
         let do_format = true;
         let encryption_details = None;
-        let quota = None;
-        let compression = None;
+        let size_details = None;
         Zfs::ensure_filesystem(
             &dataset_name.full(),
             Mountpoint::Path(Utf8PathBuf::from("/data")),
             zoned,
             do_format,
             encryption_details,
-            quota,
-            compression,
+            size_details,
         )?;
         // Ensure the dataset has a usable UUID.
         if let Ok(id_str) = Zfs::get_oxide_value(&fs_name, "uuid") {

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -369,6 +369,7 @@ impl StorageWorker {
         let do_format = true;
         let encryption_details = None;
         let quota = None;
+        let compression = None;
         Zfs::ensure_filesystem(
             &dataset_name.full(),
             Mountpoint::Path(Utf8PathBuf::from("/data")),
@@ -376,6 +377,7 @@ impl StorageWorker {
             do_format,
             encryption_details,
             quota,
+            compression,
         )?;
         // Ensure the dataset has a usable UUID.
         if let Ok(id_str) = Zfs::get_oxide_value(&fs_name, "uuid") {

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -9,6 +9,7 @@ use illumos_utils::zfs::DestroyDatasetErrorVariant;
 use illumos_utils::zfs::EncryptionDetails;
 use illumos_utils::zfs::Keypath;
 use illumos_utils::zfs::Mountpoint;
+use illumos_utils::zfs::SizeDetails;
 use illumos_utils::zfs::Zfs;
 use illumos_utils::zpool::Zpool;
 use illumos_utils::zpool::ZpoolKind;
@@ -522,7 +523,6 @@ impl Disk {
                 do_format,
                 Some(encryption_details),
                 None,
-                None,
             );
 
             keyfile.zero_and_unlink().await.map_err(|error| {
@@ -576,14 +576,17 @@ impl Disk {
             }
 
             let encryption_details = None;
+            let size_details = Some(SizeDetails {
+                quota: dataset.quota,
+                compression: dataset.compression,
+            });
             Zfs::ensure_filesystem(
                 name,
                 Mountpoint::Path(mountpoint),
                 zoned,
                 do_format,
                 encryption_details,
-                dataset.quota,
-                dataset.compression,
+                size_details,
             )?;
 
             if dataset.wipe {

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -225,11 +225,13 @@ struct ExpectedDataset {
     quota: Option<usize>,
     // Identifies if the dataset should be deleted on boot
     wipe: bool,
+    // Optional compression mode
+    compression: Option<&'static str>,
 }
 
 impl ExpectedDataset {
     const fn new(name: &'static str) -> Self {
-        ExpectedDataset { name, quota: None, wipe: false }
+        ExpectedDataset { name, quota: None, wipe: false, compression: None }
     }
 
     const fn quota(mut self, quota: usize) -> Self {
@@ -239,6 +241,11 @@ impl ExpectedDataset {
 
     const fn wipe(mut self) -> Self {
         self.wipe = true;
+        self
+    }
+
+    const fn compression(mut self, compression: &'static str) -> Self {
+        self.compression = Some(compression);
         self
     }
 }
@@ -251,6 +258,10 @@ pub const DEBUG_DATASET: &'static str = "debug";
 // TODO-correctness: This value of 100GiB is a pretty wild guess, and should be
 // tuned as needed.
 pub const DEBUG_DATASET_QUOTA: usize = 100 * (1 << 30);
+// ditto.
+pub const DUMP_DATASET_QUOTA: usize = 100 * (1 << 30);
+// passed to zfs create -o compression=
+pub const DUMP_DATASET_COMPRESSION: &'static str = "gzip-9";
 
 // U.2 datasets live under the encrypted dataset and inherit encryption
 pub const ZONE_DATASET: &'static str = "crypt/zone";
@@ -264,7 +275,9 @@ static U2_EXPECTED_DATASETS: [ExpectedDataset; U2_EXPECTED_DATASET_COUNT] = [
     // Stores filesystems for zones
     ExpectedDataset::new(ZONE_DATASET).wipe(),
     // For storing full kernel RAM dumps
-    ExpectedDataset::new(DUMP_DATASET),
+    ExpectedDataset::new(DUMP_DATASET)
+        .quota(DUMP_DATASET_QUOTA)
+        .compression(DUMP_DATASET_COMPRESSION),
 ];
 
 const M2_EXPECTED_DATASET_COUNT: usize = 5;
@@ -509,6 +522,7 @@ impl Disk {
                 do_format,
                 Some(encryption_details),
                 None,
+                None,
             );
 
             keyfile.zero_and_unlink().await.map_err(|error| {
@@ -569,6 +583,7 @@ impl Disk {
                 do_format,
                 encryption_details,
                 dataset.quota,
+                dataset.compression,
             )?;
 
             if dataset.wipe {


### PR DESCRIPTION
This also makes ensure_filesystem (re-)apply any explicit quotas to existing filesystems that were created with different ones.