### PR TITLE
update schemars to 0.8.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,9 +7349,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
 dependencies = [
  "bytes",
  "chrono",
@@ -7364,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -140,9 +140,8 @@ const GZ_ADDRESS_INDEX: usize = 2;
 pub const RSS_RESERVED_ADDRESSES: u16 = 32;
 
 /// Wraps an [`Ipv6Network`] with a compile-time prefix length.
-#[derive(
-    Debug, Clone, Copy, JsonSchema, Serialize, Deserialize, Hash, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, Copy, JsonSchema, Serialize, Hash, PartialEq, Eq)]
+#[schemars(rename = "Ipv6Subnet")]
 pub struct Ipv6Subnet<const N: u8> {
     net: Ipv6Net,
 }
@@ -159,6 +158,30 @@ impl<const N: u8> Ipv6Subnet<N> {
     /// Returns the underlying network.
     pub fn net(&self) -> Ipv6Network {
         self.net.0
+    }
+}
+
+// We need a custom Deserialize to ensure that the subnet is what we expect.
+impl<'de, const N: u8> Deserialize<'de> for Ipv6Subnet<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Inner {
+            net: Ipv6Net,
+        }
+
+        let Inner { net } = Inner::deserialize(deserializer)?;
+        if net.prefix() == N {
+            Ok(Self { net })
+        } else {
+            Err(<D::Error as serde::de::Error>::custom(format!(
+                "expected prefix {} but found {}",
+                N,
+                net.prefix(),
+            )))
+        }
     }
 }
 
@@ -537,6 +560,8 @@ impl Iterator for IpRangeIter {
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -672,5 +697,15 @@ mod test {
                 Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 3),
             ]
         );
+    }
+
+    #[test]
+    fn test_ipv6_subnet_deserialize() {
+        let value = json!({
+            "net": "ff12::3456/64"
+        });
+
+        assert!(serde_json::from_value::<Ipv6Subnet<64>>(value.clone()).is_ok());
+        assert!(serde_json::from_value::<Ipv6Subnet<56>>(value).is_err());
     }
 }


### PR DESCRIPTION
I noticed that `Ipv6Subnet` derives `Deserialize` which means that the subnet constraint is not enforced on deserialization.