### PR TITLE
[nexus] [minor] Bring BGP endpoint doc comments in line with conventions

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2609,7 +2609,7 @@ async fn networking_loopback_address_delete(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Get loopback addresses, optionally filtering by id
+/// List loopback addresses
 #[endpoint {
     method = GET,
     path = "/v1/system/networking/loopback-address",
@@ -2824,7 +2824,7 @@ async fn networking_switch_port_clear_settings(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Create a new BGP configuration.
+/// Create a new BGP configuration
 #[endpoint {
     method = POST,
     path = "/v1/system/networking/bgp",
@@ -2845,7 +2845,7 @@ async fn networking_bgp_config_create(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Get BGP configurations.
+/// List BGP configurations
 #[endpoint {
     method = GET,
     path = "/v1/system/networking/bgp",
@@ -2900,7 +2900,7 @@ async fn networking_bgp_status(
 }
 
 //TODO pagination? the normal by-name/by-id stuff does not work here
-/// Get imported IPv4 BGP routes.
+/// Get imported IPv4 BGP routes
 #[endpoint {
     method = GET,
     path = "/v1/system/networking/bgp-routes-ipv4",
@@ -2921,7 +2921,7 @@ async fn networking_bgp_imported_routes_ipv4(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Delete a BGP configuration.
+/// Delete a BGP configuration
 #[endpoint {
     method = DELETE,
     path = "/v1/system/networking/bgp",
@@ -2942,7 +2942,7 @@ async fn networking_bgp_config_delete(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Create a new BGP announce set.
+/// Create a new BGP announce set
 #[endpoint {
     method = POST,
     path = "/v1/system/networking/bgp-announce",
@@ -2964,7 +2964,7 @@ async fn networking_bgp_announce_set_create(
 }
 
 //TODO pagination? the normal by-name/by-id stuff does not work here
-/// Get originated routes for a given BGP configuration.
+/// Get originated routes for a BGP configuration
 #[endpoint {
     method = GET,
     path = "/v1/system/networking/bgp-announce",
@@ -2990,7 +2990,7 @@ async fn networking_bgp_announce_set_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Delete a BGP announce set.
+/// Delete a BGP announce set
 #[endpoint {
     method = DELETE,
     path = "/v1/system/networking/bgp-announce",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5170,7 +5170,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Get BGP configurations.",
+        "summary": "List BGP configurations",
         "operationId": "networking_bgp_config_list",
         "parameters": [
           {
@@ -5235,7 +5235,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Create a new BGP configuration.",
+        "summary": "Create a new BGP configuration",
         "operationId": "networking_bgp_config_create",
         "requestBody": {
           "content": {
@@ -5270,7 +5270,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Delete a BGP configuration.",
+        "summary": "Delete a BGP configuration",
         "operationId": "networking_bgp_config_delete",
         "parameters": [
           {
@@ -5301,7 +5301,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Get originated routes for a given BGP configuration.",
+        "summary": "Get originated routes for a BGP configuration",
         "operationId": "networking_bgp_announce_set_list",
         "parameters": [
           {
@@ -5341,7 +5341,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Create a new BGP announce set.",
+        "summary": "Create a new BGP announce set",
         "operationId": "networking_bgp_announce_set_create",
         "requestBody": {
           "content": {
@@ -5376,7 +5376,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Delete a BGP announce set.",
+        "summary": "Delete a BGP announce set",
         "operationId": "networking_bgp_announce_set_delete",
         "parameters": [
           {
@@ -5407,7 +5407,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Get imported IPv4 BGP routes.",
+        "summary": "Get imported IPv4 BGP routes",
         "operationId": "networking_bgp_imported_routes_ipv4",
         "parameters": [
           {
@@ -5482,7 +5482,7 @@
         "tags": [
           "system/networking"
         ],
-        "summary": "Get loopback addresses, optionally filtering by id",
+        "summary": "List loopback addresses",
         "operationId": "networking_loopback_address_list",
         "parameters": [
           {


### PR DESCRIPTION
I noticed there were periods in the docs sidebar. Also used the word "list" as appropriate.

<img src="https://github.com/oxidecomputer/omicron/assets/3612203/daf2e0b5-b6af-4647-ba45-394d935197b7" width="200">
