### PR TITLE
[bootstrap-agent] Refactor rack_ops

### DIFF
--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -8,9 +8,9 @@ use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use omicron_common::cmd::fatal;
 use omicron_common::cmd::CmdError;
+use omicron_sled_agent::bootstrap::RssAccessError;
 use omicron_sled_agent::bootstrap::{
-    agent as bootstrap_agent, config::Config as BootstrapConfig,
-    server as bootstrap_server,
+    config::Config as BootstrapConfig, server as bootstrap_server,
 };
 use omicron_sled_agent::rack_setup::config::SetupServiceConfig as RssConfig;
 use omicron_sled_agent::{config::Config as SledConfig, server as sled_server};
@@ -121,10 +121,7 @@ async fn do_run() -> Result<(), CmdError> {
                 match server.agent().start_rack_initialize(rss_config) {
                     // If the rack has already been initialized, we shouldn't
                     // abandon the server.
-                    Ok(_)
-                    | Err(
-                        bootstrap_agent::RssAccessError::AlreadyInitialized,
-                    ) => {}
+                    Ok(_) | Err(RssAccessError::AlreadyInitialized) => {}
                     Err(e) => {
                         return Err(CmdError::Failure(e.to_string()));
                     }

--- a/sled-agent/src/bootstrap/agent.rs
+++ b/sled-agent/src/bootstrap/agent.rs
@@ -12,6 +12,7 @@ use super::hardware::HardwareMonitor;
 use super::http_entrypoints::RackOperationStatus;
 use super::params::RackInitializeRequest;
 use super::params::StartSledAgentRequest;
+use super::rack_ops::{RackInitId, RackResetId, RssAccess, RssAccessError};
 use super::secret_retriever::LrtqOrHardcodedSecretRetriever;
 use super::views::SledAgentResponse;
 use crate::config::Config as SledConfig;
@@ -48,13 +49,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-
-mod rack_ops;
-
-pub use rack_ops::RackInitId;
-pub use rack_ops::RackResetId;
-use rack_ops::RssAccess;
-pub use rack_ops::RssAccessError;
 
 /// Describes errors which may occur while operating the bootstrap service.
 #[derive(Error, Debug)]
@@ -852,14 +846,20 @@ impl Agent {
         self: &Arc<Self>,
         request: RackInitializeRequest,
     ) -> Result<RackInitId, RssAccessError> {
-        self.rss_access.start_initializing(self, request)
+        self.rss_access.start_initializing(
+            &self.parent_log,
+            self.ip,
+            &self.storage_resources,
+            &self.bootstore,
+            request,
+        )
     }
 
     /// Spawn a task to run rack reset.
     pub fn start_rack_reset(
         self: &Arc<Self>,
     ) -> Result<RackResetId, RssAccessError> {
-        self.rss_access.start_reset(self)
+        self.rss_access.start_reset(&self.parent_log, self.ip)
     }
 
     /// Get the status of a spawned initialize or reset operation.

--- a/sled-agent/src/bootstrap/http_entrypoints.rs
+++ b/sled-agent/src/bootstrap/http_entrypoints.rs
@@ -7,9 +7,9 @@
 //! Note that the bootstrap agent also communicates over Sprockets,
 //! and has a separate interface for establishing the trust quorum.
 
-use super::agent::{RackInitId, RackResetId};
 use crate::bootstrap::agent::Agent;
 use crate::bootstrap::params::RackInitializeRequest;
+use crate::bootstrap::rack_ops::{RackInitId, RackResetId};
 use crate::updates::Component;
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseOk,

--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -12,8 +12,11 @@ mod hardware;
 mod http_entrypoints;
 mod maghemite;
 pub(crate) mod params;
+mod rack_ops;
 pub(crate) mod rss_handle;
 mod secret_retriever;
 pub mod server;
 mod sprockets_server;
 mod views;
+
+pub use rack_ops::RssAccessError;


### PR DESCRIPTION
Moves it from under `bootstrap/agent/` to just under `bootstrap/`, and removes its dependency on `Agent`. Part of #3827.