### PR TITLE
service IP pool lookup returns wrong authz error

### DIFF
--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -114,8 +114,6 @@ impl DataStore {
     ) -> LookupResult<(authz::IpPool, IpPool)> {
         use db::schema::ip_pool::dsl;
 
-        // Ensure the caller has the ability to look up these IP pools.
-        // If they don't, return "not found" instead of "forbidden".
         opctx
             .authorize(authz::Action::ListChildren, &authz::IP_POOL_LIST)
             .await?;

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -118,14 +118,7 @@ impl DataStore {
         // If they don't, return "not found" instead of "forbidden".
         opctx
             .authorize(authz::Action::ListChildren, &authz::IP_POOL_LIST)
-            .await
-            .map_err(|e| match e {
-                Error::Forbidden => {
-                    LookupType::ByCompositeId("Service IP Pool".to_string())
-                        .into_not_found(ResourceType::IpPool)
-                }
-                _ => e,
-            })?;
+            .await?;
 
         // Look up this IP pool by rack ID.
         let (authz_pool, pool) = dsl::ip_pool

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -802,7 +802,7 @@ lazy_static! {
         // IP Pool endpoint (Oxide services)
         VerifyEndpoint {
             url: &DEMO_IP_POOL_SERVICE_URL,
-            visibility: Visibility::Protected,
+            visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Get
@@ -812,7 +812,7 @@ lazy_static! {
         // IP Pool ranges endpoint (Oxide services)
         VerifyEndpoint {
             url: &DEMO_IP_POOL_SERVICE_RANGES_URL,
-            visibility: Visibility::Protected,
+            visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Get
@@ -822,7 +822,7 @@ lazy_static! {
         // IP Pool ranges/add endpoint (Oxide services)
         VerifyEndpoint {
             url: &DEMO_IP_POOL_SERVICE_RANGES_ADD_URL,
-            visibility: Visibility::Protected,
+            visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Post(
@@ -834,7 +834,7 @@ lazy_static! {
         // IP Pool ranges/delete endpoint (Oxide services)
         VerifyEndpoint {
             url: &DEMO_IP_POOL_SERVICE_RANGES_DEL_URL,
-            visibility: Visibility::Protected,
+            visibility: Visibility::Public,
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Post(


### PR DESCRIPTION
I noticed this while reading code debugging #3889.  Basically, it's a wrong pattern to `map_err()` the result of `authorize()` to replace a `Forbidden` error with a `NotFound`.  Distinguishing between these two is the responsibility of the authz subsystem because it should be consistent for all callers of `authorize()`.  If we want it to be a NotFound, the authz subsystem supports that via the impl of `AuthorizedResource::on_unauthorized()` for the resource.  Concretely, we could preserve the existing behavior (while still delegating it to the authz subsystem) by customizing the impl for `IpPoolList`:
https://github.com/oxidecomputer/omicron/blob/94cde6d72d2603a3c5160b09d2cd04d958ae1881/nexus/db-queries/src/authz/api_resources.rs#L433-L441
to look more like the one for most non-synthetic resources (which do return NotFound when someone's not authorized to read them):
https://github.com/oxidecomputer/omicron/blob/94cde6d72d2603a3c5160b09d2cd04d958ae1881/nexus/db-queries/src/authz/api_resources.rs#L132-L154

I started looking at that when I saw that we're doing a `ListChildren` here, not a `Read`.  The resource itself ("the list of service IP pools") is _not_ really hidden from end users -- the URL is even published in the OpenAPI spec.  So I think it makes more sense to return Forbidden here, just like if you try to list IP pools when not authorized to do so.