### PR TITLE
Create common scaffolding for saga undo tests

### DIFF
--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -1046,11 +1046,7 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx().nexus;
         let project_id = create_org_and_project(&client).await;
-
-        // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(cptestctx);
-
-        let params = new_test_params(&opctx, project_id);
 
         crate::app::sagas::test_helpers::action_failure_can_unwind::<
             SagaDiskCreate,
@@ -1058,7 +1054,6 @@ pub(crate) mod test {
             _,
         >(
             nexus,
-            params,
             || Box::pin(async { new_test_params(&opctx, project_id) }),
             || {
                 Box::pin(async {
@@ -1088,7 +1083,6 @@ pub(crate) mod test {
             _
         >(
             nexus,
-            new_test_params(&opctx, project_id),
             || Box::pin(async { new_test_params(&opctx, project_id) }),
             || Box::pin(async { verify_clean_slate(&cptestctx, &test).await; }),
             log

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -1051,35 +1051,23 @@ pub(crate) mod test {
         let opctx = test_opctx(cptestctx);
 
         let params = new_test_params(&opctx, project_id);
-        let dag = create_saga_dag::<SagaDiskCreate>(params).unwrap();
 
-        for node in dag.get_nodes() {
-            // Create a new saga for this node.
-            info!(
-                log,
-                "Creating new saga which will fail at index {:?}", node.index();
-                "node_name" => node.name().as_ref(),
-                "label" => node.label(),
-            );
-            let runnable_saga =
-                nexus.create_runnable_saga(dag.clone()).await.unwrap();
-
-            // Inject an error instead of running the node.
-            //
-            // This should cause the saga to unwind.
-            nexus
-                .sec()
-                .saga_inject_error(runnable_saga.id(), node.index())
-                .await
-                .unwrap();
-            nexus
-                .run_saga(runnable_saga)
-                .await
-                .expect_err("Saga should have failed");
-
-            // Check that no partial artifacts of disk creation exist:
-            verify_clean_slate(&cptestctx, &test).await;
-        }
+        crate::app::sagas::test_helpers::action_failure_can_unwind::<
+            SagaDiskCreate,
+            _,
+            _,
+        >(
+            nexus,
+            params,
+            || Box::pin(async { new_test_params(&opctx, project_id) }),
+            || {
+                Box::pin(async {
+                    verify_clean_slate(&cptestctx, &test).await;
+                })
+            },
+            log,
+        )
+        .await;
     }
 
     #[nexus_test(server = crate::Server)]

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -795,8 +795,6 @@ pub(crate) mod test {
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_common::api::external::Name;
     use omicron_sled_agent::sim::SledAgent;
-    use slog::error;
-    use slog::Logger;
     use uuid::Uuid;
 
     type ControlPlaneTestContext =
@@ -863,41 +861,6 @@ pub(crate) mod test {
             .lookup_node_output::<crate::db::model::Disk>("created_disk")
             .unwrap();
         assert_eq!(disk.project_id, project_id);
-    }
-
-    async fn no_stuck_sagas(log: &Logger, datastore: &DataStore) -> bool {
-        use crate::db::model::saga_types::SagaNodeEvent;
-
-        let saga_node_events: Vec<SagaNodeEvent> = datastore
-            .pool_for_tests()
-            .await
-            .unwrap()
-            .transaction_async(|conn| async move {
-                use crate::db::schema::saga_node_event::dsl;
-
-                conn.batch_execute_async(
-                    nexus_test_utils::db::ALLOW_FULL_TABLE_SCAN_SQL,
-                )
-                .await
-                .unwrap();
-
-                Ok::<_, crate::db::TransactionError<()>>(
-                    dsl::saga_node_event
-                        .filter(dsl::event_type.eq(String::from("undo_failed")))
-                        .select(SagaNodeEvent::as_select())
-                        .load_async::<SagaNodeEvent>(&conn)
-                        .await
-                        .unwrap(),
-                )
-            })
-            .await
-            .unwrap();
-
-        for saga_node_event in &saga_node_events {
-            error!(log, "saga {:?} is stuck!", saga_node_event.saga_id);
-        }
-
-        saga_node_events.is_empty()
     }
 
     async fn no_disk_records_exist(datastore: &DataStore) -> bool {
@@ -1019,7 +982,6 @@ pub(crate) mod test {
         let sled_agent = &cptestctx.sled_agent.sled_agent;
         let datastore = cptestctx.server.apictx().nexus.datastore();
 
-        assert!(no_stuck_sagas(&cptestctx.logctx.log, datastore).await);
         assert!(no_disk_records_exist(datastore).await);
         assert!(no_volume_records_exist(datastore).await);
         assert!(

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -180,7 +180,6 @@ pub(crate) mod test {
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::external_api::params;
     use omicron_common::api::external::Name;
-    use std::num::NonZeroU32;
     use uuid::Uuid;
 
     type ControlPlaneTestContext =
@@ -267,31 +266,10 @@ pub(crate) mod test {
             volume_id: disk.volume_id,
         };
         let dag = create_saga_dag::<SagaDiskDelete>(params).unwrap();
-
-        let runnable_saga =
-            nexus.create_runnable_saga(dag.clone()).await.unwrap();
-
-        // Cause all actions to run twice. The saga should succeed regardless!
-        for node in dag.get_nodes() {
-            nexus
-                .sec()
-                .saga_inject_repeat(
-                    runnable_saga.id(),
-                    node.index(),
-                    steno::RepeatInjected {
-                        action: NonZeroU32::new(2).unwrap(),
-                        undo: NonZeroU32::new(1).unwrap(),
-                    },
-                )
-                .await
-                .unwrap();
-        }
-
-        // Verify that the saga's execution succeeded.
-        nexus
-            .run_saga(runnable_saga)
-            .await
-            .expect("Saga should have succeeded");
+        crate::app::sagas::test_helpers::actions_succeed_idempotently(
+            nexus, dag,
+        )
+        .await;
 
         crate::app::sagas::disk_create::test::verify_clean_slate(
             &cptestctx, &test,

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1367,8 +1367,8 @@ pub mod test {
     use crate::{
         app::saga::create_saga_dag, app::sagas::instance_create::Params,
         app::sagas::instance_create::SagaInstanceCreate,
-        authn::saga::Serialized, db::datastore::DataStore,
-        external_api::params,
+        app::sagas::test_helpers::*, authn::saga::Serialized,
+        db::datastore::DataStore, external_api::params,
     };
     use async_bb8_diesel::{
         AsyncConnection, AsyncRunQueryDsl, AsyncSimpleConnection,
@@ -1435,13 +1435,6 @@ pub mod test {
             },
             boundary_switches: HashSet::from([SwitchLocation::Switch0]),
         }
-    }
-
-    pub fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
-        OpContext::for_tests(
-            cptestctx.logctx.log.new(o!()),
-            cptestctx.server.apictx().nexus.datastore().clone(),
-        )
     }
 
     #[nexus_test(server = crate::Server)]
@@ -1679,11 +1672,7 @@ pub mod test {
 
         let params = new_test_params(&opctx, project_id);
 
-        crate::app::sagas::test_helpers::action_failure_can_unwind::<
-            SagaInstanceCreate,
-            _,
-            _,
-        >(
+        action_failure_can_unwind::<SagaInstanceCreate, _, _>(
             nexus,
             params,
             || Box::pin(async { new_test_params(&opctx, project_id) }),

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1141,6 +1141,7 @@ async fn sic_delete_instance_record(
         .instance_name(&instance_name)
         .fetch()
         .await;
+
     // Although, as mentioned in the comment above, we should not be doing the
     // lookup by name here, we do want this operation to be idempotent.
     //
@@ -1367,7 +1368,7 @@ pub mod test {
     use crate::{
         app::saga::create_saga_dag, app::sagas::instance_create::Params,
         app::sagas::instance_create::SagaInstanceCreate,
-        app::sagas::test_helpers::*, authn::saga::Serialized,
+        app::sagas::test_helpers, authn::saga::Serialized,
         db::datastore::DataStore, external_api::params,
     };
     use async_bb8_diesel::{
@@ -1447,7 +1448,7 @@ pub mod test {
         let project_id = create_org_project_and_disk(&client).await;
 
         // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
         let params = new_test_params(&opctx, project_id);
         let dag = create_saga_dag::<SagaInstanceCreate>(params).unwrap();
         let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
@@ -1668,11 +1669,11 @@ pub mod test {
         let project_id = create_org_project_and_disk(&client).await;
 
         // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
 
         let params = new_test_params(&opctx, project_id);
 
-        action_failure_can_unwind::<SagaInstanceCreate, _, _>(
+        test_helpers::action_failure_can_unwind::<SagaInstanceCreate, _, _>(
             nexus,
             params,
             || Box::pin(async { new_test_params(&opctx, project_id) }),
@@ -1698,88 +1699,20 @@ pub mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx().nexus;
         let project_id = create_org_project_and_disk(&client).await;
+        let opctx = test_helpers::test_opctx(&cptestctx);
 
-        // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
-
-        // Create the DAG once to determine how many nodes it has (for iteration
-        // purposes), then recreate it in each iteration of the test. This is
-        // needed to ensure each iteration gets a distinct instance ID.
-        let params = new_test_params(&opctx, project_id);
-        let dag =
-            create_saga_dag::<SagaInstanceCreate>(params.clone()).unwrap();
-        let num_nodes = dag.get_nodes().count();
-
-        // Iterate over pairs of adjacent nodes. Inject an error into the second
-        // node, then configure the undo action for the first node to be
-        // repeated.
-        let node_indices = Vec::from_iter(0..num_nodes);
-        for indices in node_indices.windows(2) {
-            let dag =
-                create_saga_dag::<SagaInstanceCreate>(params.clone()).unwrap();
-            let undo_node = dag.get_nodes().nth(indices[0]).unwrap();
-            let error_node = dag.get_nodes().nth(indices[1]).unwrap();
-
-            // Create a new saga for this node.
-            info!(
-                log,
-                "Creating new saga which will fail at index {:?}", error_node.index();
-                "node_name" => error_node.name().as_ref(),
-                "label" => error_node.label(),
-            );
-
-            let runnable_saga =
-                nexus.create_runnable_saga(dag.clone()).await.unwrap();
-
-            // Inject an error instead of running the node.
-            //
-            // This should cause the saga to unwind.
-            nexus
-                .sec()
-                .saga_inject_error(runnable_saga.id(), error_node.index())
-                .await
-                .unwrap();
-
-            // Inject a repetition for the node being undone.
-            //
-            // This means it is executing twice while unwinding.
-            nexus
-                .sec()
-                .saga_inject_repeat(
-                    runnable_saga.id(),
-                    undo_node.index(),
-                    steno::RepeatInjected {
-                        action: NonZeroU32::new(1).unwrap(),
-                        undo: NonZeroU32::new(2).unwrap(),
-                    },
-                )
-                .await
-                .unwrap();
-
-            let saga_error = nexus
-                .run_saga_raw_result(runnable_saga)
-                .await
-                .expect("saga should have started successfully")
-                .kind
-                .expect_err("saga execution should have failed");
-
-            assert_eq!(saga_error.error_node_name, *error_node.name());
-
-            verify_clean_slate(&cptestctx).await;
-        }
-    }
-
-    async fn destroy_instance(cptestctx: &ControlPlaneTestContext) {
-        let nexus = &cptestctx.server.apictx().nexus;
-        let opctx = test_opctx(&cptestctx);
-
-        let instance_selector = params::InstanceSelector {
-            project: Some(PROJECT_NAME.to_string().try_into().unwrap()),
-            instance: INSTANCE_NAME.to_string().try_into().unwrap(),
-        };
-        let instance_lookup =
-            nexus.instance_lookup(&opctx, instance_selector).unwrap();
-        nexus.project_destroy_instance(&opctx, &instance_lookup).await.unwrap();
+        test_helpers::action_failure_can_unwind_idempotently::<
+            SagaInstanceCreate,
+            _,
+            _,
+        >(
+            nexus,
+            new_test_params(&opctx, project_id),
+            || Box::pin(async { new_test_params(&opctx, project_id) }),
+            || Box::pin(async { verify_clean_slate(&cptestctx).await }),
+            log,
+        )
+        .await;
     }
 
     #[nexus_test(server = crate::Server)]
@@ -1793,7 +1726,7 @@ pub mod test {
         let project_id = create_org_project_and_disk(&client).await;
 
         // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_helpers::test_opctx(&cptestctx);
 
         let params = new_test_params(&opctx, project_id);
         let dag = create_saga_dag::<SagaInstanceCreate>(params).unwrap();
@@ -1826,7 +1759,12 @@ pub mod test {
         // Verify that if the instance is destroyed, no detritus remains.
         // This is important to ensure that our original saga didn't
         // double-allocate during repeated actions.
-        destroy_instance(&cptestctx).await;
+        test_helpers::instance_delete_by_name(
+            &cptestctx,
+            INSTANCE_NAME,
+            PROJECT_NAME,
+        )
+        .await;
         verify_clean_slate(&cptestctx).await;
     }
 }

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1671,11 +1671,8 @@ pub mod test {
         // Build the saga DAG with the provided test parameters
         let opctx = test_helpers::test_opctx(&cptestctx);
 
-        let params = new_test_params(&opctx, project_id);
-
         test_helpers::action_failure_can_unwind::<SagaInstanceCreate, _, _>(
             nexus,
-            params,
             || Box::pin(async { new_test_params(&opctx, project_id) }),
             || {
                 Box::pin({
@@ -1707,7 +1704,6 @@ pub mod test {
             _,
         >(
             nexus,
-            new_test_params(&opctx, project_id),
             || Box::pin(async { new_test_params(&opctx, project_id) }),
             || Box::pin(async { verify_clean_slate(&cptestctx).await }),
             log,

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -364,7 +364,6 @@ mod test {
     };
     use omicron_common::api::internal::shared::SwitchLocation;
     use std::collections::HashSet;
-    use std::num::NonZeroU32;
     use uuid::Uuid;
 
     type ControlPlaneTestContext =
@@ -501,30 +500,10 @@ mod test {
         )
         .unwrap();
 
-        let runnable_saga =
-            nexus.create_runnable_saga(dag.clone()).await.unwrap();
-
-        // Cause all actions to run twice. The saga should succeed regardless!
-        for node in dag.get_nodes() {
-            nexus
-                .sec()
-                .saga_inject_repeat(
-                    runnable_saga.id(),
-                    node.index(),
-                    steno::RepeatInjected {
-                        action: NonZeroU32::new(2).unwrap(),
-                        undo: NonZeroU32::new(1).unwrap(),
-                    },
-                )
-                .await
-                .unwrap();
-        }
-
-        // Verify that the saga's execution succeeded.
-        nexus
-            .run_saga(runnable_saga)
-            .await
-            .expect("Saga should have succeeded");
+        crate::app::sagas::test_helpers::actions_succeed_idempotently(
+            nexus, dag,
+        )
+        .await;
 
         verify_clean_slate(&cptestctx).await;
     }

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -654,11 +654,6 @@ mod tests {
         let old_runtime = db_instance.runtime().clone();
         let dst_sled_id =
             select_first_alternate_sled(&db_instance, &other_sleds);
-        let params = Params {
-            serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
-            instance: db_instance,
-            migrate_params: params::InstanceMigrate { dst_sled_id },
-        };
 
         let make_params = || -> futures::future::BoxFuture<'_, Params> {
             Box::pin({
@@ -751,7 +746,7 @@ mod tests {
             SagaInstanceMigrate,
             _,
             _,
-        >(nexus, params, make_params, after_saga, log)
+        >(nexus, make_params, after_saga, log)
         .await;
     }
 }

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -469,11 +469,7 @@ async fn sim_instance_migrate(
 
 #[cfg(test)]
 mod tests {
-
-    use crate::app::{
-        saga::create_saga_dag,
-        sagas::{instance_create, test_helpers},
-    };
+    use crate::app::{saga::create_saga_dag, sagas::test_helpers};
     use camino::Utf8Path;
     use dropshot::test_util::ClientTestContext;
     use nexus_test_interface::NexusServer;
@@ -604,7 +600,7 @@ mod tests {
         let nexus = &cptestctx.server.apictx().nexus;
         let _project_id = setup_test_project(&client).await;
 
-        let opctx = instance_create::test::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
 
         // Poke the instance to get it into the Running state.
@@ -647,7 +643,7 @@ mod tests {
         let nexus = &cptestctx.server.apictx().nexus;
         let _project_id = setup_test_project(&client).await;
 
-        let opctx = instance_create::test::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
 
         // Poke the instance to get it into the Running state.

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -708,59 +708,84 @@ mod tests {
             migrate_params: params::InstanceMigrate { dst_sled_id },
         };
 
-        let dag = create_saga_dag::<SagaInstanceMigrate>(params).unwrap();
-        for node in dag.get_nodes() {
-            info!(
-                log,
-                "Creating new saga which will fail at index {:?}", node.index();
-                "node_name" => node.name().as_ref(),
-                "label" => node.label(),
-            );
+        let make_params = || -> futures::future::BoxFuture<'_, Params> {
+            Box::pin({
+                async {
+                    let db_instance = fetch_db_instance(
+                        cptestctx,
+                        &opctx,
+                        instance.identity.id,
+                    )
+                    .await;
+                    Params {
+                        serialized_authn: authn::saga::Serialized::for_opctx(
+                            &opctx,
+                        ),
+                        instance: db_instance,
+                        migrate_params: params::InstanceMigrate { dst_sled_id },
+                    }
+                }
+            })
+        };
 
-            let runnable_saga =
-                nexus.create_runnable_saga(dag.clone()).await.unwrap();
-            nexus
-                .sec()
-                .saga_inject_error(runnable_saga.id(), node.index())
-                .await
-                .unwrap();
-            nexus
-                .run_saga(runnable_saga)
-                .await
-                .expect_err("Saga should have failed");
-
-            // Unwinding at any step should clear the migration IDs from the
-            // instance record and leave the instance's location otherwise
-            // untouched.
-            let new_db_instance =
-                fetch_db_instance(cptestctx, &opctx, instance.identity.id)
+        let after_saga = || -> futures::future::BoxFuture<'_, ()> {
+            Box::pin({
+                async {
+                    // Unwinding at any step should clear the migration IDs from
+                    // the instance record and leave the instance's location
+                    // otherwise untouched.
+                    let new_db_instance = fetch_db_instance(
+                        cptestctx,
+                        &opctx,
+                        instance.identity.id,
+                    )
                     .await;
 
-            assert!(new_db_instance.runtime().migration_id.is_none());
-            assert!(new_db_instance.runtime().dst_propolis_id.is_none());
-            assert_eq!(new_db_instance.runtime().sled_id, old_runtime.sled_id);
-            assert_eq!(
-                new_db_instance.runtime().propolis_id,
-                old_runtime.propolis_id
-            );
+                    assert!(new_db_instance.runtime().migration_id.is_none());
+                    assert!(new_db_instance
+                        .runtime()
+                        .dst_propolis_id
+                        .is_none());
+                    assert_eq!(
+                        new_db_instance.runtime().sled_id,
+                        old_runtime.sled_id
+                    );
+                    assert_eq!(
+                        new_db_instance.runtime().propolis_id,
+                        old_runtime.propolis_id
+                    );
 
-            // Ensure the instance can stop. This helps to check that destroying
-            // the migration destination (if one was ensured) doesn't advance
-            // the Propolis ID generation in a way that prevents the source from
-            // issuing further state updates.
-            instance_stop(cptestctx, &instance.identity.id).await;
-            instance_simulate(cptestctx, nexus, &instance.identity.id).await;
-            let new_db_instance =
-                fetch_db_instance(cptestctx, &opctx, instance.identity.id)
+                    // Ensure the instance can stop. This helps to check that
+                    // destroying the migration destination (if one was ensured)
+                    // doesn't advance the Propolis ID generation in a way that
+                    // prevents the source from issuing further state updates.
+                    instance_stop(cptestctx, &instance.identity.id).await;
+                    instance_simulate(cptestctx, nexus, &instance.identity.id)
+                        .await;
+                    let new_db_instance = fetch_db_instance(
+                        cptestctx,
+                        &opctx,
+                        instance.identity.id,
+                    )
                     .await;
-            assert_eq!(
-                new_db_instance.runtime().state.0,
-                InstanceState::Stopped
-            );
+                    assert_eq!(
+                        new_db_instance.runtime().state.0,
+                        InstanceState::Stopped
+                    );
 
-            // Restart the instance for the next iteration.
-            instance_start(cptestctx, &instance.identity.id).await;
-            instance_simulate(cptestctx, nexus, &instance.identity.id).await;
-        }
+                    // Restart the instance for the next iteration.
+                    instance_start(cptestctx, &instance.identity.id).await;
+                    instance_simulate(cptestctx, nexus, &instance.identity.id)
+                        .await;
+                }
+            })
+        };
+
+        crate::app::sagas::test_helpers::action_failure_can_unwind::<
+            SagaInstanceMigrate,
+            _,
+            _,
+        >(nexus, params, make_params, after_saga, log)
+        .await;
     }
 }

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -499,7 +499,7 @@ async fn sis_ensure_running(
 mod test {
     use crate::external_api::params;
     use crate::{
-        app::{saga::create_saga_dag, sagas::instance_create},
+        app::{saga::create_saga_dag, sagas::test_helpers},
         authn, Nexus, TestInterfaces as _,
     };
     use dropshot::test_util::ClientTestContext;
@@ -591,7 +591,7 @@ mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = instance_create::test::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let db_instance =
             fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;
@@ -620,7 +620,7 @@ mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = instance_create::test::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
 
         // Fetch enough state to be able to reason about how many nodes are in
@@ -633,7 +633,7 @@ mod test {
             ensure_network: true,
         };
 
-        crate::app::sagas::test_helpers::action_failure_can_unwind::<
+        test_helpers::action_failure_can_unwind::<
             SagaInstanceStart,
             _,
             _,
@@ -692,7 +692,7 @@ mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.apictx().nexus;
         let _project_id = setup_test_project(&client).await;
-        let opctx = instance_create::test::test_opctx(cptestctx);
+        let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let db_instance =
             fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -623,23 +623,12 @@ mod test {
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
 
-        // Fetch enough state to be able to reason about how many nodes are in
-        // the saga.
-        let db_instance =
-            fetch_db_instance(cptestctx, &opctx, instance.identity.id).await;
-        let params = Params {
-            serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
-            instance: db_instance,
-            ensure_network: true,
-        };
-
         test_helpers::action_failure_can_unwind::<
             SagaInstanceStart,
             _,
             _,
         >(
             nexus,
-            params,
             || {
                 Box::pin({
                     async {

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -42,6 +42,9 @@ pub mod vpc_create;
 
 pub mod common_storage;
 
+#[cfg(test)]
+mod test_helpers;
+
 #[derive(Debug)]
 pub struct NexusSagaType;
 impl steno::SagaType for NexusSagaType {

--- a/nexus/src/app/sagas/project_create.rs
+++ b/nexus/src/app/sagas/project_create.rs
@@ -283,34 +283,33 @@ mod test {
         let opctx = test_opctx(&cptestctx);
         let authz_silo = opctx.authn.silo_required().unwrap();
         let params = new_test_params(&opctx, authz_silo);
-        let dag = create_saga_dag::<SagaProjectCreate>(params).unwrap();
 
-        for node in dag.get_nodes() {
-            // Create a new saga for this node.
-            info!(
-                log,
-                "Creating new saga which will fail at index {:?}", node.index();
-                "node_name" => node.name().as_ref(),
-                "label" => node.label(),
-            );
-
-            let runnable_saga =
-                nexus.create_runnable_saga(dag.clone()).await.unwrap();
-
-            // Inject an error instead of running the node.
-            //
-            // This should cause the saga to unwind.
-            nexus
-                .sec()
-                .saga_inject_error(runnable_saga.id(), node.index())
-                .await
-                .unwrap();
-            nexus
-                .run_saga(runnable_saga)
-                .await
-                .expect_err("Saga should have failed");
-
-            verify_clean_slate(nexus.datastore()).await;
-        }
+        crate::app::sagas::test_helpers::action_failure_can_unwind::<
+            SagaProjectCreate,
+            _,
+            _,
+        >(
+            nexus,
+            params,
+            || {
+                Box::pin({
+                    async {
+                        new_test_params(
+                            &opctx,
+                            opctx.authn.silo_required().unwrap(),
+                        )
+                    }
+                })
+            },
+            || {
+                Box::pin({
+                    async {
+                        verify_clean_slate(nexus.datastore()).await;
+                    }
+                })
+            },
+            log,
+        )
+        .await;
     }
 }

--- a/nexus/src/app/sagas/project_create.rs
+++ b/nexus/src/app/sagas/project_create.rs
@@ -276,21 +276,14 @@ mod test {
         cptestctx: &ControlPlaneTestContext,
     ) {
         let log = &cptestctx.logctx.log;
-
         let nexus = &cptestctx.server.apictx().nexus;
-
-        // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(&cptestctx);
-        let authz_silo = opctx.authn.silo_required().unwrap();
-        let params = new_test_params(&opctx, authz_silo);
-
         crate::app::sagas::test_helpers::action_failure_can_unwind::<
             SagaProjectCreate,
             _,
             _,
         >(
             nexus,
-            params,
             || {
                 Box::pin({
                     async {

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1991,15 +1991,6 @@ mod test {
         let silo_id = authz_silo.id();
         let project_id = authz_project.id();
 
-        let params = new_test_params(
-            &opctx,
-            silo_id,
-            project_id,
-            disk_id,
-            Name::from_str(DISK_NAME).unwrap().into(),
-            use_the_pantry,
-        );
-
         // As a concession to the test helper, make sure the disk is gone
         // before the first attempt to run the saga recreates it.
         delete_disk(client, PROJECT_NAME, DISK_NAME).await;
@@ -2028,7 +2019,6 @@ mod test {
             _,
         >(
             nexus,
-            params,
             || {
                 Box::pin({
                     async {

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1922,7 +1922,7 @@ mod test {
         cptestctx: &ControlPlaneTestContext,
         client: &ClientTestContext,
         disks_to_attach: Vec<InstanceDiskAttachment>,
-    ) -> Instance {
+    ) {
         let instances_url = format!("/v1/instances?project={}", PROJECT_NAME,);
         let instance: Instance = object_create(
             client,
@@ -1952,8 +1952,6 @@ mod test {
         let sa =
             nexus.instance_sled_by_id(&instance.identity.id).await.unwrap();
         sa.instance_finish_transition(instance.identity.id).await;
-
-        instance
     }
 
     #[nexus_test(server = crate::Server)]
@@ -2047,7 +2045,7 @@ mod test {
                         // attachment machinery and just update the disk's
                         // database record directly.
                         if !use_the_pantry {
-                            let _ = setup_test_instance(
+                            setup_test_instance(
                                 cptestctx,
                                 client,
                                 vec![params::InstanceDiskAttachment::Attach(
@@ -2324,7 +2322,7 @@ mod test {
         )
         .await;
 
-        let _ = setup_test_instance(
+        setup_test_instance(
             cptestctx,
             client,
             vec![params::InstanceDiskAttachment::Attach(

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -17,10 +17,124 @@
 //! duplicating boilerplate between saga tests.
 
 use super::NexusSaga;
-use crate::{app::saga::create_saga_dag, Nexus};
+use crate::{
+    app::{saga::create_saga_dag, test_interfaces::TestInterfaces as _},
+    Nexus,
+};
 use futures::future::BoxFuture;
+use http::{Method, StatusCode};
+use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
+use omicron_common::api::external::Instance;
+use sled_agent_client::TestInterfaces as _;
 use slog::{info, Logger};
 use std::sync::Arc;
+use uuid::Uuid;
+
+type ControlPlaneTestContext =
+    nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+pub async fn instance_start(cptestctx: &ControlPlaneTestContext, id: &Uuid) {
+    let client = &cptestctx.external_client;
+    let instance_stop_url = format!("/v1/instances/{}/start", id);
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &instance_stop_url)
+            .body(None as Option<&serde_json::Value>)
+            .expect_status(Some(StatusCode::ACCEPTED)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("Failed to start instance");
+}
+
+pub async fn instance_stop(cptestctx: &ControlPlaneTestContext, id: &Uuid) {
+    let client = &cptestctx.external_client;
+    let url = format!("/v1/instances/{}/stop", id);
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &url)
+            .body(None as Option<&serde_json::Value>)
+            .expect_status(Some(StatusCode::ACCEPTED)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("Failed to stop instance");
+}
+
+pub async fn instance_stop_by_name(
+    cptestctx: &ControlPlaneTestContext,
+    name: &str,
+    project_name: &str,
+) {
+    let client = &cptestctx.external_client;
+    let url = format!("/v1/instances/{}/stop?project={}", name, project_name);
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &url)
+            .body(None as Option<&serde_json::Value>)
+            .expect_status(Some(StatusCode::ACCEPTED)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("Failed to stop instance");
+}
+
+pub async fn instance_delete_by_name(
+    cptestctx: &ControlPlaneTestContext,
+    name: &str,
+    project_name: &str,
+) {
+    let client = &cptestctx.external_client;
+    let url = format!("/v1/instances/{}?project={}", name, project_name);
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::DELETE, &url)
+            .body(None as Option<&serde_json::Value>)
+            .expect_status(Some(StatusCode::NO_CONTENT)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("Failed to delete instance");
+}
+
+pub async fn instance_simulate(
+    cptestctx: &ControlPlaneTestContext,
+    instance_id: &Uuid,
+) {
+    info!(&cptestctx.logctx.log, "Poking simulated instance";
+          "instance_id" => %instance_id);
+    let nexus = &cptestctx.server.apictx().nexus;
+    let sa = nexus.instance_sled_by_id(instance_id).await.unwrap();
+    sa.instance_finish_transition(*instance_id).await;
+}
+
+pub async fn instance_simulate_by_name(
+    cptestctx: &ControlPlaneTestContext,
+    name: &str,
+    project_name: &str,
+) {
+    info!(&cptestctx.logctx.log, "Poking simulated instance";
+          "instance_name" => %name,
+          "project_name" => %project_name);
+
+    let client = &cptestctx.external_client;
+    let url = format!("/v1/instances/{}?project={}", name, project_name);
+    let instance = NexusRequest::new(
+        RequestBuilder::new(client, Method::GET, &url)
+            .body(None as Option<&serde_json::Value>)
+            .expect_status(Some(StatusCode::OK)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("Failed to look up instance for its ID")
+    .parsed_body::<Instance>()
+    .expect("Failed to parse instance GET response as Instance");
+
+    let nexus = &cptestctx.server.apictx().nexus;
+    let sa = nexus.instance_sled_by_id(&instance.identity.id).await.unwrap();
+    sa.instance_finish_transition(instance.identity.id).await;
+}
 
 /// Tests that a saga `S` functions properly when any of its nodes fails and
 /// causes the saga to unwind by iterating over all saga nodes, creating a new

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -250,7 +250,6 @@ pub async fn action_failure_can_unwind<'a, S, B, A>(
 ///   test. This function checks any post-saga invariants and cleans up any
 ///   objects that should be destroyed before the next test iteration.
 /// - `log`: A logger to which the scaffold should log messages.
-/// - `nexus`: A reference to the Nexus that should execute the saga.
 ///
 /// # Panics
 ///

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Helper functions that provide common scaffolding for testing sagas.
+//!
+//! These functions aim to help verify two important properties that all sagas
+//! should have:
+//!
+//! - All actions and undo actions must be idempotent.
+//! - Sagas must unwind properly from a failure in any node in the saga DAG.
+//!
+//! It is easy to accidentally write a test that tries to verify one of these
+//! properties but produces false negative results. See omicron#3265 and
+//! omicron#3894 for examples. The helpers in this module provide common
+//! scaffolding that can help prevent these mistakes. They also avoid
+//! duplicating boilerplate between saga tests.
+
+use super::NexusSaga;
+use crate::{app::saga::create_saga_dag, Nexus};
+use futures::future::BoxFuture;
+use slog::{info, Logger};
+use std::sync::Arc;
+
+/// Tests that a saga `S` functions properly when any of its nodes fails and
+/// causes the saga to unwind by iterating over all saga nodes, creating a new
+/// saga DAG for each node, injecting an error at the chosen node, and verifying
+/// both that the saga failed and that the node at which the failure was
+/// injected was the one that actually caused the saga to fail. This last check
+/// ensures that all possible unwindings are executed.
+///
+/// # Arguments
+///
+/// - `nexus`: A reference to the Nexus that should execute the saga.
+/// - `initial_params`: The parameters to use to construct an initial instance
+///   of saga `S` so that the scaffold can figure out how many nodes are in the
+///   DAG.
+/// - `generate_params`: A callback called at the beginning of each loop
+///   iteration that returns a future that yields the saga parameters to use for
+///   that loop iteration.
+/// - `after_saga`: A callback called after saga execution in each loop
+///   iteration. The caller may use this to check additional post-execution
+///   invariants and to prepare the test for the next loop iteration.
+/// - `log`: A logger to which the scaffold should log messages.
+///
+/// # Panics
+///
+/// This function asserts that each saga it executes (a) starts successfully,
+/// (b) fails, and (c) fails at the specific node at which the function injected
+/// a failure.
+pub async fn action_failure_can_unwind<'a, S, G, P>(
+    nexus: &Arc<Nexus>,
+    initial_params: S::Params,
+    generate_params: G,
+    after_saga: P,
+    log: &Logger,
+) where
+    S: NexusSaga,
+    G: Fn() -> BoxFuture<'a, S::Params>,
+    P: Fn() -> BoxFuture<'a, ()>,
+{
+    let dag = create_saga_dag::<S>(initial_params).unwrap();
+    let num_nodes = dag.get_nodes().count();
+    for failure_index in 0..num_nodes {
+        let params = generate_params().await;
+        let dag = create_saga_dag::<S>(params).unwrap();
+        let node = dag.get_nodes().nth(failure_index).unwrap();
+        info!(
+            log,
+            "Creating new saga that will fail at index {:?}", node.index();
+            "node_name" => node.name().as_ref(),
+            "label" => node.label()
+        );
+
+        let runnable_saga =
+            nexus.create_runnable_saga(dag.clone()).await.unwrap();
+
+        nexus
+            .sec()
+            .saga_inject_error(runnable_saga.id(), node.index())
+            .await
+            .unwrap();
+
+        let saga_error = nexus
+            .run_saga_raw_result(runnable_saga)
+            .await
+            .expect("saga should have started successfully")
+            .kind
+            .expect_err("saga execution should have failed");
+
+        assert_eq!(saga_error.error_node_name, *node.name());
+
+        after_saga().await;
+    }
+}

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -2,19 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Helper functions that provide common scaffolding for testing sagas.
-//!
-//! These functions aim to help verify two important properties that all sagas
-//! should have:
-//!
-//! - All actions and undo actions must be idempotent.
-//! - Sagas must unwind properly from a failure in any node in the saga DAG.
-//!
-//! It is easy to accidentally write a test that tries to verify one of these
-//! properties but produces false negative results. See omicron#3265 and
-//! omicron#3894 for examples. The helpers in this module provide common
-//! scaffolding that can help prevent these mistakes. They also avoid
-//! duplicating boilerplate between saga tests.
+//! Helper functions for writing saga undo tests and working with instances in
+//! saga tests.
 
 use super::NexusSaga;
 use crate::{

--- a/nexus/src/app/sagas/vpc_create.rs
+++ b/nexus/src/app/sagas/vpc_create.rs
@@ -734,23 +734,13 @@ pub(crate) mod test {
         let project_id = create_org_and_project(&client).await;
         delete_project_vpc_defaults(&cptestctx, project_id).await;
 
-        // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(&cptestctx);
-        let authz_project = get_authz_project(
-            &cptestctx,
-            project_id,
-            authz::Action::CreateChild,
-        )
-        .await;
-        let params = new_test_params(&opctx, authz_project);
-
         crate::app::sagas::test_helpers::action_failure_can_unwind::<
             SagaVpcCreate,
             _,
             _,
         >(
             nexus,
-            params,
             || {
                 Box::pin(async {
                     new_test_params(


### PR DESCRIPTION
Several of our saga undo tests have previously been found to have defects in
which the test verifies that all attempts to execute a saga fail but doesn't
verify that saga executions fail at the expected failure point. This loses test
coverage, since the tests don't actually execute all of the undo actions of the
saga under test.

To try to prevent this problem, add a set of saga test helpers that provide
common logic for writing undo tests. The scaffold functions handle the business
of constructing a DAG, deciding where to inject an error, and verifying that
errors occur in the right places. The callers provide a saga type and factory
functions that run before and after each saga execution to set up state, provide
saga parameters, check invariants, and clean up after each test iteration.

Convert existing tests of these types to use the new scaffolds. This revealed
that the no-pantry version of the disk snapshot test has a similar bug: the saga
requires the disk being snapshotted to be attached to an instance, but the test
wasn't creating an instance, so the saga never got past its "look up the
instance that owns the disk" step. Fix this issue.

Finally, coalesce some common instance operations (start, stop, delete,
simulate) that were used by multiple saga tests into the test helpers.

This is a test-only change, tested both by running `cargo test` and finding no
errors and by introducing bugs into some sagas and verifying that tests run with
the scaffolds catch those bugs.

Fixes #3896.