### PR TITLE
Add rudimentary command to omdb to map instance IDs to propolis zones

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -80,6 +80,8 @@ enum DbCommands {
     Services(ServicesArgs),
     /// Print information about sleds
     Sleds,
+    /// Print information about customer instances
+    Instances,
 }
 
 #[derive(Debug, Args)]
@@ -245,6 +247,9 @@ impl DbArgs {
             }
             DbCommands::Sleds => {
                 cmd_db_sleds(&opctx, &datastore, self.fetch_limit).await
+            }
+            DbCommands::Instances => {
+                cmd_db_instances(&datastore, self.fetch_limit).await
             }
         }
     }
@@ -670,6 +675,53 @@ async fn cmd_db_sleds(
     check_limit(&sleds, limit, || String::from("listing sleds"));
 
     let rows = sleds.into_iter().map(|s| SledRow::from(s));
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+struct CustomerInstanceRow {
+    id: Uuid,
+    state: String,
+    propolis_id: Uuid,
+    sled_id: Uuid,
+}
+
+impl From<Instance> for CustomerInstanceRow {
+    fn from(i: Instance) -> Self {
+        CustomerInstanceRow {
+            id: i.id(),
+            state: format!("{:?}", i.runtime_state.state.0),
+            propolis_id: i.runtime_state.propolis_id,
+            sled_id: i.runtime_state.sled_id,
+        }
+    }
+}
+
+/// Run `omdb db instances`: list data about customer VMs.
+async fn cmd_db_instances(
+    datastore: &DataStore,
+    limit: NonZeroU32,
+) -> Result<(), anyhow::Error> {
+    use db::schema::instance::dsl;
+    let instances = dsl::instance
+        .limit(i64::from(u32::from(limit)))
+        .select(Instance::as_select())
+        .load_async(datastore.pool_for_tests().await?)
+        .await
+        .context("loading instances")?;
+
+    let ctx = || "listing instances".to_string();
+    check_limit(&instances, limit, ctx);
+
+    let rows = instances.into_iter().map(|i| CustomerInstanceRow::from(i));
     let table = tabled::Table::new(rows)
         .with(tabled::settings::Style::empty())
         .with(tabled::settings::Padding::new(0, 1, 0, 0))

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -86,11 +86,12 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
-  disks     Print information about disks
-  dns       Print information about internal and external DNS
-  services  Print information about control plane services
-  sleds     Print information about sleds
-  help      Print this message or the help of the given subcommand(s)
+  disks      Print information about disks
+  dns        Print information about internal and external DNS
+  services   Print information about control plane services
+  sleds      Print information about sleds
+  instances  Print information about customer instances
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
       --db-url <DB_URL>            URL of the database SQL interface [env: OMDB_DB_URL=]
@@ -106,11 +107,12 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
-  disks     Print information about disks
-  dns       Print information about internal and external DNS
-  services  Print information about control plane services
-  sleds     Print information about sleds
-  help      Print this message or the help of the given subcommand(s)
+  disks      Print information about disks
+  dns        Print information about internal and external DNS
+  services   Print information about control plane services
+  sleds      Print information about sleds
+  instances  Print information about customer instances
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
       --db-url <DB_URL>            URL of the database SQL interface [env: OMDB_DB_URL=]


### PR DESCRIPTION
Something I often want to do while debugging issues on the dogfood rack is answer the question: Given this instance ID, where is its associated propolis zone on the rack?

This command gives an extremely basic way of querying what instances are on the system.

Example output from dogfood:

```
BRM44220005 # OMDB_DB_URL=postgresql://[fd00:1122:3344:10b::3]:32221/omicron?sslmode=disable ./omdb db instances                                                               
note: using database URL postgresql://[fd00:1122:3344:10b::3]:32221/omicron?sslmode=disable                                                                                    
note: database schema version matches expected (4.0.0)                                                                                                                         
ID                                   STATE     PROPOLIS_ID                          SLED_ID                              
0072a3ea-dc4e-4784-8984-5440336a12f1 Destroyed a1a48bed-0f21-46bf-8e25-b2d587702482 a2adea92-b56e-44fc-8a0d-7d63b5fd3b93 
01551cff-e8fa-4d3e-8d72-1179bbd79a1b Destroyed 9a15addf-1dae-410f-b100-29ef87f8a250 87c2c4fc-b0c7-4fef-a305-78f0ed265bbc 
02029f1a-f656-414d-808a-5b8bcbdb6a5f Destroyed 8d4b71fa-b26d-4d75-889f-568c69dff944 71def415-55ad-46b4-ba88-3ca55d7fb287 
02a70503-53b7-43d0-8643-856f43750e2a Destroyed 6cf17ab8-0966-4abf-88ad-6958f45da047 71def415-55ad-46b4-ba88-3ca55d7fb287 
0319c554-5f80-4c87-bdab-ffd2c7bf4994 Destroyed 87158f88-32d5-4a3e-b985-f8edb6224d42 71def415-55ad-46b4-ba88-3ca55d7fb287 
03345f81-e26a-4021-b886-743d483e94a2 Destroyed 5476440c-a618-40e6-9dc4-64ce33c3f768 71def415-55ad-46b4-ba88-3ca55d7fb287 
040a0d5e-48b5-4d0b-aaa4-5569a3127abe Destroyed 9b2f98ed-b570-4828-8252-5cc4b6e4b900 71def415-55ad-46b4-ba88-3ca55d7fb287 
062025e8-ad31-4d6b-bba2-8e68169e266f Running   ff8aa26d-6cc9-4103-a1c9-31c662b3b385 b886b58a-1e3f-4be1-b9f2-0c2e66c6bc88 
06d28a90-6f7e-44b4-9546-48d59c0c5d97 Destroyed ace10f77-3f4c-4d54-ad5b-c7f34b167833 a2adea92-b56e-44fc-8a0d-7d63b5fd3b93 
0758c04e-9fe2-4efc-b052-e8f015f649c5 Destroyed a14b1ab9-3ffc-4b6a-ac20-c2f66e6ac8e5 2707b587-9c7f-4fb0-a7af-37c3b7a9a0fa 
0897189b-1fb2-4ac4-bbeb-2dc0f44c5211 Running   23507e6f-5bc2-46eb-8a3e-94b8708c7ae2 dd83e75a-1edf-4aa1-89a0-cd8b2091a7cd 
0a91a6f6-9f89-4b34-99b1-e441c992683f Running   b441c739-8430-4d00-937f-623fcc1f1e3e b886b58a-1e3f-4be1-b9f2-0c2e66c6bc88 
0abbd2eb-da25-4ccb-a9cc-86c87f2039f8 Running   08b1679a-68a1-479a-b59c-96a88427e19f db183874-65b5-4263-a1c1-ddb2737ae0e9 
0bb61274-0e7f-428c-ab1c-0caafe4ca550 Destroyed 83cf04b5-62d6-4176-8c24-c77b417e075b 71def415-55ad-46b4-ba88-3ca55d7fb287 
0c29a552-6ef4-4fa5-9357-de5d3dac6958 Running   0ccc84ce-f254-4bff-b3f3-e72d8aa74313 a2adea92-b56e-44fc-8a0d-7d63b5fd3b93 
0d239318-73c0-453b-bc76-33d3cc2b6dc4 Destroyed b11b7ba2-6c47-47aa-af59-bd397d6b70f3 0c7011f7-a4bf-4daf-90cc-1c2410103300 
0db24ded-3808-4c94-a58b-283171df11cb Destroyed 76fed331-e22f-46af-b6a3-5eb5ce686581 2707b587-9c7f-4fb0-a7af-37c3b7a9a0fa 
0df8bfd2-ddbe-49f9-9ea7-5429c6d35db3 Destroyed ee0a988f-591d-41e9-8d1a-b04a38874825 2707b587-9c7f-4fb0-a7af-37c3b7a9a0fa 
...
```

Some easy future enhancements:
- filter by ID
- filter by state
- join with data from other tables (such as serial number for sled ID)