### PR TITLE
RSS: remove inevitable timeout on services_put call

### DIFF
--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -285,7 +285,6 @@ impl ServiceInner {
         let dur = std::time::Duration::from_secs(60);
         let client = reqwest::ClientBuilder::new()
             .connect_timeout(dur)
-            .timeout(dur)
             .build()
             .map_err(SetupServiceError::HttpClient)?;
         let client = SledAgentClient::new_with_client(
@@ -313,8 +312,13 @@ impl ServiceInner {
                 .map_err(BackoffError::transient)?;
             Ok::<(), BackoffError<SledAgentError<SledAgentTypes::Error>>>(())
         };
-        let log_failure = |error, _| {
-            warn!(self.log, "failed to initialize services"; "error" => ?error);
+        let log_failure = |error, delay| {
+            warn!(
+                self.log,
+                "failed to initialize services";
+                "error" => ?error,
+                "retry_after" => ?delay,
+            );
         };
         retry_notify(
             retry_policy_internal_service_aggressive(),


### PR DESCRIPTION
We're inevitably going to timeout this request with the current 60s timeout and subsequent requests won't make progress anyways until the task spawned from earlier ones finishes. Per @davepacheco's [comment](https://github.com/oxidecomputer/omicron/pull/3712#issuecomment-1642331418) let's just remove the timeout here.