### PR TITLE
Ignore test_build_replicated until stable on ubuntu CI job

### DIFF
--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -668,6 +668,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // TODO(https://github.com/oxidecomputer/omicron/issues/4001): This job fails intermittently
+    // on the ubuntu CI job with "Failed to detect ClickHouse subprocess within timeout"
+    #[ignore]
     async fn test_build_replicated() {
         let log = slog::Logger::root(slog::Discard, o!());
 


### PR DESCRIPTION
This test is intermittently failing on the Ubuntu CI job. As this test is currently for a feature that is disabled (multi node ClickHouse), we can safely ignore it until the test is stable.

Related: https://github.com/oxidecomputer/omicron/issues/4037 https://github.com/oxidecomputer/omicron/issues/4001