### PR TITLE
Only clean resources associated with your volume

### DIFF
--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -171,13 +171,6 @@ impl super::Nexus {
         opctx: &OpContext,
         snapshot_lookup: &lookup::Snapshot<'_>,
     ) -> DeleteResult {
-        // TODO-correctness
-        // This also requires solving how to clean up the associated resources
-        // (on-disk snapshots, running read-only downstairs) because disks
-        // *could* still be using them (if the snapshot has not yet been turned
-        // into a regular crucible volume). It will involve some sort of
-        // reference counting for volumes.
-
         let (.., authz_snapshot, db_snapshot) =
             snapshot_lookup.fetch_for(authz::Action::Delete).await?;
 
@@ -186,10 +179,12 @@ impl super::Nexus {
             authz_snapshot,
             snapshot: db_snapshot,
         };
+
         self.execute_saga::<sagas::snapshot_delete::SagaSnapshotDelete>(
             saga_params,
         )
         .await?;
+
         Ok(())
     }
 }

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -1100,3 +1100,228 @@ async fn test_region_snapshot_create_idempotent(
 
     datastore.region_snapshot_create(region_snapshot).await.unwrap();
 }
+
+/// Test that multiple DELETE calls won't be sent to a Crucible agent for the
+/// same read-only downstairs
+#[nexus_test]
+async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+    let nexus = &cptestctx.server.apictx().nexus;
+    let datastore = nexus.datastore();
+    DiskTest::new(&cptestctx).await;
+    populate_ip_pool(&client, "default", None).await;
+    let _project_id = create_org_and_project(client).await;
+    let disks_url = get_disks_url();
+
+    // Create a blank disk
+    let disk_size = ByteCount::from_gibibytes_u32(2);
+    let base_disk_name: Name = "base-disk".parse().unwrap();
+    let base_disk = params::DiskCreate {
+        identity: IdentityMetadataCreateParams {
+            name: base_disk_name.clone(),
+            description: String::from("sells rainsticks"),
+        },
+        disk_source: params::DiskSource::Blank {
+            block_size: params::BlockSize::try_from(512).unwrap(),
+        },
+        size: disk_size,
+    };
+
+    let base_disk: Disk = NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &disks_url)
+            .body(Some(&base_disk))
+            .expect_status(Some(StatusCode::CREATED)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body()
+    .unwrap();
+
+    // Create three snapshots of this disk
+    let snapshots_url = format!("/v1/snapshots?project={}", PROJECT_NAME);
+
+    let snapshot_1: views::Snapshot = object_create(
+        client,
+        &snapshots_url,
+        &params::SnapshotCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "snapshot1".parse().unwrap(),
+                description: "not attached to instance".into(),
+            },
+            disk: base_disk_name.clone().into(),
+        },
+    )
+    .await;
+
+    let snapshot_2: views::Snapshot = object_create(
+        client,
+        &snapshots_url,
+        &params::SnapshotCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "snapshot2".parse().unwrap(),
+                description: "not attached to instance".into(),
+            },
+            disk: base_disk_name.clone().into(),
+        },
+    )
+    .await;
+
+    let snapshot_3: views::Snapshot = object_create(
+        client,
+        &snapshots_url,
+        &params::SnapshotCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "snapshot3".parse().unwrap(),
+                description: "not attached to instance".into(),
+            },
+            disk: base_disk_name.clone().into(),
+        },
+    )
+    .await;
+
+    assert_eq!(snapshot_1.disk_id, base_disk.identity.id);
+    assert_eq!(snapshot_2.disk_id, base_disk.identity.id);
+    assert_eq!(snapshot_3.disk_id, base_disk.identity.id);
+
+    // Simulate all three of these have snapshot delete calls. First,
+    // concurrently delete the snapshot record:
+
+    let opctx =
+        OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
+
+    let (.., authz_snapshot_1, db_snapshot_1) =
+        LookupPath::new(&opctx, &datastore)
+            .snapshot_id(snapshot_1.identity.id)
+            .fetch_for(authz::Action::Delete)
+            .await
+            .unwrap();
+
+    datastore
+        .project_delete_snapshot(
+            &opctx,
+            &authz_snapshot_1,
+            &db_snapshot_1,
+            vec![
+                // This must match what is in the snapshot_delete saga!
+                db::model::SnapshotState::Ready,
+                db::model::SnapshotState::Faulted,
+                db::model::SnapshotState::Destroyed,
+            ],
+        )
+        .await
+        .unwrap();
+
+    let (.., authz_snapshot_2, db_snapshot_2) =
+        LookupPath::new(&opctx, &datastore)
+            .snapshot_id(snapshot_2.identity.id)
+            .fetch_for(authz::Action::Delete)
+            .await
+            .unwrap();
+
+    datastore
+        .project_delete_snapshot(
+            &opctx,
+            &authz_snapshot_2,
+            &db_snapshot_2,
+            vec![
+                // This must match what is in the snapshot_delete saga!
+                db::model::SnapshotState::Ready,
+                db::model::SnapshotState::Faulted,
+                db::model::SnapshotState::Destroyed,
+            ],
+        )
+        .await
+        .unwrap();
+
+    let (.., authz_snapshot_3, db_snapshot_3) =
+        LookupPath::new(&opctx, &datastore)
+            .snapshot_id(snapshot_3.identity.id)
+            .fetch_for(authz::Action::Delete)
+            .await
+            .unwrap();
+
+    datastore
+        .project_delete_snapshot(
+            &opctx,
+            &authz_snapshot_3,
+            &db_snapshot_3,
+            vec![
+                // This must match what is in the snapshot_delete saga!
+                db::model::SnapshotState::Ready,
+                db::model::SnapshotState::Faulted,
+                db::model::SnapshotState::Destroyed,
+            ],
+        )
+        .await
+        .unwrap();
+
+    // Then, concurrently call
+    // `decrease_crucible_resource_count_and_soft_delete_volume`. Make sure that
+    // each saga is deleting a unique set of resources, else they will be
+    // sending identical DELETE calls to Crucible agents. This is ok because the
+    // agents are idempotent, but if someone issues a DELETE for a read-only
+    // downstairs (called a "running snapshot") when the snapshot was deleted,
+    // they'll see a 404, which will cause the saga to fail.
+
+    let resources_1 = datastore
+        .decrease_crucible_resource_count_and_soft_delete_volume(
+            db_snapshot_1.volume_id,
+        )
+        .await
+        .unwrap();
+
+    let resources_2 = datastore
+        .decrease_crucible_resource_count_and_soft_delete_volume(
+            db_snapshot_2.volume_id,
+        )
+        .await
+        .unwrap();
+
+    let resources_3 = datastore
+        .decrease_crucible_resource_count_and_soft_delete_volume(
+            db_snapshot_3.volume_id,
+        )
+        .await
+        .unwrap();
+
+    let resources_1 = match resources_1 {
+        db::datastore::CrucibleResources::V1(resources_1) => resources_1,
+    };
+    let resources_2 = match resources_2 {
+        db::datastore::CrucibleResources::V1(resources_2) => resources_2,
+    };
+    let resources_3 = match resources_3 {
+        db::datastore::CrucibleResources::V1(resources_3) => resources_3,
+    };
+
+    // No region deletions yet, these are just snapshot deletes
+
+    assert!(resources_1.datasets_and_regions.is_empty());
+    assert!(resources_2.datasets_and_regions.is_empty());
+    assert!(resources_3.datasets_and_regions.is_empty());
+
+    // But there are snapshots to delete
+
+    assert!(!resources_1.datasets_and_snapshots.is_empty());
+    assert!(!resources_2.datasets_and_snapshots.is_empty());
+    assert!(!resources_3.datasets_and_snapshots.is_empty());
+
+    // Assert there are no overlaps in the datasets_and_snapshots to delete.
+
+    for tuple in &resources_1.datasets_and_snapshots {
+        assert!(!resources_2.datasets_and_snapshots.contains(tuple));
+        assert!(!resources_3.datasets_and_snapshots.contains(tuple));
+    }
+
+    for tuple in &resources_2.datasets_and_snapshots {
+        assert!(!resources_1.datasets_and_snapshots.contains(tuple));
+        assert!(!resources_3.datasets_and_snapshots.contains(tuple));
+    }
+
+    for tuple in &resources_3.datasets_and_snapshots {
+        assert!(!resources_1.datasets_and_snapshots.contains(tuple));
+        assert!(!resources_2.datasets_and_snapshots.contains(tuple));
+    }
+}


### PR DESCRIPTION
When a read-only downstairs is no longer referenced by a volume, Nexus must issue DELETE calls to the appropriate Crucible agent to clean them up. As part of the snapshot delete saga, Nexus will decrement reference counts and return a list of regions and region_snapshots to delete (along with their datasets), but currently this list of region_snapshots will contain *any* resources to clean up, not just the argument volume's:

    volume_1 references to RO1, RO2, RO3
    volume_2 references to RO4, RO5, RO6

    resources_to_clean(volume_1) => [RO1, RO2, RO3, RO4, RO5, RO6]
    resources_to_clean(volume_2) => [RO1, RO2, RO3, RO4, RO5, RO6]

Handing these duplicate lists of resources to clean up is mostly ok: the Crucible agent is idempotent for equivalent requests, as it has to be to be used by Nexus in a saga. The one case where it isn't is when issuing a DELETE call for a read-only downstairs booted from a snapshot that doesn't exist: it will return 404. This makes sagas sad, and will cause them to unwind.

Fix this by only returning the resources associated with the argument volume:

    resources_to_clean(volume_1) => [RO1, RO2, RO3]
    resources_to_clean(volume_2) => [RO4, RO5, RO6]