### PR TITLE
[wicketd] Accept TUF repos with RoT archives signed with different keys

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -25,6 +25,21 @@
 #: job = "helios / build trampoline OS image"
 #:
 #: [[publish]]
+#: series = "rot-all"
+#: name = "repo.zip.parta"
+#: from_output = "/work/repo-rot-all.zip.parta"
+#:
+#: [[publish]]
+#: series = "rot-all"
+#: name = "repo.zip.partb"
+#: from_output = "/work/repo-rot-all.zip.partb"
+#:
+#: [[publish]]
+#: series = "rot-all"
+#: name = "repo.zip.sha256.txt"
+#: from_output = "/work/repo-rot-all.zip.sha256.txt"
+#:
+#: [[publish]]
 #: series = "rot-prod-rel"
 #: name = "repo.zip.parta"
 #: from_output = "/work/repo-rot-prod-rel.zip.parta"
@@ -168,6 +183,38 @@ caboose_util_rot() {
 }
 
 SERIES_LIST=()
+
+# Create an initial `manifest-rot-all.toml` containing the SP images for all
+# boards. While we still need to build multiple TUF repos,
+# `add_hubris_artifacts` below will append RoT images to this manifest (in
+# addition to the single-RoT manifest it creates).
+prep_rot_all_series() {
+    series="rot-all"
+
+    SERIES_LIST+=("$series")
+
+    manifest=/work/manifest-$series.toml
+    cp /work/manifest.toml "$manifest"
+
+    for board_rev in "${ALL_BOARDS[@]}"; do
+        board=${board_rev%-?}
+        tufaceous_board=${board//sidecar/switch}
+        sp_image="/work/hubris/${board_rev}.zip"
+        sp_caboose_version=$(/work/caboose-util read-version "$sp_image")
+        sp_caboose_board=$(/work/caboose-util read-board "$sp_image")
+
+        cat >>"$manifest" <<EOF
+[[artifact.${tufaceous_board}_sp]]
+name = "$sp_caboose_board"
+version = "$sp_caboose_version"
+[artifact.${tufaceous_board}_sp.source]
+kind = "file"
+path = "$sp_image"
+EOF
+    done
+}
+prep_rot_all_series
+
 add_hubris_artifacts() {
     series="$1"
     rot_dir="$2"
@@ -177,6 +224,7 @@ add_hubris_artifacts() {
     SERIES_LIST+=("$series")
 
     manifest=/work/manifest-$series.toml
+    manifest_rot_all=/work/manifest-rot-all.toml
     cp /work/manifest.toml "$manifest"
 
     for board in gimlet psc sidecar; do
@@ -189,6 +237,20 @@ add_hubris_artifacts() {
         cat >>"$manifest" <<EOF
 [[artifact.${tufaceous_board}_rot]]
 name = "$rot_caboose_board"
+version = "$rot_caboose_version"
+[artifact.${tufaceous_board}_rot.source]
+kind = "composite-rot"
+[artifact.${tufaceous_board}_rot.source.archive_a]
+kind = "file"
+path = "$rot_image_a"
+[artifact.${tufaceous_board}_rot.source.archive_b]
+kind = "file"
+path = "$rot_image_b"
+EOF
+
+        cat >>"$manifest_rot_all" <<EOF
+[[artifact.${tufaceous_board}_rot]]
+name = "$rot_caboose_board-$rot_dir"
 version = "$rot_caboose_version"
 [artifact.${tufaceous_board}_rot.source]
 kind = "composite-rot"

--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -250,7 +250,7 @@ EOF
 
         cat >>"$manifest_rot_all" <<EOF
 [[artifact.${tufaceous_board}_rot]]
-name = "$rot_caboose_board-$rot_dir"
+name = "$rot_caboose_board-${rot_dir//\//-}"
 version = "$rot_caboose_version"
 [artifact.${tufaceous_board}_rot.source]
 kind = "composite-rot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1e180ae55e56bd17af35cb868ffbd18ce487351d#1e180ae55e56bd17af35cb868ffbd18ce487351d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2bab5d707a10e6ef40d988b2ee3c85701cb49f75#2bab5d707a10e6ef40d988b2ee3c85701cb49f75"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack 0.1.2",
@@ -2797,14 +2797,15 @@ dependencies = [
  "serde_repr",
  "smoltcp 0.9.1",
  "static_assertions",
+ "strum_macros 0.25.2",
  "uuid",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=1e180ae55e56bd17af35cb868ffbd18ce487351d#1e180ae55e56bd17af35cb868ffbd18ce487351d"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2bab5d707a10e6ef40d988b2ee3c85701cb49f75#2bab5d707a10e6ef40d988b2ee3c85701cb49f75"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2817,10 +2818,11 @@ dependencies = [
  "lru-cache",
  "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
  "once_cell",
+ "paste",
  "serde",
  "serde-big-array 0.5.1",
  "slog",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "string_cache",
  "thiserror",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git?branch=main)",
@@ -3261,7 +3263,7 @@ dependencies = [
  "tlvc-text",
  "toml 0.7.8",
  "x509-cert",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
  "zip",
 ]
 
@@ -3725,7 +3727,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4069,7 +4071,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "x509-cert",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -4997,6 +4999,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.4",
  "ciborium",
  "clap 4.4.3",
  "dropshot",
@@ -5611,7 +5614,7 @@ dependencies = [
  "serde",
  "smoltcp 0.8.2",
  "version_check",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -5717,7 +5720,7 @@ dependencies = [
  "opte",
  "serde",
  "smoltcp 0.8.2",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -8360,9 +8363,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -8942,7 +8945,7 @@ source = "git+https://github.com/oxidecomputer/tlvc.git?branch=main#e644a21a7ca9
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -8952,7 +8955,7 @@ source = "git+https://github.com/oxidecomputer/tlvc.git#e644a21a7ca973ed31499106
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -8963,7 +8966,7 @@ dependencies = [
  "ron 0.8.1",
  "serde",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
- "zerocopy 0.6.3",
+ "zerocopy 0.6.4",
 ]
 
 [[package]]
@@ -8992,7 +8995,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -9038,7 +9041,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.8.5",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio",
  "tokio-util",
  "whoami",
@@ -9477,8 +9480,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 
@@ -10434,12 +10437,12 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b9c234616391070b0b173963ebc65a9195068e7ed3731c6edac2ec45ebe106"
+checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.6.3",
+ "zerocopy-derive 0.6.4",
 ]
 
 [[package]]
@@ -10455,9 +10458,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7f3a471f98d0a61c34322fbbfd10c384b07687f680d4119813713f72308d91"
+checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.4.1"
-source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#2481445b80f8476041f62a1c8b6301e4918c63ed"
+source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#73cd5a84689d59ecce9da66ad4389c540d315168"
 dependencies = [
  "lpc55_areas",
  "lpc55_sign",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10087,6 +10087,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.4",
  "bootstrap-agent-client",
  "bytes",
  "camino",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2bab5d707a10e6ef40d988b2ee3c85701cb49f75#2bab5d707a10e6ef40d988b2ee3c85701cb49f75"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2739c18e80697aa6bc235c935176d14b4d757ee9#2739c18e80697aa6bc235c935176d14b4d757ee9"
 dependencies = [
  "bitflags 1.3.2",
  "hubpack 0.1.2",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2bab5d707a10e6ef40d988b2ee3c85701cb49f75#2bab5d707a10e6ef40d988b2ee3c85701cb49f75"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=2739c18e80697aa6bc235c935176d14b4d757ee9#2739c18e80697aa6bc235c935176d14b4d757ee9"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,8 +191,8 @@ foreign-types = "0.3.2"
 fs-err = "2.9.0"
 futures = "0.3.28"
 gateway-client = { path = "clients/gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2bab5d707a10e6ef40d988b2ee3c85701cb49f75", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2bab5d707a10e6ef40d988b2ee3c85701cb49f75" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9" }
 gateway-test-utils = { path = "gateway-test-utils" }
 glob = "0.3.1"
 headers = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,8 +191,8 @@ foreign-types = "0.3.2"
 fs-err = "2.9.0"
 futures = "0.3.28"
 gateway-client = { path = "clients/gateway-client" }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d" }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2bab5d707a10e6ef40d988b2ee3c85701cb49f75", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2bab5d707a10e6ef40d988b2ee3c85701cb49f75" }
 gateway-test-utils = { path = "gateway-test-utils" }
 glob = "0.3.1"
 headers = "0.3.9"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 ciborium.workspace = true
 clap.workspace = true
 dropshot.workspace = true

--- a/gateway/src/http_entrypoints.rs
+++ b/gateway/src/http_entrypoints.rs
@@ -14,6 +14,7 @@ use self::conversions::component_from_str;
 use crate::error::SpCommsError;
 use crate::http_err_with_message;
 use crate::ServerContext;
+use base64::Engine;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
@@ -27,6 +28,7 @@ use dropshot::UntypedBody;
 use dropshot::WebsocketEndpointResult;
 use dropshot::WebsocketUpgrade;
 use futures::TryFutureExt;
+use gateway_messages::SpComponent;
 use gateway_messages::SpError;
 use gateway_sp_comms::error::CommunicationError;
 use gateway_sp_comms::HostPhase2Provider;
@@ -118,6 +120,70 @@ pub enum RotSlot {
 pub struct RotImageDetails {
     pub digest: String,
     pub version: ImageVersion,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+pub struct RotCmpa {
+    pub base64_data: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+#[serde(tag = "slot", rename_all = "snake_case")]
+pub enum RotCfpaSlot {
+    Active,
+    Inactive,
+    Scratch,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+pub struct GetCfpaParams {
+    pub slot: RotCfpaSlot,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+pub struct RotCfpa {
+    pub base64_data: String,
+    pub slot: RotCfpaSlot,
 }
 
 #[derive(
@@ -968,6 +1034,75 @@ async fn sp_component_update_abort(
     Ok(HttpResponseUpdatedNoContent {})
 }
 
+/// Read the CMPA from a root of trust.
+///
+/// This endpoint is only valid for the `rot` component.
+#[endpoint {
+    method = GET,
+    path = "/sp/{type}/{slot}/component/{component}/cmpa",
+}]
+async fn sp_rot_cmpa_get(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    path: Path<PathSpComponent>,
+) -> Result<HttpResponseOk<RotCmpa>, HttpError> {
+    let apictx = rqctx.context();
+
+    let PathSpComponent { sp, component } = path.into_inner();
+
+    // Ensure the caller knows they're asking for the RoT
+    if component_from_str(&component)? != SpComponent::ROT {
+        return Err(HttpError::for_bad_request(
+            Some("RequestUnsupportedForComponent".to_string()),
+            "Only the RoT has a CFPA".into(),
+        ));
+    }
+
+    let sp = apictx.mgmt_switch.sp(sp.into())?;
+    let data = sp.read_rot_cmpa().await.map_err(SpCommsError::from)?;
+
+    let base64_data = base64::engine::general_purpose::STANDARD.encode(data);
+
+    Ok(HttpResponseOk(RotCmpa { base64_data }))
+}
+
+/// Read the requested CFPA slot from a root of trust.
+///
+/// This endpoint is only valid for the `rot` component.
+#[endpoint {
+    method = GET,
+    path = "/sp/{type}/{slot}/component/{component}/cfpa",
+}]
+async fn sp_rot_cfpa_get(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    path: Path<PathSpComponent>,
+    params: TypedBody<GetCfpaParams>,
+) -> Result<HttpResponseOk<RotCfpa>, HttpError> {
+    let apictx = rqctx.context();
+
+    let PathSpComponent { sp, component } = path.into_inner();
+    let GetCfpaParams { slot } = params.into_inner();
+
+    // Ensure the caller knows they're asking for the RoT
+    if component_from_str(&component)? != SpComponent::ROT {
+        return Err(HttpError::for_bad_request(
+            Some("RequestUnsupportedForComponent".to_string()),
+            "Only the RoT has a CFPA".into(),
+        ));
+    }
+
+    let sp = apictx.mgmt_switch.sp(sp.into())?;
+    let data = match slot {
+        RotCfpaSlot::Active => sp.read_rot_active_cfpa().await,
+        RotCfpaSlot::Inactive => sp.read_rot_inactive_cfpa().await,
+        RotCfpaSlot::Scratch => sp.read_rot_scratch_cfpa().await,
+    }
+    .map_err(SpCommsError::from)?;
+
+    let base64_data = base64::engine::general_purpose::STANDARD.encode(data);
+
+    Ok(HttpResponseOk(RotCfpa { base64_data, slot }))
+}
+
 /// List SPs via Ignition
 ///
 /// Retreive information for all SPs via the Ignition controller. This is lower
@@ -1324,6 +1459,8 @@ pub fn api() -> GatewayApiDescription {
         api.register(sp_component_update)?;
         api.register(sp_component_update_status)?;
         api.register(sp_component_update_abort)?;
+        api.register(sp_rot_cmpa_get)?;
+        api.register(sp_rot_cfpa_get)?;
         api.register(sp_host_phase2_progress_get)?;
         api.register(sp_host_phase2_progress_delete)?;
         api.register(ignition_list)?;

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -551,6 +551,70 @@
         }
       }
     },
+    "/sp/{type}/{slot}/component/{component}/cfpa": {
+      "get": {
+        "summary": "Read the requested CFPA slot from a root of trust.",
+        "description": "This endpoint is only valid for the `rot` component.",
+        "operationId": "sp_rot_cfpa_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetCfpaParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RotCfpa"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sp/{type}/{slot}/component/{component}/clear-status": {
       "post": {
         "summary": "Clear status of a component",
@@ -588,6 +652,60 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sp/{type}/{slot}/component/{component}/cmpa": {
+      "get": {
+        "summary": "Read the CMPA from a root of trust.",
+        "description": "This endpoint is only valid for the `rot` component.",
+        "operationId": "sp_rot_cmpa_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "component",
+            "description": "ID for the component of the SP; this is the internal identifier used by the SP itself to identify its components.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SpType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RotCmpa"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -1324,6 +1442,17 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "GetCfpaParams": {
+        "type": "object",
+        "properties": {
+          "slot": {
+            "$ref": "#/components/schemas/RotCfpaSlot"
+          }
+        },
+        "required": [
+          "slot"
         ]
       },
       "HostPhase2Progress": {
@@ -2069,6 +2198,78 @@
           "A0",
           "A1",
           "A2"
+        ]
+      },
+      "RotCfpa": {
+        "type": "object",
+        "properties": {
+          "base64_data": {
+            "type": "string"
+          },
+          "slot": {
+            "$ref": "#/components/schemas/RotCfpaSlot"
+          }
+        },
+        "required": [
+          "base64_data",
+          "slot"
+        ]
+      },
+      "RotCfpaSlot": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "string",
+                "enum": [
+                  "active"
+                ]
+              }
+            },
+            "required": [
+              "slot"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "string",
+                "enum": [
+                  "inactive"
+                ]
+              }
+            },
+            "required": [
+              "slot"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "string",
+                "enum": [
+                  "scratch"
+                ]
+              }
+            },
+            "required": [
+              "slot"
+            ]
+          }
+        ]
+      },
+      "RotCmpa": {
+        "type": "object",
+        "properties": {
+          "base64_data": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "base64_data"
         ]
       },
       "RotSlot": {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1282,6 +1282,25 @@ impl SpHandler for Handler {
         buf[..val.len()].copy_from_slice(val);
         Ok(val.len())
     }
+
+    fn read_sensor(
+        &mut self,
+        _request: gateway_messages::SensorRequest,
+    ) -> std::result::Result<gateway_messages::SensorResponse, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn current_time(&mut self) -> std::result::Result<u64, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn read_rot(
+        &mut self,
+        _request: gateway_messages::RotRequest,
+        _buf: &mut [u8],
+    ) -> std::result::Result<gateway_messages::RotResponse, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
 }
 
 enum UpdateState {

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -1001,6 +1001,25 @@ impl SpHandler for Handler {
         buf[..val.len()].copy_from_slice(val);
         Ok(val.len())
     }
+
+    fn read_sensor(
+        &mut self,
+        _request: gateway_messages::SensorRequest,
+    ) -> std::result::Result<gateway_messages::SensorResponse, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn current_time(&mut self) -> std::result::Result<u64, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
+
+    fn read_rot(
+        &mut self,
+        _request: gateway_messages::RotRequest,
+        _buf: &mut [u8],
+    ) -> std::result::Result<gateway_messages::RotResponse, SpError> {
+        Err(SpError::RequestUnsupportedForSp)
+    }
 }
 
 struct FakeIgnition {

--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -159,6 +159,21 @@ pub enum UpdateTerminalError {
         #[source]
         error: gateway_client::Error<gateway_client::types::Error>,
     },
+    #[error("getting RoT CMPA failed")]
+    GetRotCmpaFailed {
+        #[source]
+        error: anyhow::Error,
+    },
+    #[error("getting RoT CFPA failed")]
+    GetRotCfpaFailed {
+        #[source]
+        error: anyhow::Error,
+    },
+    #[error("failed to find correctly-singed RoT image")]
+    FailedFindingSignedRotImage {
+        #[source]
+        error: anyhow::Error,
+    },
     #[error("getting SP caboose failed")]
     GetSpCabooseFailed {
         #[source]

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 bytes.workspace = true
 camino.workspace = true
 camino-tempfile.workspace = true

--- a/wicketd/src/artifacts/extracted_artifacts.rs
+++ b/wicketd/src/artifacts/extracted_artifacts.rs
@@ -61,7 +61,7 @@ impl Eq for ExtractedArtifactDataHandle {}
 
 impl ExtractedArtifactDataHandle {
     /// File size of this artifact in bytes.
-    pub(super) fn file_size(&self) -> usize {
+    pub(crate) fn file_size(&self) -> usize {
         self.file_size
     }
 

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1654,15 +1654,14 @@ impl UpdateContext {
                 .map_err(|error| {
                     UpdateTerminalError::FailedFindingSignedRotImage { error }
                 })?;
-            let archive =
-                RawHubrisArchive::from_vec(image).map_err(|err| {
-                    UpdateTerminalError::FailedFindingSignedRotImage {
-                        error: anyhow::Error::new(err).context(format!(
-                            "failed to read hubris archive for {:?}",
-                            artifact.id
-                        )),
-                    }
-                })?;
+            let archive = RawHubrisArchive::from_vec(image).map_err(|err| {
+                UpdateTerminalError::FailedFindingSignedRotImage {
+                    error: anyhow::Error::new(err).context(format!(
+                        "failed to read hubris archive for {:?}",
+                        artifact.id
+                    )),
+                }
+            })?;
             match archive.verify(&cmpa, &cfpa) {
                 Ok(()) => {
                     artifact_to_apply = Some(artifact.clone());

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -18,18 +18,23 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
+use base64::Engine;
 use display_error_chain::DisplayErrorChain;
 use dropshot::HttpError;
+use futures::TryFutureExt;
 use gateway_client::types::HostPhase2Progress;
 use gateway_client::types::HostPhase2RecoveryImageId;
 use gateway_client::types::HostStartupOptions;
 use gateway_client::types::InstallinatorImageId;
 use gateway_client::types::PowerState;
+use gateway_client::types::RotCfpaSlot;
 use gateway_client::types::SpComponentFirmwareSlot;
 use gateway_client::types::SpIdentifier;
 use gateway_client::types::SpType;
 use gateway_client::types::SpUpdateStatus;
 use gateway_messages::SpComponent;
+use gateway_messages::ROT_PAGE_SIZE;
+use hubtools::RawHubrisArchive;
 use installinator_common::InstallinatorCompletionMetadata;
 use installinator_common::InstallinatorSpec;
 use installinator_common::M2Slot;
@@ -52,11 +57,13 @@ use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use std::time::Instant;
 use thiserror::Error;
+use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::io::StreamReader;
 use update_engine::events::ProgressUnits;
 use update_engine::AbortHandle;
 use update_engine::StepSpec;
@@ -768,19 +775,13 @@ impl UpdateDriver {
         }
 
         let (rot_a, rot_b, sp_artifacts) = match update_cx.sp.type_ {
-            SpType::Sled => (
-                plan.gimlet_rot_a.clone(),
-                plan.gimlet_rot_b.clone(),
-                &plan.gimlet_sp,
-            ),
-            SpType::Power => {
-                (plan.psc_rot_a.clone(), plan.psc_rot_b.clone(), &plan.psc_sp)
+            SpType::Sled => {
+                (&plan.gimlet_rot_a, &plan.gimlet_rot_b, &plan.gimlet_sp)
             }
-            SpType::Switch => (
-                plan.sidecar_rot_a.clone(),
-                plan.sidecar_rot_b.clone(),
-                &plan.sidecar_sp,
-            ),
+            SpType::Power => (&plan.psc_rot_a, &plan.psc_rot_b, &plan.psc_sp),
+            SpType::Switch => {
+                (&plan.sidecar_rot_a, &plan.sidecar_rot_b, &plan.sidecar_sp)
+            }
         };
 
         let rot_registrar = engine.for_component(UpdateComponent::Rot);
@@ -790,16 +791,15 @@ impl UpdateDriver {
         // currently executing; we must update the _other_ slot. We also want to
         // know its current version (so we can skip updating if we only need to
         // update the SP and/or host).
-        let rot_interrogation =
-            rot_registrar
-                .new_step(
-                    UpdateStepId::InterrogateRot,
-                    "Checking current RoT version and active slot",
-                    |_cx| async move {
-                        update_cx.interrogate_rot(rot_a, rot_b).await
-                    },
-                )
-                .register();
+        let rot_interrogation = rot_registrar
+            .new_step(
+                UpdateStepId::InterrogateRot,
+                "Checking current RoT version and active slot",
+                move |_cx| async move {
+                    update_cx.interrogate_rot(rot_a, rot_b).await
+                },
+            )
+            .register();
 
         // The SP only has one updateable firmware slot ("the inactive bank").
         // We want to ask about slot 0 (the active slot)'s current version, and
@@ -1557,8 +1557,8 @@ impl UpdateContext {
 
     async fn interrogate_rot(
         &self,
-        rot_a: ArtifactIdData,
-        rot_b: ArtifactIdData,
+        rot_a: &[ArtifactIdData],
+        rot_b: &[ArtifactIdData],
     ) -> Result<StepResult<RotInterrogation>, UpdateTerminalError> {
         let rot_active_slot = self
             .get_component_active_slot(SpComponent::ROT.const_as_str())
@@ -1569,7 +1569,7 @@ impl UpdateContext {
 
         // Flip these around: if 0 (A) is active, we want to
         // update 1 (B), and vice versa.
-        let (active_slot_name, slot_to_update, artifact_to_apply) =
+        let (active_slot_name, slot_to_update, available_artifacts) =
             match rot_active_slot {
                 0 => ('A', 1, rot_b),
                 1 => ('B', 0, rot_a),
@@ -1581,6 +1581,111 @@ impl UpdateContext {
                     })
                 }
             };
+
+        // Read the CMPA and currently-active CFPA so we can find the
+        // correctly-signed artifact.
+        let base64_decode_rot_page = |data| {
+            let mut page = [0; ROT_PAGE_SIZE];
+            let n = base64::engine::general_purpose::STANDARD
+                .decode_slice(&data, &mut page)
+                .context("failed to decode base64 string: {data:?}")?;
+            if n != ROT_PAGE_SIZE {
+                bail!(
+                    "incorrect len ({n}, expected {ROT_PAGE_SIZE}) \
+                     after decoding base64 string: {data:?}",
+                );
+            }
+            Ok(page)
+        };
+        let cmpa = self
+            .mgs_client
+            .sp_rot_cmpa_get(
+                self.sp.type_,
+                self.sp.slot,
+                SpComponent::ROT.const_as_str(),
+            )
+            .await
+            .map_err(|err| UpdateTerminalError::GetRotCmpaFailed {
+                error: err.into(),
+            })
+            .and_then(|response| {
+                let data = response.into_inner().base64_data;
+                base64_decode_rot_page(data).map_err(|error| {
+                    UpdateTerminalError::GetRotCmpaFailed { error }
+                })
+            })?;
+        let cfpa = self
+            .mgs_client
+            .sp_rot_cfpa_get(
+                self.sp.type_,
+                self.sp.slot,
+                SpComponent::ROT.const_as_str(),
+                &gateway_client::types::GetCfpaParams {
+                    slot: RotCfpaSlot::Active,
+                },
+            )
+            .await
+            .map_err(|err| UpdateTerminalError::GetRotCfpaFailed {
+                error: err.into(),
+            })
+            .and_then(|response| {
+                let data = response.into_inner().base64_data;
+                base64_decode_rot_page(data).map_err(|error| {
+                    UpdateTerminalError::GetRotCfpaFailed { error }
+                })
+            })?;
+
+        // Loop through our possible artifacts and find the first (we only
+        // expect one!) that verifies against the RoT's CMPA/CFPA.
+        let mut artifact_to_apply = None;
+        for artifact in available_artifacts {
+            let image = artifact
+                .data
+                .reader_stream()
+                .and_then(|stream| async {
+                    let mut buf = Vec::with_capacity(artifact.data.file_size());
+                    StreamReader::new(stream)
+                        .read_to_end(&mut buf)
+                        .await
+                        .context("I/O error reading extracted archive")?;
+                    Ok(buf)
+                })
+                .await
+                .map_err(|error| {
+                    UpdateTerminalError::FailedFindingSignedRotImage { error }
+                })?;
+            let mut archive =
+                RawHubrisArchive::from_vec(image).map_err(|err| {
+                    UpdateTerminalError::FailedFindingSignedRotImage {
+                        error: anyhow::Error::new(err).context(format!(
+                            "failed to read hubris archive for {:?}",
+                            artifact.id
+                        )),
+                    }
+                })?;
+            match archive.verify(&cmpa, &cfpa) {
+                Ok(()) => {
+                    artifact_to_apply = Some(artifact.clone());
+                    break;
+                }
+                Err(err) => {
+                    // We log this but don't fail - we want to continue looking
+                    // for a verifiable artifact.
+                    info!(
+                        self.log, "RoT archive verification failed";
+                        "artifact" => ?artifact.id,
+                        "err" => %DisplayErrorChain::new(&err),
+                    );
+                }
+            }
+        }
+
+        // Ensure we found a valid RoT artifact.
+        let artifact_to_apply = artifact_to_apply.ok_or_else(|| {
+            UpdateTerminalError::FailedFindingSignedRotImage {
+                error: anyhow!("no RoT image found with valid CMPA/CFPA"),
+            }
+        })?;
 
         // Read the caboose of the currently-active slot.
         let caboose = self

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1675,6 +1675,12 @@ impl UpdateContext {
             })?;
             match archive.verify(&cmpa, &cfpa) {
                 Ok(()) => {
+                    info!(
+                        self.log, "RoT archive verification success";
+                        "name" => artifact.id.name.as_str(),
+                        "version" => %artifact.id.version,
+                        "kind" => ?artifact.id.kind,
+                    );
                     artifact_to_apply = Some(artifact.clone());
                     break;
                 }

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1654,7 +1654,7 @@ impl UpdateContext {
                 .map_err(|error| {
                     UpdateTerminalError::FailedFindingSignedRotImage { error }
                 })?;
-            let mut archive =
+            let archive =
                 RawHubrisArchive::from_vec(image).map_err(|err| {
                     UpdateTerminalError::FailedFindingSignedRotImage {
                         error: anyhow::Error::new(err).context(format!(

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -169,8 +169,8 @@ async fn test_updates() {
         StepEventKind::ExecutionFailed { failed_step, .. } => {
             // TODO: obviously we shouldn't stop here, get past more of the
             // update process in this test. We currently fail when attempting to
-            // look up the SP's board in our tuf repo.
-            assert_eq!(failed_step.info.component, UpdateComponent::Sp);
+            // look up the RoT's CMPA/CFPA.
+            assert_eq!(failed_step.info.component, UpdateComponent::Rot);
         }
         other => {
             panic!("unexpected terminal event kind: {other:?}");

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -43,7 +43,7 @@ futures-io = { version = "0.3.28", default-features = false, features = ["std"] 
 futures-sink = { version = "0.3.28" }
 futures-task = { version = "0.3.28", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.0", features = ["raw"] }
@@ -135,7 +135,7 @@ futures-io = { version = "0.3.28", default-features = false, features = ["std"] 
 futures-sink = { version = "0.3.28" }
 futures-task = { version = "0.3.28", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "1e180ae55e56bd17af35cb868ffbd18ce487351d", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.0", features = ["raw"] }


### PR DESCRIPTION
As of this PR, wicketd will (a) accept TUF repos containing multiple RoT archives for the same board target (e.g., multiple gimlet RoT images), and when performing a mupdate, it will ask the RoT for its currently-active CMPA and CFPA pages and search for an RoT archive that matches.

After this is deployed to all fielded systems, we'll be able to drop the `-rot-staging-dev` and `-prod-rel` TUF repos from CI, and only build a single TUF repo with all RoT images. This PR adds a new `-rot-all` TUF repo publishing step but does not remove the old ones, as we'll need them to update into this version of wicketd.