### PR TITLE
Fix distributed engine SQL and improve testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,7 +5109,7 @@ dependencies = [
  "semver 1.0.18",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.10.0",
  "sha3",
  "sled-agent-client",
  "sled-hardware",
@@ -5476,6 +5476,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test 2.0.0",
  "slog",
  "slog-async",
  "slog-dtrace",
@@ -7561,7 +7562,21 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "serial_test_derive",
+ "serial_test_derive 0.10.0",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive 2.0.0",
 ]
 
 [[package]]
@@ -7573,6 +7588,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -7775,7 +7801,7 @@ dependencies = [
  "rand 0.8.5",
  "schemars",
  "serde",
- "serial_test",
+ "serial_test 0.10.0",
  "slog",
  "thiserror",
  "tofino",
@@ -9086,7 +9112,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5476,6 +5476,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "slog",
  "slog-async",
  "slog-dtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5476,7 +5476,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serial_test",
  "slog",
  "slog-async",
  "slog-dtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,7 +5109,7 @@ dependencies = [
  "semver 1.0.18",
  "serde",
  "serde_json",
- "serial_test 0.10.0",
+ "serial_test",
  "sha3",
  "sled-agent-client",
  "sled-hardware",
@@ -5476,7 +5476,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serial_test 2.0.0",
+ "serial_test",
  "slog",
  "slog-async",
  "slog-dtrace",
@@ -7562,21 +7562,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "serial_test_derive 0.10.0",
-]
-
-[[package]]
-name = "serial_test"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot 0.12.1",
- "serial_test_derive 2.0.0",
+ "serial_test_derive",
 ]
 
 [[package]]
@@ -7588,17 +7574,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
 ]
 
 [[package]]
@@ -7801,7 +7776,7 @@ dependencies = [
  "rand 0.8.5",
  "schemars",
  "serde",
- "serial_test 0.10.0",
+ "serial_test",
  "slog",
  "thiserror",
  "tofino",

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true, features = [ "json" ] }
 schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 serde_json.workspace = true
+serial_test.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { workspace = true, features = [ "json" ] }
 schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 serde_json.workspace = true
-serial_test = "2.0.0"
+serial_test.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true, features = [ "json" ] }
 schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 serde_json.workspace = true
+serial_test = "2.0.0"
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -18,7 +18,6 @@ reqwest = { workspace = true, features = [ "json" ] }
 schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 serde_json.workspace = true
