### PR TITLE
[wicket] switch ComponentId Display impl to lowercase

### DIFF
--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -184,7 +184,7 @@ impl Component {
     }
 }
 
-// The component type and its slot.
+/// The component type and its slot.
 #[derive(
     Debug,
     Clone,
@@ -211,12 +211,13 @@ impl ComponentId {
     }
 }
 
+/// Prints the component type in standard case.
 impl Display for ComponentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ComponentId::Sled(i) => write!(f, "sled {}", i),
             ComponentId::Switch(i) => write!(f, "switch {}", i),
-            ComponentId::Psc(i) => write!(f, "psc {}", i),
+            ComponentId::Psc(i) => write!(f, "PSC {}", i),
         }
     }
 }
@@ -262,5 +263,17 @@ impl PowerState {
             PowerState::A3 => "commanded off",
             PowerState::A4 => "mechanical off (unplugged)",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_id_display() {
+        assert_eq!(ComponentId::Sled(0).to_string(), "sled 0");
+        assert_eq!(ComponentId::Switch(1).to_string(), "switch 1");
+        assert_eq!(ComponentId::Psc(2).to_string(), "PSC 2");
     }
 }

--- a/wicket/src/state/inventory.rs
+++ b/wicket/src/state/inventory.rs
@@ -6,7 +6,6 @@
 
 use anyhow::anyhow;
 use once_cell::sync::Lazy;
-use ratatui::text::Text;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -205,24 +204,20 @@ pub enum ComponentId {
 }
 
 impl ComponentId {
-    pub fn name(&self) -> String {
-        self.to_string()
+    pub fn to_string_uppercase(&self) -> String {
+        let mut s = self.to_string();
+        s.make_ascii_uppercase();
+        s
     }
 }
 
 impl Display for ComponentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ComponentId::Sled(i) => write!(f, "SLED {}", i),
-            ComponentId::Switch(i) => write!(f, "SWITCH {}", i),
-            ComponentId::Psc(i) => write!(f, "PSC {}", i),
+            ComponentId::Sled(i) => write!(f, "sled {}", i),
+            ComponentId::Switch(i) => write!(f, "switch {}", i),
+            ComponentId::Psc(i) => write!(f, "psc {}", i),
         }
-    }
-}
-
-impl From<ComponentId> for Text<'_> {
-    fn from(value: ComponentId) -> Self {
-        value.to_string().into()
     }
 }
 

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -343,7 +343,7 @@ impl Control for InventoryView {
         let title_bar = Paragraph::new(Line::from(vec![
             Span::styled("OXIDE RACK / ", border_style),
             Span::styled(
-                state.rack_state.selected.to_string(),
+                state.rack_state.selected.to_string_uppercase(),
                 component_style,
             ),
         ]))

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -180,7 +180,7 @@ impl UpdatePane {
             tree_state,
             items: ALL_COMPONENT_IDS
                 .iter()
-                .map(|id| TreeItem::new(*id, vec![]))
+                .map(|id| TreeItem::new(id.to_string_uppercase(), vec![]))
                 .collect(),
             help: vec![
                 ("Expand", "<e>"),
@@ -531,7 +531,10 @@ impl UpdatePane {
     ) {
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("START UPDATE: {}", state.rack_state.selected),
+                format!(
+                    "START UPDATE: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::header(true),
             )]),
             body: Text::from(vec![Line::from(vec![Span::styled(
@@ -561,7 +564,10 @@ impl UpdatePane {
     ) {
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("START UPDATE: {}", state.rack_state.selected),
+                format!(
+                    "START UPDATE: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::header(true),
             )]),
             body: Text::from(vec![Line::from(vec![Span::styled(
@@ -594,7 +600,10 @@ impl UpdatePane {
 
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("START UPDATE FAILED: {}", state.rack_state.selected),
+                format!(
+                    "START UPDATE FAILED: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::failed_update(),
             )]),
             body,
@@ -635,7 +644,10 @@ impl UpdatePane {
 
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("ABORT UPDATE: {}", state.rack_state.selected),
+                format!(
+                    "ABORT UPDATE: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::header(true),
             )]),
             body,
@@ -662,7 +674,10 @@ impl UpdatePane {
     ) {
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("ABORT UPDATE: {}", state.rack_state.selected),
+                format!(
+                    "ABORT UPDATE: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::header(true),
             )]),
             body: Text::from(vec![Line::from(vec![Span::styled(
@@ -695,7 +710,10 @@ impl UpdatePane {
 
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("ABORT UPDATE FAILED: {}", state.rack_state.selected),
+                format!(
+                    "ABORT UPDATE FAILED: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::failed_update(),
             )]),
             body,
@@ -721,7 +739,10 @@ impl UpdatePane {
     ) {
         let popup_builder = PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("CLEAR UPDATE STATE: {}", state.rack_state.selected),
+                format!(
+                    "CLEAR UPDATE STATE: {}",
+                    state.rack_state.selected.to_string_uppercase()
+                ),
                 style::header(true),
             )]),
             body: Text::from(vec![Line::from(vec![Span::styled(
@@ -756,7 +777,7 @@ impl UpdatePane {
             header: Line::from(vec![Span::styled(
                 format!(
                     "CLEAR UPDATE STATE FAILED: {}",
-                    state.rack_state.selected
+                    state.rack_state.selected.to_string_uppercase()
                 ),
                 style::failed_update(),
             )]),
@@ -830,7 +851,7 @@ impl UpdatePane {
                         })
                     })
                     .collect();
-                TreeItem::new(*id, children)
+                TreeItem::new(id.to_string_uppercase(), children)
             })
             .collect();
     }
@@ -1107,7 +1128,11 @@ impl UpdatePane {
                     // `overview` pane.
                     let command = self.ignition.selected_command();
                     let selected = state.rack_state.selected;
-                    info!(self.log, "Sending {command:?} to {selected}");
+                    info!(
+                        self.log,
+                        "Sending {command:?} to {}",
+                        selected.to_string_uppercase()
+                    );
                     self.popup = None;
                     Some(Action::Ignition(selected, command))
                 }
@@ -1378,7 +1403,10 @@ impl UpdatePane {
         // Draw the title/tab bar
         let title_bar = Paragraph::new(Line::from(vec![
             Span::styled("UPDATE STATUS / ", border_style),
-            Span::styled(state.rack_state.selected.to_string(), header_style),
+            Span::styled(
+                state.rack_state.selected.to_string_uppercase(),
+                header_style,
+            ),
         ]))
         .block(block.clone());
         frame.render_widget(title_bar, self.title_rect);

--- a/wicket/src/ui/widgets/ignition.rs
+++ b/wicket/src/ui/widgets/ignition.rs
@@ -58,7 +58,7 @@ impl IgnitionPopup {
     ) -> PopupBuilder<'static> {
         PopupBuilder {
             header: Line::from(vec![Span::styled(
-                format!("IGNITION: {}", component),
+                format!("IGNITION: {}", component.to_string_uppercase()),
                 style::header(true),
             )]),
             body: Text {


### PR DESCRIPTION
The current ComponentId Display impl is uppercase, which is ok for
wicket but we'd like to use. Lowercase is a better default, so use that.
(But PSC is an acronym so leave it as uppercase.)

I checked this by commenting out the `Display` impl (and the
`Into<Text>` impl), then inspecting all the places that errored out. I
changed all the spots that seemed to fit better with uppercase, and left
the ones that would work better with lowercase (typically log messages)
untouched.

The `Into<Text>` impl seemed unnecessary so I just removed it.
