### PR TITLE
[trivial] add doc comments to snapshot ID and image ID on disk response type

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -952,7 +952,9 @@ pub struct Disk {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
     pub project_id: Uuid,
+    /// ID of snapshot from which disk was created, if any
     pub snapshot_id: Option<Uuid>,
+    /// ID of image from which disk was created, if any
     pub image_id: Option<Uuid>,
     pub size: ByteCount,
     pub block_size: ByteCount,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9615,6 +9615,7 @@
           },
           "image_id": {
             "nullable": true,
+            "description": "ID of image from which disk was created, if any",
             "type": "string",
             "format": "uuid"
           },
@@ -9635,6 +9636,7 @@
           },
           "snapshot_id": {
             "nullable": true,
+            "description": "ID of snapshot from which disk was created, if any",
             "type": "string",
             "format": "uuid"
           },


### PR DESCRIPTION
Noticed these fields on the disk response, wondered what they are, and was surprised to see no description in the docs. 


https://docs-2meozyi0z-oxidecomputer.vercel.app/api/disk_view 

<img width="693" alt="image" src="https://github.com/oxidecomputer/omicron/assets/3612203/6edb10dd-0f05-48ba-9843-527c32bb70b1">
