### PR TITLE
[workspace-hack] use workspace-dotted format and a patch directive

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -6,6 +6,10 @@ hakari-package = "omicron-workspace-hack"
 # Format for `workspace-hack = ...` lines in other Cargo.tomls. Requires cargo-hakari 0.9.8 or above.
 dep-format-version = "4"
 
+# Output lines as `omicron-workspace-hack.workspace = true`. Requires
+# cargo-hakari 0.9.28 or above.
+workspace-hack-line-style = "workspace-dotted"
+
 # Setting workspace.resolver = "2" in the root Cargo.toml is HIGHLY recommended.
 # Hakari works much better with the new feature resolver.
 # For more about the new feature resolver, see:
@@ -27,4 +31,3 @@ exact-versions = true
 
 [traversal-excludes]
 workspace-members = ["xtask"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ nexus-db-queries = { path = "nexus/db-queries" }
 nexus-defaults = { path = "nexus/defaults" }
 omicron-certificates = { path = "certificates" }
 omicron-passwords = { path = "passwords" }
+omicron-workspace-hack = "0.1.0"
 nexus-test-interface = { path = "nexus/test-interface" }
 nexus-test-utils-macros = { path = "nexus/test-utils-macros" }
 nexus-test-utils = { path = "nexus/test-utils" }
@@ -554,3 +555,10 @@ opt-level = 3
 [patch.crates-io.pq-sys]
 git = 'https://github.com/oxidecomputer/pq-sys'
 branch = "oxide/omicron"
+
+# Using the workspace-hack via this patch directive means that it only applies
+# while building within this workspace. If another workspace imports a crate
+# from here via a git dependency, it will not have the workspace-hack applied
+# to it.
+[patch.crates-io.omicron-workspace-hack]
+path = "workspace-hack"

--- a/api_identity/Cargo.toml
+++ b/api_identity/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/bootstore/Cargo.toml
+++ b/bootstore/Cargo.toml
@@ -36,7 +36,7 @@ zeroize.workspace = true
 # utils`. Unfortunately, it doesn't appear possible to put the `pq-sys` dep
 # only in `[dev-dependencies]`.
 pq-sys = "*"
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/bootstrap-agent-client/Cargo.toml
+++ b/bootstrap-agent-client/Cargo.toml
@@ -17,4 +17,4 @@ serde.workspace = true
 sled-hardware.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/caboose-util/Cargo.toml
+++ b/caboose-util/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 hubtools.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/certificates/Cargo.toml
+++ b/certificates/Cargo.toml
@@ -12,7 +12,7 @@ openssl-sys.workspace = true
 thiserror.workspace = true
 
 omicron-common.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 omicron-test-utils.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -40,7 +40,7 @@ toml.workspace = true
 uuid.workspace = true
 parse-display.workspace = true
 progenitor.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 camino-tempfile.workspace = true

--- a/crdb-seed/Cargo.toml
+++ b/crdb-seed/Cargo.toml
@@ -13,4 +13,4 @@ omicron-test-utils.workspace = true
 ring.workspace = true
 slog.workspace = true
 tokio.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/ddm-admin-client/Cargo.toml
+++ b/ddm-admin-client/Cargo.toml
@@ -15,7 +15,7 @@ tokio.workspace = true
 
 omicron-common.workspace = true
 sled-hardware.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -14,7 +14,7 @@ serde.workspace = true
 serde_derive.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [[bin]]
 name = "thing-flinger"

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -32,8 +32,8 @@ tabled.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 ipnetwork.workspace = true
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/dev-tools/omicron-dev/Cargo.toml
+++ b/dev-tools/omicron-dev/Cargo.toml
@@ -28,7 +28,7 @@ signal-hook-tokio.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
 tokio-postgres.workspace = true
 toml.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 camino-tempfile.workspace = true

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -133,12 +133,6 @@ fn cmd_check_workspace_deps() -> Result<()> {
                     }
                 }
 
-                if name == WORKSPACE_HACK_PACKAGE_NAME {
-                    // Skip over workspace-hack because hakari doesn't yet support
-                    // workspace deps: https://github.com/guppy-rs/guppy/issues/7
-                    continue;
-                }
-
                 non_workspace_dependencies
                     .entry(name.to_owned())
                     .or_insert_with(Vec::new)

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -30,7 +30,7 @@ trust-dns-proto.workspace = true
 trust-dns-resolver.workspace = true
 trust-dns-server.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/dns-service-client/Cargo.toml
+++ b/dns-service-client/Cargo.toml
@@ -14,4 +14,4 @@ serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/dpd-client/Cargo.toml
+++ b/dpd-client/Cargo.toml
@@ -17,7 +17,7 @@ ipnetwork.workspace = true
 http.workspace = true
 schemars.workspace = true
 rand.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/end-to-end-tests/Cargo.toml
