### PR TITLE
Do not attempt to delete dataset used for swap device

### DIFF
--- a/illumos-utils/src/zfs.rs
+++ b/illumos-utils/src/zfs.rs
@@ -427,6 +427,11 @@ pub fn get_all_omicron_datasets_for_delete() -> anyhow::Result<Vec<String>> {
                 continue;
             }
 
+            // The swap device might be in use, so don't assert that it can be deleted.
+            if dataset == "swap" && internal {
+                continue;
+            }
+
             datasets.push(format!("{pool}/{dataset}"));
         }
     }

--- a/smf/sled-agent/gimlet-standalone/config.toml
+++ b/smf/sled-agent/gimlet-standalone/config.toml
@@ -20,7 +20,17 @@ skip_timesync = true
 
 # Percentage of usable physical DRAM to use for the VMM reservoir, which
 # guest memory is pulled from.
-vmm_reservoir_percentage = 0
+vmm_reservoir_percentage = 80
+
+# Swap device size for the system. The device is a sparsely allocated zvol on
+# the internal zpool of the M.2 that we booted from.
+#
+# If use of the VMM reservoir is configured, it is likely the system will not
+# work without a swap device configured.
+#
+# We pick 256 GiB somewhat arbitrarily, since the device is sparsely
+# allocated.
+swap_device_size_gb = 256
 
 # An optional data link from which we extract a MAC address.
 # This is used as a unique identifier for the bootstrap address.

--- a/smf/sled-agent/gimlet/config.toml
+++ b/smf/sled-agent/gimlet/config.toml
@@ -25,10 +25,14 @@ data_link = "cxgbe0"
 # guest memory is pulled from.
 vmm_reservoir_percentage = 80
 
-# Swap device size for the system.
-# We pick 256 GiB somewhat arbitrarily, since the device is sparsely allocated.
-# This field is only needed for the gimlet configuration: helios as packaged
-# for non-gimlets will configure a swap device via /etc/vfstab.
+# Swap device size for the system. The device is a sparsely allocated zvol on
+# the internal zpool of the M.2 that we booted from.
+#
+# If use of the VMM reservoir is configured, it is likely the system will not
+# work without a swap device configured.
+#
+# We pick 256 GiB somewhat arbitrarily, since the device is sparsely
+# allocated.
 swap_device_size_gb = 256
 
 data_links = ["cxgbe0", "cxgbe1"]

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -41,8 +41,11 @@ zpools = [
 # guest memory is pulled from.
 vmm_reservoir_percentage = 50
 
-# Create a 64GB swap device. The VMM reservoir will not function without a swap
-# device.
+# Swap device size for the system. The device is a sparsely allocated zvol on
+# the internal zpool of the M.2 that we booted from.
+#
+# If use of the VMM reservoir is configured, it is likely the system will not
+# work without a swap device configured.
 swap_device_size_gb = 64
 
 # An optional data link from which we extract a MAC address.


### PR DESCRIPTION
Fixes #3651 by skipping the swap dataset where we fetch datasets that can be deleted. In the limit, we may want to log a warning here (or even try to delete the device), but I'd like to unblock folks who are hitting this issue.

I also updated the gimlet-standalone config to configure a reservoir and a swap device (to round out fixing #3743).

I tested this on dunkin using a non-gimlet configuration. I ensured there were no swap devices, installed omicron and saw that it created one, then did an uninstall to ensure it completed successfully.