### PR TITLE
Update Crucible/Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -1439,6 +1439,7 @@ dependencies = [
  "futures",
  "futures-core",
  "itertools 0.11.0",
+ "libc",
  "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
@@ -1466,7 +1467,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1481,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -1493,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "atty",
@@ -1520,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1536,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1551,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=84507ed89aced20920de73342666a8abcb8237c1#84507ed89aced20920de73342666a8abcb8237c1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "libc",
  "num-derive",
@@ -2036,7 +2037,7 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 [[package]]
 name = "dladm"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -6380,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "propolis"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "anyhow",
  "bhyve_api",
@@ -6396,7 +6397,6 @@ dependencies = [
  "libc",
  "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "num_enum 0.5.11",
- "once_cell",
  "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "propolis_types",
  "rfb",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "propolis-server"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6451,6 +6451,7 @@ dependencies = [
  "chrono",
  "clap 4.3.21",
  "const_format",
+ "crucible-client-types",
  "dropshot",
  "enum-iterator",
  "erased-serde",
@@ -6482,7 +6483,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.17.2",
  "tokio-util",
- "toml 0.5.11",
+ "toml 0.7.6",
  "usdt",
  "uuid",
 ]
@@ -6490,18 +6491,18 @@ dependencies = [
 [[package]]
 name = "propolis-server-config"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "toml 0.5.11",
+ "toml 0.7.6",
 ]
 
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "schemars",
  "serde",
@@ -9514,7 +9515,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viona_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -9524,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "viona_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3#77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3"
+source = "git+https://github.com/oxidecomputer/propolis?rev=4f371e971f9e33f5c02618b2ee95ad03cd531135#4f371e971f9e33f5c02618b2ee95ad03cd531135"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,10 +156,10 @@ cookie = "0.16"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.26.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "84507ed89aced20920de73342666a8abcb8237c1" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
 curve25519-dalek = "3"
 datatest-stable = "0.1.3"
 display-error-chain = "0.1.1"
@@ -271,9 +271,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "77a580b7e2d3fee85ffe8513a86d2c464b7b5ed3", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "4f371e971f9e33f5c02618b2ee95ad03cd531135" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "4f371e971f9e33f5c02618b2ee95ad03cd531135", features = [ "generated-migration" ] }
+propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "4f371e971f9e33f5c02618b2ee95ad03cd531135", default-features = false, features = ["mock-only"] }
 #propolis-server = { path = "../propolis/bin/propolis-server" }
 proptest = "1.2.0"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -344,10 +344,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "84507ed89aced20920de73342666a8abcb8237c1"
+source.commit = "2234dda06e653a36beda83831fbc39c432718a20"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "3e55c672a2ba17a58b17f89128257cfd9fdb57c6e7f66d03535dd8f3c60036c3"
+source.sha256 = "5d6b6be059f07490ec33f4e475bfbda12e5d6d6e206b01b18288adff0170682c"
 output.type = "zone"
 
 [package.crucible-pantry]
@@ -355,10 +355,10 @@ service_name = "crucible_pantry"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "84507ed89aced20920de73342666a8abcb8237c1"
+source.commit = "2234dda06e653a36beda83831fbc39c432718a20"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "6b53e106d1449ea6465e0d352080b63da191b890aabe8d751b0b75e5ddc18621"
+source.sha256 = "21dd8dce9cc0da1a8af5afe09e7e66972969c8129467b33db022ee8bb55fe3ba"
 output.type = "zone"
 
 # Refer to
@@ -369,10 +369,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "f2f0ad2dc7ea9a6d02f6b41d4b15ca40b8e2dcc4"
+source.commit = "4f371e971f9e33f5c02618b2ee95ad03cd531135"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "b0e6951b347bd4755ee2fc41eb51482f5de7169032c064ea54820c5dbdb63bfd"
+source.sha256 = "ae6a44d5473a910e1a539d94c27ae9273b15b921a27f58d0d15304c20ca5588d"
 output.type = "zone"
 
 [package.maghemite]

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -238,7 +238,7 @@ impl SledAgent {
             // Ensure that any disks that are in this request are attached to
             // this instance.
             let id = match disk.volume_construction_request {
-                propolis_client::instance_spec::VolumeConstructionRequest::Volume { id, .. } => id,
+                VolumeConstructionRequest::Volume { id, .. } => id,
                 _ => panic!("Unexpected construction type"),
             };
             self.disks
@@ -300,17 +300,7 @@ impl SledAgent {
             .await?;
 
         for disk_request in &initial_hardware.disks {
-            // disk_request.volume_construction_request is of type
-            // propolis_client::instance_spec::VolumeConstructionRequest, where
-            // map_disk_ids_to_region_ids expects
-            // crucible_client_types::VolumeConstructionRequest, so take a round
-            // trip through JSON serialization -> deserialization to make this
-            // work.
-            let vcr: crucible_client_types::VolumeConstructionRequest =
-                serde_json::from_str(&serde_json::to_string(
-                    &disk_request.volume_construction_request,
-                )?)?;
-
+            let vcr = &disk_request.volume_construction_request;
             self.map_disk_ids_to_region_ids(&vcr).await?;
         }
 


### PR DESCRIPTION
Updated sled-agent to no longer expect a
propolis_client::instance_spec::VolumeConstructionRequest when it is now just a Crucible VolumeConstructionRequest.

Changes in Crucible:
eliminate spurious metadb-related syncs (#881)
ACK the write after adding it to the work queue (#874) Use arc4random_buf or getrandom instead of ChaCha20Rng (#878) Fix crutest in README (#879)
Show client_id in panic messages (#843)
Reduce sqlite page cache size to 64KiB (#876)
Only flush extents that might actually be dirty. (#875)

Changes in Propolis:
Clean up and restructure CQE handling in NVMe
Improve error message when /dev/vmmctl not present (#506) new API endpoint for propolis-server to replace a crucible downstairs (#495) Update rustls-webpki for GHSA-fh2r-99q2-6mmg
Add MemAsync block backend
try reenabling PHD jobs (#484)
Define versioned instance specs (#472)
Update toml dependency to 0.7.x
Add more USDT probes to NVMe emulation
Add more to standalone-with-crucible (#490)
Update propolis with new Crucible Volume change (#485) Minor polish to standalone-crucible doc
Clean up bits for crucible in propolis-standalone
doc iteration for crucible and propolis-standalone Skeleton docs for using propolis with crucible disks in isolation propolis-standalone: Update expected crucible opts (#488) Split up README content for server and standalone
Add crucible config to propolis-standalone
Use libstd-provided OnceCell equivalent
Allow 64-vCPU instances on Helios (stlouis)
Elide test (and doctest) steps where not required
Clean up NVMe PRP parsing and add tests