### PR TITLE
tools/ directory could use a README

### DIFF
--- a/tools/README.adoc
+++ b/tools/README.adoc
@@ -1,0 +1,82 @@
+:showtitle:
+:toc: left
+:icons: font
+
+= Omicron Tools
+
+This directory is home to a number of tools related to Omicron development.
+There are some additional developer tools implemented as xtasks: Run
+`cargo xtask -h` from the root of the repository for details.
+
+NOTE: This document is intended to be an overview of the lay of the land here. The
+source of truth is always the tools themselves: That said, if you notice
+anything out of date, incorrect, or otherwise confusing, please file an issue
+(or fix it!).
+
+= Top-Level Directories
+
+There are several top-level directories, including:
+
+- `dtrace/`: a collection of dtrace scripts
+- `include/`: scripts used by other scripts
+- `populate/`: scripts to populate a running Omicron with useful guest images
+- `reflector/`: related to `oxide-reflector-bot`
+- `scrimlet/`: related to the setup of `softnpu`
+
+
+= Miscellaneous Scripts
+
+There are a fair number of scripts in the root directory, but many of them are
+related to (or literally dependent on) each other.
+
+== Dependency Management
+
+One class of scripts is related to downloading miscellaneous dependencies. These
+dependencies are not Rust dependencies, but instead various binaries depended
+upon by Omicron.
+
+Some of these dependencies are services we are using in the control plane but
+didn't write ourselves (e.g., cockroachdb, clickhouse), and some are software we
+wrote internally and fetch as artifacts from
+https://github.com/oxidecomputer/buildomat/[buildomat] (e.g.,
+https://github.com/oxidecomputer/dendrite[dendrite],
+https://github.com/oxidecomputer/maghemite[maghemite],
+https://github.com/oxidecomputer/console[console]).
+
+There are many scripts here related to each other, but they share some common
+naming. At a high-level:
+
+- scripts with names of the form `ci_download_*` are intended to install a
+  single dependency. This typically involves installing a tarfile and unpacking
+  into a known location (such as `out/` from the root of the source tree). They
+  may also fetch artifacts from buildomat.  Some of these tools will verify the
+  download binary against a checksum. Despite their name, these
+  scripts are not exclusively used in CI (they are suggested to be run by
+  developers in hint messages of other tools).
+- `\*\_checksums` contain known checksums against which `ci_download_*` will
+  verify a dependency when it is downloaded.
+- `\*\_version` files (such as `console_version`) specify a version that is used
+  by the `ci_download_*` scripts.
+- scripts of the form `install_*.sh` are intended to install specific
+  dependencies (or collections of dependencies) onto a development machine of
+  some kind, for running or deploying Omicron. A current example is
+  `install_prerequisites.sh` and the associated
+   `install_{builder,runner}_prerequisites.sh` pair.  See
+  xref:docs/how-to-run.adoc[] for details.
+
+
+=== Updating Depedencies (Rust or otherwise)
+
+The `update_*.sh` scripts are intended to help update the current supported
+version of a specific dependency. Some of these operate on Rust dependencies
+(such as https://github.com/oxidecomputer/propolis[propolis] and
+https://github.com/oxidecomputer/crucible[crucible]), while others are related
+to the binaries downloaded by the `ci_download_*` scripts.
+
+
+== "Virtual Hardware" Management
+
+Another class of scripts is related to the setup and teardown of "virtual
+hardware", which can be useful when deploying omicron with a real sled agent.
+Current examples include the `{create,destroy}_virtual_hardware.sh` pair.
+See xref:docs/how-to-run.adoc[] for details.


### PR DESCRIPTION
I find the sheer number of files in the `tools/` directory pretty overwhelming. Once #3939 lands, depending on how I end up structuring things, a number of these files should eventually be removed. At that point, it would be worth looking at whether we could add a bit more organization in terms of directory structure, which would also help. In the meantime, I figured I would write down my understanding of how these pieces fit together.

The tools here are used by a variety of people for lots of different things and it's totally possible I misrepresented something (or otherwise missed something big and useful to document): feedback welcome!

(For reviewer convenience, the rendered version of this change is [here](https://github.com/jordanhendricks/omicron/tree/doc-tools/tools).)