### PR TITLE
Implement image deletion

### DIFF
--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -14,6 +14,7 @@ use crate::db::model::Dataset;
 use crate::db::model::Region;
 use crate::db::model::RegionSnapshot;
 use crate::db::model::Volume;
+use anyhow::bail;
 use async_bb8_diesel::AsyncConnection;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
@@ -391,6 +392,16 @@ impl DataStore {
                 opts,
                 gen,
             } => {
+                if !opts.read_only {
+                    // Only one volume can "own" a Region, and that volume's
+                    // UUID is recorded in the region table accordingly. It is
+                    // an error to make a copy of a volume construction request
+                    // that references non-read-only Regions.
+                    bail!(
+                        "only one Volume can reference a Region non-read-only!"
+                    );
+                }
+
                 let mut opts = opts.clone();
                 opts.id = Uuid::new_v4();
 
@@ -416,7 +427,10 @@ impl DataStore {
     /// Checkout a copy of the Volume from the database using `volume_checkout`,
     /// then randomize the UUIDs in the construction request. Because this is a
     /// new volume, it is immediately passed to `volume_create` so that the
-    /// accounting for Crucible resources stays correct.
+    /// accounting for Crucible resources stays correct. This is only valid for
+    /// Volumes that reference regions read-only - it's important for accounting
+    /// purposes that each region in this volume construction request is
+    /// returned by `read_only_resources_associated_with_volume`.
     pub async fn volume_checkout_randomize_ids(
         &self,
         volume_id: Uuid,
@@ -469,6 +483,8 @@ impl DataStore {
                     .eq(0)
                     // Despite the SQL specifying that this column is NOT NULL,
                     // this null check is required for this function to work!
+                    // It's possible that the left join of region_snapshot above
+                    // could join zero rows, making this null.
                     .or(dsl::volume_references.is_null()),
             )
             // where the volume has already been soft-deleted

--- a/nexus/src/app/sagas/image_delete.rs
+++ b/nexus/src/app/sagas/image_delete.rs
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::{ActionRegistry, NexusActionContext, NexusSaga};
+use crate::app::sagas;
+use crate::app::sagas::declare_saga_actions;
+use nexus_db_queries::{authn, authz, db};
+use serde::Deserialize;
+use serde::Serialize;
+use steno::ActionError;
+use steno::Node;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) enum ImageParam {
+    Project { authz_image: authz::ProjectImage, image: db::model::ProjectImage },
+
+    Silo { authz_image: authz::SiloImage, image: db::model::SiloImage },
+}
+
+impl ImageParam {
+    fn volume_id(&self) -> Uuid {
+        match self {
+            ImageParam::Project { image, .. } => image.volume_id,
+
+            ImageParam::Silo { image, .. } => image.volume_id,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Params {
+    pub serialized_authn: authn::saga::Serialized,
+    pub image_param: ImageParam,
+}
+
+declare_saga_actions! {
+    image_delete;
+    DELETE_IMAGE_RECORD -> "no_result1" {
+        + sid_delete_image_record
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SagaImageDelete;
+impl NexusSaga for SagaImageDelete {
+    const NAME: &'static str = "image-delete";
+    type Params = Params;
+
+    fn register_actions(registry: &mut ActionRegistry) {
+        image_delete_register_actions(registry);
+    }
+
+    fn make_saga_dag(
+        params: &Self::Params,
+        mut builder: steno::DagBuilder,
+    ) -> Result<steno::Dag, super::SagaInitError> {
+        builder.append(delete_image_record_action());
+
+        const DELETE_VOLUME_PARAMS: &'static str = "delete_volume_params";
+
+        let volume_delete_params = sagas::volume_delete::Params {
+            serialized_authn: params.serialized_authn.clone(),
+            volume_id: params.image_param.volume_id(),
+        };
+        builder.append(Node::constant(
+            DELETE_VOLUME_PARAMS,
+            serde_json::to_value(&volume_delete_params).map_err(|e| {
+                super::SagaInitError::SerializeError(
+                    String::from("volume_id"),
+                    e,
+                )
+            })?,
+        ));
+
+        let make_volume_delete_dag = || {
+            let subsaga_builder = steno::DagBuilder::new(steno::SagaName::new(
+                sagas::volume_delete::SagaVolumeDelete::NAME,
+            ));
+            sagas::volume_delete::create_dag(subsaga_builder)
+        };
+        builder.append(steno::Node::subsaga(
+            "delete_volume",
+            make_volume_delete_dag()?,
+            DELETE_VOLUME_PARAMS,
+        ));
+
+        Ok(builder.build()?)
+    }
+}
+
+// image delete saga: action implementations
+
+async fn sid_delete_image_record(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+
+    match params.image_param {
+        ImageParam::Project { authz_image, image } => {
+            osagactx
+                .datastore()
+                .project_image_delete(&opctx, &authz_image, image)
+                .await
+                .map_err(ActionError::action_failed)?;
+        }
+
+        ImageParam::Silo { authz_image, image } => {
+            osagactx
+                .datastore()
+                .silo_image_delete(&opctx, &authz_image, image)
+                .await
+                .map_err(ActionError::action_failed)?;
+        }
+    }
+
+    Ok(())
+}

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 pub mod disk_create;
 pub mod disk_delete;
 pub mod finalize_disk;
+pub mod image_delete;
 pub mod import_blocks_from_url;
 mod instance_common;
 pub mod instance_create;
@@ -167,6 +168,9 @@ fn make_action_registry() -> ActionRegistry {
         &mut registry,
     );
     <vpc_create::SagaVpcCreate as NexusSaga>::register_actions(&mut registry);
+    <image_delete::SagaImageDelete as NexusSaga>::register_actions(
+        &mut registry,
+    );
 
     #[cfg(test)]
     <test_saga::SagaTest as NexusSaga>::register_actions(&mut registry);

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -252,6 +252,16 @@ async fn test_project_deletion_with_image(cptestctx: &ControlPlaneTestContext) {
         .await
         .expect("failed to delete image");
 
+    // Expect that trying to GET the image results in a 404
+    NexusRequest::new(
+        RequestBuilder::new(&client, http::Method::GET, &image_url)
+            .expect_status(Some(http::StatusCode::NOT_FOUND)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("GET of a deleted image did not return 404");
+
     delete_project(&url, &client).await;
 }
 

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -245,32 +245,14 @@ async fn test_project_deletion_with_image(cptestctx: &ControlPlaneTestContext) {
         delete_project_expect_fail(&url, &client).await,
     );
 
-    // TODO: finish test once image delete is implemented. Image create works
-    // and project delete with image fails as expected, but image delete is not
-    // implemented yet, so we can't show that project delete works after image
-    // delete.
     let image_url = format!("/v1/images/{}", image.identity.id);
-    NexusRequest::expect_failure_with_body(
-        client,
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Method::DELETE,
-        &image_url,
-        &image_create_params,
-    )
-    .authn_as(AuthnMode::PrivilegedUser)
-    .execute()
-    .await
-    .unwrap();
+    NexusRequest::object_delete(&client, &image_url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("failed to delete image");
 
-    // TODO: delete the image
-    // NexusRequest::object_delete(&client, &image_url)
-    //     .authn_as(AuthnMode::PrivilegedUser)
-    //     .execute()
-    //     .await
-    //     .expect("failed to delete image");
-
-    // TODO: now delete project works
-    // delete_project(&url, &client).await;
+    delete_project(&url, &client).await;
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -1240,6 +1240,9 @@ async fn delete_image_test(
     assert!(disk_test.crucible_resources_deleted().await);
 }
 
+// Make sure that whatever order disks, images, and snapshots are deleted, the
+// Crucible resource accounting that Nexus does is correct.
+
 #[nexus_test]
 async fn test_delete_image_order_1(cptestctx: &ControlPlaneTestContext) {
     delete_image_test(


### PR DESCRIPTION
Also, make sure that multiple volume construction requests can only be copied for read-only Regions: the `region` table has a column for the volume that owns it, and this means there's a one to one mapping for the volume that references the region read-write. Ensure this in `volume_checkout_randomize_ids` otherwise multiple volumes could reference the same regions and this could lead to accounting / cleanup issues.

Fixes #3033