### PR TITLE
[wicketd] Add support for TUF repo with multiple SP archives (distinct hardware revisions)

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -94,7 +94,7 @@ export TUFACEOUS_KEY
 cat >/work/manifest.toml <<EOF
 system_version = "$VERSION"
 
-[artifact.control_plane]
+[[artifact.control_plane]]
 name = "control-plane"
 version = "$VERSION"
 [artifact.control_plane.source]
@@ -116,7 +116,7 @@ done
 
 for kind in host trampoline; do
     cat >>/work/manifest.toml <<EOF
-[artifact.$kind]
+[[artifact.$kind]]
 name = "$kind"
 version = "$VERSION"
 [artifact.$kind.source]
@@ -162,7 +162,7 @@ add_hubris_artifacts() {
         sp_version=$(/work/caboose-util read-version "$sp_image")
 
         cat >>"$manifest" <<EOF
-[artifact.${tufaceous_board}_rot]
+[[artifact.${tufaceous_board}_rot]]
 name = "${tufaceous_board}_rot"
 version = "$rot_version_a"
 [artifact.${tufaceous_board}_rot.source]
@@ -173,7 +173,7 @@ path = "$rot_image_a"
 [artifact.${tufaceous_board}_rot.source.archive_b]
 kind = "file"
 path = "$rot_image_b"
-[artifact.${tufaceous_board}_sp]
+[[artifact.${tufaceous_board}_sp]]
 name = "${tufaceous_board}_sp"
 version = "$sp_version"
 [artifact.${tufaceous_board}_sp.source]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ name = "caboose-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=main)",
+ "hubtools",
 ]
 
 [[package]]
@@ -2754,7 +2754,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a954f3d1a42f56f985b4081ba6bedd0b6db8f330#a954f3d1a42f56f985b4081ba6bedd0b6db8f330"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1e180ae55e56bd17af35cb868ffbd18ce487351d#1e180ae55e56bd17af35cb868ffbd18ce487351d"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack 0.1.2",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=a954f3d1a42f56f985b4081ba6bedd0b6db8f330#a954f3d1a42f56f985b4081ba6bedd0b6db8f330"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1e180ae55e56bd17af35cb868ffbd18ce487351d#1e180ae55e56bd17af35cb868ffbd18ce487351d"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2778,17 +2778,17 @@ dependencies = [
  "gateway-messages",
  "hex",
  "hubpack 0.1.2",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git)",
+ "hubtools",
  "lru-cache",
  "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
  "once_cell",
  "serde",
  "serde-big-array 0.5.1",
  "slog",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "string_cache",
  "thiserror",
- "tlvc",
+ "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git?branch=main)",
  "tokio",
  "usdt",
  "uuid",
