### PR TITLE
Add new datum types to timeseries schema table

### DIFF
--- a/oximeter/db/src/db-replicated-init.sql
+++ b/oximeter/db/src/db-replicated-init.sql
@@ -652,7 +652,25 @@ CREATE TABLE IF NOT EXISTS oximeter.timeseries_schema ON CLUSTER oximeter_cluste
         'CumulativeI64' = 6,
         'CumulativeF64' = 7,
         'HistogramI64' = 8,
-        'HistogramF64' = 9
+        'HistogramF64' = 9,
+        'I8' = 10,
+        'U8' = 11,
+        'I16' = 12,
+        'U16' = 13,
+        'I32' = 14,
+        'U32' = 15,
+        'U64' = 16,
+        'F32' = 17,
+        'CumulativeU64' = 18,
+        'CumulativeF32' = 19,
+        'HistogramI8' = 20,
+        'HistogramU8' = 21,
+        'HistogramI16' = 23,
+        'HistogramU16' = 23,
+        'HistogramI32' = 24,
+        'HistogramU32' = 25,
+        'HistogramU64' = 26,
+        'HistogramF32' = 27
     ),
     created DateTime64(9, 'UTC')
 )

--- a/oximeter/db/src/db-single-node-init.sql
+++ b/oximeter/db/src/db-single-node-init.sql
@@ -476,7 +476,25 @@ CREATE TABLE IF NOT EXISTS oximeter.timeseries_schema
         'CumulativeI64' = 6,
         'CumulativeF64' = 7,
         'HistogramI64' = 8,
-        'HistogramF64' = 9
+        'HistogramF64' = 9,
+        'I8' = 10,
+        'U8' = 11,
+        'I16' = 12,
+        'U16' = 13,
+        'I32' = 14,
+        'U32' = 15,
+        'U64' = 16,
+        'F32' = 17,
+        'CumulativeU64' = 18,
+        'CumulativeF32' = 19,
+        'HistogramI8' = 20,
+        'HistogramU8' = 21,
+        'HistogramI16' = 22,
+        'HistogramU16' = 23,
+        'HistogramI32' = 24,
+        'HistogramU32' = 25,
+        'HistogramU64' = 26,
+        'HistogramF32' = 27
     ),
     created DateTime64(9, 'UTC')
 )

--- a/oximeter/db/src/model.rs
+++ b/oximeter/db/src/model.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 ///
 /// TODO(#4271): The current implementation of versioning will wipe the metrics
 /// database if this number is incremented.
-pub const OXIMETER_VERSION: u64 = 1;
+pub const OXIMETER_VERSION: u64 = 2;
 
 // Wrapper type to represent a boolean in the database.
 //

--- a/oximeter/oximeter/src/types.rs
+++ b/oximeter/oximeter/src/types.rs
@@ -275,6 +275,7 @@ pub struct Field {
     JsonSchema,
     Serialize,
     Deserialize,
+    strum::EnumIter,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum DatumType {


### PR DESCRIPTION
- Fixes https://github.com/oxidecomputer/omicron/issues/4336
- Adds regression test making sure a query selecting all datum types from the schema table succeeds, even if it returns zero results. This uses an iterator over the datum type enum, so it should catch future changes to the type.
- Adds new datum types to schema table
- Bumps oximeter database version number