### PR TITLE
Make propolis zone name more consistent with other serivces

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -8,11 +8,11 @@
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/oxide-*.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_*/root/var/svc/log/system-illumos-*.log*",
 #:  "%/pool/ext/*/crypt/zone/oxz_ntp_*/root/var/log/chrony/*.log*",
-#:  "!/pool/ext/*/crypt/zone/oxz_propolis-server_*/root/var/svc/log/*.log*",
+#:  "!/pool/ext/*/crypt/zone/oxz_propolis_*/root/var/svc/log/*.log*",
 #:  "%/pool/ext/*/crypt/debug/global/oxide-sled-agent:default.log.*",
 #:  "%/pool/ext/*/crypt/debug/oxz_*/oxide-*.log.*",
 #:  "%/pool/ext/*/crypt/debug/oxz_*/system-illumos-*.log.*",
-#:  "!/pool/ext/*/crypt/debug/oxz_propolis-server_*/*.log.*"
+#:  "!/pool/ext/*/crypt/debug/oxz_propolis_*/*.log.*"
 #: ]
 #: skip_clone = true
 #:

--- a/illumos-utils/src/zone.rs
+++ b/illumos-utils/src/zone.rs
@@ -25,7 +25,7 @@ pub const ZLOGIN: &str = "/usr/sbin/zlogin";
 
 // TODO: These could become enums
 pub const ZONE_PREFIX: &str = "oxz_";
-pub const PROPOLIS_ZONE_PREFIX: &str = "oxz_propolis-server_";
+pub const PROPOLIS_ZONE_PREFIX: &str = "oxz_propolis_";
 
 #[derive(thiserror::Error, Debug)]
 enum Error {


### PR DESCRIPTION
Rename the service-specific portion of propolis zone names from "propolis-server" to just "propolis".

This may be my nittiest PR ever, but this naming brings the propolis zone more in line with other service zone names such as crucible. `propolis-server` is the binary name, but the userspace VMM service that runs VMs is propolis.

I am still working on testing this PR in a real omicron cluster (working on understanding whether some issue I've run in to there are from my PR or something else).