### PR TITLE
[buildomat] authorize PRs generated by oxide-renovate

### DIFF
--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -17,5 +17,6 @@ org_only = true
 allow_users = [
 	"dependabot[bot]",
 	"oxide-reflector-bot[bot]",
+	"oxide-renovate[bot]",
 	"renovate[bot]",
 ]

--- a/tools/renovate-post-upgrade.sh
+++ b/tools/renovate-post-upgrade.sh
@@ -22,6 +22,13 @@ function retry_command {
     done
 }
 
+# If cargo isn't present, skip this -- it implies that a non-Rust dependency was
+# updated.
+if ! command -v cargo &> /dev/null; then
+    echo "Skipping cargo-hakari update because cargo is not present."
+    exit 0
+fi
+
 # Download and install cargo-hakari if it is not already installed.
 if ! command -v cargo-hakari &> /dev/null; then
     # Need cargo-binstall to install cargo-hakari.


### PR DESCRIPTION
Means that PRs like https://github.com/oxidecomputer/omicron/pull/4241
will be automatically authorized.

Also skip cargo-hakari update if cargo isn't present.

Thanks @iliana!
