### PR TITLE
Update propolis rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -2030,7 +2030,7 @@ checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 [[package]]
 name = "dladm"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -6374,7 +6374,7 @@ dependencies = [
 [[package]]
 name = "propolis"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "anyhow",
  "bhyve_api",
@@ -6407,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -6431,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "propolis-server"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "propolis-server-config"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "schemars",
  "serde",
@@ -9510,7 +9510,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viona_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "libc",
  "num_enum 0.5.11",
@@ -9520,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "viona_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=79c1bf8c70a3a0d3902c68891324cb1095e7aee6#79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source = "git+https://github.com/oxidecomputer/propolis?rev=f78820b1e1510e02dec63c6578c91a469d9f3aa4#f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,10 +271,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "79c1bf8c70a3a0d3902c68891324cb1095e7aee6" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "79c1bf8c70a3a0d3902c68891324cb1095e7aee6", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "79c1bf8c70a3a0d3902c68891324cb1095e7aee6", default-features = false, features = ["mock-only"] }
-#propolis-server = { path = "../propolis/bin/propolis-server" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "f78820b1e1510e02dec63c6578c91a469d9f3aa4" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "f78820b1e1510e02dec63c6578c91a469d9f3aa4", features = [ "generated-migration" ] }
+propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "f78820b1e1510e02dec63c6578c91a469d9f3aa4", default-features = false, features = ["mock-only"] }
 proptest = "1.2.0"
 quote = "1.0"
 rand = "0.8.5"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -369,10 +369,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "79c1bf8c70a3a0d3902c68891324cb1095e7aee6"
+source.commit = "f78820b1e1510e02dec63c6578c91a469d9f3aa4"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "f817c7153a92c35b094c05010a41cbe450d4896fac16cec848b4331cc66a69c9"
+source.sha256 = "38e710e47c8c277ae432d953bc6707796feaacf75224d56033e69aa82094ddba"
 output.type = "zone"
 
 [package.maghemite]


### PR DESCRIPTION
This picks up:
- Make Oximeter producer endpoint registration best effort (oxidecomputer/propolis#511)
- vioblk: add flush support (oxidecomputer/propolis#504)