### PR TITLE
[nexus] Silo IP pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5093,6 +5093,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
+ "similar-asserts",
  "sled-agent-client",
  "slog",
  "slog-async",
@@ -7830,6 +7831,20 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+dependencies = [
+ "bstr 0.2.17",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
+dependencies = [
+ "console",
+ "similar",
+]
 
 [[package]]
 name = "siphasher"
@@ -9208,7 +9223,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ sha3 = "0.10.8"
 shell-words = "1.1.0"
 signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
+similar-asserts = "1.5.0"
 sled = "0.34"
 sled-agent-client = { path = "sled-agent-client" }
 sled-hardware = { path = "sled-hardware" }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -68,6 +68,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 serde_with.workspace = true
+similar-asserts.workspace = true
 sled-agent-client.workspace = true
 slog.workspace = true
 slog-async.workspace = true

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -68,7 +68,6 @@ serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 serde_with.workspace = true
-similar-asserts.workspace = true
 sled-agent-client.workspace = true
 slog.workspace = true
 slog-async.workspace = true
@@ -118,6 +117,7 @@ petgraph.workspace = true
 pretty_assertions.workspace = true
 rcgen.workspace = true
 regex.workspace = true
+similar-asserts.workspace = true
 rustls = { workspace = true }
 subprocess.workspace = true
 term.workspace = true

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -48,12 +48,15 @@ pub struct IpPool {
 
     /// Project, if IP pool is associated with a particular project
     pub project_id: Option<Uuid>,
+
+    pub default: bool,
 }
 
 impl IpPool {
     pub fn new(
         pool_identity: &external::IdentityMetadataCreateParams,
         silo_id: Option<Uuid>,
+        default: bool,
     ) -> Self {
         Self {
             identity: IpPoolIdentity::new(
@@ -63,6 +66,7 @@ impl IpPool {
             rcgen: 0,
             silo_id,
             project_id: None,
+            default,
         }
     }
 }

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -73,7 +73,7 @@ impl IpPool {
 
 impl From<IpPool> for views::IpPool {
     fn from(pool: IpPool) -> Self {
-        Self { identity: pool.identity() }
+        Self { identity: pool.identity(), silo_id: pool.silo_id }
     }
 }
 

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -39,7 +39,7 @@ pub struct IpPool {
     /// Silo, if IP pool is associated with a particular silo. One special use
     /// for this is  associating a pool with the internal silo oxide-internal,
     /// which is used for internal services. If there is no silo ID, the
-    /// pool is considered a fleet-wide silo and will be used for allocating
+    /// pool is considered a fleet-wide pool and will be used for allocating
     /// instance IPs in silos that don't have their own pool. Must be non-
     /// null if project_id is non-null (this is enforced as a DB constraint).
     /// When project_id is non-null, silo_id will (naturally) be the ID of the

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -57,6 +57,7 @@ impl IpPool {
     pub fn new(
         pool_identity: &external::IdentityMetadataCreateParams,
         internal: bool,
+        silo_id: Option<Uuid>,
     ) -> Self {
         Self {
             identity: IpPoolIdentity::new(
@@ -65,7 +66,7 @@ impl IpPool {
             ),
             internal,
             rcgen: 0,
-            silo_id: None,
+            silo_id,
             project_id: None,
         }
     }

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -49,14 +49,14 @@ pub struct IpPool {
     /// Project, if IP pool is associated with a particular project
     pub project_id: Option<Uuid>,
 
-    pub default: bool,
+    pub is_default: bool,
 }
 
 impl IpPool {
     pub fn new(
         pool_identity: &external::IdentityMetadataCreateParams,
         silo_id: Option<Uuid>,
-        default: bool,
+        is_default: bool,
     ) -> Self {
         Self {
             identity: IpPoolIdentity::new(
@@ -66,7 +66,7 @@ impl IpPool {
             rcgen: 0,
             silo_id,
             project_id: None,
-            default,
+            is_default,
         }
     }
 }

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -40,14 +40,8 @@ pub struct IpPool {
     /// for this is  associating a pool with the internal silo oxide-internal,
     /// which is used for internal services. If there is no silo ID, the
     /// pool is considered a fleet-wide pool and will be used for allocating
-    /// instance IPs in silos that don't have their own pool. Must be non-
-    /// null if project_id is non-null (this is enforced as a DB constraint).
-    /// When project_id is non-null, silo_id will (naturally) be the ID of the
-    /// project's silo.
+    /// instance IPs in silos that don't have their own pool.
     pub silo_id: Option<Uuid>,
-
-    /// Project, if IP pool is associated with a particular project
-    pub project_id: Option<Uuid>,
 
     pub is_default: bool,
 }
@@ -65,7 +59,6 @@ impl IpPool {
             ),
             rcgen: 0,
             silo_id,
-            project_id: None,
             is_default,
         }
     }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -455,6 +455,7 @@ table! {
         rcgen -> Int8,
         silo_id -> Nullable<Uuid>,
         project_id -> Nullable<Uuid>,
+        default -> Bool,
     }
 }
 

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1131,7 +1131,7 @@ table! {
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(3, 0, 2);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(3, 0, 3);
 
 allow_tables_to_appear_in_same_query!(
     system_update,

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -455,7 +455,7 @@ table! {
         rcgen -> Int8,
         silo_id -> Nullable<Uuid>,
         project_id -> Nullable<Uuid>,
-        default -> Bool,
+        is_default -> Bool,
     }
 }
 

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -452,7 +452,6 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
-        internal -> Bool,
         rcgen -> Int8,
         silo_id -> Nullable<Uuid>,
         project_id -> Nullable<Uuid>,
@@ -1131,7 +1130,7 @@ table! {
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(3, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(3, 0, 2);
 
 allow_tables_to_appear_in_same_query!(
     system_update,

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -454,7 +454,6 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
         rcgen -> Int8,
         silo_id -> Nullable<Uuid>,
-        project_id -> Nullable<Uuid>,
         is_default -> Bool,
     }
 }

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -50,21 +50,15 @@ impl DataStore {
         opctx: &OpContext,
         ip_id: Uuid,
         instance_id: Uuid,
-        project_id: Uuid,
         pool_name: Option<Name>,
     ) -> CreateResult<ExternalIp> {
         // If we have a pool name, look up the pool by name and return it
         // as long as its scopes don't conflict with the current scope.
         // Otherwise, not found.
         let pool = match pool_name {
-            Some(name) => {
-                self.ip_pools_fetch_for(&opctx, &name, Some(project_id)).await?
-            }
+            Some(name) => self.ip_pools_fetch_for(&opctx, &name).await?,
             // If no name given, use the default logic
-            None => {
-                self.ip_pools_fetch_default_for(&opctx, Some(project_id))
-                    .await?
-            }
+            None => self.ip_pools_fetch_default_for(&opctx).await?,
         };
 
         let pool_id = pool.identity.id;

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -52,30 +52,15 @@ impl DataStore {
         instance_id: Uuid,
         pool_name: Option<Name>,
     ) -> CreateResult<ExternalIp> {
-        let current_silo = opctx.authn.silo_required()?;
-
         // If we have a pool name, look up the pool by name and return it
         // as long as its scopes don't conflict with the current scope.
         // Otherwise, not found.
         let pool = match pool_name {
-            Some(name) => {
-                self.ip_pools_fetch_for(
-                    &opctx,
-                    &name,
-                    current_silo.id(),
-                    None, // TODO: include current project ID
-                )
-                .await?
-            }
+            // TODO: include current project ID
+            Some(name) => self.ip_pools_fetch_for(&opctx, &name, None).await?,
             // If no name given, use the default logic
-            None => {
-                self.ip_pools_fetch_default_for(
-                    &opctx,
-                    Some(current_silo.id()),
-                    None, // TODO: include current project ID
-                )
-                .await?
-            }
+            // TODO: include current project ID
+            None => self.ip_pools_fetch_default_for(&opctx, None).await?,
         };
 
         let pool_id = pool.identity.id;

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -64,7 +64,7 @@ impl DataStore {
                     &opctx,
                     authz::Action::CreateChild, // TODO: wtf
                     &name,
-                    Some(current_silo.id()),
+                    current_silo.id(),
                     None, // TODO: include current project ID
                 )
                 .await?

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -58,6 +58,13 @@ impl DataStore {
         let name = pool_name.unwrap_or_else(|| {
             Name(ExternalName::from_str("default").unwrap())
         });
+
+        // TODO: this is the whole thing -- update this call to EITHER look up
+        // the pool by name (only allowing access to pools matching the scope of
+        // the current project, i.e., you can pick a pool by name only if it's
+        // scoped to your project, silo, or the whole fleet) or use the default
+        // logic in ip_pool_fetch_default_for
+
         let (.., pool) = self
             .ip_pools_fetch_for(opctx, authz::Action::CreateChild, &name)
             .await?;

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -56,9 +56,9 @@ impl DataStore {
         // as long as its scopes don't conflict with the current scope.
         // Otherwise, not found.
         let pool = match pool_name {
-            Some(name) => self.ip_pools_fetch_for(&opctx, &name).await?,
+            Some(name) => self.ip_pools_fetch(&opctx, &name).await?,
             // If no name given, use the default logic
-            None => self.ip_pools_fetch_default_for(&opctx).await?,
+            None => self.ip_pools_fetch_default(&opctx).await?,
         };
 
         let pool_id = pool.identity.id;

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -5,7 +5,6 @@
 //! [`DataStore`] methods on [`ExternalIp`]s.
 
 use super::DataStore;
-use crate::authz;
 use crate::context::OpContext;
 use crate::db;
 use crate::db::error::public_error_from_diesel_pool;
@@ -62,7 +61,6 @@ impl DataStore {
             Some(name) => {
                 self.ip_pools_fetch_for(
                     &opctx,
-                    authz::Action::CreateChild, // TODO: wtf
                     &name,
                     current_silo.id(),
                     None, // TODO: include current project ID
@@ -73,7 +71,6 @@ impl DataStore {
             None => {
                 self.ip_pools_fetch_default_for(
                     &opctx,
-                    authz::Action::CreateChild, // TODO: wtf
                     Some(current_silo.id()),
                     None, // TODO: include current project ID
                 )

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -50,17 +50,21 @@ impl DataStore {
         opctx: &OpContext,
         ip_id: Uuid,
         instance_id: Uuid,
+        project_id: Uuid,
         pool_name: Option<Name>,
     ) -> CreateResult<ExternalIp> {
         // If we have a pool name, look up the pool by name and return it
         // as long as its scopes don't conflict with the current scope.
         // Otherwise, not found.
         let pool = match pool_name {
-            // TODO: include current project ID
-            Some(name) => self.ip_pools_fetch_for(&opctx, &name, None).await?,
+            Some(name) => {
+                self.ip_pools_fetch_for(&opctx, &name, Some(project_id)).await?
+            }
             // If no name given, use the default logic
-            // TODO: include current project ID
-            None => self.ip_pools_fetch_default_for(&opctx, None).await?,
+            None => {
+                self.ip_pools_fetch_default_for(&opctx, Some(project_id))
+                    .await?
+            }
         };
 
         let pool_id = pool.identity.id;

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -116,7 +116,8 @@ impl DataStore {
         opctx: &OpContext,
         action: authz::Action,
         name: &Name,
-        silo_id: Option<Uuid>,
+        silo_id: Uuid,
+        // TODO: project_id should always be defined, this is temporary
         project_id: Option<Uuid>,
     ) -> LookupResult<IpPool> {
         let (.., authz_pool, pool) = LookupPath::new(opctx, &self)
@@ -124,32 +125,23 @@ impl DataStore {
             .fetch_for(action)
             .await?;
 
-        if pool.silo_id == Some(*INTERNAL_SILO_ID) {
-            return Err(authz_pool.not_found());
-        }
+        // You can't look up a pool by name if it conflicts with your current
+        // scope, i.e., if it has a silo or project and those are different from
+        // your current silo or project
 
-        // You can't look up the internal pool by name, and you can't look up
-        // a pool by name if it conflicts with your current scope, i.e., if it
-        // has a silo or project and those are different from your current silo
-        // or project
         if let Some(pool_silo_id) = pool.silo_id {
-            if pool_silo_id == *INTERNAL_SILO_ID {
+            if pool_silo_id != silo_id {
                 return Err(authz_pool.not_found());
             }
-
-            if let Some(current_silo_id) = silo_id {
-                if current_silo_id != pool_silo_id {
-                    return Err(authz_pool.not_found());
-                }
-            }
         }
 
-        if let Some(pool_project_id) = pool.project_id {
-            if let Some(current_project_id) = project_id {
-                if current_project_id != pool_project_id {
+        match (pool.project_id, project_id) {
+            (Some(pool_project_id), Some(current_project_id)) => {
+                if pool_project_id != current_project_id {
                     return Err(authz_pool.not_found());
                 }
             }
+            _ => {}
         }
 
         Ok(pool)

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -72,16 +72,18 @@ impl DataStore {
         .map_err(|e| public_error_from_diesel_pool(e, ErrorHandler::Server))
     }
 
-    /// Looks up the default IP pool for a given scope, i.e., a given
-    /// combination of silo and project ID. If there is no default at a given
-    /// scope, fall back up a level. There should always be a default at fleet
-    /// level, though this query can theoretically fail.
+    /// Look up the default IP pool for a given scope, i.e., a given combination
+    /// of silo and project ID. If there is no default at a given scope, fall
+    /// back to the next level up. There should always be a default pool at the
+    /// fleet level, though this query can theoretically fail if someone is able
+    /// to delete that pool or make another one the default and delete that.
     pub async fn ip_pools_fetch_default_for(
         &self,
         opctx: &OpContext,
-        // Optional primarily because there are test contexts where we don't care
-        // about the project. If project ID is None, we will only get back pools
-        // that themselves have no project.
+        // Optional primarily because there are test contexts where we don't
+        // care about the project. If project ID is None, we will only get back
+        // pools that themselves have no associated project, i.e., are fleet-
+        // scoped or silo-scoped.
         project_id: Option<Uuid>,
     ) -> LookupResult<IpPool> {
         use db::schema::ip_pool::dsl;

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -77,7 +77,7 @@ impl DataStore {
     /// There should always be a default pool at the fleet level, though this
     /// query can theoretically fail if someone is able to delete that pool or
     /// make another one the default and delete that.
-    pub async fn ip_pools_fetch_default_for(
+    pub async fn ip_pools_fetch_default(
         &self,
         opctx: &OpContext,
     ) -> LookupResult<IpPool> {
@@ -112,7 +112,7 @@ impl DataStore {
     }
 
     /// Looks up an IP pool by name if it does not conflict with your current scope.
-    pub(crate) async fn ip_pools_fetch_for(
+    pub(crate) async fn ip_pools_fetch(
         &self,
         opctx: &OpContext,
         name: &Name,
@@ -480,7 +480,7 @@ mod test {
         // we start out with the default fleet-level pool already created,
         // so when we ask for a default silo, we get it back
         let fleet_default_pool =
-            datastore.ip_pools_fetch_default_for(&opctx).await.unwrap();
+            datastore.ip_pools_fetch_default(&opctx).await.unwrap();
 
         assert_eq!(fleet_default_pool.identity.name.as_str(), "default");
         assert!(fleet_default_pool.is_default);
@@ -520,7 +520,7 @@ mod test {
         // because that one was not a default, when we ask for the silo default
         // pool, we still get the fleet default
         let ip_pool = datastore
-            .ip_pools_fetch_default_for(&opctx)
+            .ip_pools_fetch_default(&opctx)
             .await
             .expect("Failed to get silo default IP pool");
         assert_eq!(ip_pool.id(), fleet_default_pool.id());
@@ -536,14 +536,14 @@ mod test {
 
         // now when we ask for the default pool, we get the one we just made
         let ip_pool = datastore
-            .ip_pools_fetch_default_for(&opctx)
+            .ip_pools_fetch_default(&opctx)
             .await
             .expect("Failed to get silo's default IP pool");
         assert_eq!(ip_pool.name().as_str(), "default-for-silo");
 
         // if we ask for the fleet default by name, we can still get that one
         let ip_pool = datastore
-            .ip_pools_fetch_for(&opctx, &Name("default".parse().unwrap()))
+            .ip_pools_fetch(&opctx, &Name("default".parse().unwrap()))
             .await
             .expect("Failed to get fleet default IP pool");
         assert_eq!(ip_pool.id(), fleet_default_pool.id());

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -91,7 +91,7 @@ impl DataStore {
             .filter(
                 dsl::project_id.eq(project_id).or(dsl::project_id.is_null()),
             )
-            .filter(dsl::default.eq(true))
+            .filter(dsl::is_default.eq(true))
             .filter(dsl::time_deleted.is_null())
             // this will sort by most specific first, i.e.,
             //
@@ -479,7 +479,7 @@ mod test {
             .unwrap();
 
         assert_eq!(fleet_default_pool.identity.name.as_str(), "default");
-        assert!(fleet_default_pool.default);
+        assert!(fleet_default_pool.is_default);
         assert_eq!(fleet_default_pool.silo_id, None);
         assert_eq!(fleet_default_pool.project_id, None);
 

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -149,12 +149,13 @@ impl DataStore {
         opctx: &OpContext,
         new_pool: &params::IpPoolCreate,
         internal: bool,
+        silo_id: Option<Uuid>,
     ) -> CreateResult<IpPool> {
         use db::schema::ip_pool::dsl;
         opctx
             .authorize(authz::Action::CreateChild, &authz::IP_POOL_LIST)
             .await?;
-        let pool = IpPool::new(&new_pool.identity, internal);
+        let pool = IpPool::new(&new_pool.identity, internal, silo_id);
         let pool_name = pool.name().as_str().to_string();
 
         diesel::insert_into(dsl::ip_pool)

--- a/nexus/db-queries/src/db/datastore/project.rs
+++ b/nexus/db-queries/src/db/datastore/project.rs
@@ -351,7 +351,8 @@ impl DataStore {
         }
         // TODO(2148, 2056): filter only pools accessible by the given
         // project, once specific projects for pools are implemented
-        .filter(dsl::internal.eq(false))
+        // != excludes nulls so we explicitly include them
+        .filter(dsl::silo_id.ne(*INTERNAL_SILO_ID).or(dsl::silo_id.is_null()))
         .filter(dsl::time_deleted.is_null())
         .select(db::model::IpPool::as_select())
         .get_results_async(self.pool_authorized(opctx).await?)

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -563,13 +563,15 @@ impl DataStore {
             },
             silo: None,
         };
-        self.ip_pool_create(opctx, &params, /*internal=*/ true)
-            .await
-            .map(|_| ())
-            .or_else(|e| match e {
-                Error::ObjectAlreadyExists { .. } => Ok(()),
-                _ => Err(e),
-            })?;
+        self.ip_pool_create(
+            opctx, &params, /*internal=*/ true, /*silo_id*/ None,
+        )
+        .await
+        .map(|_| ())
+        .or_else(|e| match e {
+            Error::ObjectAlreadyExists { .. } => Ok(()),
+            _ => Err(e),
+        })?;
 
         let params = external_params::IpPoolCreate {
             identity: IdentityMetadataCreateParams {
@@ -578,13 +580,15 @@ impl DataStore {
             },
             silo: None,
         };
-        self.ip_pool_create(opctx, &params, /*internal=*/ false)
-            .await
-            .map(|_| ())
-            .or_else(|e| match e {
-                Error::ObjectAlreadyExists { .. } => Ok(()),
-                _ => Err(e),
-            })?;
+        self.ip_pool_create(
+            opctx, &params, /*internal=*/ false, /*silo_id*/ None,
+        )
+        .await
+        .map(|_| ())
+        .or_else(|e| match e {
+            Error::ObjectAlreadyExists { .. } => Ok(()),
+            _ => Err(e),
+        })?;
 
         Ok(())
     }

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -561,6 +561,7 @@ impl DataStore {
                 name: SERVICE_IP_POOL_NAME.parse::<Name>().unwrap(),
                 description: String::from("IP Pool for Oxide Services"),
             },
+            silo: None,
         };
         self.ip_pool_create(opctx, &params, /*internal=*/ true)
             .await
@@ -575,6 +576,7 @@ impl DataStore {
                 name: "default".parse::<Name>().unwrap(),
                 description: String::from("default IP pool"),
             },
+            silo: None,
         };
         self.ip_pool_create(opctx, &params, /*internal=*/ false)
             .await

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -563,6 +563,7 @@ impl DataStore {
                 description: String::from("IP Pool for Oxide Services"),
             },
             Some(*INTERNAL_SILO_ID),
+            true, // default for internal silo
         );
 
         self.ip_pool_create(opctx, internal_pool).await.map(|_| ()).or_else(
@@ -578,6 +579,7 @@ impl DataStore {
                 description: String::from("default IP pool"),
             },
             None, // no silo ID, fleet scoped
+            true, // default for fleet
         );
         self.ip_pool_create(opctx, default_pool).await.map(|_| ()).or_else(
             |e| match e {

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -995,6 +995,7 @@ mod tests {
         let context =
             TestContext::new("test_ephemeral_and_snat_ips_do_not_overlap")
                 .await;
+        let project_id = Uuid::new_v4();
         let range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 1),
@@ -1011,6 +1012,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
+                project_id,
                 /* pool_name = */ None,
             )
             .await
@@ -1050,6 +1052,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
+                project_id,
                 /* pool_name = */ None,
             )
             .await;
@@ -1184,6 +1187,7 @@ mod tests {
         .unwrap();
         context.initialize_ip_pool("default", range).await;
 
+        let project_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
         let id = Uuid::new_v4();
         let pool_name = None;
@@ -1194,6 +1198,7 @@ mod tests {
                 &context.opctx,
                 id,
                 instance_id,
+                project_id,
                 pool_name,
             )
             .await
@@ -1713,6 +1718,7 @@ mod tests {
 
         // Allocating an address on an instance in the second pool should be
         // respected, even though there are IPs available in the first.
+        let project_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
         let id = Uuid::new_v4();
         let pool_name = Some(Name("p1".parse().unwrap()));
@@ -1723,6 +1729,7 @@ mod tests {
                 &context.opctx,
                 id,
                 instance_id,
+                project_id,
                 pool_name,
             )
             .await
@@ -1742,6 +1749,7 @@ mod tests {
         )
         .await;
 
+        let project_id = Uuid::new_v4();
         let first_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 3),
@@ -1766,6 +1774,7 @@ mod tests {
                     &context.opctx,
                     Uuid::new_v4(),
                     instance_id,
+                    project_id,
                     pool_name.clone(),
                 )
                 .await
@@ -1785,6 +1794,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
+                project_id,
                 pool_name,
             )
             .await

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -816,6 +816,7 @@ mod tests {
     use crate::context::OpContext;
     use crate::db::datastore::DataStore;
     use crate::db::datastore::SERVICE_IP_POOL_NAME;
+    use crate::db::fixed_data::silo::INTERNAL_SILO_ID;
     use crate::db::identity::Resource;
     use crate::db::model::IpKind;
     use crate::db::model::IpPool;
@@ -862,14 +863,12 @@ mod tests {
         }
 
         async fn create_ip_pool(&self, name: &str, range: IpRange) {
-            let internal = false;
             let pool = IpPool::new(
                 &IdentityMetadataCreateParams {
                     name: String::from(name).parse().unwrap(),
                     description: format!("ip pool {}", name),
                 },
-                internal,
-                None, // silo id
+                Some(*INTERNAL_SILO_ID),
             );
 
             use crate::db::schema::ip_pool::dsl as ip_pool_dsl;

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -924,12 +924,7 @@ mod tests {
         async fn default_pool_id(&self) -> Uuid {
             let pool = self
                 .db_datastore
-                .ip_pools_fetch_default_for(
-                    &self.opctx,
-                    crate::authz::Action::ListChildren,
-                    None,
-                    None,
-                )
+                .ip_pools_fetch_default_for(&self.opctx, None, None)
                 .await
                 .expect("Failed to lookup default ip pool");
             pool.identity.id

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -924,7 +924,7 @@ mod tests {
         async fn default_pool_id(&self) -> Uuid {
             let pool = self
                 .db_datastore
-                .ip_pools_fetch_default_for(&self.opctx, None)
+                .ip_pools_fetch_default_for(&self.opctx)
                 .await
                 .expect("Failed to lookup default ip pool");
             pool.identity.id
@@ -995,7 +995,6 @@ mod tests {
         let context =
             TestContext::new("test_ephemeral_and_snat_ips_do_not_overlap")
                 .await;
-        let project_id = Uuid::new_v4();
         let range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 1),
@@ -1012,7 +1011,6 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                project_id,
                 /* pool_name = */ None,
             )
             .await
@@ -1052,7 +1050,6 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                project_id,
                 /* pool_name = */ None,
             )
             .await;
@@ -1187,7 +1184,6 @@ mod tests {
         .unwrap();
         context.initialize_ip_pool("default", range).await;
 
-        let project_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
         let id = Uuid::new_v4();
         let pool_name = None;
@@ -1198,7 +1194,6 @@ mod tests {
                 &context.opctx,
                 id,
                 instance_id,
-                project_id,
                 pool_name,
             )
             .await
@@ -1718,7 +1713,6 @@ mod tests {
 
         // Allocating an address on an instance in the second pool should be
         // respected, even though there are IPs available in the first.
-        let project_id = Uuid::new_v4();
         let instance_id = Uuid::new_v4();
         let id = Uuid::new_v4();
         let pool_name = Some(Name("p1".parse().unwrap()));
@@ -1729,7 +1723,6 @@ mod tests {
                 &context.opctx,
                 id,
                 instance_id,
-                project_id,
                 pool_name,
             )
             .await
@@ -1749,7 +1742,6 @@ mod tests {
         )
         .await;
 
-        let project_id = Uuid::new_v4();
         let first_range = IpRange::try_from((
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(10, 0, 0, 3),
@@ -1774,7 +1766,6 @@ mod tests {
                     &context.opctx,
                     Uuid::new_v4(),
                     instance_id,
-                    project_id,
                     pool_name.clone(),
                 )
                 .await
@@ -1794,7 +1785,6 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                project_id,
                 pool_name,
             )
             .await

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -74,7 +74,7 @@ const MAX_PORT: u16 = u16::MAX;
 ///
 /// In general, the query:
 ///
-/// - Selects the next available IP address and port range from _any_ IP Pool
+/// - Selects the next available IP address and port range from the specified IP pool
 /// - Inserts that record into the `external_ip` table
 /// - Updates the rcgen and time modified of the parent `ip_pool_range` table
 ///

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -924,7 +924,7 @@ mod tests {
         async fn default_pool_id(&self) -> Uuid {
             let pool = self
                 .db_datastore
-                .ip_pools_fetch_default_for(&self.opctx)
+                .ip_pools_fetch_default(&self.opctx)
                 .await
                 .expect("Failed to lookup default ip pool");
             pool.identity.id

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -869,6 +869,7 @@ mod tests {
                     description: format!("ip pool {}", name),
                 },
                 Some(*INTERNAL_SILO_ID),
+                true,
             );
 
             use crate::db::schema::ip_pool::dsl as ip_pool_dsl;
@@ -916,11 +917,13 @@ mod tests {
         }
 
         async fn default_pool_id(&self) -> Uuid {
-            let (.., pool) = self
+            let pool = self
                 .db_datastore
                 .ip_pools_fetch_default_for(
                     &self.opctx,
                     crate::authz::Action::ListChildren,
+                    None,
+                    None,
                 )
                 .await
                 .expect("Failed to lookup default ip pool");

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -924,7 +924,7 @@ mod tests {
         async fn default_pool_id(&self) -> Uuid {
             let pool = self
                 .db_datastore
-                .ip_pools_fetch_default_for(&self.opctx, None, None)
+                .ip_pools_fetch_default_for(&self.opctx, None)
                 .await
                 .expect("Failed to lookup default ip pool");
             pool.identity.id

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -869,6 +869,7 @@ mod tests {
                     description: format!("ip pool {}", name),
                 },
                 internal,
+                None, // silo id
             );
 
             use crate::db::schema::ip_pool::dsl as ip_pool_dsl;

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -69,7 +69,7 @@ impl super::Nexus {
         let pool = db::model::IpPool::new(
             &pool_params.identity,
             silo_id,
-            pool_params.default,
+            pool_params.is_default,
         );
         self.db_datastore.ip_pool_create(opctx, pool).await
     }

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -24,6 +24,7 @@ use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
 use ref_cast::RefCast;
+use uuid::Uuid;
 
 impl super::Nexus {
     pub fn ip_pool_lookup<'a>(
@@ -49,9 +50,18 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         new_pool: &params::IpPoolCreate,
+        // TODO: should this be passed here as a lookup::Silo? adding this flag
+        // all the way down the chain is clearly a smell. The `internal` arg
+        // is too, really, though it is kind of nice to see at each call what's
+        // internal. But I'm thinking maybe there should be an IpPoolCreate'
+        // that is produced from IpPoolCreate and includes internal and the silo
+        // id (or lookup) resolved from the NameOrId.
+        silo_id: Option<Uuid>,
     ) -> CreateResult<db::model::IpPool> {
         self.db_datastore
-            .ip_pool_create(opctx, new_pool, /* internal= */ false)
+            .ip_pool_create(
+                opctx, new_pool, /* internal= */ false, silo_id,
+            )
             .await
     }
 
@@ -61,7 +71,10 @@ impl super::Nexus {
         new_pool: &params::IpPoolCreate,
     ) -> CreateResult<db::model::IpPool> {
         self.db_datastore
-            .ip_pool_create(opctx, new_pool, /* internal= */ true)
+            .ip_pool_create(
+                opctx, new_pool, /* internal= */ true,
+                /* silo_id= */ None,
+            )
             .await
     }
 

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -66,7 +66,11 @@ impl super::Nexus {
             }
             _ => None,
         };
-        let pool = db::model::IpPool::new(&pool_params.identity, silo_id);
+        let pool = db::model::IpPool::new(
+            &pool_params.identity,
+            silo_id,
+            pool_params.default,
+        );
         self.db_datastore.ip_pool_create(opctx, pool).await
     }
 

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -12,7 +12,9 @@ use crate::db::model::Name;
 use crate::external_api::params;
 use crate::external_api::shared::IpRange;
 use ipnetwork::IpNetwork;
+use nexus_db_model::IpPool;
 use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::fixed_data::silo::INTERNAL_SILO_ID;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DataPageParams;
@@ -24,7 +26,10 @@ use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
 use ref_cast::RefCast;
-use uuid::Uuid;
+
+fn is_internal(pool: &IpPool) -> bool {
+    pool.silo_id == Some(*INTERNAL_SILO_ID)
+}
 
 impl super::Nexus {
     pub fn ip_pool_lookup<'a>(
@@ -49,33 +54,20 @@ impl super::Nexus {
     pub async fn ip_pool_create(
         &self,
         opctx: &OpContext,
-        new_pool: &params::IpPoolCreate,
-        // TODO: should this be passed here as a lookup::Silo? adding this flag
-        // all the way down the chain is clearly a smell. The `internal` arg
-        // is too, really, though it is kind of nice to see at each call what's
-        // internal. But I'm thinking maybe there should be an IpPoolCreate'
-        // that is produced from IpPoolCreate and includes internal and the silo
-        // id (or lookup) resolved from the NameOrId.
-        silo_id: Option<Uuid>,
+        pool_params: &params::IpPoolCreate,
     ) -> CreateResult<db::model::IpPool> {
-        self.db_datastore
-            .ip_pool_create(
-                opctx, new_pool, /* internal= */ false, silo_id,
-            )
-            .await
-    }
-
-    pub async fn ip_pool_services_create(
-        &self,
-        opctx: &OpContext,
-        new_pool: &params::IpPoolCreate,
-    ) -> CreateResult<db::model::IpPool> {
-        self.db_datastore
-            .ip_pool_create(
-                opctx, new_pool, /* internal= */ true,
-                /* silo_id= */ None,
-            )
-            .await
+        let silo_id = match pool_params.clone().silo {
+            Some(silo) => {
+                let (.., authz_silo) = self
+                    .silo_lookup(&opctx, silo)?
+                    .lookup_for(authz::Action::Read)
+                    .await?;
+                Some(authz_silo.id())
+            }
+            _ => None,
+        };
+        let pool = db::model::IpPool::new(&pool_params.identity, silo_id);
+        self.db_datastore.ip_pool_create(opctx, pool).await
     }
 
     pub async fn ip_pools_list(
@@ -117,7 +109,7 @@ impl super::Nexus {
     ) -> ListResultVec<db::model::IpPoolRange> {
         let (.., authz_pool, db_pool) =
             pool_lookup.fetch_for(authz::Action::ListChildren).await?;
-        if db_pool.internal {
+        if is_internal(&db_pool) {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 &db_pool.identity.name,
@@ -137,7 +129,7 @@ impl super::Nexus {
     ) -> UpdateResult<db::model::IpPoolRange> {
         let (.., authz_pool, db_pool) =
             pool_lookup.fetch_for(authz::Action::Modify).await?;
-        if db_pool.internal {
+        if is_internal(&db_pool) {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 &db_pool.identity.name,
@@ -154,7 +146,7 @@ impl super::Nexus {
     ) -> DeleteResult {
         let (.., authz_pool, db_pool) =
             pool_lookup.fetch_for(authz::Action::Modify).await?;
-        if db_pool.internal {
+        if is_internal(&db_pool) {
             return Err(Error::not_found_by_name(
                 ResourceType::IpPool,
                 &db_pool.identity.name,

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -825,10 +825,10 @@ async fn sic_allocate_instance_snat_ip(
     );
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
+    let project_id = saga_params.project_id;
 
     let pool = datastore
-        // TODO: pass project ID
-        .ip_pools_fetch_default_for(&opctx, None)
+        .ip_pools_fetch_default_for(&opctx, Some(project_id))
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;
@@ -877,6 +877,7 @@ async fn sic_allocate_instance_external_ip(
         &sagactx,
         &saga_params.serialized_authn,
     );
+    let project_id = saga_params.project_id;
     let instance_id = repeat_saga_params.instance_id;
     let ip_id = repeat_saga_params.new_id;
 
@@ -887,7 +888,13 @@ async fn sic_allocate_instance_external_ip(
         }
     };
     datastore
-        .allocate_instance_ephemeral_ip(&opctx, ip_id, instance_id, pool_name)
+        .allocate_instance_ephemeral_ip(
+            &opctx,
+            ip_id,
+            instance_id,
+            project_id,
+            pool_name,
+        )
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -827,7 +827,7 @@ async fn sic_allocate_instance_snat_ip(
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
 
     let pool = datastore
-        .ip_pools_fetch_default_for(&opctx)
+        .ip_pools_fetch_default(&opctx)
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -827,8 +827,8 @@ async fn sic_allocate_instance_snat_ip(
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
 
     let pool = datastore
-        // TODO: pass silo ID and project ID
-        .ip_pools_fetch_default_for(&opctx, None, None)
+        // TODO: pass project ID
+        .ip_pools_fetch_default_for(&opctx, None)
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -826,8 +826,14 @@ async fn sic_allocate_instance_snat_ip(
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
 
-    let (.., pool) = datastore
-        .ip_pools_fetch_default_for(&opctx, authz::Action::CreateChild)
+    let pool = datastore
+        .ip_pools_fetch_default_for(
+            &opctx,
+            authz::Action::CreateChild,
+            // TODO: get these values right
+            None,
+            None,
+        )
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -825,10 +825,9 @@ async fn sic_allocate_instance_snat_ip(
     );
     let instance_id = sagactx.lookup::<Uuid>("instance_id")?;
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
-    let project_id = saga_params.project_id;
 
     let pool = datastore
-        .ip_pools_fetch_default_for(&opctx, Some(project_id))
+        .ip_pools_fetch_default_for(&opctx)
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;
@@ -877,7 +876,6 @@ async fn sic_allocate_instance_external_ip(
         &sagactx,
         &saga_params.serialized_authn,
     );
-    let project_id = saga_params.project_id;
     let instance_id = repeat_saga_params.instance_id;
     let ip_id = repeat_saga_params.new_id;
 
@@ -888,13 +886,7 @@ async fn sic_allocate_instance_external_ip(
         }
     };
     datastore
-        .allocate_instance_ephemeral_ip(
-            &opctx,
-            ip_id,
-            instance_id,
-            project_id,
-            pool_name,
-        )
+        .allocate_instance_ephemeral_ip(&opctx, ip_id, instance_id, pool_name)
         .await
         .map_err(ActionError::action_failed)?;
     Ok(())

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -827,13 +827,8 @@ async fn sic_allocate_instance_snat_ip(
     let ip_id = sagactx.lookup::<Uuid>("snat_ip_id")?;
 
     let pool = datastore
-        .ip_pools_fetch_default_for(
-            &opctx,
-            authz::Action::CreateChild,
-            // TODO: get these values right
-            None,
-            None,
-        )
+        // TODO: pass silo ID and project ID
+        .ip_pools_fetch_default_for(&opctx, None, None)
         .await
         .map_err(ActionError::action_failed)?;
     let pool_id = pool.identity.id;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -141,6 +141,7 @@ pub async fn create_ip_pool(
                 description: String::from("an ip pool"),
             },
             silo: None,
+            default: false,
         },
     )
     .await;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -140,6 +140,7 @@ pub async fn create_ip_pool(
                 name: pool_name.parse().unwrap(),
                 description: String::from("an ip pool"),
             },
+            silo: None,
         },
     )
     .await;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -141,7 +141,7 @@ pub async fn create_ip_pool(
                 description: String::from("an ip pool"),
             },
             silo: None,
-            default: false,
+            is_default: false,
         },
     )
     .await;

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -455,6 +455,8 @@ lazy_static! {
                 description: String::from("an IP pool"),
             },
             silo: None,
+            // TODO: this might error due to the unique index
+            default: true,
         };
     pub static ref DEMO_IP_POOL_PROJ_URL: String =
         format!("/v1/ip-pools/{}?project={}", *DEMO_IP_POOL_NAME, *DEMO_PROJECT_NAME);

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -455,7 +455,6 @@ lazy_static! {
                 description: String::from("an IP pool"),
             },
             silo: None,
-            // TODO: this might error due to the unique index
             is_default: true,
         };
     pub static ref DEMO_IP_POOL_PROJ_URL: String =

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -454,6 +454,7 @@ lazy_static! {
                 name: DEMO_IP_POOL_NAME.clone(),
                 description: String::from("an IP pool"),
             },
+            silo: None,
         };
     pub static ref DEMO_IP_POOL_PROJ_URL: String =
         format!("/v1/ip-pools/{}?project={}", *DEMO_IP_POOL_NAME, *DEMO_PROJECT_NAME);

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -456,7 +456,7 @@ lazy_static! {
             },
             silo: None,
             // TODO: this might error due to the unique index
-            default: true,
+            is_default: true,
         };
     pub static ref DEMO_IP_POOL_PROJ_URL: String =
         format!("/v1/ip-pools/{}?project={}", *DEMO_IP_POOL_NAME, *DEMO_PROJECT_NAME);

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3434,6 +3434,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     );
 }
 
+// TODO: this test fails
 #[nexus_test]
 async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
@@ -3502,6 +3503,8 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         .authn_as(AuthnMode::SiloUser(user_id))
         .execute()
         .await
+        // fails here with 403 that comes from the default IP pool query,
+        // which checks ListChildren on IP_POOL_LIST
         .expect("Failed to create instance")
         .parsed_body::<Instance>()
         .expect("Failed to parse instance");

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3434,7 +3434,6 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     );
 }
 
-// TODO: this test fails
 #[nexus_test]
 async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
@@ -3503,8 +3502,6 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         .authn_as(AuthnMode::SiloUser(user_id))
         .execute()
         .await
-        // fails here with 403 that comes from the default IP pool query,
-        // which checks ListChildren on IP_POOL_LIST
         .expect("Failed to create instance")
         .parsed_body::<Instance>()
         .expect("Failed to parse instance");

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -104,7 +104,7 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             description: String::from(description),
         },
         silo: None,
-        default: false,
+        is_default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -284,7 +284,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
             description: String::from(""),
         },
         silo: Some(NameOrId::Name(cptestctx.silo_name.clone())),
-        default: false,
+        is_default: false,
     };
     let created_pool = create_pool(client, &params).await;
     assert_eq!(created_pool.identity.name, "p0");
@@ -299,7 +299,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
             description: String::from(""),
         },
         silo: Some(NameOrId::Id(silo_id)),
-        default: false,
+        is_default: false,
     };
     let created_pool = create_pool(client, &params).await;
     assert_eq!(created_pool.identity.name, "p1");
@@ -314,7 +314,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
         silo: Some(NameOrId::Name(
             String::from("not-a-thing").parse().unwrap(),
         )),
-        default: false,
+        is_default: false,
     };
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, "/v1/system/ip-pools")
@@ -373,7 +373,7 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
             description: String::from(description),
         },
         silo: None,
-        default: false,
+        is_default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -556,7 +556,7 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
             description: String::from(description),
         },
         silo: None,
-        default: false,
+        is_default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -694,7 +694,7 @@ async fn test_ip_pool_list_usable_by_project(
             description: String::from("right on cue"),
         },
         silo: None,
-        default: false,
+        is_default: false,
     };
     NexusRequest::objects_post(client, ip_pools_url, &params)
         .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -102,6 +102,7 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        silo: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -298,6 +299,7 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        silo: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -479,6 +481,7 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
             name: String::from(pool_name).parse().unwrap(),
             description: String::from(description),
         },
+        silo: None,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -615,6 +618,7 @@ async fn test_ip_pool_list_usable_by_project(
             name: String::from(mypool_name).parse().unwrap(),
             description: String::from("right on cue"),
         },
+        silo: None,
     };
     NexusRequest::objects_post(client, ip_pools_url, &params)
         .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -113,6 +113,7 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             .unwrap();
     assert_eq!(created_pool.identity.name, pool_name);
     assert_eq!(created_pool.identity.description, description);
+    assert_eq!(created_pool.silo_id, None);
 
     let list = NexusRequest::iter_collection_authn::<IpPool>(
         client,

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -104,6 +104,7 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
             description: String::from(description),
         },
         silo: None,
+        default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -283,6 +284,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
             description: String::from(""),
         },
         silo: Some(NameOrId::Name(cptestctx.silo_name.clone())),
+        default: false,
     };
     let created_pool = create_pool(client, &params).await;
     assert_eq!(created_pool.identity.name, "p0");
@@ -297,6 +299,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
             description: String::from(""),
         },
         silo: Some(NameOrId::Id(silo_id)),
+        default: false,
     };
     let created_pool = create_pool(client, &params).await;
     assert_eq!(created_pool.identity.name, "p1");
@@ -311,6 +314,7 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
         silo: Some(NameOrId::Name(
             String::from("not-a-thing").parse().unwrap(),
         )),
+        default: false,
     };
     let error: HttpErrorResponseBody = NexusRequest::new(
         RequestBuilder::new(client, Method::POST, "/v1/system/ip-pools")
@@ -369,6 +373,7 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
             description: String::from(description),
         },
         silo: None,
+        default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -551,6 +556,7 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
             description: String::from(description),
         },
         silo: None,
+        default: false,
     };
     let created_pool: IpPool =
         NexusRequest::objects_post(client, ip_pools_url, &params)
@@ -688,6 +694,7 @@ async fn test_ip_pool_list_usable_by_project(
             description: String::from("right on cue"),
         },
         silo: None,
+        default: false,
     };
     NexusRequest::objects_post(client, ip_pools_url, &params)
         .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -12,6 +12,7 @@ use omicron_common::nexus_config::Config;
 use omicron_common::nexus_config::SchemaConfig;
 use omicron_test_utils::dev::db::CockroachInstance;
 use pretty_assertions::assert_eq;
+use similar_asserts;
 use slog::Logger;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
@@ -470,16 +471,24 @@ struct InformationSchema {
 
 impl InformationSchema {
     fn pretty_assert_eq(&self, other: &Self) {
-        // TODO: We could manually iterate here too - the Debug outputs for
-        // each of these is pretty large, and can be kinda painful to read
-        // when comparing e.g. "All columns that exist in the database".
-        assert_eq!(self.columns, other.columns);
-        assert_eq!(self.check_constraints, other.check_constraints);
-        assert_eq!(self.key_column_usage, other.key_column_usage);
-        assert_eq!(self.referential_constraints, other.referential_constraints);
-        assert_eq!(self.views, other.views);
-        assert_eq!(self.statistics, other.statistics);
-        assert_eq!(self.tables, other.tables);
+        // similar_asserts gets us nice diff that only includes the relevant context.
+        // the columns diff especially needs this: it can be 20k lines otherwise
+        similar_asserts::assert_eq!(self.columns, other.columns);
+        similar_asserts::assert_eq!(
+            self.check_constraints,
+            other.check_constraints
+        );
+        similar_asserts::assert_eq!(
+            self.key_column_usage,
+            other.key_column_usage
+        );
+        similar_asserts::assert_eq!(
+            self.referential_constraints,
+            other.referential_constraints
+        );
+        similar_asserts::assert_eq!(self.views, other.views);
+        similar_asserts::assert_eq!(self.statistics, other.statistics);
+        similar_asserts::assert_eq!(self.tables, other.tables);
     }
 
     async fn new(crdb: &CockroachInstance) -> Self {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -736,6 +736,11 @@ pub struct IpPoolCreate {
     /// silo can draw from that pool.
     pub silo: Option<NameOrId>,
 
+    /// Whether the IP pool is considered a default pool for its scope (fleet,
+    /// silo, or project). If a pool is marked default and is associated with a
+    /// silo and there is no default pool for the project, instances created in
+    /// that silo will draw IPs from that pool unless another pool is specified
+    /// at instance create time.
     #[serde(default)]
     pub is_default: bool,
 }

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -736,7 +736,8 @@ pub struct IpPoolCreate {
     /// silo can draw from that pool.
     pub silo: Option<NameOrId>,
 
-    pub default: bool,
+    #[serde(default)]
+    pub is_default: bool,
 }
 
 /// Parameters for updating an IP Pool

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -735,6 +735,8 @@ pub struct IpPoolCreate {
     /// If an IP pool is associated with a silo, instance IP allocations in that
     /// silo can draw from that pool.
     pub silo: Option<NameOrId>,
+
+    pub default: bool,
 }
 
 /// Parameters for updating an IP Pool

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -731,6 +731,10 @@ impl std::fmt::Debug for CertificateCreate {
 pub struct IpPoolCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
+
+    /// If an IP pool is associated with a silo, instance IP allocations in that
+    /// silo can draw from that pool.
+    pub silo: Option<NameOrId>,
 }
 
 /// Parameters for updating an IP Pool

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -737,10 +737,9 @@ pub struct IpPoolCreate {
     pub silo: Option<NameOrId>,
 
     /// Whether the IP pool is considered a default pool for its scope (fleet,
-    /// silo, or project). If a pool is marked default and is associated with a
-    /// silo and there is no default pool for the project, instances created in
-    /// that silo will draw IPs from that pool unless another pool is specified
-    /// at instance create time.
+    /// or silo). If a pool is marked default and is associated with a silo,
+    /// instances created in that silo will draw IPs from that pool unless
+    /// another pool is specified at instance create time.
     #[serde(default)]
     pub is_default: bool,
 }

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -244,6 +244,7 @@ pub struct VpcRouter {
 pub struct IpPool {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
+    pub silo_id: Option<Uuid>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10173,7 +10173,7 @@
             "type": "string"
           },
           "is_default": {
-            "description": "Whether the IP pool is considered a default pool for its scope (fleet, silo, or project). If a pool is marked default and is associated with a silo and there is no default pool for the project, instances created in that silo will draw IPs from that pool unless another pool is specified at instance create time.",
+            "description": "Whether the IP pool is considered a default pool for its scope (fleet, or silo). If a pool is marked default and is associated with a silo, instances created in that silo will draw IPs from that pool unless another pool is specified at instance create time.",
             "default": false,
             "type": "boolean"
           },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10169,6 +10169,9 @@
         "description": "Create-time parameters for an `IpPool`",
         "type": "object",
         "properties": {
+          "default": {
+            "type": "boolean"
+          },
           "description": {
             "type": "string"
           },
@@ -10186,6 +10189,7 @@
           }
         },
         "required": [
+          "default",
           "description",
           "name"
         ]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10141,6 +10141,11 @@
               }
             ]
           },
+          "silo_id": {
+            "nullable": true,
+            "type": "string",
+            "format": "uuid"
+          },
           "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10174,6 +10174,15 @@
           },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "silo": {
+            "nullable": true,
+            "description": "If an IP pool is associated with a silo, instance IP allocations in that silo can draw from that pool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameOrId"
+              }
+            ]
           }
         },
         "required": [

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10169,11 +10169,12 @@
         "description": "Create-time parameters for an `IpPool`",
         "type": "object",
         "properties": {
-          "default": {
-            "type": "boolean"
-          },
           "description": {
             "type": "string"
+          },
+          "is_default": {
+            "default": false,
+            "type": "boolean"
           },
           "name": {
             "$ref": "#/components/schemas/Name"
@@ -10189,7 +10190,6 @@
           }
         },
         "required": [
-          "default",
           "description",
           "name"
         ]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10173,6 +10173,7 @@
             "type": "string"
           },
           "is_default": {
+            "description": "Whether the IP pool is considered a default pool for its scope (fleet, silo, or project). If a pool is marked default and is associated with a silo and there is no default pool for the project, instances created in that silo will draw IPs from that pool unless another pool is specified at instance create time.",
             "default": false,
             "type": "boolean"
           },

--- a/schema/crdb/3.0.0/up.sql
+++ b/schema/crdb/3.0.0/up.sql
@@ -12,7 +12,7 @@ SELECT CAST(
 );
 
 ALTER TABLE omicron.public.ip_pool
-    ADD COLUMN IF NOT EXISTS "default" BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT FALSE,
 
     ADD COLUMN IF NOT EXISTS silo_ID UUID,
     ADD COLUMN IF NOT EXISTS project_id UUID,
@@ -42,6 +42,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.i
     COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
     COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
 ) WHERE
-    "default" = true AND time_deleted IS NULL;
+    is_default = true AND time_deleted IS NULL;
 
 COMMIT;

--- a/schema/crdb/3.0.0/up.sql
+++ b/schema/crdb/3.0.0/up.sql
@@ -1,11 +1,3 @@
--- CRDB documentation recommends the following:
---  "Execute schema changes either as single statements (as an implicit transaction),
---   or in an explicit transaction consisting of the single schema change statement."
---
--- For each schema change, we transactionally:
--- 1. Check the current version
--- 2. Apply the idempotent update
-
 BEGIN;
 
 SELECT CAST(
@@ -20,17 +12,35 @@ SELECT CAST(
 );
 
 ALTER TABLE omicron.public.ip_pool
+    ADD COLUMN IF NOT EXISTS "default" BOOLEAN NOT NULL DEFAULT FALSE,
+
     ADD COLUMN IF NOT EXISTS silo_ID UUID,
     ADD COLUMN IF NOT EXISTS project_id UUID,
-    
+   
     -- if silo_id is null, then project_id must be null
     ADD CONSTRAINT IF NOT EXISTS project_implies_silo CHECK (
       NOT ((silo_id IS NULL) AND (project_id IS NOT NULL))
-    ),
-
-    -- if internal = true, non-null silo_id and project_id are not allowed 
-    ADD CONSTRAINT IF NOT EXISTS internal_pools_have_null_silo_and_project CHECK (
-       NOT (INTERNAL AND ((silo_id IS NOT NULL) OR (project_id IS NOT NULL)))
     );
+COMMIT;
+
+-- needs to be in its own transaction because of this thrilling bug
+-- https://github.com/cockroachdb/cockroach/issues/83593
+BEGIN;
+
+SELECT CAST(
+    IF(
+        (
+            SELECT version = '2.0.0' and target_version = '3.0.0'
+            FROM omicron.public.db_metadata WHERE singleton = true
+        ),
+        'true',
+        'Invalid starting version for schema change'
+    ) AS BOOL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
+    silo_id, project_id
+) WHERE
+    "default" AND time_deleted IS NULL;
 
 COMMIT;

--- a/schema/crdb/3.0.0/up.sql
+++ b/schema/crdb/3.0.0/up.sql
@@ -39,8 +39,9 @@ SELECT CAST(
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
-    silo_id, project_id
+    COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
+    COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
 ) WHERE
-    "default" AND time_deleted IS NULL;
+    "default" = true AND time_deleted IS NULL;
 
 COMMIT;

--- a/schema/crdb/3.0.0/up.sql
+++ b/schema/crdb/3.0.0/up.sql
@@ -1,3 +1,11 @@
+-- CRDB documentation recommends the following:
+--  "Execute schema changes either as single statements (as an implicit transaction),
+--   or in an explicit transaction consisting of the single schema change statement."
+--
+-- For each schema change, we transactionally:
+-- 1. Check the current version
+-- 2. Apply the idempotent update
+
 BEGIN;
 
 SELECT CAST(
@@ -12,36 +20,17 @@ SELECT CAST(
 );
 
 ALTER TABLE omicron.public.ip_pool
-    ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT FALSE,
-
     ADD COLUMN IF NOT EXISTS silo_ID UUID,
     ADD COLUMN IF NOT EXISTS project_id UUID,
-   
+    
     -- if silo_id is null, then project_id must be null
     ADD CONSTRAINT IF NOT EXISTS project_implies_silo CHECK (
       NOT ((silo_id IS NULL) AND (project_id IS NOT NULL))
+    ),
+
+    -- if internal = true, non-null silo_id and project_id are not allowed 
+    ADD CONSTRAINT IF NOT EXISTS internal_pools_have_null_silo_and_project CHECK (
+       NOT (INTERNAL AND ((silo_id IS NOT NULL) OR (project_id IS NOT NULL)))
     );
-COMMIT;
-
--- needs to be in its own transaction because of this thrilling bug
--- https://github.com/cockroachdb/cockroach/issues/83593
-BEGIN;
-
-SELECT CAST(
-    IF(
-        (
-            SELECT version = '2.0.0' and target_version = '3.0.0'
-            FROM omicron.public.db_metadata WHERE singleton = true
-        ),
-        'true',
-        'Invalid starting version for schema change'
-    ) AS BOOL
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
-    COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
-    COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
-) WHERE
-    is_default = true AND time_deleted IS NULL;
 
 COMMIT;

--- a/schema/crdb/3.0.1/up.sql
+++ b/schema/crdb/3.0.1/up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+SELECT CAST(
+    IF(
+        (
+            SELECT version = '3.0.0' and target_version = '3.0.1'
+            FROM omicron.public.db_metadata WHERE singleton = true
+        ),
+        'true',
+        'Invalid starting version for schema change'
+    ) AS BOOL
+);
+
+-- to get ready to drop the internal column, take any IP pools with internal =
+-- true and set silo_id = INTERNAL_SILO_ID
+
+UPDATE omicron.public.ip_pool
+    SET silo_id = '001de000-5110-4000-8000-000000000001'
+    WHERE internal = true and time_deleted is null;
+
+UPDATE omicron.public.ip_pool
+    SET "default" = true
+    WHERE name = 'default' and time_deleted is null;
+
+COMMIT;

--- a/schema/crdb/3.0.1/up.sql
+++ b/schema/crdb/3.0.1/up.sql
@@ -19,7 +19,7 @@ UPDATE omicron.public.ip_pool
     WHERE internal = true and time_deleted is null;
 
 UPDATE omicron.public.ip_pool
-    SET "default" = true
+    SET is_default = true
     WHERE name = 'default' and time_deleted is null;
 
 COMMIT;

--- a/schema/crdb/3.0.1/up.sql
+++ b/schema/crdb/3.0.1/up.sql
@@ -12,7 +12,9 @@ SELECT CAST(
 );
 
 ALTER TABLE omicron.public.ip_pool
+    DROP COLUMN IF EXISTS project_id,
     ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    DROP CONSTRAINT IF EXISTS project_implies_silo,
     DROP CONSTRAINT IF EXISTS internal_pools_have_null_silo_and_project;
 
 COMMIT;
@@ -33,8 +35,7 @@ SELECT CAST(
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
-    COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
-    COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
+    COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid) 
 ) WHERE
     is_default = true AND time_deleted IS NULL;
 

--- a/schema/crdb/3.0.2/up.sql
+++ b/schema/crdb/3.0.2/up.sql
@@ -11,7 +11,15 @@ SELECT CAST(
     ) AS BOOL
 );
 
-ALTER TABLE omicron.public.ip_pool
-    DROP COLUMN IF EXISTS internal;
+-- to get ready to drop the internal column, take any IP pools with internal =
+-- true and set silo_id = INTERNAL_SILO_ID
+
+UPDATE omicron.public.ip_pool
+    SET silo_id = '001de000-5110-4000-8000-000000000001'
+    WHERE internal = true and time_deleted is null;
+
+UPDATE omicron.public.ip_pool
+    SET is_default = true
+    WHERE name = 'default' and time_deleted is null;
 
 COMMIT;

--- a/schema/crdb/3.0.2/up.sql
+++ b/schema/crdb/3.0.2/up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+SELECT CAST(
+    IF(
+        (
+            SELECT version = '3.0.1' and target_version = '3.0.2'
+            FROM omicron.public.db_metadata WHERE singleton = true
+        ),
+        'true',
+        'Invalid starting version for schema change'
+    ) AS BOOL
+);
+
+ALTER TABLE omicron.public.ip_pool
+    DROP COLUMN IF EXISTS internal;
+
+COMMIT;

--- a/schema/crdb/3.0.3/up.sql
+++ b/schema/crdb/3.0.3/up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+SELECT CAST(
+    IF(
+        (
+            SELECT version = '3.0.2' and target_version = '3.0.3'
+            FROM omicron.public.db_metadata WHERE singleton = true
+        ),
+        'true',
+        'Invalid starting version for schema change'
+    ) AS BOOL
+);
+
+ALTER TABLE omicron.public.ip_pool
+    DROP COLUMN IF EXISTS internal;
+
+COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1483,7 +1483,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL,
 
-    "default" BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
 
     /*
      * Fields representating association with a silo or project. silo_id must
@@ -1508,7 +1508,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.i
     COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
     COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
 ) WHERE
-    "default" = true AND time_deleted IS NULL;
+    is_default = true AND time_deleted IS NULL;
 
 /*
  * Index ensuring uniqueness of IP Pool names, globally.

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1483,8 +1483,6 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL,
 
-    is_default BOOLEAN NOT NULL DEFAULT FALSE,
-
     /*
      * Fields representating association with a silo or project. silo_id must
      * be non-null if project_id is non-null. silo_id is also used to mark an IP
@@ -1492,6 +1490,9 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
      */
     silo_id UUID,
     project_id UUID,
+
+    /* Is this the default pool for its scope (fleet, silo, or project) */
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
 
     -- if silo_id is null, then project_id must be null
     CONSTRAINT project_implies_silo CHECK (
@@ -2566,7 +2567,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '3.0.2', NULL)
+    ( TRUE, NOW(), NOW(), '3.0.3', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1480,17 +1480,15 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
     time_modified TIMESTAMPTZ NOT NULL,
     time_deleted TIMESTAMPTZ,
 
-    /* Identifies if the IP Pool is dedicated to Control Plane services */
-    internal BOOL NOT NULL,
-
     /* The collection's child-resource generation number */
     rcgen INT8 NOT NULL,
 
+    "default" BOOLEAN NOT NULL DEFAULT FALSE,
+
     /*
-     * Fields representating association with a silo or project. silo_id must be
-     * non-null if project_id is non-null. When project_id is non-null, silo_id
-     * will (naturally) be the ID of the project's silo. Both must be null if
-     * internal is true, i.e., internal IP pools must be fleet-level pools.
+     * Fields representating association with a silo or project. silo_id must
+     * be non-null if project_id is non-null. silo_id is also used to mark an IP
+     * pool as "internal" by associating it with the oxide-internal silo.
      */
     silo_id UUID,
     project_id UUID,
@@ -1498,13 +1496,16 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
     -- if silo_id is null, then project_id must be null
     CONSTRAINT project_implies_silo CHECK (
       NOT ((silo_id IS NULL) AND (project_id IS NOT NULL))
-    ),
-
-    -- if internal = true, non-null silo_id and project_id are not allowed 
-    CONSTRAINT internal_pools_have_null_silo_and_project CHECK (
-       NOT (INTERNAL AND ((silo_id IS NOT NULL) OR (project_id IS NOT NULL)))
     )
 );
+
+/*
+ * Ensure there can only be one default pool for the fleet or a given silo or project
+ */
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
+    silo_id, project_id
+) WHERE
+    "default" = true AND time_deleted IS NULL;
 
 /*
  * Index ensuring uniqueness of IP Pool names, globally.
@@ -2562,7 +2563,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '3.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '3.0.2', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1500,10 +1500,13 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool (
 );
 
 /*
- * Ensure there can only be one default pool for the fleet or a given silo or project
+ * Ensure there can only be one default pool for the fleet or a given silo or
+ * project. Coalesce is needed because otherwise different nulls are considered
+ * to be distinct from each other.
  */
 CREATE UNIQUE INDEX IF NOT EXISTS one_default_pool_per_scope ON omicron.public.ip_pool (
-    silo_id, project_id
+    COALESCE(silo_id, '00000000-0000-0000-0000-000000000000'::uuid), 
+    COALESCE(project_id, '00000000-0000-0000-0000-000000000000'::uuid) 
 ) WHERE
     "default" = true AND time_deleted IS NULL;
 


### PR DESCRIPTION
Closes #3926 

A lot going on here. I will update this description as I finish things out. 

## Important background

* #3981 added `silo_id` and `project_id` columns to the IP pools table in the hope that that would be sufficient for the rest of the work schema-wise, but it turns out there was more needed.
* Before this change, the concept of a **default** IP pool was implemented through the `name` on the IP pool, i.e., the IP pool named `default` is the one used by default for instance IP allocation if no pool name is specified as part of the instance create POST
* Before this change the concept of an **internal** IP pool was implemented through a boolean `internal` column on the `ip_pool` table

## IP pool selection logic

There are two situations where we pick an IP pool to allocate IPs from. For an instance's **source NAT**, we always use the default pool. Before this change, with only fleet pools, this simply meant picking the one named `default` (analogous now to the one with `is_default == true`). With the possibility of silo pools, we now pick the most specific default available. That means that if there is a silo-scoped pool marked default _matching the current silo_, we use that. If not, we pick the fleet-level pool marked default, which should always exist (see possible todos at the bottom — we might want to take steps to guarantee this).

For instance ephemeral IPs, the instance create POST body takes an optional pool name. If none is specified, we follow the same defaulting logic as above — the most-specific pool marked `is_default`. We are leaving pool names globally unique (as opposed to per-scope) which IMO makes the following lookup logic easy to understand and implement: given a pool name, look up the pool by name. (That part we were already going.) The difference now with scopes is that we need to make sure that the scope of the selected pool (assuming it exists) **does not conflict** with the current scope, i.e., the current silo. In this situation, we do not care about what's marked default, and we are not trying to get an exact match on scope. We just need to disallow an instance from using an IP pool reserved for a different silo. We can revisit this, but as implemented here you can, for example, specify a non-default pool scoped to fleet or silo (if one exists) even if there exists a default pool scoped to your silo.

## DB migrations on `ip_pool` table

There are three migrations here based on guidance from @smklein based on [CRDB docs about limitations to online schema changes](https://www.cockroachlabs.com/docs/stable/online-schema-changes#limitations) and some conversations he had with them. It's possible they could be made into two. I don't think it can be done in one.

* Add `is_default` column and a unique index ensuring there is only one default IP pool per "scope" (unique `silo_id`, including null as a distinct value)
* Populate correct data in new columns
  * Populate `is_default = true` for any IP pools named `default` (there should be exactly one, but nothing depends on that)
  * `silo_id = INTERNAL_SILO_ID` for any IP pools marked `internal` (there should be exactly one, but nothing depends on that)
* Drop the `internal` column


## Code changes

- [x] Add [`similar-asserts`](https://crates.io/crates/similar-asserts) so we can get a usable diff when the schema migration tests fail. Without this you could get a 20k+ line diff with 4 relevant lines.
- [x] Use `silo_id == INTERNAL_SILO_ID` everywhere we were previously looking at the `internal` flag (thanks @luqmana for the [suggestion](https://github.com/oxidecomputer/omicron/pull/3981#discussion_r1309136684))
- [x] Add `silo_id` and `default` to `IpPoolCreate` (create POST params) and plumb them down the create chain
  * Leave off `project_id` for now, we can add that later
- [x] Fix index that is failing to prevent multiple `default` pools for a given scope (see comment https://github.com/oxidecomputer/omicron/pull/3985#discussion_r1309624130)
- [x] Source NAT IP allocation uses new defaulting logic to get the most specific available default IP Pool
- [x] Instance ephemeral IP allocation uses that default logic if no pool name specified in the create POST, otherwise look up pool by specified name (but can only get pools matching its scope, i.e., its project, silo, or the whole fleet)

### Limitations that we might want to turn into to-dos

* You can't update `default` on a pool, i.e., you can't make a pool default. You have to delete it and make a new one. This one isn't that hard — I would think of it like image promotion, where it's not a regular update pool, it's a special endpoint for making a pool default that can unset the current default if it's a different pool.
* Project-scoped IP pools endpoints are fake — they just return all IP pools. They were made in anticipation of being able to make them real. I'm thinking we should remove them or make them work, but I don't think we have time to make them work.
* Ensure somehow that there is always a fleet-level default pool to fall back to