### PR TITLE
[nexus] Add `/v1/ping` endpoint

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -98,7 +98,7 @@ type NexusApiDescription = ApiDescription<Arc<ServerContext>>;
 /// Returns a description of the external nexus API
 pub(crate) fn external_api() -> NexusApiDescription {
     fn register_endpoints(api: &mut NexusApiDescription) -> Result<(), String> {
-        api.register(system_health)?;
+        api.register(ping)?;
 
         api.register(system_policy_view)?;
         api.register(system_policy_update)?;
@@ -366,20 +366,18 @@ pub(crate) fn external_api() -> NexusApiDescription {
 // clients. Client generators use operationId to name API methods, so changing
 // a function name is a breaking change from a client perspective.
 
-/// Fetch system status
+/// Ping API
 ///
 /// Always responds with Ok if it responds at all.
 #[endpoint {
     method = GET,
-    path = "/v1/system/health",
-    tags = ["system"],
+    path = "/v1/ping",
+    tags = ["system/status"],
 }]
-async fn system_health(
+async fn ping(
     _rqctx: RequestContext<Arc<ServerContext>>,
-) -> Result<HttpResponseOk<views::SystemHealth>, HttpError> {
-    Ok(HttpResponseOk(views::SystemHealth {
-        api: views::SystemHealthStatus::Ok,
-    }))
+) -> Result<HttpResponseOk<views::Ping>, HttpError> {
+    Ok(HttpResponseOk(views::Ping { status: views::PingStatus::Ok }))
 }
 
 /// Fetch the top-level IAM policy

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -98,6 +98,8 @@ type NexusApiDescription = ApiDescription<Arc<ServerContext>>;
 /// Returns a description of the external nexus API
 pub(crate) fn external_api() -> NexusApiDescription {
     fn register_endpoints(api: &mut NexusApiDescription) -> Result<(), String> {
+        api.register(system_health)?;
+
         api.register(system_policy_view)?;
         api.register(system_policy_update)?;
 
@@ -363,6 +365,22 @@ pub(crate) fn external_api() -> NexusApiDescription {
 // operationId for each endpoint, and therefore represent a contract with
 // clients. Client generators use operationId to name API methods, so changing
 // a function name is a breaking change from a client perspective.
+
+/// Fetch system status
+///
+/// Always responds with Ok if it responds at all.
+#[endpoint {
+    method = GET,
+    path = "/v1/system/health",
+    tags = ["system"],
+}]
+async fn system_health(
+    _rqctx: RequestContext<Arc<ServerContext>>,
+) -> Result<HttpResponseOk<views::SystemHealth>, HttpError> {
+    Ok(HttpResponseOk(views::SystemHealth {
+        api: views::SystemHealthStatus::Ok,
+    }))
+}
 
 /// Fetch the top-level IAM policy
 #[endpoint {

--- a/nexus/src/external_api/tag-config.json
+++ b/nexus/src/external_api/tag-config.json
@@ -80,10 +80,10 @@
         "url": "http://docs.oxide.computer/api/vpcs"
       }
     },
-    "system": {
-      "description": "General system endpoints",
+    "system/status": {
+      "description": "Endpoints related to system health",
       "external_docs": {
-        "url": "http://docs.oxide.computer/api/system"
+        "url": "http://docs.oxide.computer/api/system-status"
       }
     },
     "system/hardware": {

--- a/nexus/src/external_api/tag-config.json
+++ b/nexus/src/external_api/tag-config.json
@@ -80,6 +80,12 @@
         "url": "http://docs.oxide.computer/api/vpcs"
       }
     },
+    "system": {
+      "description": "General system endpoints",
+      "external_docs": {
+        "url": "http://docs.oxide.computer/api/system"
+      }
+    },
     "system/hardware": {
       "description": "These operations pertain to hardware inventory and management. Racks are the unit of expansion of an Oxide deployment. Racks are in turn composed of sleds, switches, power supplies, and a cabled backplane.",
       "external_docs": {

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -10,7 +10,8 @@
 use dropshot::HttpErrorResponseBody;
 use http::method::Method;
 use http::StatusCode;
-use nexus_types::external_api::{params, views::Project};
+use nexus_types::external_api::params;
+use nexus_types::external_api::views::{self, Project};
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::Name;
@@ -545,4 +546,14 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
             .map(|v| v.identity.id)
             .collect::<Vec<Uuid>>()
     );
+}
+
+#[nexus_test]
+async fn test_system_health(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+
+    let health = NexusRequest::object_get(client, "/v1/system/health")
+        .execute_and_parse_unwrap::<views::SystemHealth>()
+        .await;
+    assert_eq!(health.api, views::SystemHealthStatus::Ok);
 }

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -549,11 +549,11 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
 }
 
 #[nexus_test]
