### PR TITLE
[db] omdb db disk for physical disks

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -226,7 +226,10 @@ impl DbArgs {
             }
             DbCommands::Disks(DiskArgs {
                 command: DiskCommands::Physical(uuid),
-            }) => cmd_db_disk_physical(&opctx, &datastore, self.fetch_limit, uuid).await,
+            }) => {
+                cmd_db_disk_physical(&opctx, &datastore, self.fetch_limit, uuid)
+                    .await
+            }
             DbCommands::Dns(DnsArgs { command: DnsCommands::Show }) => {
                 cmd_db_dns_show(&opctx, &datastore, self.fetch_limit).await
             }
@@ -526,7 +529,6 @@ async fn cmd_db_disk_physical(
     limit: NonZeroU32,
     args: &DiskPhysicalArgs,
 ) -> Result<(), anyhow::Error> {
-
     // We start by finding any zpools that are using the physical disk.
     use db::schema::zpool::dsl as zpool_dsl;
     let zpools = zpool_dsl::zpool
@@ -572,7 +574,8 @@ async fn cmd_db_disk_physical(
             .await
             .context("failed to look up sled")?;
 
-        println!("Physical disk: {} found on sled: {}",
+        println!(
+            "Physical disk: {} found on sled: {}",
             args.uuid,
             my_sled.serial_number()
         );
@@ -626,7 +629,9 @@ async fn cmd_db_disk_physical(
         if volume_ids.contains(&disk.volume_id) {
             // If the disk is attached to an instance, determine the name of the
             // instance.
-            let instance_name = if let Some(instance_uuid) = disk.runtime().attach_instance_id {
+            let instance_name = if let Some(instance_uuid) =
+                disk.runtime().attach_instance_id
+            {
                 // Get the instance this disk is attached to
                 use db::schema::instance::dsl as instance_dsl;
                 let instance = instance_dsl::instance
@@ -646,7 +651,7 @@ async fn cmd_db_disk_physical(
                 "-".to_string()
             };
 
-            rows.push( DiskRow {
+            rows.push(DiskRow {
                 name: disk.name().to_string(),
                 id: disk.id().to_string(),
                 state: disk.runtime().disk_state,

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -24,13 +24,16 @@ use clap::ValueEnum;
 use diesel::expression::SelectableHelper;
 use diesel::query_dsl::QueryDsl;
 use diesel::ExpressionMethods;
+use nexus_db_model::Dataset;
 use nexus_db_model::Disk;
 use nexus_db_model::DnsGroup;
 use nexus_db_model::DnsName;
 use nexus_db_model::DnsVersion;
 use nexus_db_model::DnsZone;
 use nexus_db_model::Instance;
+use nexus_db_model::Region;
 use nexus_db_model::Sled;
+use nexus_db_model::Zpool;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::identity::Asset;
@@ -45,6 +48,7 @@ use omicron_common::api::external::Generation;
 use omicron_common::postgres_config::PostgresConfigWithUrl;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -94,11 +98,19 @@ enum DiskCommands {
     Info(DiskInfoArgs),
     /// Summarize current disks
     List,
+    /// Determine what crucible resources are on the given physical disk.
+    Physical(DiskPhysicalArgs),
 }
 
 #[derive(Debug, Args)]
 struct DiskInfoArgs {
     /// The UUID of the volume
+    uuid: Uuid,
+}
+
+#[derive(Debug, Args)]
+struct DiskPhysicalArgs {
+    /// The UUID of the physical disk
     uuid: Uuid,
 }
 
@@ -212,6 +224,9 @@ impl DbArgs {
             DbCommands::Disks(DiskArgs { command: DiskCommands::List }) => {
                 cmd_db_disk_list(&datastore, self.fetch_limit).await
             }
+            DbCommands::Disks(DiskArgs {
+                command: DiskCommands::Physical(uuid),
+            }) => cmd_db_disk_physical(&opctx, &datastore, self.fetch_limit, uuid).await,
             DbCommands::Dns(DnsArgs { command: DnsCommands::Show }) => {
                 cmd_db_dns_show(&opctx, &datastore, self.fetch_limit).await
             }
@@ -501,6 +516,151 @@ async fn cmd_db_disk_info(
 
     println!("{}", table);
 
+    Ok(())
+}
+
+/// Run `omdb db disk physical <UUID>`.
+async fn cmd_db_disk_physical(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    limit: NonZeroU32,
+    args: &DiskPhysicalArgs,
+) -> Result<(), anyhow::Error> {
+
+    // We start by finding any zpools that are using the physical disk.
+    use db::schema::zpool::dsl as zpool_dsl;
+    let zpools = zpool_dsl::zpool
+        .filter(zpool_dsl::time_deleted.is_null())
+        .filter(zpool_dsl::physical_disk_id.eq(args.uuid))
+        .select(Zpool::as_select())
+        .load_async(datastore.pool_for_tests().await?)
+        .await
+        .context("loading zpool from pysical disk id")?;
+
+    let mut sled_ids = HashSet::new();
+    let mut dataset_ids = HashSet::new();
+
+    // The current plan is a single zpool per physical disk, so we expect that
+    // this will have a single item.  However, If single zpool per disk ever
+    // changes, this code will still work.
+    for zp in zpools {
+        // zpool has the sled id, record that so we can find the serial number.
+        sled_ids.insert(zp.sled_id);
+
+        // Next, we find all the datasets that are on our zpool.
+        use db::schema::dataset::dsl as dataset_dsl;
+        let datasets = dataset_dsl::dataset
+            .filter(dataset_dsl::time_deleted.is_null())
+            .filter(dataset_dsl::pool_id.eq(zp.id()))
+            .select(Dataset::as_select())
+            .load_async(datastore.pool_for_tests().await?)
+            .await
+            .context("loading dataset")?;
+
+        // Add all the datasets ids that are using this pool.
+        for ds in datasets {
+            dataset_ids.insert(ds.id());
+        }
+    }
+
+    // If we do have more than one sled ID, then something is wrong, but
+    // go ahead and print out whatever we have found.
+    for sid in sled_ids {
+        let (_, my_sled) = LookupPath::new(opctx, datastore)
+            .sled_id(sid)
+            .fetch()
+            .await
+            .context("failed to look up sled")?;
+
+        println!("Physical disk: {} found on sled: {}",
+            args.uuid,
+            my_sled.serial_number()
+        );
+    }
+
+    let mut volume_ids = HashSet::new();
+    // Now, take the list of datasets we found and search all the regions
+    // to see if any of them are on the dataset.  If we find a region that
+    // is on one of our datasets, then record the volume ID of that region.
+    for did in dataset_ids.clone().into_iter() {
+        use db::schema::region::dsl as region_dsl;
+        let regions = region_dsl::region
+            .filter(region_dsl::dataset_id.eq(did))
+            .select(Region::as_select())
+            .load_async(datastore.pool_for_tests().await?)
+            .await
+            .context("loading region")?;
+
+        for rs in regions {
+            volume_ids.insert(rs.volume_id());
+        }
+    }
+
+    // At this point, we have a list of volume IDs that contain a region
+    // that is part of a dataset on a pool on our disk.  The final step is
+    // to find the virtual disks associated with these volume IDs and
+    // display information about those disks.
+    use db::schema::disk::dsl;
+    let disks = dsl::disk
+        .filter(dsl::time_deleted.is_null())
+        .limit(i64::from(u32::from(limit)))
+        .select(Disk::as_select())
+        .load_async(datastore.pool_for_tests().await?)
+        .await
+        .context("loading disks")?;
+
+    check_limit(&disks, limit, || "listing disks".to_string());
+
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct DiskRow {
+        name: String,
+        id: String,
+        state: String,
+        instance_name: String,
+    }
+
+    let mut rows = Vec::new();
+
+    for disk in disks {
+        if volume_ids.contains(&disk.volume_id) {
+            // If the disk is attached to an instance, determine the name of the
+            // instance.
+            let instance_name = if let Some(instance_uuid) = disk.runtime().attach_instance_id {
+                // Get the instance this disk is attached to
+                use db::schema::instance::dsl as instance_dsl;
+                let instance = instance_dsl::instance
+                    .filter(instance_dsl::id.eq(instance_uuid))
+                    .limit(1)
+                    .select(Instance::as_select())
+                    .load_async(datastore.pool_for_tests().await?)
+                    .await
+                    .context("loading requested instance")?;
+
+                if let Some(instance) = instance.into_iter().next() {
+                    instance.name().to_string()
+                } else {
+                    "???".to_string()
+                }
+            } else {
+                "-".to_string()
+            };
+
+            rows.push( DiskRow {
+                name: disk.name().to_string(),
+                id: disk.id().to_string(),
+                state: disk.runtime().disk_state,
+                instance_name: instance_name,
+            });
+        }
+    }
+
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
     Ok(())
 }
 

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -7,7 +7,7 @@ sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "--db-url", "junk", "sleds"]
 termination: Exited(2)
@@ -172,7 +172,7 @@ stderr:
 note: database URL not specified.  Will search DNS.
 note: (override with --db-url or OMDB_DB_URL)
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["--dns-server", "[::1]:REDACTED_PORT", "db", "sleds"]
 termination: Exited(0)
@@ -185,5 +185,5 @@ stderr:
 note: database URL not specified.  Will search DNS.
 note: (override with --db-url or OMDB_DB_URL)
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -8,7 +8,7 @@ external oxide-dev.test               2   <REDACTED_TIMESTAMP> create silo: "tes
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "diff", "external", "2"]
 termination: Exited(0)
@@ -24,7 +24,7 @@ changes:                    names added: 1, names removed: 0
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "names", "external", "2"]
 termination: Exited(0)
@@ -36,7 +36,7 @@ External zone: oxide-dev.test
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-instances"]
 termination: Exited(0)
@@ -52,7 +52,7 @@ Nexus          REDACTED_UUID_REDACTED_UUID_REDACTED [::ffff:127.0.0.1]:REDACTED_
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-by-sled"]
 termination: Exited(0)
@@ -71,7 +71,7 @@ sled: sim-b6d65341 (id REDACTED_UUID_REDACTED_UUID_REDACTED)
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["db", "sleds"]
 termination: Exited(0)
@@ -82,7 +82,7 @@ sim-b6d65341 [::1]:REDACTED_PORT -    REDACTED_UUID_REDACTED_UUID_REDACTED
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (4.0.0)
+note: database schema version matches expected (5.0.0)
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "background-tasks", "doc"]
 termination: Exited(0)

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1130,7 +1130,7 @@ table! {
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(4, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(5, 0, 0);
 
 allow_tables_to_appear_in_same_query!(
     system_update,

--- a/schema/crdb/5.0.0/up1.sql
+++ b/schema/crdb/5.0.0/up1.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk ON omicron.public.zpool (physical_disk_id, id) WHERE time_deleted IS NULL;

--- a/schema/crdb/5.0.0/up1.sql
+++ b/schema/crdb/5.0.0/up1.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk ON omicron.public.zpool (physical_disk_id, id) WHERE time_deleted IS NULL;
+CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk ON omicron.public.zpool (physical_disk_id, id) WHERE physical_disk_id IS NOT NULL AND time_deleted IS NULL;

--- a/schema/crdb/5.0.0/up2.sql
+++ b/schema/crdb/5.0.0/up2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS lookup_dataset_by_zpool ON omicron.public.dataset (pool_id, id) WHERE time_deleted IS NULL;

--- a/schema/crdb/5.0.0/up2.sql
+++ b/schema/crdb/5.0.0/up2.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS lookup_dataset_by_zpool ON omicron.public.dataset (pool_id, id) WHERE time_deleted IS NULL;
+CREATE INDEX IF NOT EXISTS lookup_dataset_by_zpool ON omicron.public.dataset (pool_id, id) WHERE pool_id IS NOT NULL AND time_deleted IS NULL;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -388,6 +388,11 @@ CREATE TABLE IF NOT EXISTS omicron.public.zpool (
     total_size INT NOT NULL
 );
 
+/* Create an index on the physical disk id */
+CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk on omicron.public.zpool (
+    physical_disk_id
+) WHERE physical_disk_id IS NOT NULL AND time_deleted IS NULL;
+
 CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'crucible',
   'cockroach',
@@ -436,6 +441,11 @@ CREATE INDEX IF NOT EXISTS lookup_dataset_by_size_used_crucible on omicron.publi
 CREATE INDEX IF NOT EXISTS lookup_dataset_by_size_used on omicron.public.dataset (
     size_used
 ) WHERE size_used IS NOT NULL AND time_deleted IS NULL;
+
+/* Create an index on the zpool id */
+CREATE INDEX IF NOT EXISTS lookup_dataset_by_zpool on omicron.public.dataset (
+    pool_id
+) WHERE pool_id IS NOT NULL AND time_deleted IS NULL;
 
 /*
  * A region of space allocated to Crucible Downstairs, within a dataset.
@@ -2562,7 +2572,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '4.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '5.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -390,7 +390,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.zpool (
 
 /* Create an index on the physical disk id */
 CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk on omicron.public.zpool (
-    physical_disk_id
+    physical_disk_id,
+    id
 ) WHERE physical_disk_id IS NOT NULL AND time_deleted IS NULL;
 
 CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
@@ -444,7 +445,8 @@ CREATE INDEX IF NOT EXISTS lookup_dataset_by_size_used on omicron.public.dataset
 
 /* Create an index on the zpool id */
 CREATE INDEX IF NOT EXISTS lookup_dataset_by_zpool on omicron.public.dataset (
-    pool_id
+    pool_id,
+    id
 ) WHERE pool_id IS NOT NULL AND time_deleted IS NULL;
 
 /*


### PR DESCRIPTION
**New omdb command and database schema updates**

This adds a new subcommand: `physical <UUID>` to `omdb db disks`.  
This will show the disk resources that reside on a physical disk.

This change requires additional indexes in the zpool and dataset tables as 
we lookup which zpool is on a physical disk, and we lookup which
datasets are on a given zpool.  The usage here is just for the omdb tool, but 
those same searches will need to happen when Omicron needs to figure out 
what resources are on a physical disk.

Tested both initial install, and schema update

**Some example output**

First, show info for a given disk UUID
```
root@EVT22200005:~# /alan/omdb db disks info 33261623-bbc6-459f-9b7f-78d9c6ec3229
note: using database URL postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable
note: database schema version matches expected (5.0.0)
HOST_SERIAL DISK_NAME INSTANCE_NAME PROPOLIS_ZONE
unknown     jamdisk   jammy         oxz_propolis-server_9a65590e-ce4e-49bf-a977-e645f3cf1eaa
HOST_SERIAL REGION                               ZONE                                              PHYSICAL_DISK
unknown     b84972fb-e694-4348-8b13-cd39f57b7cc1 oxz_crucible_5d1bde40-9c4f-49ab-932f-71bf467e4692 191c7ca8-3a4d-40ef-9d5b-bc68ca1fd94e
unknown     3bcff9ce-c781-47fb-8f14-b364840e5e09 oxz_crucible_6f6af522-75fe-4943-a34b-a4a11f6b5407 1fdd29a4-e6eb-4cbd-8c13-c9d2118686bb
unknown     555dc434-7b83-422c-aa3f-c2ba5fb33b50 oxz_crucible_f581e85e-fa80-4313-bf98-b0419348271c 63f56a60-4930-4b15-92ae-8f73fe8dc9ec
```

From the above, we can see the UUID of a physical disk.  We can go from
that physical disk UUID and see what resources are using it.
```
root@EVT22200005:~# /alan/omdb db disks physical 191c7ca8-3a4d-40ef-9d5b-bc68ca1fd94e
note: using database URL postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable
note: database schema version matches expected (5.0.0)
Physical disk: 191c7ca8-3a4d-40ef-9d5b-bc68ca1fd94e found on sled: unknown
NAME    ID                                   STATE    INSTANCE_NAME
jamdisk 33261623-bbc6-459f-9b7f-78d9c6ec3229 attached jammy
fluffy  901d2245-b45a-4193-b8c1-e57ce164c933 detached -
```

We see there are two disks that are using that physical disk, get info on the other disk: 
```
root@EVT22200005:~# /alan/omdb db disks info 901d2245-b45a-4193-b8c1-e57ce164c933
note: using database URL postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable
note: database schema version matches expected (5.0.0)
HOST_SERIAL DISK_NAME INSTANCE_NAME PROPOLIS_ZONE
-           fluffy    -             -
HOST_SERIAL REGION                               ZONE                                              PHYSICAL_DISK
unknown     31ea0278-3f49-4610-926d-c779ca7b3da7 oxz_crucible_5d1bde40-9c4f-49ab-932f-71bf467e4692 191c7ca8-3a4d-40ef-9d5b-bc68ca1fd94e
unknown     0a0cffc3-062a-42dc-a1e1-0b1b424e7d5f oxz_crucible_b4148a3a-60a4-4271-b500-f38a7cb9ede3 70daa40e-c542-40e4-a002-86024fdfc736
unknown     ff9bb5ad-0bdc-4e24-a69f-15389dc4242d oxz_crucible_f581e85e-fa80-4313-bf98-b0419348271c 63f56a60-4930-4b15-92ae-8f73fe8dc9ec
```



Update of the database from 4.0 to 5.0
```
root@oxz_nexus_8bd5e3ce-09fd-4cea-88e8-8beddb2711d2:~# /opt/oxide/nexus/bin/schema-updater --crdb postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable ls
Current Version: 4.0.0
Known Versions:
  1.0.0
  2.0.0
  3.0.0
  3.0.1
  3.0.2
  3.0.3
  4.0.0 (reported by database)
  5.0.0 (expected by Nexus)
root@oxz_nexus_8bd5e3ce-09fd-4cea-88e8-8beddb2711d2:~# /opt/oxide/nexus/bin/schema-updater --crdb postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable up
Upgrading to 5.0.0
Sep 25 22:25:32.813 WARN Database schema 4.0.0 does not match expected 5.0.0, unit: schema_updater
Upgrade to 5.0.0 complete
root@oxz_nexus_8bd5e3ce-09fd-4cea-88e8-8beddb2711d2:~# /opt/oxide/nexus/bin/schema-updater --crdb postgresql://root@[fd00:1122:3344:101::5]:32221/omicron?sslmode=disable ls
Current Version: 5.0.0
Known Versions:
  1.0.0
  2.0.0
  3.0.0
  3.0.1
  3.0.2
  3.0.3
  4.0.0
  5.0.0 (reported by database) (expected by Nexus)
```