### PR TITLE
don't declare time synchronization too early

### DIFF
--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2418,10 +2418,16 @@
             "type": "number",
             "format": "double"
           },
-          "skew": {
-            "description": "The estimated error bound on the frequency.",
-            "type": "number",
-            "format": "double"
+          "ip_addr": {
+            "description": "The NTP reference IP address.",
+            "type": "string",
+            "format": "ip"
+          },
+          "ref_id": {
+            "description": "The NTP reference ID.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           },
           "sync": {
             "description": "The synchronization state of the sled, true when the system clock and the NTP clock are in sync (to within a small window).",
@@ -2430,7 +2436,8 @@
         },
         "required": [
           "correction",
-          "skew",
+          "ip_addr",
+          "ref_id",
           "sync"
         ]
       },

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -823,12 +823,14 @@ pub struct TimeSync {
     /// The synchronization state of the sled, true when the system clock
     /// and the NTP clock are in sync (to within a small window).
     pub sync: bool,
-    // These could both be f32, but there is a problem with progenitor/typify
+    /// The NTP reference ID.
+    pub ref_id: u32,
+    /// The NTP reference IP address.
+    pub ip_addr: IpAddr,
+    // This could be f32, but there is a problem with progenitor/typify
     // where, although the f32 correctly becomes "float" (and not "double") in
     // the API spec, that "float" gets converted back to f64 when generating
     // the client.
-    /// The estimated error bound on the frequency.
-    pub skew: f64,
     /// The current offset between the NTP clock and system clock.
     pub correction: f64,
 }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -451,7 +451,12 @@ impl ServiceInner {
         );
 
         let ts = client.timesync_get().await?.into_inner();
-        Ok(TimeSync { sync: ts.sync, skew: ts.skew, correction: ts.correction })
+        Ok(TimeSync {
+            sync: ts.sync,
+            ref_id: ts.ref_id,
+            ip_addr: ts.ip_addr,
+            correction: ts.correction,
+        })
     }
 
     async fn wait_for_timesync(


### PR DESCRIPTION
Fixes #3831, I think. See https://github.com/oxidecomputer/omicron/issues/3831#issuecomment-1673767592 for analysis.

This changes the logic for deciding when NTP is synchronized to match that of [`chronyc waitsync`](https://github.com/mlichvar/chrony/blob/43320a1d6b3ef0e35ef377e3b0899990f31023ac/client.c#L2994-L3011); that is, if chrony has not selected a reference source, do not consider ourselves synchronized.

I can say with some confidence that the code changes here work as intended, but am somewhat limited in my testing as I'm trying to figure out why my box falls off the network once sled-agent reaches a certain point of the setup process.