### PR TITLE
omicron-rpaths: emit dummy rerun-if-* directive to reduce excessive rebuilds.

### DIFF
--- a/rpaths/src/lib.rs
+++ b/rpaths/src/lib.rs
@@ -100,6 +100,17 @@
 // arguments here that specify exactly which ones are expected to be found.
 pub fn configure_default_omicron_rpaths() {
     internal::configure_default_omicron_rpaths();
+    // If no 'rerun-if-*' directives are emitted, cargo conservatively [1]
+    // assumes the build-script should be rerun if any file within the
+    // package changes. Unfortunately this can result in overzealous,
+    // rebuilds, e.g., a change to an integration test triggering a
+    // rebuild for its containing package.
+    //
+    // To get around this we output this dummy directive to ensure a
+    // build.rs using just the rpath logic isn't rerun constantly.
+    //
+    // [1]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection
+    println!("cargo:rerun-if-changed=build.rs");
 }
 
 // None of this behavior is needed on MacOS.


### PR DESCRIPTION
Clean Build + Build Nexus Tests:
```
$ ptime -m cargo test -p omicron-nexus --no-run
[...snip...]
    Finished test [unoptimized + debuginfo] target(s) in 8m 30s
  Executable unittests src/lib.rs (target/debug/deps/omicron_nexus-70ef40f90de05c35)
  Executable unittests src/bin/nexus.rs (target/debug/deps/nexus-fda452494fa76f0a)
  Executable unittests src/bin/schema-updater.rs (target/debug/deps/schema_updater-1f7072a2a35d3035)
  Executable tests/test_all.rs (target/debug/deps/test_all-2d041df658f0bbf5)
real     8:30.885528811
user  1:16:40.111846486
sys     12:03.156805156
trap        3.421956588
tflt        3.835087313
dflt        7.421815315
kflt        0.019123796
lock  2:07:06.077830066
slp   2:30:40.465433688
lat      2:06.994429886
stop    16:11.787555415
```

Re-run w/ no changes:
```
$ ptime -m cargo test -p omicron-nexus --no-run
    Finished test [unoptimized + debuginfo] target(s) in 0.75s
  Executable unittests src/lib.rs (target/debug/deps/omicron_nexus-70ef40f90de05c35)
  Executable unittests src/bin/nexus.rs (target/debug/deps/nexus-fda452494fa76f0a)
  Executable unittests src/bin/schema-updater.rs (target/debug/deps/schema_updater-1f7072a2a35d3035)
  Executable tests/test_all.rs (target/debug/deps/test_all-2d041df658f0bbf5)

real        0.837082298
user        0.554632931
sys         0.281578872
trap        0.000060162
tflt        0.000747831
dflt        0.000000000
kflt        0.000000000
lock        0.000171075
slp         0.019855409
lat         0.000290876
stop        0.000205266
```

Poke one (*) integration test and rebuild:

(*) really nexus only has a single integration test from cargo's perspective which maybe we should revist now that we use nextest.
```
$ touch nexus/tests/integration_tests/address_lots.rs
$ ptime -m cargo test -p omicron-nexus --no-run
   Compiling omicron-nexus v0.1.0 (/home/luqman/omicron/nexus)
    Finished test [unoptimized + debuginfo] target(s) in 3m 27s
  Executable unittests src/lib.rs (target/debug/deps/omicron_nexus-70ef40f90de05c35)
  Executable unittests src/bin/nexus.rs (target/debug/deps/nexus-fda452494fa76f0a)
  Executable unittests src/bin/schema-updater.rs (target/debug/deps/schema_updater-1f7072a2a35d3035)
  Executable tests/test_all.rs (target/debug/deps/test_all-2d041df658f0bbf5)

real     3:27.742548789
user     5:29.233637776
sys      1:44.703883330
trap        0.036784903
tflt        0.000757975
dflt        0.174864261
kflt        0.012907044
lock    16:52.496307292
slp     32:20.939488964
lat         0.092969108
stop        1.671105635
```

Why's it rebuilding `omicron-nexus`? Because of the conservative build.rs logic around [change detection](https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection):
>When rebuilding a package, Cargo does not necessarily know if the build script needs to be run again. By default, it takes a conservative approach of always re-running the build script if any file within the package is changed (or the list of files controlled by the exclude and include fields). For most cases, this is not a good choice, so it is recommended that every build script emit at least one of the rerun-if instructions (described below). If these are emitted, then Cargo will only re-run the script if the given value has changed.

`omicron-nexus`' build.rs only has the rpath logic which doesn't emit any `rerun-if-*` directives, so we can take the suggestion from the cargo docs and add a dummy `cargo:rerun-if-changed=build.rs`.

With that, rebuilding after poking the same test:
```
$ touch nexus/tests/integration_tests/address_lots.rs
$ ptime -m cargo test -p omicron-nexus --no-run
   Compiling omicron-nexus v0.1.0 (/home/luqman/omicron/nexus)
    Finished test [unoptimized + debuginfo] target(s) in 2m 59s
  Executable unittests src/lib.rs (target/debug/deps/omicron_nexus-70ef40f90de05c35)
  Executable unittests src/bin/nexus.rs (target/debug/deps/nexus-fda452494fa76f0a)
  Executable unittests src/bin/schema-updater.rs (target/debug/deps/schema_updater-1f7072a2a35d3035)
  Executable tests/test_all.rs (target/debug/deps/test_all-2d041df658f0bbf5)

real     2:59.342161222
user     2:30.843928740
sys        27.446642585
trap        0.018731179
tflt        0.000032670
dflt        0.000911926
kflt        0.000000000
lock     8:54.404476833
slp     14:27.120408884
lat         0.010701702
stop        0.204432442
```
It no longer rebuilds `omicon-nexus`!

(All times running on atrium)