### PR TITLE
we don't need workspace deps for dev-tools (and omdb is stale)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,10 +236,8 @@ nexus-types = { path = "nexus/types" }
 num-integer = "0.1.45"
 num = { version = "0.4.1", default-features = false, features = [ "libm" ] }
 omicron-common = { path = "common" }
-omicron-dev = { path = "dev-tools/omicron-dev" }
 omicron-gateway = { path = "gateway" }
 omicron-nexus = { path = "nexus" }
-omicron-omdb = { path = "omdb" }
 omicron-package = { path = "package" }
 omicron-rpaths = { path = "rpaths" }
 omicron-sled-agent = { path = "sled-agent" }


### PR DESCRIPTION
We don't seem to need the `omicron-dev` dependency in `Cargo.toml` and the `omdb` one refers to its old location.