### PR TITLE
Use opctx_alloc in start saga to query boundary switches

### DIFF
--- a/nexus/db-queries/src/authn/mod.rs
+++ b/nexus/db-queries/src/authn/mod.rs
@@ -228,8 +228,8 @@ impl Context {
         )
     }
 
-    /// Returns an authenticated context for the specific Silo user.
-    #[cfg(test)]
+    /// Returns an authenticated context for the specific Silo user. Not marked
+    /// as #[cfg(test)] so that this is available in integration tests.
     pub fn for_test_user(
         silo_user_id: Uuid,
         silo_id: Uuid,

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -323,6 +323,8 @@ async fn sis_dpd_ensure(
     );
     let datastore = osagactx.datastore();
 
+    // Querying sleds requires fleet access; use the instance allocator context
+    // for this.
     let sled_uuid = sagactx.lookup::<Uuid>("sled_id")?;
     let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, &datastore)
         .sled_id(sled_uuid)
@@ -330,9 +332,11 @@ async fn sis_dpd_ensure(
         .await
         .map_err(ActionError::action_failed)?;
 
+    // Querying boundary switches also requires fleet access and the use of the
+    // instance allocator context.
     let boundary_switches = osagactx
         .nexus()
-        .boundary_switches(&opctx)
+        .boundary_switches(&osagactx.nexus().opctx_alloc)
         .await
         .map_err(ActionError::action_failed)?;
 


### PR DESCRIPTION
Finding boundary switches in the instance start saga requires fleet query access. Use the Nexus instance allocation context to get it instead of the saga initiator's operation context. (This was introduced in #3873; it wasn't previously a problem because the instance create saga set up instance NAT state, and that saga received a boundary switch list as a parameter, which parameter was generated by using the instance allocation context. #4194 made this worse by making instance create use the start saga to start instances instead of using its own saga nodes.)

Update the instance-in-silo integration test to make sure that instances created by a silo collaborator actually start. This is unfortunately not very elegant. The `instance_simulate` function family normally uses `OpContext::for_tests` to get an operation context, but that context is associated with a user that isn't in the test silo. To get around this, add some simulation interfaces that take an explicit `OpContext` and then generate one corresponding to the silo user for the test case in question. It seems like it'd be nicer to give helper routines like `instance_simulate` access to a context that is omnipotent across all silos, but I wasn't sure how best to do this. I'm definitely open to suggestions here.

Tested via cargo tests.

Fixes #4272.