+++ b/end-to-end-tests/Cargo.toml
@@ -24,4 +24,4 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 trust-dns-resolver.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -24,4 +24,4 @@ uuid.workspace = true
 
 gateway-client.workspace = true
 gateway-messages.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/gateway-client/Cargo.toml
+++ b/gateway-client/Cargo.toml
@@ -15,4 +15,4 @@ serde_json.workspace = true
 schemars.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/gateway-test-utils/Cargo.toml
+++ b/gateway-test-utils/Cargo.toml
@@ -14,4 +14,4 @@ slog.workspace = true
 sp-sim.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -34,7 +34,7 @@ tokio-tungstenite.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -29,7 +29,7 @@ zone.workspace = true
 
 # only enabled via the `testing` feature
 mockall = { workspace = true, optional = true }
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 opte-ioctl.workspace = true

--- a/installinator-artifact-client/Cargo.toml
+++ b/installinator-artifact-client/Cargo.toml
@@ -15,4 +15,4 @@ serde_json.workspace = true
 slog.workspace = true
 update-engine.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/installinator-artifactd/Cargo.toml
+++ b/installinator-artifactd/Cargo.toml
@@ -20,7 +20,7 @@ uuid.workspace = true
 
 installinator-common.workspace = true
 omicron-common.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/installinator-common/Cargo.toml
+++ b/installinator-common/Cargo.toml
@@ -15,4 +15,4 @@ serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
 update-engine.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -42,7 +42,7 @@ toml.workspace = true
 tufaceous-lib.workspace = true
 update-engine.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 omicron-test-utils.workspace = true

--- a/internal-dns-cli/Cargo.toml
+++ b/internal-dns-cli/Cargo.toml
@@ -13,4 +13,4 @@ omicron-common.workspace = true
 slog.workspace = true
 tokio.workspace = true
 trust-dns-resolver.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -17,7 +17,7 @@ thiserror.workspace = true
 trust-dns-proto.workspace = true
 trust-dns-resolver.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/ipcc-key-value/Cargo.toml
+++ b/ipcc-key-value/Cargo.toml
@@ -11,7 +11,7 @@ omicron-common.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 omicron-common = { workspace = true, features = ["testing"] }

--- a/key-manager/Cargo.toml
+++ b/key-manager/Cargo.toml
@@ -14,5 +14,5 @@ slog.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 zeroize.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 

--- a/nexus-client/Cargo.toml
+++ b/nexus-client/Cargo.toml
@@ -18,4 +18,4 @@ serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -90,7 +90,7 @@ oximeter.workspace = true
 oximeter-instruments = { workspace = true, features = ["http-instruments"] }
 oximeter-producer.workspace = true
 rustls = { workspace = true }
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 async-bb8-diesel.workspace = true

--- a/nexus/authz-macros/Cargo.toml
+++ b/nexus/authz-macros/Cargo.toml
@@ -14,4 +14,4 @@ quote.workspace = true
 serde.workspace = true
 serde_tokenstream.workspace = true
 syn.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/db-macros/Cargo.toml
+++ b/nexus/db-macros/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 serde.workspace = true
 serde_tokenstream.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 rustfmt-wrapper.workspace = true

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -36,7 +36,7 @@ nexus-defaults.workspace = true
 nexus-types.workspace = true
 omicron-passwords.workspace = true
 sled-agent-client.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/nexus/db-queries/Cargo.toml
+++ b/nexus/db-queries/Cargo.toml
@@ -63,7 +63,7 @@ nexus-types.workspace = true
 omicron-common.workspace = true
 omicron-passwords.workspace = true
 oximeter.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/nexus/defaults/Cargo.toml
+++ b/nexus/defaults/Cargo.toml
@@ -11,4 +11,4 @@ rand.workspace = true
 serde_json.workspace = true
 
 omicron-common.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/test-interface/Cargo.toml
+++ b/nexus/test-interface/Cargo.toml
@@ -12,4 +12,4 @@ nexus-types.workspace = true
 omicron-common.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/test-utils-macros/Cargo.toml
+++ b/nexus/test-utils-macros/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = [ "fold", "parsing" ] }
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -38,4 +38,4 @@ tempfile.workspace = true
 trust-dns-proto.workspace = true
 trust-dns-resolver.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -25,4 +25,4 @@ api_identity.workspace = true
 dns-service-client.workspace = true
 omicron-common.workspace = true
 omicron-passwords.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/oxide-client/Cargo.toml
+++ b/oxide-client/Cargo.toml
@@ -21,4 +21,4 @@ thiserror.workspace = true
 tokio = { workspace = true, features = [ "net" ] }
 trust-dns-resolver.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/oximeter-client/Cargo.toml
+++ b/oximeter-client/Cargo.toml
@@ -12,4 +12,4 @@ reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 serde.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -22,7 +22,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -25,7 +25,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = [ "rt-multi-thread", "macros" ] }
 usdt.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 itertools.workspace = true

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -12,7 +12,7 @@ oximeter.workspace = true
 tokio.workspace = true
 http = { workspace = true, optional = true }
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [features]
 default = ["http-instruments"]