@@ -3226,26 +3226,7 @@ dependencies = [
  "path-slash",
  "rsa",
  "thiserror",
- "tlvc",
- "tlvc-text",
- "toml 0.7.6",
- "x509-cert",
- "zerocopy 0.6.1",
- "zip",
-]
-
-[[package]]
-name = "hubtools"
-version = "0.4.1"
-source = "git+https://github.com/oxidecomputer/hubtools.git#fbd499ceb440b838b9d8f6d9d73d046586bc24b8"
-dependencies = [
- "lpc55_areas",
- "lpc55_sign",
- "object",
- "path-slash",
- "rsa",
- "thiserror",
- "tlvc",
+ "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
  "tlvc-text",
  "toml 0.7.6",
  "x509-cert",
@@ -8024,12 +8005,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8583,8 +8564,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tlvc"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/tlvc.git#559c72856a215ae217e9e6f25ff317edde0b0041"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/tlvc.git?branch=main#e644a21a7ca973ed31499106ea926bd63ebccc6f"
+dependencies = [
+ "byteorder",
+ "crc",
+ "zerocopy 0.6.1",
+]
+
+[[package]]
+name = "tlvc"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/tlvc.git#e644a21a7ca973ed31499106ea926bd63ebccc6f"
 dependencies = [
  "byteorder",
  "crc",
@@ -8594,11 +8585,11 @@ dependencies = [
 [[package]]
 name = "tlvc-text"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/tlvc.git#559c72856a215ae217e9e6f25ff317edde0b0041"
+source = "git+https://github.com/oxidecomputer/tlvc.git#e644a21a7ca973ed31499106ea926bd63ebccc6f"
 dependencies = [
  "ron 0.8.0",
  "serde",
- "tlvc",
+ "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
  "zerocopy 0.6.1",
 ]
 
@@ -8674,7 +8665,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "tokio",
  "tokio-util",
 ]
@@ -9107,7 +9098,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ name = "caboose-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "hubtools",
+ "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
 ]
 
 [[package]]
@@ -2778,7 +2778,7 @@ dependencies = [
  "gateway-messages",
  "hex",
  "hubpack 0.1.2",
- "hubtools",
+ "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=main)",
  "lru-cache",
  "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
  "once_cell",
@@ -3213,6 +3213,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "hubtools"
+version = "0.4.1"
+source = "git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder#a7d98332b7ccc2da9fbb3478cf24edc5217679d3"
+dependencies = [
+ "lpc55_areas",
+ "lpc55_sign",
+ "object",
+ "path-slash",
+ "rsa",
+ "thiserror",
+ "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
+ "tlvc-text",
+ "toml 0.7.6",
+ "x509-cert",
+ "zerocopy 0.6.1",
+ "zip",
 ]
 
 [[package]]
@@ -9015,6 +9034,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "hex",
+ "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
  "itertools 0.10.5",
  "omicron-common 0.1.0",
  "rand 0.8.5",
@@ -9738,7 +9758,7 @@ dependencies = [
  "gateway-test-utils",
  "hex",
  "http",
- "hubtools",
+ "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
  "hyper",
  "installinator",
  "installinator-artifact-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9738,6 +9738,7 @@ dependencies = [
  "gateway-test-utils",
  "hex",
  "http",
+ "hubtools",
  "hyper",
  "installinator",
  "installinator-artifact-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,7 +807,7 @@ name = "caboose-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
+ "hubtools",
 ]
 
 [[package]]
@@ -1026,6 +1035,7 @@ dependencies = [
  "anstyle",
  "clap_lex 0.5.0",
  "strsim 0.10.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -2778,7 +2788,7 @@ dependencies = [
  "gateway-messages",
  "hex",
  "hubpack 0.1.2",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=main)",
+ "hubtools",
  "lru-cache",
  "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
  "once_cell",
@@ -3218,26 +3228,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.4.1"
-source = "git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder#a7d98332b7ccc2da9fbb3478cf24edc5217679d3"
-dependencies = [
- "lpc55_areas",
- "lpc55_sign",
- "object",
- "path-slash",
- "rsa",
- "thiserror",
- "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
- "tlvc-text",
- "toml 0.7.6",
- "x509-cert",
- "zerocopy 0.6.1",
- "zip",
-]
-
-[[package]]
-name = "hubtools"
-version = "0.4.1"
-source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#fbd499ceb440b838b9d8f6d9d73d046586bc24b8"
+source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#0c642f6e1f83b74725c7119a546bc26ac7452a48"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",
@@ -4037,18 +4028,19 @@ dependencies = [
 
 [[package]]
 name = "lpc55_areas"
-version = "0.2.2"
-source = "git+https://github.com/oxidecomputer/lpc55_support#914e495b9a6a6dd94e15a20d7ef271730996154a"
+version = "0.2.4"
+source = "git+https://github.com/oxidecomputer/lpc55_support#4051a3b9421573dc36ed6098b292a7609a3cf98b"
 dependencies = [
  "bitfield",
+ "clap 4.3.21",
  "packed_struct",
  "serde",
 ]
 
 [[package]]
 name = "lpc55_sign"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#914e495b9a6a6dd94e15a20d7ef271730996154a"
+version = "0.3.2"
+source = "git+https://github.com/oxidecomputer/lpc55_support#4051a3b9421573dc36ed6098b292a7609a3cf98b"
 dependencies = [
  "byteorder",
  "const-oid",
@@ -4063,6 +4055,7 @@ dependencies = [
  "pem-rfc7468",
  "rsa",
  "serde",
+ "serde-hex",
  "sha2 0.10.7",
  "thiserror",
  "x509-cert",
@@ -4110,6 +4103,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
@@ -4527,7 +4526,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec",
+ "smallvec 1.10.0",
 ]
 
 [[package]]
@@ -4556,6 +4555,12 @@ dependencies = [
  "pin-utils",
  "static_assertions",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -4607,7 +4612,8 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
- "smallvec",
+ "serde",
+ "smallvec 1.10.0",
  "zeroize",
 ]
 
@@ -5693,7 +5699,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "winapi",
 ]
 
@@ -5706,7 +5712,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "windows-sys 0.45.0",
 ]
 
@@ -6937,6 +6943,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.10.7",
  "signature 2.1.0",
  "subtle",
@@ -6964,7 +6971,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec",
+ "smallvec 1.10.0",
 ]
 
 [[package]]
@@ -7430,6 +7437,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
 ]
 
 [[package]]
