### PR TITLE
update softnpu version

### DIFF
--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -15,7 +15,7 @@ OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="41b3a67b3d44f51528816ff8e539b4001df48305"
+SOFTNPU_COMMIT="eb27e6a00f1082c9faac7cf997e57d0609f7a309"
 
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -37,7 +37,7 @@ function ensure_simulated_links {
             dladm create-simnet -t "net$I"
             dladm create-simnet -t "sc${I}_0"
             dladm modify-simnet -t -p "net$I" "sc${I}_0"
-            dladm set-linkprop -p mtu=1600 "sc${I}_0" # encap headroom
+            dladm set-linkprop -p mtu=9000 "sc${I}_0" # match emulated devices
         fi
         success "Simnet net$I/sc${I}_0 exists"
     done


### PR DESCRIPTION
This pulls in a new version of the `npuzone` tool from the softnpu repo that automatically pulls the latest sidecar-lite code.