### PR TITLE
Fix logadm cron entry in non-global zones

### DIFF
--- a/smf/logadm/crontab.root
+++ b/smf/logadm/crontab.root
@@ -1,1 +1,1 @@
-*/15 * * * /usr/sbin/logadm
+*/15 * * * * /usr/sbin/logadm


### PR DESCRIPTION
Ran into this on latest main:

```
$  pfexec zlogin oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2
[Connected to zone 'oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2' pts/10]
The illumos Project     helios-2.0.22094        July 2023
You have new mail.
root@oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2:~# mail
From root@oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2 Wed Jul 26 13:41:31 2023
To: root
Subject: Your crontab file has an error in it
Content-Length: 162
Date: Wed, 26 Jul 2023 13:41:31 -0700
Message-Id: <64c184fb.11631.5f07a55f@oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2>
From: <root@oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2>

Your "crontab" on oxz_crucible_4b0907c4-f3a6-4e04-991a-4c265f3bd8e2
Line(s) with errors:

   1: */15 * * * /usr/sbin/logadm

Entries or crontab have been ignored
```