### PR TITLE
Use RSS provided DNS servers for resolving external hosts in Nexus

### DIFF
--- a/common/src/nexus_config.rs
+++ b/common/src/nexus_config.rs
@@ -20,6 +20,7 @@ use serde_with::DurationSeconds;
 use serde_with::SerializeDisplay;
 use std::collections::HashMap;
 use std::fmt;
+use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -139,7 +140,7 @@ pub struct DeploymentConfig {
     /// DB configuration.
     pub database: Database,
     /// External DNS servers Nexus can use to resolve external hosts.
-    pub external_dns_servers: Vec<String>,
+    pub external_dns_servers: Vec<IpAddr>,
 }
 
 impl DeploymentConfig {
@@ -614,8 +615,8 @@ mod test {
                     },
                     database: Database::FromDns,
                     external_dns_servers: vec![
-                        "1.1.1.1".to_string(),
-                        "9.9.9.9".to_string(),
+                        "1.1.1.1".parse().unwrap(),
+                        "9.9.9.9".parse().unwrap(),
                     ],
                 },
                 pkg: PackageConfig {

--- a/common/src/nexus_config.rs
+++ b/common/src/nexus_config.rs
@@ -138,6 +138,8 @@ pub struct DeploymentConfig {
     pub internal_dns: InternalDns,
     /// DB configuration.
     pub database: Database,
+    /// External DNS servers Nexus can use to resolve external hosts.
+    pub external_dns_servers: Vec<String>,
 }
 
 impl DeploymentConfig {
@@ -554,6 +556,7 @@ mod test {
             [deployment]
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
+            external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
             [deployment.dropshot_external]
             bind_address = "10.1.2.3:4567"
             request_body_max_bytes = 1024
@@ -610,6 +613,10 @@ mod test {
                         )
                     },
                     database: Database::FromDns,
+                    external_dns_servers: vec![
+                        "1.1.1.1".to_string(),
+                        "9.9.9.9".to_string(),
+                    ],
                 },
                 pkg: PackageConfig {
                     console: ConsoleConfig {
@@ -678,6 +685,7 @@ mod test {
             [deployment]
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
+            external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
             [deployment.dropshot_external]
             bind_address = "10.1.2.3:4567"
             request_body_max_bytes = 1024
@@ -732,6 +740,7 @@ mod test {
             [deployment]
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
+            external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
             [deployment.dropshot_external]
             bind_address = "10.1.2.3:4567"
             request_body_max_bytes = 1024
@@ -788,6 +797,7 @@ mod test {
             [deployment]
             id = "28b90dc4-c22a-65ba-f49a-f051fe01208f"
             rack_id = "38b90dc4-c22a-65ba-f49a-f051fe01208f"
+            external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
             [deployment.dropshot_external]
             bind_address = "10.1.2.3:4567"
             request_body_max_bytes = 1024

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -79,6 +79,7 @@ tokio-postgres = { workspace = true, features = ["with-serde_json-1"] }
 tokio-tungstenite.workspace = true
 toml.workspace = true
 tough.workspace = true
+trust-dns-resolver.workspace = true
 uuid.workspace = true
 usdt.workspace = true
 

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -33,6 +33,10 @@ address = "[::1]:8123"
 id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
 rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
 
+# Nexus may need to resolve external hosts (e.g. to grab IdP metadata).
+# These are the DNS servers it should use.
+external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
 [deployment.dropshot_external]
 # IP Address and TCP port on which to listen for the external API
 bind_address = "127.0.0.1:12220"

--- a/nexus/src/app/external_dns.rs
+++ b/nexus/src/app/external_dns.rs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::net::IpAddr;
+use std::net::SocketAddr;
+
+use hyper::client::connect::dns::Name;
+use omicron_common::address::DNS_PORT;
+use trust_dns_resolver::config::NameServerConfig;
+use trust_dns_resolver::config::Protocol;
+use trust_dns_resolver::config::ResolverConfig;
+use trust_dns_resolver::config::ResolverOpts;
+use trust_dns_resolver::TokioAsyncResolver;
+
+/// Wrapper around trust-dns-resolver to provide name resolution
+/// using a given set of DNS servers for use with reqwest.
+pub struct Resolver(TokioAsyncResolver);
+
+impl Resolver {
+    pub fn new(dns_servers: &[IpAddr]) -> Resolver {
+        let mut rc = ResolverConfig::new();
+        for addr in dns_servers {
+            rc.add_name_server(NameServerConfig {
+                socket_addr: SocketAddr::new(*addr, DNS_PORT),
+                protocol: Protocol::Udp,
+                tls_dns_name: None,
+                trust_nx_responses: false,
+                bind_addr: None,
+            });
+        }
+        let mut opts = ResolverOpts::default();
+        opts.use_hosts_file = false;
+        opts.num_concurrent_reqs = dns_servers.len();
+        Resolver(
+            TokioAsyncResolver::tokio(rc, opts)
+                .expect("creating resovler shouldn't fail"),
+        )
+    }
+}
+
+impl reqwest::dns::Resolve for Resolver {
+    fn resolve(&self, name: Name) -> reqwest::dns::Resolving {
+        let resolver = self.0.clone();
+        Box::pin(async move {
+            let ips = resolver.lookup_ip(name.as_str()).await?;
+            Ok(Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)))
+                as Box<_>)
+        })
+    }
+}

--- a/nexus/src/app/external_dns.rs
+++ b/nexus/src/app/external_dns.rs
@@ -19,6 +19,7 @@ pub struct Resolver(TokioAsyncResolver);
 
 impl Resolver {
     pub fn new(dns_servers: &[IpAddr]) -> Resolver {
+        assert!(!dns_servers.is_empty());
         let mut rc = ResolverConfig::new();
         for addr in dns_servers {
             rc.add_name_server(NameServerConfig {
@@ -31,6 +32,7 @@ impl Resolver {
         }
         let mut opts = ResolverOpts::default();
         opts.use_hosts_file = false;
+        // Do as many requests in parallel as we have configured servers
         opts.num_concurrent_reqs = dns_servers.len();
         Resolver(
             TokioAsyncResolver::tokio(rc, opts)

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -283,17 +283,9 @@ impl Nexus {
             if config.deployment.external_dns_servers.is_empty() {
                 return Err("expected at least 1 external DNS server".into());
             }
-            let servers = config
-                .deployment
-                .external_dns_servers
-                .iter()
-                // TODO(luqman): pass this in as an IpAddr to begin with
-                .map(|addr| addr.parse())
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| {
-                    format!("expected IP address for external DNS servers: {e}")
-                })?;
-            Arc::new(external_dns::Resolver::new(&servers))
+            Arc::new(external_dns::Resolver::new(
+                &config.deployment.external_dns_servers,
+            ))
         };
 
         let nexus = Nexus {

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -781,6 +781,7 @@ impl super::Nexus {
                 let client = reqwest::ClientBuilder::new()
                     .connect_timeout(dur)
                     .timeout(dur)
+                    .dns_resolver(self.external_resolver.clone())
                     .build()
                     .map_err(|e| {
                         Error::internal_error(&format!(

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -40,6 +40,10 @@ max_vpc_ipv4_subnet_prefix = 29
 id = "e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c"
 rack_id = "c19a698f-c6f9-4a17-ae30-20d711b8f7dc"
 
+# Nexus may need to resolve external hosts (e.g. to grab IdP metadata).
+# These are the DNS servers it should use.
+external_dns_servers = [ "1.1.1.1", "9.9.9.9" ]
+
 [deployment.dropshot_external]
 # NOTE: for the test suite, the port MUST be 0 (in order to bind to any
 # available port) because the test suite will be running many servers

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -446,7 +446,8 @@
             "description": "The external DNS server addresses.",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "ip"
             }
           },
           "external_certificates": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1917,7 +1917,8 @@
                 "description": "External DNS servers Nexus can use to resolve external hosts.",
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "ip"
                 }
               },
               "external_ip": {
@@ -2070,7 +2071,8 @@
               "dns_servers": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "ip"
                 }
               },
               "domain": {
@@ -2124,7 +2126,8 @@
               "dns_servers": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "ip"
                 }
               },
               "domain": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1913,6 +1913,13 @@
           {
             "type": "object",
             "properties": {
+              "external_dns_servers": {
+                "description": "External DNS servers Nexus can use to resolve external hosts.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "external_ip": {
                 "description": "The address at which the external nexus server is reachable.",
                 "type": "string",
@@ -1942,6 +1949,7 @@
               }
             },
             "required": [
+              "external_dns_servers",
               "external_ip",
               "external_tls",
               "internal_address",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -901,7 +901,8 @@
           "dns_servers": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "ip"
             }
           },
           "external_dns_ips": {
@@ -1738,7 +1739,8 @@
           "dns_servers": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "ip"
             }
           },
           "external_dns_ips": {

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -1074,7 +1074,7 @@ mod tests {
                 id: Uuid::new_v4(),
                 rack_id: Uuid::new_v4(),
                 ntp_servers: vec![String::from("test.pool.example.com")],
-                dns_servers: vec![String::from("1.1.1.1")],
+                dns_servers: vec!["1.1.1.1".parse().unwrap()],
                 use_trust_quorum: false,
                 subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
             }),

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -33,7 +33,7 @@ struct UnvalidatedRackInitializeRequest {
     trust_quorum_peers: Option<Vec<Baseboard>>,
     bootstrap_discovery: BootstrapAddressDiscovery,
     ntp_servers: Vec<String>,
-    dns_servers: Vec<String>,
+    dns_servers: Vec<IpAddr>,
     internal_services_ip_pool_ranges: Vec<address::IpRange>,
     external_dns_ips: Vec<IpAddr>,
     external_dns_zone_name: String,
@@ -65,7 +65,7 @@ pub struct RackInitializeRequest {
     pub ntp_servers: Vec<String>,
 
     /// The external DNS server addresses.
-    pub dns_servers: Vec<String>,
+    pub dns_servers: Vec<IpAddr>,
 
     /// Ranges of the service IP pool which may be used for internal services.
     // TODO(https://github.com/oxidecomputer/omicron/issues/1530): Eventually,
@@ -185,7 +185,7 @@ pub struct StartSledAgentRequest {
     pub ntp_servers: Vec<String>,
 
     /// The external DNS servers to use
-    pub dns_servers: Vec<String>,
+    pub dns_servers: Vec<IpAddr>,
 
     /// Use trust quorum for key generation
     pub use_trust_quorum: bool,
@@ -294,7 +294,7 @@ mod tests {
                     id: Uuid::new_v4(),
                     rack_id: Uuid::new_v4(),
                     ntp_servers: vec![String::from("test.pool.example.com")],
-                    dns_servers: vec![String::from("1.1.1.1")],
+                    dns_servers: vec!["1.1.1.1".parse().unwrap()],
                     use_trust_quorum: false,
                     subnet: Ipv6Subnet::new(Ipv6Addr::LOCALHOST),
                 },

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -278,7 +278,7 @@ pub enum ServiceType {
         /// Whether Nexus's external endpoint should use TLS
         external_tls: bool,
         /// External DNS servers Nexus can use to resolve external hosts.
-        external_dns_servers: Vec<String>,
+        external_dns_servers: Vec<IpAddr>,
     },
     ExternalDns {
         /// The address at which the external DNS server API is reachable.
@@ -336,7 +336,7 @@ pub enum ServiceType {
     BoundaryNtp {
         address: SocketAddrV6,
         ntp_servers: Vec<String>,
-        dns_servers: Vec<String>,
+        dns_servers: Vec<IpAddr>,
         domain: Option<String>,
         /// The service vNIC providing outbound connectivity using OPTE.
         nic: NetworkInterface,
@@ -346,7 +346,7 @@ pub enum ServiceType {
     InternalNtp {
         address: SocketAddrV6,
         ntp_servers: Vec<String>,
-        dns_servers: Vec<String>,
+        dns_servers: Vec<IpAddr>,
         domain: Option<String>,
     },
     Clickhouse {

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -277,6 +277,8 @@ pub enum ServiceType {
         nic: NetworkInterface,
         /// Whether Nexus's external endpoint should use TLS
         external_tls: bool,
+        /// External DNS servers Nexus can use to resolve external hosts.
+        external_dns_servers: Vec<String>,
     },
     ExternalDns {
         /// The address at which the external DNS server API is reachable.
@@ -414,14 +416,19 @@ impl TryFrom<ServiceType> for sled_agent_client::types::ServiceType {
         use ServiceType as St;
 
         match s {
-            St::Nexus { internal_address, external_ip, nic, external_tls } => {
-                Ok(AutoSt::Nexus {
-                    internal_address: internal_address.to_string(),
-                    external_ip,
-                    nic: nic.into(),
-                    external_tls,
-                })
-            }
+            St::Nexus {
+                internal_address,
+                external_ip,
+                nic,
+                external_tls,
+                external_dns_servers,
+            } => Ok(AutoSt::Nexus {
+                internal_address: internal_address.to_string(),
+                external_ip,
+                nic: nic.into(),
+                external_tls,
+                external_dns_servers,
+            }),
             St::ExternalDns { http_address, dns_address, nic } => {
                 Ok(AutoSt::ExternalDns {
                     http_address: http_address.to_string(),

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -101,7 +101,7 @@ mod test {
             trust_quorum_peers: None,
             bootstrap_discovery: BootstrapAddressDiscovery::OnlyOurs,
             ntp_servers: vec![String::from("test.pool.example.com")],
-            dns_servers: vec![String::from("1.1.1.1")],
+            dns_servers: vec!["1.1.1.1".parse().unwrap()],
             external_dns_zone_name: String::from("oxide.test"),
             internal_services_ip_pool_ranges: vec![IpRange::from(IpAddr::V4(
                 Ipv4Addr::new(129, 168, 1, 20),

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -301,8 +301,8 @@ impl Plan {
             &reserved_rack_subnet.get_dns_subnets()[0..DNS_REDUNDANCY];
         let rack_dns_servers = dns_subnets
             .into_iter()
-            .map(|dns_subnet| dns_subnet.dns_address().ip().to_string())
-            .collect::<Vec<String>>();
+            .map(|dns_subnet| dns_subnet.dns_address().ip().into())
+            .collect::<Vec<IpAddr>>();
         for i in 0..dns_subnets.len() {
             let dns_subnet = &dns_subnets[i];
             let ip = dns_subnet.dns_address().ip();

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -475,6 +475,7 @@ impl Plan {
                         // always expect TLS to be enabled.  It's only in
                         // development that it might not be.
                         external_tls: !config.external_certificates.is_empty(),
+                        external_dns_servers: config.dns_servers.clone(),
                     },
                 }],
                 boundary_switches: vec![],

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -912,7 +912,7 @@ impl ServiceManager {
     async fn configure_dns_client(
         &self,
         running_zone: &RunningZone,
-        dns_servers: &Vec<String>,
+        dns_servers: &[IpAddr],
         domain: &Option<String>,
     ) -> Result<(), Error> {
         struct DnsClient {}
@@ -1815,7 +1815,7 @@ impl ServiceManager {
                     }
                     self.configure_dns_client(
                         &running_zone,
-                        &dns_servers,
+                        dns_servers,
                         &domain,
                     )
                     .await?;

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1336,7 +1336,10 @@ impl ServiceManager {
 
             match &service.details {
                 ServiceType::Nexus {
-                    internal_address, external_tls, ..
+                    internal_address,
+                    external_tls,
+                    external_dns_servers,
+                    ..
                 } => {
                     info!(self.inner.log, "Setting up Nexus service");
 
@@ -1390,6 +1393,7 @@ impl ServiceManager {
                             ),
                         },
                         database: nexus_config::Database::FromDns,
+                        external_dns_servers: external_dns_servers.clone(),
                     };
 
                     // Copy the partial config file to the expected location.

--- a/wicket-common/src/rack_setup.rs
+++ b/wicket-common/src/rack_setup.rs
@@ -23,7 +23,7 @@ pub struct PutRssUserConfigInsensitive {
     /// `CurrentRssUserConfigInsensitive`.
     pub bootstrap_sleds: BTreeSet<u32>,
     pub ntp_servers: Vec<String>,
-    pub dns_servers: Vec<String>,
+    pub dns_servers: Vec<IpAddr>,
     pub internal_services_ip_pool_ranges: Vec<address::IpRange>,
     pub external_dns_ips: Vec<IpAddr>,
     pub external_dns_zone_name: String,

--- a/wicket/src/rack_setup/config_template.toml
+++ b/wicket/src/rack_setup/config_template.toml
@@ -19,7 +19,7 @@ external_dns_ips = []
 ntp_servers = [
 ]
 
-# External DNS servers; e.g., "1.1.1.1", "9.9.9.9".
+# External DNS server IP Addresses; e.g., "1.1.1.1", "9.9.9.9".
 dns_servers = []
 
 # Ranges of the service IP pool which may be used for internal services.

--- a/wicket/src/rack_setup/config_toml.rs
+++ b/wicket/src/rack_setup/config_toml.rs
@@ -51,7 +51,7 @@ impl TomlTemplate {
         *doc.get_mut("dns_servers").unwrap().as_array_mut().unwrap() = config
             .dns_servers
             .iter()
-            .map(|s| Value::String(Formatted::new(s.into())))
+            .map(|s| Value::String(Formatted::new(s.to_string())))
             .collect();
 
         *doc.get_mut("internal_services_ip_pool_ranges")
@@ -380,7 +380,10 @@ mod tests {
                     bootstrap_ip: Some(Ipv6Addr::LOCALHOST),
                 },
             ],
-            dns_servers: vec!["1.1.1.1".into(), "2.2.2.2".into()],
+            dns_servers: vec![
+                "1.1.1.1".parse().unwrap(),
+                "2.2.2.2".parse().unwrap(),
+            ],
             external_dns_zone_name: "oxide.computer".into(),
             internal_services_ip_pool_ranges: vec![IpRange::V4(
                 wicketd_client::types::Ipv4Range {

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -804,7 +804,11 @@ fn rss_config_text<'a>(
     append_list(
         &mut spans,
         "DNS servers: ".into(),
-        insensitive.dns_servers.iter().cloned().map(plain_list_item).collect(),
+        insensitive
+            .dns_servers
+            .iter()
+            .map(|s| plain_list_item(s.to_string()))
+            .collect(),
     );
     append_list(
         &mut spans,

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -156,7 +156,7 @@ pub struct BootstrapSledDescription {
 pub struct CurrentRssUserConfigInsensitive {
     pub bootstrap_sleds: BTreeSet<BootstrapSledDescription>,
     pub ntp_servers: Vec<String>,
-    pub dns_servers: Vec<String>,
+    pub dns_servers: Vec<IpAddr>,
     pub internal_services_ip_pool_ranges: Vec<address::IpRange>,
     pub external_dns_ips: Vec<IpAddr>,
     pub external_dns_zone_name: String,

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -56,7 +56,7 @@ pub(crate) struct CurrentRssConfig {
 
     bootstrap_sleds: BTreeSet<BootstrapSledDescription>,
     ntp_servers: Vec<String>,
-    dns_servers: Vec<String>,
+    dns_servers: Vec<IpAddr>,
     internal_services_ip_pool_ranges: Vec<address::IpRange>,
     external_dns_ips: Vec<IpAddr>,
     external_dns_zone_name: String,


### PR DESCRIPTION
Fixes #3724

Side-steps the question of what to populate in `/etc/resolv.conf` for Nexus. I think being explicit where we need to do any external name resolution (which only consists of grabbing IdP metadata via URL today AFAIK) seems better than relying on ambient system config.

Most of the changes are just plumbing up the RSS provided external DNS servers up to Nexus and some `String`->`IpAddr` changes. Longer term we'd probably want to persist those to the DB and have some API to update them (https://github.com/oxidecomputer/omicron/issues/3732).