### PR TITLE
destroy_virtual_hardware.sh needs to unmount backing filesystems

### DIFF
--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -56,7 +56,23 @@ function remove_softnpu_zone {
         --ports sc0_1,tfportqsfp0_0
 }
 
+# Some services have their working data overlaid by backing mounts from the
+# internal boot disk. Before we can destroy the ZFS pools, we need to unmount
+# these.
+
+BACKED_SERVICES="svc:/system/fmd:default"
+
+function demount_backingfs {
+    svcadm disable -st $BACKED_SERVICES
+    zpool list -Hpo name | grep '^oxi_' \
+        | xargs -i zfs list -Hpo name,canmount,mounted -r {}/backing \
+        | awk '$3 == "yes" && $2 == "noauto" { print $1 }' \
+        | xargs -l zfs umount
+    svcadm enable -st $BACKED_SERVICES
+}
+
 verify_omicron_uninstalled
+demount_backingfs
 unload_xde_driver
 remove_softnpu_zone
 try_remove_vnics


### PR DESCRIPTION
The backing filesystems added in d624bce9af2 prevent the destroy_virtual_hardware.sh script from properly cleaning up all ZFS pools and cause the fmd service to go into maintenance which delays control plane startup. This updates the script to unwind the backing datasets as part of its work.