### PR TITLE
Contract error could be named better

### DIFF
--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -53,8 +53,8 @@ pub enum ExecutionError {
     #[error("{0}")]
     CommandFailure(Box<CommandFailureInfo>),
 
-    #[error("Failed to enter zone: {err}")]
-    ZoneEnter { err: std::io::Error },
+    #[error("Failed to manipulate process contract: {err}")]
+    ContractFailure { err: std::io::Error },
 
     #[error("Zone is not running")]
     NotRunning,


### PR DESCRIPTION
This is just a nit so feel free to ignore and close this PR.

While looking through sled-agent I noticed the contract(3contract) calls were returning a `ZoneEnter` error. It seems to make more sense to rename that error `ContractFailure` and introduce a new log line where the `zone_enter()` call actually occurs.