### PR TITLE
Fix path checks for archived log files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "static_assertions",
  "subprocess",
  "tar",
+ "tempfile",
  "thiserror",
  "tofino",
  "tokio",

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -987,7 +987,7 @@ impl RunningZone {
         let output = self.run_cmd(&["svcs", "-H", "-o", "fmri"])?;
         Ok(output
             .lines()
-            .filter(|line| is_oxide_smf_log_file(line))
+            .filter(|line| is_oxide_smf_service(line))
             .map(|line| line.trim().to_string())
             .collect())
     }
@@ -1267,10 +1267,51 @@ impl InstalledZone {
     }
 }
 
-/// Return true if the named file appears to be a log file for an Oxide SMF
-/// service.
-pub fn is_oxide_smf_log_file(name: impl AsRef<str>) -> bool {
-    const SMF_SERVICE_PREFIXES: [&str; 2] = ["/oxide", "/system/illumos"];
-    let name = name.as_ref();
-    SMF_SERVICE_PREFIXES.iter().any(|needle| name.contains(needle))
+/// Return true if the service with the given FMRI appears to be an
+/// Oxide-managed service.
+pub fn is_oxide_smf_service(fmri: impl AsRef<str>) -> bool {
+    const SMF_SERVICE_PREFIXES: [&str; 2] =
+        ["svc:/oxide/", "svc:/system/illumos/"];
+    let fmri = fmri.as_ref();
+    SMF_SERVICE_PREFIXES.iter().any(|prefix| fmri.starts_with(prefix))
+}
+
+/// Return true if the provided file name appears to be a valid log file for an
+/// Oxide-managed SMF service.
+///
+/// Note that this operates on the _file name_. Any leading path components will
+/// cause this check to return `false`.
+pub fn is_oxide_smf_log_file(filename: impl AsRef<str>) -> bool {
+    // Log files are named by the SMF services, with the `/` in the FMRI
+    // translated to a `-`.
+    const PREFIXES: [&str; 2] = ["oxide-", "system-illumos-"];
+    let filename = filename.as_ref();
+    PREFIXES
+        .iter()
+        .any(|prefix| filename.starts_with(prefix) && filename.contains(".log"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_oxide_smf_log_file;
+    use super::is_oxide_smf_service;
+
+    #[test]
+    fn test_is_oxide_smf_service() {
+        assert!(is_oxide_smf_service("svc:/oxide/blah:default"));
+        assert!(is_oxide_smf_service("svc:/system/illumos/blah:default"));
+        assert!(!is_oxide_smf_service("svc:/system/blah:default"));
+        assert!(!is_oxide_smf_service("svc:/not/oxide/blah:default"));
+    }
+
+    #[test]
+    fn test_is_oxide_smf_log_file() {
+        assert!(is_oxide_smf_log_file("oxide-blah:default.log"));
+        assert!(is_oxide_smf_log_file("oxide-blah:default.log.0"));
+        assert!(is_oxide_smf_log_file("oxide-blah:default.log.1111"));
+        assert!(is_oxide_smf_log_file("system-illumos-blah:default.log"));
+        assert!(is_oxide_smf_log_file("system-illumos-blah:default.log.0"));
+        assert!(!is_oxide_smf_log_file("not-oxide-blah:default.log"));
+        assert!(!is_oxide_smf_log_file("not-system-illumos-blah:default.log"));
+    }
 }

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -94,6 +94,7 @@ serial_test.workspace = true
 subprocess.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
+tempfile.workspace = true
 
 illumos-utils = { workspace = true, features = ["testing"] }
 


### PR DESCRIPTION
- Fixes #4160.
- Checks for archived log files were wrong. This used the SMF FMRI, rather than the derived log filename, which translates slashes into dashes. This separates checks for Oxide-managed FMRIs and the log files for those.
- Use the _log file_ check when looking for archived files.
- Add tests for both checks and the method for finding archived log files for a service.