--- a/oximeter/oximeter-macro-impl/Cargo.toml
+++ b/oximeter/oximeter-macro-impl/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = [ "full", "extra-traits" ] }
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -15,7 +15,7 @@ schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/oximeter/producer/Cargo.toml
+++ b/oximeter/producer/Cargo.toml
@@ -19,4 +19,4 @@ slog-dtrace.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true, features = [ "full" ] }
 toml.workspace = true
 topological-sort.workspace = true
 walkdir.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/passwords/Cargo.toml
+++ b/passwords/Cargo.toml
@@ -11,7 +11,7 @@ thiserror.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_with.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 argon2alt = { package = "rust-argon2", version = "1.0" }

--- a/rpaths/Cargo.toml
+++ b/rpaths/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/sled-agent-client/Cargo.toml
+++ b/sled-agent-client/Cargo.toml
@@ -15,4 +15,4 @@ reqwest = { workspace = true, features = [ "json", "rustls-tls", "stream" ] }
 serde.workspace = true
 slog.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -76,7 +76,7 @@ uuid.workspace = true
 zeroize.workspace = true
 zone.workspace = true
 static_assertions.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 opte-ioctl.workspace = true

--- a/sled-hardware/Cargo.toml
+++ b/sled-hardware/Cargo.toml
@@ -24,7 +24,7 @@ thiserror.workspace = true
 tofino.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 illumos-devinfo = { git = "https://github.com/oxidecomputer/illumos-devinfo", branch = "main" }

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -21,7 +21,7 @@ sprockets-rot.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
 toml.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [[bin]]
 name = "sp-sim"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -25,7 +25,7 @@ usdt.workspace = true
 rcgen.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/tufaceous-lib/Cargo.toml
+++ b/tufaceous-lib/Cargo.toml
@@ -32,7 +32,7 @@ toml.workspace = true
 tough.workspace = true
 url = "2.4.1"
 zip.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 omicron-test-utils.workspace = true

--- a/tufaceous/Cargo.toml
+++ b/tufaceous/Cargo.toml
@@ -18,7 +18,7 @@ slog-async.workspace = true
 slog-envlogger.workspace = true
 slog-term.workspace = true
 tufaceous-lib.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/update-engine/Cargo.toml
+++ b/update-engine/Cargo.toml
@@ -21,7 +21,7 @@ schemars = { workspace = true, features = ["uuid1"] }
 slog.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "time", "rt-multi-thread"] }
 uuid.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 buf-list.workspace = true

--- a/wicket-common/Cargo.toml
+++ b/wicket-common/Cargo.toml
@@ -13,4 +13,4 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 update-engine.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/wicket-dbg/Cargo.toml
+++ b/wicket-dbg/Cargo.toml
@@ -22,7 +22,7 @@ wicket.workspace = true
 
 # used only by wicket-dbg binary
 reedline = "0.23.0"
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [[bin]]
 name = "wicket-dbg"

--- a/wicket/Cargo.toml
+++ b/wicket/Cargo.toml
@@ -46,7 +46,7 @@ omicron-passwords.workspace = true
 update-engine.workspace = true
 wicket-common.workspace = true
 wicketd-client.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/wicketd-client/Cargo.toml
+++ b/wicketd-client/Cargo.toml
@@ -18,4 +18,4 @@ slog.workspace = true
 update-engine.workspace = true
 uuid.workspace = true
 wicket-common.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -54,7 +54,7 @@ sled-hardware.workspace = true
 tufaceous-lib.workspace = true
 update-engine.workspace = true
 wicket-common.workspace = true
-omicron-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+omicron-workspace-hack.workspace = true
 
 [[bin]]
 name = "wicketd"


### PR DESCRIPTION
Two changes:

1. Switch to the workspace-dotted format (`.workspace = true`) for
   uniformity with the rest of omicron. This is new in cargo-hakari
   0.9.28.

2. Use a patch directive, which means that the workspace-hack only
   applies while building within this workspace. If another workspace
   imports a crate from here via a git dependency, it will not have the
   workspace-hack applied to it (instead, it will use [this empty crate](https://crates.io/crates/omicron-workspace-hack)
   on crates.io). Thanks so much to @pfmooney for this
   suggestion!

Also remove one of the exceptions made in the xtask (workspace-hack
lines in *other* `Cargo.toml`s are now output as `.workspace = true`,
but hakari cannot yet generate workspace lines in its own `Cargo.toml`).

I verified by creating an empty project that the workspace-hack isn't applied to downstream projects that import e.g. `omicron-common` as a git (or path) dependency.

Folks will have to update to cargo-hakari 0.9.28 to use this, but hopefully that won't be too much of a bother.