### PR TITLE
change ARC primarycache away from `all` for crucible datasets

### DIFF
--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1046,6 +1046,16 @@
           "target"
         ]
       },
+      "DatasetArcPrimaryCache": {
+        "description": "What data should be kept in the primary ARC cache?",
+        "type": "string",
+        "enum": [
+          "inherit",
+          "all",
+          "metadata",
+          "no_cache"
+        ]
+      },
       "DatasetKind": {
         "description": "The type of a dataset, and an auxiliary information necessary to successfully launch a zone managing the associated data.",
         "oneOf": [
@@ -1150,71 +1160,13 @@
           "pool_name"
         ]
       },
-      "DatasetArcPrimaryCache": {
-        "description": "What data the dataset should cache in ARC.",
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "default"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "all"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "metadata"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "none"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-        ]
-      },
       "DatasetRequest": {
         "description": "Describes a request to provision a specific dataset",
         "type": "object",
         "properties": {
+          "arc_primary_cache": {
+            "$ref": "#/components/schemas/DatasetArcPrimaryCache"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -1224,12 +1176,10 @@
           },
           "service_address": {
             "type": "string"
-          },
-          "arc_primary_cache": {
-            "$ref": "#/components/schemas/DatasetArcPrimaryCache"
           }
         },
         "required": [
+          "arc_primary_cache",
           "id",
           "name",
           "service_address"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1150,6 +1150,67 @@
           "pool_name"
         ]
       },
