### PR TITLE
Chrony logs rotate too quickly

### DIFF
--- a/smf/ntp/etc/logadm.d/chrony.logadm.conf
+++ b/smf/ntp/etc/logadm.d/chrony.logadm.conf
@@ -1,4 +1,2 @@
-# Rotate chrony logs daily and keep at most 8 old files.
-# This is daily by virtue of the `logadm` entry in root's crontab only running
-# once a day; the thresholds specified here are >= 1 byte, and now.
-chrony_logs /var/log/chrony/*.log -C 8 -z 3 -p now -s 1b -c -t '$file.$secs'
+# Rotate chrony logs at 10MiB and keep 10 compressed old logs.
+chrony_logs /var/log/chrony/*.log -C 10 -z 0 -s 10m -c -t '$file.$secs'


### PR DESCRIPTION
After #3745, chrony logs are rotating every 15 minutes instead of
daily. This changes the strategy to rotate every 10 MiB and keep the
last 10 files compressed with gzip. These logs don't grow quickly
once time is stable.
