### PR TITLE
Reduce direct dependencies on Diesel from nexus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,7 +4874,6 @@ dependencies = [
  "assert_matches",
  "async-bb8-diesel",
  "async-trait",
- "authz-macros",
  "base64 0.21.3",
  "bb8",
  "camino",
@@ -4885,9 +4884,7 @@ dependencies = [
  "criterion",
  "crucible-agent-client",
  "crucible-pantry-client",
- "db-macros",
  "diesel",
- "diesel-dtrace",
  "dns-server",
  "dns-service-client 0.1.0",
  "dpd-client",
@@ -9086,7 +9083,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ db-macros = { path = "nexus/db-macros" }
 debug-ignore = "1.0.5"
 derive_more = "0.99.17"
 derive-where = "1.2.5"
-diesel = { version = "2.1.1" }
+diesel = { version = "2.1.1", features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
 diesel-dtrace = { git = "https://github.com/oxidecomputer/diesel-dtrace", branch = "main" }
 dns-server = { path = "dns-server" }
 dns-service-client = { path = "dns-service-client" }

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -9,7 +9,6 @@ omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-bb8-diesel.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bb8.workspace = true
@@ -20,8 +19,6 @@ chrono.workspace = true
 cookie.workspace = true
 crucible-agent-client.workspace = true
 crucible-pantry-client.workspace = true
-diesel = { workspace = true, features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
-diesel-dtrace.workspace = true
 dns-service-client.workspace = true
 dpd-client.workspace = true
 dropshot.workspace = true
@@ -82,8 +79,6 @@ trust-dns-resolver.workspace = true
 uuid.workspace = true
 usdt.workspace = true
 
-authz-macros.workspace = true
-db-macros.workspace = true
 nexus-defaults.workspace = true
 nexus-db-model.workspace = true
 nexus-db-queries.workspace = true
@@ -97,7 +92,9 @@ rustls = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true
+async-bb8-diesel.workspace = true
 criterion.workspace = true
+diesel.workspace = true
 dns-server.workspace = true
 expectorate.workspace = true
 hyper-rustls.workspace = true

--- a/nexus/db-queries/Cargo.toml
+++ b/nexus/db-queries/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 bb8.workspace = true
 chrono.workspace = true
 cookie.workspace = true
-diesel = { workspace = true, features = ["postgres", "r2d2", "chrono", "serde_json", "network-address", "uuid"] }
+diesel.workspace = true
 diesel-dtrace.workspace = true
 dropshot.workspace = true
 futures.workspace = true


### PR DESCRIPTION
Instead, let nexus-db-queries handle them