### PR TITLE
Add hostname validation to certs uploaded to nexus

### DIFF
--- a/certificates/src/lib.rs
+++ b/certificates/src/lib.rs
@@ -39,7 +39,7 @@ pub enum CertificateError {
     #[error("Error validating certificate hostname")]
     ErrorValidatingHostname(#[source] openssl::error::ErrorStack),
 
-    #[error("Certificate not valid for {hostname:?}: {cert_description}")]
+    #[error("Certificate not valid for given hostnames {hostname:?}: {cert_description}")]
     NoDnsNameMatchingHostname { hostname: String, cert_description: String },
 
     #[error("Unsupported certificate purpose (not usable for server auth)")]
@@ -106,7 +106,7 @@ impl CertificateValidator {
     ///
     /// If `possible_hostnames` is empty, no hostname validation is performed.
     /// If `possible_hostnames` is not empty, we require _at least one_ of its
-    /// hostnames to match the SANs (or CN, of no SANs are present) of the leaf
+    /// hostnames to match the SANs (or CN, if no SANs are present) of the leaf
     /// certificate.
     pub fn validate<S: Borrow<str>>(
         &self,

--- a/certificates/src/lib.rs
+++ b/certificates/src/lib.rs
@@ -39,7 +39,7 @@ pub enum CertificateError {
     #[error("Error validating certificate hostname")]
     ErrorValidatingHostname(#[source] openssl::error::ErrorStack),
 
-    #[error("Certificate not valid for {hostname:?}: {cert_description:?}")]
+    #[error("Certificate not valid for {hostname:?}: {cert_description}")]
     NoDnsNameMatchingHostname { hostname: String, cert_description: String },
 
     #[error("Unsupported certificate purpose (not usable for server auth)")]

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -53,7 +53,7 @@ impl Certificate {
             params.key.as_bytes(),
             // TODO-correctness: We should pass a hostname here for cert
             // validation: https://github.com/oxidecomputer/omicron/issues/4045
-            None,
+            &[] as &[&str],
         )?;
 
         Ok(Self::new_unvalidated(silo_id, id, service, params))

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -45,15 +45,14 @@ impl Certificate {
         id: Uuid,
         service: ServiceKind,
         params: params::CertificateCreate,
+        possible_dns_names: &[String],
     ) -> Result<Self, CertificateError> {
         let validator = CertificateValidator::default();
 
         validator.validate(
             params.cert.as_bytes(),
             params.key.as_bytes(),
-            // TODO-correctness: We should pass a hostname here for cert
-            // validation: https://github.com/oxidecomputer/omicron/issues/4045
-            &[] as &[&str],
+            possible_dns_names,
         )?;
 
         Ok(Self::new_unvalidated(silo_id, id, service, params))

--- a/nexus/db-queries/src/db/datastore/dns.rs
+++ b/nexus/db-queries/src/db/datastore/dns.rs
@@ -407,7 +407,7 @@ impl DataStore {
     /// **Callers almost certainly want to wake up the corresponding Nexus
     /// background task to cause these changes to be propagated to the
     /// corresponding DNS servers.**
-    pub(crate) async fn dns_update<ConnErr>(
+    pub async fn dns_update<ConnErr>(
         &self,
         opctx: &OpContext,
         conn: &(impl async_bb8_diesel::AsyncConnection<

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -721,6 +721,10 @@ mod test {
                     tls_certificates: vec![],
                     mapped_fleet_roles: Default::default(),
                 },
+                recovery_silo_fq_dns_name: format!(
+                    "test-silo.sys.{}",
+                    internal_dns::DNS_ZONE
+                ),
                 recovery_user_id: "test-user".parse().unwrap(),
                 // empty string password
                 recovery_user_password_hash: "$argon2id$v=19$m=98304,t=13,\

--- a/nexus/db-queries/src/db/datastore/silo.rs
+++ b/nexus/db-queries/src/db/datastore/silo.rs
@@ -123,6 +123,7 @@ impl DataStore {
         opctx: &OpContext,
         nexus_opctx: &OpContext,
         new_silo_params: params::SiloCreate,
+        new_silo_dns_names: &[String],
         dns_update: DnsVersionUpdateBuilder,
     ) -> CreateResult<Silo> {
         let conn = self.pool_authorized(opctx).await?;
@@ -131,6 +132,7 @@ impl DataStore {
             opctx,
             nexus_opctx,
             new_silo_params,
+            new_silo_dns_names,
             dns_update,
         )
         .await
@@ -143,6 +145,7 @@ impl DataStore {
         opctx: &OpContext,
         nexus_opctx: &OpContext,
         new_silo_params: params::SiloCreate,
+        new_silo_dns_names: &[String],
         dns_update: DnsVersionUpdateBuilder,
     ) -> CreateResult<Silo>
     where
@@ -253,6 +256,7 @@ impl DataStore {
                         Uuid::new_v4(),
                         ServiceKind::Nexus,
                         c,
+                        new_silo_dns_names,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()

--- a/nexus/src/app/certificate.rs
+++ b/nexus/src/app/certificate.rs
@@ -4,7 +4,6 @@
 
 //! x.509 Certificates
 
-use super::silo::silo_dns_name;
 use crate::external_api::params;
 use crate::external_api::shared;
 use nexus_db_queries::authz;
@@ -14,7 +13,6 @@ use nexus_db_queries::db::lookup;
 use nexus_db_queries::db::lookup::LookupPath;
 use nexus_db_queries::db::model::Name;
 use nexus_db_queries::db::model::ServiceKind;
-use nexus_types::identity::Resource;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DeleteResult;
@@ -76,25 +74,6 @@ impl super::Nexus {
                 Ok(cert)
             }
         }
-    }
-
-    async fn silo_fq_dns_names(
-        &self,
-        opctx: &OpContext,
-        silo_id: Uuid,
-    ) -> ListResultVec<String> {
-        let (_, silo) =
-            self.silo_lookup(opctx, silo_id.into())?.fetch().await?;
-        let silo_dns_name = silo_dns_name(&silo.name());
-        let external_dns_zones = self
-            .db_datastore
-            .dns_zones_list_all(opctx, nexus_db_model::DnsGroup::External)
-            .await?;
-
-        Ok(external_dns_zones
-            .into_iter()
-            .map(|zone| format!("{silo_dns_name}.{}", zone.zone_name))
-            .collect())
     }
 
     pub(crate) async fn certificates_list(

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -933,6 +933,7 @@ mod test {
             Uuid::new_v4(),
             ServiceKind::Nexus,
             cert_create,
+            &["dummy.sys.oxide1.test".to_string()],
         )
         .unwrap();
         let ee2 = ExternalEndpoints::new(vec![], vec![cert], vec![]);
@@ -962,6 +963,7 @@ mod test {
             Uuid::new_v4(),
             ServiceKind::Nexus,
             cert_create,
+            &["dummy.sys.oxide1.test".to_string()],
         )
         .unwrap();
 
@@ -1095,6 +1097,7 @@ mod test {
             Uuid::new_v4(),
             ServiceKind::Nexus,
             silo1_cert1_params,
+            &["silo1.sys.oxide1.test".to_string()],
         )
         .unwrap();
         let silo1_cert2_params =
@@ -1120,6 +1123,7 @@ mod test {
             Uuid::new_v4(),
             ServiceKind::Nexus,
             silo2_cert2_params,
+            &["silo2.sys.oxide1.test".to_string()],
         )
         .unwrap();
         let silo3_cert_params =
@@ -1129,6 +1133,7 @@ mod test {
             Uuid::new_v4(),
             ServiceKind::Nexus,
             silo3_cert_params,
+            &["silo3.sys.oxide1.test".to_string()],
         )
         .unwrap();
         // Corrupt a byte of this last certificate.  (This has to be done after

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -164,7 +164,10 @@ impl super::Nexus {
             format!("create silo: {:?}", silo_name),
             self.id.to_string(),
         );
-        dns_update.add_name(silo_dns_name(silo_name), dns_records)?;
+        let silo_dns_name = silo_dns_name(silo_name);
+        let recovery_silo_fq_dns_name =
+            format!("{silo_dns_name}.{}", request.external_dns_zone_name);
+        dns_update.add_name(silo_dns_name, dns_records)?;
 
         // Administrators of the Recovery Silo are automatically made
         // administrators of the Fleet.
@@ -196,6 +199,7 @@ impl super::Nexus {
                     internal_dns,
                     external_dns,
                     recovery_silo,
+                    recovery_silo_fq_dns_name,
                     recovery_user_id: request.recovery_silo.user_name,
                     recovery_user_password_hash: request
                         .recovery_silo

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -79,9 +79,9 @@ impl super::Nexus {
 
         // Set up an external DNS name for this Silo's API and console
         // endpoints (which are the same endpoint).
-        let dns_records: Vec<DnsRecord> = datastore
-            .nexus_external_addresses(nexus_opctx)
-            .await?
+        let (nexus_external_ips, nexus_external_dns_zones) =
+            datastore.nexus_external_addresses(nexus_opctx).await?;
+        let dns_records: Vec<DnsRecord> = nexus_external_ips
             .into_iter()
             .map(|addr| match addr {
                 IpAddr::V4(addr) => DnsRecord::A(addr),
@@ -95,10 +95,22 @@ impl super::Nexus {
             format!("create silo: {:?}", silo_name),
             self.id.to_string(),
         );
-        dns_update.add_name(silo_dns_name(silo_name), dns_records)?;
+        let silo_dns_name = silo_dns_name(silo_name);
+        let new_silo_dns_names = nexus_external_dns_zones
+            .into_iter()
+            .map(|zone| format!("{silo_dns_name}.{}", zone.zone_name))
+            .collect::<Vec<_>>();
+
+        dns_update.add_name(silo_dns_name, dns_records)?;
 
         let silo = datastore
-            .silo_create(&opctx, &nexus_opctx, new_silo_params, dns_update)
+            .silo_create(
+                &opctx,
+                &nexus_opctx,
+                new_silo_params,
+                &new_silo_dns_names,
+                dns_update,
+            )
             .await?;
         self.background_tasks
             .activate(&self.background_tasks.task_external_dns_config);

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -65,6 +65,25 @@ impl super::Nexus {
         }
     }
 
+    pub(crate) async fn silo_fq_dns_names(
+        &self,
+        opctx: &OpContext,
+        silo_id: Uuid,
+    ) -> ListResultVec<String> {
+        let (_, silo) =
+            self.silo_lookup(opctx, silo_id.into())?.fetch().await?;
+        let silo_dns_name = silo_dns_name(&silo.name());
+        let external_dns_zones = self
+            .db_datastore
+            .dns_zones_list_all(opctx, nexus_db_model::DnsGroup::External)
+            .await?;
+
+        Ok(external_dns_zones
+            .into_iter()
+            .map(|zone| format!("{silo_dns_name}.{}", zone.zone_name))
+            .collect())
+    }
+
     pub(crate) async fn silo_create(
         &self,
         opctx: &OpContext,

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -93,6 +93,10 @@ pub struct ControlPlaneTestContext<N> {
 }
 
 impl<N: NexusServer> ControlPlaneTestContext<N> {
+    pub fn wildcard_silo_dns_name(&self) -> String {
+        format!("*.sys.{}", self.external_dns_zone_name)
+    }
+
     pub async fn teardown(mut self) {
         self.server.close().await;
         self.database.cleanup().await.unwrap();

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -334,7 +334,8 @@ lazy_static! {
     pub static ref DEMO_CERTIFICATES_URL: String = format!("/v1/certificates");
     pub static ref DEMO_CERTIFICATE_URL: String =
         format!("/v1/certificates/demo-certificate");
-    pub static ref DEMO_CERTIFICATE: CertificateChain = CertificateChain::new();
+    pub static ref DEMO_CERTIFICATE: CertificateChain =
+        CertificateChain::new("localhost");
     pub static ref DEMO_CERTIFICATE_CREATE: params::CertificateCreate =
         params::CertificateCreate {
             identity: IdentityMetadataCreateParams {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -10,6 +10,7 @@
 use crate::integration_tests::unauthorized::HTTP_SERVER;
 use chrono::Utc;
 use http::method::Method;
+use internal_dns::names::DNS_ZONE_EXTERNAL_TESTING;
 use lazy_static::lazy_static;
 use nexus_db_queries::authn;
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
@@ -335,7 +336,7 @@ lazy_static! {
     pub static ref DEMO_CERTIFICATE_URL: String =
         format!("/v1/certificates/demo-certificate");
     pub static ref DEMO_CERTIFICATE: CertificateChain =
-        CertificateChain::new("localhost");
+        CertificateChain::new(format!("*.sys.{DNS_ZONE_EXTERNAL_TESTING}"));
     pub static ref DEMO_CERTIFICATE_CREATE: params::CertificateCreate =
         params::CertificateCreate {
             identity: IdentityMetadataCreateParams {

--- a/test-utils/src/certificates.rs
+++ b/test-utils/src/certificates.rs
@@ -13,8 +13,9 @@ pub struct CertificateChain {
 }
 
 impl CertificateChain {
-    pub fn new() -> Self {
-        let params = rcgen::CertificateParams::new(vec!["localhost".into()]);
+    pub fn new<S: Into<String>>(subject_alt_name: S) -> Self {
+        let params =
+            rcgen::CertificateParams::new(vec![subject_alt_name.into()]);
         Self::with_params(params)
     }
 

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -556,10 +556,14 @@ impl CertificateValidator {
     }
 
     fn validate(&self, cert: &str, key: &str) -> Result<(), CertificateError> {
-        self.inner.validate(
-            cert.as_bytes(),
-            key.as_bytes(),
-            self.silo_dns_name.as_deref(),
-        )
+        // Cert validation accepts multiple possible silo DNS names, but at rack
+        // setup time we only have one. Stuff it into a Vec.
+        let silo_dns_names =
+            if let Some(silo_dns_name) = self.silo_dns_name.as_deref() {
+                vec![silo_dns_name]
+            } else {
+                vec![]
+            };
+        self.inner.validate(cert.as_bytes(), key.as_bytes(), &silo_dns_names)
     }
 }


### PR DESCRIPTION
This PR changes the `CertificateValidator` from taking "0 or 1" hostname to validate to taking a list of hostnames, and the cert passes validation if _any_ hostname from the list matches. This is to support a future world where we support adding and removing external DNS zone names, where an operator might perform an operation like:

1. The rack has an external name of `myrack.oxide.computer`, and every silo has a `$SILO.sys.myrack.oxide.computer` cert
2. Add a new external name of `something-else.oxide.computer`
3. Upload new certs to all silos with SAN `$SILO.sys.something-else.oxide.computer`
4. Remove the external name `myrack.oxide.computer`

To be clear this is a hypothetical world, because today we don't support modifying the external DNS name at all. But step 3 from this sequence is the argument for why the validation logic is "any of the hostnames" instead of "all of the hostnames": we want to add certs for the new hostname (that don't need to also work for the old hostname we're about to remove).

The check is performed three places:

1. When the recovery silo is created (which is maybe wrong? I could see an argument for omitting this check, although since wicket is also performing it it should certainly pass)
2. When any other silo is created
3. When a cert is uploaded to an existing silo

In all cases we build the list of hostnames for the validator by combining the list of external DNS zone names (which is currently always length 1) with the silo's `.sys` prefix. For the recovery silo specifically we build the list of length 1 by hand; for other silos and when adding to an existing silo, we query CRDB for all external DNS zone names.

I haven't yet deployed this to a full system and want to do that before merging, but this passes tests and we're about to have a busy week, so I wanted to go ahead and open it as an easy way to keep it on the radar.

Fixes #4045.