-async fn test_system_health(cptestctx: &ControlPlaneTestContext) {
+async fn test_ping(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    let health = NexusRequest::object_get(client, "/v1/system/health")
-        .execute_and_parse_unwrap::<views::SystemHealth>()
+    let health = NexusRequest::object_get(client, "/v1/ping")
+        .execute_and_parse_unwrap::<views::Ping>()
         .await;
-    assert_eq!(health.api, views::SystemHealthStatus::Ok);
+    assert_eq!(health.status, views::PingStatus::Ok);
 }

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1876,6 +1876,5 @@ lazy_static! {
                 AllowedMethod::GetNonexistent
             ],
         },
-
     ];
 }

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -108,6 +108,10 @@ snapshot_delete                          DELETE   /v1/snapshots/{snapshot}
 snapshot_list                            GET      /v1/snapshots
 snapshot_view                            GET      /v1/snapshots/{snapshot}
 
+API operations found with tag "system"
+OPERATION ID                             METHOD   URL PATH
+system_health                            GET      /v1/system/health
+
 API operations found with tag "system/hardware"
 OPERATION ID                             METHOD   URL PATH
 networking_switch_port_apply_settings    POST     /v1/system/hardware/switch-port/{port}/settings

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -108,10 +108,6 @@ snapshot_delete                          DELETE   /v1/snapshots/{snapshot}
 snapshot_list                            GET      /v1/snapshots
 snapshot_view                            GET      /v1/snapshots/{snapshot}
 
-API operations found with tag "system"
-OPERATION ID                             METHOD   URL PATH
-system_health                            GET      /v1/system/health
-
 API operations found with tag "system/hardware"
 OPERATION ID                             METHOD   URL PATH
 networking_switch_port_apply_settings    POST     /v1/system/hardware/switch-port/{port}/settings
@@ -175,6 +171,10 @@ silo_user_view                           GET      /v1/system/users/{user_id}
 silo_view                                GET      /v1/system/silos/{silo}
 user_builtin_list                        GET      /v1/system/users-builtin
 user_builtin_view                        GET      /v1/system/users-builtin/{user}
+
+API operations found with tag "system/status"
+OPERATION ID                             METHOD   URL PATH
+ping                                     GET      /v1/ping
 
 API operations found with tag "vpcs"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,5 +1,5 @@
 API endpoints with no coverage in authz tests:
-system_health                            (get    "/v1/system/health")
+ping                                     (get    "/v1/ping")
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")
 device_access_token                      (post   "/device/token")

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,4 +1,5 @@
 API endpoints with no coverage in authz tests:
