### PR TITLE
Update crucible and propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +106,12 @@ checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -283,6 +304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,20 +480,20 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "bhyve_api_sys",
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
 ]
 
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
 ]
 
 [[package]]
@@ -826,6 +858,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -1201,7 +1236,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -1223,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1343,9 +1378,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible"
+version = "0.0.1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+dependencies = [
+ "aes-gcm-siv",
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "base64 0.21.2",
+ "bytes",
+ "chrono",
+ "crucible-client-types",
+ "crucible-common",
+ "crucible-protocol",
+ "dropshot",
+ "futures",
+ "futures-core",
+ "itertools 0.11.0",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "reqwest",
+ "ringbuffer",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-dtrace",
+ "slog-term",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tokio-util",
+ "toml 0.7.6",
+ "tracing",
+ "usdt",
+ "uuid",
+ "version_check",
+]
+
+[[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=179e68b8718d24673893dac46a8ab4a9249ec318#179e68b8718d24673893dac46a8ab4a9249ec318"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1360,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=179e68b8718d24673893dac46a8ab4a9249ec318#179e68b8718d24673893dac46a8ab4a9249ec318"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -1370,9 +1448,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-common"
+version = "0.0.1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+dependencies = [
+ "anyhow",
+ "atty",
+ "nix 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite",
+ "rustls-pemfile",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-dtrace",
+ "slog-term",
+ "tempfile",
+ "thiserror",
+ "tokio-rustls 0.23.4",
+ "toml 0.7.6",
+ "twox-hash",
+ "uuid",
+ "vergen",
+]
+
+[[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=179e68b8718d24673893dac46a8ab4a9249ec318#179e68b8718d24673893dac46a8ab4a9249ec318"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1386,9 +1491,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-protocol"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "crucible-common",
+ "num_enum 0.6.1",
+ "serde",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=179e68b8718d24673893dac46a8ab4a9249ec318#179e68b8718d24673893dac46a8ab4a9249ec318"
+source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
 dependencies = [
  "libc",
  "num-derive",
@@ -1873,10 +1993,10 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 [[package]]
 name = "dladm"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
 ]
 
 [[package]]
@@ -1886,7 +2006,7 @@ source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0
 dependencies = [
  "libc",
  "libdlpi-sys",
- "num_enum",
+ "num_enum 0.5.11",
  "pretty-hex 0.2.1",
  "thiserror",
  "tokio",
@@ -2032,7 +2152,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "proc-macro2",
- "rustls",
+ "rustls 0.21.3",
  "rustls-pemfile",
  "schemars",
  "serde",
@@ -2046,7 +2166,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "toml 0.7.6",
  "usdt",
  "uuid",
@@ -2304,6 +2424,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2654,7 +2780,7 @@ dependencies = [
  "hubpack 0.1.2",
  "hubtools",
  "lru-cache",
- "nix",
+ "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
  "once_cell",
  "serde",
  "serde-big-array 0.5.1",
@@ -2744,6 +2870,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2969,19 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+dependencies = [
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "headers"
@@ -3123,10 +3275,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.3",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3219,7 +3371,7 @@ source = "git+https://github.com/oxidecomputer/illumos-devinfo?branch=main#4323b
 dependencies = [
  "anyhow",
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
 ]
 
 [[package]]
@@ -3341,7 +3493,7 @@ dependencies = [
  "installinator-artifact-client",
  "installinator-common",
  "ipcc-key-value",
- "itertools",
+ "itertools 0.10.5",
  "libc",
  "omicron-common 0.1.0",
  "omicron-test-utils",
@@ -3571,10 +3723,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3629,7 +3799,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "regex",
@@ -3690,6 +3860,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b024e211b1b371da58cd69e4fb8fa4ed16915edcc0e2e1fb04ac4bad61959f25"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,13 +3903,23 @@ dependencies = [
  "colored",
  "dlpi",
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
  "nvpair",
  "nvpair-sys",
  "rusty-doors",
  "socket2 0.4.9",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3756,6 +3948,18 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca310e4db05e9b7386ad0734975fabc912b66f6bc50a98f525e690822da1ee0e"
 dependencies = [
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -4148,7 +4352,7 @@ dependencies = [
  "hyper-rustls",
  "internal-dns 0.1.0",
  "ipnetwork",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "macaddr",
  "newtype_derive",
@@ -4180,7 +4384,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
- "rustls",
+ "rustls 0.21.3",
  "samael",
  "serde",
  "serde_json",
@@ -4311,6 +4515,20 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
 source = "git+https://github.com/jgallagher/nix?branch=r0.26-illumos#c1a3636db0524f194b714cfd117cd9b637b8b10e"
 dependencies = [
  "bitflags 1.3.2",
@@ -4377,13 +4595,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4433,7 +4651,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -4446,6 +4673,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4727,7 +4966,7 @@ dependencies = [
  "hyper-rustls",
  "internal-dns 0.1.0",
  "ipnetwork",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "macaddr",
  "mime_guess",
@@ -4772,7 +5011,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
- "rustls",
+ "rustls 0.21.3",
  "samael",
  "schemars",
  "semver 1.0.17",
@@ -4904,7 +5143,7 @@ dependencies = [
  "illumos-utils",
  "internal-dns 0.1.0",
  "ipnetwork",
- "itertools",
+ "itertools 0.10.5",
  "key-manager",
  "libc",
  "macaddr",
@@ -5283,7 +5522,7 @@ dependencies = [
  "chrono",
  "clap 4.3.8",
  "dropshot",
- "itertools",
+ "itertools 0.10.5",
  "omicron-test-utils",
  "oximeter 0.1.0",
  "regex",
@@ -5881,7 +6120,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -5896,7 +6135,7 @@ dependencies = [
  "anstyle",
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -6060,20 +6299,24 @@ dependencies = [
 [[package]]
 name = "propolis"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "anyhow",
  "bhyve_api",
  "bitflags 1.3.2",
  "bitstruct",
  "byteorder",
+ "crucible",
+ "crucible-client-types",
  "dladm",
  "erased-serde",
  "futures",
  "lazy_static",
  "libc",
- "num_enum",
+ "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "num_enum 0.5.11",
  "once_cell",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "propolis_types",
  "rfb",
  "serde",
@@ -6090,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -6114,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "propolis-server"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6136,7 +6379,7 @@ dependencies = [
  "internal-dns 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "lazy_static",
  "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "num_enum",
+ "num_enum 0.5.11",
  "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
@@ -6166,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "propolis-server-config"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6177,7 +6420,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "schemars",
  "serde",
@@ -6444,7 +6687,7 @@ dependencies = [
  "chrono",
  "crossterm 0.26.1",
  "fd-lock",
- "itertools",
+ "itertools 0.10.5",
  "nu-ansi-term",
  "serde",
  "strip-ansi-escapes",
@@ -6560,14 +6803,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.3",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -6618,6 +6861,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "ringbuffer"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00cd23b78b7c0c29b99a7840f540c48def3cfd303024faf2f45d7b064e4cb930"
 
 [[package]]
 name = "ron"
@@ -6682,6 +6931,20 @@ checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.3.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6845,6 +7108,18 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -8358,11 +8633,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.8",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.3",
  "tokio",
 ]
 
@@ -8690,7 +8976,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "omicron-common 0.1.0",
  "rand 0.8.5",
  "ring",
@@ -8765,6 +9051,17 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
+ "static_assertions",
 ]
 
 [[package]]
@@ -9042,6 +9339,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "time 0.3.20",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9050,17 +9360,17 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viona_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "libc",
- "num_enum",
+ "num_enum 0.5.11",
  "viona_api_sys",
 ]
 
 [[package]]
 name = "viona_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fbd701c0a54f25208712b0b3b2dc7931c875d347#fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 dependencies = [
  "libc",
 ]
@@ -9294,7 +9604,7 @@ dependencies = [
  "hex",
  "humantime",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "libsw",
  "omicron-common 0.1.0",
  "omicron-passwords 0.1.0",
@@ -9781,7 +10091,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0545a42fbd7a81245726d54a0146cb4fd93882ebb6da50d60acf2e37394f198"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "thiserror",
  "tokio",
  "zone_cfg_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,10 +156,10 @@ cookie = "0.16"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.26.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "179e68b8718d24673893dac46a8ab4a9249ec318" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "179e68b8718d24673893dac46a8ab4a9249ec318" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "179e68b8718d24673893dac46a8ab4a9249ec318" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "179e68b8718d24673893dac46a8ab4a9249ec318" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
 curve25519-dalek = "3"
 datatest-stable = "0.1.3"
 display-error-chain = "0.1.1"
@@ -270,9 +270,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "fbd701c0a54f25208712b0b3b2dc7931c875d347" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "fbd701c0a54f25208712b0b3b2dc7931c875d347", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "fbd701c0a54f25208712b0b3b2dc7931c875d347", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3", features = [ "generated-migration" ] }
+propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3", default-features = false, features = ["mock-only"] }
 #propolis-server = { path = "../propolis/bin/propolis-server" }
 proptest = "1.2.0"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -344,10 +344,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "179e68b8718d24673893dac46a8ab4a9249ec318"
+source.commit = "84507ed89aced20920de73342666a8abcb8237c1"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "92d83450a48c3bca7775a8b00b453dfb48d1c6a3519bc1a4a75c9f9c46543e8f"
+source.sha256 = "3e55c672a2ba17a58b17f89128257cfd9fdb57c6e7f66d03535dd8f3c60036c3"
 output.type = "zone"
 
 [package.crucible-pantry]
@@ -355,10 +355,10 @@ service_name = "crucible_pantry"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "179e68b8718d24673893dac46a8ab4a9249ec318"
+source.commit = "84507ed89aced20920de73342666a8abcb8237c1"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "88d86e90f1c0e45eb371b57ecf05f15ac869d642adf343b76217bb2cdb7a928d"
+source.sha256 = "6b53e106d1449ea6465e0d352080b63da191b890aabe8d751b0b75e5ddc18621"
 output.type = "zone"
 
 # Refer to
@@ -369,10 +369,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "fbd701c0a54f25208712b0b3b2dc7931c875d347"
+source.commit = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "1bc7c6fc6a029d34493adef16457029bc2cd3b3624beab376136f0e08e4550e7"
+source.sha256 = "9bd2fabc32ba1031a22a2345dc945d97653939ad36630033c39b20e6b2d06112"
 output.type = "zone"
 
 [package.maghemite]

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -41,6 +41,10 @@ zpools = [
 # guest memory is pulled from.
 vmm_reservoir_percentage = 50
 
+# Create a 64GB swap device. The VMM reservoir will not function without a swap
+# device.
+swap_device_size_gb = 64
+
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.
 #

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -39,7 +39,7 @@ zpools = [
 
 # Percentage of usable physical DRAM to use for the VMM reservoir, which
 # guest memory is pulled from.
-vmm_reservoir_percentage = 0
+vmm_reservoir_percentage = 50
 
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.


### PR DESCRIPTION
Bump crucible rev to pick up:

- Do not eat ErrorReport messages related to repairs
- A bounced agent must reinitialize all SMF config
- Turn off show_work on every ds ping response
- Wait for ZFS snapshot directory + agent fixes
- Bump openssl from 0.10.48 to 0.10.55
- Bump h2 from 0.3.12 to 0.3.20
- Update Rust crate async-trait to 0.1.72
- Update Rust crate indicatif to 0.17.5
- Update Rust crate vergen to 8.2
- Update Rust crate omicron-zone-package to 0.9.1
- Update Rust crate rustls-pemfile to 1.0.3
- Update Rust crate signal-hook to 0.3.17
- Update Rust crate test-strategy to 0.3.1
- Update Rust crate itertools to 0.11.0
- Update Rust crate num-derive to 0.4
- Update Rust crate tokio to 1.29

Bump propolis rev to pick up:

- Bump crucible rev to latest
- Add xtask for checking license headers
- Make license headers consistent
- Tweak docs CI job and fix existing nits
- Disable PHD test in buildomat until CI is fixed
- propolis-server should use reservoir on prod gear
- PHD: add Ubuntu 22.04 guest adapter

Also ran `cargo update -p 'async-trait@0.1.71'`, then manually edited Cargo.lock to set ringbuffer's version to 0.14.1, because of a breaking change in 0.14.2.