### PR TITLE
Update resource limits as per #3212

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -78,13 +78,13 @@ pub(crate) const MAX_NICS_PER_INSTANCE: usize = 8;
 // TODO-completeness: Support multiple external IPs
 pub(crate) const MAX_EXTERNAL_IPS_PER_INSTANCE: usize = 1;
 
-pub const MAX_VCPU_PER_INSTANCE: u16 = 32;
+pub const MAX_VCPU_PER_INSTANCE: u16 = 64;
 
 pub const MIN_MEMORY_BYTES_PER_INSTANCE: u32 = 1 << 30; // 1 GiB
-pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 64 * (1 << 30); // 64 GiB
+pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 256 * (1 << 30); // 256 GiB
 
 pub const MIN_DISK_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
-pub const MAX_DISK_SIZE_BYTES: u64 = 1 << 40; // 1 TiB
+pub const MAX_DISK_SIZE_BYTES: u64 = 1023 * (1 << 30); // 1023 GiB
 
 /// Manages an Oxide fleet -- the heart of the control plane
 pub struct Nexus {


### PR DESCRIPTION
vCPUs: 32 -> 64
memory: 64 GiB -> 256 GiB
disk size: 1 TiB -> 1023 GiB 