### PR TITLE
Add support for publishing kernel statistics to oximeter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3805,6 +3805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstat-rs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc713c7902f757cf0c04012dbad3864ea505f2660467b704847ea7ea2ff6d67"
+dependencies = [
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5344,6 +5354,7 @@ dependencies = [
  "openapiv3",
  "opte-ioctl",
  "oximeter 0.1.0",
+ "oximeter-instruments",
  "oximeter-producer 0.1.0",
  "percent-encoding",
  "pretty_assertions",
@@ -5870,12 +5881,19 @@ dependencies = [
 name = "oximeter-instruments"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 1.0.0",
  "chrono",
  "dropshot",
  "futures",
  "http",
+ "kstat-rs",
  "omicron-workspace-hack",
  "oximeter 0.1.0",
+ "rand 0.8.5",
+ "slog",
+ "slog-async",
+ "slog-term",
+ "thiserror",
  "tokio",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ ipcc-key-value = { path = "ipcc-key-value" }
 ipnetwork = { version = "0.20", features = ["schemars"] }
 itertools = "0.11.0"
 key-manager = { path = "key-manager" }
+kstat-rs = "0.2.3"
 lazy_static = "1.4.0"
 libc = "0.2.150"
 linear-map = "1.2.0"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -289,6 +289,45 @@
         }
       }
     },
+    "/metrics/collect/{producer_id}": {
+      "get": {
+        "summary": "Collect oximeter samples from the sled agent.",
+        "operationId": "metrics_collect",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "producer_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ProducerResultsItem",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProducerResultsItem"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/network-bootstore-config": {
       "get": {
         "summary": "This API endpoint is only reading the local sled agent's view of the",
@@ -1096,6 +1135,962 @@
           "port"
         ]
       },
+      "BinRangedouble": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "number",
+                "format": "double"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "number",
+                "format": "double"
+              },
+              "start": {
+                "type": "number",
+                "format": "double"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "number",
+                "format": "double"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangefloat": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "number",
+                "format": "float"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "number",
+                "format": "float"
+              },
+              "start": {
+                "type": "number",
+                "format": "float"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "number",
+                "format": "float"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeint16": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int16"
+              },
+              "start": {
+                "type": "integer",
+                "format": "int16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "int16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeint32": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "start": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeint64": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "start": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeint8": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "int8"
+              },
+              "start": {
+                "type": "integer",
+                "format": "int8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "int8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeuint16": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "start": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeuint32": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "start": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeuint64": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "start": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BinRangeuint8": {
+        "description": "A type storing a range over `T`.\n\nThis type supports ranges similar to the `RangeTo`, `Range` and `RangeFrom` types in the standard library. Those cover `(..end)`, `(start..end)`, and `(start..)` respectively.",
+        "oneOf": [
+          {
+            "description": "A range unbounded below and exclusively above, `..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_to"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and exclusively above, `start..end`.",
+            "type": "object",
+            "properties": {
+              "end": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              },
+              "start": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range"
+                ]
+              }
+            },
+            "required": [
+              "end",
+              "start",
+              "type"
+            ]
+          },
+          {
+            "description": "A range bounded inclusively below and unbounded above, `start..`.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "range_from"
+                ]
+              }
+            },
+            "required": [
+              "start",
+              "type"
+            ]
+          }
+        ]
+      },
+      "Bindouble": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangedouble"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binfloat": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangefloat"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binint16": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeint16"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binint32": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeint32"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binint64": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeint64"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binint8": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeint8"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binuint16": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeuint16"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binuint32": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeuint32"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binuint64": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeuint64"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
+      "Binuint8": {
+        "description": "Type storing bin edges and a count of samples within it.",
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The total count of samples in this bin.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "range": {
+            "description": "The range of the support covered by this bin.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BinRangeuint8"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "range"
+        ]
+      },
       "BundleUtilization": {
         "description": "The portion of a debug dataset used for zone bundles.",
         "type": "object",
@@ -1279,6 +2274,79 @@
           "target"
         ]
       },
+      "Cumulativedouble": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
+      "Cumulativefloat": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
+      "Cumulativeint64": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
+      "Cumulativeuint64": {
+        "description": "A cumulative or counter data type.",
+        "type": "object",
+        "properties": {
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "start_time",
+          "value"
+        ]
+      },
       "DatasetKind": {
         "description": "The type of a dataset, and an auxiliary information necessary to successfully launch a zone managing the associated data.",
         "oneOf": [
@@ -1402,6 +2470,516 @@
           "id",
           "name",
           "service_address"
+        ]
+      },
+      "Datum": {
+        "description": "A `Datum` is a single sampled data point from a metric.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "boolean"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bool"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "int8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i8"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u8"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "int16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i16"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u16"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "number",
+                "format": "float"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "f32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "number",
+                "format": "double"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "f64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bytes"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Cumulativeint64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cumulative_i64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Cumulativeuint64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cumulative_u64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Cumulativefloat"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cumulative_f32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Cumulativedouble"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cumulative_f64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramint8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_i8"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramuint8"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_u8"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramint16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_i16"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramuint16"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_u16"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramint32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_i32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramuint32"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_u32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramint64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_i64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramuint64"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_u64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramfloat"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_f32"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "$ref": "#/components/schemas/Histogramdouble"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_f64"
+                ]
+              }
+            },
+            "required": [
+              "datum",
+              "type"
+            ]
+          }
         ]
       },
       "DeleteVirtualNetworkInterfaceHost": {
@@ -1901,11 +3479,678 @@
           "request_id"
         ]
       },
+      "Field": {
+        "description": "A `Field` is a named aspect of a target or metric.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/FieldValue"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "FieldSet": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Field"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fields",
+          "name"
+        ]
+      },
+      "FieldValue": {
+        "description": "The `FieldValue` contains the value of a target or metric field.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i8"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "int8"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u8"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i16"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "int16"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u16"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i32"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u32"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i64"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "int64"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "u64"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip_addr"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "uuid"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bool"
+                ]
+              },
+              "value": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
       "Generation": {
         "description": "Generation numbers stored in the database, used for optimistic concurrency control",
         "type": "integer",
         "format": "uint64",
         "minimum": 0
+      },
+      "HistogramError": {
+        "description": "Errors related to constructing histograms or adding samples into them.",
+        "oneOf": [
+          {
+            "description": "An attempt to construct a histogram with an empty set of bins.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "empty_bins"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "An attempt to construct a histogram with non-monotonic bins.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nonmonotonic_bins"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "A non-finite was encountered, either as a bin edge or a sample.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "non_finite_value"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "Error returned when two neighboring bins are not adjoining (there's space between them)",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "object",
+                "properties": {
+                  "left": {
+                    "type": "string"
+                  },
+                  "right": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "left",
+                  "right"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "non_adjoining_bins"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "Bin and count arrays are of different sizes.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "object",
+                "properties": {
+                  "n_bins": {
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0
+                  },
+                  "n_counts": {
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "n_bins",
+                  "n_counts"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "array_size_mismatch"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "content": {
+                "$ref": "#/components/schemas/QuantizationError"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "quantization"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          }
+        ]
+      },
+      "Histogramdouble": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bindouble"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramfloat": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binfloat"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramint16": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binint16"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramint32": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binint32"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramint64": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binint64"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramint8": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binint8"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramuint16": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binuint16"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramuint32": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binuint32"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramuint64": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binuint64"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
+      },
+      "Histogramuint8": {
+        "description": "Histogram metric\n\nA histogram maintains the count of any number of samples, over a set of bins. Bins are specified on construction via their _left_ edges, inclusive. There can't be any \"gaps\" in the bins, and an additional bin may be added to the left, right, or both so that the bins extend to the entire range of the support.\n\nNote that any gaps, unsorted bins, or non-finite values will result in an error.",
+        "type": "object",
+        "properties": {
+          "bins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Binuint8"
+            }
+          },
+          "n_samples": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "bins",
+          "n_samples",
+          "start_time"
+        ]
       },
       "HostIdentifier": {
         "description": "A `HostIdentifier` represents either an IP host or network (v4 or v6), or an entire VPC (identified by its VNI). It is used in firewall rule host filters.",
@@ -2521,6 +4766,143 @@
         "minLength": 5,
         "maxLength": 17
       },
+      "Measurement": {
+        "description": "A `Measurement` is a timestamped datum from a single metric",
+        "type": "object",
+        "properties": {
+          "datum": {
+            "$ref": "#/components/schemas/Datum"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "datum",
+          "timestamp"
+        ]
+      },
+      "MetricsError": {
+        "description": "Errors related to the generation or collection of metrics.",
+        "oneOf": [
+          {
+            "description": "An error related to generating metric data points",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "datum_error"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "An error running an `Oximeter` server",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "oximeter_server"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "An error related to creating or sampling a [`histogram::Histogram`] metric.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "$ref": "#/components/schemas/HistogramError"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram_error"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "An error parsing a field or measurement from a string.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "object",
+                "properties": {
+                  "src": {
+                    "type": "string"
+                  },
+                  "typ": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "src",
+                  "typ"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "parse_error"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          },
+          {
+            "description": "A field name is duplicated between the target and metric.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duplicate_field_name"
+                ]
+              }
+            },
+            "required": [
+              "content",
+              "type"
+            ]
+          }
+        ]
+      },
       "Name": {
         "title": "A name unique within the parent collection",
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",
@@ -2737,6 +5119,138 @@
         "minItems": 2,
         "maxItems": 2
       },
