### PR TITLE
Use event channel for contract reaping

### DIFF
--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -65,7 +65,6 @@ pub enum ExecutionError {
 #[cfg_attr(any(test, feature = "testing"), mockall::automock, allow(dead_code))]
 mod inner {
     use super::*;
-    use std::process::Stdio;
 
     fn to_string(command: &mut std::process::Command) -> String {
         command
@@ -91,35 +90,8 @@ mod inner {
         }))
     }
 
-    // Helper functions for starting the process and checking the
+    // Helper function for starting the process and checking the
     // exit code result.
-
-    pub fn spawn_with_piped_stdout_and_stderr(
-        command: &mut std::process::Command,
-    ) -> Result<std::process::Child, ExecutionError> {
-        command.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn().map_err(
-            |err| ExecutionError::ExecutionStart {
-                command: to_string(command),
-                err,
-            },
-        )
-    }
-
-    pub fn run_child(
-        command: &mut std::process::Command,
-        child: std::process::Child,
-    ) -> Result<std::process::Output, ExecutionError> {
-        let output = child.wait_with_output().map_err(|err| {
-            ExecutionError::ExecutionStart { command: to_string(command), err }
-        })?;
-
-        if !output.status.success() {
-            return Err(output_to_exec_error(command, &output));
-        }
-
-        Ok(output)
-    }
-
     pub fn execute(
         command: &mut std::process::Command,
     ) -> Result<std::process::Output, ExecutionError> {

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -17,6 +17,7 @@ use slog::{error, info, o, warn, Logger};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 #[cfg(target_os = "illumos")]
 use std::sync::OnceLock;
+#[cfg(target_os = "illumos")]
 use std::thread;
 use uuid::Uuid;
 
@@ -164,7 +165,7 @@ pub fn ensure_contract_reaper(log: &Logger) {
 }
 
 #[cfg(not(target_os = "illumos"))]
-pub fn init_contract_reaper(log: &Logger) {
+pub fn ensure_contract_reaper(log: &Logger) {
     info!(log, "Not illumos, skipping contract reaper thread");
 }
 

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -12,14 +12,8 @@ use crate::svc::wait_for_service;
 use crate::zone::{AddressRequest, IPADM, ZONE_PREFIX};
 use camino::{Utf8Path, Utf8PathBuf};
 use ipnetwork::IpNetwork;
-#[cfg(target_os = "illumos")]
-use libc::pid_t;
 use omicron_common::backoff;
-use slog::error;
-use slog::info;
-use slog::o;
-use slog::warn;
-use slog::Logger;
+use slog::{debug, error, info, o, warn, Logger};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use uuid::Uuid;
 
@@ -154,19 +148,33 @@ pub enum GetZoneError {
     },
 }
 
+#[cfg(target_os = "illumos")]
+pub fn init_contract_reaper(log: &Logger) {
+    info!(log, "Starting contract reaper thread");
+    let log = log.clone();
+    let _ = std::thread::spawn(move || zenter::contract_reaper(&log));
+}
+
+#[cfg(not(target_os = "illumos"))]
+pub fn init_contract_reaper(log: &Logger) {
+    info!(log, "Not illumos, skipping contract reaper thread");
+}
+
 // Helper module for setting up and running `zone_enter()` for subprocesses run
 // inside a non-global zone.
 #[cfg(target_os = "illumos")]
 mod zenter {
     use libc::ctid_t;
-    use libc::pid_t;
     use libc::zoneid_t;
+    use slog::{error, Logger};
     use std::ffi::c_int;
     use std::ffi::c_uint;
+    use std::ffi::c_void;
     use std::ffi::{CStr, CString};
-    use std::fs::File;
-    use std::os::unix::prelude::FileExt;
     use std::process;
+
+    #[allow(non_camel_case_types)]
+    type ct_evthdl_t = *mut c_void;
 
     #[link(name = "contract")]
     extern "C" {
@@ -177,11 +185,48 @@ mod zenter {
         fn ct_tmpl_activate(fd: c_int) -> c_int;
         fn ct_tmpl_clear(fd: c_int) -> c_int;
         fn ct_ctl_abandon(fd: c_int) -> c_int;
+        fn ct_event_read_critical(fd: c_int, ev: *mut ct_evthdl_t) -> c_int;
+        fn ct_event_get_type(ev: ct_evthdl_t) -> u64;
+        fn ct_event_get_ctid(ev: ct_evthdl_t) -> ctid_t;
+        fn ct_event_free(ev: ct_evthdl_t);
     }
 
     #[link(name = "c")]
     extern "C" {
         pub fn zone_enter(zid: zoneid_t) -> c_int;
+    }
+
+    // This thread watches for critical events coming from all process
+    // contracts held by sled-agent, and reaps (abandons) contracts which
+    // become empty. Process contracts are used in conjunction with
+    // zone_enter() in order to run commands within non-global zones, and
+    // the contracts used for this come from templates that define becoming
+    // empty as a critical event.
+    pub fn contract_reaper(log: &Logger) {
+        const EVENT_PATH: &[u8] = b"/system/contract/process/pbundle";
+        const CT_PR_EV_EMPTY: u64 = 1;
+
+        let cpath = CString::new(EVENT_PATH).unwrap();
+        let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDONLY) };
+
+        loop {
+            let mut ev: ct_evthdl_t = std::ptr::null_mut();
+            let evp: *mut ct_evthdl_t = &mut ev;
+            if unsafe { ct_event_read_critical(fd, evp) } == 0 {
+                let typ = unsafe { ct_event_get_type(ev) };
+                if typ == CT_PR_EV_EMPTY {
+                    let ctid = unsafe { ct_event_get_ctid(ev) };
+                    match abandon_contract(ctid) {
+                        Err(e) => error!(
+                            log,
+                            "Failed to abandon contract {}: {}", ctid, e
+                        ),
+                        Ok(_) => debug!(log, "Abandoned contract {}", ctid),
+                    }
+                }
+                unsafe { ct_event_free(ev) };
+            }
+        }
     }
 
     #[derive(thiserror::Error, Debug)]
@@ -194,19 +239,6 @@ mod zenter {
 
         #[error("Error closing file {file}: {error}")]
         Close { file: String, error: std::io::Error },
-    }
-
-    pub fn get_contract(pid: pid_t) -> std::io::Result<ctid_t> {
-        // The offset of "id_t pr_contract" in struct psinfo which is an
-        // interface documented in proc(5).
-        const CONTRACT_OFFSET: u64 = 280;
-
-        let path = format!("/proc/{}/psinfo", pid);
-
-        let file = File::open(path)?;
-        let mut buffer = [0; 4];
-        file.read_exact_at(&mut buffer, CONTRACT_OFFSET)?;
-        Ok(ctid_t::from_ne_bytes(buffer))
     }
 
     pub fn abandon_contract(ctid: ctid_t) -> Result<(), AbandonContractError> {
@@ -260,6 +292,8 @@ mod zenter {
         // `usr/src/uts/common/sys/contract/process.h` in the illumos sources
         // for details.
 
+        // Contract has become empty.
+        const CT_PR_EV_EMPTY: c_uint = 0x1;
         // Process experienced an uncorrectable error.
         const CT_PR_EV_HWERR: c_uint = 0x20;
         // Only kill process group on fatal errors.
@@ -282,7 +316,7 @@ mod zenter {
             //
             // See illumos sources in `usr/src/cmd/zlogin/zlogin.c` in the
             // implementation of `init_template()` for details.
-            if unsafe { ct_tmpl_set_critical(fd, 0) } != 0
+            if unsafe { ct_tmpl_set_critical(fd, Self::CT_PR_EV_EMPTY) } != 0
                 || unsafe { ct_tmpl_set_informative(fd, 0) } != 0
                 || unsafe { ct_pr_tmpl_set_fatal(fd, Self::CT_PR_EV_HWERR) }
                     != 0
@@ -381,45 +415,13 @@ impl RunningZone {
         }
         let command = command.args(args);
 
-        let child =
-            crate::spawn_with_piped_stdout_and_stderr(command).map_err(
-                |err| RunCommandError { zone: self.name().to_string(), err },
-            )?;
-
-        // Record the process contract now in use by the child; the contract
-        // just created from the template that we applied to this thread
-        // moments ago. We need to abandon it once the child is finished
-        // executing.
-        // unwrap() safety - child.id() returns u32 but pid_t is i32.
-        // PID_MAX is 999999 so this will not overflow.
-        let child_pid: pid_t = child.id().try_into().unwrap();
-        let contract = zenter::get_contract(child_pid);
-
         // Capture the result, and be sure to clear the template for this
         // process itself before returning.
-        let res = crate::run_child(command, child).map_err(|err| {
-            RunCommandError { zone: self.name().to_string(), err }
+        let res = crate::execute(command).map_err(|err| RunCommandError {
+            zone: self.name().to_string(),
+            err,
         });
         template.clear();
-
-        // Now abandon the contract that was used for the child.
-        match contract {
-            Err(e) => error!(
-                self.inner.log,
-                "Could not retrieve contract for pid {}: {}", child_pid, e
-            ),
-            Ok(ctid) => {
-                if let Err(e) = zenter::abandon_contract(ctid) {
-                    error!(
-                        self.inner.log,
-                        "Failed to abandon contract {} for pid {}: {}",
-                        ctid,
-                        child_pid,
-                        e
-                    );
-                }
-            }
-        }
 
         res.map(|output| String::from_utf8_lossy(&output.stdout).to_string())
     }
@@ -437,11 +439,7 @@ impl RunningZone {
         // that's actually run is irrelevant.
         let mut command = std::process::Command::new("echo");
         let command = command.args(args);
-        let child =
-            crate::spawn_with_piped_stdout_and_stderr(command).map_err(
-                |err| RunCommandError { zone: self.name().to_string(), err },
-            )?;
-        crate::run_child(command, child)
+        crate::execute(command)
             .map_err(|err| RunCommandError {
                 zone: self.name().to_string(),
                 err,

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -243,7 +243,9 @@ mod zenter {
                                 &log,
                                 "Failed to abandon contract {}: {}", ctid, e
                             ),
-                            Ok(_) => debug!(&log, "Abandoned contract {}", ctid),
+                            Ok(_) => {
+                                debug!(&log, "Abandoned contract {}", ctid)
+                            }
                         }
                     }
                     unsafe { ct_event_free(ev) };

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -352,7 +352,7 @@ mod zenter {
             // Initialize the contract template.
             //
             // Nothing is inherited, we do not allow the contract to be
-            // orphaned, and the only event which is delivered is EMPTY,
+            // orphaned, and the only event which is delivered is EV_EMPTY,
             // indicating that the contract has become empty. These events are
             // consumed by contract_reaper() above.
             //

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2908,20 +2908,8 @@ mod test {
         wait_ctx.expect().return_once(|_, _| Ok(()));
 
         // Import the manifest, enable the service
-        let spawn_ctx =
-            illumos_utils::spawn_with_piped_stdout_and_stderr_context();
-        spawn_ctx.expect().times(..).returning(|_| {
-            std::process::Command::new("/bin/false").spawn().map_err(|err| {
-                illumos_utils::ExecutionError::ExecutionStart {
-                    command: "mock".to_string(),
-                    err,
-                }
-            })
-        });
-        let run_child_ctx = illumos_utils::run_child_context();
-        run_child_ctx.expect().times(..).returning(|_, mut child| {
-            let _ = child.kill();
-
+        let execute_ctx = illumos_utils::execute_context();
+        execute_ctx.expect().times(..).returning(|_| {
             Ok(std::process::Output {
                 status: std::process::ExitStatus::from_raw(0),
                 stdout: vec![],
@@ -2936,8 +2924,7 @@ mod test {
             Box::new(id_ctx),
             Box::new(ensure_address_ctx),
             Box::new(wait_ctx),
-            Box::new(spawn_ctx),
-            Box::new(run_child_ctx),
+            Box::new(execute_ctx),
         ]
     }
 

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -284,6 +284,11 @@ impl SledAgent {
             }
         }
 
+        // Ensure we have a thread that automatically reaps process contracts
+        // when they become empty. See the comments in
+        // illumos-utils/src/running_zone.rs for more detail.
+        illumos_utils::running_zone::ensure_contract_reaper(&parent_log);
+
         let etherstub = Dladm::ensure_etherstub(
             illumos_utils::dladm::UNDERLAY_ETHERSTUB_NAME,
         )
@@ -345,8 +350,6 @@ impl SledAgent {
                 panic!("invalid requested VMM reservoir percentage: {}", sz);
             }
         }
-
-        illumos_utils::running_zone::init_contract_reaper(&log);
 
         let update_config = ConfigUpdates {
             zone_artifact_path: Utf8PathBuf::from("/opt/oxide"),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -346,6 +346,8 @@ impl SledAgent {
             }
         }
 
+        illumos_utils::running_zone::init_contract_reaper(&log);
+
         let update_config = ConfigUpdates {
             zone_artifact_path: Utf8PathBuf::from("/opt/oxide"),
         };


### PR DESCRIPTION
Should fix #3828 

The previous solution was relying on being able to get in and read the child's contract ID after the initial fork()/exec() but before the child exited. There were occasions where this race was lost and the contract ended up being leaked.