### PR TITLE
[wicketd] switch to a watch channel for installinator reports

### DIFF
--- a/installinator-artifactd/src/http_entrypoints.rs
+++ b/installinator-artifactd/src/http_entrypoints.rs
@@ -117,11 +117,6 @@ async fn report_progress(
                 format!("update ID {update_id} unrecognized by this server"),
             ))
         }
-        EventReportStatus::ReceiverFull => Err(HttpError::for_client_error(
-            None,
-            StatusCode::TOO_MANY_REQUESTS,
-            format!("update ID {update_id}: receiver full, retry later"),
-        )),
         EventReportStatus::ReceiverClosed => Err(HttpError::for_client_error(
             None,
             StatusCode::GONE,

--- a/installinator-artifactd/src/http_entrypoints.rs
+++ b/installinator-artifactd/src/http_entrypoints.rs
@@ -117,6 +117,16 @@ async fn report_progress(
                 format!("update ID {update_id} unrecognized by this server"),
             ))
         }
+        EventReportStatus::ReceiverFull => Err(HttpError::for_client_error(
+            None,
+            StatusCode::TOO_MANY_REQUESTS,
+            format!("update ID {update_id}: receiver full, retry later"),
+        )),
+        EventReportStatus::ReceiverClosed => Err(HttpError::for_client_error(
+            None,
+            StatusCode::GONE,
+            format!("update ID {update_id}: receiver closed"),
+        )),
     }
 }
 

--- a/installinator-artifactd/src/store.rs
+++ b/installinator-artifactd/src/store.rs
@@ -41,10 +41,7 @@ pub enum EventReportStatus {
     /// The update ID was not recognized by the server.
     UnrecognizedUpdateId,
 
-    /// The progress receiver is full: retry later.
-    ReceiverFull,
-
-    /// The progress receiver is closed: abort.
+    /// The progress receiver is closed.
     ReceiverClosed,
 }
 

--- a/installinator-artifactd/src/store.rs
+++ b/installinator-artifactd/src/store.rs
@@ -40,6 +40,12 @@ pub enum EventReportStatus {
 
     /// The update ID was not recognized by the server.
     UnrecognizedUpdateId,
+
+    /// The progress receiver is full: retry later.
+    ReceiverFull,
+
+    /// The progress receiver is closed: abort.
+    ReceiverClosed,
 }
 
 /// The artifact store -- a simple wrapper around a dynamic [`ArtifactGetter`] that does some basic

--- a/installinator/src/peers.rs
+++ b/installinator/src/peers.rs
@@ -417,12 +417,6 @@ impl Peers {
                         "received HTTP 422 Unprocessable Entity \
                          for update ID {update_id} (update ID unrecognized)",
                     );
-                } else if err.status() == Some(StatusCode::TOO_MANY_REQUESTS) {
-                    slog::warn!(
-                        log,
-                        "received HTTP 429 Too Many Requests \
-                         for update ID {update_id} (receiver full, retry later)",
-                    );
                 } else if err.status() == Some(StatusCode::GONE) {
                     // XXX If we establish a 1:1 relationship
                     // between a particular instance of wicketd and

--- a/installinator/src/peers.rs
+++ b/installinator/src/peers.rs
@@ -393,28 +393,57 @@ impl Peers {
     ) -> impl Stream<Item = Result<(), ClientError>> + Send + '_ {
         futures::stream::iter(self.peers())
             .map(move |peer| {
-                let log = self.log.new(slog::o!("peer" => peer.to_string()));
                 let report = report.clone();
-                async move {
-                    // For each peer, report it to the network.
-                    match self.imp
-                        .report_progress_impl(peer, update_id, report)
-                        .await
-                    {
-                        Ok(()) => Ok(()),
-                        Err(err) => {
-                            // Error 422 means that the server didn't accept the update ID.
-                            if err.status() == Some(StatusCode::UNPROCESSABLE_ENTITY) {
-                                slog::debug!(log, "returned HTTP 422 for update ID {update_id}");
-                            } else {
-                                slog::debug!(log, "failed for update ID {update_id}");
-                            }
-                            Err(err)
-                        }
-                    }
-                }
+                self.send_report_to_peer(peer, update_id, report)
             })
             .buffer_unordered(8)
+    }
+
+    async fn send_report_to_peer(
+        &self,
+        peer: SocketAddr,
+        update_id: Uuid,
+        report: EventReport,
+    ) -> Result<(), ClientError> {
+        let log = self.log.new(slog::o!("peer" => peer.to_string()));
+        // For each peer, report it to the network.
+        match self.imp.report_progress_impl(peer, update_id, report).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // Error 422 means that the server didn't accept the update ID.
+                if err.status() == Some(StatusCode::UNPROCESSABLE_ENTITY) {
+                    slog::debug!(
+                        log,
+                        "received HTTP 422 Unprocessable Entity \
+                         for update ID {update_id} (update ID unrecognized)",
+                    );
+                } else if err.status() == Some(StatusCode::TOO_MANY_REQUESTS) {
+                    slog::warn!(
+                        log,
+                        "received HTTP 429 Too Many Requests \
+                         for update ID {update_id} (receiver full, retry later)",
+                    );
+                } else if err.status() == Some(StatusCode::GONE) {
+                    // XXX If we establish a 1:1 relationship
+                    // between a particular instance of wicketd and
+                    // installinator, 410 Gone can be used to abort
+                    // the update. But we don't have that kind of
+                    // relationship at the moment.
+                    slog::warn!(
+                        log,
+                        "received HTTP 410 Gone for update ID {update_id} \
+                         (receiver closed)",
+                    );
+                } else {
+                    slog::warn!(
+                        log,
+                        "received HTTP error code {:?} for update ID {update_id}",
+                        err.status()
+                    );
+                }
+                Err(err)
+            }
+        }
     }
 }
 

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1338,9 +1338,7 @@ impl UpdateContext {
     async fn process_installinator_reports<'engine>(
         &self,
         cx: &StepContext,
-        mut ipr_receiver: mpsc::UnboundedReceiver<
-            EventReport<InstallinatorSpec>,
-        >,
+        mut ipr_receiver: mpsc::Receiver<EventReport<InstallinatorSpec>>,
     ) -> anyhow::Result<WriteOutput> {
         let mut write_output = None;
 
@@ -1490,8 +1488,7 @@ impl UpdateContext {
         cx: &StepContext,
         mut ipr_start_receiver: IprStartReceiver,
         image_id: HostPhase2RecoveryImageId,
-    ) -> anyhow::Result<mpsc::UnboundedReceiver<EventReport<InstallinatorSpec>>>
-    {
+    ) -> anyhow::Result<mpsc::Receiver<EventReport<InstallinatorSpec>>> {
         const MGS_PROGRESS_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
         // Waiting for the installinator to start is a little strange. It can't

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -229,7 +229,7 @@ async fn test_installinator_fetch() {
     let recv_handle = tokio::task::spawn(async move {
         let mut receiver =
             start_receiver.await.expect("start_receiver succeeded");
-        while let Some(_) = receiver.recv().await {
+        while receiver.changed().await.is_ok() {
             // TODO: do something with the reports?
         }
     });


### PR DESCRIPTION
This was originally changed to an unbounded receiver in #3579, but in
the comments to RFD 400 it was pointed out that maybe we shouldn't give
up on backpressure. Switch to a watch channel, since we only care about
the last element anyway.

(This isn't a hugely pressing issue, but I want to include it as a case
study in RFD 400.)

Also treat the receiver being closed as HTTP 410 Gone. We don't do
anything with this at the moment, but could abort installinator on
receiving this signal in the future.