### PR TITLE
[wicketd] Avoid copying artifacts into memory during ingest

### DIFF
--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -61,6 +61,11 @@ impl Artifact {
             kind: self.kind.clone(),
         }
     }
+
+    /// Returns the artifact ID for this artifact without clones.
+    pub fn into_id(self) -> ArtifactId {
+        ArtifactId { name: self.name, version: self.version, kind: self.kind }
+    }
 }
 
 /// An identifier for an artifact.

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -953,7 +953,9 @@ mod tests {
         Event, InstallinatorCompletionMetadata, InstallinatorComponent,
         InstallinatorStepId, StepEventKind, StepOutcome,
     };
-    use omicron_common::api::internal::nexus::KnownArtifactKind;
+    use omicron_common::{
+        api::internal::nexus::KnownArtifactKind, update::ArtifactKind,
+    };
     use omicron_test_utils::dev::test_setup_log;
     use partial_io::{
         proptest_types::{
@@ -1072,7 +1074,7 @@ mod tests {
             data2.into_iter().map(Bytes::from).collect();
 
         let host_id = ArtifactHashId {
-            kind: KnownArtifactKind::Host.into(),
+            kind: ArtifactKind::HOST_PHASE_2,
             hash: {
                 // The `validate_written_host_phase_2_hash()` will fail unless
                 // we give the actual hash of the host phase 2 data, so compute

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -724,6 +724,25 @@
           "message"
         ]
       },
+      "ArtifactHashId": {
+        "description": "A hash-based identifier for an artifact.\n\nSome places, e.g. the installinator, request artifacts by hash rather than by name and version. This type indicates that.",
+        "type": "object",
+        "properties": {
+          "hash": {
+            "description": "The hash of the artifact.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "kind": {
+            "description": "The kind of artifact this is.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hash",
+          "kind"
+        ]
+      },
       "ArtifactId": {
         "description": "An identifier for an artifact.\n\nThe kind is [`ArtifactKind`], indicating that it might represent an artifact whose kind is unknown.",
         "type": "object",
@@ -1154,9 +1173,10 @@
         "type": "object",
         "properties": {
           "artifacts": {
+            "description": "Map of artifacts we ingested from the most-recently-uploaded TUF repository to a list of artifacts we're serving over the bootstrap network. In some cases the list of artifacts being served will have length 1 (when we're serving the artifact directly); in other cases the artifact in the TUF repo contains multiple nested artifacts inside it (e.g., RoT artifacts contain both A and B images), and we serve the list of extracted artifacts but not the original combination.\n\nConceptually, this is a `BTreeMap<ArtifactId, Vec<ArtifactHashId>>`, but JSON requires string keys for maps, so we give back a vec of pairs instead.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ArtifactId"
+              "$ref": "#/components/schemas/InstallableArtifacts"
             }
           },
           "event_reports": {
@@ -1300,6 +1320,24 @@
             ]
           }
         }
+      },
+      "InstallableArtifacts": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId"
+          },
+          "installable": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactHashId"
+            }
+          }
+        },
+        "required": [
+          "artifact_id",
+          "installable"
+        ]
       },
       "IpRange": {
         "oneOf": [

--- a/tufaceous-lib/src/assemble/manifest.rs
+++ b/tufaceous-lib/src/assemble/manifest.rs
@@ -146,8 +146,8 @@ impl ArtifactManifest {
                              artifact kind {kind:?}"
                         );
 
-                        let buf = Vec::new();
-                        let mut builder = CompositeRotArchiveBuilder::new(buf)?;
+                        let mut builder =
+                            CompositeRotArchiveBuilder::new(Vec::new())?;
                         archive_a.with_data(
                             FakeDataAttributes::new(
                                 "fake-rot-archive-a",

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -446,7 +446,11 @@ impl WicketdManager {
                     Ok(val) => {
                         // TODO: Only send on changes
                         let rsp = val.into_inner();
-                        let artifacts = rsp.artifacts;
+                        let artifacts = rsp
+                            .artifacts
+                            .into_iter()
+                            .map(|artifact| artifact.artifact_id)
+                            .collect();
                         let system_version = rsp.system_version;
                         let event_reports: EventReportMap = rsp.event_reports;
                         let _ = tx.send(Event::ArtifactsAndEventReports {

--- a/wicketd/src/artifacts/extracted_artifacts.rs
+++ b/wicketd/src/artifacts/extracted_artifacts.rs
@@ -4,8 +4,8 @@
 
 use super::RepositoryError;
 use anyhow::Context;
-use bytes::Bytes;
 use camino::Utf8PathBuf;
+use camino_tempfile::NamedUtf8TempFile;
 use camino_tempfile::Utf8TempDir;
 use omicron_common::update::ArtifactHash;
 use omicron_common::update::ArtifactHashId;
@@ -54,13 +54,6 @@ impl ExtractedArtifactDataHandle {
         self.file_size
     }
 
-    pub(super) fn read_to_vec(&self) -> Result<Vec<u8>, RepositoryError> {
-        let path = path_for_artifact(&self.tempdir, &self.hash_id);
-        std::fs::read(&path).map_err(|error| {
-            RepositoryError::ReadExtractedArtifact { path, error }
-        })
-    }
-
     pub(crate) fn hash(&self) -> ArtifactHash {
         self.hash_id.hash
     }
@@ -85,12 +78,12 @@ impl ExtractedArtifactDataHandle {
 /// `ExtractedArtifacts` is a temporary wrapper around a `Utf8TempDir` for use
 /// when ingesting a new TUF repository.
 ///
-/// It provides methods to copy artifacts into the tempdir (`store` and
-/// `store_and_hash`) that return `ExtractedArtifactDataHandle`. The handles
-/// keep shared references to the `Utf8TempDir`, so it will not be removed until
-/// all handles are dropped (e.g., when a new TUF repository is uploaded). The
-/// handles can be used to on-demand read files that were copied into the temp
-/// dir during ingest.
+/// It provides methods to copy artifacts into the tempdir (`store` and the
+/// combo of `new_tempfile` + `store_tempfile`) that return
+/// `ExtractedArtifactDataHandle`. The handles keep shared references to the
+/// `Utf8TempDir`, so it will not be removed until all handles are dropped
+/// (e.g., when a new TUF repository is uploaded). The handles can be used to
+/// on-demand read files that were copied into the temp dir during ingest.
 #[derive(Debug)]
 pub(crate) struct ExtractedArtifacts {
     // Directory in which we store extracted artifacts. This is currently a
@@ -112,6 +105,13 @@ impl ExtractedArtifacts {
         Ok(Self { tempdir: Arc::new(tempdir) })
     }
 
+    fn path_for_artifact(
+        &self,
+        artifact_hash_id: &ArtifactHashId,
+    ) -> Utf8PathBuf {
+        self.tempdir.path().join(format!("{}", artifact_hash_id.hash))
+    }
+
     /// Copy from `reader` into our temp directory, returning a handle to the
     /// extracted artifact on success.
     pub(super) fn store(
@@ -119,8 +119,7 @@ impl ExtractedArtifacts {
         artifact_hash_id: ArtifactHashId,
         mut reader: impl Read,
     ) -> Result<ExtractedArtifactDataHandle, RepositoryError> {
-        let output_path =
-            self.tempdir.path().join(format!("{}", artifact_hash_id.hash));
+        let output_path = self.path_for_artifact(&artifact_hash_id);
 
         let mut writer = BufWriter::new(
             File::create(&output_path)
@@ -155,16 +154,64 @@ impl ExtractedArtifacts {
         })
     }
 
-    /// Copy from `bytes` into our temp directory while computing its artifact
-    /// hash.
-    pub(super) fn store_and_hash(
-        &mut self,
+    /// Create a new temporary file inside this temporary directory.
+    ///
+    /// As the returned file is written to, the data will be hashed; once
+    /// writing is complete, call [`ExtractedArtifacts::store_tempfile()`] to
+    /// persist the temporary file into an [`ExtractedArtifactDataHandle()`].
+    pub(super) fn new_tempfile(
+        &self,
+    ) -> Result<HashingNamedUtf8TempFile, RepositoryError> {
+        let file = NamedUtf8TempFile::new_in(self.tempdir.path()).map_err(
+            |error| RepositoryError::TempFileCreate {
+                path: self.tempdir.path().to_owned(),
+                error,
+            },
+        )?;
+        Ok(HashingNamedUtf8TempFile {
+            file: io::BufWriter::new(file),
+            hasher: Sha256::new(),
+            bytes_written: 0,
+        })
+    }
+
+    /// Persist a temporary file that was returned by
+    /// [`ExtractedArtifacts::new_tempfile()`] as an extracted artifact.
+    pub(super) fn store_tempfile(
+        &self,
         kind: ArtifactKind,
-        data: &Bytes,
+        file: HashingNamedUtf8TempFile,
     ) -> Result<ExtractedArtifactDataHandle, RepositoryError> {
-        let hash = ArtifactHash(Sha256::digest(data).into());
+        let HashingNamedUtf8TempFile { file, hasher, bytes_written } = file;
+
+        // We don't need to `.flush()` explicitly: `into_inner()` does that for
+        // us.
+        let file = file
+            .into_inner()
+            .context("failed to flush temp file")
+            .map_err(|error| RepositoryError::CopyExtractedArtifact {
+                kind: kind.clone(),
+                error,
+            })?;
+
+        let hash = ArtifactHash(hasher.finalize().into());
         let artifact_hash_id = ArtifactHashId { kind, hash };
-        self.store(artifact_hash_id, io::Cursor::new(data))
+        let output_path = self.path_for_artifact(&artifact_hash_id);
+        file.persist(&output_path)
+            .map_err(|error| error.error)
+            .with_context(|| {
+                format!("failed to persist temp file to {output_path}")
+            })
+            .map_err(|error| RepositoryError::CopyExtractedArtifact {
+                kind: artifact_hash_id.kind.clone(),
+                error,
+            })?;
+
+        Ok(ExtractedArtifactDataHandle {
+            tempdir: Arc::clone(&self.tempdir),
+            file_size: bytes_written,
+            hash_id: artifact_hash_id,
+        })
     }
 }
 
@@ -173,4 +220,24 @@ fn path_for_artifact(
     artifact_hash_id: &ArtifactHashId,
 ) -> Utf8PathBuf {
     tempdir.path().join(format!("{}", artifact_hash_id.hash))
+}
+
+// Wrapper around a `NamedUtf8TempFile` that hashes contents as they're written.
+pub(super) struct HashingNamedUtf8TempFile {
+    file: io::BufWriter<NamedUtf8TempFile>,
+    hasher: Sha256,
+    bytes_written: usize,
+}
+
+impl Write for HashingNamedUtf8TempFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.file.write(buf)?;
+        self.hasher.update(&buf[..n]);
+        self.bytes_written += n;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
 }

--- a/wicketd/src/artifacts/update_plan.rs
+++ b/wicketd/src/artifacts/update_plan.rs
@@ -1,0 +1,1026 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Constructor for the `UpdatePlan` wicketd uses to drive sled mupdates.
+//!
+//! This is a "plan" in name only: it is a strict list of which artifacts to
+//! apply to which components; the ordering and application of the plan lives
+//! elsewhere.
+
+use super::extracted_artifacts::ExtractedArtifacts;
+use super::extracted_artifacts::HashingNamedUtf8TempFile;
+use super::ArtifactIdData;
+use super::Board;
+use super::ExtractedArtifactDataHandle;
+use super::RepositoryError;
+use super::UpdatePlan;
+use anyhow::anyhow;
+use hubtools::RawHubrisArchive;
+use omicron_common::api::external::SemverVersion;
+use omicron_common::api::internal::nexus::KnownArtifactKind;
+use omicron_common::update::ArtifactHash;
+use omicron_common::update::ArtifactHashId;
+use omicron_common::update::ArtifactId;
+use omicron_common::update::ArtifactKind;
+use slog::info;
+use slog::Logger;
+use std::collections::btree_map;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::io;
+use std::io::Read;
+use tufaceous_lib::HostPhaseImages;
+use tufaceous_lib::RotArchives;
+
+/// `UpdatePlanBuilder` mirrors all the fields of `UpdatePlan`, but they're all
+/// optional: it can be filled in as we read a TUF repository.
+/// [`UpdatePlanBuilder::build()`] will (fallibly) convert from the builder to
+/// the final plan.
+#[derive(Debug)]
+pub(super) struct UpdatePlanBuilder<'a> {
+    // fields that mirror `UpdatePlan`
+    system_version: SemverVersion,
+    gimlet_sp: BTreeMap<Board, ArtifactIdData>,
+    gimlet_rot_a: Option<ArtifactIdData>,
+    gimlet_rot_b: Option<ArtifactIdData>,
+    psc_sp: BTreeMap<Board, ArtifactIdData>,
+    psc_rot_a: Option<ArtifactIdData>,
+    psc_rot_b: Option<ArtifactIdData>,
+    sidecar_sp: BTreeMap<Board, ArtifactIdData>,
+    sidecar_rot_a: Option<ArtifactIdData>,
+    sidecar_rot_b: Option<ArtifactIdData>,
+    host_phase_1: Option<ArtifactIdData>,
+    trampoline_phase_1: Option<ArtifactIdData>,
+    trampoline_phase_2: Option<ArtifactIdData>,
+    host_phase_2_hash: Option<ArtifactHash>,
+    control_plane_hash: Option<ArtifactHash>,
+
+    // extra fields we use to build the plan
+    extracted_artifacts: ExtractedArtifacts,
+    log: &'a Logger,
+}
+
+impl<'a> UpdatePlanBuilder<'a> {
+    pub(super) fn new(
+        system_version: SemverVersion,
+        log: &'a Logger,
+    ) -> Result<Self, RepositoryError> {
+        let extracted_artifacts = ExtractedArtifacts::new(log)?;
+        Ok(Self {
+            system_version,
+            gimlet_sp: BTreeMap::new(),
+            gimlet_rot_a: None,
+            gimlet_rot_b: None,
+            psc_sp: BTreeMap::new(),
+            psc_rot_a: None,
+            psc_rot_b: None,
+            sidecar_sp: BTreeMap::new(),
+            sidecar_rot_a: None,
+            sidecar_rot_b: None,
+            host_phase_1: None,
+            trampoline_phase_1: None,
+            trampoline_phase_2: None,
+            host_phase_2_hash: None,
+            control_plane_hash: None,
+
+            extracted_artifacts,
+            log,
+        })
+    }
+
+    pub(super) fn add_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_hash: ArtifactHash,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        // If we don't know this artifact kind, we'll still serve it up by hash,
+        // but we don't do any further processing on it.
+        let Some(artifact_kind) = artifact_id.kind.to_known() else {
+            return self.add_unknown_artifact(
+                artifact_id,
+                artifact_hash,
+                reader,
+                by_id,
+                by_hash,
+            );
+        };
+
+        match artifact_kind {
+            KnownArtifactKind::GimletSp
+            | KnownArtifactKind::PscSp
+            | KnownArtifactKind::SwitchSp => self.add_sp_artifact(
+                artifact_id,
+                artifact_kind,
+                artifact_hash,
+                reader,
+                by_id,
+                by_hash,
+            ),
+            KnownArtifactKind::GimletRot
+            | KnownArtifactKind::PscRot
+            | KnownArtifactKind::SwitchRot => self.add_rot_artifact(
+                artifact_id,
+                artifact_kind,
+                reader,
+                by_id,
+                by_hash,
+            ),
+            KnownArtifactKind::Host => self.add_host_artifact(
+                artifact_id,
+                artifact_kind,
+                reader,
+                by_id,
+                by_hash,
+            ),
+            KnownArtifactKind::Trampoline => self.add_trampoline_artifact(
+                artifact_id,
+                artifact_kind,
+                reader,
+                by_id,
+                by_hash,
+            ),
+            KnownArtifactKind::ControlPlane => self.add_control_plane_artifact(
+                artifact_id,
+                artifact_kind,
+                artifact_hash,
+                reader,
+                by_id,
+                by_hash,
+            ),
+        }
+    }
+
+    fn add_sp_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_kind: KnownArtifactKind,
+        artifact_hash: ArtifactHash,
+        mut reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        let sp_map = match artifact_kind {
+            KnownArtifactKind::GimletSp => &mut self.gimlet_sp,
+            KnownArtifactKind::PscSp => &mut self.psc_sp,
+            KnownArtifactKind::SwitchSp => &mut self.sidecar_sp,
+            // We're only called with an SP artifact kind.
+            KnownArtifactKind::GimletRot
+            | KnownArtifactKind::Host
+            | KnownArtifactKind::Trampoline
+            | KnownArtifactKind::ControlPlane
+            | KnownArtifactKind::PscRot
+            | KnownArtifactKind::SwitchRot => unreachable!(),
+        };
+
+        // SP images are small, and hubtools wants a `&[u8]` to parse, so we'll
+        // read the whole thing into memory.
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data).map_err(|error| {
+            RepositoryError::CopyExtractedArtifact {
+                kind: artifact_kind.into(),
+                error: anyhow!(error),
+            }
+        })?;
+
+        let (artifact_id, board) =
+            read_hubris_board_from_archive(artifact_id, data.clone())?;
+
+        let slot = match sp_map.entry(board) {
+            btree_map::Entry::Vacant(slot) => slot,
+            btree_map::Entry::Occupied(slot) => {
+                return Err(RepositoryError::DuplicateBoardEntry {
+                    board: slot.key().0.clone(),
+                    kind: artifact_kind,
+                });
+            }
+        };
+
+        let artifact_hash_id =
+            ArtifactHashId { kind: artifact_kind.into(), hash: artifact_hash };
+        let data = self
+            .extracted_artifacts
+            .store(artifact_hash_id, io::Cursor::new(&data))?;
+        slot.insert(ArtifactIdData {
+            id: artifact_id.clone(),
+            data: data.clone(),
+        });
+
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            data,
+            artifact_kind.into(),
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    fn add_rot_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_kind: KnownArtifactKind,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        let (rot_a, rot_a_kind, rot_b, rot_b_kind) = match artifact_kind {
+            KnownArtifactKind::GimletRot => (
+                &mut self.gimlet_rot_a,
+                ArtifactKind::GIMLET_ROT_IMAGE_A,
+                &mut self.gimlet_rot_b,
+                ArtifactKind::GIMLET_ROT_IMAGE_B,
+            ),
+            KnownArtifactKind::PscRot => (
+                &mut self.psc_rot_a,
+                ArtifactKind::PSC_ROT_IMAGE_A,
+                &mut self.psc_rot_b,
+                ArtifactKind::PSC_ROT_IMAGE_B,
+            ),
+            KnownArtifactKind::SwitchRot => (
+                &mut self.sidecar_rot_a,
+                ArtifactKind::SWITCH_ROT_IMAGE_A,
+                &mut self.sidecar_rot_b,
+                ArtifactKind::SWITCH_ROT_IMAGE_B,
+            ),
+            // We're only called with an RoT artifact kind.
+            KnownArtifactKind::GimletSp
+            | KnownArtifactKind::Host
+            | KnownArtifactKind::Trampoline
+            | KnownArtifactKind::ControlPlane
+            | KnownArtifactKind::PscSp
+            | KnownArtifactKind::SwitchSp => unreachable!(),
+        };
+
+        if rot_a.is_some() || rot_b.is_some() {
+            return Err(RepositoryError::DuplicateArtifactKind(artifact_kind));
+        }
+
+        let (rot_a_data, rot_b_data) = Self::extract_nested_artifact_pair(
+            &mut self.extracted_artifacts,
+            artifact_kind,
+            |out_a, out_b| RotArchives::extract_into(reader, out_a, out_b),
+        )?;
+
+        // Technically we've done all we _need_ to do with the RoT images. We
+        // send them directly to MGS ourself, so don't expect anyone to ask for
+        // them via `by_id` or `by_hash`. However, it's more convenient to
+        // record them in `by_id` and `by_hash`: their addition will be
+        // consistently logged the way other artifacts are, and they'll show up
+        // in our dropshot endpoint that reports the artifacts we have.
+        let rot_a_id = ArtifactId {
+            name: artifact_id.name.clone(),
+            version: artifact_id.version.clone(),
+            kind: rot_a_kind.clone(),
+        };
+        let rot_b_id = ArtifactId {
+            name: artifact_id.name.clone(),
+            version: artifact_id.version.clone(),
+            kind: rot_b_kind.clone(),
+        };
+
+        *rot_a = Some(ArtifactIdData {
+            id: rot_a_id.clone(),
+            data: rot_a_data.clone(),
+        });
+        *rot_b = Some(ArtifactIdData {
+            id: rot_b_id.clone(),
+            data: rot_b_data.clone(),
+        });
+
+        record_extracted_artifact(
+            artifact_id.clone(),
+            by_id,
+            by_hash,
+            rot_a_data,
+            rot_a_kind,
+            self.log,
+        )?;
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            rot_b_data,
+            rot_b_kind,
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    fn add_host_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_kind: KnownArtifactKind,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        // We're only called for host (not trampoline!) artifacts.
+        assert_eq!(artifact_kind, KnownArtifactKind::Host);
+
+        if self.host_phase_1.is_some() || self.host_phase_2_hash.is_some() {
+            return Err(RepositoryError::DuplicateArtifactKind(artifact_kind));
+        }
+
+        let (phase_1_data, phase_2_data) = Self::extract_nested_artifact_pair(
+            &mut self.extracted_artifacts,
+            artifact_kind,
+            |out_1, out_2| HostPhaseImages::extract_into(reader, out_1, out_2),
+        )?;
+
+        // Similarly to the RoT, we need to create new, non-conflicting artifact
+        // IDs for each image.
+        let phase_1_id = ArtifactId {
+            name: artifact_id.name.clone(),
+            version: artifact_id.version.clone(),
+            kind: ArtifactKind::HOST_PHASE_1,
+        };
+
+        self.host_phase_1 = Some(ArtifactIdData {
+            id: phase_1_id.clone(),
+            data: phase_1_data.clone(),
+        });
+        self.host_phase_2_hash = Some(phase_2_data.hash());
+
+        record_extracted_artifact(
+            artifact_id.clone(),
+            by_id,
+            by_hash,
+            phase_1_data,
+            ArtifactKind::HOST_PHASE_1,
+            self.log,
+        )?;
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            phase_2_data,
+            ArtifactKind::HOST_PHASE_2,
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    fn add_trampoline_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_kind: KnownArtifactKind,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        // We're only called for trampoline (not host!) artifacts.
+        assert_eq!(artifact_kind, KnownArtifactKind::Trampoline);
+
+        if self.trampoline_phase_1.is_some()
+            || self.trampoline_phase_2.is_some()
+        {
+            return Err(RepositoryError::DuplicateArtifactKind(artifact_kind));
+        }
+
+        let (phase_1_data, phase_2_data) = Self::extract_nested_artifact_pair(
+            &mut self.extracted_artifacts,
+            artifact_kind,
+            |out_1, out_2| HostPhaseImages::extract_into(reader, out_1, out_2),
+        )?;
+
+        // Similarly to the RoT, we need to create new, non-conflicting artifact
+        // IDs for each image. We'll append a suffix to the name; keep the
+        // version and kind the same.
+        let phase_1_id = ArtifactId {
+            name: artifact_id.name.clone(),
+            version: artifact_id.version.clone(),
+            kind: ArtifactKind::TRAMPOLINE_PHASE_1,
+        };
+        let phase_2_id = ArtifactId {
+            name: artifact_id.name.clone(),
+            version: artifact_id.version.clone(),
+            kind: ArtifactKind::TRAMPOLINE_PHASE_2,
+        };
+
+        self.trampoline_phase_1 = Some(ArtifactIdData {
+            id: phase_1_id.clone(),
+            data: phase_1_data.clone(),
+        });
+        self.trampoline_phase_2 = Some(ArtifactIdData {
+            id: phase_2_id.clone(),
+            data: phase_2_data.clone(),
+        });
+
+        record_extracted_artifact(
+            artifact_id.clone(),
+            by_id,
+            by_hash,
+            phase_1_data,
+            ArtifactKind::TRAMPOLINE_PHASE_1,
+            self.log,
+        )?;
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            phase_2_data,
+            ArtifactKind::TRAMPOLINE_PHASE_2,
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    fn add_control_plane_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_kind: KnownArtifactKind,
+        artifact_hash: ArtifactHash,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        // We're only called for control plane artifacts.
+        assert_eq!(artifact_kind, KnownArtifactKind::ControlPlane);
+        if self.control_plane_hash.is_some() {
+            return Err(RepositoryError::DuplicateArtifactKind(artifact_kind));
+        }
+
+        // The control plane artifact is the easiest one: we just need to copy
+        // it into our tempdir and record it. Nothing to inspect or extract.
+        let artifact_hash_id = ArtifactHashId {
+            kind: artifact_id.kind.clone(),
+            hash: artifact_hash,
+        };
+
+        let data = self.extracted_artifacts.store(artifact_hash_id, reader)?;
+
+        self.control_plane_hash = Some(data.hash());
+
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            data,
+            artifact_kind.into(),
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    fn add_unknown_artifact(
+        &mut self,
+        artifact_id: ArtifactId,
+        artifact_hash: ArtifactHash,
+        reader: io::BufReader<impl io::Read>,
+        by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+        by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    ) -> Result<(), RepositoryError> {
+        let artifact_kind = artifact_id.kind.clone();
+        let artifact_hash_id =
+            ArtifactHashId { kind: artifact_kind.clone(), hash: artifact_hash };
+
+        let data = self.extracted_artifacts.store(artifact_hash_id, reader)?;
+
+        record_extracted_artifact(
+            artifact_id,
+            by_id,
+            by_hash,
+            data,
+            artifact_kind,
+            self.log,
+        )?;
+
+        Ok(())
+    }
+
+    // RoT, host OS, and trampoline OS artifacts all contain a pair of artifacts
+    // we actually care about (RoT: A/B images; host/trampoline: phase1/phase2
+    // images). This method is a helper that converts a single artifact `reader`
+    // into a pair of extracted artifacts.
+    fn extract_nested_artifact_pair<F>(
+        extracted_artifacts: &mut ExtractedArtifacts,
+        kind: KnownArtifactKind,
+        extract: F,
+    ) -> Result<
+        (ExtractedArtifactDataHandle, ExtractedArtifactDataHandle),
+        RepositoryError,
+    >
+    where
+        F: FnOnce(
+            &mut HashingNamedUtf8TempFile,
+            &mut HashingNamedUtf8TempFile,
+        ) -> anyhow::Result<()>,
+    {
+        // Create two temp files for the pair of images we want to
+        // extract from `reader`.
+        let mut image1_out = extracted_artifacts.new_tempfile()?;
+        let mut image2_out = extracted_artifacts.new_tempfile()?;
+
+        // Extract the two images from `reader`.
+        extract(&mut image1_out, &mut image2_out)
+            .map_err(|error| RepositoryError::TarballExtract { kind, error })?;
+
+        // Persist the two images we just extracted.
+        let image1 =
+            extracted_artifacts.store_tempfile(kind.into(), image1_out)?;
+        let image2 =
+            extracted_artifacts.store_tempfile(kind.into(), image2_out)?;
+
+        Ok((image1, image2))
+    }
+
+    pub(super) fn build(self) -> Result<UpdatePlan, RepositoryError> {
+        // Ensure our multi-board-supporting kinds have at least one board
+        // present.
+        if self.gimlet_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::GimletSp,
+            ));
+        }
+        if self.psc_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::PscSp,
+            ));
+        }
+        if self.sidecar_sp.is_empty() {
+            return Err(RepositoryError::MissingArtifactKind(
+                KnownArtifactKind::SwitchSp,
+            ));
+        }
+
+        Ok(UpdatePlan {
+            system_version: self.system_version,
+            gimlet_sp: self.gimlet_sp, // checked above
+            gimlet_rot_a: self.gimlet_rot_a.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::GimletRot,
+                ),
+            )?,
+            gimlet_rot_b: self.gimlet_rot_b.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::GimletRot,
+                ),
+            )?,
+            psc_sp: self.psc_sp, // checked above
+            psc_rot_a: self.psc_rot_a.ok_or(
+                RepositoryError::MissingArtifactKind(KnownArtifactKind::PscRot),
+            )?,
+            psc_rot_b: self.psc_rot_b.ok_or(
+                RepositoryError::MissingArtifactKind(KnownArtifactKind::PscRot),
+            )?,
+            sidecar_sp: self.sidecar_sp, // checked above
+            sidecar_rot_a: self.sidecar_rot_a.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::SwitchRot,
+                ),
+            )?,
+            sidecar_rot_b: self.sidecar_rot_b.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::SwitchRot,
+                ),
+            )?,
+            host_phase_1: self.host_phase_1.ok_or(
+                RepositoryError::MissingArtifactKind(KnownArtifactKind::Host),
+            )?,
+            trampoline_phase_1: self.trampoline_phase_1.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::Trampoline,
+                ),
+            )?,
+            trampoline_phase_2: self.trampoline_phase_2.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::Trampoline,
+                ),
+            )?,
+            host_phase_2_hash: self.host_phase_2_hash.ok_or(
+                RepositoryError::MissingArtifactKind(KnownArtifactKind::Host),
+            )?,
+            control_plane_hash: self.control_plane_hash.ok_or(
+                RepositoryError::MissingArtifactKind(
+                    KnownArtifactKind::ControlPlane,
+                ),
+            )?,
+        })
+    }
+}
+
+// This function takes and returns `id` to avoid an unnecessary clone; `id` will
+// be present in either the Ok tuple or the error.
+fn read_hubris_board_from_archive(
+    id: ArtifactId,
+    data: Vec<u8>,
+) -> Result<(ArtifactId, Board), RepositoryError> {
+    let archive = match RawHubrisArchive::from_vec(data).map_err(Box::new) {
+        Ok(archive) => archive,
+        Err(error) => {
+            return Err(RepositoryError::ParsingHubrisArchive { id, error });
+        }
+    };
+    let caboose = match archive.read_caboose().map_err(Box::new) {
+        Ok(caboose) => caboose,
+        Err(error) => {
+            return Err(RepositoryError::ReadHubrisCaboose { id, error });
+        }
+    };
+    let board = match caboose.board() {
+        Ok(board) => board,
+        Err(error) => {
+            return Err(RepositoryError::ReadHubrisCabooseBoard { id, error });
+        }
+    };
+    let board = match std::str::from_utf8(board) {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(RepositoryError::ReadHubrisCabooseBoardUtf8(id));
+        }
+    };
+    Ok((id, Board(board.to_string())))
+}
+
+// Record an artifact in `by_id` and `by_hash`, or fail if either already has an
+// entry for this id/hash.
+fn record_extracted_artifact(
+    tuf_repo_artifact_id: ArtifactId,
+    by_id: &mut BTreeMap<ArtifactId, Vec<ArtifactHashId>>,
+    by_hash: &mut HashMap<ArtifactHashId, ExtractedArtifactDataHandle>,
+    data: ExtractedArtifactDataHandle,
+    data_kind: ArtifactKind,
+    log: &Logger,
+) -> Result<(), RepositoryError> {
+    use std::collections::hash_map::Entry;
+
+    let artifact_hash_id =
+        ArtifactHashId { kind: data_kind, hash: data.hash() };
+
+    let by_hash_slot = match by_hash.entry(artifact_hash_id) {
+        Entry::Occupied(slot) => {
+            return Err(RepositoryError::DuplicateHashEntry(
+                slot.key().clone(),
+            ));
+        }
+        Entry::Vacant(slot) => slot,
+    };
+
+    info!(
+        log, "added artifact";
+        "name" => %tuf_repo_artifact_id.name,
+        "kind" => %by_hash_slot.key().kind,
+        "version" => %tuf_repo_artifact_id.version,
+        "hash" => %by_hash_slot.key().hash,
+        "length" => data.file_size(),
+    );
+
+    by_id
+        .entry(tuf_repo_artifact_id)
+        .or_default()
+        .push(by_hash_slot.key().clone());
+    by_hash_slot.insert(data);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use omicron_test_utils::dev::test_setup_log;
+    use rand::{distributions::Standard, thread_rng, Rng};
+    use sha2::{Digest, Sha256};
+
+    fn make_random_bytes() -> Vec<u8> {
+        thread_rng().sample_iter(Standard).take(128).collect()
+    }
+
+    struct RandomHostOsImage {
+        phase1: Bytes,
+        phase2: Bytes,
+        tarball: Bytes,
+    }
+
+    fn make_random_host_os_image() -> RandomHostOsImage {
+        use tufaceous_lib::CompositeHostArchiveBuilder;
+
+        let phase1 = make_random_bytes();
+        let phase2 = make_random_bytes();
+
+        let mut builder = CompositeHostArchiveBuilder::new(Vec::new()).unwrap();
+        builder.append_phase_1(phase1.len(), phase1.as_slice()).unwrap();
+        builder.append_phase_2(phase2.len(), phase2.as_slice()).unwrap();
+
+        let tarball = builder.finish().unwrap();
+
+        RandomHostOsImage {
+            phase1: Bytes::from(phase1),
+            phase2: Bytes::from(phase2),
+            tarball: Bytes::from(tarball),
+        }
+    }
+
+    struct RandomRotImage {
+        archive_a: Bytes,
+        archive_b: Bytes,
+        tarball: Bytes,
+    }
+
+    fn make_random_rot_image() -> RandomRotImage {
+        use tufaceous_lib::CompositeRotArchiveBuilder;
+
+        let archive_a = make_random_bytes();
+        let archive_b = make_random_bytes();
+
+        let mut builder = CompositeRotArchiveBuilder::new(Vec::new()).unwrap();
+        builder
+            .append_archive_a(archive_a.len(), archive_a.as_slice())
+            .unwrap();
+        builder
+            .append_archive_b(archive_b.len(), archive_b.as_slice())
+            .unwrap();
+
+        let tarball = builder.finish().unwrap();
+
+        RandomRotImage {
+            archive_a: Bytes::from(archive_a),
+            archive_b: Bytes::from(archive_b),
+            tarball: Bytes::from(tarball),
+        }
+    }
+
+    fn make_fake_sp_image(board: &str) -> Vec<u8> {
+        use hubtools::{CabooseBuilder, HubrisArchiveBuilder};
+
+        let caboose = CabooseBuilder::default()
+            .git_commit("this-is-fake-data")
+            .board(board)
+            .version("0.0.0")
+            .name(board)
+            .build();
+
+        let mut builder = HubrisArchiveBuilder::with_fake_image();
+        builder.write_caboose(caboose.as_slice()).unwrap();
+        builder.build_to_vec().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_from_artifacts() {
+        const VERSION_0: SemverVersion = SemverVersion::new(0, 0, 0);
+
+        let logctx = test_setup_log("test_update_plan_from_artifacts");
+
+        let mut by_id = BTreeMap::new();
+        let mut by_hash = HashMap::new();
+        let mut plan_builder =
+            UpdatePlanBuilder::new("0.0.0".parse().unwrap(), &logctx.log)
+                .unwrap();
+
+        // Add a couple artifacts with kinds wicketd doesn't understand; it
+        // should still ingest and serve them.
+        let mut expected_unknown_artifacts = BTreeSet::new();
+
+        for kind in ["test-kind-1", "test-kind-2"] {
+            let data = make_random_bytes();
+            let hash = ArtifactHash(Sha256::digest(&data).into());
+            let id = ArtifactId {
+                name: kind.to_string(),
+                version: VERSION_0,
+                kind: kind.parse().unwrap(),
+            };
+            expected_unknown_artifacts.insert(id.clone());
+            plan_builder
+                .add_artifact(
+                    id,
+                    hash,
+                    io::BufReader::new(io::Cursor::new(&data)),
+                    &mut by_id,
+                    &mut by_hash,
+                )
+                .unwrap();
+        }
+
+        // The control plane artifact can be arbitrary bytes; just populate it
+        // with random data.
+        {
+            let kind = KnownArtifactKind::ControlPlane;
+            let data = make_random_bytes();
+            let hash = ArtifactHash(Sha256::digest(&data).into());
+            let id = ArtifactId {
+                name: format!("{kind:?}"),
+                version: VERSION_0,
+                kind: kind.into(),
+            };
+            plan_builder
+                .add_artifact(
+                    id,
+                    hash,
+                    io::BufReader::new(io::Cursor::new(&data)),
+                    &mut by_id,
+                    &mut by_hash,
+                )
+                .unwrap();
+        }
+
+        // For each SP image, we'll insert two artifacts: these should end up in
+        // the update plan's SP image maps keyed by their "board". Normally the
+        // board is read from the archive itself via hubtools; we'll inject a
+        // test function that returns the artifact ID name as the board instead.
+        for (kind, boards) in [
+            (KnownArtifactKind::GimletSp, ["test-gimlet-a", "test-gimlet-b"]),
+            (KnownArtifactKind::PscSp, ["test-psc-a", "test-psc-b"]),
+            (KnownArtifactKind::SwitchSp, ["test-switch-a", "test-switch-b"]),
+        ] {
+            for board in boards {
+                let data = make_fake_sp_image(board);
+                let hash = ArtifactHash(Sha256::digest(&data).into());
+                let id = ArtifactId {
+                    name: board.to_string(),
+                    version: VERSION_0,
+                    kind: kind.into(),
+                };
+                plan_builder
+                    .add_artifact(
+                        id,
+                        hash,
+                        io::BufReader::new(io::Cursor::new(&data)),
+                        &mut by_id,
+                        &mut by_hash,
+                    )
+                    .unwrap();
+            }
+        }
+
+        // The Host, Trampoline, and RoT artifacts must be structed the way we
+        // expect (i.e., .tar.gz's containing multiple inner artifacts).
+        let host = make_random_host_os_image();
+        let trampoline = make_random_host_os_image();
+
+        for (kind, image) in [
+            (KnownArtifactKind::Host, &host),
+            (KnownArtifactKind::Trampoline, &trampoline),
+        ] {
+            let data = &image.tarball;
+            let hash = ArtifactHash(Sha256::digest(data).into());
+            let id = ArtifactId {
+                name: format!("{kind:?}"),
+                version: VERSION_0,
+                kind: kind.into(),
+            };
+            plan_builder
+                .add_artifact(
+                    id,
+                    hash,
+                    io::BufReader::new(io::Cursor::new(data)),
+                    &mut by_id,
+                    &mut by_hash,
+                )
+                .unwrap();
+        }
+
+        let gimlet_rot = make_random_rot_image();
+        let psc_rot = make_random_rot_image();
+        let sidecar_rot = make_random_rot_image();
+
+        for (kind, artifact) in [
+            (KnownArtifactKind::GimletRot, &gimlet_rot),
+            (KnownArtifactKind::PscRot, &psc_rot),
+            (KnownArtifactKind::SwitchRot, &sidecar_rot),
+        ] {
+            let data = &artifact.tarball;
+            let hash = ArtifactHash(Sha256::digest(data).into());
+            let id = ArtifactId {
+                name: format!("{kind:?}"),
+                version: VERSION_0,
+                kind: kind.into(),
+            };
+            plan_builder
+                .add_artifact(
+                    id,
+                    hash,
+                    io::BufReader::new(io::Cursor::new(data)),
+                    &mut by_id,
+                    &mut by_hash,
+                )
+                .unwrap();
+        }
+
+        let plan = plan_builder.build().unwrap();
+
+        assert_eq!(plan.gimlet_sp.len(), 2);
+        assert_eq!(plan.psc_sp.len(), 2);
+        assert_eq!(plan.sidecar_sp.len(), 2);
+
+        for (id, hash_ids) in &by_id {
+            let kind = match id.kind.to_known() {
+                Some(kind) => kind,
+                None => {
+                    assert!(
+                        expected_unknown_artifacts.remove(id),
+                        "unexpected unknown artifact ID {id:?}"
+                    );
+                    continue;
+                }
+            };
+            match kind {
+                KnownArtifactKind::GimletSp => {
+                    assert!(
+                        id.name.starts_with("test-gimlet-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(hash_ids.len(), 1);
+                    assert_eq!(
+                        plan.gimlet_sp.get(&id.name).unwrap().data.hash(),
+                        hash_ids[0].hash
+                    );
+                }
+                KnownArtifactKind::ControlPlane => {
+                    assert_eq!(hash_ids.len(), 1);
+                    assert_eq!(plan.control_plane_hash, hash_ids[0].hash);
+                }
+                KnownArtifactKind::PscSp => {
+                    assert!(
+                        id.name.starts_with("test-psc-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(hash_ids.len(), 1);
+                    assert_eq!(
+                        plan.psc_sp.get(&id.name).unwrap().data.hash(),
+                        hash_ids[0].hash
+                    );
+                }
+                KnownArtifactKind::SwitchSp => {
+                    assert!(
+                        id.name.starts_with("test-switch-"),
+                        "unexpected id.name {:?}",
+                        id.name
+                    );
+                    assert_eq!(hash_ids.len(), 1);
+                    assert_eq!(
+                        plan.sidecar_sp.get(&id.name).unwrap().data.hash(),
+                        hash_ids[0].hash
+                    );
+                }
+                // These are special (we import their inner parts) and we'll
+                // check them below.
+                KnownArtifactKind::Host
+                | KnownArtifactKind::Trampoline
+                | KnownArtifactKind::GimletRot
+                | KnownArtifactKind::PscRot
+                | KnownArtifactKind::SwitchRot => {}
+            }
+        }
+
+        // Check extracted host and trampoline data
+        assert_eq!(read_to_vec(&plan.host_phase_1.data).await, host.phase1);
+        assert_eq!(
+            read_to_vec(&plan.trampoline_phase_1.data).await,
+            trampoline.phase1
+        );
+        assert_eq!(
+            read_to_vec(&plan.trampoline_phase_2.data).await,
+            trampoline.phase2
+        );
+
+        let hash = Sha256::digest(&host.phase2);
+        assert_eq!(plan.host_phase_2_hash.0, *hash);
+
+        // Check extracted RoT data
+        assert_eq!(
+            read_to_vec(&plan.gimlet_rot_a.data).await,
+            gimlet_rot.archive_a
+        );
+        assert_eq!(
+            read_to_vec(&plan.gimlet_rot_b.data).await,
+            gimlet_rot.archive_b
+        );
+        assert_eq!(read_to_vec(&plan.psc_rot_a.data).await, psc_rot.archive_a);
+        assert_eq!(read_to_vec(&plan.psc_rot_b.data).await, psc_rot.archive_b);
+        assert_eq!(
+            read_to_vec(&plan.sidecar_rot_a.data).await,
+            sidecar_rot.archive_a
+        );
+        assert_eq!(
+            read_to_vec(&plan.sidecar_rot_b.data).await,
+            sidecar_rot.archive_b
+        );
+
+        logctx.cleanup_successful();
+    }
+
+    async fn read_to_vec(data: &ExtractedArtifactDataHandle) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(data.file_size());
+        let mut stream = data.reader_stream().await.unwrap();
+        while let Some(data) = stream.next().await {
+            let data = data.unwrap();
+            buf.extend_from_slice(&data);
+        }
+        buf
+    }
+}

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -31,6 +31,7 @@ use omicron_common::address;
 use omicron_common::api::external::SemverVersion;
 use omicron_common::api::internal::shared::RackNetworkConfig;
 use omicron_common::api::internal::shared::SwitchLocation;
+use omicron_common::update::ArtifactHashId;
 use omicron_common::update::ArtifactId;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -606,13 +607,33 @@ async fn put_repository(
     Ok(HttpResponseUpdatedNoContent())
 }
 
+#[derive(Clone, Debug, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct InstallableArtifacts {
+    pub artifact_id: ArtifactId,
+    pub installable: Vec<ArtifactHashId>,
+}
+
 /// The response to a `get_artifacts` call: the system version, and the list of
 /// all artifacts currently held by wicketd.
 #[derive(Clone, Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct GetArtifactsAndEventReportsResponse {
     pub system_version: Option<SemverVersion>,
-    pub artifacts: Vec<ArtifactId>,
+
+    /// Map of artifacts we ingested from the most-recently-uploaded TUF
+    /// repository to a list of artifacts we're serving over the bootstrap
+    /// network. In some cases the list of artifacts being served will have
+    /// length 1 (when we're serving the artifact directly); in other cases the
+    /// artifact in the TUF repo contains multiple nested artifacts inside it
+    /// (e.g., RoT artifacts contain both A and B images), and we serve the list
+    /// of extracted artifacts but not the original combination.
+    ///
+    /// Conceptually, this is a `BTreeMap<ArtifactId, Vec<ArtifactHashId>>`, but
+    /// JSON requires string keys for maps, so we give back a vec of pairs
+    /// instead.
+    pub artifacts: Vec<InstallableArtifacts>,
+
     pub event_reports: BTreeMap<SpType, BTreeMap<u32, EventReport>>,
 }
 

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -61,18 +61,52 @@ async fn test_updates() {
         .expect("get_artifacts_and_event_reports succeeded")
         .into_inner();
 
+    // We should have an artifact for every known artifact kind...
+    let expected_kinds: BTreeSet<_> =
+        KnownArtifactKind::iter().map(ArtifactKind::from).collect();
+
+    // ... and installable artifacts that replace the top level host,
+    // trampoline, and RoT with their inner parts (phase1/phase2 for OS images
+    // and A/B images for the RoT) during import.
+    let mut expected_installable_kinds = expected_kinds.clone();
+    for remove in [
+        KnownArtifactKind::Host,
+        KnownArtifactKind::Trampoline,
+        KnownArtifactKind::GimletRot,
+        KnownArtifactKind::PscRot,
+        KnownArtifactKind::SwitchRot,
+    ] {
+        assert!(expected_installable_kinds.remove(&remove.into()));
+    }
+    for add in [
+        ArtifactKind::HOST_PHASE_1,
+        ArtifactKind::HOST_PHASE_2,
+        ArtifactKind::TRAMPOLINE_PHASE_1,
+        ArtifactKind::TRAMPOLINE_PHASE_2,
+        ArtifactKind::GIMLET_ROT_IMAGE_A,
+        ArtifactKind::GIMLET_ROT_IMAGE_B,
+        ArtifactKind::PSC_ROT_IMAGE_A,
+        ArtifactKind::PSC_ROT_IMAGE_B,
+        ArtifactKind::SWITCH_ROT_IMAGE_A,
+        ArtifactKind::SWITCH_ROT_IMAGE_B,
+    ] {
+        assert!(expected_installable_kinds.insert(add));
+    }
+
     // Ensure that this is a sensible result.
-    let kinds = response
-        .artifacts
-        .iter()
-        .map(|artifact| {
-            artifact.kind.parse::<KnownArtifactKind>().unwrap_or_else(|error| {
-                panic!("unrecognized artifact kind {}: {error}", artifact.kind)
-            })
-        })
-        .collect();
-    let expected_kinds: BTreeSet<_> = KnownArtifactKind::iter().collect();
+    let mut kinds = BTreeSet::new();
+    let mut installable_kinds = BTreeSet::new();
+    for artifact in response.artifacts {
+        kinds.insert(artifact.artifact_id.kind.parse().unwrap());
+        for installable in artifact.installable {
+            installable_kinds.insert(installable.kind.parse().unwrap());
+        }
+    }
     assert_eq!(expected_kinds, kinds, "all expected kinds present");
+    assert_eq!(
+        expected_installable_kinds, installable_kinds,
+        "all expected installable kinds present"
+    );
 
     let target_sp = SpIdentifier { type_: SpType::Sled, slot: 0 };
 


### PR DESCRIPTION
This continues on the work in #3953 to shrink `wicketd`'s heap usage by moving the TUF artifacts we ingest out of memory and onto disk (in a temporary directory).

Briefly recapping where we are on `main` after uploading a TUF repo:

```
root@oxz_switch:/opt/oxide# pgrep wicketd | xargs pmap -S | grep heap
0000000002979000    3390440    3390440 rw---    [ heap ]
00000000D1873000    2392080    2392080 rw---    [ heap ]
```

and where we are as of #3953 after uploading a TUF repo:

```
root@oxz_switch:/opt/oxide# pgrep wicketd | xargs pmap -S | grep heap
000000000297C000    1684440    1684440 rw---    [ heap ]
```

and now where we are as of this branch after uploading a TUF repo:

```
root@oxz_switch:/opt/oxide# pgrep wicketd | xargs pmap -S | grep heap
000000000296D000      48960      48960 rw---    [ heap ]
```

The big impact here is that when we're unpacking the host and trampoline artifacts, we no longer unpack them to memory then write them to disk; we stream them straight to the temporary directory as we unpack.

Fixes #3943.