### PR TITLE
omdb could be easier to configure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5056,6 +5056,7 @@ dependencies = [
  "dropshot",
  "expectorate",
  "humantime",
+ "internal-dns 0.1.0",
  "nexus-client 0.1.0",
  "nexus-db-model",
  "nexus-db-queries",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -15,6 +15,7 @@ clap.workspace = true
 diesel.workspace = true
 dropshot.workspace = true
 humantime.workspace = true
+internal-dns.workspace = true
 nexus-client.workspace = true
 nexus-db-model.workspace = true
 nexus-db-queries.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -57,7 +57,7 @@ pub struct DbArgs {
     /// limit to apply to queries that fetch rows
     #[clap(
         long = "fetch-limit",
-        default_value_t = NonZeroU32::new(100).unwrap()
+        default_value_t = NonZeroU32::new(500).unwrap()
     )]
     fetch_limit: NonZeroU32,
 

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -12,6 +12,7 @@
 //! would be the only consumer -- and in that case it's okay to query the
 //! database directly.
 
+use crate::Omdb;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
@@ -131,17 +132,38 @@ enum ServicesCommands {
 
 impl DbArgs {
     /// Run a `omdb db` subcommand.
-    pub async fn run_cmd(
+    pub(crate) async fn run_cmd(
         &self,
+        omdb: &Omdb,
         log: &slog::Logger,
     ) -> Result<(), anyhow::Error> {
-        // This is a little goofy.  The database URL is required, but can come
-        // from the environment, in which case it won't be on the command line.
-        let Some(db_url) = &self.db_url else {
-            bail!(
-                "database URL must be specified with --db-url or OMDB_DB_URL"
-            );
+        let db_url = match &self.db_url {
+            Some(cli_or_env_url) => cli_or_env_url.clone(),
+            None => {
+                eprintln!(
+                    "note: database URL not specified.  Will search DNS."
+                );
+                eprintln!("note: (override with --db-url or OMDB_DB_URL)");
+                let addrs = omdb
+                    .dns_lookup_all(
+                        log.clone(),
+                        internal_dns::ServiceName::Cockroach,
+                    )
+                    .await?;
+
+                format!(
+                    "postgresql://root@{}/omicron?sslmode=disable",
+                    addrs
+                        .into_iter()
+                        .map(|a| a.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+                .parse()
+                .context("failed to parse constructed postgres URL")?
+            }
         };
+        eprintln!("note: using database URL {}", &db_url);
 
         let db_config = db::Config { url: db_url.clone() };
         let pool = Arc::new(db::Pool::new(&log.clone(), &db_config));

--- a/dev-tools/omdb/src/bin/omdb/sled_agent.rs
+++ b/dev-tools/omdb/src/bin/omdb/sled_agent.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use clap::Args;
 use clap::Subcommand;
 
-/// Arguments to the "omdb sled" subcommand
+/// Arguments to the "omdb sled-agent" subcommand
 #[derive(Debug, Args)]
 pub struct SledAgentArgs {
     /// URL of the Sled internal API
@@ -21,7 +21,7 @@ pub struct SledAgentArgs {
     command: SledAgentCommands,
 }
 
-/// Subcommands for the "omdb sled" subcommand
+/// Subcommands for the "omdb sled-agent" subcommand
 #[derive(Debug, Subcommand)]
 enum SledAgentCommands {
     /// print information about zones
@@ -46,7 +46,7 @@ enum ZpoolCommands {
 }
 
 impl SledAgentArgs {
-    /// Run a `omdb sled` subcommand.
+    /// Run a `omdb sled-agent` subcommand.
     pub(crate) async fn run_cmd(
         &self,
         _omdb: &Omdb,
@@ -74,7 +74,7 @@ impl SledAgentArgs {
     }
 }
 
-/// Runs `omdb sled zones list`
+/// Runs `omdb sled-agent zones list`
 async fn cmd_zones_list(
     client: &sled_agent_client::Client,
 ) -> Result<(), anyhow::Error> {
@@ -93,7 +93,7 @@ async fn cmd_zones_list(
     Ok(())
 }
 
-/// Runs `omdb sled zpools list`
+/// Runs `omdb sled-agent zpools list`
 async fn cmd_zpools_list(
     client: &sled_agent_client::Client,
 ) -> Result<(), anyhow::Error> {

--- a/dev-tools/omdb/src/bin/omdb/sled_agent.rs
+++ b/dev-tools/omdb/src/bin/omdb/sled_agent.rs
@@ -4,6 +4,7 @@
 
 //! omdb commands that query or update specific Sleds
 
+use crate::Omdb;
 use anyhow::bail;
 use anyhow::Context;
 use clap::Args;
@@ -46,8 +47,9 @@ enum ZpoolCommands {
 
 impl SledAgentArgs {
     /// Run a `omdb sled` subcommand.
-    pub async fn run_cmd(
+    pub(crate) async fn run_cmd(
         &self,
+        _omdb: &Omdb,
         log: &slog::Logger,
     ) -> Result<(), anyhow::Error> {
         // This is a little goofy. The sled URL is required, but can come

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -6,6 +6,7 @@ SERIAL       IP          ROLE ID
 sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED 
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "--db-url", "junk", "sleds"]
@@ -58,6 +59,7 @@ task: "external_endpoints"
 
 ---------------------------------------------
 stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "--nexus-internal-url", "junk", "background-tasks", "doc"]
 termination: Exited(1)
@@ -65,10 +67,123 @@ termination: Exited(1)
 stdout:
 ---------------------------------------------
 stderr:
+note: using Nexus URL junk
 Error: listing background tasks
 
 Caused by:
     0: Communication Error: builder error: relative URL without a base
     1: builder error: relative URL without a base
     2: relative URL without a base
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "doc"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+task: "dns_config_external"
+    watches external DNS data stored in CockroachDB
+
+
+task: "dns_config_internal"
+    watches internal DNS data stored in CockroachDB
+
+
+task: "dns_propagation_external"
+    propagates latest external DNS configuration (from "dns_config_external"
+    background task) to the latest list of DNS servers (from
+    "dns_servers_external" background task)
+
+
+task: "dns_propagation_internal"
+    propagates latest internal DNS configuration (from "dns_config_internal"
+    background task) to the latest list of DNS servers (from
+    "dns_servers_internal" background task)
+
+
+task: "dns_servers_external"
+    watches list of external DNS servers stored in CockroachDB
+
+
+task: "dns_servers_internal"
+    watches list of internal DNS servers stored in CockroachDB
+
+
+task: "external_endpoints"
+    reads config for silos and TLS certificates to determine the right set of
+    HTTP endpoints, their HTTP server names, and which TLS certificates to use
+    on each one
+
+
+---------------------------------------------
+stderr:
+note: Nexus URL not specified.  Will pick one from DNS.
+note: using Nexus URL http://[::ffff:127.0.0.1]:REDACTED_PORT
+=============================================
+EXECUTING COMMAND: omdb ["--dns-server", "[::1]:REDACTED_PORT", "nexus", "background-tasks", "doc"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+task: "dns_config_external"
+    watches external DNS data stored in CockroachDB
+
+
+task: "dns_config_internal"
+    watches internal DNS data stored in CockroachDB
+
+
+task: "dns_propagation_external"
+    propagates latest external DNS configuration (from "dns_config_external"
+    background task) to the latest list of DNS servers (from
+    "dns_servers_external" background task)
+
+
+task: "dns_propagation_internal"
+    propagates latest internal DNS configuration (from "dns_config_internal"
+    background task) to the latest list of DNS servers (from
+    "dns_servers_internal" background task)
+
+
+task: "dns_servers_external"
+    watches list of external DNS servers stored in CockroachDB
+
+
+task: "dns_servers_internal"
+    watches list of internal DNS servers stored in CockroachDB
+
+
+task: "external_endpoints"
+    reads config for silos and TLS certificates to determine the right set of
+    HTTP endpoints, their HTTP server names, and which TLS certificates to use
+    on each one
+
+
+---------------------------------------------
+stderr:
+note: Nexus URL not specified.  Will pick one from DNS.
+note: using Nexus URL http://[::ffff:127.0.0.1]:REDACTED_PORT
+=============================================
+EXECUTING COMMAND: omdb ["db", "sleds"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+SERIAL       IP          ROLE ID                                   
+sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED 
+---------------------------------------------
+stderr:
+note: database URL not specified.  Will search DNS.
+note: (override with --db-url or OMDB_DB_URL)
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
+note: database schema version matches expected (4.0.0)
+=============================================
+EXECUTING COMMAND: omdb ["--dns-server", "[::1]:REDACTED_PORT", "db", "sleds"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+SERIAL       IP          ROLE ID                                   
+sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED 
+---------------------------------------------
+stderr:
+note: database URL not specified.  Will search DNS.
+note: (override with --db-url or OMDB_DB_URL)
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
+note: database schema version matches expected (4.0.0)
 =============================================

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -7,6 +7,7 @@ internal control-plane.oxide.internal 1   <REDACTED_TIMESTAMP> rack setup
 external oxide-dev.test               2   <REDACTED_TIMESTAMP> create silo: "test-suite-silo" 
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "diff", "external", "2"]
@@ -22,6 +23,7 @@ changes:                    names added: 1, names removed: 0
 +  test-suite-silo.sys                                A    127.0.0.1
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "names", "external", "2"]
@@ -33,6 +35,7 @@ External zone: oxide-dev.test
   test-suite-silo.sys                                A    127.0.0.1
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-instances"]
@@ -48,6 +51,7 @@ InternalDns    REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT         
 Nexus          REDACTED_UUID_REDACTED_UUID_REDACTED [::ffff:127.0.0.1]:REDACTED_PORT sim-b6d65341 
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-by-sled"]
@@ -66,6 +70,7 @@ sled: sim-b6d65341 (id REDACTED_UUID_REDACTED_UUID_REDACTED)
 
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "sleds"]
@@ -76,6 +81,7 @@ SERIAL       IP          ROLE ID
 sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED 
 ---------------------------------------------
 stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (4.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "background-tasks", "doc"]
@@ -118,6 +124,7 @@ task: "external_endpoints"
 
 ---------------------------------------------
 stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show"]
 termination: Exited(0)
@@ -198,4 +205,5 @@ task: "external_endpoints"
 
 ---------------------------------------------
 stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -38,7 +38,6 @@ async fn test_omdb_usage_errors() {
         &["db"],
         &["db", "--help"],
         &["db", "dns"],
-        &["db", "dns", "show"],
         &["db", "dns", "diff"],
         &["db", "dns", "names"],
         &["db", "services"],

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -107,7 +107,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     let postgres_url = cptestctx.database.listen_url().to_string();
     let nexus_internal_url =
         format!("http://{}", cptestctx.internal_client.bind_address);
-    let dns_sockaddr = *cptestctx.internal_dns.dns_server.local_address();
+    let dns_sockaddr = cptestctx.internal_dns.dns_server.local_address();
     let mut output = String::new();
 
     // Database URL

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -15,8 +15,9 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help (see more with '--help')
+      --log-level <LOG_LEVEL>    log level filter [env: LOG_LEVEL=] [default: warn]
+      --dns-server <DNS_SERVER>  [env: OMDB_DNS_SERVER=]
+  -h, --help                     Print help (see more with '--help')
 =============================================
 EXECUTING COMMAND: omdb ["--help"]
 termination: Exited(0)
@@ -41,6 +42,9 @@ Options:
           
           [env: LOG_LEVEL=]
           [default: warn]
+
+      --dns-server <DNS_SERVER>
+          [env: OMDB_DNS_SERVER=]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -89,7 +93,7 @@ Commands:
 
 Options:
       --db-url <DB_URL>            URL of the database SQL interface [env: OMDB_DB_URL=]
-      --fetch-limit <FETCH_LIMIT>  limit to apply to queries that fetch rows [default: 100]
+      --fetch-limit <FETCH_LIMIT>  limit to apply to queries that fetch rows [default: 500]
   -h, --help                       Print help
 =============================================
 EXECUTING COMMAND: omdb ["db", "--help"]
@@ -108,7 +112,7 @@ Commands:
 
 Options:
       --db-url <DB_URL>            URL of the database SQL interface [env: OMDB_DB_URL=]
-      --fetch-limit <FETCH_LIMIT>  limit to apply to queries that fetch rows [default: 100]
+      --fetch-limit <FETCH_LIMIT>  limit to apply to queries that fetch rows [default: 500]
   -h, --help                       Print help
 ---------------------------------------------
 stderr:
@@ -138,7 +142,14 @@ termination: Exited(1)
 stdout:
 ---------------------------------------------
 stderr:
-Error: database URL must be specified with --db-url or OMDB_DB_URL
+note: database URL not specified.  Will search DNS.
+note: (override with --db-url or OMDB_DB_URL)
+note: using DNS server for subnet fd00:1122:3344::/48
+note: (if this is not right, use --dns-server to specify an alternate DNS server)
+Error: looking up Cockroach in DNS
+
+Caused by:
+    proto error: io error: No route to host (os error 148)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "diff"]
 termination: Exited(2)
@@ -219,6 +230,59 @@ Commands:
   doc   Show documentation about background tasks
   list  Print a summary of the status of all background tasks
   show  Print human-readable summary of the status of each background task
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+=============================================
+EXECUTING COMMAND: omdb ["sled-agent"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+Debug a specific Sled
+
+Usage: omdb sled-agent [OPTIONS] <COMMAND>
+
+Commands:
+  zones   print information about zones
+  zpools  print information about zpools
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --sled-agent-url <SLED_AGENT_URL>  URL of the Sled internal API [env: OMDB_SLED_AGENT_URL=]
+  -h, --help                             Print help
+=============================================
+EXECUTING COMMAND: omdb ["sled-agent", "zones"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+print information about zones
+
+Usage: omdb sled-agent zones <COMMAND>
+
+Commands:
+  list  Print list of all running control plane zones
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+=============================================
+EXECUTING COMMAND: omdb ["sled-agent", "zpools"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+print information about zpools
+
+Usage: omdb sled-agent zpools <COMMAND>
+
+Commands:
+  list  Print list of all zpools managed by the sled agent
   help  Print this message or the help of the given subcommand(s)
 
 Options:

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -136,21 +136,6 @@ Commands:
 Options:
   -h, --help  Print help
 =============================================
-EXECUTING COMMAND: omdb ["db", "dns", "show"]
-termination: Exited(1)
----------------------------------------------
-stdout:
----------------------------------------------
-stderr:
-note: database URL not specified.  Will search DNS.
-note: (override with --db-url or OMDB_DB_URL)
-note: using DNS server for subnet fd00:1122:3344::/48
-note: (if this is not right, use --dns-server to specify an alternate DNS server)
-Error: looking up Cockroach in DNS
-
-Caused by:
-    proto error: io error: No route to host (os error 148)
-=============================================
 EXECUTING COMMAND: omdb ["db", "dns", "diff"]
 termination: Exited(2)
 ---------------------------------------------

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -56,8 +56,8 @@ impl Drop for ServerHandle {
 }
 
 impl ServerHandle {
-    pub fn local_address(&self) -> &SocketAddr {
-        &self.local_address
+    pub fn local_address(&self) -> SocketAddr {
+        self.local_address
     }
 }
 

--- a/dns-server/src/lib.rs
+++ b/dns-server/src/lib.rs
@@ -164,7 +164,7 @@ impl TransientServer {
     pub async fn resolver(&self) -> Result<TokioAsyncResolver, anyhow::Error> {
         let mut resolver_config = ResolverConfig::new();
         resolver_config.add_name_server(NameServerConfig {
-            socket_addr: *self.dns_server.local_address(),
+            socket_addr: self.dns_server.local_address(),
             protocol: Protocol::Udp,
             tls_dns_name: None,
             trust_nx_responses: false,

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -375,7 +375,7 @@ async fn init_client_server(
 
     let mut rc = ResolverConfig::new();
     rc.add_name_server(NameServerConfig {
-        socket_addr: *dns_server.local_address(),
+        socket_addr: dns_server.local_address(),
         protocol: Protocol::Udp,
         tls_dns_name: None,
         trust_nx_responses: false,

--- a/internal-dns-cli/src/bin/dnswait.rs
+++ b/internal-dns-cli/src/bin/dnswait.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
     } else {
         let addrs = opt.nameserver_addresses;
         info!(&log, "using explicit nameservers"; "nameservers" => ?addrs);
-        Resolver::new_from_addrs(log.clone(), addrs)
+        Resolver::new_from_addrs(log.clone(), &addrs)
             .context("creating resolver with explicit nameserver addresses")?
     };
 

--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -281,7 +281,7 @@ impl DnsConfigBuilder {
 
         let set = self
             .service_instances_zones
-            .entry(service.clone())
+            .entry(service)
             .or_insert_with(BTreeMap::new);
         match set.insert(zone.clone(), port) {
             None => Ok(()),
@@ -320,7 +320,7 @@ impl DnsConfigBuilder {
 
         let set = self
             .service_instances_sleds
-            .entry(service.clone())
+            .entry(service)
             .or_insert_with(BTreeMap::new);
         let sled_id = sled.0;
         match set.insert(sled.clone(), port) {

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -14,7 +14,7 @@ pub const DNS_ZONE: &str = "control-plane.oxide.internal";
 pub const DNS_ZONE_EXTERNAL_TESTING: &str = "oxide-dev.test";
 
 /// Names of services within the control plane
-#[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ServiceName {
     Clickhouse,
     ClickhouseKeeper,

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -465,7 +465,7 @@ mod test {
 
         fn resolver(&self) -> anyhow::Result<Resolver> {
             let log = self.log.new(o!("component" => "DnsResolver"));
-            Resolver::new_from_addrs(log, vec![self.dns_server_address()])
+            Resolver::new_from_addrs(log, &[self.dns_server_address()])
                 .context("creating resolver for test DNS server")
         }
 
@@ -591,7 +591,7 @@ mod test {
             let zone =
                 dns_builder.host_zone(Uuid::new_v4(), *db_ip.ip()).unwrap();
             dns_builder
-                .service_backend_zone(srv_crdb.clone(), &zone, db_ip.port())
+                .service_backend_zone(srv_crdb, &zone, db_ip.port())
                 .unwrap();
         }
 
@@ -599,21 +599,13 @@ mod test {
             .host_zone(Uuid::new_v4(), *clickhouse_addr.ip())
             .unwrap();
         dns_builder
-            .service_backend_zone(
-                srv_clickhouse.clone(),
-                &zone,
-                clickhouse_addr.port(),
-            )
+            .service_backend_zone(srv_clickhouse, &zone, clickhouse_addr.port())
             .unwrap();
 
         let zone =
             dns_builder.host_zone(Uuid::new_v4(), *crucible_addr.ip()).unwrap();
         dns_builder
-            .service_backend_zone(
-                srv_backend.clone(),
-                &zone,
-                crucible_addr.port(),
-            )
+            .service_backend_zone(srv_backend, &zone, crucible_addr.port())
             .unwrap();
 
         let mut dns_config = dns_builder.build();
@@ -694,9 +686,7 @@ mod test {
         let ip1 = Ipv6Addr::from_str("ff::01").unwrap();
         let zone = dns_builder.host_zone(Uuid::new_v4(), ip1).unwrap();
         let srv_crdb = ServiceName::Cockroach;
-        dns_builder
-            .service_backend_zone(srv_crdb.clone(), &zone, 12345)
-            .unwrap();
+        dns_builder.service_backend_zone(srv_crdb, &zone, 12345).unwrap();
         let dns_config = dns_builder.build();
         dns_server.update(&dns_config).await.unwrap();
         let found_ip = resolver
@@ -711,9 +701,7 @@ mod test {
         let ip2 = Ipv6Addr::from_str("ee::02").unwrap();
         let zone = dns_builder.host_zone(Uuid::new_v4(), ip2).unwrap();
         let srv_crdb = ServiceName::Cockroach;
-        dns_builder
-            .service_backend_zone(srv_crdb.clone(), &zone, 54321)
-            .unwrap();
+        dns_builder.service_backend_zone(srv_crdb, &zone, 54321).unwrap();
         let mut dns_config = dns_builder.build();
         dns_config.generation += 1;
         dns_server.update(&dns_config).await.unwrap();
@@ -802,7 +790,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            vec![*dns_server.dns_server.local_address()],
+            &[*dns_server.dns_server.local_address()],
         )
         .unwrap();
 
@@ -879,7 +867,7 @@ mod test {
         let dns_server2 = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            vec![
+            &[
                 *dns_server1.dns_server.local_address(),
                 *dns_server2.dns_server.local_address(),
             ],
@@ -955,7 +943,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            vec![*dns_server.dns_server.local_address()],
+            &[*dns_server.dns_server.local_address()],
         )
         .unwrap();
 

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -55,7 +55,7 @@ impl Resolver {
     /// Construct a new DNS resolver from specific DNS server addresses.
     pub fn new_from_addrs(
         log: slog::Logger,
-        dns_addrs: Vec<SocketAddr>,
+        dns_addrs: &[SocketAddr],
     ) -> Result<Self, ResolveError> {
         info!(log, "new DNS resolver"; "addresses" => ?dns_addrs);
 
@@ -63,7 +63,7 @@ impl Resolver {
         let dns_server_count = dns_addrs.len();
         for socket_addr in dns_addrs.into_iter() {
             rc.add_name_server(NameServerConfig {
-                socket_addr,
+                socket_addr: *socket_addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
                 trust_nx_responses: false,
@@ -137,7 +137,7 @@ impl Resolver {
         subnet: Ipv6Subnet<AZ_PREFIX>,
     ) -> Result<Self, ResolveError> {
         let dns_ips = Self::servers_from_subnet(subnet);
-        Resolver::new_from_addrs(log, dns_ips)
+        Resolver::new_from_addrs(log, &dns_ips)
     }
 
     /// Remove all entries from the resolver's cache.

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -61,9 +61,9 @@ impl Resolver {
 
         let mut rc = ResolverConfig::new();
         let dns_server_count = dns_addrs.len();
-        for socket_addr in dns_addrs.into_iter() {
+        for &socket_addr in dns_addrs.into_iter() {
             rc.add_name_server(NameServerConfig {
-                socket_addr: *socket_addr,
+                socket_addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
                 trust_nx_responses: false,

--- a/internal-dns/src/resolver.rs
+++ b/internal-dns/src/resolver.rs
@@ -455,7 +455,7 @@ mod test {
         }
 
         fn dns_server_address(&self) -> SocketAddr {
-            *self.dns_server.local_address()
+            self.dns_server.local_address()
         }
 
         fn cleanup_successful(mut self) {
@@ -790,7 +790,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[*dns_server.dns_server.local_address()],
+            &[dns_server.dns_server.local_address()],
         )
         .unwrap();
 
@@ -868,8 +868,8 @@ mod test {
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
             &[
-                *dns_server1.dns_server.local_address(),
-                *dns_server2.dns_server.local_address(),
+                dns_server1.dns_server.local_address(),
+                dns_server2.dns_server.local_address(),
             ],
         )
         .unwrap();
@@ -943,7 +943,7 @@ mod test {
         let dns_server = DnsServer::create(&logctx.log).await;
         let resolver = Resolver::new_from_addrs(
             logctx.log.clone(),
-            &[*dns_server.dns_server.local_address()],
+            &[dns_server.dns_server.local_address()],
         )
         .unwrap();
 

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -158,7 +158,7 @@ impl ServerContext {
 
                 internal_dns::resolver::Resolver::new_from_addrs(
                     log.new(o!("component" => "DnsResolver")),
-                    vec![address],
+                    &[address],
                 )
                 .map_err(|e| format!("Failed to create DNS resolver: {}", e))?
             }
@@ -169,11 +169,12 @@ impl ServerContext {
             nexus_config::Database::FromUrl { url } => url.clone(),
             nexus_config::Database::FromDns => {
                 info!(log, "Accessing DB url from DNS");
-                // It's been requested but unfortunately not supported to directly
-                // connect using SRV based lookup.
-                // TODO-robustness: the set of cockroachdb hosts we'll use will be
-                // fixed to whatever we got back from DNS at Nexus start. This means
-                // a new cockroachdb instance won't picked up until Nexus restarts.
+                // It's been requested but unfortunately not supported to
+                // directly connect using SRV based lookup.
+                // TODO-robustness: the set of cockroachdb hosts we'll use will
+                // be fixed to whatever we got back from DNS at Nexus start.
+                // This means a new cockroachdb instance won't picked up until
+                // Nexus restarts.
                 let addrs = loop {
                     match resolver
                         .lookup_all_socket_v6(ServiceName::Cockroach)

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -433,7 +433,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
 
         self.config.deployment.internal_dns =
             nexus_config::InternalDns::FromAddress {
-                address: *self
+                address: self
                     .internal_dns
                     .as_ref()
                     .expect("Must initialize internal DNS server first")
@@ -659,8 +659,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
 
         let dns = dns_server::TransientServer::new(&log).await.unwrap();
 
-        let SocketAddr::V6(dns_address) = *dns.dns_server.local_address()
-        else {
+        let SocketAddr::V6(dns_address) = dns.dns_server.local_address() else {
             panic!("Unsupported IPv4 DNS address");
         };
         let SocketAddr::V6(dropshot_address) = dns.dropshot_server.local_addr()
@@ -998,7 +997,7 @@ pub async fn start_dns_server(
 
     let mut resolver_config = ResolverConfig::new();
     resolver_config.add_name_server(NameServerConfig {
-        socket_addr: *dns_server.local_address(),
+        socket_addr: dns_server.local_address(),
         protocol: Protocol::Udp,
         tls_dns_name: None,
         trust_nx_responses: false,

--- a/nexus/tests/integration_tests/certificates.rs
+++ b/nexus/tests/integration_tests/certificates.rs
@@ -360,7 +360,7 @@ async fn test_silo_certificates() {
     // create the other Silos and their users.
     let resolver = Arc::new(
         CustomDnsResolver::new(
-            *cptestctx.external_dns.dns_server.local_address(),
+            cptestctx.external_dns.dns_server.local_address(),
         )
         .unwrap(),
     );

--- a/nexus/tests/integration_tests/initialization.rs
+++ b/nexus/tests/integration_tests/initialization.rs
@@ -41,7 +41,7 @@ async fn test_nexus_boots_before_cockroach() {
         omicron_common::nexus_config::Database::FromDns;
     builder.config.deployment.internal_dns =
         omicron_common::nexus_config::InternalDns::FromAddress {
-            address: *builder
+            address: builder
                 .internal_dns
                 .as_ref()
                 .expect("Must start Internal DNS before acquiring an address")
@@ -121,7 +121,7 @@ async fn test_nexus_boots_before_dendrite() {
     builder.config.pkg.dendrite = HashMap::new();
     builder.config.deployment.internal_dns =
         omicron_common::nexus_config::InternalDns::FromAddress {
-            address: *builder
+            address: builder
                 .internal_dns
                 .as_ref()
                 .expect("Must start Internal DNS before acquiring an address")


### PR DESCRIPTION
Before this change:

- to use the `nexus` command you need to provide OMDB_NEXUS_URL in the environment or `--nexus-internal-url` on the command line
- to use the `db` command you need to provide OMDB_DB_URL in the environment or `--db-url` on the command line
- to use the `sled-agent` command you need to provide OMDB_SLED_AGENT_URL in the environment or `--sled-agent-url` on the command line

The database one is particularly annoying because it has pieces besides the IP address and port that are easy to forget or get wrong: the database name and `sslmode=disable`.

After this change:

- You _can_ still do all of the things above.  This is useful when for whatever reason you want to control precisely which component omdb talks to.
- For the `sled-agent` command, you still _have_ to provide the URL as described above.
- For the `nexus` and `db` commands, instead of providing the URLs for those, you can instead provide OMDB_DNS_SERVER in the environment or `--dns-server` on the command line.  Assuming you haven't _also_ provided a Nexus or DB URL (which still take precedence), then `omdb` will consult the DNS server to find database instances and Nexus instances.  As a side benefit, when connecting to the database, it uses _all_ of the addresses it finds, which means it should work as long as any of them is up without the user having to figure out which instances are up.
- If you provide none of these, then `omdb` falls back to the DNS server for `fd00:1122:3344::/48`.  This is not technically correct, in that Omicron can be deployed using a different base subnet for the underlay network.  But in practice, this is the right value for all deployments that I know about (including dogfood), so it allows the tool to work in most places with no configuration.

The upshot should be:
- In most real deployments, you don't need to configure _anything_ because `omdb` will consult the internal DNS server (which it already knows how to find) to find everything else.
- Even when one needs to override the DNS server, it should be more convenient to just have to specify OMDB_DNS_SERVER instead of a variety of other URLs.

Unrelated to all this, I bumped the built-in db query row limit from 100 to 500 records.  This value is somewhat arbitrary.  It's just there to avoid having to implement client pagination and to avoid us fetching a zillion records from the database at once. 100 was a little too small (@jgallagher ran into this listing DNS names in dogfood).  500 is enough so far.  A few thousand would probably also be fine.