### PR TITLE
sled-agent performs archival of rotated logs for all zones onto U.2 debug dataset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,6 +4891,7 @@ dependencies = [
  "flate2",
  "futures",
  "gateway-client",
+ "glob",
  "http",
  "hyper",
  "hyper-staticfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ gateway-client = { path = "gateway-client" }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", default-features = false, features = ["std"], rev = "146a687f7413bfe580869bb6017f3bfe8b4710b1" }
 gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "146a687f7413bfe580869bb6017f3bfe8b4710b1" }
 gateway-test-utils = { path = "gateway-test-utils" }
+glob = "0.3.1"
 headers = "0.3.8"
 heck = "0.4"
 hex = "0.4.3"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -29,6 +29,7 @@ dpd-client.workspace = true
 dropshot.workspace = true
 flate2.workspace = true
 futures.workspace = true
+glob.workspace = true
 http.workspace = true
 hyper-staticfile.workspace = true
 gateway-client.workspace = true

--- a/sled-agent/src/storage/dump_setup.rs
+++ b/sled-agent/src/storage/dump_setup.rs
@@ -425,10 +425,18 @@ impl DumpSetupWorker {
                         if let Some(path) = entry.file_name().to_str() {
                             let dest = debug_dir.join(path);
 
-                            if let Err(err) = Self::copy_sync_and_remove(&entry.path(), &dest) {
-                                error!(self.log, "Failed to archive {entry:?}: {err:?}");
+                            if let Err(err) =
+                                Self::copy_sync_and_remove(&entry.path(), &dest)
+                            {
+                                error!(
+                                    self.log,
+                                    "Failed to archive {entry:?}: {err:?}"
+                                );
                             } else {
-                                info!(self.log, "Relocated {entry:?} to {dest:?}");
+                                info!(
+                                    self.log,
+                                    "Relocated {entry:?} to {dest:?}"
+                                );
                             }
                         } else {
                             error!(self.log, "Non-UTF8 path found while archiving core dumps: {entry:?}");
@@ -519,7 +527,10 @@ impl DumpSetupWorker {
         if !rotated_log_files.is_empty() {
             std::fs::create_dir_all(&dest_dir)?;
             let count = rotated_log_files.len();
-            info!(self.log, "Archiving {count} log files from {zone_name} zone");
+            info!(
+                self.log,
+                "Archiving {count} log files from {zone_name} zone"
+            );
         }
         for entry in rotated_log_files {
             let src_name = entry.file_name().unwrap();


### PR DESCRIPTION
(for #2478, depends on #3677 (https://github.com/lifning/omicron/compare/coreadm...log-rotate))

This periodically moves logs rotated by logadm in cron (https://github.com/oxidecomputer/helios/pull/107) into the crypt/debug zfs dataset on the U.2 chosen by the logic in #3677. It replaces the rotated number (*.log.0, *.log.1) with the unix epoch timestamp of the rotated log's modification time such that they don't collide when collected repeatedly (logadm will reset numbering when the previous ones are moved away).

---

After putting kernel dumps on both M.2 dump slices, starting sled-agent, forcing `logadm -p now smf_logs_daily` in every zone, then running `int main() { return *(int*)0; }` to generate a core in an oxz_nexus_ zone and the global zone:

```
EVT22200004 # ls /pool/ext/*/crypt/debug/*
/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/bounds
/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/core.global.a.out.9465.1689907180
/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/core.oxz_nexus_57947b25-e3c3-4109-8676-2abae5096d1c.a.out.29236.1689908216
/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/vmdump.0
/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/vmdump.1

/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/global:
milestone-devices:default.log.1689900201
milestone-devices:default.log.1689907251
milestone-multi-user-server:default.log.1689900201
milestone-multi-user-server:default.log.1689907250
[...]
system-zones-monitoring:default.log.1689900201
system-zones-monitoring:default.log.1689907250

/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/oxz_nexus_57947b25-e3c3-4109-8676-2abae5096d1c:
oxide-nexus:default.log.1689907587

/pool/ext/5439cec8-dd17-46e8-ae32-8b694639d3b5/crypt/debug/oxz_switch:
system-illumos-mg-ddm:default.log.1689907595
```