### PR TITLE
Enable timesync for the non-gimlet config and in CI

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -7,6 +7,7 @@
 #:  "%/var/svc/log/oxide-sled-agent:default.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log*",
+#:  "%/pool/ext/*/crypt/zone/oxz_ntp_*/root/var/log/chrony/*.log*",
 #:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log*",
 #:  "%/pool/ext/*/crypt/debug/global/oxide-sled-agent:default.log.*",
 #:  "%/pool/ext/*/crypt/debug/oxz_*/oxide-*.log.*",
@@ -53,6 +54,7 @@ _exit_trap() {
 	z_swadm addr list
 	z_swadm route list
 	z_swadm arp list
+	z_swadm nat list
 
 	PORTS=$(pfexec /opt/oxide/opte/bin/opteadm list-ports | tail +2 | awk '{ print $1; }')
 	for p in $PORTS; do
@@ -77,6 +79,13 @@ _exit_trap() {
 		pfexec zlogin "$z" arp -an
 	done
 
+	for z in $(zoneadm list -n | grep oxz_ntp); do
+		banner "${z/oxz_/}"
+		pfexec zlogin "$z" chronyc tracking
+		pfexec zlogin "$z" chronyc sources
+		pfexec zlogin "$z" cat /etc/inet/chrony.conf
+	done
+
 	pfexec zlogin sidecar_softnpu cat /var/log/softnpu.log
 
 	exit $status
@@ -84,6 +93,7 @@ _exit_trap() {
 trap _exit_trap EXIT
 
 z_swadm () {
+	echo "== swadm $@"
 	pfexec zlogin oxz_switch /opt/oxide/dendrite/bin/swadm $@
 }
 
@@ -139,19 +149,53 @@ for p in /input/ci-tools/work/end-to-end-tests/*.gz; do
 	chmod a+x "tests/$(basename "${p%.gz}")"
 done
 
-# Lab gateway ip
-export GATEWAY_IP=192.168.1.199
-# Proxy arp settings.
-export PXA_START="192.168.1.50"
-export PXA_END="192.168.1.90"
+# Ask buildomat for the range of extra addresses that we're allowed to use, and
+# break them up into the ranges we need.
 
-# Nexus (and any instances using the above IP pool) are configured to use external
-# IPs from a fixed subnet (192.168.1.0/24). OPTE/SoftNPU/Boundary Services take care
-# of NATing between the private VPC networks and this "external network".
-# We create a static IP in this subnet in the global zone and configure the switch
-# to use it as the default gateway.
-# NOTE: Keep in sync with $[SERVICE_]IP_POOL_{START,END}
-pfexec ipadm create-addr -T static -a $GATEWAY_IP/24 igb0/sidehatch
+bmat address ls
+set -- $(bmat address ls -f extra -Ho first,last,count)
+EXTRA_IP_START="${1:?No extra start IP address found}"
+EXTRA_IP_END="${2:?No extra end IP address found}"
+EXTRA_IP_COUNT="${3:?No extra IP address count found}"
+
+# We need at least 32 IP addresses
+((EXTRA_IP_COUNT >= 32))
+
+EXTRA_IP_BASE="${EXTRA_IP_START%.*}"
+EXTRA_IP_FOCTET="${EXTRA_IP_START##*.}"
+EXTRA_IP_LOCTET="${EXTRA_IP_END##*.}"
+
+# We will break up this additional IP address range as follows (offsets from
+# base address shown)
+#
+# 0-9	internal service pool
+#     0 external DNS server
+#     1 external DNS server
+#
+# 10	infra IP/uplink
+# 11+   IP pool
+
+SERVICE_IP_POOL_START="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 0))"
+SERVICE_IP_POOL_END="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 9))"
+DNS_IP1="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 0))"
+DNS_IP2="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 1))"
+UPLINK_IP="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 10))"
+PXA_START="$EXTRA_IP_BASE.$((EXTRA_IP_FOCTET + 11))"
+PXA_END="$EXTRA_IP_BASE.$((EXTRA_IP_LOCTET + 0))"
+
+# Set the gateway IP address to be the GZ IP...
+GATEWAY_IP=$(ipadm show-addr -po type,addr | \
+    awk -F'[:/]' '$1 == "dhcp" {print $2}')
+[[ -n "$GATEWAY_IP" ]]
+ping -s "$GATEWAY_IP" 56 1 || true
+GATEWAY_MAC=$(arp -an | awk -vgw=$GATEWAY_IP '$2 == gw {print $NF}')
+# ...and enable IP forwarding so that zones can reach external networks
+# through the GZ. This allows the NTP zone to talk to DNS and NTP servers on
+# the Internet.
+routeadm -e ipv4-forwarding -u
+
+# These variables are used by softnpu_init, so export them.
+export GATEWAY_IP GATEWAY_MAC PXA_START PXA_END
 
 pfexec zpool create -f scratch c1t1d0 c2t1d0
 ZPOOL_VDEV_DIR=/scratch ptime -m pfexec ./tools/create_virtual_hardware.sh
@@ -166,7 +210,34 @@ ZPOOL_VDEV_DIR=/scratch ptime -m pfexec ./tools/create_virtual_hardware.sh
 tar xf out/omicron-sled-agent.tar pkg/config-rss.toml
 SILO_NAME="$(sed -n 's/silo_name = "\(.*\)"/\1/p' pkg/config-rss.toml)"
 EXTERNAL_DNS_DOMAIN="$(sed -n 's/external_dns_zone_name = "\(.*\)"/\1/p' pkg/config-rss.toml)"
-rm -f pkg/config-rss.toml
+
+# Substitute addresses from the external network range into the RSS config.
+sed -i~ "
+	/^external_dns_ips/c\\
+external_dns_ips = [ \"$DNS_IP1\", \"$DNS_IP2\" ]
+	/^\\[\\[internal_services_ip_pool_ranges/,/^\$/ {
+		/^first/c\\
+first = \"$SERVICE_IP_POOL_START\"
+		/^last/c\\
+last = \"$SERVICE_IP_POOL_END\"
+	}
+	/^\\[rack_network_config/,/^$/ {
+		/^infra_ip_first/c\\
+infra_ip_first = \"$UPLINK_IP\"
+		/^infra_ip_last/c\\
+infra_ip_last = \"$UPLINK_IP\"
+	}
+	/^\\[\\[rack_network_config.uplinks/,/^\$/ {
+		/^gateway_ip/c\\
+gateway_ip = \"$GATEWAY_IP\"
+		/^uplink_cidr/c\\
+uplink_cidr = \"$UPLINK_IP/32\"
+	}
+" pkg/config-rss.toml
+diff -u pkg/config-rss.toml{~,} || true
+
+tar rvf out/omicron-sled-agent.tar pkg/config-rss.toml
+rm -f pkg/config-rss.toml*
 
 #
 # By default, OpenSSL creates self-signed certificates with "CA:true".  The TLS
@@ -239,13 +310,10 @@ do
 	retry=$((retry + 1))
 done
 
-
-# We also need to configure proxy arp for any services which use OPTE for external connectivity (e.g. Nexus)
-tar xf out/omicron-sled-agent.tar pkg/config-rss.toml
-SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress | sed -E 's/[ :]/&0/g; s/0([^:]{2}(:|$))/\1/g')
-SERVICE_IP_POOL_START="$(sed -n 's/^first = "\(.*\)"/\1/p' pkg/config-rss.toml)"
-SERVICE_IP_POOL_END="$(sed -n 's/^last = "\(.*\)"/\1/p' pkg/config-rss.toml)"
-rm -r pkg
+# We also need to configure proxy arp for any services which use OPTE for
+# external connectivity (e.g. Nexus)
+SOFTNPU_MAC=$(dladm show-vnic sc0_1 -p -o macaddress \
+    | sed -E 's/[ :]/&0/g; s/0([^:]{2}(:|$))/\1/g')
 
 pfexec zlogin sidecar_softnpu /softnpu/scadm \
 	--server /softnpu/server \
@@ -258,6 +326,19 @@ pfexec zlogin sidecar_softnpu /softnpu/scadm \
 	--client /softnpu/client \
 	standalone \
 	dump-state
+
+# Wait for the chrony service in the NTP zone to come up
+retry=0
+while [[ $(pfexec svcs -z $(zoneadm list -n | grep oxz_ntp) \
+    -Hostate oxide/ntp || true) != online ]]; do
+	if [[ $retry -gt 60 ]]; then
+		echo "NTP zone chrony failed to come up after 60 seconds"
+		exit 1
+	fi
+	sleep 1
+	retry=$((retry + 1))
+done
+echo "Waited for chrony: ${retry}s"
 
 export RUST_BACKTRACE=1
 export E2E_TLS_CERT

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -1,6 +1,13 @@
 :showtitle:
 :toc: left
 :icons: font
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 = Running Omicron
 
@@ -108,14 +115,30 @@ As an example, in this doc:
 ** 192.168.1.20 - 192.168.1.29 for externally-facing services provided by the system,
 ** 192.168.1.30 as the address used by SoftNPU on the external network, and
 ** 192.168.1.31 - 192.168.1.40 as the addresses used for Instances that need some public IPs (even if just for NAT to the internet).
-2. Alternatively, you'll set up an "external" network that only exists on your test machine.  If you go this route, we'll choose 192.168.1.0/24 and all the same other details as in the case above, just for convenience.  In this mode, you'll need create your made-up network and give the global zone an IP address on it.  We'll use 192.168.1.199:
-+
+
+2. Alternatively, you'll set up an "external" network that only exists on your
+   test machine.  If you go this route, we'll choose 192.168.1.0/24 and all the
+   same other details as in the case above, just for convenience, and it happens
+   to match what is in the non-gimlet.toml file.  In this mode, you'll need to
+   create your made-up network, give the global zone an IP address on it,
+   and set up IPv4 forwarding and address translation (NAT) so that the NTP
+   zone and any instances can get out to the outside world.
+   We'll use 192.168.1.199 for the GZ interface.
+
+NOTE: In the two `map` lines, replace `igb0` with the name of your machine's
+      physical interface that connects to the outside world.
+
 [source,text]
 ----
-# pfexec dladm create-etherstub -t fake_external_stub0
+$ pfexec dladm create-etherstub -t fake_external_stub0
 $ pfexec dladm create-vnic -t -l fake_external_stub0 fake_external0
 $ pfexec ipadm create-if -t fake_external0
 $ pfexec ipadm create-addr -t -T static --address 192.168.1.199 fake_external0/external
+$ echo "map igb0 192.168.1.0/24 -> 0/32 portmap tcp/udp auto" > /tmp/ipnat.conf
+$ echo "map igb0 192.168.1.0/24 -> 0/32" >> /tmp/ipnat.conf
+$ pfexec cp /tmp/ipnat.conf /etc/ipf/ipnat.conf
+$ pfexec routeadm -e ipv4-forwarding -u
+$ svcadm enable ipfilter
 ----
 
 Other network configurations are possible but beyond the scope of this doc.
@@ -305,7 +328,7 @@ Options:
 
 ----
 
-To setup a build target for a non-Gimlet machine with simulated (but fully functional) external networking, you would run:
+To set up a build target for a non-Gimlet machine with simulated (but fully functional) external networking, you would run:
 
 [source,console]
 ----

--- a/end-to-end-tests/src/bin/bootstrap.rs
+++ b/end-to-end-tests/src/bin/bootstrap.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     let (first, last) = get_system_ip_pool().await?;
 
     // ===== CREATE IP POOL ===== //
-    eprintln!("creating IP pool...");
+    eprintln!("creating IP pool... {:?} - {:?}", first, last);
     client
         .ip_pool_range_add()
         .pool("default")

--- a/end-to-end-tests/src/helpers/mod.rs
+++ b/end-to-end-tests/src/helpers/mod.rs
@@ -4,6 +4,7 @@ use self::ctx::nexus_addr;
 use anyhow::{bail, Result};
 use oxide_client::types::Name;
 use rand::{thread_rng, Rng};
+use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 
 pub fn generate_name(prefix: &str) -> Result<Name> {
@@ -12,17 +13,24 @@ pub fn generate_name(prefix: &str) -> Result<Name> {
         .map_err(anyhow::Error::msg)
 }
 
-/// HACK: we're picking a range that doesn't conflict with either iliana's or
-/// the lab environment's IP ranges. This is not terribly robust. (in both
-/// iliana's environment and the lab, the last octet is 20; in my environment
-/// the DHCP range is 100-249, and in the buildomat lab environment the network
-/// is currently private.)
 pub async fn get_system_ip_pool() -> Result<(Ipv4Addr, Ipv4Addr)> {
+    if let (Ok(s), Ok(e)) = (env::var("PXA_START"), env::var("PXA_END")) {
+        return Ok((
+            s.parse::<Ipv4Addr>().expect("PXA_START is not an IP address"),
+            e.parse::<Ipv4Addr>().expect("PXA_END is not an IP address"),
+        ));
+    }
+
     let nexus_addr = match nexus_addr().await? {
         IpAddr::V4(addr) => addr.octets(),
         IpAddr::V6(_) => bail!("not sure what to do about IPv6 here"),
     };
 
+    // HACK: we're picking a range that doesn't conflict with either iliana's
+    // or the lab environment's IP ranges. This is not terribly robust. (in
+    // both iliana's environment and the lab, the last octet is 20; in my
+    // environment the DHCP range is 100-249, and in the buildomat lab
+    // environment the network is currently private.)
     let first = [nexus_addr[0], nexus_addr[1], nexus_addr[2], 50].into();
     let last = [nexus_addr[0], nexus_addr[1], nexus_addr[2], 90].into();
 

--- a/end-to-end-tests/src/helpers/mod.rs
+++ b/end-to-end-tests/src/helpers/mod.rs
@@ -14,10 +14,10 @@ pub fn generate_name(prefix: &str) -> Result<Name> {
 }
 
 pub async fn get_system_ip_pool() -> Result<(Ipv4Addr, Ipv4Addr)> {
-    if let (Ok(s), Ok(e)) = (env::var("PXA_START"), env::var("PXA_END")) {
+    if let (Ok(s), Ok(e)) = (env::var("IPPOOL_START"), env::var("IPPOOL_END")) {
         return Ok((
-            s.parse::<Ipv4Addr>().expect("PXA_START is not an IP address"),
-            e.parse::<Ipv4Addr>().expect("PXA_END is not an IP address"),
+            s.parse::<Ipv4Addr>().expect("IPPOOL_START is not an IP address"),
+            e.parse::<Ipv4Addr>().expect("IPPOOL_END is not an IP address"),
         ));
     }
 

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -15,7 +15,7 @@ rack_subnet = "fd00:1122:3344:0100::"
 # Only include "our own sled" in the bootstrap network
 bootstrap_discovery.type = "only_ours"
 
-ntp_servers = [ "ntp.eng.oxide.computer" ]
+ntp_servers = [ "0.pool.ntp.org" ]
 dns_servers = [ "1.1.1.1", "9.9.9.9" ]
 
 # Delegated external DNS zone name

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -16,7 +16,7 @@ sidecar_revision.soft = { front_port_count = 1, rear_port_count = 1 }
 
 # Setting this to true causes sled-agent to always report that its time is
 # in-sync, rather than querying its NTP zone.
-skip_timesync = true
+skip_timesync = false
 
 # For testing purposes, A file-backed zpool can be manually created with the
 # following:


### PR DESCRIPTION
This changes non-gimlet/config-rss.toml so that time synchronisation is enabled, and updates the CI deploy job to support that.

Fixes #3501 