### PR TITLE
wicket: fix alignment after uplink_ip -> uplink_cidr rename

### DIFF
--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -755,7 +755,7 @@ fn rss_config_text<'a>(
                     Span::styled(uplink.gateway_ip.to_string(), ok_style),
                 ],
                 vec![
-                    Span::styled("  • Uplink CIDR        : ", label_style),
+                    Span::styled("  • Uplink CIDR      : ", label_style),
                     Span::styled(uplink.uplink_cidr.to_string(), ok_style),
                 ],
                 vec![


### PR DESCRIPTION
Small follow-up to #3755

![image](https://github.com/oxidecomputer/omicron/assets/287063/1ffb1666-61f7-40b5-ba62-737732993602)

