### PR TITLE
Add MPL-2.0 license to a handful of crates

### DIFF
--- a/ddm-admin-client/Cargo.toml
+++ b/ddm-admin-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ddm-admin-client"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 [dependencies]
 either.workspace = true

--- a/dpd-client/Cargo.toml
+++ b/dpd-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dpd-client"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 [dependencies]
 futures.workspace = true

--- a/nexus/test-utils-macros/Cargo.toml
+++ b/nexus/test-utils-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nexus-test-utils-macros"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 [lib]
 proc-macro = true

--- a/tufaceous-lib/Cargo.toml
+++ b/tufaceous-lib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tufaceous-lib"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 publish = false
 
 [dependencies]

--- a/tufaceous/Cargo.toml
+++ b/tufaceous/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tufaceous"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 publish = false
 
 [dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
I was doing some experiments with `cargo-deny` and it noted a handful of crates in `omicron` that were missing licenses in the crate metadata. This fixes them.

`cargo-deny` might be too heavy handed to add to CI for now; it is unhappy with many of our dependencies, at least with the default config.