### PR TITLE
disable RIP for general deployments

### DIFF
--- a/smf/switch_zone_setup/switch_zone_setup
+++ b/smf/switch_zone_setup/switch_zone_setup
@@ -37,8 +37,4 @@ for i in "${!USERS[@]}"; do
     fi
 done
 
-# enable ipv6 forwarding and routing
-pfexec routeadm -e ipv6-forwarding -u
-pfexec routeadm -e ipv6-routing -u
-
 exit $SMF_EXIT_OK


### PR DESCRIPTION
RIP's method of gratuitous advertisements can accidentally create routing loops or blackhole traffic when used in conjunction with DDM.