### PR TITLE
deploy job should save rotated and archived log files

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -4,10 +4,14 @@
 #: variety = "basic"
 #: target = "lab-2.0-opte-0.23"
 #: output_rules = [
-#:  "%/var/svc/log/oxide-sled-agent:default.log",
-#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log",
-#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log",
-#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log"
+#:  "%/var/svc/log/oxide-sled-agent:default.log*",
+#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log*",
+#:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log*",
+#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log*"
+#:  "%/pool/ext/*/crypt/debug/global/oxide-sled-agent:default.log.*",
+#:  "%/pool/ext/*/crypt/debug/oxz_*/oxide-*.log.*",
+#:  "%/pool/ext/*/crypt/debug/oxz_*/system-illumos-*.log.*",
+#:  "!/pool/ext/*/crypt/debug/oxz_propolis-server_*/*.log.*"
 #: ]
 #: skip_clone = true
 #:

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -7,7 +7,7 @@
 #:  "%/var/svc/log/oxide-sled-agent:default.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log*",
-#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log*"
+#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log*",
 #:  "%/pool/ext/*/crypt/debug/global/oxide-sled-agent:default.log.*",
 #:  "%/pool/ext/*/crypt/debug/oxz_*/oxide-*.log.*",
 #:  "%/pool/ext/*/crypt/debug/oxz_*/system-illumos-*.log.*",


### PR DESCRIPTION
See #3889 for motivation.  I think after the landing of #3713, the log files saved by buildomat are generally incomplete.  This PR seeks to fix that.

I tested by doing `ls -l` of each of the modified patterns on a dogfood system.  All of the ones that succeeded returned some files.  There were a couple that failed because they matched too many log files.  I think this is less likely in this job, and I doubt it's a problem for buildomat unless it's using the shell to expand these globs.  If it is, we can iterate.