### PR TITLE
omdb could care less about the current database version

### DIFF
--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -7,7 +7,7 @@ sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "--db-url", "junk", "sleds"]
 termination: Exited(2)
@@ -172,7 +172,7 @@ stderr:
 note: database URL not specified.  Will search DNS.
 note: (override with --db-url or OMDB_DB_URL)
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["--dns-server", "[::1]:REDACTED_PORT", "db", "sleds"]
 termination: Exited(0)
@@ -185,5 +185,5 @@ stderr:
 note: database URL not specified.  Will search DNS.
 note: (override with --db-url or OMDB_DB_URL)
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -8,7 +8,7 @@ external oxide-dev.test               2   <REDACTED_TIMESTAMP> create silo: "tes
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "diff", "external", "2"]
 termination: Exited(0)
@@ -24,7 +24,7 @@ changes:                    names added: 1, names removed: 0
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "dns", "names", "external", "2"]
 termination: Exited(0)
@@ -36,7 +36,7 @@ External zone: oxide-dev.test
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-instances"]
 termination: Exited(0)
@@ -54,7 +54,7 @@ Mgd            REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT         
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-by-sled"]
 termination: Exited(0)
@@ -75,7 +75,7 @@ sled: sim-b6d65341 (id REDACTED_UUID_REDACTED_UUID_REDACTED)
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["db", "sleds"]
 termination: Exited(0)
@@ -86,7 +86,7 @@ sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (8.0.0)
+note: database schema version matches expected (<redacted database version>)
 =============================================
 EXECUTING COMMAND: omdb ["mgs", "inventory"]
 termination: Exited(0)

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -304,5 +304,16 @@ fn redact_variable(input: &str) -> String {
         .replace_all(&s, "<REDACTED DURATION>ms")
         .to_string();
 
+    let s = regex::Regex::new(
+        r"note: database schema version matches expected \(\d+\.\d+\.\d+\)",
+    )
+    .unwrap()
+    .replace_all(
+        &s,
+        "note: database schema version matches expected \
+        (<redacted database version>)",
+    )
+    .to_string();
+
     s
 }


### PR DESCRIPTION
`omdb` has a cheesy test to check that its output doesn't change accidentally.  It currently captures the current database schema version.  We should redact this the way we do timestamps, uuids, etc. so that people don't have to update this test when they bump the database version.