### PR TITLE
Exclude packages that are built into the ramdisk from the control plane image

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -106,10 +106,7 @@ EOF
 # for development workflows using `omicron-package install` that don't build a
 # full omicron OS ramdisk, so we filter them out here.
 for zone in $(find /work/package/install -maxdepth 1 -type f -name '*.tar.gz' \
-    | grep -v propolis-server.tar.gz \
-    | grep -v mgs.tar.gz \
-    | grep -v overlay.tar.gz \
-    | grep -v switch.tar.gz); do
+    | egrep -v '(propolis-server|mgs|overlay|switch)\.tar\.gz'); do
     cat >>/work/manifest.toml <<EOF
 [[artifact.control_plane.source.zones]]
 kind = "file"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -101,11 +101,15 @@ version = "$VERSION"
 kind = "composite-control-plane"
 EOF
 
-# Exclude `propolis-server` from the list of control plane zones: it is bundled
-# into the OS ramdisk. It still shows up under `.../install` for development
-# workflows using `omicron-package install` that don't build a full omicron OS
-# ramdisk, so we filter it out here.
-for zone in $(find /work/package/install -maxdepth 1 -type f -name '*.tar.gz' | grep -v propolis-server.tar.gz); do
+# Exclude a handful of tarballs from the list of control plane zones because
+# they are bundled into the OS ramdisk. They still show up under `.../install`
+# for development workflows using `omicron-package install` that don't build a
+# full omicron OS ramdisk, so we filter them out here.
+for zone in $(find /work/package/install -maxdepth 1 -type f -name '*.tar.gz' \
+    | grep -v propolis-server.tar.gz \
+    | grep -v mgs.tar.gz \
+    | grep -v overlay.tar.gz \
+    | grep -v switch.tar.gz); do
     cat >>/work/manifest.toml <<EOF
 [[artifact.control_plane.source.zones]]
 kind = "file"


### PR DESCRIPTION
Currently on `main`, the `control-plane.tar.gz` in the TUF repo includes a few tarballs it doesn't need (because they're already bundled into the OS ramdisk). This PR prunes them out explicitly when building the TUF manifest. This doesn't really feel like a sustainable way to do this - maybe it should be an allowlist instead of a denylist? Or maybe there's already a better way to do this but I don't understand `package.sh` well enough to see it.