@@ -7947,6 +7965,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
@@ -8388,6 +8415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8924,7 +8961,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -8945,7 +8982,7 @@ dependencies = [
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -9034,7 +9071,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "hex",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
+ "hubtools",
  "itertools 0.10.5",
  "omicron-common 0.1.0",
  "rand 0.8.5",
@@ -9118,8 +9155,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 
@@ -9758,7 +9795,7 @@ dependencies = [
  "gateway-test-utils",
  "hex",
  "http",
- "hubtools 0.4.1 (git+https://github.com/oxidecomputer/hubtools.git?branch=archive-builder)",
+ "hubtools",
  "hyper",
  "installinator",
  "installinator-artifact-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,8 +192,7 @@ hex-literal = "0.3.4"
 hkdf = "0.12.3"
 http = "0.2.9"
 httptest = "0.15.4"
-# TODO point back to main after merging
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "archive-builder" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "main" }
 humantime = "2.1.0"
 hyper = "0.14"
 hyper-rustls = "0.24.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,8 @@ hex-literal = "0.3.4"
 hkdf = "0.12.3"
 http = "0.2.9"
 httptest = "0.15.4"
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "main" }
+# TODO point back to main after merging
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "archive-builder" }
 humantime = "2.1.0"
 hyper = "0.14"
 hyper-rustls = "0.24.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,8 +181,8 @@ flate2 = "1.0.26"
 fs-err = "2.9.0"
 futures = "0.3.28"
 gateway-client = { path = "gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a954f3d1a42f56f985b4081ba6bedd0b6db8f330", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "a954f3d1a42f56f985b4081ba6bedd0b6db8f330" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d" }
 gateway-test-utils = { path = "gateway-test-utils" }
 glob = "0.3.1"
 headers = "0.3.8"

--- a/tufaceous-lib/Cargo.toml
+++ b/tufaceous-lib/Cargo.toml
@@ -16,6 +16,7 @@ debug-ignore.workspace = true
 flate2.workspace = true
 fs-err.workspace = true
 hex.workspace = true
+hubtools.workspace = true
 itertools.workspace = true
 omicron-common.workspace = true
 rand.workspace = true

--- a/tufaceous-lib/src/assemble/build.rs
+++ b/tufaceous-lib/src/assemble/build.rs
@@ -103,16 +103,18 @@ impl OmicronRepoAssembler {
         .into_editor()?;
 
         // Add all the artifacts.
-        for (kind, data) in &self.manifest.artifacts {
-            let new_artifact = AddArtifact::new(
-                (*kind).into(),
-                data.name.clone(),
-                data.version.clone(),
-                data.source.clone(),
-            );
-            repository.add_artifact(&new_artifact).with_context(|| {
-                format!("error adding artifact with kind `{kind}`")
-            })?;
+        for (kind, entries) in &self.manifest.artifacts {
+            for data in entries {
+                let new_artifact = AddArtifact::new(
+                    (*kind).into(),
+                    data.name.clone(),
+                    data.version.clone(),
+                    data.source.clone(),
+                );
+                repository.add_artifact(&new_artifact).with_context(|| {
+                    format!("error adding artifact with kind `{kind}`")
+                })?;
+            }
         }
 
         // Write out the repository.

--- a/tufaceous/manifests/fake.toml
+++ b/tufaceous/manifests/fake.toml
@@ -4,12 +4,12 @@
 
 system_version = "1.0.0"
 
-[artifact.gimlet_sp]
+[[artifact.gimlet_sp]]
 name = "fake-gimlet-sp"
 version = "1.0.0"
 source = { kind = "fake", size = "1MiB" }
 
-[artifact.gimlet_rot]
+[[artifact.gimlet_rot]]
 name = "fake-gimlet-rot"
 version = "1.0.0"
 [artifact.gimlet_rot.source]
@@ -17,7 +17,7 @@ kind = "composite-rot"
 archive_a = { kind = "fake", size = "512KiB" }
 archive_b = { kind = "fake", size = "512KiB" }
 
-[artifact.host]
+[[artifact.host]]
 name = "fake-host"
 version = "1.0.0"
 [artifact.host.source]
@@ -25,7 +25,7 @@ kind = "composite-host"
 phase_1 = { kind = "fake", size = "512KiB" }
 phase_2 = { kind = "fake", size = "3MiB" }
 
-[artifact.trampoline]
+[[artifact.trampoline]]
 name = "fake-trampoline"
 version = "1.0.0"
 [artifact.trampoline.source]
@@ -33,7 +33,7 @@ kind = "composite-host"
 phase_1 = { kind = "fake", size = "512KiB" }
 phase_2 = { kind = "fake", size = "3MiB" }
 
-[artifact.control_plane]
+[[artifact.control_plane]]
 name = "fake-control-plane"
 version = "1.0.0"
 [artifact.control_plane.source]
@@ -43,12 +43,12 @@ zones = [
     { kind = "fake", name = "zone2.tar.gz", size = "1MiB" },
 ]
 
-[artifact.psc_sp]
+[[artifact.psc_sp]]
 name = "fake-psc-sp"
 version = "1.0.0"
 source = { kind = "fake", size = "1MiB" }
 
-[artifact.psc_rot]
+[[artifact.psc_rot]]
 name = "fake-psc-rot"
 version = "1.0.0"
 [artifact.psc_rot.source]
@@ -56,12 +56,12 @@ kind = "composite-rot"
 archive_a = { kind = "fake", size = "512KiB" }
 archive_b = { kind = "fake", size = "512KiB" }
 
-[artifact.switch_sp]
+[[artifact.switch_sp]]
 name = "fake-switch-sp"
 version = "1.0.0"
 source = { kind = "fake", size = "1MiB" }
 
-[artifact.switch_rot]
+[[artifact.switch_rot]]
 name = "fake-switch-rot"
 version = "1.0.0"
 [artifact.switch_rot.source]

--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -163,6 +163,8 @@ pub enum UpdateTerminalError {
         #[source]
         error: gateway_client::Error<gateway_client::types::Error>,
     },
+    #[error("TUF repository missing SP image for board {board}")]
+    MissingSpImageForBoard { board: String },
     #[error("setting installinator image ID failed")]
     SetInstallinatorImageIdFailed {
         #[source]

--- a/wicket/src/upload.rs
+++ b/wicket/src/upload.rs
@@ -19,7 +19,9 @@ use tokio_util::io::ReaderStream;
 
 use crate::wicketd::create_wicketd_client;
 
-const WICKETD_UPLOAD_TIMEOUT: Duration = Duration::from_millis(30_000);
+// We have observed wicketd running in a switch zone under load take ~60 seconds
+// to accept a repository; set the timeout to double that to give some headroom.
+const WICKETD_UPLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Args)]
 pub(crate) struct UploadArgs {

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -18,6 +18,7 @@ dropshot.workspace = true
 futures.workspace = true
 gateway-messages.workspace = true
 hex.workspace = true
+hubtools.workspace = true
 http.workspace = true
 hyper.workspace = true
 reqwest.workspace = true

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -27,7 +27,7 @@ use omicron_common::update::{
     ArtifactHash, ArtifactHashId, ArtifactId, ArtifactKind,
 };
 use sha2::{Digest, Sha256};
-use slog::Logger;
+use slog::{info, Logger};
 use thiserror::Error;
 use tough::TargetName;
 use tufaceous_lib::{
@@ -199,7 +199,7 @@ impl ArtifactsWithPlan {
         let dir = camino_tempfile::tempdir()
             .map_err(RepositoryError::TempDirCreate)?;
 
-        slog::info!(log, "extracting uploaded archive to {}", dir.path());
+        info!(log, "extracting uploaded archive to {}", dir.path());
 
         // XXX: might be worth differentiating between server-side issues (503)
         // and issues with the uploaded archive (400).
@@ -318,7 +318,7 @@ impl ArtifactsWithPlan {
                 }
             }
 
-            slog::info!(
+            info!(
                 log, "added artifact";
                 "kind" => %artifact_id.kind,
                 "id" => format!("{}:{}", artifact_id.name, artifact_id.version),
@@ -617,6 +617,11 @@ impl UpdatePlan {
 
             match out.entry(board) {
                 btree_map::Entry::Vacant(slot) => {
+                    info!(
+                        log, "found SP archive";
+                        "kind" => ?id.kind,
+                        "board" => &slot.key().0,
+                    );
                     slot.insert(ArtifactIdData {
                         id,
                         data: DebugIgnore(data.clone()),
@@ -665,7 +670,7 @@ impl UpdatePlan {
 
             match artifact_kind {
                 KnownArtifactKind::GimletSp => {
-                    sp_image_found(&mut gimlet_sp, artifact_id, hash, data)?
+                    sp_image_found(&mut gimlet_sp, artifact_id, hash, data)?;
                 }
                 KnownArtifactKind::GimletRot => {
                     slog::debug!(log, "extracting gimlet rot tarball");
@@ -684,7 +689,7 @@ impl UpdatePlan {
                     )?;
                 }
                 KnownArtifactKind::PscSp => {
-                    sp_image_found(&mut psc_sp, artifact_id, hash, data)?
+                    sp_image_found(&mut psc_sp, artifact_id, hash, data)?;
                 }
                 KnownArtifactKind::PscRot => {
                     slog::debug!(log, "extracting psc rot tarball");
@@ -703,7 +708,7 @@ impl UpdatePlan {
                     )?;
                 }
                 KnownArtifactKind::SwitchSp => {
-                    sp_image_found(&mut sidecar_sp, artifact_id, hash, data)?
+                    sp_image_found(&mut sidecar_sp, artifact_id, hash, data)?;
                 }
                 KnownArtifactKind::SwitchRot => {
                     slog::debug!(log, "extracting switch rot tarball");
@@ -795,7 +800,7 @@ impl UpdatePlan {
                 ));
             }
             Entry::Vacant(entry) => {
-                slog::info!(log, "added host phase 2 artifact";
+                info!(log, "added host phase 2 artifact";
                     "kind" => %host_phase_2_hash_id.kind,
                     "hash" => %host_phase_2_hash_id.hash,
                     "length" => host_phase_2.data.len(),

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -3,7 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    borrow::Borrow,
+    collections::{btree_map, hash_map::Entry, BTreeMap, HashMap},
     convert::Infallible,
     io::{self, Read},
     sync::{Arc, Mutex},
@@ -16,6 +17,7 @@ use debug_ignore::DebugIgnore;
 use display_error_chain::DisplayErrorChain;
 use dropshot::HttpError;
 use futures::stream;
+use hubtools::RawHubrisArchive;
 use hyper::Body;
 use installinator_artifactd::{ArtifactGetter, EventReportStatus};
 use omicron_common::api::{
@@ -332,6 +334,7 @@ impl ArtifactsWithPlan {
             &by_id,
             &mut by_hash,
             log,
+            read_hubris_board_from_archive,
         )?;
 
         Ok(Self {
@@ -414,6 +417,35 @@ enum RepositoryError {
     #[error("multiple artifacts found for kind `{0:?}`")]
     DuplicateArtifactKind(KnownArtifactKind),
 
+    #[error("duplicate board found for kind `{kind:?}`: `{board}`")]
+    DuplicateBoardEntry { board: String, kind: KnownArtifactKind },
+
+    #[error("error parsing artifact {id:?} as hubris archive")]
+    ParsingHubrisArchive {
+        id: ArtifactId,
+        #[source]
+        error: Box<hubtools::Error>,
+    },
+
+    #[error("error reading hubris caboose from {id:?}")]
+    ReadHubrisCaboose {
+        id: ArtifactId,
+        #[source]
+        error: Box<hubtools::Error>,
+    },
+
+    #[error("error reading board from hubris caboose of {id:?}")]
+    ReadHubrisCabooseBoard {
+        id: ArtifactId,
+        #[source]
+        error: hubtools::CabooseError,
+    },
+
+    #[error(
+        "error reading board from hubris caboose of {0:?}: non-utf8 value"
+    )]
+    ReadHubrisCabooseBoardUtf8(ArtifactId),
+
     #[error("missing artifact of kind `{0:?}`")]
     MissingArtifactKind(KnownArtifactKind),
 
@@ -441,7 +473,12 @@ impl RepositoryError {
             | RepositoryError::TargetHashLength(_)
             | RepositoryError::MissingArtifactKind(_)
             | RepositoryError::MissingTarget(_)
-            | RepositoryError::DuplicateHashEntry(_) => {
+            | RepositoryError::DuplicateHashEntry(_)
+            | RepositoryError::DuplicateBoardEntry { .. }
+            | RepositoryError::ParsingHubrisArchive { .. }
+            | RepositoryError::ReadHubrisCaboose { .. }
+            | RepositoryError::ReadHubrisCabooseBoard { .. }
+            | RepositoryError::ReadHubrisCabooseBoardUtf8(_) => {
                 HttpError::for_bad_request(None, message)
             }
 
@@ -470,19 +507,28 @@ pub(crate) struct ArtifactIdData {
     pub(crate) hash: ArtifactHash,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Board(pub(crate) String);
+
+impl Borrow<String> for Board {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+
 /// The update plan currently in effect.
 ///
 /// Exposed for testing.
 #[derive(Debug, Clone)]
 pub struct UpdatePlan {
     pub(crate) system_version: SemverVersion,
-    pub(crate) gimlet_sp: ArtifactIdData,
+    pub(crate) gimlet_sp: BTreeMap<Board, ArtifactIdData>,
     pub(crate) gimlet_rot_a: ArtifactIdData,
     pub(crate) gimlet_rot_b: ArtifactIdData,
-    pub(crate) psc_sp: ArtifactIdData,
+    pub(crate) psc_sp: BTreeMap<Board, ArtifactIdData>,
     pub(crate) psc_rot_a: ArtifactIdData,
     pub(crate) psc_rot_b: ArtifactIdData,
-    pub(crate) sidecar_sp: ArtifactIdData,
+    pub(crate) sidecar_sp: BTreeMap<Board, ArtifactIdData>,
     pub(crate) sidecar_rot_a: ArtifactIdData,
     pub(crate) sidecar_rot_b: ArtifactIdData,
 
@@ -513,22 +559,39 @@ pub struct UpdatePlan {
 }
 
 impl UpdatePlan {
-    fn new(
+    // `read_hubris_board` should always be `read_hubris_board_from_archive`; we
+    // take it as an argument to allow unit tests to give us invalid/fake
+    // "hubris archives" `read_hubris_board_from_archive` wouldn't be able to
+    // handle.
+    fn new<F>(
         system_version: SemverVersion,
         by_id: &HashMap<ArtifactId, (ArtifactHash, Bytes)>,
         by_hash: &mut HashMap<ArtifactHashId, Bytes>,
         log: &Logger,
-    ) -> Result<Self, RepositoryError> {
+        read_hubris_board: F,
+    ) -> Result<Self, RepositoryError>
+    where
+        F: Fn(
+            ArtifactId,
+            Vec<u8>,
+        ) -> Result<(ArtifactId, Board), RepositoryError>,
+    {
+        // We expect at least one of each of these kinds to be present, but we
+        // allow multiple (keyed by the Hubris archive caboose `board` value,
+        // which identifies hardware revision). We could do the same for the RoT
+        // images, but to date the RoT images are applicable to all revs; only
+        // the SP images change from rev to rev.
+        let mut gimlet_sp = BTreeMap::new();
+        let mut psc_sp = BTreeMap::new();
+        let mut sidecar_sp = BTreeMap::new();
+
         // We expect exactly one of each of these kinds to be present in the
         // snapshot. Scan the snapshot and record the first of each we find,
         // failing if we find a second.
-        let mut gimlet_sp = None;
         let mut gimlet_rot_a = None;
         let mut gimlet_rot_b = None;
-        let mut psc_sp = None;
         let mut psc_rot_a = None;
         let mut psc_rot_b = None;
-        let mut sidecar_sp = None;
         let mut sidecar_rot_a = None;
         let mut sidecar_rot_b = None;
         let mut host_phase_1 = None;
@@ -545,6 +608,33 @@ impl UpdatePlan {
             ArtifactHash(hasher.finalize().into())
         };
 
+        // Helper called for each SP image found in the loop below.
+        let sp_image_found = |out: &mut BTreeMap<Board, ArtifactIdData>,
+                              id,
+                              hash: &ArtifactHash,
+                              data: &Bytes| {
+            let (id, board) = read_hubris_board(id, data.clone().into())?;
+
+            match out.entry(board) {
+                btree_map::Entry::Vacant(slot) => {
+                    slot.insert(ArtifactIdData {
+                        id,
+                        data: DebugIgnore(data.clone()),
+                        hash: *hash,
+                    });
+                    Ok(())
+                }
+                btree_map::Entry::Occupied(slot) => {
+                    Err(RepositoryError::DuplicateBoardEntry {
+                        board: slot.key().0.clone(),
+                        // This closure is only called with well-known kinds.
+                        kind: slot.get().id.kind.to_known().unwrap(),
+                    })
+                }
+            }
+        };
+
+        // Helper called for each non-SP artifact found in the loop below.
         let artifact_found = |out: &mut Option<ArtifactIdData>,
                               id,
                               hash: Option<&ArtifactHash>,
@@ -568,16 +658,15 @@ impl UpdatePlan {
             // In generating an update plan, skip any artifact kinds that are
             // unknown to us (we wouldn't know how to incorporate them into our
             // plan).
-            let Some(artifact_kind) = artifact_id.kind.to_known() else { continue };
+            let Some(artifact_kind) = artifact_id.kind.to_known() else {
+                continue;
+            };
             let artifact_id = artifact_id.clone();
 
             match artifact_kind {
-                KnownArtifactKind::GimletSp => artifact_found(
-                    &mut gimlet_sp,
-                    artifact_id,
-                    Some(hash),
-                    data,
-                )?,
+                KnownArtifactKind::GimletSp => {
+                    sp_image_found(&mut gimlet_sp, artifact_id, hash, data)?
+                }
                 KnownArtifactKind::GimletRot => {
                     slog::debug!(log, "extracting gimlet rot tarball");
                     let archives = unpack_rot_artifact(artifact_kind, data)?;
@@ -595,7 +684,7 @@ impl UpdatePlan {
                     )?;
                 }
                 KnownArtifactKind::PscSp => {
-                    artifact_found(&mut psc_sp, artifact_id, Some(hash), data)?
+                    sp_image_found(&mut psc_sp, artifact_id, hash, data)?
                 }
                 KnownArtifactKind::PscRot => {
                     slog::debug!(log, "extracting psc rot tarball");
@@ -613,12 +702,9 @@ impl UpdatePlan {
                         &archives.archive_b,
                     )?;
                 }
-                KnownArtifactKind::SwitchSp => artifact_found(
-                    &mut sidecar_sp,
-                    artifact_id,
-                    Some(hash),
-                    data,
-                )?,
+                KnownArtifactKind::SwitchSp => {
+                    sp_image_found(&mut sidecar_sp, artifact_id, hash, data)?
+                }
                 KnownArtifactKind::SwitchRot => {
                     slog::debug!(log, "extracting switch rot tarball");
                     let archives = unpack_rot_artifact(artifact_kind, data)?;
@@ -718,13 +804,27 @@ impl UpdatePlan {
             }
         }
 
+        // Ensure our multi-board-supporting kinds have at least one board
+        // present.
+        if gimlet_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::GimletSp,
+            ));
+        }
+        if psc_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::PscSp,
+            ));
+        }
+        if sidecar_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::SwitchSp,
+            ));
+        }
+
         Ok(Self {
             system_version,
-            gimlet_sp: gimlet_sp.ok_or(
-                RepositoryError::MissingArtifactKind(
-                    KnownArtifactKind::GimletSp,
-                ),
-            )?,
+            gimlet_sp,
             gimlet_rot_a: gimlet_rot_a.ok_or(
                 RepositoryError::MissingArtifactKind(
                     KnownArtifactKind::GimletRot,
@@ -735,20 +835,14 @@ impl UpdatePlan {
                     KnownArtifactKind::GimletRot,
                 ),
             )?,
-            psc_sp: psc_sp.ok_or(RepositoryError::MissingArtifactKind(
-                KnownArtifactKind::PscSp,
-            ))?,
+            psc_sp,
             psc_rot_a: psc_rot_a.ok_or(
                 RepositoryError::MissingArtifactKind(KnownArtifactKind::PscRot),
             )?,
             psc_rot_b: psc_rot_b.ok_or(
                 RepositoryError::MissingArtifactKind(KnownArtifactKind::PscRot),
             )?,
-            sidecar_sp: sidecar_sp.ok_or(
-                RepositoryError::MissingArtifactKind(
-                    KnownArtifactKind::SwitchSp,
-                ),
-            )?,
+            sidecar_sp,
             sidecar_rot_a: sidecar_rot_a.ok_or(
                 RepositoryError::MissingArtifactKind(
                     KnownArtifactKind::SwitchRot,
@@ -794,6 +888,39 @@ fn unpack_rot_artifact(
         .map_err(|error| RepositoryError::TarballExtract { kind, error })
 }
 
+// This function takes and returns `id` to avoid an unnecessary clone; `id` will
+// be present in either the Ok tuple or the error.
+fn read_hubris_board_from_archive(
+    id: ArtifactId,
+    data: Vec<u8>,
+) -> Result<(ArtifactId, Board), RepositoryError> {
+    let archive = match RawHubrisArchive::from_vec(data).map_err(Box::new) {
+        Ok(archive) => archive,
+        Err(error) => {
+            return Err(RepositoryError::ParsingHubrisArchive { id, error });
+        }
+    };
+    let caboose = match archive.read_caboose().map_err(Box::new) {
+        Ok(caboose) => caboose,
+        Err(error) => {
+            return Err(RepositoryError::ReadHubrisCaboose { id, error });
+        }
+    };
+    let board = match caboose.board() {
+        Ok(board) => board,
+        Err(error) => {
+            return Err(RepositoryError::ReadHubrisCabooseBoard { id, error });
+        }
+    };
+    let board = match std::str::from_utf8(board) {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(RepositoryError::ReadHubrisCabooseBoardUtf8(id));
+        }
+    };
+    Ok((id, Board(board.to_string())))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -806,8 +933,8 @@ mod tests {
     use omicron_test_utils::dev::test_setup_log;
     use rand::{distributions::Standard, thread_rng, Rng};
 
-    /// Test that `ArtifactsWithPlan` can extract the fake repository generated by
-    /// tufaceous.
+    /// Test that `ArtifactsWithPlan` can extract the fake repository generated
+    /// by tufaceous.
     #[test]
     fn test_extract_fake() -> Result<()> {
         let logctx = test_setup_log("test_extract_fake");
@@ -920,13 +1047,10 @@ mod tests {
         let mut by_id = HashMap::new();
         let mut by_hash = HashMap::new();
 
-        // Some artifacts can just be arbitrary data; fill those in.
-        for kind in [
-            KnownArtifactKind::GimletSp,
-            KnownArtifactKind::ControlPlane,
-            KnownArtifactKind::PscSp,
-            KnownArtifactKind::SwitchSp,
-        ] {
+        // The control plane artifact can be arbitrary bytes; just populate it
+        // with random data.
+        {
+            let kind = KnownArtifactKind::ControlPlane;
             let data = Bytes::from(make_random_bytes());
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
@@ -937,6 +1061,30 @@ mod tests {
             let hash_id = ArtifactHashId { kind: kind.into(), hash };
             by_id.insert(id, (hash, data.clone()));
             by_hash.insert(hash_id, data);
+        }
+
+        // For each SP image, we'll insert two artifacts: these should end up in
+        // the update plan's SP image maps keyed by their "board". Normally the
+        // board is read from the archive itself via hubtools; we'll inject a
+        // test function that returns the artifact ID name as the board instead.
+        for (kind, boards) in [
+            (KnownArtifactKind::GimletSp, ["test-gimlet-a", "test-gimlet-b"]),
+            (KnownArtifactKind::PscSp, ["test-psc-a", "test-psc-b"]),
+            (KnownArtifactKind::SwitchSp, ["test-switch-a", "test-switch-b"]),
+        ] {
+            for board in boards {
+                let data = Bytes::from(make_random_bytes());
+                let hash = ArtifactHash(Sha256::digest(&data).into());
+                let id = ArtifactId {
+                    name: board.to_string(),
+                    version: VERSION_0,
+                    kind: kind.into(),
+                };
+                println!("{kind:?}={board:?} => {id:?}");
+                let hash_id = ArtifactHashId { kind: kind.into(), hash };
+                by_id.insert(id, (hash, data.clone()));
+                by_hash.insert(hash_id, data);
+            }
         }
 
         // The Host, Trampoline, and RoT artifacts must be structed the way we
@@ -981,23 +1129,56 @@ mod tests {
 
         let logctx = test_setup_log("test_update_plan_from_artifacts");
 
-        let plan =
-            UpdatePlan::new(VERSION_0, &by_id, &mut by_hash, &logctx.log)
-                .unwrap();
+        let plan = UpdatePlan::new(
+            VERSION_0,
+            &by_id,
+            &mut by_hash,
+            &logctx.log,
+            |id, _data| {
+                let board = id.name.clone();
+                Ok((id, Board(board)))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.gimlet_sp.len(), 2);
+        assert_eq!(plan.psc_sp.len(), 2);
+        assert_eq!(plan.sidecar_sp.len(), 2);
 
         for (id, (hash, data)) in &by_id {
             match id.kind.to_known().unwrap() {
                 KnownArtifactKind::GimletSp => {
-                    assert_eq!(*plan.gimlet_sp.data, data);
+                    assert!(
+                        id.name.starts_with("test-gimlet-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(
+                        *plan.gimlet_sp.get(&id.name).unwrap().data,
+                        data
+                    );
                 }
                 KnownArtifactKind::ControlPlane => {
                     assert_eq!(plan.control_plane_hash, *hash);
                 }
                 KnownArtifactKind::PscSp => {
-                    assert_eq!(*plan.psc_sp.data, data);
+                    assert!(
+                        id.name.starts_with("test-psc-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(*plan.psc_sp.get(&id.name).unwrap().data, data);
                 }
                 KnownArtifactKind::SwitchSp => {
-                    assert_eq!(*plan.sidecar_sp.data, data);
+                    assert!(
+                        id.name.starts_with("test-switch-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(
+                        *plan.sidecar_sp.get(&id.name).unwrap().data,
+                        data
+                    );
                 }
                 KnownArtifactKind::Host
                 | KnownArtifactKind::Trampoline

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -673,7 +673,8 @@ impl UpdateDriver {
                     let sp_artifact = sp_artifact.clone();
 
                     let message = format!(
-                        "SP version {} (git commit {})",
+                        "SP board {}, version {} (git commit {})",
+                        caboose.board,
                         caboose.version.as_deref().unwrap_or("unknown"),
                         caboose.git_commit
                     );

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -648,7 +648,7 @@ impl UpdateDriver {
         let sp_artifact_and_version = sp_registrar
             .new_step(
                 UpdateStepId::InterrogateSp,
-                "Checking current SP version",
+                "Checking SP board and current version",
                 move |_cx| async move {
                     let caboose = update_cx
                         .mgs_client

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -620,9 +620,13 @@ impl UpdateDriver {
             ),
         };
 
-        // To update the RoT, we have to know which slot (A or B) it is
-        // currently executing; we must update the _other_ slot.
         let rot_registrar = engine.for_component(UpdateComponent::Rot);
+        let sp_registrar = engine.for_component(UpdateComponent::Sp);
+
+        // To update the RoT, we have to know which slot (A or B) it is
+        // currently executing; we must update the _other_ slot. We also want to
+        // know its current version (so we can skip updating if we only need to
+        // update the SP and/or host).
         let rot_interrogation =
             rot_registrar
                 .new_step(
@@ -634,6 +638,64 @@ impl UpdateDriver {
                 )
                 .register();
 
+        // The SP only has one updateable firmware slot ("the inactive bank").
+        // We want to ask about slot 0 (the active slot)'s current version, and
+        // we are supposed to always pass 0 when updating.
+        let sp_firmware_slot = 0;
+
+        // To update the SP, we want to know both its version and its board (so
+        // we can map to the correct artifact from our update plan).
+        let sp_artifact_and_version = sp_registrar
+            .new_step(
+                UpdateStepId::InterrogateSp,
+                "Checking current SP version",
+                move |_cx| async move {
+                    let caboose = update_cx
+                        .mgs_client
+                        .sp_component_caboose_get(
+                            update_cx.sp.type_,
+                            update_cx.sp.slot,
+                            SpComponent::SP_ITSELF.const_as_str(),
+                            sp_firmware_slot,
+                        )
+                        .await
+                        .map_err(|error| {
+                            UpdateTerminalError::GetSpCabooseFailed { error }
+                        })?
+                        .into_inner();
+
+                    let Some(sp_artifact) = sp_artifacts.get(&caboose.board)
+                    else {
+                        return Err(UpdateTerminalError::MissingSpImageForBoard {
+                            board: caboose.board,
+                        });
+                    };
+                    let sp_artifact = sp_artifact.clone();
+
+                    let message = format!(
+                        "SP version {} (git commit {})",
+                        caboose.version.as_deref().unwrap_or("unknown"),
+                        caboose.git_commit
+                    );
+                    match caboose.version.map(|v| v.parse::<SemverVersion>()) {
+                        Some(Ok(version)) => {
+                            StepSuccess::new((sp_artifact, Some(version)))
+                                .with_message(message)
+                                .into()
+                        }
+                        Some(Err(err)) => StepWarning::new(
+                            (sp_artifact, None),
+                            format!(
+                                "{message} (failed to parse SP version: {err})"
+                            ),
+                        )
+                        .into(),
+                        None => StepWarning::new((sp_artifact, None), message)
+                            .into(),
+                    }
+                },
+            )
+            .register();
         // Send the update to the RoT.
         let inner_cx =
             SpComponentUpdateContext::new(update_cx, UpdateComponent::Rot);
@@ -695,64 +757,6 @@ impl UpdateDriver {
             )
             .register();
 
-        let sp_registrar = engine.for_component(UpdateComponent::Sp);
-
-        // The SP only has one updateable firmware slot ("the inactive bank").
-        // We want to ask about slot 0 (the active slot)'s current version, and
-        // we are supposed to always pass 0 when updating.
-        let sp_firmware_slot = 0;
-
-        let sp_artifact_and_version = sp_registrar
-            .new_step(
-                UpdateStepId::InterrogateSp,
-                "Checking current SP version",
-                move |_cx| async move {
-                    let caboose = update_cx
-                        .mgs_client
-                        .sp_component_caboose_get(
-                            update_cx.sp.type_,
-                            update_cx.sp.slot,
-                            SpComponent::SP_ITSELF.const_as_str(),
-                            sp_firmware_slot,
-                        )
-                        .await
-                        .map_err(|error| {
-                            UpdateTerminalError::GetSpCabooseFailed { error }
-                        })?
-                        .into_inner();
-
-                    let Some(sp_artifact) = sp_artifacts.get(&caboose.board)
-                    else {
-                        return Err(UpdateTerminalError::MissingSpImageForBoard {
-                            board: caboose.board,
-                        });
-                    };
-                    let sp_artifact = sp_artifact.clone();
-
-                    let message = format!(
-                        "SP version {} (git commit {})",
-                        caboose.version.as_deref().unwrap_or("unknown"),
-                        caboose.git_commit
-                    );
-                    match caboose.version.map(|v| v.parse::<SemverVersion>()) {
-                        Some(Ok(version)) => {
-                            StepSuccess::new((sp_artifact, Some(version)))
-                                .with_message(message)
-                                .into()
-                        }
-                        Some(Err(err)) => StepWarning::new(
-                            (sp_artifact, None),
-                            format!(
-                                "{message} (failed to parse SP version: {err})"
-                            ),
-                        )
-                        .into(),
-                        None => StepWarning::new((sp_artifact, None), message)
-                            .into(),
-                    }
-                },
-            )
-            .register();
         let inner_cx =
             SpComponentUpdateContext::new(update_cx, UpdateComponent::Sp);
         sp_registrar

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -136,8 +136,9 @@ async fn test_updates() {
     match terminal_event.kind {
         StepEventKind::ExecutionFailed { failed_step, .. } => {
             // TODO: obviously we shouldn't stop here, get past more of the
-            // update process in this test.
-            assert_eq!(failed_step.info.component, UpdateComponent::Rot);
+            // update process in this test. We currently fail when attempting to
+            // look up the SP's board in our tuf repo.
+            assert_eq!(failed_step.info.component, UpdateComponent::Sp);
         }
         other => {
             panic!("unexpected terminal event kind: {other:?}");


### PR DESCRIPTION
This PR also teaches tufaceous-lib how to generate fake hubris artifacts that look like real hubris archives (at least up to having a valid caboose), via the not-yet-merged `HubrisArchiveBuilder` from `hubtools`.

There are a couple things I need to do before merging this PR:

- [x] Update `hubtools` in Cargo.toml once https://github.com/oxidecomputer/hubtools/pull/19 lands
- [x] Test on madrid with a manually-built repo with multiple SP images

but I think it's close enough it can be reviewed.

Fixes #3394.