### PR TITLE
flesh out `omdb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5007,6 +5007,7 @@ dependencies = [
  "nexus-client 0.1.0",
  "nexus-db-model",
  "nexus-db-queries",
+ "nexus-types",
  "omicron-common 0.1.0",
  "omicron-rpaths",
  "pq-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5010,6 +5010,7 @@ dependencies = [
  "omicron-common 0.1.0",
  "omicron-rpaths",
  "pq-sys",
+ "serde",
  "serde_json",
  "slog",
  "strum",
@@ -6617,7 +6618,7 @@ dependencies = [
  "indoc 2.0.3",
  "itertools 0.11.0",
  "paste",
- "strum 0.25.0",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,8 +5000,10 @@ name = "omicron-omdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-bb8-diesel",
  "chrono",
  "clap 4.4.2",
+ "diesel",
  "dropshot",
  "humantime",
  "nexus-client 0.1.0",

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -652,6 +652,12 @@ impl From<&Generation> for i64 {
     }
 }
 
+impl From<u32> for Generation {
+    fn from(value: u32) -> Self {
+        Generation(u64::from(value))
+    }
+}
+
 impl TryFrom<i64> for Generation {
     type Error = anyhow::Error;
 

--- a/nexus/db-queries/src/db/datastore/dns.rs
+++ b/nexus/db-queries/src/db/datastore/dns.rs
@@ -149,7 +149,7 @@ impl DataStore {
 
     /// List all DNS names in the given DNS zone at the given group version
     /// (paginated)
-    async fn dns_names_list(
+    pub async fn dns_names_list(
         &self,
         opctx: &OpContext,
         dns_zone_id: Uuid,

--- a/nexus/db-queries/src/db/datastore/dns.rs
+++ b/nexus/db-queries/src/db/datastore/dns.rs
@@ -873,7 +873,7 @@ mod test {
                 NonZeroU32::new(1).unwrap(),
                 &DnsVersion {
                     dns_group: DnsGroup::Internal,
-                    version: Generation(1.try_into().unwrap()),
+                    version: Generation(1u32.try_into().unwrap()),
                     time_created: dns_config.time_created,
                     creator: "unused".to_string(),
                     comment: "unused".to_string(),
@@ -938,9 +938,9 @@ mod test {
         let z2_id = Uuid::new_v4();
         let z3_id = Uuid::new_v4();
         let zinternal_id = Uuid::new_v4();
-        let g1 = Generation(1.try_into().unwrap());
-        let g2 = Generation(2.try_into().unwrap());
-        let g3 = Generation(3.try_into().unwrap());
+        let g1 = Generation(1u32.try_into().unwrap());
+        let g2 = Generation(2u32.try_into().unwrap());
+        let g3 = Generation(3u32.try_into().unwrap());
         let v1 = DnsVersion {
             dns_group: DnsGroup::External,
             version: g1,
@@ -1320,8 +1320,8 @@ mod test {
             use crate::db::schema::dns_name::dsl;
             let dns_zone_id = Uuid::new_v4();
             let name = "n1".to_string();
-            let g1 = Generation(1.try_into().unwrap());
-            let g2 = Generation(2.try_into().unwrap());
+            let g1 = Generation(1u32.try_into().unwrap());
+            let g2 = Generation(2u32.try_into().unwrap());
             let r1 = DnsRecord::Aaaa("fe80::1:2:3:4".parse().unwrap());
             let r2 = DnsRecord::Aaaa("fe80::1:1:1:1".parse().unwrap());
 

--- a/nexus/src/app/background/common.rs
+++ b/nexus/src/app/background/common.rs
@@ -283,6 +283,8 @@ impl Driver {
         self.tasks.keys()
     }
 
+    // XXX-dap helper function
+
     /// Returns a summary of what this task does (for developers)
     pub fn task_description(&self, task: &TaskHandle) -> &str {
         // It should be hard to hit this in practice, since you'd have to have

--- a/nexus/src/app/background/dns_propagation.rs
+++ b/nexus/src/app/background/dns_propagation.rs
@@ -190,7 +190,9 @@ mod test {
     use httptest::Expectation;
     use nexus_db_queries::context::OpContext;
     use nexus_test_utils_macros::nexus_test;
+    use serde::Deserialize;
     use serde_json::json;
+    use std::collections::BTreeMap;
     use tokio::sync::watch;
 
     type ControlPlaneTestContext =
@@ -228,10 +230,19 @@ mod test {
         let value = task.activate(&opctx).await;
         assert_eq!(value, json!({ "error": "no config" }));
 
+        // Define a type we can use to pick stuff out of error objects.
+        #[derive(Deserialize)]
+        struct ServerResult {
+            server_results: BTreeMap<String, Result<(), String>>,
+            generation: u32,
+        }
+
         // With a config and no servers, the operation should be a noop.
         config_tx.send(Some(dns_config)).unwrap();
         let value = task.activate(&opctx).await;
-        assert_eq!(value, json!([]));
+        let result: ServerResult = serde_json::from_value(value).unwrap();
+        assert_eq!(result.generation, 1);
+        assert!(result.server_results.is_empty());
 
         // Now, create some fake servers ready to respond successfully to a
         // propagation attempt.
@@ -251,16 +262,12 @@ mod test {
             );
         }
 
-        // Define a type we can use to pick stuff out of error objects.
-        type ServerResult = Vec<Result<(), String>>;
-
         // Do it!
         let value = task.activate(&opctx).await;
         // Check the results.
         let result: ServerResult = serde_json::from_value(value).unwrap();
-        assert_eq!(result.len(), 2);
-        assert!(result[0].is_ok());
-        assert!(result[1].is_ok());
+        assert_eq!(result.server_results.len(), 2);
+        assert!(result.server_results.values().all(|r| r.is_ok()));
         s1.verify_and_clear();
         s2.verify_and_clear();
 
@@ -275,9 +282,8 @@ mod test {
 
         let value = task.activate(&opctx).await;
         let result: ServerResult = serde_json::from_value(value).unwrap();
-        assert_eq!(result.len(), 2);
-        assert!(result[0].is_ok());
-        assert!(result[1].is_ok());
+        assert_eq!(result.server_results.len(), 2);
+        assert!(result.server_results.values().all(|r| r.is_ok()));
         s1.verify_and_clear();
         s2.verify_and_clear();
 
@@ -295,10 +301,16 @@ mod test {
         let value = task.activate(&opctx).await;
         println!("{:?}", value);
         let result: ServerResult = serde_json::from_value(value).unwrap();
-        assert_eq!(result.len(), 2);
-        assert!(result[0].is_ok());
-        assert!(result[1].is_err());
-        assert!(result[1].as_ref().unwrap_err().starts_with(&format!(
+        assert_eq!(result.server_results.len(), 2);
+        assert!(result.server_results.values().any(|r| r.is_ok()));
+        let message = result
+            .server_results
+            .values()
+            .find(|r| r.is_err())
+            .cloned()
+            .unwrap()
+            .unwrap_err();
+        assert!(message.starts_with(&format!(
             "failed to propagate DNS generation 1 to server {}",
             s2.addr()
         )));
@@ -316,9 +328,8 @@ mod test {
 
         let value = task.activate(&opctx).await;
         let result: ServerResult = serde_json::from_value(value).unwrap();
-        assert_eq!(result.len(), 2);
-        assert!(result[0].is_ok());
-        assert!(result[1].is_ok());
+        assert_eq!(result.server_results.len(), 2);
+        assert!(result.server_results.values().all(|r| r.is_ok()));
         s1.verify_and_clear();
         s2.verify_and_clear();
     }

--- a/nexus/src/app/background/dns_propagation.rs
+++ b/nexus/src/app/background/dns_propagation.rs
@@ -110,7 +110,7 @@ impl BackgroundTask for DnsPropagator {
                 info!(&log, "DNS propagation: done");
             }
 
-            serde_json::to_value(
+            let server_results = serde_json::to_value(
                 result
                     .into_iter()
                     .map(|(e, r)| (e, r.map_err(|e| format!("{:#}", e))))
@@ -121,6 +121,11 @@ impl BackgroundTask for DnsPropagator {
                     "error":
                         format!("failed to serialize final value: {:#}", error)
                 })
+            });
+
+            json!({
+                "generation": dns_config.generation,
+                "server_results": server_results,
             })
         }
         .boxed()

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -380,7 +380,7 @@ pub mod test {
                         diesel::insert_into(dsl::dns_version)
                             .values(DnsVersion {
                                 dns_group: DnsGroup::Internal,
-                                version: Generation(2.try_into().unwrap()),
+                                version: Generation(2u32.try_into().unwrap()),
                                 time_created: chrono::Utc::now(),
                                 creator: String::from("test suite"),
                                 comment: String::from("test suite"),
@@ -399,7 +399,7 @@ pub mod test {
                                 DnsName::new(
                                     internal_dns_zone_id,
                                     String::from("we-got-beets"),
-                                    Generation(2.try_into().unwrap()),
+                                    Generation(2u32.try_into().unwrap()),
                                     None,
                                     vec![nexus_params::DnsRecord::Aaaa(
                                         "fe80::3".parse().unwrap(),

--- a/nexus/src/app/background/status.rs
+++ b/nexus/src/app/background/status.rs
@@ -26,10 +26,11 @@ impl Nexus {
             .map(|t| {
                 let name = t.name();
                 let description = driver.task_description(t);
+                let period = driver.task_period(t);
                 let status = driver.task_status(t);
                 (
                     name.to_owned(),
-                    BackgroundTask::new(name, description, status),
+                    BackgroundTask::new(name, description, period, status),
                 )
             })
             .collect())
@@ -49,6 +50,7 @@ impl Nexus {
             })?;
         let description = driver.task_description(task);
         let status = driver.task_status(task);
-        Ok(BackgroundTask::new(task.name(), description, status))
+        let period = driver.task_period(task);
+        Ok(BackgroundTask::new(task.name(), description, period, status))
     }
 }

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -73,6 +73,7 @@ use uuid::Uuid;
 pub struct ExternalEndpoints {
     by_dns_name: BTreeMap<String, Arc<ExternalEndpoint>>,
     warnings: Vec<ExternalEndpointError>,
+    // XXX-dap should serialize some other way?
     default_endpoint: Option<Arc<ExternalEndpoint>>,
 }
 

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -73,7 +73,6 @@ use uuid::Uuid;
 pub struct ExternalEndpoints {
     by_dns_name: BTreeMap<String, Arc<ExternalEndpoint>>,
     warnings: Vec<ExternalEndpointError>,
-    // XXX-dap should serialize some other way?
     default_endpoint: Option<Arc<ExternalEndpoint>>,
 }
 

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -161,7 +161,7 @@ impl super::Nexus {
             .collect();
         let mut dns_update = DnsVersionUpdateBuilder::new(
             DnsGroup::External,
-            format!("create silo: {:?}", silo_name),
+            format!("create silo: {:?}", silo_name.as_str()),
             self.id.to_string(),
         );
         dns_update.add_name(silo_dns_name(silo_name), dns_records)?;

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -92,7 +92,7 @@ impl super::Nexus {
         let silo_name = &new_silo_params.identity.name;
         let mut dns_update = DnsVersionUpdateBuilder::new(
             DnsGroup::External,
-            format!("create silo: {:?}", silo_name),
+            format!("create silo: {:?}", silo_name.as_str()),
             self.id.to_string(),
         );
         dns_update.add_name(silo_dns_name(silo_name), dns_records)?;

--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -159,6 +159,11 @@ pub struct BackgroundTask {
     name: String,
     /// brief summary (for developers) of what this task does
     description: String,
+    /// how long after an activation completes before another will be triggered
+    /// automatically
+    ///
+    /// (activations can also be triggered for other reasons)
+    period: Duration,
 
     #[serde(flatten)]
     status: TaskStatus,
@@ -168,11 +173,13 @@ impl BackgroundTask {
     pub fn new(
         name: &str,
         description: &str,
+        period: Duration,
         status: TaskStatus,
     ) -> BackgroundTask {
         BackgroundTask {
             name: name.to_owned(),
             description: description.to_owned(),
+            period,
             status,
         }
     }

--- a/omdb/Cargo.toml
+++ b/omdb/Cargo.toml
@@ -9,8 +9,10 @@ omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-bb8-diesel.workspace = true
 chrono.workspace = true
 clap.workspace = true
+diesel.workspace = true
 dropshot.workspace = true
 humantime.workspace = true
 nexus-client.workspace = true

--- a/omdb/Cargo.toml
+++ b/omdb/Cargo.toml
@@ -19,6 +19,7 @@ nexus-db-queries.workspace = true
 omicron-common.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
+serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
 strum.workspace = true

--- a/omdb/Cargo.toml
+++ b/omdb/Cargo.toml
@@ -16,6 +16,7 @@ humantime.workspace = true
 nexus-client.workspace = true
 nexus-db-model.workspace = true
 nexus-db-queries.workspace = true
+nexus-types.workspace = true
 omicron-common.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"

--- a/omdb/src/bin/omdb/db.rs
+++ b/omdb/src/bin/omdb/db.rs
@@ -505,6 +505,8 @@ async fn cmd_db_dns_names(
     // There will almost never be more than one zone.  But just in case, we'll
     // iterate over whatever we find and print all the names in each one.
     let version = Generation::try_from(i64::from(args.version)).unwrap();
+    // XXX-dap if we give a later version, we get the latest version!  maybe
+    // fetch version first?
     for zone in group_zones {
         println!("{} zone: {}", group, zone.zone_name);
         println!("  {:50} {}", "NAME", "RECORDS");

--- a/omdb/src/bin/omdb/db.rs
+++ b/omdb/src/bin/omdb/db.rs
@@ -3,6 +3,14 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! omdb commands that query or update the database
+//!
+//! GROUND RULES: There aren't many ground rules (see top-level docs).  But
+//! where possible, stick to operations provided by `DataStore` rather than
+//! querying the database directly.  The DataStore operations generally provide
+//! a safer level of abstraction.  But there are cases where we want to do
+//! things that really don't need to be in the DataStore -- i.e., where `omdb`
+//! would be the only consumer -- and in that case it's okay to query the
+//! database directly.
 
 use anyhow::anyhow;
 use anyhow::bail;
@@ -435,7 +443,6 @@ async fn cmd_db_sleds(
 }
 
 // DNS
-// XXX-dap add "history" command?
 
 /// Run `omdb db dns show`.
 async fn cmd_db_dns_show(

--- a/omdb/src/bin/omdb/main.rs
+++ b/omdb/src/bin/omdb/main.rs
@@ -3,6 +3,21 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! CLI for debugging Omicron internal state
+//!
+//! GROUND RULES:
+//!
+//! 1. There aren't a lot of ground rules here.  At least for now, this is a
+//!    place to put any kind of runtime tooling for Omicron that seems useful.
+//!    You can query the database directly (see notes in db.rs), use internal
+//!    APIs, etc.  To the degree that we can stick to stable interfaces, great.
+//!    But at this stage we'd rather have tools that work on latest than not
+//!    have them because we couldn't prioritize keeping them stable.
+//!
+//! 2. Where possible, when the tool encounters something unexpected, it should
+//!    print what it can (including the error message and bad data) and then
+//!    continue.  It generally shouldn't stop on the first error.  (We often
+//!    find strange things when debugging but we need our tools to tell us as
+//!    much as they can!)
 
 use anyhow::Context;
 use clap::Parser;

--- a/omdb/src/bin/omdb/nexus.rs
+++ b/omdb/src/bin/omdb/nexus.rs
@@ -248,8 +248,8 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
         match serde_json::from_value::<DnsConfigSuccess>(details.clone()) {
             Err(error) => eprintln!(
-                "warning: failed to interpret task details: {:?}",
-                error
+                "warning: failed to interpret task details: {:?}: {:?}",
+                error, details
             ),
             Ok(found_dns_config) => println!(
                 "    last generation found: {}",
@@ -265,8 +265,8 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
         match serde_json::from_value::<DnsServersSuccess>(details.clone()) {
             Err(error) => eprintln!(
-                "warning: failed to interpret task details: {:?}",
-                error
+                "warning: failed to interpret task details: {:?}: {:?}",
+                error, details
             ),
             Ok(found_dns_servers) => {
                 println!(
@@ -318,8 +318,8 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
         match serde_json::from_value::<DnsPropSuccess>(details.clone()) {
             Err(error) => eprintln!(
-                "warning: failed to interpret task details: {:?}",
-                error
+                "warning: failed to interpret task details: {:?}: {:?}",
+                error, details
             ),
             Ok(details) => {
                 println!(
@@ -403,8 +403,8 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
         match serde_json::from_value::<EndpointsFound>(details.clone()) {
             Err(error) => eprintln!(
-                "warning: failed to interpret task details: {:?}",
-                error
+                "warning: failed to interpret task details: {:?}: {:?}",
+                error, details
             ),
             Ok(details) => {
                 println!(

--- a/omdb/src/bin/omdb/nexus.rs
+++ b/omdb/src/bin/omdb/nexus.rs
@@ -300,7 +300,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                             dns_server_addr: addr,
                             last_result: match result {
                                 Ok(_) => "success".to_string(),
-                                Err(error) => format!("error: {}", error),
+                                Err(_) => format!("error (see below)"),
                             },
                         }
                     });
@@ -313,6 +313,18 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                         "{}",
                         textwrap::indent(&table.to_string(), "    ")
                     );
+                }
+
+                println!("");
+                for (addr, error) in
+                    server_results.iter().filter_map(|(addr, result)| {
+                        match result {
+                            Ok(_) => None,
+                            Err(error) => Some((addr, error)),
+                        }
+                    })
+                {
+                    println!("    error: server {}: {}", addr, error);
                 }
             }
         };

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -728,13 +728,22 @@
           "name": {
             "description": "unique identifier for this background task",
             "type": "string"
+          },
+          "period": {
+            "description": "how long after an activation completes before another will be triggered automatically\n\n(activations can also be triggered for other reasons)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
           }
         },
         "required": [
           "current",
           "description",
           "last",
-          "name"
+          "name",
+          "period"
         ]
       },
       "Baseboard": {


### PR DESCRIPTION
This PR has a bunch of small improvements to omdb:

* `omdb nexus background-tasks`:
    * prints the configured period
    * propagation task: shows per-server propagation results
    * lots of little display improvements
* adds `omdb db dns` (subcommands for `show`, `diff`, and `names`)
* adds support for configuring URLs through the environment
* adds some (very rough) guidance for people wanting to add stuff (in the form of some module-level comments)