### PR TITLE
test-utils: use a per-user temp crdb seed dir

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -69,7 +69,7 @@ ptime -m timeout 1h cargo test --doc --locked --verbose --no-fail-fast
 # We expect the seed CRDB to be placed here, so we explicitly remove it so the
 # rmdir check below doesn't get triggered. Nextest doesn't have support for
 # teardown scripts so this is the best we've got.
-rm -rf "$TEST_TMPDIR/crdb-base"
+rm -rf "$TEST_TMPDIR/crdb-base*"
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -69,7 +69,7 @@ ptime -m timeout 1h cargo test --doc --locked --verbose --no-fail-fast
 # We expect the seed CRDB to be placed here, so we explicitly remove it so the
 # rmdir check below doesn't get triggered. Nextest doesn't have support for
 # teardown scripts so this is the best we've got.
-rm -rf "$TEST_TMPDIR/crdb-base*"
+rm -rf "$TEST_TMPDIR/crdb-base"*
 
 #
 # Make sure that we have left nothing around in $TEST_TMPDIR.  The easiest way

--- a/test-utils/src/dev/seed.rs
+++ b/test-utils/src/dev/seed.rs
@@ -92,12 +92,14 @@ pub async fn ensure_seed_tarball_exists(
         );
     }
 
-    // XXX: we aren't considering cross-user permissions for this file. Might be
-    // worth setting more restrictive permissions on it, or using a per-user
-    // cache dir.
+    // If possible, try for a per-user folder in the temp dir
+    // to avoid clashes on shared build environments.
+    let crdb_base = std::env::var("USER")
+        .map(|user| format!("crdb-base-{user}"))
+        .unwrap_or("crdb-base".into());
     let base_seed_dir = Utf8PathBuf::from_path_buf(std::env::temp_dir())
         .expect("Not a UTF-8 path")
-        .join("crdb-base");
+        .join(crdb_base);
     std::fs::create_dir_all(&base_seed_dir).unwrap();
     let mut desired_seed_tar = base_seed_dir.join(digest_unique_to_schema());
     desired_seed_tar.set_extension("tar");


### PR DESCRIPTION
Gets tests passing for me on atrium whereas before I'd see errors like:

```
Error: failed to setup seed tarball                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                               
Caused by:                                                                                                                                                                                                                                                     
    0: failed to create temporary seed directory                                                                                                                                                                                                               
    1: Permission denied (os error 13) at path "/tmp/crdb-base/.tmpdFyvGf"                                                                                                                                                                                     
  SETUP FAIL [      1/1] crdb-seed: cargo run -p crdb-seed                                                                                                                                                                                                     
                                                                                                                                                                                                                                                               
   Canceling due to setup script failure
```
(because @leftwo got there first 😅️)