### PR TITLE
Change ledger file extensions to .json

### DIFF
--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -227,7 +227,7 @@ pub struct Agent {
     bootstore_peer_update_handle: JoinHandle<()>,
 }
 
-const SLED_AGENT_REQUEST_FILE: &str = "sled-agent-request.toml";
+const SLED_AGENT_REQUEST_FILE: &str = "sled-agent-request.json";
 const BOOTSTORE_FSM_STATE_FILE: &str = "bootstore-fsm-state.json";
 const BOOTSTORE_NETWORK_CONFIG_FILE: &str = "bootstore-network-config.json";
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -114,7 +114,7 @@ impl Ledgerable for Plan {
     }
     fn generation_bump(&mut self) {}
 }
-const RSS_SERVICE_PLAN_FILENAME: &str = "rss-service-plan.toml";
+const RSS_SERVICE_PLAN_FILENAME: &str = "rss-service-plan.json";
 
 impl Plan {
     pub async fn load(

--- a/sled-agent/src/rack_setup/plan/sled.rs
+++ b/sled-agent/src/rack_setup/plan/sled.rs
@@ -39,7 +39,7 @@ impl Ledgerable for Plan {
     }
     fn generation_bump(&mut self) {}
 }
-const RSS_SLED_PLAN_FILENAME: &str = "rss-sled-plan.toml";
+const RSS_SLED_PLAN_FILENAME: &str = "rss-sled-plan.json";
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Plan {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -16,8 +16,8 @@
 //! Rack setup occurs in distinct phases which are denoted by the prescence of
 //! configuration files.
 //!
-//! - /pool/int/UUID/config/rss-sled-plan.toml (Sled Plan)
-//! - /pool/int/UUID/config/rss-service-plan.toml (Service Plan)
+//! - /pool/int/UUID/config/rss-sled-plan.json (Sled Plan)
+//! - /pool/int/UUID/config/rss-service-plan.json (Service Plan)
 //! - /pool/int/UUID/config/rss-plan-completed.marker (Plan Execution Complete)
 //!
 //! ## Sled Plan

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -284,7 +284,7 @@ impl Config {
 }
 
 // The filename of the ledger, within the provided directory.
-const SERVICES_LEDGER_FILENAME: &str = "services.toml";
+const SERVICES_LEDGER_FILENAME: &str = "services.json";
 
 // The directory within the debug dataset in which bundles are created.
 const BUNDLE_DIRECTORY: &str = "bundle";
@@ -296,7 +296,7 @@ const ZONE_BUNDLE_DIRECTORY: &str = "zone";
 const ZONE_BUNDLE_METADATA_FILENAME: &str = "metadata.toml";
 
 // A wrapper around `ZoneRequest`, which allows it to be serialized
-// to a toml file.
+// to a JSON file.
 #[derive(Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 struct AllZoneRequests {
     generation: Generation,


### PR DESCRIPTION
Ledger files are now serialized as json, and not toml. Change the extension to reflect this.

Fixes #3723