### PR TITLE
Small IP pools fixes

### DIFF
--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -66,7 +66,11 @@ impl IpPool {
 
 impl From<IpPool> for views::IpPool {
     fn from(pool: IpPool) -> Self {
-        Self { identity: pool.identity(), silo_id: pool.silo_id }
+        Self {
+            identity: pool.identity(),
+            silo_id: pool.silo_id,
+            is_default: pool.is_default,
+        }
     }
 }
 

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -288,9 +288,9 @@ async fn test_ip_pool_with_silo(cptestctx: &ControlPlaneTestContext) {
     };
     let created_pool = create_pool(client, &params).await;
     assert_eq!(created_pool.identity.name, "p0");
-    assert!(created_pool.silo_id.is_some());
 
-    let silo_id = created_pool.silo_id.unwrap();
+    let silo_id =
+        created_pool.silo_id.expect("Expected pool to have a silo_id");
 
     // now we'll create another IP pool using that silo ID
     let params = IpPoolCreate {

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -61,6 +61,8 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(ip_pools.len(), 1, "Expected to see default IP pool");
 
     assert_eq!(ip_pools[0].identity.name, "default",);
+    assert_eq!(ip_pools[0].silo_id, None);
+    assert!(ip_pools[0].is_default);
 
     // Verify 404 if the pool doesn't exist yet, both for creating or deleting
     let error: HttpErrorResponseBody = NexusRequest::expect_failure(

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -736,7 +736,7 @@ pub struct IpPoolCreate {
     /// silo can draw from that pool.
     pub silo: Option<NameOrId>,
 
-    /// Whether the IP pool is considered a default pool for its scope (fleet,
+    /// Whether the IP pool is considered a default pool for its scope (fleet
     /// or silo). If a pool is marked default and is associated with a silo,
     /// instances created in that silo will draw IPs from that pool unless
     /// another pool is specified at instance create time.

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -245,6 +245,7 @@ pub struct IpPool {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
     pub silo_id: Option<Uuid>,
+    pub is_default: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10133,6 +10133,9 @@
             "type": "string",
             "format": "uuid"
           },
+          "is_default": {
+            "type": "boolean"
+          },
           "name": {
             "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
@@ -10160,6 +10163,7 @@
         "required": [
           "description",
           "id",
+          "is_default",
           "name",
           "time_created",
           "time_modified"
@@ -10173,7 +10177,7 @@
             "type": "string"
           },
           "is_default": {
-            "description": "Whether the IP pool is considered a default pool for its scope (fleet, or silo). If a pool is marked default and is associated with a silo, instances created in that silo will draw IPs from that pool unless another pool is specified at instance create time.",
+            "description": "Whether the IP pool is considered a default pool for its scope (fleet or silo). If a pool is marked default and is associated with a silo, instances created in that silo will draw IPs from that pool unless another pool is specified at instance create time.",
             "default": false,
             "type": "boolean"
           },


### PR DESCRIPTION
Followup to #3985, closes #4005.

- Add `is_default` to IP pool response
- Inline `ip_pools_fetch` into the one callsite and delete it (per discussion https://github.com/oxidecomputer/omicron/pull/3985#discussion_r1312320845)
- Other small test tweaks suggested by @luqmana 