### PR TITLE
Bundle rotated log files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6609,7 +6609,7 @@ dependencies = [
  "indoc 2.0.3",
  "itertools 0.11.0",
  "paste",
- "strum 0.25.0",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -1026,10 +1026,12 @@ impl RunningZone {
             let path = entry.path();
 
             // Camino's Utf8Path only considers whole path components to match,
-            // so convert both paths into a String and use that object's
+            // so convert both paths into a &str and use that object's
             // starts_with. See the `camino_starts_with_behaviour` test.
+            let path_ref: &str = path.as_ref();
+            let current_log_file_ref: &str = current_log_file.as_ref();
             if path != current_log_file
-                && path.to_string().starts_with(&current_log_file.to_string())
+                && path_ref.starts_with(current_log_file_ref)
             {
                 rotated_files.push(path.clone().into());
             }
@@ -1046,8 +1048,8 @@ fn camino_starts_with_behaviour() {
     let rotated_logfile =
         Utf8PathBuf::from("/zonepath/var/svc/log/oxide-nexus:default.log.0");
 
-    let logfile_as_string = logfile.to_string();
-    let rotated_logfile_as_string = rotated_logfile.to_string();
+    let logfile_as_string: &str = logfile.as_ref();
+    let rotated_logfile_as_string: &str = rotated_logfile.as_ref();
 
     assert!(logfile != rotated_logfile);
     assert!(logfile_as_string != rotated_logfile_as_string);


### PR DESCRIPTION
Camino's Utf8Path only considers whole path components to match, and this was causing the zone bundle tool to miss rotated logfiles. Convert the paths into Strings, then use those object's `starts_with` instead.