### PR TITLE
ntp: ensure output makes it to /var/svc/log

### DIFF
--- a/smf/ntp/method/svc-site-ntp
+++ b/smf/ntp/method/svc-site-ntp
@@ -75,7 +75,7 @@ function generate_config_file {
 
 function start_daemon {
 	echo "* Starting daemon"
-	/usr/sbin/chronyd -f "$file"
+	/usr/sbin/chronyd -d -f "$file" &
 }
 
 function stop_daemon {


### PR DESCRIPTION
Adds the `-d` option to chronyd:

> When run in this mode, the program will not detach itself from the terminal, and all messages will be written to the terminal instead of syslog. If chronyd was compiled with enabled support for debugging, this option can be used twice to enable debug messages.

These messages are not ending up anywhere currently, and with this change we can see chrony's logic a little more clearly:

```
$ sudo cat $(sudo svcs -z oxz_ntp_eb18dcf0-4036-429e-986d-cb413922122f -L ntp)
[ Sep 19 03:25:21 Disabled. ]
[ Sep 19 03:25:21 Rereading configuration. ]
[ Sep 19 03:25:23 Rereading configuration. ]
[ Sep 19 03:25:29 Rereading configuration. ]
[ Sep 19 03:25:29 Enabled. ]
[ Sep 19 03:25:29 Executing start method ("/var/svc/method/svc-site-ntp start"). ]
NTP Service Configuration
-------------------------
 Servers: 0.pool.ntp.org
   Allow: fd00:1122:3344:100::/56
Boundary: true
Template: /etc/inet/chrony.conf.boundary
  Config: /etc/inet/chrony.conf
* Updating logadm
* Starting daemon
2023-09-19T03:25:30Z chronyd version 4.3 starting (+CMDMON +NTP +REFCLOCK -RTC +PRIVDROP -SCFILTER +SIGND +ASYNCDNS -NTS +SECHASH +IPV6 -DEBUG)
[ Sep 19 03:25:30 Method "start" exited with status 0. ]
2023-09-19T03:25:30Z Initial frequency 16.808 ppm
2023-09-19T03:25:35Z Selected source 104.131.155.175 (0.pool.ntp.org)
2023-09-19T03:25:36Z Selected source 69.89.207.99 (0.pool.ntp.org)
2023-09-19T03:26:41Z Selected source 99.119.214.210 (0.pool.ntp.org)
```

While not displayed in this particular log because my system time was already reasonable, I've noticed on an unrelated system without an RTC (a Raspberry Pi) that chronyd reports in this same way information on the system initial offset and whether it stepped the clock instead of slewing it.