### PR TITLE
Clean up some shellcheck errors and warnings

### DIFF
--- a/tools/build-global-zone-packages.sh
+++ b/tools/build-global-zone-packages.sh
@@ -5,20 +5,20 @@ set -eux
 TOOLS_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Use the default "out" dir in omicron to find the needed packages if one isn't given
-tarball_src_dir="$(readlink -f ${1:-"$TOOLS_DIR/../out"})"
+tarball_src_dir="$(readlink -f "${1:-"$TOOLS_DIR/../out"}")"
 # Stash the final tgz in the given src dir if a different target isn't given
-out_dir="$(readlink -f ${2:-$tarball_src_dir})"
+out_dir="$(readlink -f "${2:-"$tarball_src_dir"}")"
 
 # Make sure needed packages exist
 deps=(
-    $tarball_src_dir/omicron-sled-agent.tar
-    $tarball_src_dir/maghemite.tar
-    $tarball_src_dir/propolis-server.tar.gz
-    $tarball_src_dir/overlay.tar.gz
+    "$tarball_src_dir/omicron-sled-agent.tar"
+    "$tarball_src_dir/maghemite.tar"
+    "$tarball_src_dir/propolis-server.tar.gz"
+    "$tarball_src_dir/overlay.tar.gz"
 )
-for dep in ${deps[@]}; do
+for dep in "${deps[@]}"; do
     if [[ ! -e $dep ]]; then
-        echo "Missing Global Zone dep: $(basename $dep)"
+        echo "Missing Global Zone dep: $(basename "$dep")"
         exit 1
     fi
 done
@@ -57,4 +57,4 @@ cp "$tarball_src_dir/propolis-server.tar.gz" "$tmp_gz/root/opt/oxide"
 cp "$tarball_src_dir/overlay.tar.gz" "$tmp_gz/root/opt/oxide"
 
 # Create the final output and we're done
-cd "$tmp_gz" && tar cvfz $out_dir/global-zone-packages.tar.gz oxide.json root
+cd "$tmp_gz" && tar cvfz "$out_dir"/global-zone-packages.tar.gz oxide.json root

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -60,7 +60,7 @@ function main
     HELIOS_PATH=$1
     GLOBAL_ZONE_TARBALL_PATH=$2
 
-    TOOLS_DIR="$(pwd)/$(dirname $0)"
+    TOOLS_DIR="$(pwd)/$(dirname "$0")"
 
     # Grab the opte version
     OPTE_VER=$(cat "$TOOLS_DIR/opte_version")
@@ -73,7 +73,7 @@ function main
 
     # Extract the global zone tarball into a tmp_gz directory
     echo "Extracting gz packages into $tmp_gz"
-    ptime -m tar xvzf $GLOBAL_ZONE_TARBALL_PATH -C $tmp_gz
+    ptime -m tar xvzf "$GLOBAL_ZONE_TARBALL_PATH" -C "$tmp_gz"
 
     # If the user specified a switch zone (which is probably named
     # `switch-SOME_VARIANT.tar.gz`), stage it in the right place and rename it
@@ -86,11 +86,11 @@ function main
     if [ "x$BUILD_STANDARD" != "x" ]; then
         mkdir -p "$tmp_gz/root/root"
         echo "# Add opteadm, ddmadm to PATH" >> "$tmp_gz/root/root/.profile"
-        echo 'export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm' >> "$tmp_gz/root/root/.profile"
+        echo "export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm" >> "$tmp_gz/root/root/.profile"
     fi
 
     # Move to the helios checkout
-    cd $HELIOS_PATH
+    cd "$HELIOS_PATH"
 
     # Create the "./helios-build" command, which lets us build images
     gmake setup
@@ -106,14 +106,14 @@ function main
         *) exit $rc ;;
     esac
 
-    pfexec zfs create -p rpool/images/$USER
+    pfexec zfs create -p rpool/images/"$USER"
 
     HELIOS_REPO=https://pkg.oxide.computer/helios/2/dev/
 
     # Build an image name that includes the omicron and host OS hashes
     IMAGE_NAME="$IMAGE_PREFIX ${GITHUB_SHA:0:7}"
     # The ${os_short_commit} token will be expanded by `helios-build`
-    IMAGE_NAME+='/${os_short_commit}'
+    IMAGE_NAME+="/${os_short_commit}"
     IMAGE_NAME+=" $(date +'%Y-%m-%d %H:%M')"
 
     ./helios-build experiment-image \

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -86,7 +86,7 @@ function main
     if [ "x$BUILD_STANDARD" != "x" ]; then
         mkdir -p "$tmp_gz/root/root"
         echo "# Add opteadm, ddmadm to PATH" >> "$tmp_gz/root/root/.profile"
-        echo "export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm" >> "$tmp_gz/root/root/.profile"
+        echo 'export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm' >> "$tmp_gz/root/root/.profile"
     fi
 
     # Move to the helios checkout

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -113,7 +113,7 @@ function main
     # Build an image name that includes the omicron and host OS hashes
     IMAGE_NAME="$IMAGE_PREFIX ${GITHUB_SHA:0:7}"
     # The ${os_short_commit} token will be expanded by `helios-build`
