### PR TITLE
KeyManager: Fix a misleading warning

### DIFF
--- a/key-manager/src/lib.rs
+++ b/key-manager/src/lib.rs
@@ -209,8 +209,12 @@ impl<S: SecretRetriever> KeyManager<S> {
             } else {
                 warn!(
                     self.log,
-                    "Failed to receive from a storage key requester",
+                    concat!(
+                        "KeyManager shutting down: ",
+                        "all storage key requesters dropped.",
+                    )
                 );
+                return;
             }
         }
     }


### PR DESCRIPTION
When all the senders drop on the key requester channel, there is no way for `KeyManager` to recover. This is an abnormal situation because there is a sender held onto by bootstrap agent at all times and so this should never happen.

However, we have seen this error when omicron was not packaged correctly and `BootstrapAgent::new` exits with an error before it is constructed. The tokio task for the `KeyManager` continued to run and report the following repeatedly:

```
WARN SledAgent (KeyManager): Failed to receive from a storage key requester
```

Instead of that repetitive, misleading error, we become more precise and exit the `KeyManager` tokio task.