### PR TITLE
[wicket] mark skipped components as SKIPPED

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -2521,6 +2521,24 @@
               }
             ]
           },
+          "test_simulate_rot_result": {
+            "nullable": true,
+            "description": "If passed in, simulates a result for the RoT update.\n\nThis is used for testing.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateSimulatedResult"
+              }
+            ]
+          },
+          "test_simulate_sp_result": {
+            "nullable": true,
+            "description": "If passed in, simulates a result for the SP update.\n\nThis is used for testing.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UpdateSimulatedResult"
+              }
+            ]
+          },
           "test_step_seconds": {
             "nullable": true,
             "description": "If passed in, creates a test step that lasts these many seconds long.\n\nThis is used for testing.",
@@ -3982,6 +4000,16 @@
               "component"
             ]
           }
+        ]
+      },
+      "UpdateSimulatedResult": {
+        "description": "A simulated result for a component update.\n\nUsed by [`StartUpdateOptions`].",
+        "type": "string",
+        "enum": [
+          "success",
+          "warning",
+          "skipped",
+          "failure"
         ]
       },
       "UpdateStepId": {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -4,6 +4,8 @@
 
 use crate::config::GimletConfig;
 use crate::config::SpComponentConfig;
+use crate::helpers::rot_slot_id_from_u16;
+use crate::helpers::rot_slot_id_to_u16;
 use crate::rot::RotSprocketExt;
 use crate::serial_number_padded;
 use crate::server;
@@ -494,6 +496,10 @@ struct Handler {
 
     attached_mgs: Arc<Mutex<Option<(SpComponent, SpPort, SocketAddrV6)>>>,
     incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
+    // Use RotSlotId for both RoT and SP slots since they both have two elements
+    // each.
+    rot_active_slot: RotSlotId,
+    sp_active_slot: RotSlotId,
     power_state: PowerState,
     startup_options: StartupOptions,
     update_state: UpdateState,
@@ -527,6 +533,8 @@ impl Handler {
             serial_number,
             attached_mgs,
             incoming_serial_console,
+            rot_active_slot: RotSlotId::A,
+            sp_active_slot: RotSlotId::A,
             power_state: PowerState::A2,
             startup_options: StartupOptions::empty(),
             update_state: UpdateState::NotPrepared,
@@ -1107,12 +1115,18 @@ impl SpHandler for Handler {
         component: SpComponent,
     ) -> Result<u16, SpError> {
         warn!(
-            &self.log, "asked for component active slot (not supported for sim components)";
+            &self.log, "asked for component active slot";
             "sender" => %sender,
             "port" => ?port,
             "component" => ?component,
         );
-        Err(SpError::RequestUnsupportedForComponent)
+        if component == SpComponent::ROT {
+            Ok(rot_slot_id_to_u16(self.rot_active_slot))
+        } else if component == SpComponent::SP_ITSELF {
+            Ok(rot_slot_id_to_u16(self.sp_active_slot))
+        } else {
+            Err(SpError::RequestUnsupportedForComponent)
+        }
     }
 
     fn component_set_active_slot(
@@ -1124,14 +1138,22 @@ impl SpHandler for Handler {
         persist: bool,
     ) -> Result<(), SpError> {
         warn!(
-            &self.log, "asked to set component active slot (not supported for sim components)";
+            &self.log, "asked to set component active slot";
             "sender" => %sender,
             "port" => ?port,
             "component" => ?component,
             "slot" => slot,
             "persist" => persist,
         );
-        Err(SpError::RequestUnsupportedForComponent)
+        if component == SpComponent::ROT {
+            self.rot_active_slot = rot_slot_id_from_u16(slot)?;
+            Ok(())
+        } else if component == SpComponent::SP_ITSELF {
+            self.sp_active_slot = rot_slot_id_from_u16(slot)?;
+            Ok(())
+        } else {
+            Err(SpError::RequestUnsupportedForComponent)
+        }
     }
 
     fn component_action(

--- a/sp-sim/src/helpers.rs
+++ b/sp-sim/src/helpers.rs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use gateway_messages::{RotSlotId, SpError};
+
+pub(crate) fn rot_slot_id_to_u16(slot_id: RotSlotId) -> u16 {
+    match slot_id {
+        RotSlotId::A => 0,
+        RotSlotId::B => 1,
+    }
+}
+
+pub(crate) fn rot_slot_id_from_u16(slot_id: u16) -> Result<RotSlotId, SpError> {
+    match slot_id {
+        0 => Ok(RotSlotId::A),
+        1 => Ok(RotSlotId::B),
+        _ => Err(SpError::InvalidSlotForComponent),
+    }
+}

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 mod gimlet;
+mod helpers;
 mod rot;
 mod server;
 mod sidecar;

--- a/update-engine/src/events.rs
+++ b/update-engine/src/events.rs
@@ -955,6 +955,23 @@ impl<S: StepSpec> StepOutcome<S> {
             }
         }
     }
+
+    /// Returns true if the step was successful, including success with
+    /// warning.
+    pub fn is_success_or_warning(&self) -> bool {
+        match self {
+            Self::Success { .. } | Self::Warning { .. } => true,
+            Self::Skipped { .. } => false,
+        }
+    }
+
+    /// Returns true if the step was skipped.
+    pub fn is_skipped(&self) -> bool {
+        match self {
+            Self::Skipped { .. } => true,
+            Self::Success { .. } | Self::Warning { .. } => false,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, JsonSchema)]

--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -146,6 +146,8 @@ pub enum UpdateTerminalError {
         #[from]
         error: NestedEngineError<TestStepSpec>,
     },
+    #[error("simulated failure result")]
+    SimulatedFailure,
     #[error("error updating component")]
     ComponentNestedError {
         #[from]

--- a/wicket/README.md
+++ b/wicket/README.md
@@ -136,6 +136,34 @@ an appropriate value. For example:
 WICKET_UPDATE_TEST_STEP_SECONDS=15 cargo run --bin wicket
 ```
 
+## Adding simulated results to individual steps
+
+Some individual steps support having simulated results via environment variables.
+
+Environment variables supported are:
+
+* `WICKET_UPDATE_TEST_SIMULATE_ROT_RESULT`: Simulates a result for the "Updating RoT" step.
+* `WICKET_UPDATE_TEST_SIMULATE_SP_RESULT`: Simulates a result for the "Updating SP" step.
+
+The environment variable can be set to:
+
+* `success`: A success outcome.
+* `warning`: Success with warning.
+* `failure`: A failure.
+* `skipped`: A skipped outcome.
+
+### Example
+
+If wicket is invoked as:
+
+```
+WICKET_UPDATE_TEST_SIMULATE_ROT_RESULT=skipped cargo run --bin wicket
+```
+
+Then, while performing an update, the "Updating RoT" step will be simulated as skipped.
+
+![Screenshot showing that the "Updating RoT" step has a "skipped" status with a message saying "Simulated skipped result"](https://user-images.githubusercontent.com/180618/254689686-99259bc0-4e68-421d-98ca-362774eef155.png).
+
 ## Testing upload functionality
 
 Test upload functionality without setting up wicket as an SSH captive shell (see below for instructions). (This is the most common use case.)

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -598,6 +598,16 @@ pub(crate) struct StartUpdateOptions {
     /// This is used for testing.
     pub(crate) test_step_seconds: Option<u64>,
 
+    /// If passed in, simulates a result for the RoT update.
+    ///
+    /// This is used for testing.
+    pub(crate) test_simulate_rot_result: Option<UpdateSimulatedResult>,
+
+    /// If passed in, simulates a result for the SP update.
+    ///
+    /// This is used for testing.
+    pub(crate) test_simulate_sp_result: Option<UpdateSimulatedResult>,
+
     /// If true, skip the check on the current RoT version and always update it
     /// regardless of whether the update appears to be neeeded.
     #[allow(dead_code)] // TODO actually use this
@@ -606,6 +616,18 @@ pub(crate) struct StartUpdateOptions {
     /// If true, skip the check on the current SP version and always update it
     /// regardless of whether the update appears to be neeeded.
     pub(crate) skip_sp_version_check: bool,
+}
+
+/// A simulated result for a component update.
+///
+/// Used by [`StartUpdateOptions`].
+#[derive(Clone, Debug, JsonSchema, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UpdateSimulatedResult {
+    Success,
+    Warning,
+    Skipped,
+    Failure,
 }
 
 #[derive(Clone, Debug, JsonSchema, Deserialize)]


### PR DESCRIPTION
Just check that the "UpdateComponent" step was skipped.

To test this, I had to add two facilities:

1. Detecting and storing the currently active slot in sp-sim.
2. New environment variables for simulating SP and RoT results.
