### PR TITLE
[sled agent] Service API now uses generation numbers

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -627,6 +627,7 @@ impl Generation {
         Generation(1)
     }
 
+    #[must_use]
     pub fn next(&self) -> Generation {
         // It should technically be an operational error if this wraps or even
         // exceeds the value allowed by an i64.  But it seems unlikely enough to

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -303,8 +303,15 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "resource updated"
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceEnsureResponse"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -2262,6 +2269,9 @@
         "description": "Used to request that the Sled initialize multiple services.",
         "type": "object",
         "properties": {
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          },
           "services": {
             "type": "array",
             "items": {
@@ -2270,7 +2280,30 @@
           }
         },
         "required": [
+          "generation",
           "services"
+        ]
+      },
+      "ServiceEnsureResponse": {
+        "type": "object",
+        "properties": {
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ServiceEnsureStatus"
+          }
+        },
+        "required": [
+          "generation",
+          "status"
+        ]
+      },
+      "ServiceEnsureStatus": {
+        "type": "string",
+        "enum": [
+          "updated",
+          "not_updated"
         ]
       },
       "ServiceType": {

--- a/schema/all-zone-requests.json
+++ b/schema/all-zone-requests.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AllZoneRequests",
+  "description": "A wrapper around `ZoneRequest`, which allows it to be serialized to a JSON file.",
   "type": "object",
   "required": [
     "generation",

--- a/schema/all-zone-requests.json
+++ b/schema/all-zone-requests.json
@@ -720,6 +720,7 @@
       "minimum": 0.0
     },
     "ZoneRequest": {
+      "description": "The combo of \"what zone did you ask for\" + \"where did we put it\".",
       "type": "object",
       "required": [
         "root",

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -28,6 +28,7 @@ mod profile;
 pub mod rack_setup;
 pub mod server;
 mod services;
+mod services_ledger;
 mod sled_agent;
 mod smf_helper;
 pub(crate) mod storage;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -8,6 +8,7 @@ pub use crate::zone_bundle::ZoneBundleId;
 pub use crate::zone_bundle::ZoneBundleMetadata;
 pub use illumos_utils::opte::params::VpcFirewallRule;
 pub use illumos_utils::opte::params::VpcFirewallRulesEnsureBody;
+use omicron_common::api::external::Generation;
 use omicron_common::api::internal::nexus::{
     DiskRuntimeState, InstanceRuntimeState,
 };
@@ -843,7 +844,23 @@ impl TryFrom<ServiceZoneService>
 /// Used to request that the Sled initialize multiple services.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct ServiceEnsureBody {
+    pub generation: Generation,
     pub services: Vec<ServiceZoneRequest>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceEnsureStatus {
+    Updated,
+    NotUpdated,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct ServiceEnsureResponse {
+    // Returns the current generation number.
+    pub generation: Generation,
+    // Identifies whether or not this request updated the services on the sled.
+    pub status: ServiceEnsureStatus,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -300,7 +300,10 @@ impl ServiceInner {
                         continue;
                     }
                     SledAgentTypes::ServiceEnsureStatus::Updated => {
-                        return Ok::<(), BackoffError<SledAgentError<SledAgentTypes::Error>>>(());
+                        return Ok::<
+                            (),
+                            BackoffError<SledAgentError<SledAgentTypes::Error>>,
+                        >(());
                     }
                 }
             }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -296,15 +296,14 @@ impl ServiceInner {
                 match response.status {
                     SledAgentTypes::ServiceEnsureStatus::NotUpdated => {
                         generation = response.generation.clone().into();
-                        generation.next();
+                        generation = generation.next();
                         continue;
                     }
                     SledAgentTypes::ServiceEnsureStatus::Updated => {
-                        break;
+                        return Ok::<(), BackoffError<SledAgentError<SledAgentTypes::Error>>>(());
                     }
                 }
             }
-            Ok::<(), BackoffError<SledAgentError<SledAgentTypes::Error>>>(())
         };
         let log_failure = |error, delay| {
             warn!(

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -272,7 +272,7 @@ impl Config {
 // TODO: Should this be here? Could be in a different file
 #[derive(Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct AllZoneRequests {
-    generation: Generation,
+    pub generation: Generation,
     // TODO: Limit visibility
     pub requests: Vec<ZoneRequest>,
 }

--- a/sled-agent/src/services_ledger.rs
+++ b/sled-agent/src/services_ledger.rs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Durable record of "what services should be initialized on this Sled?"
+
+use crate::params::ServiceZoneRequest;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use omicron_common::api::external::Generation;
+use omicron_common::ledger::Ledgerable;
+
+/// A wrapper around `ZoneRequest`, which allows it to be serialized
+/// to a JSON file.
+#[derive(Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct AllZoneRequests {
+    generation: Generation,
+    requests: Vec<ZoneRequest>,
+}
+
+impl AllZoneRequests {
+    pub fn generation(&self) -> &Generation {
+        &self.generation
+    }
+
+    pub fn set_generation(&mut self, generation: Generation) {
+        self.generation = generation;
+    }
+
+    pub fn requests(&self) -> &Vec<ZoneRequest> {
+        &self.requests
+    }
+
+    pub fn requests_mut(&mut self) -> &mut Vec<ZoneRequest> {
+        &mut self.requests
+    }
+
+    pub fn take_requests(self) -> Vec<ZoneRequest> {
+        self.requests
+    }
+}
+
+impl Default for AllZoneRequests {
+    fn default() -> Self {
+        Self { generation: Generation::new(), requests: vec![] }
+    }
+}
+
+impl Ledgerable for AllZoneRequests {
+    fn is_newer_than(&self, other: &AllZoneRequests) -> bool {
+        self.generation >= other.generation
+    }
+
+    fn generation_bump(&mut self) {
+        self.generation = self.generation.next();
+    }
+}
+
+/// The combo of "what zone did you ask for" + "where did we put it".
+#[derive(Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct ZoneRequest {
+    zone: ServiceZoneRequest,
+    // TODO: Consider collapsing "root" into ServiceZoneRequest
+    #[schemars(with = "String")]
+    root: Utf8PathBuf,
+}
+
+impl ZoneRequest {
+    pub fn new(zone: ServiceZoneRequest, root: Utf8PathBuf) -> Self {
+        ZoneRequest { zone, root }
+    }
+
+    pub fn zone(&self) -> &ServiceZoneRequest {
+        &self.zone
+    }
+
+    pub fn root(&self) -> &Utf8Path {
+        &self.root
+    }
+}


### PR DESCRIPTION
- Adds a generation number to the Sled Agent API when asking for services
- Sled Agent uses this generation number to discard out-of-date requests
- Sled Agent also responds with the existing generation number if requests arrive that are out-of-date

This is a necessary pre-requisite to performing #732 safely.

Fixes https://github.com/oxidecomputer/omicron/issues/2977 , https://github.com/oxidecomputer/omicron/issues/2978