+      "DatasetArcPrimaryCache": {
+        "description": "What data the dataset should cache in ARC.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "default"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "all"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "metadata"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+        ]
+      },
       "DatasetRequest": {
         "description": "Describes a request to provision a specific dataset",
         "type": "object",
@@ -1163,6 +1224,9 @@
           },
           "service_address": {
             "type": "string"
+          },
+          "arc_primary_cache": {
+            "$ref": "#/components/schemas/DatasetArcPrimaryCache"
           }
         },
         "required": [

--- a/schema/all-zone-requests.json
+++ b/schema/all-zone-requests.json
@@ -18,6 +18,16 @@
     }
   },
   "definitions": {
+    "DatasetArcPrimaryCache": {
+      "description": "What data should be kept in the primary ARC cache?",
+      "type": "string",
+      "enum": [
+        "inherit",
+        "all",
+        "metadata",
+        "no_cache"
+      ]
+    },
     "DatasetKind": {
       "description": "The type of a dataset, and an auxiliary information necessary to successfully launch a zone managing the associated data.",
       "oneOf": [
@@ -126,11 +136,15 @@
       "description": "Describes a request to provision a specific dataset",
       "type": "object",
       "required": [
+        "arc_primary_cache",
         "id",
         "name",
         "service_address"
       ],
       "properties": {
+        "arc_primary_cache": {
+          "$ref": "#/definitions/DatasetArcPrimaryCache"
+        },
         "id": {
           "type": "string",
           "format": "uuid"

--- a/schema/rss-service-plan.json
+++ b/schema/rss-service-plan.json
@@ -18,6 +18,16 @@
     }
   },
   "definitions": {
+    "DatasetArcPrimaryCache": {
+      "description": "What data should be kept in the primary ARC cache?",
+      "type": "string",
+      "enum": [
+        "inherit",
+        "all",
+        "metadata",
+        "no_cache"
+      ]
+    },
     "DatasetKind": {
       "description": "The type of a dataset, and an auxiliary information necessary to successfully launch a zone managing the associated data.",
       "oneOf": [
@@ -126,11 +136,15 @@
       "description": "Describes a request to provision a specific dataset",
       "type": "object",
       "required": [
+        "arc_primary_cache",
         "id",
         "name",
         "service_address"
       ],
       "properties": {
+        "arc_primary_cache": {
+          "$ref": "#/definitions/DatasetArcPrimaryCache"
+        },
         "id": {
           "type": "string",
           "format": "uuid"

--- a/sled-agent/src/backing_fs.rs
+++ b/sled-agent/src/backing_fs.rs
@@ -133,6 +133,7 @@ pub(crate) fn ensure_backing_fs(
             true,  // do_format
             None,  // encryption_details,
             size_details,
+            None,
             Some(vec!["canmount=noauto".to_string()]), // options
         )?;
 

--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -382,6 +382,7 @@ fn ensure_zfs_ramdisk_dataset() -> Result<(), StartError> {
         encryption_details,
         quota,
         None,
+        None,
     )
     .map_err(StartError::EnsureZfsRamdiskDataset)
 }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -595,6 +595,7 @@ pub struct DatasetRequest {
     pub id: Uuid,
     pub name: crate::storage::dataset::DatasetName,
     pub service_address: SocketAddrV6,
+    pub arc_primary_cache: crate::storage::dataset::DatasetArcPrimaryCache,
 }
 
 impl From<DatasetRequest> for sled_agent_client::types::DatasetRequest {
@@ -603,6 +604,7 @@ impl From<DatasetRequest> for sled_agent_client::types::DatasetRequest {
             id: d.id,
             name: d.name.into(),
             service_address: d.service_address.to_string(),
+            arc_primary_cache: d.arc_primary_cache.into(),
         }
     }
 }

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -10,7 +10,7 @@ use crate::params::{
     ServiceZoneService, ZoneType,
 };
 use crate::rack_setup::config::SetupServiceConfig as Config;
-use crate::storage::dataset::DatasetName;
+use crate::storage::dataset::{DatasetArcPrimaryCache, DatasetName};
 use crate::storage_manager::StorageResources;
 use camino::Utf8PathBuf;
 use dns_service_client::types::DnsConfigParams;
@@ -342,6 +342,7 @@ impl Plan {
                     id,
                     name: dataset_name,
                     service_address: http_address,
+                    arc_primary_cache: DatasetArcPrimaryCache::Inherit,
                 }),
                 services: vec![ServiceZoneService {
                     id,
@@ -380,6 +381,7 @@ impl Plan {
                     id,
                     name: dataset_name,
                     service_address: address,
+                    arc_primary_cache: DatasetArcPrimaryCache::Inherit,
                 }),
                 services: vec![ServiceZoneService {
                     id,
@@ -427,6 +429,7 @@ impl Plan {
                     id,
                     name: dataset_name,
                     service_address: http_address,
+                    arc_primary_cache: DatasetArcPrimaryCache::Inherit,
                 }),
                 services: vec![ServiceZoneService {
                     id,
@@ -549,6 +552,7 @@ impl Plan {
                     id,
                     name: dataset_name,
                     service_address: address,
+                    arc_primary_cache: DatasetArcPrimaryCache::Inherit,
                 }),
                 services: vec![ServiceZoneService {
                     id,
@@ -589,6 +593,7 @@ impl Plan {
                     id,
                     name: dataset_name,
                     service_address: address,
+                    arc_primary_cache: DatasetArcPrimaryCache::Inherit,
                 }),
                 services: vec![ServiceZoneService {
                     id,
@@ -654,6 +659,7 @@ impl Plan {
                             DatasetKind::Crucible,
                         ),
                         service_address: address,
+                        arc_primary_cache: DatasetArcPrimaryCache::Metadata,
                     }),
                     services: vec![ServiceZoneService {
                         id,

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -736,7 +736,11 @@ impl SledAgent {
             // First, ensure the dataset exists
             self.inner
                 .storage
-                .upsert_filesystem(dataset.id, dataset.name.clone())
+                .upsert_filesystem(
+                    dataset.id,
+                    dataset.name.clone(),
+                    dataset.arc_primary_cache.clone(),
+                )
                 .await?;
         }
 

--- a/sled-agent/src/storage/dataset.rs
+++ b/sled-agent/src/storage/dataset.rs
@@ -48,6 +48,31 @@ impl From<DatasetName> for sled_agent_client::types::DatasetName {
     }
 }
 
+/// What data should be kept in the primary ARC cache?
+#[derive(
+    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DatasetArcPrimaryCache {
+    Inherit,
+    All,
+    Metadata,
+    NoCache,
+}
+
+impl From<DatasetArcPrimaryCache>
+    for sled_agent_client::types::DatasetArcPrimaryCache
+{
+    fn from(d: DatasetArcPrimaryCache) -> Self {
+        match d {
+            DatasetArcPrimaryCache::Inherit => Self::Inherit,
+            DatasetArcPrimaryCache::All => Self::All,
+            DatasetArcPrimaryCache::Metadata => Self::Metadata,
+            DatasetArcPrimaryCache::NoCache => Self::NoCache,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -530,6 +530,7 @@ impl Disk {
                 Some(encryption_details),
                 None,
                 None,
+                None,
             );
 
             keyfile.zero_and_unlink().await.map_err(|error| {
@@ -594,6 +595,7 @@ impl Disk {
                 do_format,
                 encryption_details,
                 size_details,
+                None,
                 None,
             )?;
 


### PR DESCRIPTION
Currently untested - creating the draft now to see if CI is ok with it.

https://github.com/oxidecomputer/crucible/issues/692

Logic is caching block data downstairs doesn't make sense. 3x downstairs means 3x cache of the same data, taking memory away from other usecases. It's on the other side of a network link so what is that cache really getting, if anything. Plus, the guest VM will have its own block cache. Want more block cache? Give the VM more ram.

Right now I'm threading config in from the very stop of when the `DatasetRequests`s are created in `sled-agent/src/rack_setup/plan/service.rs`. We could instead make this attribute be dependent on the `DatasetKind`, so that the code which does the final bridging from the sled-agent layer down through the lower "running zfs commands" layer is the only part that changes.

Doing it at the level my current code does feels like it might be digging some low-level stuff too high in the stack. On the other hand, if any other service datasets want to make this change later, it's very clear how to do it. I don't have strong feelings here, happy to leave as-is or change things around.