+system_health                            (get    "/v1/system/health")
 device_auth_request                      (post   "/device/auth")
 device_auth_confirm                      (post   "/device/confirm")
 device_access_token                      (post   "/device/token")

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -527,13 +527,13 @@ pub struct UpdateDeployment {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum SystemHealthStatus {
+pub enum PingStatus {
     Ok,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub struct SystemHealth {
+pub struct Ping {
     /// Whether the external API is reachable. Will always be Ok if the endpoint
     /// returns anything at all.
-    pub api: SystemHealthStatus,
+    pub status: PingStatus,
 }

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -522,3 +522,18 @@ pub struct UpdateDeployment {
     pub version: SemverVersion,
     pub status: UpdateStatus,
 }
+
+// SYSTEM HEALTH
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemHealthStatus {
+    Ok,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SystemHealth {
+    /// Whether the external API is reachable. Will always be Ok if the endpoint
+    /// returns anything at all.
+    pub api: SystemHealthStatus,
+}

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2816,6 +2816,34 @@
         }
       }
     },
+    "/v1/ping": {
+      "get": {
+        "tags": [
+          "system/status"
+        ],
+        "summary": "Ping API",
+        "description": "Always responds with Ok if it responds at all.",
+        "operationId": "ping",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ping"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/policy": {
       "get": {
         "tags": [
@@ -4023,34 +4051,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Switch"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/v1/system/health": {
-      "get": {
-        "tags": [
-          "system"
-        ],
-        "summary": "Fetch system status",
-        "description": "Always responds with Ok if it responds at all.",
-        "operationId": "system_health",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemHealth"
                 }
               }
             }
@@ -12057,6 +12057,28 @@
           "items"
         ]
       },
+      "Ping": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "description": "Whether the external API is reachable. Will always be Ok if the endpoint returns anything at all.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PingStatus"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "PingStatus": {
+        "type": "string",
+        "enum": [
+          "ok"
+        ]
+      },
       "Project": {
         "description": "View of a Project",
         "type": "object",
@@ -14059,28 +14081,6 @@
           "vlan_id"
         ]
       },
-      "SystemHealth": {
-        "type": "object",
-        "properties": {
-          "api": {
-            "description": "Whether the external API is reachable. Will always be Ok if the endpoint returns anything at all.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SystemHealthStatus"
-              }
-            ]
-          }
-        },
-        "required": [
-          "api"
-        ]
-      },
-      "SystemHealthStatus": {
-        "type": "string",
-        "enum": [
-          "ok"
-        ]
-      },
       "User": {
         "description": "View of a User",
         "type": "object",
@@ -15298,13 +15298,6 @@
       }
     },
     {
-      "name": "system",
-      "description": "General system endpoints",
-      "externalDocs": {
-        "url": "http://docs.oxide.computer/api/system"
-      }
-    },
-    {
       "name": "system/hardware",
       "description": "These operations pertain to hardware inventory and management. Racks are the unit of expansion of an Oxide deployment. Racks are in turn composed of sleds, switches, power supplies, and a cabled backplane.",
       "externalDocs": {
@@ -15330,6 +15323,13 @@
       "description": "Silos represent a logical partition of users and resources.",
       "externalDocs": {
         "url": "http://docs.oxide.computer/api/system-silos"
+      }
+    },
+    {
+      "name": "system/status",
+      "description": "Endpoints related to system health",
+      "externalDocs": {
+        "url": "http://docs.oxide.computer/api/system-status"
       }
     },
     {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4036,6 +4036,34 @@
         }
       }
     },
+    "/v1/system/health": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Fetch system status",
+        "description": "Always responds with Ok if it responds at all.",
+        "operationId": "system_health",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemHealth"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/system/identity-providers": {
       "get": {
         "tags": [
@@ -14031,6 +14059,28 @@
           "vlan_id"
         ]
       },
+      "SystemHealth": {
+        "type": "object",
+        "properties": {
+          "api": {
+            "description": "Whether the external API is reachable. Will always be Ok if the endpoint returns anything at all.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SystemHealthStatus"
+              }
+            ]
+          }
+        },
+        "required": [
+          "api"
+        ]
+      },
+      "SystemHealthStatus": {
+        "type": "string",
+        "enum": [
+          "ok"
+        ]
+      },
       "User": {
         "description": "View of a User",
         "type": "object",
@@ -15245,6 +15295,13 @@
       "description": "Snapshots of virtual disks at a particular point in time.",
       "externalDocs": {
         "url": "http://docs.oxide.computer/api/snapshots"
+      }
+    },
+    {
+      "name": "system",
+      "description": "General system endpoints",
+      "externalDocs": {
+        "url": "http://docs.oxide.computer/api/system"
       }
     },
     {


### PR DESCRIPTION
Closes #3923 

Adds `/v1/ping` that always returns `{ "status": "ok" }` if it returns anything at all. I went with `ping` over the initial `/v1/system/health` because the latter is vague about its meaning, whereas everyone know ping means a trivial request and response. I also thought it was weird to put an endpoint with no auth check under `/v1/system`, where ~all the other endpoints require fleet-level perms.

This doesn't add too much over hitting an existing endpoint, but I think it's worth it because

* It doesn't hit the DB
* It has no auth check
* It gives a very simple answer to "what endpoint should I use to ping the API?" (a question we have gotten at least once)
* It's easy (I already did it)

Questions that occurred to me while working through this:

- Should we actually attempt to do something in the handler that would tell us, e.g., whether the DB is up?
  - No, that would be more than a ping
  - Raises DoS questions if not auth gated
  - Could add a db status endpoint or or you could use any endpoint that returns data
- What tag should this be under? 
  - Initially added a `system` tag because a) this doesn't fit under existing `system/blah` tags and b) it really does feel miscellaneous
  - Changed to `system/status`, with the idea that if we add other kinds of checks, they would be new endpoints under this tag.