### PR TITLE
Update propolis mock-server dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,21 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,12 +71,6 @@ checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -191,16 +170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "api_identity"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,17 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=44a5d0bca91393229091a48026bc00e6de37f2a3#44a5d0bca91393229091a48026bc00e6de37f2a3"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -505,7 +457,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=44a5d0bca91393229091a48026bc00e6de37f2a3#44a5d0bca91393229091a48026bc00e6de37f2a3"
 dependencies = [
  "libc",
  "strum",
@@ -559,12 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,26 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitstruct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b10c3912af09af44ea1dafe307edb5ed374b2a32658eb610e372270c9017b4"
-dependencies = [
- "bitstruct_derive",
-]
-
-[[package]]
-name = "bitstruct_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fd19022c2b750d14eb9724c204d08ab7544570105b3b466d8a9f2f3feded27"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -678,7 +604,7 @@ dependencies = [
  "derive_more",
  "hex",
  "hkdf",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-rpaths",
  "omicron-test-utils",
  "omicron-workspace-hack",
@@ -707,7 +633,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ipnetwork",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -879,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
- "toml 0.8.0",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -909,7 +835,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -1154,26 +1079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
-name = "const_format"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,18 +1135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cpuid_profile_config"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "propolis",
- "serde",
- "serde_derive",
- "thiserror",
- "toml 0.7.8",
 ]
 
 [[package]]
@@ -1441,51 +1334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible"
-version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "aes-gcm-siv",
- "anyhow",
- "async-recursion",
- "async-trait",
- "base64 0.21.4",
- "bytes",
- "chrono",
- "crucible-client-types",
- "crucible-common",
- "crucible-protocol",
- "crucible-workspace-hack",
- "dropshot",
- "futures",
- "futures-core",
- "itertools 0.11.0",
- "libc",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reqwest",
- "ringbuffer",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-dtrace",
- "slog-term",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "toml 0.8.0",
- "tracing",
- "usdt",
- "uuid",
- "version_check",
-]
-
-[[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
 source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
@@ -1515,34 +1363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible-common"
-version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "anyhow",
- "atty",
- "crucible-workspace-hack",
- "nix 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite",
- "rustls-pemfile",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-bunyan",
- "slog-dtrace",
- "slog-term",
- "tempfile",
- "thiserror",
- "tokio-rustls",
- "toml 0.8.0",
- "twox-hash",
- "uuid",
- "vergen",
-]
-
-[[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
 source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
@@ -1556,23 +1376,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "crucible-protocol"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "crucible-common",
- "crucible-workspace-hack",
- "num_enum 0.7.0",
- "schemars",
- "serde",
- "tokio-util",
  "uuid",
 ]
 
@@ -1748,7 +1551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -1791,7 +1594,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "progenitor",
@@ -2027,22 +1830,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1a8646b2c125eeb9a84ef0faa6d2d102ea0d5da60b824ade2743263117b848"
 
 [[package]]
-name = "dladm"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
- "strum",
-]
-
-[[package]]
 name = "dlpi"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0b960559c76d475d2"
 dependencies = [
  "libc",
  "libdlpi-sys",
- "num_enum 0.5.11",
+ "num_enum",
  "pretty-hex 0.2.1",
  "thiserror",
  "tokio",
@@ -2056,14 +1850,14 @@ dependencies = [
  "camino",
  "chrono",
  "clap 4.4.3",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "expectorate",
  "http",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "pretty-hex 0.3.0",
  "schemars",
  "serde",
@@ -2093,22 +1887,6 @@ dependencies = [
  "chrono",
  "http",
  "omicron-workspace-hack",
- "progenitor",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "uuid",
-]
-
-[[package]]
-name = "dns-service-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "http",
  "progenitor",
  "reqwest",
  "schemars",
@@ -2169,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fa728d07970824fd5f3bd57a3d4dc0fdbea09bfd"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#7bd2ce547ebf0b955b02236fe3fef0c52bf2fae4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2184,9 +1962,9 @@ dependencies = [
  "hostname",
  "http",
  "hyper",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "multer",
- "openapiv3",
+ "openapiv3 2.0.0-rc.1",
  "paste",
  "percent-encoding",
  "proc-macro2",
@@ -2205,7 +1983,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-rustls",
- "toml 0.7.8",
+ "toml 0.8.2",
  "usdt",
  "uuid",
  "version_check",
@@ -2215,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fa728d07970824fd5f3bd57a3d4dc0fdbea09bfd"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#7bd2ce547ebf0b955b02236fe3fef0c52bf2fae4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2368,19 +2146,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -2395,15 +2160,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "erased-serde"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837c0466252947ada828b975e12daf82e18bb5444e4df87be6038d4469e2a3d2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "errno"
@@ -2442,12 +2198,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2755,7 +2505,7 @@ dependencies = [
  "gateway-messages",
  "hex",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "reqwest",
  "serde",
@@ -2816,7 +2566,7 @@ dependencies = [
  "hubpack 0.1.2",
  "hubtools",
  "lru-cache",
- "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
+ "nix",
  "once_cell",
  "paste",
  "serde",
@@ -2910,19 +2660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "git2"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,22 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
-dependencies = [
- "hashbrown 0.14.0",
-]
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "headers"
@@ -3402,7 +3126,7 @@ source = "git+https://github.com/oxidecomputer/illumos-devinfo?branch=main#4323b
 dependencies = [
  "anyhow",
  "libc",
- "num_enum 0.5.11",
+ "num_enum",
 ]
 
 [[package]]
@@ -3426,7 +3150,7 @@ dependencies = [
  "libc",
  "macaddr",
  "mockall",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "opte-ioctl",
  "oxide-vpc",
@@ -3467,12 +3191,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "serde",
 ]
 
@@ -3535,7 +3259,7 @@ dependencies = [
  "ipcc-key-value",
  "itertools 0.11.0",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
@@ -3591,11 +3315,11 @@ dependencies = [
  "expectorate",
  "hyper",
  "installinator-common",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "schemars",
  "serde",
  "serde_json",
@@ -3612,7 +3336,7 @@ dependencies = [
  "anyhow",
  "camino",
  "illumos-utils",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -3639,12 +3363,12 @@ dependencies = [
  "assert_matches",
  "chrono",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "expectorate",
  "futures",
  "hyper",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "progenitor",
@@ -3662,33 +3386,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "internal-dns"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "anyhow",
- "chrono",
- "dns-service-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "futures",
- "hyper",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "reqwest",
- "slog",
- "thiserror",
- "trust-dns-proto",
- "trust-dns-resolver",
- "uuid",
-]
-
-[[package]]
 name = "internal-dns-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.4.3",
  "dropshot",
- "internal-dns 0.1.0",
- "omicron-common 0.1.0",
+ "internal-dns",
+ "omicron-common",
  "omicron-workspace-hack",
  "slog",
  "tokio",
@@ -3712,7 +3417,7 @@ version = "0.1.0"
 dependencies = [
  "ciborium",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "proptest",
  "serde",
@@ -3785,15 +3490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,7 +3513,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "hkdf",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "secrecy",
  "sha3",
@@ -3908,18 +3604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b024e211b1b371da58cd69e4fb8fa4ed16915edcc0e2e1fb04ac4bad61959f25"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.15.2+1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,23 +3629,13 @@ dependencies = [
  "colored",
  "dlpi",
  "libc",
- "num_enum 0.5.11",
+ "num_enum",
  "nvpair",
  "nvpair-sys",
  "rusty-doors",
  "socket2 0.4.9",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3981,18 +3655,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe73cdec2bcb36d25a9fe3f607ffcd44bb8907ca0100c4098d1aa342d1e7bec"
 dependencies = [
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -4058,7 +3720,7 @@ dependencies = [
  "const-oid",
  "crc-any",
  "der",
- "env_logger 0.10.0",
+ "env_logger",
  "hex",
  "log",
  "lpc55_areas",
@@ -4167,7 +3829,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "progenitor",
@@ -4330,29 +3992,9 @@ dependencies = [
  "chrono",
  "futures",
  "ipnetwork",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
- "progenitor",
- "regress",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "uuid",
-]
-
-[[package]]
-name = "nexus-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "futures",
- "ipnetwork",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-passwords 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "progenitor",
  "regress",
  "reqwest",
@@ -4379,8 +4021,8 @@ dependencies = [
  "nexus-defaults",
  "nexus-types",
  "omicron-certificates",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-workspace-hack",
  "parse-display",
@@ -4423,7 +4065,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "lazy_static",
@@ -4433,19 +4075,19 @@ dependencies = [
  "nexus-defaults",
  "nexus-test-utils",
  "nexus-types",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
- "openapiv3",
+ "openapiv3 1.0.3",
  "openssl",
  "openssl-probe",
  "openssl-sys",
  "oso",
- "oximeter 0.1.0",
+ "oximeter",
  "paste",
  "pem",
  "petgraph",
@@ -4484,7 +4126,7 @@ version = "0.1.0"
 dependencies = [
  "ipnetwork",
  "lazy_static",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "rand 0.8.5",
  "serde_json",
@@ -4496,9 +4138,9 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "dropshot",
- "internal-dns 0.1.0",
+ "internal-dns",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "slog",
  "uuid",
@@ -4515,24 +4157,24 @@ dependencies = [
  "chrono",
  "crucible-agent-client",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "headers",
  "http",
  "hyper",
- "internal-dns 0.1.0",
+ "internal-dns",
  "nexus-db-queries",
  "nexus-test-interface",
  "nexus-types",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-sled-agent",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-collector",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "parse-display",
  "serde",
  "serde_json",
@@ -4559,14 +4201,14 @@ name = "nexus-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "base64 0.21.4",
  "chrono",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "futures",
  "newtype_derive",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
  "openssl",
  "openssl-probe",
@@ -4587,20 +4229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec 1.11.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -4768,16 +4396,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
-dependencies = [
- "num_enum_derive 0.7.0",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -4790,18 +4409,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -4872,7 +4479,7 @@ version = "0.1.0"
 dependencies = [
  "display-error-chain",
  "foreign-types 0.3.2",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openssl",
@@ -4886,7 +4493,7 @@ name = "omicron-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "async-trait",
  "backoff",
  "camino",
@@ -4929,46 +4536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "omicron-common"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "anyhow",
- "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "async-trait",
- "backoff",
- "camino",
- "chrono",
- "dropshot",
- "futures",
- "hex",
- "http",
- "hyper",
- "ipnetwork",
- "lazy_static",
- "macaddr",
- "parse-display",
- "progenitor",
- "rand 0.8.5",
- "reqwest",
- "ring",
- "schemars",
- "semver 1.0.20",
- "serde",
- "serde_derive",
- "serde_human_bytes",
- "serde_json",
- "serde_with",
- "slog",
- "strum",
- "thiserror",
- "tokio",
- "tokio-postgres",
- "toml 0.7.8",
- "uuid",
-]
-
-[[package]]
 name = "omicron-deploy"
 version = "0.1.0"
 dependencies = [
@@ -4999,7 +4566,7 @@ dependencies = [
  "libc",
  "nexus-test-interface",
  "nexus-test-utils",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-nexus",
  "omicron-rpaths",
  "omicron-sled-agent",
@@ -5037,12 +4604,12 @@ dependencies = [
  "hyper",
  "illumos-utils",
  "ipcc-key-value",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "schemars",
  "serde",
  "serde_human_bytes",
@@ -5082,7 +4649,7 @@ dependencies = [
  "crucible-pantry-client",
  "diesel",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -5097,7 +4664,7 @@ dependencies = [
  "httptest",
  "hyper",
  "hyper-rustls",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "lazy_static",
@@ -5113,25 +4680,25 @@ dependencies = [
  "nexus-test-utils-macros",
  "nexus-types",
  "num-integer",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "openssl",
  "openssl-probe",
  "openssl-sys",
  "oso",
  "oxide-client",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-db",
  "oximeter-instruments",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "parse-display",
  "paste",
  "pem",
@@ -5191,15 +4758,15 @@ dependencies = [
  "gateway-messages",
  "gateway-test-utils",
  "humantime",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
- "nexus-client 0.1.0",
+ "nexus-client",
  "nexus-db-model",
  "nexus-db-queries",
  "nexus-test-utils",
  "nexus-test-utils-macros",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-nexus",
  "omicron-rpaths",
  "omicron-test-utils",
@@ -5230,7 +4797,7 @@ dependencies = [
  "hex",
  "illumos-utils",
  "indicatif",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "petgraph",
@@ -5271,19 +4838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "omicron-passwords"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "argon2",
- "rand 0.8.5",
- "schemars",
- "serde",
- "serde_with",
- "thiserror",
-]
-
-[[package]]
 name = "omicron-rpaths"
 version = "0.1.0"
 dependencies = [
@@ -5313,7 +4867,7 @@ dependencies = [
  "ddm-admin-client",
  "derive_more",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -5325,27 +4879,27 @@ dependencies = [
  "hyper",
  "hyper-staticfile",
  "illumos-utils",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "key-manager",
  "libc",
  "macaddr",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "opte-ioctl",
- "oximeter 0.1.0",
- "oximeter-producer 0.1.0",
+ "oximeter",
+ "oximeter-producer",
  "percent-encoding",
  "pretty_assertions",
  "progenitor",
  "propolis-client",
- "propolis-server",
+ "propolis-mock-server",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
@@ -5393,7 +4947,7 @@ dependencies = [
  "hex",
  "http",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "pem",
  "rcgen",
@@ -5420,11 +4974,9 @@ dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
  "bitflags 2.4.0",
- "bitvec",
  "bstr 0.2.17",
  "bstr 1.6.0",
  "bytes",
- "cc",
  "chrono",
  "cipher",
  "clap 4.4.3",
@@ -5449,11 +5001,10 @@ dependencies = [
  "generic-array",
  "getrandom 0.2.10",
  "hashbrown 0.13.2",
- "hashbrown 0.14.0",
  "hex",
  "hyper",
  "hyper-rustls",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "inout",
  "ipnetwork",
  "itertools 0.10.5",
@@ -5469,7 +5020,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "once_cell",
- "openapiv3",
+ "openapiv3 2.0.0-rc.1",
  "petgraph",
  "postgres-types",
  "ppv-lite86",
@@ -5477,8 +5028,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
  "reqwest",
  "ring",
  "rustix 0.38.9",
@@ -5508,7 +5059,6 @@ dependencies = [
  "trust-dns-proto",
  "unicode-bidi",
  "unicode-normalization",
- "unicode-xid",
  "usdt",
  "uuid",
  "yasna",
@@ -5564,9 +5114,9 @@ version = "0.4.0"
 source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#bb69a3a4a184d966bac2a0df2be5c9038d9867d0"
 dependencies = [
  "heck 0.4.1",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "lazy_static",
- "openapiv3",
+ "openapiv3 1.0.3",
  "regex",
 ]
 
@@ -5576,7 +5126,18 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e56d5c441965b6425165b7e3223cc933ca469834f4a8b4786817a1f9dc4f13"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "openapiv3"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25316406f0191559189c56d99731b63130775de7284d98df5e976ce67882ca8a"
+dependencies = [
+ "indexmap 2.0.2",
  "serde",
  "serde_json",
 ]
@@ -5756,9 +5317,9 @@ dependencies = [
  "bytes",
  "chrono",
  "num",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
- "oximeter-macro-impl 0.1.0",
+ "oximeter-macro-impl",
  "rstest",
  "schemars",
  "serde",
@@ -5769,28 +5330,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "bytes",
- "chrono",
- "num-traits",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "schemars",
- "serde",
- "thiserror",
- "uuid",
-]
-
-[[package]]
 name = "oximeter-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "reqwest",
@@ -5808,15 +5353,15 @@ dependencies = [
  "dropshot",
  "expectorate",
  "futures",
- "internal-dns 0.1.0",
- "nexus-client 0.1.0",
+ "internal-dns",
+ "nexus-client",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
- "oximeter 0.1.0",
+ "openapiv3 1.0.3",
+ "oximeter",
  "oximeter-client",
  "oximeter-db",
  "rand 0.8.5",
@@ -5851,7 +5396,7 @@ dependencies = [
  "itertools 0.11.0",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "regex",
  "reqwest",
  "schemars",
@@ -5877,7 +5422,7 @@ dependencies = [
  "futures",
  "http",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "tokio",
  "uuid",
 ]
@@ -5887,16 +5432,6 @@ name = "oximeter-macro-impl"
 version = "0.1.0"
 dependencies = [
  "omicron-workspace-hack",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "oximeter-macro-impl"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.32",
@@ -5910,30 +5445,10 @@ dependencies = [
  "chrono",
  "clap 4.4.3",
  "dropshot",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
- "reqwest",
- "schemars",
- "serde",
- "slog",
- "slog-dtrace",
- "thiserror",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "oximeter-producer"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "dropshot",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter",
  "reqwest",
  "schemars",
  "serde",
@@ -6217,7 +5732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_derive",
 ]
@@ -6569,17 +6084,17 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "progenitor"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a6bc0624803b9483983f03269533cc35db66a54b"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -6589,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a6bc0624803b9483983f03269533cc35db66a54b"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6603,14 +6118,14 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a6bc0624803b9483983f03269533cc35db66a54b"
 dependencies = [
  "getopts",
  "heck 0.4.1",
  "http",
- "indexmap 2.0.0",
- "openapiv3",
+ "indexmap 2.0.2",
+ "openapiv3 2.0.0-rc.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -6625,10 +6140,10 @@ dependencies = [
 
 [[package]]
 name = "progenitor-macro"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a6bc0624803b9483983f03269533cc35db66a54b"
 dependencies = [
- "openapiv3",
+ "openapiv3 2.0.0-rc.1",
  "proc-macro2",
  "progenitor-impl",
  "quote",
@@ -6641,42 +6156,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "anyhow",
- "bhyve_api",
- "bitflags 2.4.0",
- "bitstruct",
- "byteorder",
- "crucible",
- "crucible-client-types",
- "dladm",
- "erased-serde",
- "futures",
- "lazy_static",
- "libc",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "propolis_types",
- "rfb",
- "serde",
- "serde_arrays",
- "serde_json",
- "slog",
- "strum",
- "thiserror",
- "tokio",
- "usdt",
- "uuid",
- "viona_api",
-]
-
-[[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=44a5d0bca91393229091a48026bc00e6de37f2a3#44a5d0bca91393229091a48026bc00e6de37f2a3"
 dependencies = [
  "async-trait",
  "base64 0.21.4",
@@ -6698,73 +6180,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis-server"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+name = "propolis-mock-server"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=44a5d0bca91393229091a48026bc00e6de37f2a3#44a5d0bca91393229091a48026bc00e6de37f2a3"
 dependencies = [
  "anyhow",
- "async-trait",
  "atty",
  "base64 0.21.4",
- "bit_field",
- "bitvec",
- "bytes",
- "cfg-if 1.0.0",
- "chrono",
  "clap 4.4.3",
- "const_format",
- "crucible-client-types",
  "dropshot",
- "erased-serde",
  "futures",
- "http",
  "hyper",
- "internal-dns 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "lazy_static",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "propolis",
  "propolis-client",
- "propolis-server-config",
- "rfb",
- "ron 0.7.1",
- "schemars",
- "serde",
- "serde_derive",
  "serde_json",
  "slog",
  "slog-async",
  "slog-bunyan",
  "slog-dtrace",
  "slog-term",
- "strum",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.20.1",
- "tokio-util",
- "toml 0.7.8",
- "usdt",
- "uuid",
-]
-
-[[package]]
-name = "propolis-server-config"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "cpuid_profile_config",
- "serde",
- "serde_derive",
- "thiserror",
- "toml 0.7.8",
 ]
 
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=44a5d0bca91393229091a48026bc00e6de37f2a3#44a5d0bca91393229091a48026bc00e6de37f2a3"
 dependencies = [
  "schemars",
  "serde",
@@ -7081,14 +6523,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -7102,10 +6544,16 @@ name = "regex-automata"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -7119,6 +6567,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "regress"
@@ -7147,9 +6601,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.4",
  "bytes",
@@ -7175,6 +6629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -7200,21 +6655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfb"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rfb?rev=0cac8d9c25eb27acfa35df80f3b9d371de98ab3b#0cac8d9c25eb27acfa35df80f3b9d371de98ab3b"
-dependencies = [
- "ascii",
- "async-trait",
- "bitflags 1.3.2",
- "env_logger 0.9.3",
- "futures",
- "log",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7227,23 +6667,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "ringbuffer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
-
-[[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "serde",
 ]
 
 [[package]]
@@ -7330,20 +6753,6 @@ checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
-dependencies = [
- "bitflags 2.4.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -7768,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -7805,19 +7214,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_arrays"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7963,7 +7363,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -7997,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -8155,7 +7555,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ipnetwork",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -8179,8 +7579,8 @@ dependencies = [
  "libc",
  "libefi-illumos",
  "macaddr",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "rand 0.8.5",
@@ -8407,7 +7807,7 @@ dependencies = [
  "futures",
  "gateway-messages",
  "hex",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-gateway",
  "omicron-workspace-hack",
  "serde",
@@ -8680,6 +8080,27 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -8988,7 +8409,7 @@ name = "tlvc-text"
 version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/tlvc.git#e644a21a7ca973ed31499106ea926bd63ebccc6f"
 dependencies = [
- "ron 0.8.1",
+ "ron",
  "serde",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
  "zerocopy 0.6.4",
@@ -9154,14 +8575,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.0",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -9179,7 +8600,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9188,11 +8609,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9405,7 +8826,7 @@ dependencies = [
  "datatest-stable",
  "fs-err",
  "humantime",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "predicates 3.0.4",
@@ -9434,7 +8855,7 @@ dependencies = [
  "hex",
  "hubtools",
  "itertools 0.11.0",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "rand 0.8.5",
@@ -9500,17 +8921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
- "static_assertions",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9518,8 +8928,8 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "typify"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#3ee46b53c872312e1fe7b8acd7776eb4ce066513"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -9527,8 +8937,8 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#3ee46b53c872312e1fe7b8acd7776eb4ce066513"
 dependencies = [
  "heck 0.4.1",
  "log",
@@ -9544,8 +8954,8 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#3ee46b53c872312e1fe7b8acd7776eb4ce066513"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9659,7 +9069,7 @@ dependencies = [
  "derive-where",
  "either",
  "futures",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "indicatif",
  "linear-map",
  "omicron-test-utils",
@@ -9783,40 +9193,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "vergen"
-version = "8.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
-dependencies = [
- "anyhow",
- "git2",
- "rustc_version 0.4.0",
- "rustversion",
- "time",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "viona_api"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
- "viona_api_sys",
-]
-
-[[package]]
-name = "viona_api_sys"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "vsss-rs"
@@ -10035,11 +9415,11 @@ dependencies = [
  "futures",
  "hex",
  "humantime",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "indicatif",
  "itertools 0.11.0",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
  "once_cell",
  "owo-colors",
@@ -10075,7 +9455,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "gateway-client",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -10141,16 +9521,16 @@ dependencies = [
  "installinator-artifact-client",
  "installinator-artifactd",
  "installinator-common",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "omicron-certificates",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "rand 0.8.5",
  "reqwest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,9 +284,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "44a5d0bca91393229091a48026bc00e6de37f2a3" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "44a5d0bca91393229091a48026bc00e6de37f2a3", features = [ "generated-migration" ] }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "44a5d0bca91393229091a48026bc00e6de37f2a3" }
 proptest = "1.3.1"
 quote = "1.0"
 rand = "0.8.5"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -49,7 +49,7 @@ oximeter-producer.workspace = true
 percent-encoding.workspace = true
 progenitor.workspace = true
 propolis-client = { workspace = true, features = [ "generated-migration" ] }
-propolis-server.workspace = true # Only used by the simulated sled agent
+propolis-mock-server.workspace = true # Only used by the simulated sled agent
 rand = { workspace = true, features = ["getrandom"] }
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
 schemars = { workspace = true, features = [ "chrono", "uuid1" ] }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -43,7 +43,7 @@ use illumos_utils::opte::params::{
 use nexus_client::types::PhysicalDiskKind;
 use omicron_common::address::PROPOLIS_PORT;
 use propolis_client::Client as PropolisClient;
-use propolis_server::mock_server::Context as PropolisContext;
+use propolis_mock_server::Context as PropolisContext;
 
 /// Simulates management of the control plane on a sled
 ///
@@ -640,11 +640,10 @@ impl SledAgent {
             ..Default::default()
         };
         let propolis_log = log.new(o!("component" => "propolis-server-mock"));
-        let private =
-            Arc::new(PropolisContext::new(Default::default(), propolis_log));
+        let private = Arc::new(PropolisContext::new(propolis_log));
         info!(log, "Starting mock propolis-server...");
         let dropshot_log = log.new(o!("component" => "dropshot"));
-        let mock_api = propolis_server::mock_server::api();
+        let mock_api = propolis_mock_server::api();
 
         let srv = dropshot::HttpServerStarter::new(
             &dropshot_config,

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -19,7 +19,6 @@ bit-set = { version = "0.5.3" }
 bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["serde"] }
-bitvec = { version = "1.0.1" }
 bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2.17" }
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1.6.0" }
 bytes = { version = "1.5.0", features = ["serde"] }
@@ -46,11 +45,10 @@ futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.0", features = ["raw"] }
-hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13.2" }
+hashbrown = { version = "0.13.2" }
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = { version = "0.14.27", features = ["full"] }
-indexmap = { version = "2.0.0", features = ["serde"] }
+indexmap = { version = "2.0.2", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
 ipnetwork = { version = "0.20.0", features = ["schemars"] }
 itertools = { version = "0.10.5" }
@@ -64,21 +62,21 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
-openapiv3 = { version = "1.0.3", default-features = false, features = ["skip_serializing_defaults"] }
+openapiv3 = { version = "2.0.0-rc.1", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
-rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
-rand_chacha = { version = "0.3.1" }
-regex = { version = "1.9.5" }
-regex-automata = { version = "0.3.8", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.7.5" }
-reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "stream"] }
+rand = { version = "0.8.5" }
+rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
+regex = { version = "1.10.2" }
+regex-automata = { version = "0.4.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.8.2" }
+reqwest = { version = "0.11.22", features = ["blocking", "json", "rustls-tls", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.188", features = ["alloc", "derive", "rc"] }
+serde = { version = "1.0.189", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.107", features = ["raw_value"] }
 sha2 = { version = "0.10.8", features = ["oid"] }
 signature = { version = "2.1.0", default-features = false, features = ["digest", "rand_core", "std"] }
@@ -111,11 +109,9 @@ bit-set = { version = "0.5.3" }
 bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["serde"] }
-bitvec = { version = "1.0.1" }
 bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2.17" }
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1.6.0" }
 bytes = { version = "1.5.0", features = ["serde"] }
-cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.31", features = ["alloc", "serde"] }
 cipher = { version = "0.4.4", default-features = false, features = ["block-padding", "zeroize"] }
 clap = { version = "4.4.3", features = ["derive", "env", "wrap_help"] }
@@ -139,11 +135,10 @@ futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.0", features = ["raw"] }
-hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13.2" }
+hashbrown = { version = "0.13.2" }
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = { version = "0.14.27", features = ["full"] }
-indexmap = { version = "2.0.0", features = ["serde"] }
+indexmap = { version = "2.0.2", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
 ipnetwork = { version = "0.20.0", features = ["schemars"] }
 itertools = { version = "0.10.5" }
@@ -157,21 +152,21 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
-openapiv3 = { version = "1.0.3", default-features = false, features = ["skip_serializing_defaults"] }
+openapiv3 = { version = "2.0.0-rc.1", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
-rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
-rand_chacha = { version = "0.3.1" }
-regex = { version = "1.9.5" }
-regex-automata = { version = "0.3.8", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.7.5" }
-reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "stream"] }
+rand = { version = "0.8.5" }
+rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
+regex = { version = "1.10.2" }
+regex-automata = { version = "0.4.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.8.2" }
+reqwest = { version = "0.11.22", features = ["blocking", "json", "rustls-tls", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.188", features = ["alloc", "derive", "rc"] }
+serde = { version = "1.0.189", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.107", features = ["raw_value"] }
 sha2 = { version = "0.10.8", features = ["oid"] }
 signature = { version = "2.1.0", default-features = false, features = ["digest", "rand_core", "std"] }
@@ -193,7 +188,6 @@ tracing = { version = "0.1.37", features = ["log"] }
 trust-dns-proto = { version = "0.22.0" }
 unicode-bidi = { version = "0.3.13" }
 unicode-normalization = { version = "0.1.22" }
-unicode-xid = { version = "0.2.4" }
 usdt = { version = "0.3.5" }
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 yasna = { version = "0.5.2", features = ["bit-vec", "num-bigint", "std", "time"] }


### PR DESCRIPTION
This switches simulated sled-agent to used the now-independent propolis mock server from oxidecomputer/propolis#556.

Once that has landed, this PR will need to be updated w/ the as-committed git hash.