### PR TITLE
ci/tuf-repo: fix dvt-dock fetch

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -125,8 +125,13 @@ EOF
 done
 
 source "$TOP/tools/dvt_dock_version"
-git clone --depth 1 https://github.com/oxidecomputer/dvt-dock.git /work/dvt-dock
-(cd /work/dvt-dock; git checkout "$COMMIT")
+git init /work/dvt-dock
+(
+    cd /work/dvt-dock
+    git remote add origin https://github.com/oxidecomputer/dvt-dock.git
+    git fetch --depth 1 origin "$COMMIT"
+    git checkout FETCH_HEAD
+)
 
 add_hubris_artifacts() {
     series="$1"


### PR DESCRIPTION
Adding `--depth 1` here broke clones when tools/dvt_dock_commit is not exactly equal to whatever the HEAD of the dvt-dock repo is, because I didn't ask GitHub for that commit, and also `git clone -b` doesn't work that way anyway. This awful four-liner is equivalent to what I want though, and avoids fetching the full history of the repository.