### PR TITLE
Queue disks for upsert when a transient error occurs

### DIFF
--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -500,8 +500,8 @@ impl Agent {
             addr: SocketAddrV6::new(ip, BOOTSTORE_PORT, 0, 0),
             time_per_tick: std::time::Duration::from_millis(250),
             learn_timeout: std::time::Duration::from_secs(5),
-            rack_init_timeout: std::time::Duration::from_secs(60),
-            rack_secret_request_timeout: std::time::Duration::from_secs(30),
+            rack_init_timeout: std::time::Duration::from_secs(300),
+            rack_secret_request_timeout: std::time::Duration::from_secs(5),
             fsm_state_ledger_paths: bootstore_fsm_state_paths(
                 &storage_resources,
             )

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -618,7 +618,6 @@ impl StorageWorker {
         unparsed_disk: UnparsedDisk,
         queued_u2_drives: &mut Option<HashSet<QueuedDiskCreate>>,
     ) -> Result<Disk, sled_hardware::DiskError> {
-        // Ensure the disk conforms to an expected partition layout.
         match sled_hardware::Disk::new(
             &self.log,
             unparsed_disk.clone(),

--- a/sled-agent/src/storage_manager.rs
+++ b/sled-agent/src/storage_manager.rs
@@ -45,7 +45,7 @@ use illumos_utils::{zfs::Zfs, zpool::Zpool};
 
 // A key manager can only become ready once. This occurs during RSS or cold
 // boot when the bootstore has detected it has a key share.
-static KEY_MANAGER_READY: OnceLock<bool> = OnceLock::new();
+static KEY_MANAGER_READY: OnceLock<()> = OnceLock::new();
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -1108,7 +1108,7 @@ impl StorageWorker {
                 let _ = responder.send(Ok(()));
             }
             KeyManagerReady => {
-                let _ = KEY_MANAGER_READY.set(true);
+                let _ = KEY_MANAGER_READY.set(());
                 self.upsert_queued_disks(resources, queued_u2_drives).await;
             }
         }


### PR DESCRIPTION
Check every 5 seconds if there are any queued disks and we have a ready
key manager, meaning that this replica has a key share or it is using
the `HardcodedKeyRetriever`. If there are disks that need upserting then
try to do that. This allows not just for cold boot but for hot insert of
new disks when the trust quorum may not be available.

Current the only transient error is a `KeyManager::Error` which
indicates that the trust quorum is unavailable becaue not enough sleds
are online.

Fixes https://github.com/oxidecomputer/omicron/issues/3789