+      "ProducerResultsItem": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "info": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Sample"
+                }
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "ok"
+                ]
+              }
+            },
+            "required": [
+              "info",
+              "status"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "info": {
+                "$ref": "#/components/schemas/MetricsError"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "info",
+              "status"
+            ]
+          }
+        ]
+      },
+      "QuantizationError": {
+        "description": "Errors occurring during quantizated bin generation.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "overflow"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "precision"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "invalid_base"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "invalid_steps"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "uneven_steps_for_base"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "powers_out_of_order"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
       "RackNetworkConfigV1": {
         "description": "Initial network configuration",
         "type": "object",
@@ -2797,6 +5311,36 @@
         "required": [
           "destination",
           "nexthop"
+        ]
+      },
+      "Sample": {
+        "description": "A concrete type representing a single, timestamped measurement from a timeseries.",
+        "type": "object",
+        "properties": {
+          "measurement": {
+            "description": "The measured value of the metric at this sample",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Measurement"
+              }
+            ]
+          },
+          "metric": {
+            "$ref": "#/components/schemas/FieldSet"
+          },
+          "target": {
+            "$ref": "#/components/schemas/FieldSet"
+          },
+          "timeseries_name": {
+            "description": "The name of the timeseries this sample belongs to",
+            "type": "string"
+          }
+        },
+        "required": [
+          "measurement",
+          "metric",
+          "target",
+          "timeseries_name"
         ]
       },
       "SemverVersion": {

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -5,15 +5,27 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
+cfg-if.workspace = true
 chrono.workspace = true
 dropshot.workspace = true
 futures.workspace = true
-oximeter.workspace = true
-tokio.workspace = true
 http = { workspace = true, optional = true }
+oximeter.workspace = true
+slog.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
 
 [features]
-default = ["http-instruments"]
+default = ["http-instruments", "kstat"]
 http-instruments = ["http"]
+kstat = ["kstat-rs"]
+
+[dev-dependencies]
+rand.workspace = true
+slog-async.workspace = true
+slog-term.workspace = true
+
+[target.'cfg(target_os = "illumos")'.dependencies]
+kstat-rs = { workspace = true, optional = true }

--- a/oximeter/instruments/src/kstat/link.rs
+++ b/oximeter/instruments/src/kstat/link.rs
@@ -1,0 +1,653 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Report metrics about Ethernet data links on the host system
+
+use crate::kstat::hrtime_to_utc;
+use crate::kstat::ConvertNamedData;
+use crate::kstat::Error;
+use crate::kstat::KstatList;
+use crate::kstat::KstatTarget;
+use chrono::DateTime;
+use chrono::Utc;
+use kstat_rs::Data;
+use kstat_rs::Kstat;
+use kstat_rs::Named;
+use oximeter::types::Cumulative;
+use oximeter::Metric;
+use oximeter::Sample;
+use oximeter::Target;
+use uuid::Uuid;
+
+/// Information about a single physical Ethernet link on a host.
+#[derive(Clone, Debug, Target)]
+pub struct PhysicalDataLink {
+    /// The ID of the rack (cluster) containing this host.
+    pub rack_id: Uuid,
+    /// The ID of the sled itself.
+    pub sled_id: Uuid,
+    /// The serial number of the hosting sled.
+    pub serial: String,
+    /// The name of the host.
+    pub hostname: String,
+    /// The name of the link.
+    pub link_name: String,
+}
+
+/// Information about a virtual Ethernet link on a host.
+///
+/// Note that this is specifically for a VNIC in on the host system, not a guest
+/// data link.
+#[derive(Clone, Debug, Target)]
+pub struct VirtualDataLink {
+    /// The ID of the rack (cluster) containing this host.
+    pub rack_id: Uuid,
+    /// The ID of the sled itself.
+    pub sled_id: Uuid,
+    /// The serial number of the hosting sled.
+    pub serial: String,
+    /// The name of the host, or the zone name for links in a zone.
+    pub hostname: String,
+    /// The name of the link.
+    pub link_name: String,
+}
+
+/// Information about a guest virtual Ethernet link.
+#[derive(Clone, Debug, Target)]
+pub struct GuestDataLink {
+    /// The ID of the rack (cluster) containing this host.
+    pub rack_id: Uuid,
+    /// The ID of the sled itself.
+    pub sled_id: Uuid,
+    /// The serial number of the hosting sled.
+    pub serial: String,
+    /// The name of the host, or the zone name for links in a zone.
+    pub hostname: String,
+    /// The ID of the project containing the instance.
+    pub project_id: Uuid,
+    /// The ID of the instance.
+    pub instance_id: Uuid,
+    /// The name of the link.
+    pub link_name: String,
+}
+
+/// The number of packets received on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct PacketsReceived {
+    pub datum: Cumulative<u64>,
+}
+
+/// The number of packets sent on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct PacketsSent {
+    pub datum: Cumulative<u64>,
+}
+
+/// The number of bytes sent on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct BytesSent {
+    pub datum: Cumulative<u64>,
+}
+
+/// The number of bytes received on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct BytesReceived {
+    pub datum: Cumulative<u64>,
+}
+
+/// The number of errors received on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct ErrorsReceived {
+    pub datum: Cumulative<u64>,
+}
+
+/// The number of errors sent on the link.
+#[derive(Clone, Copy, Metric)]
+pub struct ErrorsSent {
+    pub datum: Cumulative<u64>,
+}
+
+// Helper function to extract the same kstat metrics from all link targets.
+fn extract_link_kstats<T>(
+    target: &T,
+    named_data: &Named,
+    creation_time: DateTime<Utc>,
+    snapshot_time: DateTime<Utc>,
+) -> Option<Result<Sample, Error>>
+where
+    T: KstatTarget,
+{
+    let Named { name, value } = named_data;
+    if *name == "rbytes64" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = BytesReceived {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "obytes64" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = BytesSent {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "ipackets64" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = PacketsReceived {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "opackets64" {
+        Some(value.as_u64().and_then(|x| {
+            let metric = PacketsSent {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "ierrors" {
+        Some(value.as_u32().and_then(|x| {
+            let metric = ErrorsReceived {
+                datum: Cumulative::with_start_time(creation_time, x.into()),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == "oerrors" {
+        Some(value.as_u32().and_then(|x| {
+            let metric = ErrorsSent {
+                datum: Cumulative::with_start_time(creation_time, x.into()),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else {
+        None
+    }
+}
+
+// Helper trait for defining `KstatTarget` for all the link-based stats.
+trait LinkKstatTarget: KstatTarget {
+    fn link_name(&self) -> &str;
+}
+
+impl LinkKstatTarget for PhysicalDataLink {
+    fn link_name(&self) -> &str {
+        &self.link_name
+    }
+}
+
+impl LinkKstatTarget for VirtualDataLink {
+    fn link_name(&self) -> &str {
+        &self.link_name
+    }
+}
+
+impl LinkKstatTarget for GuestDataLink {
+    fn link_name(&self) -> &str {
+        &self.link_name
+    }
+}
+
+impl<T> KstatTarget for T
+where
+    T: LinkKstatTarget,
+{
+    fn interested(&self, kstat: &Kstat<'_>) -> bool {
+        kstat.ks_module == "link"
+            && kstat.ks_instance == 0
+            && kstat.ks_name == self.link_name()
+    }
+
+    fn to_samples(
+        &self,
+        kstats: KstatList<'_, '_>,
+    ) -> Result<Vec<Sample>, Error> {
+        let Some((creation_time, kstat, data)) = kstats.first() else {
+            return Ok(vec![]);
+        };
+        let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
+        let Data::Named(named) = data else {
+            return Err(Error::ExpectedNamedKstat);
+        };
+        named
+            .iter()
+            .filter_map(|nd| {
+                extract_link_kstats(self, nd, *creation_time, snapshot_time)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kstat::sampler::KstatPath;
+    use crate::kstat::sampler::CREATION_TIME_PRUNE_INTERVAL;
+    use crate::kstat::CollectionDetails;
+    use crate::kstat::KstatSampler;
+    use crate::kstat::TargetStatus;
+    use kstat_rs::Ctl;
+    use oximeter::Producer;
+    use rand::distributions::Uniform;
+    use rand::Rng;
+    use slog::info;
+    use slog::Drain;
+    use slog::Logger;
+    use std::time::Duration;
+    use tokio::time::Instant;
+    use uuid::uuid;
+    use uuid::Uuid;
+
+    fn test_logger() -> Logger {
+        let dec =
+            slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter);
+        let drain = slog_term::FullFormat::new(dec).build().fuse();
+        let log =
+            Logger::root(drain, slog::o!("component" => "fake-cleanup-task"));
+        log
+    }
+
+    const RACK_ID: Uuid = uuid!("de784702-cafb-41a9-b3e5-93af189def29");
+    const SLED_ID: Uuid = uuid!("88240343-5262-45f4-86f1-3c82fe383f2a");
+
+    // An etherstub we can use for testing.
+    //
+    // This is not meant to produce real data. It is simply a data link that
+    // shows up with the `link:::` kstat scheme, and which doesn't require us to
+    // decide which physical link over which to create something like a VNIC.
+    #[derive(Debug)]
+    struct TestEtherstub {
+        name: String,
+    }
+
+    impl TestEtherstub {
+        const PFEXEC: &str = "/usr/bin/pfexec";
+        const DLADM: &str = "/usr/sbin/dladm";
+        fn new() -> Self {
+            let name = format!(
+                "kstest{}0",
+                rand::thread_rng()
+                    .sample_iter(Uniform::new('a', 'z'))
+                    .take(5)
+                    .map(char::from)
+                    .collect::<String>(),
+            );
+            Self::create(&name);
+            Self { name }
+        }
+
+        fn create(name: &str) {
+            let output = std::process::Command::new(Self::PFEXEC)
+                .env_clear()
+                .arg(Self::DLADM)
+                .arg("create-etherstub")
+                .arg("-t")
+                .arg(name)
+                .output()
+                .expect("failed to spawn dladm");
+            assert!(
+                output.status.success(),
+                "failed to create test etherstub:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    impl Drop for TestEtherstub {
+        fn drop(&mut self) {
+            let output = std::process::Command::new(Self::PFEXEC)
+                .env_clear()
+                .arg(Self::DLADM)
+                .arg("delete-etherstub")
+                .arg(&self.name)
+                .output()
+                .expect("failed to spawn dladm");
+            if !output.status.success() {
+                eprintln!(
+                    "Failed to delete etherstub '{}'.\n\
+                    Delete manually with `dladm delete-etherstub {}`:\n{}",
+                    &self.name,
+                    &self.name,
+                    String::from_utf8_lossy(&output.stderr),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_physical_datalink() {
+        let link = TestEtherstub::new();
+        let sn = String::from("BRM000001");
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let ctl = Ctl::new().unwrap();
+        let ctl = ctl.update().unwrap();
+        let mut kstat = ctl
+            .filter(Some("link"), Some(0), Some(dl.link_name.as_str()))
+            .next()
+            .unwrap();
+        let creation_time = hrtime_to_utc(kstat.ks_crtime).unwrap();
+        let data = ctl.read(&mut kstat).unwrap();
+        let samples = dl.to_samples(&[(creation_time, kstat, data)]).unwrap();
+        println!("{samples:#?}");
+    }
+
+    #[tokio::test]
+    async fn test_kstat_sampler() {
+        let mut sampler = KstatSampler::new(&test_logger()).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let details = CollectionDetails::never(Duration::from_secs(1));
+        let id = sampler.add_target(dl, details).await.unwrap();
+        let samples: Vec<_> = sampler.produce().unwrap().collect();
+        assert!(samples.is_empty());
+
+        // Pause time, and advance until we're notified of new samples.
+        tokio::time::pause();
+        const MAX_DURATION: Duration = Duration::from_secs(3);
+        const STEP_DURATION: Duration = Duration::from_secs(1);
+        let now = Instant::now();
+        let expected_counts = loop {
+            tokio::time::advance(STEP_DURATION).await;
+            if now.elapsed() > MAX_DURATION {
+                panic!("Waited too long for samples");
+            }
+            if let Some(counts) = sampler.sample_counts() {
+                break counts;
+            }
+        };
+        let samples: Vec<_> = sampler.produce().unwrap().collect();
+        println!("{samples:#?}");
+        assert_eq!(samples.len(), expected_counts.total);
+        assert_eq!(expected_counts.overflow, 0);
+
+        // Test status and remove behavior.
+        tokio::time::resume();
+        assert!(matches!(
+            sampler.target_status(id).await.unwrap(),
+            TargetStatus::Ok { .. },
+        ));
+        sampler.remove_target(id).await.unwrap();
+        assert!(sampler.target_status(id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_kstat_sampler_with_overflow() {
+        let limit = 2;
+        let mut sampler =
+            KstatSampler::with_sample_limit(&test_logger(), limit).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let details = CollectionDetails::never(Duration::from_secs(1));
+        sampler.add_target(dl, details).await.unwrap();
+        let samples: Vec<_> = sampler.produce().unwrap().collect();
+        assert!(samples.is_empty());
+
+        // Pause time, and advance until we're notified of new samples.
+        tokio::time::pause();
+        const MAX_DURATION: Duration = Duration::from_secs(3);
+        const STEP_DURATION: Duration = Duration::from_secs(1);
+        let now = Instant::now();
+        let expected_counts = loop {
+            tokio::time::advance(STEP_DURATION).await;
+            if now.elapsed() > MAX_DURATION {
+                panic!("Waited too long for samples");
+            }
+            if let Some(counts) = sampler.sample_counts() {
+                break counts;
+            }
+        };
+
+        // We should have produced 2 samples from the actual target, plus one
+        // from the counter indicating we've dropped some samples!
+        let samples: Vec<_> = sampler.produce().unwrap().collect();
+        let (link_samples, dropped_samples): (Vec<_>, Vec<_>) = samples
+            .iter()
+            .partition(|s| s.timeseries_name.contains("physical_data_link"));
+        println!("{link_samples:#?}");
+        assert_eq!(link_samples.len(), limit);
+
+        // The total number of samples less overflow should be match the number
+        // of samples for the link we've produced.
+        assert_eq!(
+            link_samples.len(),
+            expected_counts.total - expected_counts.overflow
+        );
+
+        // The worker must have produced one sample representing the number of
+        // overflows.
+        println!("{dropped_samples:#?}");
+        assert_eq!(dropped_samples.len(), 1);
+
+        // Verify that we actually counted the correct number of dropped
+        // samples.
+        let oximeter::Datum::CumulativeU64(overflow) =
+            dropped_samples[0].measurement.datum()
+        else {
+            unreachable!();
+        };
+        assert_eq!(overflow.value(), expected_counts.overflow as u64);
+    }
+
+    #[tokio::test]
+    async fn test_kstat_with_expiration() {
+        // Create a VNIC, which we'll start tracking from, then delete it and
+        // make sure we expire after the expected period.
+        let log = test_logger();
+        let mut sampler = KstatSampler::new(&log).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        info!(log, "created test etherstub"; "name" => &link.name);
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let collection_interval = Duration::from_secs(1);
+        let expiry = Duration::from_secs(1);
+        let details = CollectionDetails::duration(collection_interval, expiry);
+        let id = sampler.add_target(dl, details).await.unwrap();
+        info!(log, "target added"; "id" => ?id);
+        assert!(matches!(
+            sampler.target_status(id).await.unwrap(),
+            TargetStatus::Ok { .. },
+        ));
+
+        // Delete the link right away.
+        drop(link);
+        info!(log, "dropped test etherstub");
+
+        // Pause time, and advance until we should have expired the target.
+        tokio::time::pause();
+        const MAX_DURATION: Duration = Duration::from_secs(3);
+        let now = Instant::now();
+        let is_expired = loop {
+            tokio::time::advance(expiry).await;
+            if now.elapsed() > MAX_DURATION {
+                panic!("Waited too long for samples");
+            }
+            if let TargetStatus::Expired { .. } =
+                sampler.target_status(id).await.unwrap()
+            {
+                break true;
+            }
+        };
+        assert!(is_expired, "Target should have expired by now");
+
+        // We should have some self-stat expiration samples now.
+        let samples = sampler.produce().unwrap();
+        let expiration_samples: Vec<_> = samples
+            .filter(|sample| {
+                sample.timeseries_name == "kstat_sampler:expired_targets"
+            })
+            .collect();
+        assert_eq!(expiration_samples.len(), 1);
+    }
+
+    // A sanity check that a cumulative start time does not change over time,
+    // since we've fixed the time reference at the time it was added.
+    #[tokio::test]
+    async fn test_kstat_start_time_is_equal() {
+        let log = test_logger();
+        let mut sampler = KstatSampler::new(&log).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        info!(log, "created test etherstub"; "name" => &link.name);
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let collection_interval = Duration::from_secs(1);
+        let expiry = Duration::from_secs(1);
+        let details = CollectionDetails::duration(collection_interval, expiry);
+        let id = sampler.add_target(dl, details).await.unwrap();
+        info!(log, "target added"; "id" => ?id);
+        assert!(matches!(
+            sampler.target_status(id).await.unwrap(),
+            TargetStatus::Ok { .. },
+        ));
+        tokio::time::pause();
+        let now = Instant::now();
+        while now.elapsed() < (expiry * 10) {
+            tokio::time::advance(expiry).await;
+        }
+        let samples = sampler.produce().unwrap();
+        let mut start_times = samples
+            .filter(|sample| {
+                sample.timeseries_name.as_str().starts_with("physical")
+            })
+            .map(|sample| sample.measurement.start_time().unwrap());
+        let first = start_times.next().unwrap();
+        println!("{first}");
+        assert!(start_times.all(|t| {
+            println!("{t}");
+            t == first
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_prune_creation_times_when_kstat_is_gone() {
+        // Create a VNIC, which we'll start tracking from, then delete it and
+        // make sure the creation times are pruned.
+        let log = test_logger();
+        let sampler = KstatSampler::new(&log).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        let path = KstatPath {
+            module: "link".to_string(),
+            instance: 0,
+            name: link.name.clone(),
+        };
+        info!(log, "created test etherstub"; "name" => &link.name);
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let collection_interval = Duration::from_secs(1);
+        let expiry = Duration::from_secs(1);
+        let details = CollectionDetails::duration(collection_interval, expiry);
+        let id = sampler.add_target(dl, details).await.unwrap();
+        info!(log, "target added"; "id" => ?id);
+        assert!(matches!(
+            sampler.target_status(id).await.unwrap(),
+            TargetStatus::Ok { .. },
+        ));
+
+        // Delete the link right away.
+        drop(link);
+        info!(log, "dropped test etherstub");
+
+        // Advance time through the prune interval.
+        tokio::time::pause();
+        let now = Instant::now();
+        while now.elapsed() < CREATION_TIME_PRUNE_INTERVAL + expiry {
+            tokio::time::advance(expiry).await;
+        }
+
+        // Now check that the creation times are pruned.
+        let times = sampler.creation_times().await;
+        assert!(!times.contains_key(&path));
+    }
+
+    #[tokio::test]
+    async fn test_prune_creation_times_when_target_is_removed() {
+        // Create a VNIC, which we'll start tracking from, then delete it and
+        // make sure the creation times are pruned.
+        let log = test_logger();
+        let sampler = KstatSampler::new(&log).unwrap();
+        let sn = String::from("BRM000001");
+        let link = TestEtherstub::new();
+        let path = KstatPath {
+            module: "link".to_string(),
+            instance: 0,
+            name: link.name.clone(),
+        };
+        info!(log, "created test etherstub"; "name" => &link.name);
+        let dl = PhysicalDataLink {
+            rack_id: RACK_ID,
+            sled_id: SLED_ID,
+            serial: sn.clone(),
+            hostname: sn,
+            link_name: link.name.to_string(),
+        };
+        let collection_interval = Duration::from_secs(1);
+        let expiry = Duration::from_secs(1);
+        let details = CollectionDetails::duration(collection_interval, expiry);
+        let id = sampler.add_target(dl, details).await.unwrap();
+        info!(log, "target added"; "id" => ?id);
+        assert!(matches!(
+            sampler.target_status(id).await.unwrap(),
+            TargetStatus::Ok { .. },
+        ));
+
+        // Remove the target, but do not drop the link. This will mean that the
+        // underlying kstat is still around, even though there's no target
+        // that's interested in it. We should keep it, in this case.
+        sampler.remove_target(id).await.unwrap();
+
+        // Advance time through the prune interval.
+        tokio::time::pause();
+        let now = Instant::now();
+        while now.elapsed() < CREATION_TIME_PRUNE_INTERVAL + expiry {
+            tokio::time::advance(expiry).await;
+        }
+
+        // Now check that the creation time is still around.
+        let times = sampler.creation_times().await;
+        assert!(times.contains_key(&path));
+    }
+}

--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -1,0 +1,267 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Types for publishing kernel statistics via oximeter.
+//!
+//! # illumos kernel statistics
+//!
+//! illumos defines a generic framework for tracking statistics throughout the
+//! OS, called `kstat`. These statistics are generally defined by the kernel or
+//! device drivers, and made available to userspace for reading through
+//! `libkstat`.
+//!
+//! Kernel statistics are defined by a 4-tuple of names, canonically separated
+//! with a ":". For example, the `cpu:0:vm:pgin` kstat tracks the number of
+//! memory pages paged in for CPU 0. In this case, the kstat is tracked by a
+//! u64, though several data types are supported.
+//!
+//! This module uses the `kstat-rs` crate, which is a fairly low-level wrapper
+//! around `libkstat`. For the purposes of this module, most folks will be
+//! interested in the types [`kstat_rs::Kstat`], [`kstat_rs::Data`], and
+//! [`kstat_rs::NamedData`].
+//!
+//! # Oximeter
+//!
+//! Oximeter is the Oxide control plane component which collects telemetry from
+//! other parts of the system, called _producers_. Statistics are defined using
+//! a _target_, which is an object about which statistics are collected, and
+//! _metrics_, which are the actual measurements about a target. As an example,
+//! a target might be an NVMe drive on the rack, and a metric might be its
+//! temperature, or the estimated remaining drive lifetime.
+//!
+//! Targets and metrics are encapsulated by traits of the same name. Using
+//! these, producers can generate timestamped [`Sample`]s, which the `oximeter`
+//! collector program pulls at regular intervals for storage in the timeseries
+//! database.
+//!
+//! # What does this mod do?
+//!
+//! This module is intended to connect illumos kstats with oximeter. Developers
+//! can use this to define a mapping betweeen one or more kstats, and an
+//! oximeter `Target` and `Metric`. This mapping is encapsulated in the
+//! [`KstatTarget`] trait, which extends the `Target` trait itself.
+//!
+//! To implement the trait, developers register their interest in a particular
+//! [`Kstat`] through the [`KstatTarget::interested()`] method. They then
+//! describe how to generate any number of [`Sample`]s from that set of kstats,
+//! through the [`KstatTarget::to_samples()`] method.
+//!
+//! # The [`KstatSampler`]
+//!
+//! Most folks will instantiate a [`KstatSampler`], which manages any number of
+//! tracked `KstatTarget`s. Users can register their implementation of
+//! `KstatTarget` with the sampler, and it will periodically generate samples
+//! from it, converting the "interesting" kstats into `Sample`s.
+//!
+//! # Intervals and expiration
+//!
+//! When users register a target for sampling, they are required to include
+//! details about how often their target should be sampled, and what to do if we
+//! cannot produce samples due to an error, or if there are _no kstats_ that the
+//! target is interested in. These details are captured in the
+//! [`CollectionDetails`] type.
+//!
+//! After a configurable period of errors (expressed in either consecutive error
+//! counts or a duration of concecutive errors), a target is _expired_, and will
+//! no longer be collected from. A target's status may be queried with the
+//! [`KstatSampler::target_status()`] method, which will inform the caller if
+//! the target has expired. In this case, users can re-register a target, which
+//! will replace the expired one, generating new samples (assuming the error
+//! condition has been resolved).
+
+use chrono::DateTime;
+use chrono::Utc;
+use kstat_rs::Data;
+use kstat_rs::Error as KstatError;
+use kstat_rs::Kstat;
+use kstat_rs::NamedData;
+use kstat_rs::NamedType;
+use oximeter::FieldValue;
+use oximeter::MetricsError;
+use oximeter::Sample;
+use oximeter::Target;
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+pub mod link;
+mod sampler;
+
+pub use sampler::CollectionDetails;
+pub use sampler::ExpirationBehavior;
+pub use sampler::KstatSampler;
+pub use sampler::TargetId;
+pub use sampler::TargetStatus;
+
+/// The reason a kstat target was expired and removed from a sampler.
+#[derive(Clone, Copy, Debug)]
+pub enum ExpirationReason {
+    /// Expired after too many failed attempts.
+    Attempts(usize),
+    /// Expired after a defined interval of consistent failures.
+    Duration(Duration),
+}
+
+/// An error describing why a kstat target was expired.
+#[derive(Debug)]
+pub struct Expiration {
+    /// The reason for expiration.
+    pub reason: ExpirationReason,
+    /// The last error before expiration.
+    pub error: Box<Error>,
+    /// The time at which the expiration occurred.
+    #[cfg(test)]
+    pub expired_at: tokio::time::Instant,
+    #[cfg(not(test))]
+    pub expired_at: DateTime<Utc>,
+}
+
+/// Errors resulting from reporting kernel statistics.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Could not find kstat with the expected name")]
+    NoSuchKstat,
+
+    #[error("Kstat does not have the expected data type")]
+    UnexpectedDataType { expected: NamedType, found: NamedType },
+
+    #[error("Expected a named kstat")]
+    ExpectedNamedKstat,
+
+    #[error("Duplicate target instance")]
+    DuplicateTarget {
+        target_name: String,
+        fields: BTreeMap<String, FieldValue>,
+    },
+
+    #[error("No such kstat target exists")]
+    NoSuchTarget,
+
+    #[error("Error generating sample")]
+    Sample(#[from] MetricsError),
+
+    #[error("Kstat library error")]
+    Kstat(#[from] KstatError),
+
+    #[error("Kstat control handle is not available")]
+    NoKstatCtl,
+
+    #[error("Overflow computing kstat creation or snapshot time")]
+    TimestampOverflow,
+
+    #[error("Failed to send message to background sampling task")]
+    SendError,
+
+    #[error("Failed to receive message from background sampling task")]
+    RecvError,
+
+    #[error("Expired following too many unsuccessful collection attempts")]
+    Expired(Expiration),
+
+    #[error("Expired after unsucessfull collections for {duration:?}")]
+    ExpiredAfterDuration { duration: Duration, error: Box<Error> },
+}
+
+/// Type alias for a list of kstats.
+///
+/// This includes the kstat's creation time, the kstat itself, and its data.
+pub type KstatList<'a, 'k> = &'a [(DateTime<Utc>, Kstat<'k>, Data<'k>)];
+
+/// A trait for generating oximeter samples from a kstat.
+///
+/// This trait is used to describe the kernel statistics that are relevant for
+/// an `oximeter::Target`, and how to generate samples from them.
+pub trait KstatTarget:
+    Target + Send + Sync + 'static + std::fmt::Debug
+{
+    /// Return true for any kstat you're interested in.
+    fn interested(&self, kstat: &Kstat<'_>) -> bool;
+
+    /// Convert from a kstat and its data to a list of samples.
+    fn to_samples(
+        &self,
+        kstats: KstatList<'_, '_>,
+    ) -> Result<Vec<Sample>, Error>;
+}
+
+/// Convert from a high-res timestamp into UTC, if possible.
+pub fn hrtime_to_utc(hrtime: i64) -> Result<DateTime<Utc>, Error> {
+    let utc_now = Utc::now();
+    let hrtime_now = unsafe { gethrtime() };
+    match hrtime_now.cmp(&hrtime) {
+        Ordering::Equal => Ok(utc_now),
+        Ordering::Less => {
+            let offset = u64::try_from(hrtime - hrtime_now)
+                .map_err(|_| Error::TimestampOverflow)?;
+            Ok(utc_now + Duration::from_nanos(offset))
+        }
+        Ordering::Greater => {
+            let offset = u64::try_from(hrtime_now - hrtime)
+                .map_err(|_| Error::TimestampOverflow)?;
+            Ok(utc_now - Duration::from_nanos(offset))
+        }
+    }
+}
+
+// Helper trait for converting a `NamedData` item into a specific contained data
+// type, if possible.
+pub(crate) trait ConvertNamedData {
+    fn as_i32(&self) -> Result<i32, Error>;
+    fn as_u32(&self) -> Result<u32, Error>;
+    fn as_i64(&self) -> Result<i64, Error>;
+    fn as_u64(&self) -> Result<u64, Error>;
+}
+
+impl<'a> ConvertNamedData for NamedData<'a> {
+    fn as_i32(&self) -> Result<i32, Error> {
+        if let NamedData::Int32(x) = self {
+            Ok(*x)
+        } else {
+            Err(Error::UnexpectedDataType {
+                expected: NamedType::Int32,
+                found: self.data_type(),
+            })
+        }
+    }
+
+    fn as_u32(&self) -> Result<u32, Error> {
+        if let NamedData::UInt32(x) = self {
+            Ok(*x)
+        } else {
+            Err(Error::UnexpectedDataType {
+                expected: NamedType::UInt32,
+                found: self.data_type(),
+            })
+        }
+    }
+
+    fn as_i64(&self) -> Result<i64, Error> {
+        if let NamedData::Int64(x) = self {
+            Ok(*x)
+        } else {
+            Err(Error::UnexpectedDataType {
+                expected: NamedType::Int64,
+                found: self.data_type(),
+            })
+        }
+    }
+
+    fn as_u64(&self) -> Result<u64, Error> {
+        if let NamedData::UInt64(x) = self {
+            Ok(*x)
+        } else {
+            Err(Error::UnexpectedDataType {
+                expected: NamedType::UInt64,
+                found: self.data_type(),
+            })
+        }
+    }
+}
+
+#[link(name = "c")]
+extern "C" {
+    fn gethrtime() -> i64;
+}

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -1,0 +1,1225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Generate oximeter samples from kernel statistics.
+
+use crate::kstat::hrtime_to_utc;
+use crate::kstat::Error;
+use crate::kstat::Expiration;
+use crate::kstat::ExpirationReason;
+use crate::kstat::KstatTarget;
+use chrono::DateTime;
+use chrono::Utc;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use kstat_rs::Ctl;
+use kstat_rs::Kstat;
+use oximeter::types::Cumulative;
+use oximeter::Metric;
+use oximeter::MetricsError;
+use oximeter::Sample;
+use slog::debug;
+use slog::error;
+use slog::o;
+use slog::trace;
+use slog::warn;
+use slog::Logger;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::time::interval;
+use tokio::time::sleep;
+use tokio::time::Sleep;
+
+#[cfg(test)]
+use tokio::time::Instant;
+
+// The `KstatSampler` generates some statistics about its own operation, mostly
+// for surfacing failures to collect and dropped samples.
+mod self_stats {
+    use super::BTreeMap;
+    use super::Cumulative;
+    use super::TargetId;
+
+    /// Information identifying this kstat sampler.
+    #[derive(Debug, oximeter::Target)]
+    pub struct KstatSampler {
+        /// The hostname (or zonename) of the host machine.
+        pub hostname: String,
+    }
+
+    /// The total number of samples dropped for a single target.
+    #[derive(Debug, oximeter::Metric)]
+    pub struct SamplesDropped {
+        /// The ID of the target being tracked.
+        pub target_id: u64,
+        /// The name of the target being tracked.
+        pub target_name: String,
+        pub datum: Cumulative<u64>,
+    }
+
+    /// The cumulative number of expired targets.
+    #[derive(Debug, oximeter::Metric)]
+    pub struct ExpiredTargets {
+        pub datum: Cumulative<u64>,
+    }
+
+    #[derive(Debug)]
+    pub struct SelfStats {
+        pub target: KstatSampler,
+        // We'll store it this way for quick lookups, and build the type as we
+        // need it when publishing the samples, from the key and value.
+        pub drops: BTreeMap<(TargetId, String), Cumulative<u64>>,
+        pub expired: ExpiredTargets,
+    }
+
+    impl SelfStats {
+        pub fn new(hostname: String) -> Self {
+            Self {
+                target: KstatSampler { hostname },
+                drops: BTreeMap::new(),
+                expired: ExpiredTargets { datum: Cumulative::new(0) },
+            }
+        }
+    }
+}
+
+/// An identifier for a single tracked kstat target.
+///
+/// This opaque identifier can be used to unregister targets from the sampler.
+/// If not removed, data from the targets will be produced according to the
+/// [`ExpirationBehavior`] configured for the target.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TargetId(u64);
+
+impl fmt::Debug for TargetId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for TargetId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// When to expire kstat which can no longer be collected from.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ExpirationBehavior {
+    /// Never stop attempting to produce data from this target.
+    Never,
+    /// Expire after a number of sequential failed collections.
+    ///
+    /// If the payload is 0, expire after the first failure.
+    Attempts(usize),
+    /// Expire after a specified period of failing to collect.
+    Duration(Duration),
+}
+
+/// Details about the collection and expiration intervals for a target.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CollectionDetails {
+    /// The interval on which data from the target is collected.
+    pub interval: Duration,
+    /// The expiration behavior, specifying how to handle situations in which we
+    /// cannot collect kstat samples.
+    ///
+    /// Note that this includes both errors during an attempt to collect, and
+    /// situations in which the target doesn't signal interest in any kstats.
+    /// The latter can occur if the physical resource (such as a datalink) that
+    /// underlies the kstat has disappeared, for example.
+    pub expiration: ExpirationBehavior,
+}
+
+impl CollectionDetails {
+    /// Return collection details with no expiration.
+    pub fn never(interval: Duration) -> Self {
+        Self { interval, expiration: ExpirationBehavior::Never }
+    }
+
+    /// Return collection details that expires after a number of attempts.
+    pub fn attempts(interval: Duration, count: usize) -> Self {
+        Self { interval, expiration: ExpirationBehavior::Attempts(count) }
+    }
+
+    /// Return collection details that expires after a duration has elapsed.
+    pub fn duration(interval: Duration, duration: Duration) -> Self {
+        Self { interval, expiration: ExpirationBehavior::Duration(duration) }
+    }
+}
+
+/// The status of a sampled kstat-based target.
+#[derive(Clone, Debug)]
+pub enum TargetStatus {
+    /// The target is currently being collected from normally.
+    ///
+    /// The timestamp of the last collection is included.
+    Ok {
+        #[cfg(test)]
+        last_collection: Option<Instant>,
+        #[cfg(not(test))]
+        last_collection: Option<DateTime<Utc>>,
+    },
+    /// The target has been expired.
+    ///
+    /// The details about the expiration are included.
+    Expired {
+        reason: ExpirationReason,
+        // NOTE: The error is a string, because it's not cloneable.
+        error: String,
+        #[cfg(test)]
+        expired_at: Instant,
+        #[cfg(not(test))]
+        expired_at: DateTime<Utc>,
+    },
+}
+
+/// A request sent from `KstatSampler` to the worker task.
+// NOTE: The docstrings here are public for ease of consumption by IDEs and
+// other tooling.
+#[derive(Debug)]
+enum Request {
+    /// Add a new target for sampling.
+    AddTarget {
+        target: Box<dyn KstatTarget>,
+        details: CollectionDetails,
+        reply_tx: oneshot::Sender<Result<TargetId, Error>>,
+    },
+    /// Request the status for a target
+    TargetStatus {
+        id: TargetId,
+        reply_tx: oneshot::Sender<Result<TargetStatus, Error>>,
+    },
+    /// Remove a target.
+    RemoveTarget { id: TargetId, reply_tx: oneshot::Sender<Result<(), Error>> },
+    /// Return the creation times of all tracked / extant kstats.
+    #[cfg(test)]
+    CreationTimes {
+        reply_tx: oneshot::Sender<BTreeMap<KstatPath, DateTime<Utc>>>,
+    },
+}
+
+/// Data about a single kstat target.
+#[derive(Debug)]
+struct SampledKstat {
+    /// The target from which to collect.
+    target: Box<dyn KstatTarget>,
+    /// The details around collection and expiration behavior.
+    details: CollectionDetails,
+    /// The time at which we _added_ this target to the sampler.
+    #[cfg(test)]
+    time_added: Instant,
+    #[cfg(not(test))]
+    time_added: DateTime<Utc>,
+    /// The last time we successfully collected from the target.
+    #[cfg(test)]
+    time_of_last_collection: Option<Instant>,
+    #[cfg(not(test))]
+    time_of_last_collection: Option<DateTime<Utc>>,
+    /// Attempts since we last successfully collected from the target.
+    attempts_since_last_collection: usize,
+}
+
+/// Represents the current state of a registered target.
+///
+/// We use this to report the status of a kstat target, such as reporting if its
+/// been expired.
+#[derive(Debug)]
+enum SampledObject {
+    Kstat(SampledKstat),
+    Expired(Expiration),
+}
+
+/// Helper to hash a target, used for creating unique IDs for them.
+fn hash_target(t: &dyn KstatTarget) -> TargetId {
+    use std::hash::Hash;
+    use std::hash::Hasher;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    t.name().hash(&mut hasher);
+    for f in t.fields() {
+        f.hash(&mut hasher);
+    }
+    TargetId(hasher.finish())
+}
+
+/// Small future that yields an ID for a target to be sampled after its
+/// predefined interval expires.
+struct YieldIdAfter {
+    /// Future to which we delegate to awake us after our interval.
+    sleep: Pin<Box<Sleep>>,
+    /// The next interval to yield when we complete.
+    interval: Duration,
+    /// The ID of the target to yield when we complete.
+    id: TargetId,
+}
+
+impl std::fmt::Debug for YieldIdAfter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("YieldIdAfter")
+            .field("sleep", &"_")
+            .field("interval", &self.interval)
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
+impl YieldIdAfter {
+    fn new(id: TargetId, interval: Duration) -> Self {
+        Self { sleep: Box::pin(sleep(interval)), interval, id }
+    }
+}
+
+impl core::future::Future for YieldIdAfter {
+    type Output = (TargetId, Duration);
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        match self.sleep.as_mut().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(_) => Poll::Ready((self.id, self.interval)),
+        }
+    }
+}
+
+/// An owned type used to keep track of the creation time for each kstat in
+/// which interest has been signaled.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct KstatPath {
+    pub module: String,
+    pub instance: i32,
+    pub name: String,
+}
+
+impl<'a> From<Kstat<'a>> for KstatPath {
+    fn from(k: Kstat<'a>) -> Self {
+        Self {
+            module: k.ks_module.to_string(),
+            instance: k.ks_instance,
+            name: k.ks_name.to_string(),
+        }
+    }
+}
+
+/// The interval on which we prune creation times.
+///
+/// As targets are added and kstats are tracked, we store their creation times
+/// in the `KstatSamplerWorker::creation_times` mapping. This lets us keep a
+/// consistent start time, which is important for cumulative metrics. In order
+/// to keep these consistent, we don't necessarily prune them as a target is
+/// removed or interest in the kstat changes, since the target may be added
+/// again. Instead, we prune the creation times only when the _kstat itself_ is
+/// removed from the kstat chain.
+pub(crate) const CREATION_TIME_PRUNE_INTERVAL: Duration =
+    Duration::from_secs(60);
+
+/// Type which owns the `kstat` chain and samples each target on an interval.
+///
+/// This type runs in a separate tokio task. As targets are added, it schedules
+/// futures which expire after the target's sampling interval, yielding the
+/// target's ID. (This is the `YieldIdAfter` type.) When those futures complete,
+/// this type then samples the kstats they indicate, and push those onto a
+/// per-target queue of samples.
+#[derive(Debug)]
+struct KstatSamplerWorker {
+    log: Logger,
+
+    /// The kstat chain.
+    ctl: Option<Ctl>,
+
+    /// The set of registered targets to collect kstats from, ordered by their
+    /// IDs.
+    targets: BTreeMap<TargetId, SampledObject>,
+
+    /// The set of creation times for all tracked kstats.
+    ///
+    /// As interest in kstats is noted, we add a creation time for those kstats
+    /// here. It is removed only when the kstat itself no longer appears on the
+    /// kstat chain, even if a caller removes the target or no longer signals
+    /// interest in it.
+    creation_times: BTreeMap<KstatPath, DateTime<Utc>>,
+
+    /// The per-target queue of samples, pulled by the main `KstatSampler` type
+    /// when producing metrics.
+    samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+
+    /// Inbox channel on which the `KstatSampler` sends messages.
+    inbox: mpsc::Receiver<Request>,
+
+    /// The maximum number of samples we allow in each per-target buffer, to
+    /// avoid huge allocations when we produce data faster than it's collected.
+    sample_limit: usize,
+
+    /// Outbound queue on which to publish self statistics, which are expected to
+    /// be low-volume.
+    self_stat_queue: mpsc::Sender<Sample>,
+
+    /// The statistics we maintain about ourselves.
+    ///
+    /// This is an option, since it's possible we fail to extract the hostname
+    /// at construction time. In that case, we'll try again the next time we
+    /// need it.
+    self_stats: Option<self_stats::SelfStats>,
+}
+
+fn hostname() -> Option<String> {
+    let out =
+        std::process::Command::new("hostname").env_clear().output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Stores the number of samples taken, used for testing.
+#[cfg(test)]
+pub(crate) struct SampleCounts {
+    pub total: usize,
+    pub overflow: usize,
+}
+
+impl KstatSamplerWorker {
+    /// Create a new sampler worker.
+    fn new(
+        log: Logger,
+        inbox: mpsc::Receiver<Request>,
+        self_stat_queue: mpsc::Sender<Sample>,
+        samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+        sample_limit: usize,
+    ) -> Result<Self, Error> {
+        let ctl = Some(Ctl::new().map_err(Error::Kstat)?);
+        let self_stats = hostname().map(self_stats::SelfStats::new);
+        Ok(Self {
+            ctl,
+            log,
+            targets: BTreeMap::new(),
+            creation_times: BTreeMap::new(),
+            samples,
+            inbox,
+            sample_limit,
+            self_stat_queue,
+            self_stats,
+        })
+    }
+
+    /// Consume self and run its main polling loop.
+    ///
+    /// This will accept messages on its inbox, and also sample the registered
+    /// kstats at their intervals. Samples will be pushed onto the queue.
+    async fn run(
+        mut self,
+        #[cfg(test)] sample_count_tx: mpsc::UnboundedSender<SampleCounts>,
+    ) {
+        let mut sample_timeouts = FuturesUnordered::new();
+        let mut creation_prune_interval =
+            interval(CREATION_TIME_PRUNE_INTERVAL);
+        creation_prune_interval.tick().await; // Completes immediately.
+        loop {
+            tokio::select! {
+                _ = creation_prune_interval.tick() => {
+                    if let Err(e) = self.prune_creation_times() {
+                        error!(
+                            self.log,
+                            "failed to prune creation times";
+                            "error" => ?e,
+                        );
+                    }
+                }
+                maybe_id = sample_timeouts.next(), if !sample_timeouts.is_empty() => {
+                    let Some((id, interval)) = maybe_id else {
+                        unreachable!();
+                    };
+                    match self.sample_one(id) {
+                        Ok(Some(samples)) => {
+                            if samples.is_empty() {
+                                debug!(
+                                    self.log,
+                                    "no new samples from target, requeueing";
+                                    "id" => ?id,
+                                );
+                                sample_timeouts.push(YieldIdAfter::new(id, interval));
+                                continue;
+                            }
+                            let n_samples = samples.len();
+                            debug!(
+                                self.log,
+                                "pulled samples from target";
+                                "id" => ?id,
+                                "n_samples" => n_samples,
+                            );
+
+                            // Append any samples to the per-target queues.
+                            //
+                            // This returns None if there was no queue, and logs
+                            // the error internally. We'll just go round the
+                            // loop again in that case.
+                            let Some(n_overflow_samples) =
+                                self.append_per_target_samples(id, samples) else {
+                                continue;
+                            };
+
+                            // Safety: We only get here if the `sample_one()`
+                            // method works, which means we have a record of the
+                            // target, and it's not expired.
+                            if n_overflow_samples > 0 {
+                                let SampledObject::Kstat(ks) = self.targets.get(&id).unwrap() else {
+                                    unreachable!();
+                                };
+                                self.increment_dropped_sample_counter(
+                                    id,
+                                    ks.target.name().to_string(),
+                                    n_overflow_samples,
+                                ).await;
+                            }
+
+                            // Send the total number of samples we've actually
+                            // taken and the number we've appended over to any
+                            // testing code which might be listening.
+                            #[cfg(test)]
+                            sample_count_tx.send(SampleCounts {
+                                total: n_samples,
+                                overflow: n_overflow_samples,
+                            }).unwrap();
+
+                            trace!(
+                                self.log,
+                                "re-queueing target for sampling";
+                                "id" => ?id,
+                                "interval" => ?interval,
+                            );
+                            sample_timeouts.push(YieldIdAfter::new(id, interval));
+                        }
+                        Ok(None) => {
+                            debug!(
+                                self.log,
+                                "sample timeout triggered for non-existent target";
+                                "id" => ?id,
+                            );
+                        }
+                        Err(Error::Expired(expiration)) => {
+                            error!(
+                                self.log,
+                                "expiring kstat after too many failures";
+                                "id" => ?id,
+                                "reason" => ?expiration.reason,
+                                "error" => ?expiration.error,
+                            );
+                            let _ = self.targets.insert(id, SampledObject::Expired(expiration));
+                            self.increment_expired_target_counter().await;
+                        }
+                        Err(e) => {
+                            error!(
+                                self.log,
+                                "failed to sample kstat target, requeueing";
+                                "id" => ?id,
+                                "error" => ?e,
+                            );
+                            sample_timeouts.push(YieldIdAfter::new(id, interval));
+                        }
+                    }
+                }
+                maybe_request = self.inbox.recv() => {
+                    let Some(request) = maybe_request else {
+                        debug!(self.log, "inbox returned None, exiting");
+                        return;
+                    };
+                    trace!(
+                        self.log,
+                        "received request on inbox";
+                        "request" => ?request,
+                    );
+                    match request {
+                        Request::AddTarget {
+                            target,
+                            details,
+                            reply_tx,
+                        } => {
+                            match self.add_target(target, details) {
+                                Ok(id) => {
+                                    let timeout = YieldIdAfter::new(id, details.interval);
+                                    sample_timeouts.push(timeout);
+                                    trace!(
+                                        self.log,
+                                        "added target with timeout";
+                                        "id" => ?id,
+                                        "details" => ?details,
+                                    );
+                                    match reply_tx.send(Ok(id)) {
+                                        Ok(_) => trace!(self.log, "sent reply"),
+                                        Err(e) => error!(
+                                            self.log,
+                                            "failed to send reply";
+                                            "id" => ?id,
+                                            "error" => ?e,
+                                        )
+                                    }
+                                }
+                                Err(e) => {
+                                    error!(
+                                        self.log,
+                                        "failed to add target";
+                                        "error" => ?e,
+                                    );
+                                    match reply_tx.send(Err(e)) {
+                                        Ok(_) => trace!(self.log, "sent reply"),
+                                        Err(e) => error!(
+                                            self.log,
+                                            "failed to send reply";
+                                            "error" => ?e,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        Request::RemoveTarget { id, reply_tx } => {
+                            self.targets.remove(&id);
+                            if let Some(remaining_samples) = self.samples.lock().unwrap().remove(&id) {
+                                if !remaining_samples.is_empty() {
+                                    warn!(
+                                        self.log,
+                                        "target removed with queued samples";
+                                        "id" => ?id,
+                                        "n_samples" => remaining_samples.len(),
+                                    );
+                                }
+                            }
+                            match reply_tx.send(Ok(())) {
+                                Ok(_) => trace!(self.log, "sent reply"),
+                                Err(e) => error!(
+                                    self.log,
+                                    "failed to send reply";
+                                    "error" => ?e,
+                                )
+                            }
+                        }
+                        Request::TargetStatus { id, reply_tx } => {
+                            trace!(
+                                self.log,
+                                "request for target status";
+                                "id" => ?id,
+                            );
+                            let response = match self.targets.get(&id) {
+                                None => Err(Error::NoSuchTarget),
+                                Some(SampledObject::Kstat(k)) => {
+                                    Ok(TargetStatus::Ok {
+                                        last_collection: k.time_of_last_collection,
+                                    })
+                                }
+                                Some(SampledObject::Expired(e)) => {
+                                    Ok(TargetStatus::Expired {
+                                        reason: e.reason,
+                                        error: e.error.to_string(),
+                                        expired_at: e.expired_at,
+                                    })
+                                }
+                            };
+                            match reply_tx.send(response) {
+                                Ok(_) => trace!(self.log, "sent reply"),
+                                Err(e) => error!(
+                                    self.log,
+                                    "failed to send reply";
+                                    "id" => ?id,
+                                    "error" => ?e,
+                                ),
+                            }
+                        }
+                        #[cfg(test)]
+                        Request::CreationTimes { reply_tx } => {
+                            debug!(self.log, "request for creation times");
+                            reply_tx.send(self.creation_times.clone()).unwrap();
+                            debug!(self.log, "sent reply for creation times");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn append_per_target_samples(
+        &self,
+        id: TargetId,
+        mut samples: Vec<Sample>,
+    ) -> Option<usize> {
+        // Limit the number of samples we actually contain
+        // in the sample queue. This is to avoid huge
+        // allocations when we produce lots of data, but
+        // we're not polled quickly enough by oximeter.
+        //
+        // Note that this is a _per-target_ queue.
+        let mut all_samples = self.samples.lock().unwrap();
+        let Some(current_samples) = all_samples.get_mut(&id) else {
+            error!(
+                self.log,
+                "per-target sample queue not found!";
+                "id" => ?id,
+            );
+            return None;
+        };
+        let n_new_samples = samples.len();
+        let n_current_samples = current_samples.len();
+        let n_total_samples = n_new_samples + n_current_samples;
+        let n_overflow_samples =
+            n_total_samples.checked_sub(self.sample_limit).unwrap_or(0);
+        if n_overflow_samples > 0 {
+            warn!(
+                self.log,
+                "sample queue is too full, dropping oldest samples";
+                "n_new_samples" => n_new_samples,
+                "n_current_samples" => n_current_samples,
+                "n_overflow_samples" => n_overflow_samples,
+            );
+            // It's possible that the number of new samples
+            // is big enough to overflow the current
+            // capacity, and also require removing new
+            // samples.
+            if n_overflow_samples < n_current_samples {
+                let _ = current_samples.drain(..n_overflow_samples);
+            } else {
+                // Clear all the current samples, and some
+                // of the new ones. The subtraction below
+                // cannot panic, because
+                // `n_overflow_samples` is computed above by
+                // adding `n_current_samples`.
+                current_samples.clear();
+                let _ =
+                    samples.drain(..(n_overflow_samples - n_current_samples));
+            }
+        }
+        current_samples.extend(samples);
+        Some(n_overflow_samples)
+    }
+
+    /// Add samples for one target to the internal queue.
+    ///
+    /// Note that this updates the kstat chain.
+    fn sample_one(
+        &mut self,
+        id: TargetId,
+    ) -> Result<Option<Vec<Sample>>, Error> {
+        self.update_chain()?;
+        let ctl = self.ctl.as_ref().unwrap();
+        let Some(maybe_kstat) = self.targets.get_mut(&id) else {
+            return Ok(None);
+        };
+        let SampledObject::Kstat(sampled_kstat) = maybe_kstat else {
+            panic!("Should not be sampling an expired kstat");
+        };
+
+        // Fetch each interested kstat, and include the data and creation times
+        // for each of them.
+        let kstats = ctl
+            .iter()
+            .filter(|kstat| sampled_kstat.target.interested(kstat))
+            .map(|mut kstat| {
+                let data = ctl.read(&mut kstat)?;
+                let creation_time = Self::ensure_kstat_creation_time(
+                    &self.log,
+                    kstat,
+                    &mut self.creation_times,
+                )?;
+                Ok((creation_time, kstat, data))
+            })
+            .collect::<Result<Vec<_>, _>>();
+        match kstats {
+            Ok(k) if !k.is_empty() => {
+                cfg_if::cfg_if! {
+                    if #[cfg(test)] {
+                        sampled_kstat.time_of_last_collection = Some(Instant::now());
+                    } else {
+                        sampled_kstat.time_of_last_collection = Some(Utc::now());
+                    }
+                }
+                sampled_kstat.attempts_since_last_collection = 0;
+                sampled_kstat.target.to_samples(&k).map(Option::Some)
+            }
+            other => {
+                // Convert a list of zero interested kstats into an error.
+                let e = match other {
+                    Err(e) => e,
+                    Ok(k) if k.is_empty() => {
+                        trace!(
+                            self.log,
+                            "no matching samples for target, converting \
+                            to sampling error";
+                            "id" => ?id,
+                        );
+                        Error::NoSuchKstat
+                    }
+                    _ => unreachable!(),
+                };
+                sampled_kstat.attempts_since_last_collection += 1;
+
+                // Check if this kstat should be expired, based on the attempts
+                // we've previously made and the expiration policy.
+                match sampled_kstat.details.expiration {
+                    ExpirationBehavior::Never => {}
+                    ExpirationBehavior::Attempts(n_attempts) => {
+                        if sampled_kstat.attempts_since_last_collection
+                            >= n_attempts
+                        {
+                            cfg_if::cfg_if! {
+                                if #[cfg(test)] {
+                                    let expired_at = Instant::now();
+                                } else {
+                                    let expired_at = Utc::now();
+                                }
+                            }
+                            return Err(Error::Expired(Expiration {
+                                reason: ExpirationReason::Attempts(n_attempts),
+                                error: Box::new(e),
+                                expired_at,
+                            }));
+                        }
+                    }
+                    ExpirationBehavior::Duration(duration) => {
+                        // Use the time of the last collection, if one exists,
+                        // or the time we added the kstat if not.
+                        let start = sampled_kstat
+                            .time_of_last_collection
+                            .unwrap_or_else(|| sampled_kstat.time_added);
+                        let expire_at = start + duration;
+                        cfg_if::cfg_if! {
+                            if #[cfg(test)] {
+                                let now = Instant::now();
+                            } else {
+                                let now = Utc::now();
+                            }
+                        }
+                        if now >= expire_at {
+                            return Err(Error::Expired(Expiration {
+                                reason: ExpirationReason::Duration(duration),
+                                error: Box::new(e),
+                                expired_at: now,
+                            }));
+                        }
+                    }
+                }
+
+                // Do not expire the kstat, simply fail this collection.
+                Err(e)
+            }
+        }
+    }
+
+    async fn increment_dropped_sample_counter(
+        &mut self,
+        target_id: TargetId,
+        target_name: String,
+        n_overflow_samples: usize,
+    ) {
+        assert!(n_overflow_samples > 0);
+        if let Some(stats) = self.get_or_try_build_self_stats() {
+            // Get the entry for this target, or build a counter starting a 0.
+            // We'll always add the number of overflow samples afterwards.
+            let drops = stats
+                .drops
+                .entry((target_id, target_name.clone()))
+                .or_default();
+            *drops += n_overflow_samples as u64;
+            let metric = self_stats::SamplesDropped {
+                target_id: target_id.0,
+                target_name,
+                datum: *drops,
+            };
+            let sample = match Sample::new(&stats.target, &metric) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(
+                        self.log,
+                        "could not generate sample for dropped sample counter";
+                        "error" => ?e,
+                    );
+                    return;
+                }
+            };
+            match self.self_stat_queue.send(sample).await {
+                Ok(_) => trace!(self.log, "sent dropped sample counter stat"),
+                Err(e) => error!(
+                    self.log,
+                    "failed to send dropped sample counter to self stat queue";
+                    "error" => ?e,
+                ),
+            }
+        } else {
+            warn!(
+                self.log,
+                "cannot record dropped sample statistic, failed to get hostname"
+            );
+        }
+    }
+
+    async fn increment_expired_target_counter(&mut self) {
+        if let Some(stats) = self.get_or_try_build_self_stats() {
+            stats.expired.datum_mut().increment();
+            let sample = match Sample::new(&stats.target, &stats.expired) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(
+                        self.log,
+                        "could not generate sample for expired target counter";
+                        "error" => ?e,
+                    );
+                    return;
+                }
+            };
+            match self.self_stat_queue.send(sample).await {
+                Ok(_) => trace!(self.log, "sent expired target counter stat"),
+                Err(e) => error!(
+                    self.log,
+                    "failed to send target counter to self stat queue";
+                    "error" => ?e,
+                ),
+            }
+        } else {
+            warn!(
+                self.log,
+                "cannot record expiration statistic, failed to get hostname"
+            );
+        }
+    }
+
+    /// If we have an actual `SelfStats` struct, return it, or try to create one.
+    /// We'll still return `None` in that latter case, and we fail to make one.
+    fn get_or_try_build_self_stats(
+        &mut self,
+    ) -> Option<&mut self_stats::SelfStats> {
+        if self.self_stats.is_none() {
+            self.self_stats = hostname().map(self_stats::SelfStats::new);
+        }
+        self.self_stats.as_mut()
+    }
+
+    /// Ensure that we have recorded the creation time for all interested kstats
+    /// for a new target.
+    fn ensure_creation_times_for_target(
+        &mut self,
+        target: &dyn KstatTarget,
+    ) -> Result<(), Error> {
+        self.update_chain()?;
+        let ctl = self.ctl.as_ref().unwrap();
+        for kstat in ctl.iter().filter(|k| target.interested(k)) {
+            Self::ensure_kstat_creation_time(
+                &self.log,
+                kstat,
+                &mut self.creation_times,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Ensure that we store the creation time for the provided kstat.
+    fn ensure_kstat_creation_time(
+        log: &Logger,
+        kstat: Kstat,
+        creation_times: &mut BTreeMap<KstatPath, DateTime<Utc>>,
+    ) -> Result<DateTime<Utc>, Error> {
+        let path = KstatPath::from(kstat);
+        match creation_times.entry(path.clone()) {
+            Entry::Occupied(entry) => {
+                trace!(
+                    log,
+                    "creation time already exists for tracked target";
+                    "path" => ?path,
+                );
+                Ok(*entry.get())
+            }
+            Entry::Vacant(entry) => {
+                let creation_time = hrtime_to_utc(kstat.ks_crtime)?;
+                debug!(
+                    log,
+                    "storing new creation time for tracked target";
+                    "path" => ?path,
+                    "creation_time" => ?creation_time,
+                );
+                entry.insert(creation_time);
+                Ok(creation_time)
+            }
+        }
+    }
+
+    /// Prune the stored creation times, removing any that no longer have
+    /// corresponding kstats on the chain.
+    fn prune_creation_times(&mut self) -> Result<(), Error> {
+        if self.creation_times.is_empty() {
+            trace!(self.log, "no creation times to prune");
+            return Ok(());
+        }
+        // We'll create a list of all the creation times to prune, by
+        // progressively removing any _extant_ kstats from the set of keys we
+        // currently have. If something is _not_ on the chain, it'll remain in
+        // this map at the end of the loop below, and thus we know we need to
+        // remove it.
+        let mut to_remove: BTreeSet<_> =
+            self.creation_times.keys().cloned().collect();
+
+        // Iterate the chain, and remove any current keys that do _not_ appear
+        // on the chain.
+        self.update_chain()?;
+        let ctl = self.ctl.as_ref().unwrap();
+        for kstat in ctl.iter() {
+            let path = KstatPath::from(kstat);
+            let _ = to_remove.remove(&path);
+        }
+
+        if to_remove.is_empty() {
+            trace!(self.log, "kstat creation times is already pruned");
+        } else {
+            debug!(
+                self.log,
+                "pruning creation times for kstats that are gone";
+                "to_remove" => ?to_remove,
+                "n_to_remove" => to_remove.len(),
+            );
+            self.creation_times.retain(|key, _value| !to_remove.contains(key));
+        }
+        Ok(())
+    }
+
+    /// Start tracking a single KstatTarget object.
+    fn add_target(
+        &mut self,
+        target: Box<dyn KstatTarget>,
+        details: CollectionDetails,
+    ) -> Result<TargetId, Error> {
+        let id = hash_target(&*target);
+        match self.targets.get(&id) {
+            Some(SampledObject::Kstat(_)) => {
+                return Err(Error::DuplicateTarget {
+                    target_name: target.name().to_string(),
+                    fields: target
+                        .field_names()
+                        .iter()
+                        .map(ToString::to_string)
+                        .zip(target.field_values())
+                        .collect(),
+                });
+            }
+            Some(SampledObject::Expired(e)) => {
+                warn!(
+                    self.log,
+                    "replacing expired kstat target";
+                    "id" => ?id,
+                    "expiration_reason" => ?e.reason,
+                    "error" => ?e.error,
+                    "expired_at" => ?e.expired_at,
+                );
+            }
+            None => {}
+        }
+        self.ensure_creation_times_for_target(&*target)?;
+
+        cfg_if::cfg_if! {
+            if #[cfg(test)] {
+                let time_added = Instant::now();
+            } else {
+                let time_added = Utc::now();
+            }
+        }
+        let item = SampledKstat {
+            target,
+            details,
+            time_added,
+            time_of_last_collection: None,
+            attempts_since_last_collection: 0,
+        };
+        let _ = self.targets.insert(id, SampledObject::Kstat(item));
+
+        // Add to the per-target queues, making sure to keep any samples that
+        // were already there previously. This would be a bit odd, since it
+        // means that the target expired, but we hadn't been polled by oximeter.
+        // Nonetheless keep these samples anyway.
+        let n_samples =
+            self.samples.lock().unwrap().entry(id).or_default().len();
+        match n_samples {
+            0 => debug!(
+                self.log,
+                "inserted empty per-target sample queue";
+                "id" => ?id,
+            ),
+            n => debug!(
+                self.log,
+                "per-target queue appears to have old samples";
+                "id" => ?id,
+                "n_samples" => n,
+            ),
+        }
+        Ok(id)
+    }
+
+    fn update_chain(&mut self) -> Result<(), Error> {
+        let new_ctl = match self.ctl.take() {
+            None => Ctl::new(),
+            Some(old) => old.update(),
+        }
+        .map_err(Error::Kstat)?;
+        let _ = self.ctl.insert(new_ctl);
+        Ok(())
+    }
+}
+
+/// A type for reporting kernel statistics as oximeter samples.
+#[derive(Clone, Debug)]
+pub struct KstatSampler {
+    samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
+    outbox: mpsc::Sender<Request>,
+    self_stat_rx: Arc<Mutex<mpsc::Receiver<Sample>>>,
+    _worker_task: Arc<tokio::task::JoinHandle<()>>,
+    #[cfg(test)]
+    sample_count_rx: Arc<Mutex<mpsc::UnboundedReceiver<SampleCounts>>>,
+}
+
+impl KstatSampler {
+    /// The maximum number of samples allowed in the internal buffer, before
+    /// oldest samples are dropped.
+    ///
+    /// This is to avoid unbounded allocations in situations where data is
+    /// produced faster than it is collected.
+    ///
+    /// Note that this is a _per-target_ sample limit!
+    pub const DEFAULT_SAMPLE_LIMIT: usize = 500;
+
+    /// Create a new sampler.
+    pub fn new(log: &Logger) -> Result<Self, Error> {
+        Self::with_sample_limit(log, Self::DEFAULT_SAMPLE_LIMIT)
+    }
+
+    /// Create a new sampler with a sample limit.
+    pub fn with_sample_limit(
+        log: &Logger,
+        limit: usize,
+    ) -> Result<Self, Error> {
+        let samples = Arc::new(Mutex::new(BTreeMap::new()));
+        let (self_stat_tx, self_stat_rx) = mpsc::channel(4096);
+        let (outbox, inbox) = mpsc::channel(1);
+        let worker = KstatSamplerWorker::new(
+            log.new(o!("component" => "kstat-sampler-worker")),
+            inbox,
+            self_stat_tx,
+            samples.clone(),
+            limit,
+        )?;
+        #[cfg(test)]
+        let (sample_count_rx, _worker_task) = {
+            let (sample_count_tx, sample_count_rx) = mpsc::unbounded_channel();
+            (
+                Arc::new(Mutex::new(sample_count_rx)),
+                Arc::new(tokio::task::spawn(worker.run(sample_count_tx))),
+            )
+        };
+        #[cfg(not(test))]
+        let _worker_task = Arc::new(tokio::task::spawn(worker.run()));
+        Ok(Self {
+            samples,
+            outbox,
+            self_stat_rx: Arc::new(Mutex::new(self_stat_rx)),
+            _worker_task,
+            #[cfg(test)]
+            sample_count_rx,
+        })
+    }
+
+    /// Add a target, which can be used to produce zero or more samples.
+    ///
+    /// Note that adding a target which has previously expired is _not_ an
+    /// error, and instead replaces the expired target.
+    pub async fn add_target(
+        &self,
+        target: impl KstatTarget,
+        details: CollectionDetails,
+    ) -> Result<TargetId, Error> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request =
+            Request::AddTarget { target: Box::new(target), details, reply_tx };
+        self.outbox.send(request).await.map_err(|_| Error::SendError)?;
+        reply_rx.await.map_err(|_| Error::RecvError)?
+    }
+
+    /// Remove a tracked target.
+    pub async fn remove_target(&self, id: TargetId) -> Result<(), Error> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = Request::RemoveTarget { id, reply_tx };
+        self.outbox.send(request).await.map_err(|_| Error::SendError)?;
+        reply_rx.await.map_err(|_| Error::RecvError)?
+    }
+
+    /// Fetch the status for a target.
+    ///
+    /// If the target is being collected normally, then `TargetStatus::Ok` is
+    /// returned, which contains the time of the last collection, if any.
+    ///
+    /// If the target exists, but has been expired, then the details about the
+    /// expiration are returned in `TargetStatus::Expired`.
+    ///
+    /// If the target doesn't exist at all, then an error is returned.
+    pub async fn target_status(
+        &self,
+        id: TargetId,
+    ) -> Result<TargetStatus, Error> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = Request::TargetStatus { id, reply_tx };
+        self.outbox.send(request).await.map_err(|_| Error::SendError)?;
+        reply_rx.await.map_err(|_| Error::RecvError)?
+    }
+
+    /// Return the number of samples pushed by the sampling task, if any.
+    #[cfg(test)]
+    pub(crate) fn sample_counts(&self) -> Option<SampleCounts> {
+        match self.sample_count_rx.lock().unwrap().try_recv() {
+            Ok(c) => Some(c),
+            Err(mpsc::error::TryRecvError::Empty) => None,
+            _ => panic!("sample_tx disconnected"),
+        }
+    }
+
+    /// Return the creation times for all tracked kstats.
+    #[cfg(test)]
+    pub(crate) async fn creation_times(
+        &self,
+    ) -> BTreeMap<KstatPath, DateTime<Utc>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = Request::CreationTimes { reply_tx };
+        self.outbox.send(request).await.map_err(|_| Error::SendError).unwrap();
+        reply_rx.await.map_err(|_| Error::RecvError).unwrap()
+    }
+}
+
+impl oximeter::Producer for KstatSampler {
+    fn produce(
+        &mut self,
+    ) -> Result<Box<(dyn Iterator<Item = Sample>)>, MetricsError> {
+        // Swap the _entries_ of all the existing per-target sample queues, but
+        // we need to leave empty queues in their place. I.e., we can't remove
+        // keys.
+        let mut samples = Vec::new();
+        for (_id, queue) in self.samples.lock().unwrap().iter_mut() {
+            samples.append(queue);
+        }
+
+        // Append any self-stat samples as well.
+        let mut rx = self.self_stat_rx.lock().unwrap();
+        loop {
+            match rx.try_recv() {
+                Ok(sample) => samples.push(sample),
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!("kstat stampler self-stat queue tx disconnected");
+                }
+            }
+        }
+        drop(rx);
+
+        Ok(Box::new(samples.into_iter()))
+    }
+}

--- a/oximeter/instruments/src/lib.rs
+++ b/oximeter/instruments/src/lib.rs
@@ -4,7 +4,10 @@
 
 //! General-purpose types for instrumenting code to producer oximeter metrics.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 #[cfg(feature = "http-instruments")]
 pub mod http;
+
+#[cfg(all(feature = "kstat", target_os = "illumos"))]
+pub mod kstat;

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -45,6 +45,7 @@ nexus-client.workspace = true
 omicron-common.workspace = true
 once_cell.workspace = true
 oximeter.workspace = true
+oximeter-instruments.workspace = true
 oximeter-producer.workspace = true
 percent-encoding.workspace = true
 progenitor.workspace = true

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -23,6 +23,7 @@ pub mod config;
 mod http_entrypoints;
 mod instance;
 mod instance_manager;
+mod metrics;
 mod nexus;
 pub mod params;
 mod profile;

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -1,0 +1,260 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Metrics produced by the sled-agent for collection by oximeter.
+
+use oximeter::types::MetricsError;
+use oximeter::types::ProducerRegistry;
+use sled_hardware::Baseboard;
+use slog::Logger;
+use std::time::Duration;
+use uuid::Uuid;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "illumos")] {
+        use oximeter_instruments::kstat::link;
+        use oximeter_instruments::kstat::CollectionDetails;
+        use oximeter_instruments::kstat::Error as KstatError;
+        use oximeter_instruments::kstat::KstatSampler;
+        use oximeter_instruments::kstat::TargetId;
+        use std::collections::BTreeMap;
+    } else {
+        use anyhow::anyhow;
+    }
+}
+
+/// The interval on which we ask `oximeter` to poll us for metric data.
+pub(crate) const METRIC_COLLECTION_INTERVAL: Duration = Duration::from_secs(30);
+
+/// The interval on which we sample link metrics.
+pub(crate) const LINK_SAMPLE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// An error during sled-agent metric production.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[cfg(target_os = "illumos")]
+    #[error("Kstat-based metric failure")]
+    Kstat(#[source] KstatError),
+
+    #[cfg(not(target_os = "illumos"))]
+    #[error("Kstat-based metric failure")]
+    Kstat(#[source] anyhow::Error),
+
+    #[error("Failed to insert metric producer into registry")]
+    Registry(#[source] MetricsError),
+
+    #[error("Failed to fetch hostname")]
+    Hostname(#[source] std::io::Error),
+}
+
+/// Type managing all oximeter metrics produced by the sled-agent.
+//
+// TODO-completeness: We probably want to get kstats or other metrics in to this
+// type from other parts of the code, possibly before the `SledAgent` itself
+// exists. This is similar to the storage resources or other objects, most of
+// which are essentially an `Arc<Mutex<Inner>>`. It would be nice to avoid that
+// pattern, but until we have more statistics, it's not clear whether that's
+// worth it right now.
+#[derive(Clone, Debug)]
+// NOTE: The ID fields aren't used on non-illumos systems, rather than changing
+// the name of fields that are not yet used.
+#[cfg_attr(not(target_os = "illumos"), allow(dead_code))]
+pub struct MetricsManager {
+    sled_id: Uuid,
+    rack_id: Uuid,
+    baseboard: Baseboard,
+    hostname: Option<String>,
+    _log: Logger,
+    #[cfg(target_os = "illumos")]
+    kstat_sampler: KstatSampler,
+    // TODO-scalability: We may want to generalize this to store any kind of
+    // tracked target, and use a naming scheme that allows us pick out which
+    // target we're interested in from the arguments.
+    //
+    // For example, we can use the link name to do this, for any physical or
+    // virtual link, because they need to be unique. We could also do the same
+    // for disks or memory. If we wanted to guarantee uniqueness, we could
+    // namespace them internally, e.g., `"datalink:{link_name}"` would be the
+    // real key.
+    #[cfg(target_os = "illumos")]
+    tracked_links: BTreeMap<String, TargetId>,
+    registry: ProducerRegistry,
+}
+
+impl MetricsManager {
+    /// Construct a new metrics manager.
+    ///
+    /// This takes a few key pieces of identifying information that are used
+    /// when reporting sled-specific metrics.
+    pub fn new(
+        sled_id: Uuid,
+        rack_id: Uuid,
+        baseboard: Baseboard,
+        log: Logger,
+    ) -> Result<Self, Error> {
+        let registry = ProducerRegistry::with_id(sled_id);
+
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "illumos")] {
+                let kstat_sampler = KstatSampler::new(&log).map_err(Error::Kstat)?;
+                registry
+                    .register_producer(kstat_sampler.clone())
+                    .map_err(Error::Registry)?;
+                let tracked_links = BTreeMap::new();
+            }
+        }
+        Ok(Self {
+            sled_id,
+            rack_id,
+            baseboard,
+            hostname: None,
+            _log: log,
+            #[cfg(target_os = "illumos")]
+            kstat_sampler,
+            #[cfg(target_os = "illumos")]
+            tracked_links,
+            registry,
+        })
+    }
+
+    /// Return a reference to the contained producer registry.
+    pub fn registry(&self) -> &ProducerRegistry {
+        &self.registry
+    }
+}
+
+#[cfg(target_os = "illumos")]
+impl MetricsManager {
+    /// Track metrics for a physical datalink.
+    pub async fn track_physical_link(
+        &mut self,
+        link_name: impl AsRef<str>,
+        interval: Duration,
+    ) -> Result<(), Error> {
+        let hostname = self.hostname().await?;
+        let link = link::PhysicalDataLink {
+            rack_id: self.rack_id,
+            sled_id: self.sled_id,
+            serial: self.serial_number(),
+            hostname,
+            link_name: link_name.as_ref().to_string(),
+        };
+        let details = CollectionDetails::never(interval);
+        let id = self
+            .kstat_sampler
+            .add_target(link, details)
+            .await
+            .map_err(Error::Kstat)?;
+        self.tracked_links.insert(link_name.as_ref().to_string(), id);
+        Ok(())
+    }
+
+    /// Stop tracking metrics for a datalink.
+    ///
+    /// This works for both physical and virtual links.
+    #[allow(dead_code)]
+    pub async fn stop_tracking_link(
+        &mut self,
+        link_name: impl AsRef<str>,
+    ) -> Result<(), Error> {
+        if let Some(id) = self.tracked_links.remove(link_name.as_ref()) {
+            self.kstat_sampler.remove_target(id).await.map_err(Error::Kstat)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Track metrics for a virtual datalink.
+    #[allow(dead_code)]
+    pub async fn track_virtual_link(
+        &self,
+        link_name: impl AsRef<str>,
+        hostname: impl AsRef<str>,
+        interval: Duration,
+    ) -> Result<(), Error> {
+        let link = link::VirtualDataLink {
+            rack_id: self.rack_id,
+            sled_id: self.sled_id,
+            serial: self.serial_number(),
+            hostname: hostname.as_ref().to_string(),
+            link_name: link_name.as_ref().to_string(),
+        };
+        let details = CollectionDetails::never(interval);
+        self.kstat_sampler
+            .add_target(link, details)
+            .await
+            .map(|_| ())
+            .map_err(Error::Kstat)
+    }
+
+    // Return the serial number out of the baseboard, if one exists.
+    fn serial_number(&self) -> String {
+        match &self.baseboard {
+            Baseboard::Gimlet { identifier, .. } => identifier.clone(),
+            Baseboard::Unknown => String::from("unknown"),
+            Baseboard::Pc { identifier, .. } => identifier.clone(),
+        }
+    }
+
+    // Return the system's hostname.
+    //
+    // If we've failed to get it previously, we try again. If _that_ fails,
+    // return an error.
+    //
+    // TODO-cleanup: This will become much simpler once
+    // `OnceCell::get_or_try_init` is stabilized.
+    async fn hostname(&mut self) -> Result<String, Error> {
+        if let Some(hn) = &self.hostname {
+            return Ok(hn.clone());
+        }
+        let hn = tokio::process::Command::new("hostname")
+            .env_clear()
+            .output()
+            .await
+            .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+            .map_err(Error::Hostname)?;
+        self.hostname.replace(hn.clone());
+        Ok(hn)
+    }
+}
+
+#[cfg(not(target_os = "illumos"))]
+impl MetricsManager {
+    /// Track metrics for a physical datalink.
+    pub async fn track_physical_link(
+        &mut self,
+        _link_name: impl AsRef<str>,
+        _interval: Duration,
+    ) -> Result<(), Error> {
+        Err(Error::Kstat(anyhow!(
+            "kstat metrics are not supported on this platform"
+        )))
+    }
+
+    /// Stop tracking metrics for a datalink.
+    ///
+    /// This works for both physical and virtual links.
+    #[allow(dead_code)]
+    pub async fn stop_tracking_link(
+        &mut self,
+        _link_name: impl AsRef<str>,
+    ) -> Result<(), Error> {
+        Err(Error::Kstat(anyhow!(
+            "kstat metrics are not supported on this platform"
+        )))
+    }
+
+    /// Track metrics for a virtual datalink.
+    #[allow(dead_code)]
+    pub async fn track_virtual_link(
+        &self,
+        _link_name: impl AsRef<str>,
+        _hostname: impl AsRef<str>,
+        _interval: Duration,
+    ) -> Result<(), Error> {
+        Err(Error::Kstat(anyhow!(
+            "kstat metrics are not supported on this platform"
+        )))
+    }
+}


### PR DESCRIPTION
- Add a `kstat` module in `oximeter_instruments`. This includes a trait for describing how to map from one or more kstats into oximeter targets and metrics. It can be used to convert name-value kernel statistics in a pretty straightforward way into oximeter samples.
- Add a `KstatSampler`, which is used to register kstat targets, and will periodically poll them to generate samples. It is an `oximeter::Producer`, so that it can be easily hooked up to produce data for an `oximeter` collector.
- Add targets for tracking physical, virtual, and guest datalinks.
- Add metrics for bytes in/out, packets in/out, and errors in/out for the above.
- Use the `KstatStampler` in a new `MetricsManager` type in the sled agent, and track the physical (underlay) data links on a system. Does not yet track any virtual or guest links. The manager can be used to also collect other statistics, such as HTTP request latencies similar to nexus, or any kstats through the sampler.