### PR TITLE
Sled Agent service initialization cleanup

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2424,9 +2424,14 @@ impl ServiceManager {
         {
             zone_names.push(String::from(zone.name()))
         }
-        for zone in self.inner.zones.lock().await.values() {
-            zone_names.push(String::from(zone.name()));
-        }
+        zone_names.extend(
+            self.inner
+                .zones
+                .lock()
+                .await
+                .values()
+                .map(|zone| zone.name().to_string()),
+        );
         zone_names.sort();
         Ok(zone_names)
     }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2521,7 +2521,7 @@ impl ServiceManager {
             let name = zone.zone_name();
             let running = existing_zones.contains_key(&name);
             if running {
-                info!(log, "skipping running: {name}");
+                info!(log, "skipping running zone: {name}");
             }
             !running
         });

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2511,6 +2511,16 @@ impl ServiceManager {
             }
         }
 
+        // Filter out already running zones
+        let zones_to_be_added = zones_to_be_added.filter(|zone| {
+            let name = zone.zone_name();
+            let running = existing_zones.contains_key(&name);
+            if running {
+                info!(log, "skipping running: {name}");
+            }
+            !running
+        });
+
         // Create zones that should be running
         let mut zone_requests = AllZoneRequests::default();
         let all_u2_roots =

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -210,6 +210,7 @@ impl SledAgentInner {
 #[derive(Clone)]
 pub struct SledAgent {
     inner: Arc<SledAgentInner>,
+    log: Logger,
 }
 
 impl SledAgent {
@@ -351,6 +352,7 @@ impl SledAgent {
                 // Also, we could maybe de-dup some of the backoff code in the request queue?
                 nexus_request_queue: NexusRequestQueue::new(),
             }),
+            log: log.clone(),
         };
 
         // We immediately add a notification to the request queue about our
@@ -473,6 +475,10 @@ impl SledAgent {
 
     pub fn id(&self) -> Uuid {
         self.inner.id
+    }
+
+    pub fn logger(&self) -> &Logger {
+        &self.log
     }
 
     // Sends a request to Nexus informing it that the current sled exists.

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -47,7 +47,7 @@ function ensure_zpools {
             echo "Zpool: [$ZPOOL]"
             VDEV_PATH="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
             if ! [[ -f "$VDEV_PATH" ]]; then
-                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=10G
+                dd if=/dev/zero of="$VDEV_PATH" bs=1 count=0 seek=15G
             fi
             success "ZFS vdev $VDEV_PATH exists"
             if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -108,7 +108,7 @@ function try_destroy_zpools {
         for ZPOOL in "${ZPOOLS[@]}"; do
             VDEV_FILE="${ZPOOL_VDEV_DIR:-$OMICRON_TOP}/$ZPOOL.vdev"
             zfs destroy -r "$ZPOOL" && \
-                    zfs unmount "$ZPOOL" && \
+                    (zfs unmount "$ZPOOL" || true) && \
                     zpool destroy "$ZPOOL" && \
                     rm -f "$VDEV_FILE" || \
                     warn "Failed to remove ZFS pool and vdev: $ZPOOL"


### PR DESCRIPTION
Roughly 3 changes:
1. Skip initializing any zones we already know are running (both from sled-agent's perspective and as reflected via `zoneadm`)
2. Log any errors `service_put` would return on the server-side.
3. Bump file-based zpools to 15G

Lack of space was causing service initialization to fail on single-machine deployments using the `create_virtual_hardware` script. (3) should fix this.

Because of `ENOSPC` errors, we were running into some future cancellation issues which #3707 addressed. But actually determining the underlying cause was a bit difficult as `RSS` was timing out (*) on the `services_put` call and so never got back the error. (2) should hopefully make this easier to catch in the future, e.g.:
```
04:12:31.312Z ERRO SledAgent: failed to init services: Failed to install zone 'oxz_clickhouse_32ce0d6f-38fa-41e7-b699-f0af4f4f1127' from '/opt/oxide/clickhouse.tar.gz': Failed to execute zoneadm command '
Install' for zone 'oxz_clickhouse_32ce0d6f-38fa-41e7-b699-f0af4f4f1127': Failed to parse command output: exit code 1
    stdout:
    A ZFS file system has been created for this zone.
    INFO: omicron: installing zone oxz_clickhouse_32ce0d6f-38fa-41e7-b699-f0af4f4f1127 @ "/pool/ext/24b4dc87-ab46-49fb-a4b4-d361ae214c03/crypt/zone/oxz_clickhouse_32ce0d6f-38fa-41e7-b699-f0af4f4f1127"...
    INFO: omicron: replicating /usr tree...
    INFO: omicron: replicating /lib tree...
    INFO: omicron: replicating /sbin tree...
    INFO: omicron: pruning SMF manifests...
    INFO: omicron: pruning global-only files...
    INFO: omicron: unpacking baseline archive...
    INFO: omicron: unpacking image "/opt/oxide/clickhouse.tar.gz"...
    stderr:
    Error: No space left on device (os error 28)
    sled_id = 8fd66238-6bb3-4f08-89bf-f88fc2320d83

```

(*) speaking of which, do we want to increase that timeout from just 60s? it's not like any subsequent requests will work considering they'll be blocked on a lock from the initial request. and in failure cases like this the subsequent requests will timeout as well, leaving a bunch of tasks in sled-agent all waiting on the same lock to try initializing. might be worth switching to the single processing task model rack/sled initialization use.

Finally, (1) is to address the case where we try to initialize a zone that's already running. That's sometimes fine as we'll eventually realize the zone already exists. But in the case of a zone with an OPTE port, we'll run into errors like so:
```
    error_message_internal = Failed to create OPTE port for service nexus: Failure interacting with the OPTE ioctl(2) interface: command CreateXde failed: MacExists { port: "opte12", vni: Vni { inner: 100 }, mac: MacAddr { inner: A8:40:25:FF:EC:09 } }
```
This happens because the [check](https://github.com/oxidecomputer/omicron/blob/ebd3db27f6bbd08af3194cae84b0efc6b6e7248d/illumos-utils/src/zone.rs#L282C27-L282C27) for "is zone running" comes after we do all the work necessary to create the zone (e.g. creating an opte port). (1) updates `initialize_services_locked` to cross-reference sled-agent and the system's view of what zones are running so that we don't try to do the unnecessary work.