### PR TITLE
ci/tuf-repo: use the caboose board tag as SP/ROT artifact names

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -134,6 +134,19 @@ git init /work/dvt-dock
     git checkout FETCH_HEAD
 )
 
+caboose_util_rot() {
+    # usage: caboose_util_rot ACTION IMAGE_A IMAGE_B
+    output_a=$(/work/caboose-util "$1" "$2")
+    output_b=$(/work/caboose-util "$1" "$3")
+    if [[ "$output_a" != "$output_b" ]]; then
+        >&2 echo "\`caboose-util $1\` mismatch:"
+        >&2 echo "  $2: $output_a"
+        >&2 echo "  $3: $output_b"
+        exit 1
+    fi
+    echo "$output_a"
+}
+
 add_hubris_artifacts() {
     series="$1"
     rot_dir="$2"
@@ -151,20 +164,15 @@ add_hubris_artifacts() {
         rot_image_b="/work/dvt-dock/${rot_dir}/${board}/build-${board}-rot-image-b-${rot_version}.zip"
         sp_image="/work/dvt-dock/sp/${board}/build-${board_rev}-image-default.zip"
 
-        rot_version_a=$(/work/caboose-util read-version "$rot_image_a")
-        rot_version_b=$(/work/caboose-util read-version "$rot_image_b")
-        if [[ "$rot_version_a" != "$rot_version_b" ]]; then
-            echo "version mismatch:"
-            echo "  $rot_image_a: $rot_version_a"
-            echo "  $rot_image_b: $rot_version_b"
-            exit 1
-        fi
-        sp_version=$(/work/caboose-util read-version "$sp_image")
+        rot_caboose_version=$(caboose_util_rot read-version "$rot_image_a" "$rot_image_b")
+        sp_caboose_version=$(/work/caboose-util read-version "$sp_image")
+        rot_caboose_board=$(caboose_util_rot read-board "$rot_image_a" "$rot_image_b")
+        sp_caboose_board=$(/work/caboose-util read-board "$sp_image")
 
         cat >>"$manifest" <<EOF
 [[artifact.${tufaceous_board}_rot]]
-name = "${tufaceous_board}_rot"
-version = "$rot_version_a"
+name = "$rot_caboose_board"
+version = "$rot_caboose_version"
 [artifact.${tufaceous_board}_rot.source]
 kind = "composite-rot"
 [artifact.${tufaceous_board}_rot.source.archive_a]
@@ -174,8 +182,8 @@ path = "$rot_image_a"
 kind = "file"
 path = "$rot_image_b"
 [[artifact.${tufaceous_board}_sp]]
-name = "${tufaceous_board}_sp"
-version = "$sp_version"
+name = "$sp_caboose_board"
+version = "$sp_caboose_version"
 [artifact.${tufaceous_board}_sp.source]
 kind = "file"
 path = "$sp_image"

--- a/caboose-util/src/main.rs
+++ b/caboose-util/src/main.rs
@@ -5,19 +5,28 @@
 // Copyright 2023 Oxide Computer Company
 
 use anyhow::{bail, Context, Result};
-use hubtools::RawHubrisArchive;
+use hubtools::{Caboose, RawHubrisArchive};
 
 fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
     match args.next().context("subcommand required")?.as_str() {
+        "read-board" => {
+            let caboose = read_caboose(args.next())?;
+            println!("{}", std::str::from_utf8(caboose.board()?)?);
+            Ok(())
+        }
         "read-version" => {
-            let archive = RawHubrisArchive::load(
-                &args.next().context("path to hubris archive required")?,
-            )?;
-            let caboose = archive.read_caboose()?;
+            let caboose = read_caboose(args.next())?;
             println!("{}", std::str::from_utf8(caboose.version()?)?);
             Ok(())
         }
         unknown => bail!("unknown command {}", unknown),
     }
+}
+
+fn read_caboose(path: Option<String>) -> Result<Caboose> {
+    let archive = RawHubrisArchive::load(
+        &path.context("path to hubris archive required")?,
+    )?;
+    Ok(archive.read_caboose()?)
 }

--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -35,6 +35,17 @@ impl ArtifactsDocument {
 /// internally in Nexus and Sled Agent.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Artifact {
+    /// Used to differentiate between different series of artifacts of the same
+    /// kind. This is used by the control plane to select the correct artifact.
+    ///
+    /// For SP and ROT images ([`KnownArtifactKind::GimletSp`],
+    /// [`KnownArtifactKind::GimletRot`], [`KnownArtifactKind::PscSp`],
+    /// [`KnownArtifactKind::PscRot`], [`KnownArtifactKind::SwitchSp`],
+    /// [`KnownArtifactKind::SwitchRot`]), `name` is the value of the board
+    /// (`BORD`) tag in the image caboose.
+    ///
+    /// In the future when [`KnownArtifactKind::ControlPlane`] is split up into
+    /// separate zones, `name` will be the zone name.
     pub name: String,
     pub version: SemverVersion,
     pub kind: ArtifactKind,


### PR DESCRIPTION
As a follow-up to #3887, use the artifact's `name` field for the board field for SP/ROT artifacts. This will allow Nexus / sled-agent / whatever to make decisions on which artifacts to fetch from the repository in a world where the control plane is accessing a TUF repo over HTTPS.

The original intent of the `name` field was to provide some key for the control plane to make decisions on. In the original update system mockup this was for zone names (i.e. your `kind` would be `KnownArtifactKind::Zone`, and then your `name` would be something like `omicron-nexus`). Given hindsight I probably would have named this something like `key`, or `identifier`, or whatever. (Maybe we still ought to?)

I had completely forgotten that this is what `name` was for, so I've written a comment for future me, and hopefully others, explaining it in `common/src/update.rs`. (For a while I was convinced I needed to plumb an optional `board` field all the way through the control plane!)

This doesn't matter to Wicket today, as it has the entire repository present and can read cabooses directly, and that is probably a safer fallback option anyway.