### PR TITLE
wicket: alias `upload` to `upload-repo`

### DIFF
--- a/wicket/src/dispatch.rs
+++ b/wicket/src/dispatch.rs
@@ -52,6 +52,7 @@ pub fn exec() -> Result<()> {
 #[derive(Debug, Parser)]
 enum ShellCommand {
     /// Upload a TUF repository to wicketd.
+    #[command(visible_alias = "upload")]
     UploadRepo(UploadArgs),
     /// Interact with rack setup configuration.
     #[command(subcommand)]


### PR DESCRIPTION
10baa3aa7bda0ed11e223b2640b43958b1cfdc47 changed wicket's `Upload` command to `UploadRepo`, but the TUI still says to run `upload`. This results in sadness:

```
iliana@jeeves /staff/dock/rack2/mupdate-20230818 $ cat tuf-mupdate.zip | ssh wicket@fe80::aa40:25ff:fe05:402%rack2sw1tp1 upload
error: unrecognized subcommand 'upload'

  tip: a similar subcommand exists: 'upload-repo'

Usage: wicket <COMMAND>

For more information, try '--help'.
iliana@jeeves /staff/dock/rack2/mupdate-20230818 $ cat tuf-mupdate.zip | ssh wicket@fe80::aa40:25ff:fe05:402%rack2sw1tp1 upload-repo
Aug 18 17:53:42.976 INFO beginning read of repository from stdin, file: wicket/src/upload.rs:84
```

Instead of attempting to fix all the places where we reference `upload`, an alias seems sensible.