### PR TITLE
Update dendrite and maghemite auto-prs

### DIFF
--- a/.github/reflector/update-dendrite.toml
+++ b/.github/reflector/update-dendrite.toml
@@ -9,14 +9,10 @@ branch = "main"
 
 requires_token = true
 
-# Debounce values are used to batch together multiple pushes that occur in a relatively short
-# timeframe
+# Run in response to the image buildomat job in dendrite completing
 
 [[on]]
 repository = "oxidecomputer/dendrite"
-paths = [
-  "**",
-]
-
-# Wait one hour for binary builds to complete
-debounce = 3600
+event = "check_run"
+action = "completed"
+check = "image"

--- a/.github/reflector/update-maghemite.toml
+++ b/.github/reflector/update-maghemite.toml
@@ -9,14 +9,10 @@ branch = "main"
 
 requires_token = true
 
-# Debounce values are used to batch together multiple pushes that occur in a relatively short
-# timeframe
+# Run in response to the image buildomat job in maghemite completing
 
 [[on]]
 repository = "oxidecomputer/maghemite"
-paths = [
-  "**",
-]
-
-# Wait one hour for binary builds to complete
-debounce = 3600
+event = "check_run"
+action = "completed"
+check = "image"


### PR DESCRIPTION
Updates the creation / update mechanism that is used for creating dendrite and maghemite update PRs. Previously only GitHub `push` events could be used as a notification source. This caused an issue as the artifacts necessary for updating were still in the process of being built by a buildomat job. To work around this a long (1 hour) debounce delay was used so that by the time PR creation logic ran, the artifacts should have been generated.

Now that `check_run` events are available, they can be used to more accurately specify when PR creation should run. This update changes the dendrite and maghemite listeners to listen for the completion of the `image` buildomat job in their respective repos.

Resolves #3259