-    IMAGE_NAME+="/${os_short_commit}"
+    IMAGE_NAME+='/${os_short_commit}'
     IMAGE_NAME+=" $(date +'%Y-%m-%d %H:%M')"
 
     ./helios-build experiment-image \

--- a/tools/build-trampoline-global-zone-packages.sh
+++ b/tools/build-trampoline-global-zone-packages.sh
@@ -12,7 +12,7 @@ out_dir="$(readlink -f "${2:-$tarball_src_dir}")"
 # Make sure needed packages exist
 deps=(
     "$tarball_src_dir"/installinator.tar
-    "tarball_src_dir"/maghemite.tar
+    "$tarball_src_dir"/maghemite.tar
 )
 for dep in "${deps[@]}"; do
     if [[ ! -e $dep ]]; then

--- a/tools/build-trampoline-global-zone-packages.sh
+++ b/tools/build-trampoline-global-zone-packages.sh
@@ -5,18 +5,18 @@ set -eux
 TOOLS_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Use the default "out" dir in omicron to find the needed packages if one isn't given
-tarball_src_dir="$(readlink -f ${1:-"$TOOLS_DIR/../out"})"
+tarball_src_dir="$(readlink -f "${1:-"$TOOLS_DIR/../out"}")"
 # Stash the final tgz in the given src dir if a different target isn't given
-out_dir="$(readlink -f ${2:-$tarball_src_dir})"
+out_dir="$(readlink -f "${2:-$tarball_src_dir}")"
 
 # Make sure needed packages exist
 deps=(
-    $tarball_src_dir/installinator.tar
-    $tarball_src_dir/maghemite.tar
+    "$tarball_src_dir"/installinator.tar
+    "tarball_src_dir"/maghemite.tar
 )
-for dep in ${deps[@]}; do
+for dep in "${deps[@]}"; do
     if [[ ! -e $dep ]]; then
-        echo "Missing Trampoline Global Zone dep: $(basename $dep)"
+        echo "Missing Trampoline Global Zone dep: $(basename "$dep")"
         exit 1
     fi
 done
@@ -48,4 +48,4 @@ tar -xvfz "$tarball_src_dir/maghemite.tar"
 cd -
 
 # Create the final output and we're done
-cd "$tmp_trampoline" && tar cvfz $out_dir/trampoline-global-zone-packages.tar.gz oxide.json root
+cd "$tmp_trampoline" && tar cvfz "$out_dir"/trampoline-global-zone-packages.tar.gz oxide.json root

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -15,7 +15,7 @@ for rev in "${opte_deps_revs[@]}"; do
 done
 
 # Grab the API version for this revision
-API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/$OPTE_REV/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')
+API_VER="$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_REV"/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')"
 
 # Grab the patch version which is based on the number of commits.
 # Essentially `git rev-list --count $OPTE_REV` but without cloning the repo.

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -15,7 +15,7 @@ for rev in "${opte_deps_revs[@]}"; do
 done
 
 # Grab the API version for this revision
-API_VER="$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_REV"/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')"
+API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_REV"/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')
 
 # Grab the patch version which is based on the number of commits.
 # Essentially `git rev-list --count $OPTE_REV` but without cloning the repo.

--- a/tools/ci_download_clickhouse
+++ b/tools/ci_download_clickhouse
@@ -11,7 +11,7 @@ set -o xtrace
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename ${BASH_SOURCE[0]})"
+ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 TARGET_DIR="out"
 # Location where intermediate artifacts are downloaded / unpacked.
@@ -89,7 +89,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 
@@ -124,7 +124,6 @@ function configure_os
 	TARBALL_FILENAME="$TARBALL_DIRNAME$CIDL_DASHREV.$CIDL_PLATFORM.tar.gz"
 
 	TARBALL_FILE="$DOWNLOAD_DIR/$TARBALL_FILENAME"
-	TARBALL_DIR="$DOWNLOAD_DIR/$TARBALL_DIRNAME"
 }
 
 function do_download_curl

--- a/tools/ci_download_cockroachdb
+++ b/tools/ci_download_cockroachdb
@@ -11,7 +11,7 @@ set -o xtrace
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename ${BASH_SOURCE[0]})"
+ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 # If you change this, you must also update the md5sums below
 CIDL_VERSION="$(cat "$SOURCE_DIR/cockroachdb_version")"
@@ -93,7 +93,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 

--- a/tools/ci_download_console
+++ b/tools/ci_download_console
@@ -9,15 +9,13 @@ set -o xtrace
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename ${BASH_SOURCE[0]})"
+ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 TARGET_DIR="out"
 # Location where intermediate artifacts are downloaded / unpacked.
 DOWNLOAD_DIR="$TARGET_DIR/downloads"
 # Location where the final console directory should end up.
 DEST_DIR="./$TARGET_DIR/console-assets"
-# Base URL
-URL_BASE="https://dl.oxide.computer/releases/console"
 
 source "$SOURCE_DIR/console_version"
 
@@ -71,7 +69,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 

--- a/tools/ci_download_dendrite_openapi
+++ b/tools/ci_download_dendrite_openapi
@@ -9,7 +9,7 @@ set -o xtrace
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename ${BASH_SOURCE[0]})"
+ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 TARGET_DIR="out"
 # Location where intermediate artifacts are downloaded / unpacked.
@@ -60,7 +60,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 