-serial_test.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -636,7 +636,6 @@ mod tests {
     use omicron_test_utils::dev::clickhouse::ClickHouseInstance;
     use oximeter::test_util;
     use oximeter::{Metric, Target};
-    use serial_test::serial;
     use slog::o;
     use std::time::Duration;
     use tokio::time::sleep;
@@ -669,7 +668,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_build_replicated() {
         let log = slog::Logger::root(slog::Discard, o!());
 

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -787,7 +787,7 @@ mod tests {
         assert!(result.contains("hiya"));
 
         // TODO(https://github.com/oxidecomputer/omicron/issues/4001): With distributed
-        // engine, it can take a long time to sync the data. This means it's tricky to 
+        // engine, it can take a long time to sync the data. This means it's tricky to
         // test that the data exists on both nodes.
 
         k1.cleanup().await.expect("Failed to cleanup ClickHouse keeper 1");

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -636,6 +636,7 @@ mod tests {
     use omicron_test_utils::dev::clickhouse::ClickHouseInstance;
     use oximeter::test_util;
     use oximeter::{Metric, Target};
+    use serial_test::serial;
     use slog::o;
     use std::time::Duration;
     use tokio::time::sleep;
@@ -668,6 +669,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_build_replicated() {
         let log = slog::Logger::root(slog::Discard, o!());
 

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -787,8 +787,8 @@ mod tests {
         assert!(result.contains("hiya"));
 
         // TODO(https://github.com/oxidecomputer/omicron/issues/4001): With distributed
-        // engine, it can take a long time to sync the data. So it's tricky to test that
-        // the data exists on both nodes.
+        // engine, it can take a long time to sync the data. This means it's tricky to 
+        // test that the data exists on both nodes.
 
         k1.cleanup().await.expect("Failed to cleanup ClickHouse keeper 1");
         k2.cleanup().await.expect("Failed to cleanup ClickHouse keeper 2");

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -776,12 +776,12 @@ mod tests {
 
         // Insert row into one of the tables
         let sql = String::from(
-            "INSERT INTO oximeter.measurements_string (datum) VALUES ('hiya');"
+            "INSERT INTO oximeter.measurements_string (datum) VALUES ('hiya');",
         );
         client_2.execute_with_body(sql).await.unwrap();
 
         let sql = String::from(
-            "SELECT * FROM oximeter.measurements_string FORMAT JSONEachRow;"
+            "SELECT * FROM oximeter.measurements_string FORMAT JSONEachRow;",
         );
         let result = client_2.execute_with_body(sql.clone()).await.unwrap();
         assert!(result.contains("hiya"));

--- a/oximeter/db/src/db-replicated-init.sql
+++ b/oximeter/db/src/db-replicated-init.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool ON CLUSTER oximeter_cluste
     timestamp DateTime64(9, 'UTC'),
     datum UInt8
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bool_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bool_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64_local ON CLUSTER oximeter_cluster
 (
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_i64 ON CLUSTER oximeter_cluster
     timestamp DateTime64(9, 'UTC'),
     datum Int64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_i64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_i64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64_local ON CLUSTER oximeter_cluster
 (
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f64 ON CLUSTER oximeter_cluster
     timestamp DateTime64(9, 'UTC'),
     datum Float64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string_local ON CLUSTER oximeter_cluster
 (
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_string ON CLUSTER oximeter_clus
     timestamp DateTime64(9, 'UTC'),
     datum String
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_string_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_string_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes_local ON CLUSTER oximeter_cluster
 (
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes ON CLUSTER oximeter_clust
     timestamp DateTime64(9, 'UTC'),
     datum Array(UInt8)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bytes_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bytes_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64_local ON CLUSTER oximeter_cluster
 (
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64 ON CLUSTER oximet
     timestamp DateTime64(9, 'UTC'),
     datum Int64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativei64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativei64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64_local ON CLUSTER oximeter_cluster
 (
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64 ON CLUSTER oximet
     timestamp DateTime64(9, 'UTC'),
     datum Float64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativef64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativef64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64_local ON CLUSTER oximeter_cluster
 (
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64 ON CLUSTER oximete
     bins Array(Int64),
     counts Array(UInt64)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogrami64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogrami64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64_local ON CLUSTER oximeter_cluster
 (
@@ -190,7 +190,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64 ON CLUSTER oximete
     bins Array(Float64),
     counts Array(UInt64)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogramf64_local', timeseries_key);
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogramf64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool ON CLUSTER oximeter_cluster
 (
@@ -200,7 +200,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_bool ON CLUSTER oximeter_cluster
     field_value UInt8
 )
 ENGINE = ReplicatedReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_i64 ON CLUSTER oximeter_cluster
 (
@@ -210,7 +210,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_i64 ON CLUSTER oximeter_cluster
     field_value Int64
 )
 ENGINE = ReplicatedReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr ON CLUSTER oximeter_cluster
 (
@@ -220,7 +220,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr ON CLUSTER oximeter_cluster
     field_value IPv6
 )
 ENGINE = ReplicatedReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_string ON CLUSTER oximeter_cluster
 (
@@ -230,7 +230,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_string ON CLUSTER oximeter_cluster
     field_value String
 )
 ENGINE = ReplicatedReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_uuid ON CLUSTER oximeter_cluster
 (
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_uuid ON CLUSTER oximeter_cluster
     field_value UUID
 )
 ENGINE = ReplicatedReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.timeseries_schema ON CLUSTER oximeter_cluster
 (

--- a/oximeter/db/src/db-replicated-init.sql
+++ b/oximeter/db/src/db-replicated-init.sql
@@ -18,9 +18,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool ON CLUSTER oximeter_cluste
     timestamp DateTime64(9, 'UTC'),
     datum UInt8
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bool_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bool_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_i64_local ON CLUSTER oximeter_cluster
 (
@@ -40,9 +38,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_i64 ON CLUSTER oximeter_cluster
     timestamp DateTime64(9, 'UTC'),
     datum Int64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_i64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_i64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64_local ON CLUSTER oximeter_cluster
 (
@@ -62,9 +58,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f64 ON CLUSTER oximeter_cluster
     timestamp DateTime64(9, 'UTC'),
     datum Float64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_string_local ON CLUSTER oximeter_cluster
 (
@@ -84,9 +78,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_string ON CLUSTER oximeter_clus
     timestamp DateTime64(9, 'UTC'),
     datum String
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_string_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_string_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes_local ON CLUSTER oximeter_cluster
 (
@@ -106,9 +98,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bytes ON CLUSTER oximeter_clust
     timestamp DateTime64(9, 'UTC'),
     datum Array(UInt8)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bytes_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_bytes_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64_local ON CLUSTER oximeter_cluster
 (
@@ -130,9 +120,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativei64 ON CLUSTER oximet
     timestamp DateTime64(9, 'UTC'),
     datum Int64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativei64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativei64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64_local ON CLUSTER oximeter_cluster
 (
@@ -154,9 +142,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64 ON CLUSTER oximet
     timestamp DateTime64(9, 'UTC'),
     datum Float64
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativef64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_cumulativef64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64_local ON CLUSTER oximeter_cluster
 (
@@ -180,9 +166,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogrami64 ON CLUSTER oximete
     bins Array(Int64),
     counts Array(UInt64)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogrami64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogrami64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64_local ON CLUSTER oximeter_cluster
 (
@@ -206,9 +190,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_histogramf64 ON CLUSTER oximete
     bins Array(Float64),
     counts Array(UInt64)
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogramf64_local', timeseries_name)
-ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_histogramf64_local', timeseries_key);
 --
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool ON CLUSTER oximeter_cluster
 (

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -21,7 +21,7 @@ use crate::dev::poll;
 
 // Timeout used when starting up ClickHouse subprocess.
 // build-and-test (ubuntu-20.04) needs a little longer to get going
-const CLICKHOUSE_TIMEOUT: Duration = Duration::from_secs(90);
+const CLICKHOUSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A `ClickHouseInstance` is used to start and manage a ClickHouse single node server process.
 #[derive(Debug)]


### PR DESCRIPTION
Closes: https://github.com/oxidecomputer/omicron/issues/4037
Related: https://github.com/oxidecomputer/omicron/issues/4001

## Issues with this test

First, the `Failed to detect ClickHouse subprocess within timeout` error came from the tests running in parallel.  Replicated mode in Linux seems to have problems when there are other CH servers running on the same host.

There were also some `DB::Exception` errors in the replicated SQL config. These would be caught by helios/deploy in practice, but since the feature is disabled, the test passed. These errors came from the `DistributedEngine` tables SQL. `ORDER_BY` and `TTL` are not supported in `DistributedEngine`. Additionally, the sharding key must be a uint. While I tested the `ReplicatedEngine` tables manually thoroughly, I relied on the test for the `DistributedEngine` tables which were added in the last iteration of the PR.

Why did the test pass on buildomat/helios, atrium and local linux? A race condition. The test asserted that the oximeter database existed before the ClickHouse server had time to report an error with the distributed tables.

## Solutions

The `test_build_replicated` test does not run in parallel anymore. I've added `#[serial]`.

The `DistributedEngine` tables' SQL is now correct.

I've added a few extra checks on the tables themselves to make sure the race condition doesn't show its face again.

## Results

I've ran the test suite three times and have not had a flake. Happy to trigger another build if anyone thinks that's necessary.
https://github.com/oxidecomputer/omicron/pull/4040/checks?check_run_id=16560625902
https://github.com/oxidecomputer/omicron/pull/4040/checks?check_run_id=16561939535
https://github.com/oxidecomputer/omicron/pull/4040/checks?check_run_id=16563532055
