### PR TITLE
[dependencies] add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>oxidecomputer/renovate-config",
+    "local>oxidecomputer/renovate-config//rust/autocreate",
+    "helpers:pinGitHubActionDigests"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "local>oxidecomputer/renovate-config",
     "local>oxidecomputer/renovate-config//rust/autocreate",
+    "local>oxidecomputer/renovate-config:post-upgrade",
     "helpers:pinGitHubActionDigests"
   ]
 }

--- a/tools/renovate-post-upgrade.sh
+++ b/tools/renovate-post-upgrade.sh
@@ -4,18 +4,37 @@
 
 set -euo pipefail
 
+# Function to retry a command up to 3 times.
+function retry_command {
+    local retries=3
+    local delay=5
+    local count=0
+    until "$@"; do
+        exit_code=$?
+        count=$((count+1))
+        if [ $count -lt $retries ]; then
+            echo "Command failed with exit code $exit_code. Retrying in $delay seconds..."
+            sleep $delay
+        else
+            echo "Command failed with exit code $exit_code after $count attempts."
+            return $exit_code
+        fi
+    done
+}
+
 # Download and install cargo-hakari if it is not already installed.
 if ! command -v cargo-hakari &> /dev/null; then
     # Need cargo-binstall to install cargo-hakari.
     if ! command -v cargo-binstall &> /dev/null; then
         # Fetch cargo binstall.
         echo "Installing cargo-binstall..."
-        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        curl --retry 3 -L --proto '=https' --tlsv1.2 -sSfO https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh
+        retry_command bash install-from-binstall-release.sh
     fi
 
     # Install cargo-hakari.
     echo "Installing cargo-hakari..."
-    cargo binstall cargo-hakari --no-confirm
+    retry_command cargo binstall cargo-hakari --no-confirm
 fi
 
 # Run cargo hakari to regenerate the workspace-hack file.

--- a/tools/renovate-post-upgrade.sh
+++ b/tools/renovate-post-upgrade.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script is run after Renovate upgrades dependencies or lock files.
+
+set -euo pipefail
+
+# Download and install cargo-hakari if it is not already installed.
+if ! command -v cargo-hakari &> /dev/null; then
+    # Need cargo-binstall to install cargo-hakari.
+    if ! command -v cargo-binstall &> /dev/null; then
+        # Fetch cargo binstall.
+        echo "Installing cargo-binstall..."
+        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    fi
+
+    # Install cargo-hakari.
+    echo "Installing cargo-hakari..."
+    cargo binstall cargo-hakari --no-confirm
+fi
+
+# Run cargo hakari to regenerate the workspace-hack file.
+echo "Running cargo-hakari..."
+cargo hakari generate


### PR DESCRIPTION
* Add configuration for automatically creating dependencies, and for pinning GitHub Actions digests
* Add a post-upgrade script that runs cargo-hakari.

Things to check before we land this:

- [x] Make sure the Mend Renovate App isn't enabled for Omicron (Augustus verified this)

Depends on https://github.com/oxidecomputer/renovate-config/pull/5.

See [RFD 434](https://rfd.shared.oxide.computer/rfd/0434) and #4166.