--- a/tools/ci_download_dendrite_stub
+++ b/tools/ci_download_dendrite_stub
@@ -75,7 +75,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 
@@ -119,7 +119,7 @@ function do_assemble
 	mkdir "$DEST_DIR"
 	cp -r "$DOWNLOAD_DIR/root" "$DEST_DIR/root"
 	# Symbolic links for backwards compatibility with existing setups
-	ln -s $PWD/out/dendrite-stub/root/opt/oxide/dendrite/bin/ $PWD/out/dendrite-stub/bin
+	ln -s "$PWD"/out/dendrite-stub/root/opt/oxide/dendrite/bin/ "$PWD"/out/dendrite-stub/bin
 }
 
 function fetch_and_verify

--- a/tools/ci_download_maghemite_openapi
+++ b/tools/ci_download_maghemite_openapi
@@ -9,7 +9,7 @@ set -o xtrace
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename ${BASH_SOURCE[0]})"
+ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 TARGET_DIR="out"
 # Location where intermediate artifacts are downloaded / unpacked.
@@ -60,7 +60,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -20,7 +20,7 @@ SOFTNPU_COMMIT="64beaff129b7f63a04a53dd5ed0ec09f012f5756"
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"
 mkdir -p $OUT_DIR
-$TOOLS_DIR/ensure_buildomat_artifact.sh \
+"$TOOLS_DIR"/ensure_buildomat_artifact.sh \
     -O $OUT_DIR \
     "npuzone" \
     "$SOFTNPU_REPO" \

--- a/tools/ci_download_transceiver_control
+++ b/tools/ci_download_transceiver_control
@@ -74,7 +74,7 @@ function main
 
 function fail
 {
-	echo "$ARG0: $@" >&2
+	echo "$ARG0: $*" >&2
 	exit 1
 }
 

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -43,7 +43,7 @@ function ensure_simulated_links {
     done
 
     if [[ -z "$(get_vnic_name_if_exists "sc0_1")" ]]; then
-        dladm create-vnic -t "sc0_1" -l $PHYSICAL_LINK -m a8:e1:de:01:70:1d
+        dladm create-vnic -t "sc0_1" -l "$PHYSICAL_LINK" -m a8:e1:de:01:70:1d
     fi
     success "Vnic sc0_1 exists"
 }
@@ -60,7 +60,7 @@ function ensure_softnpu_zone {
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0
     }
-    $SOURCE_DIR/scrimlet/softnpu-init.sh
+    "$SOURCE_DIR"/scrimlet/softnpu-init.sh
     success "softnpu zone exists"
 }
 

--- a/tools/destroy_gimlet_virtual_hardware.sh
+++ b/tools/destroy_gimlet_virtual_hardware.sh
@@ -11,7 +11,7 @@ set -u
 set -x
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "${SOURCE_DIR}/.."
+cd "${SOURCE_DIR}/.." || exit
 OMICRON_TOP="$PWD"
 
 . "$SOURCE_DIR/virtual_hardware.sh"

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -11,7 +11,7 @@ set -u
 set -x
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "${SOURCE_DIR}/.."
+cd "${SOURCE_DIR}/.." || exit
 OMICRON_TOP="$PWD"
 
 . "$SOURCE_DIR/virtual_hardware.sh"

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -53,7 +53,7 @@ OPTE_VERSION="$(cat "$OMICRON_TOP/tools/opte_version")"
 
 # Actually install the xde kernel module and opteadm tool
 RC=0
-pfexec pkg install -v pkg://helios-dev/driver/network/opte@$OPTE_VERSION || RC=$?
+pfexec pkg install -v pkg://helios-dev/driver/network/opte@"$OPTE_VERSION" || RC=$?
 if [[ "$RC" -eq 0 ]]; then
     echo "xde driver installed successfully"
 elif [[ "$RC" -eq 4 ]]; then

