### PR TITLE
[wicket] Disable updating the sled/switch where wicketd is running

### DIFF
--- a/wicket/src/state/mod.rs
+++ b/wicket/src/state/mod.rs
@@ -65,4 +65,36 @@ impl State {
             },
         }
     }
+
+    pub fn selected_component_matches_wicked_location(&self) -> bool {
+        match self.rack_state.selected {
+            ComponentId::Sled(i) => {
+                // Do we know the wicketd sled ID? If so, we can compare
+                // directly. (We will almost always know this.)
+                if let Some(wicketd_sled_id) = self.wicketd_location.sled_id {
+                    wicketd_sled_id.slot == u32::from(i)
+                } else {
+                    // We _could_ check and see if wicketd knows its sled's
+                    // baseboard (even though it didn't know the sled) and then
+                    // compare that against `self.inventory`, but it's
+                    // exceedingly unlikely that we'd find anything (since we
+                    // get the inventory from wicketd itself), so we'll just
+                    // return false.
+                    false
+                }
+            }
+            ComponentId::Switch(i) => {
+                // See comments above for `ComponentId::Sled(_)`; we do the same
+                // thing here for the switch.
+                if let Some(wicketd_switch_id) = self.wicketd_location.switch_id
+                {
+                    wicketd_switch_id.slot == u32::from(i)
+                } else {
+                    false
+                }
+            }
+            // wicketd's location is never related to a PSC.
+            ComponentId::Psc(_) => false,
+        }
+    }
 }


### PR DESCRIPTION
We already have server-side rejection of updating the sled where wicketd is running, but we have neither:

1. server-side rejection of updating the switch connected to the scrimlet where wicketd is running
2. client-side rejection of updating the sled / switch where wicketd is running

Rejecting updates of the switch we're connected via is correct today, because resetting the sidecar currently requires resetting the scrimlet it's attached to. That might not always be the case, so I'm a little hesitant to do the work to implement 1. But after #3810 it's really easy to do 2. This PR changes the update pane to not even give the option to update the sled or switch where we're currently connected:

![wicket-no-update](https://github.com/oxidecomputer/omicron/assets/1435635/680bd900-513c-4580-afea-cc464f9918a7)

Fixes #3505.