### PR TITLE
[wicketd] Add step to ensure RoT update landed before proceeding

### DIFF
--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -110,6 +110,7 @@ pub enum SpComponentUpdateStepId {
     Writing,
     SettingActiveBootSlot,
     Resetting,
+    CheckingActiveBootSlot,
 }
 
 impl StepSpec for SpComponentUpdateSpec {
@@ -222,6 +223,11 @@ pub enum SpComponentUpdateTerminalError {
         #[source]
         error: anyhow::Error,
     },
+    #[error("getting currently-active RoT slot failed")]
+    GetRotActiveSlotFailed {
+        #[source]
+        error: anyhow::Error,
+    },
     #[error("resetting RoT failed")]
     RotResetFailed {
         #[source]
@@ -232,6 +238,8 @@ pub enum SpComponentUpdateTerminalError {
         #[source]
         error: anyhow::Error,
     },
+    #[error("RoT booted into unexpected slot {active_slot}")]
+    RotUnexpectedActiveSlot { active_slot: u16 },
 }
 
 impl update_engine::AsError for SpComponentUpdateTerminalError {


### PR DESCRIPTION
Example failure when using an incorrectly-signed RoT image, causing bootleby to fall back to the original slot:

![madrid](https://github.com/oxidecomputer/omicron/assets/1435635/9d2665e4-0a94-4ecb-be1d-ab62987c2918)

Fixes #3937.