--- a/tools/reflector/helpers.sh
+++ b/tools/reflector/helpers.sh
@@ -96,9 +96,9 @@ function update_pr {
 
   # Compare the integration branch with the target branch
   local TARGET_TO_INTEGRATION
-  TARGET_TO_INTEGRATION="$(git rev-list --count $TARGET_BRANCH..$INTEGRATION_BRANCH)"
+  TARGET_TO_INTEGRATION="$(git rev-list --count "$TARGET_BRANCH".."$INTEGRATION_BRANCH")"
   local INTEGRATION_TO_TARGET
-  INTEGRATION_TO_TARGET="$(git rev-list --count $INTEGRATION_BRANCH..$TARGET_BRANCH)"
+  INTEGRATION_TO_TARGET="$(git rev-list --count "$INTEGRATION_BRANCH".."$TARGET_BRANCH")"
 
   # Check for an existing pull request from the integration branch to the target branch
   eval "$(gh pr view "$INTEGRATION_BRANCH" --repo "$GITHUB_REPOSITORY" --json url,number,state | jq -r 'to_entries[] | "\(.key | ascii_upcase)=\(.value)"')"

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -9,13 +9,13 @@ GATEWAY_IP=${GATEWAY_IP:=$(netstat -rn -f inet | grep default | awk -F ' ' '{pri
 echo "Using $GATEWAY_IP as gateway ip"
 
 if [[ ! -v GATEWAY_MAC ]]; then
-    ping $GATEWAY_IP
+    ping "$GATEWAY_IP"
     sleep 1
-    ping $GATEWAY_IP
+    ping "$GATEWAY_IP"
     sleep 1
-    ping $GATEWAY_IP
+    ping "$GATEWAY_IP"
     sleep 1
-    ping $GATEWAY_IP
+    ping "$GATEWAY_IP"
     sleep 1
 fi
 
@@ -52,16 +52,16 @@ z_scadm () {
         --server /softnpu/server \
         --client /softnpu/client \
         standalone \
-        $@
+        "$@"
 }
 
 
 # Configure upstream network gateway ARP entry
-z_scadm add-arp-entry $GATEWAY_IP $GATEWAY_MAC
+z_scadm add-arp-entry "$GATEWAY_IP" "$GATEWAY_MAC"
 
 PXA_MAC=${PXA_MAC:-a8:e1:de:01:70:1d}
 
 if [[ -v PXA_START ]]; then
-    z_scadm add-proxy-arp $PXA_START $PXA_END $PXA_MAC
+    z_scadm add-proxy-arp "$PXA_START" "$PXA_END" "$PXA_MAC"
 fi
 z_scadm dump-state

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -95,7 +95,7 @@ function to_stock_helios {
 
     # If we have packages to reject, prompt the user to confirm.
     if [[ ${#PKGS_TO_REJECT[@]} -gt 0 ]]; then
-        echo "These packages will be removed: ${PKGS_TO_REJECT[@]}"
+        echo "These packages will be removed: ${PKGS_TO_REJECT[*]}"
         read -p "Confirm (Y/n): " RESPONSE
         case $(echo $RESPONSE | tr '[A-Z]' '[a-z]') in
             n|no )
@@ -122,7 +122,7 @@ function to_stock_helios {
     pkg set-publisher --sticky --search-first "$HELIOS_PUBLISHER"
 
     # Now install stock consolidation but reject the packages we don't want.
-    pkg install --no-refresh -v ${REJECT_ARGS[@]} "$CONSOLIDATION"
+    pkg install --no-refresh -v "${REJECT_ARGS[@]}" "$CONSOLIDATION"
 }
 
 # If helios-dev exists, echo the full osnet-incorporation package we'll be

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"

--- a/tools/update_dendrite.sh
+++ b/tools/update_dendrite.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
@@ -38,7 +37,7 @@ function update_openapi {
     fi
     echo "Updating Dendrite OpenAPI from: $TARGET_COMMIT"
     set -x
-    echo "$OUTPUT" > $OPENAPI_PATH
+    echo "$OUTPUT" > "$OPENAPI_PATH"
     set +x
 }
 
@@ -61,7 +60,7 @@ function update_dendrite_stub_shas {
     fi
     echo "Updating Dendrite stub checksums from: $TARGET_COMMIT"
     set -x
-    echo "$OUTPUT" > $STUB_CHECKSUM_PATH
+    echo "$OUTPUT" > "$STUB_CHECKSUM_PATH"
     set +x
 }
 

--- a/tools/update_maghemite.sh
+++ b/tools/update_maghemite.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
@@ -37,7 +36,7 @@ function update_openapi {
     fi
     echo "Updating Maghemite OpenAPI from: $TARGET_COMMIT"
     set -x
-    echo "$OUTPUT" > $OPENAPI_PATH
+    echo "$OUTPUT" > "$OPENAPI_PATH"
     set +x
 }
 

--- a/tools/update_propolis.sh
+++ b/tools/update_propolis.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"

--- a/tools/update_transceiver_control.sh
+++ b/tools/update_transceiver_control.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o errexit
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARG0="$(basename "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
@@ -14,10 +13,6 @@ function usage {
     echo "  -n          Dry-run"
     exit 1
 }
-
-PACKAGES=(
-  "xcvradm"
-)
 
 REPO="oxidecomputer/transceiver-control"
 
@@ -37,7 +32,7 @@ function update_transceiver_control {
     fi
     echo "Updating transceiver control from: $TARGET_COMMIT"
     set -x
-    echo "$OUTPUT" > $OPENAPI_PATH
+    echo "$OUTPUT" > "$OPENAPI_PATH"
     set +x
 }
 


### PR DESCRIPTION
On current main (79fee6a2), there are a number of complaints from the bash linter [shellcheck](https://github.com/koalaman/shellcheck) in the `tools/` directory:
```
jordan@muggsy:~/src/omicron/tools$ uname -a
Linux muggsy 6.2.0-32-generic #32~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Aug 18 10:40:13 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
jordan@muggsy:~/src/omicron/tools$ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
jordan@muggsy:~/src/omicron/tools$ find . -type f -name \*.sh | xargs -n1 shellcheck | wc -l
672
```

This PR cleans some of those up. The warnings that required more invasive measures I did not touch, as I hope to remove a lot of the bash scripts here.

After this PR:

```
jordan@muggsy:~/src/omicron/tools$ find . -type f -name \*.sh | xargs -n1 shellcheck | wc -l
308
```

Full accounting of shellcheck complaints on main:
<details>
<summary>Current shellcheck warnings/errors</summary>  

```
$ find . -type f -name \*.sh | xargs -n1 shellcheck

In ./update_dendrite.sh line 7:
ARG0="$(basename "${BASH_SOURCE[0]}")"
^--^ SC2034 (warning): ARG0 appears unused. Verify use (or export if used externally).


In ./update_dendrite.sh line 26:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).


In ./update_dendrite.sh line 41:
    echo "$OUTPUT" > $OPENAPI_PATH
                     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT" > "$OPENAPI_PATH"


In ./update_dendrite.sh line 64:
    echo "$OUTPUT" > $STUB_CHECKSUM_PATH
                     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT" > "$STUB_CHECKSUM_PATH"

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ARG0 appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./populate/populate-alpine.sh line 24:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...

In ./build-global-zone-packages.sh line 8:
tarball_src_dir="$(readlink -f ${1:-"$TOOLS_DIR/../out"})"
                               ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
tarball_src_dir="$(readlink -f "${1:-"$TOOLS_DIR/../out"}")"


In ./build-global-zone-packages.sh line 10:
out_dir="$(readlink -f ${2:-$tarball_src_dir})"
                       ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
out_dir="$(readlink -f "${2:-$tarball_src_dir}")"


In ./build-global-zone-packages.sh line 14:
    $tarball_src_dir/omicron-sled-agent.tar
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-global-zone-packages.sh line 15:
    $tarball_src_dir/maghemite.tar
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-global-zone-packages.sh line 16:
    $tarball_src_dir/propolis-server.tar.gz
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-global-zone-packages.sh line 17:
    $tarball_src_dir/overlay.tar.gz
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-global-zone-packages.sh line 19:
for dep in ${deps[@]}; do
           ^--------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./build-global-zone-packages.sh line 21:
        echo "Missing Global Zone dep: $(basename $dep)"
                                                  ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        echo "Missing Global Zone dep: $(basename "$dep")"


In ./build-global-zone-packages.sh line 60:
cd "$tmp_gz" && tar cvfz $out_dir/global-zone-packages.tar.gz oxide.json root
                         ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$tmp_gz" && tar cvfz "$out_dir"/global-zone-packages.tar.gz oxide.json root

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./create_gimlet_virtual_hardware.sh line 21:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_gimlet_virtual_hardware.sh line 23:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./virtual_hardware.sh line 43:
            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
                  ^-- SC2143 (style): Use ! grep -q instead of comparing output with [ -z .. ].
                                                  ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            if [[ -z "$(zpool list -o name | grep "$ZPOOL")" ]]; then


In ./virtual_hardware.sh line 59:
                    zpool destroy "$ZPOOL" && \
                                           ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.


In ./virtual_hardware.sh line 88:
    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
                                         ^--^ SC2069 (warning): To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).


In ./virtual_hardware.sh line 93:
    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
          ^-- SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2069 -- To redirect stdout+stderr, 2>&1 m...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2015 -- Note that A && B || C is not if-t...

In ./update_crucible.sh line 7:
ARG0="$(basename "${BASH_SOURCE[0]}")"
^--^ SC2034 (warning): ARG0 appears unused. Verify use (or export if used externally).


In ./update_crucible.sh line 32:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ARG0 appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./create_virtual_hardware.sh line 18:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_virtual_hardware.sh line 20:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).


In ./create_virtual_hardware.sh line 46:
        dladm create-vnic -t "sc0_1" -l $PHYSICAL_LINK -m a8:e1:de:01:70:1d
                                        ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        dladm create-vnic -t "sc0_1" -l "$PHYSICAL_LINK" -m a8:e1:de:01:70:1d


In ./create_virtual_hardware.sh line 63:
    $SOURCE_DIR/scrimlet/softnpu-init.sh
    ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "$SOURCE_DIR"/scrimlet/softnpu-init.sh

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./destroy_scrimlet_virtual_hardware.sh line 13:
cd "${SOURCE_DIR}/.."
^-------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "${SOURCE_DIR}/.." || exit


In ./destroy_scrimlet_virtual_hardware.sh line 14:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_scrimlet_virtual_hardware.sh line 16:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).


In ./destroy_scrimlet_virtual_hardware.sh line 36:
        --ports $TFP0,tfportrear0_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP0",tfportrear0_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 37:
        --ports $TFP1,tfportrear1_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP1",tfportrear1_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 38:
        --ports $TFP2,tfportrear2_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP2",tfportrear2_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 39:
        --ports $TFP3,tfportrear3_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP3",tfportrear3_0 \

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./create_scrimlet_virtual_hardware.sh line 21:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_scrimlet_virtual_hardware.sh line 23:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).


In ./create_scrimlet_virtual_hardware.sh line 43:
        dladm create-vnic -t "up0" -l $PHYSICAL_LINK -m a8:e1:de:01:70:1d
                                      ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        dladm create-vnic -t "up0" -l "$PHYSICAL_LINK" -m a8:e1:de:01:70:1d


In ./create_scrimlet_virtual_hardware.sh line 52:
            --ports $TFP0,tfportrear0_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP0",tfportrear0_0 \


In ./create_scrimlet_virtual_hardware.sh line 53:
            --ports $TFP1,tfportrear1_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP1",tfportrear1_0 \


In ./create_scrimlet_virtual_hardware.sh line 54:
            --ports $TFP2,tfportrear2_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP2",tfportrear2_0 \


In ./create_scrimlet_virtual_hardware.sh line 55:
            --ports $TFP3,tfportrear3_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP3",tfportrear3_0 \


In ./create_scrimlet_virtual_hardware.sh line 58:
    $SOURCE_DIR/scrimlet/softnpu-init.sh
    ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "$SOURCE_DIR"/scrimlet/softnpu-init.sh

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./build-host-image.sh line 22:
                FORCE=1
                ^---^ SC2034 (warning): FORCE appears unused. Verify use (or export if used externally).


In ./build-host-image.sh line 63:
    TOOLS_DIR="$(pwd)/$(dirname $0)"
                                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    TOOLS_DIR="$(pwd)/$(dirname "$0")"


In ./build-host-image.sh line 76:
    ptime -m tar xvzf $GLOBAL_ZONE_TARBALL_PATH -C $tmp_gz
                      ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                   ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    ptime -m tar xvzf "$GLOBAL_ZONE_TARBALL_PATH" -C "$tmp_gz"


In ./build-host-image.sh line 89:
        echo 'export PATH=$PATH:/opt/oxide/opte/bin:/opt/oxide/mg-ddm' >> "$tmp_gz/root/root/.profile"
             ^-- SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.


In ./build-host-image.sh line 93:
    cd $HELIOS_PATH
       ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    cd "$HELIOS_PATH"


In ./build-host-image.sh line 109:
    pfexec zfs create -p rpool/images/$USER
                                      ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    pfexec zfs create -p rpool/images/"$USER"


In ./build-host-image.sh line 116:
    IMAGE_NAME+='/${os_short_commit}'
                ^-------------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- FORCE appears unused. Verify use ...
  https://www.shellcheck.net/wiki/SC2016 -- Expressions don't expand in singl...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./uninstall_opte.sh line 43:
    local LINE="$(pkg publisher | grep "$PUBLISHER" | tr -s ' ')"
          ^--^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ./uninstall_opte.sh line 48:
    local ORIGIN="$(echo "$LINE" | cut -d ' ' -f 5)"
          ^----^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ./uninstall_opte.sh line 86:
    local PKGS_TO_REJECT=($(\
                          ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).


In ./uninstall_opte.sh line 87:
        LANG= LC_CTYPE= LC_NUMERIC= LC_TIME= LC_COLLATE= LC_MONETARY= LC_MESSAGES= LC_ALL=C.UTF-8 \
             ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                       ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                   ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                            ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                        ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                                     ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                                                  ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).


In ./uninstall_opte.sh line 98:
        echo "These packages will be removed: ${PKGS_TO_REJECT[@]}"
                                              ^------------------^ SC2145 (error): Argument mixes string and array. Use * or separate argument.


In ./uninstall_opte.sh line 99:
        read -p "Confirm (Y/n): " RESPONSE
        ^--^ SC2162 (info): read without -r will mangle backslashes.


In ./uninstall_opte.sh line 100:
        case $(echo $RESPONSE | tr '[A-Z]' '[a-z]') in
                    ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.
                                           ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.

Did you mean: 
        case $(echo "$RESPONSE" | tr '[A-Z]' '[a-z]') in


In ./uninstall_opte.sh line 125:
    pkg install --no-refresh -v ${REJECT_ARGS[@]} "$CONSOLIDATION"
                                ^---------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./uninstall_opte.sh line 133:
    local CONSOLIDATION="$(pkg list --no-refresh -H -af "$STOCK_CONSOLIDATION"@latest || echo "")"
          ^-----------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2145 -- Argument mixes string and array. ...
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...

In ./update_propolis.sh line 7:
ARG0="$(basename "${BASH_SOURCE[0]}")"
^--^ SC2034 (warning): ARG0 appears unused. Verify use (or export if used externally).


In ./update_propolis.sh line 29:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ARG0 appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./update_maghemite.sh line 7:
ARG0="$(basename "${BASH_SOURCE[0]}")"
^--^ SC2034 (warning): ARG0 appears unused. Verify use (or export if used externally).


In ./update_maghemite.sh line 25:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).


In ./update_maghemite.sh line 40:
    echo "$OUTPUT" > $OPENAPI_PATH
                     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT" > "$OPENAPI_PATH"

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ARG0 appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./destroy_virtual_hardware.sh line 14:
cd "${SOURCE_DIR}/.."
^-------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "${SOURCE_DIR}/.." || exit


In ./destroy_virtual_hardware.sh line 15:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_virtual_hardware.sh line 17:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./scrimlet/softnpu-init.sh line 12:
    ping $GATEWAY_IP
         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    ping "$GATEWAY_IP"


In ./scrimlet/softnpu-init.sh line 14:
    ping $GATEWAY_IP
         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    ping "$GATEWAY_IP"


In ./scrimlet/softnpu-init.sh line 16:
    ping $GATEWAY_IP
         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    ping "$GATEWAY_IP"


In ./scrimlet/softnpu-init.sh line 18:
    ping $GATEWAY_IP
         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    ping "$GATEWAY_IP"


In ./scrimlet/softnpu-init.sh line 55:
        $@
        ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./scrimlet/softnpu-init.sh line 60:
z_scadm add-arp-entry $GATEWAY_IP $GATEWAY_MAC
                      ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                  ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
z_scadm add-arp-entry "$GATEWAY_IP" "$GATEWAY_MAC"


In ./scrimlet/softnpu-init.sh line 65:
    z_scadm add-proxy-arp $PXA_START $PXA_END $PXA_MAC
                          ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                              ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    z_scadm add-proxy-arp "$PXA_START" "$PXA_END" "$PXA_MAC"

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./build-trampoline-global-zone-packages.sh line 8:
tarball_src_dir="$(readlink -f ${1:-"$TOOLS_DIR/../out"})"
                               ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
tarball_src_dir="$(readlink -f "${1:-"$TOOLS_DIR/../out"}")"


In ./build-trampoline-global-zone-packages.sh line 10:
out_dir="$(readlink -f ${2:-$tarball_src_dir})"
                       ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
out_dir="$(readlink -f "${2:-$tarball_src_dir}")"


In ./build-trampoline-global-zone-packages.sh line 14:
    $tarball_src_dir/installinator.tar
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-trampoline-global-zone-packages.sh line 15:
    $tarball_src_dir/maghemite.tar
    ^--------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ./build-trampoline-global-zone-packages.sh line 17:
for dep in ${deps[@]}; do
           ^--------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./build-trampoline-global-zone-packages.sh line 19:
        echo "Missing Trampoline Global Zone dep: $(basename $dep)"
                                                             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        echo "Missing Trampoline Global Zone dep: $(basename "$dep")"


In ./build-trampoline-global-zone-packages.sh line 51:
cd "$tmp_trampoline" && tar cvfz $out_dir/trampoline-global-zone-packages.tar.gz oxide.json root
                                 ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$tmp_trampoline" && tar cvfz "$out_dir"/trampoline-global-zone-packages.tar.gz oxide.json root

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./install_opte.sh line 56:
pfexec pkg install -v pkg://helios-dev/driver/network/opte@$OPTE_VERSION || RC=$?
                                                           ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
pfexec pkg install -v pkg://helios-dev/driver/network/opte@"$OPTE_VERSION" || RC=$?

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./ci_check_opte_ver.sh line 18:
API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/$OPTE_REV/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')
                                                                       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
API_VER=$(curl -s https://raw.githubusercontent.com/oxidecomputer/opte/"$OPTE_REV"/crates/opte-api/src/lib.rs | sed -n 's/pub const API_VERSION: u64 = \([0-9]*\);/\1/p')


In ./ci_check_opte_ver.sh line 46:
BUILDOMAT_DEPLOY_TARGET=$(cat .github/buildomat/jobs/deploy.sh | sed -n 's/#:[ ]*target[ ]*=[ ]*"\(.*\)"/\1/p')
                              ^-- SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...

In ./update_transceiver_control.sh line 7:
ARG0="$(basename "${BASH_SOURCE[0]}")"
^--^ SC2034 (warning): ARG0 appears unused. Verify use (or export if used externally).


In ./update_transceiver_control.sh line 18:
PACKAGES=(
^------^ SC2034 (warning): PACKAGES appears unused. Verify use (or export if used externally).


In ./update_transceiver_control.sh line 24:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).


In ./update_transceiver_control.sh line 40:
    echo "$OUTPUT" > $OPENAPI_PATH
                     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT" > "$OPENAPI_PATH"

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ARG0 appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./destroy_gimlet_virtual_hardware.sh line 14:
cd "${SOURCE_DIR}/.."
^-------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "${SOURCE_DIR}/.." || exit


In ./destroy_gimlet_virtual_hardware.sh line 15:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_gimlet_virtual_hardware.sh line 17:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./reflector/helpers.sh line 99:
  TARGET_TO_INTEGRATION="$(git rev-list --count $TARGET_BRANCH..$INTEGRATION_BRANCH)"
                                                ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  TARGET_TO_INTEGRATION="$(git rev-list --count "$TARGET_BRANCH".."$INTEGRATION_BRANCH")"


In ./reflector/helpers.sh line 101:
  INTEGRATION_TO_TARGET="$(git rev-list --count $INTEGRATION_BRANCH..$TARGET_BRANCH)"
                                                ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                     ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  INTEGRATION_TO_TARGET="$(git rev-list --count "$INTEGRATION_BRANCH".."$TARGET_BRANCH")"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

```
</details>

After this PR:
<details>
<summary>Complaints from shellcheck with these changes</summary> 

```
$ find . -type f -name \*.sh | xargs -n1 shellcheck

In ./update_dendrite.sh line 25:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./populate/populate-alpine.sh line 24:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...

In ./create_gimlet_virtual_hardware.sh line 21:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_gimlet_virtual_hardware.sh line 23:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./virtual_hardware.sh line 43:
            if [[ -z "$(zpool list -o name | grep $ZPOOL)" ]]; then
                  ^-- SC2143 (style): Use ! grep -q instead of comparing output with [ -z .. ].
                                                  ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            if [[ -z "$(zpool list -o name | grep "$ZPOOL")" ]]; then


In ./virtual_hardware.sh line 59:
                    zpool destroy "$ZPOOL" && \
                                           ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.


In ./virtual_hardware.sh line 88:
    svcs "svc:/oxide/sled-agent:default" 2>&1 > /dev/null && \
                                         ^--^ SC2069 (warning): To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).


In ./virtual_hardware.sh line 93:
    local ID="$(modinfo | grep xde | cut -d ' ' -f 1)"
          ^-- SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2069 -- To redirect stdout+stderr, 2>&1 m...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2015 -- Note that A && B || C is not if-t...

In ./update_crucible.sh line 31:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./create_virtual_hardware.sh line 18:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_virtual_hardware.sh line 20:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./destroy_scrimlet_virtual_hardware.sh line 13:
cd "${SOURCE_DIR}/.."
^-------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "${SOURCE_DIR}/.." || exit


In ./destroy_scrimlet_virtual_hardware.sh line 14:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_scrimlet_virtual_hardware.sh line 16:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).


In ./destroy_scrimlet_virtual_hardware.sh line 36:
        --ports $TFP0,tfportrear0_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP0",tfportrear0_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 37:
        --ports $TFP1,tfportrear1_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP1",tfportrear1_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 38:
        --ports $TFP2,tfportrear2_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP2",tfportrear2_0 \


In ./destroy_scrimlet_virtual_hardware.sh line 39:
        --ports $TFP3,tfportrear3_0 \
                ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        --ports "$TFP3",tfportrear3_0 \

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./create_scrimlet_virtual_hardware.sh line 21:
OMICRON_TOP="$SOURCE_DIR/.."
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./create_scrimlet_virtual_hardware.sh line 23:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).


In ./create_scrimlet_virtual_hardware.sh line 43:
        dladm create-vnic -t "up0" -l $PHYSICAL_LINK -m a8:e1:de:01:70:1d
                                      ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        dladm create-vnic -t "up0" -l "$PHYSICAL_LINK" -m a8:e1:de:01:70:1d


In ./create_scrimlet_virtual_hardware.sh line 52:
            --ports $TFP0,tfportrear0_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP0",tfportrear0_0 \


In ./create_scrimlet_virtual_hardware.sh line 53:
            --ports $TFP1,tfportrear1_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP1",tfportrear1_0 \


In ./create_scrimlet_virtual_hardware.sh line 54:
            --ports $TFP2,tfportrear2_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP2",tfportrear2_0 \


In ./create_scrimlet_virtual_hardware.sh line 55:
            --ports $TFP3,tfportrear3_0 \
                    ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
            --ports "$TFP3",tfportrear3_0 \


In ./create_scrimlet_virtual_hardware.sh line 58:
    $SOURCE_DIR/scrimlet/softnpu-init.sh
    ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "$SOURCE_DIR"/scrimlet/softnpu-init.sh

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./build-host-image.sh line 22:
                FORCE=1
                ^---^ SC2034 (warning): FORCE appears unused. Verify use (or export if used externally).


In ./build-host-image.sh line 116:
    IMAGE_NAME+="/${os_short_commit}"
                  ^----------------^ SC2154 (warning): os_short_commit is referenced but not assigned.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- FORCE appears unused. Verify use ...
  https://www.shellcheck.net/wiki/SC2154 -- os_short_commit is referenced but...

In ./uninstall_opte.sh line 43:
    local LINE="$(pkg publisher | grep "$PUBLISHER" | tr -s ' ')"
          ^--^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ./uninstall_opte.sh line 48:
    local ORIGIN="$(echo "$LINE" | cut -d ' ' -f 5)"
          ^----^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ./uninstall_opte.sh line 86:
    local PKGS_TO_REJECT=($(\
                          ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).


In ./uninstall_opte.sh line 87:
        LANG= LC_CTYPE= LC_NUMERIC= LC_TIME= LC_COLLATE= LC_MONETARY= LC_MESSAGES= LC_ALL=C.UTF-8 \
             ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                       ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                   ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                            ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                        ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                                     ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).
                                                                                  ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).


In ./uninstall_opte.sh line 99:
        read -p "Confirm (Y/n): " RESPONSE
        ^--^ SC2162 (info): read without -r will mangle backslashes.


In ./uninstall_opte.sh line 100:
        case $(echo $RESPONSE | tr '[A-Z]' '[a-z]') in
                    ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.
                                           ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.

Did you mean: 
        case $(echo "$RESPONSE" | tr '[A-Z]' '[a-z]') in


In ./uninstall_opte.sh line 133:
    local CONSOLIDATION="$(pkg list --no-refresh -H -af "$STOCK_CONSOLIDATION"@latest || echo "")"
          ^-----------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...

In ./update_propolis.sh line 28:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./update_maghemite.sh line 24:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./destroy_virtual_hardware.sh line 15:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_virtual_hardware.sh line 17:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

In ./ci_check_opte_ver.sh line 46:
BUILDOMAT_DEPLOY_TARGET=$(cat .github/buildomat/jobs/deploy.sh | sed -n 's/#:[ ]*target[ ]*=[ ]*"\(.*\)"/\1/p')
                              ^-- SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...

In ./update_transceiver_control.sh line 19:
. "$SOURCE_DIR/update_helpers.sh"
  ^-----------------------------^ SC1091 (info): Not following: ./update_helpers.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./update_helpers.s...

In ./destroy_gimlet_virtual_hardware.sh line 15:
OMICRON_TOP="$PWD"
^---------^ SC2034 (warning): OMICRON_TOP appears unused. Verify use (or export if used externally).


In ./destroy_gimlet_virtual_hardware.sh line 17:
. "$SOURCE_DIR/virtual_hardware.sh"
  ^-- SC1091 (info): Not following: ./virtual_hardware.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OMICRON_TOP appears unused. Verif...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./virtual_hardware...

```
</details>
