### PR TITLE
[renovate] use actions/pin checked into our global renovate-config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
     "local>oxidecomputer/renovate-config",
     "local>oxidecomputer/renovate-config//rust/autocreate",
     "local>oxidecomputer/renovate-config:post-upgrade",
-    "helpers:pinGitHubActionDigests"
+    "local>oxidecomputer/renovate-config//actions/pin"
   ]
 }


### PR DESCRIPTION
See https://github.com/oxidecomputer/renovate-config/blob/main/actions/pin.json.
