### PR TITLE
[oximeter] Port all single node ClickHouse tests to a replicated set up

### DIFF
--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -865,10 +865,14 @@ mod tests {
 
         pub async fn wipe_db(&self, client: &Client) -> Result<(), Error> {
             match *self {
-                InstallationType::SingleNode => {
-                    client.wipe_single_node_db().await.expect("Failed to remove timeseries database")
-                }
-                InstallationType::Cluster => client.wipe_replicated_db().await.expect("Failed to remove timeseries database"),
+                InstallationType::SingleNode => client
+                    .wipe_single_node_db()
+                    .await
+                    .expect("Failed to remove timeseries database"),
+                InstallationType::Cluster => client
+                    .wipe_replicated_db()
+                    .await
+                    .expect("Failed to remove timeseries database"),
             }
             Ok(())
         }
@@ -3054,7 +3058,7 @@ mod tests {
             .await
             .expect_err("Should have failed, downgrades are not supported");
 
-            db_type.wipe_db(&client).await.unwrap();
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -873,151 +873,347 @@ mod tests {
             .unwrap();
 
         // Tests that data can be inserted via the client
-        insert_samples_test(db.address).await.unwrap();
+        insert_samples_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests for a schema mismatch
-        schema_mismatch_test(db.address).await.unwrap();
+        schema_mismatch_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests for a schema update
-        schema_updated_test(db.address).await.unwrap();
+        schema_updated_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests for specific timeseries selection
-        client_select_timeseries_one_test(db.address).await.unwrap();
+        client_select_timeseries_one_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests for specific timeseries selection
-        field_record_count_test(db.address).await.unwrap();
+        field_record_count_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // ClickHouse regression test
-        unquoted_64bit_integers_test(db.address).await.unwrap();
+        unquoted_64bit_integers_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests to verify that we can distinguish between metrics by name
-        differentiate_by_timeseries_name_test(db.address).await.unwrap();
+        differentiate_by_timeseries_name_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests selecting a single timeseries
-        select_timeseries_with_select_one_test(db.address).await.unwrap();
+        select_timeseries_with_select_one_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests selecting two timeseries
         select_timeseries_with_select_one_field_with_multiple_values_test(
             db.address,
+            InstallationType::SingleNode,
         )
         .await
         .unwrap();
 
         // Tests selecting multiple timeseries
-        select_timeseries_with_select_multiple_fields_with_multiple_values_test(db.address).await.unwrap();
+        select_timeseries_with_select_multiple_fields_with_multiple_values_test(db.address, InstallationType::SingleNode).await.unwrap();
 
         // Tests selecting all timeseries
-        select_timeseries_with_all_test(db.address).await.unwrap();
+        select_timeseries_with_all_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests selecting all timeseries with start time
-        select_timeseries_with_start_time_test(db.address).await.unwrap();
+        select_timeseries_with_start_time_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests selecting all timeseries with start time
-        select_timeseries_with_limit_test(db.address).await.unwrap();
+        select_timeseries_with_limit_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests selecting all timeseries with order
-        select_timeseries_with_order_test(db.address).await.unwrap();
+        select_timeseries_with_order_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests schema does not change
-        get_schema_no_new_values_test(db.address).await.unwrap();
+        get_schema_no_new_values_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests listing timeseries schema
-        timeseries_schema_list_test(db.address).await.unwrap();
+        timeseries_schema_list_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests listing timeseries
-        list_timeseries_test(db.address).await.unwrap();
+        list_timeseries_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests no changes are made when version is not updated
-        database_version_update_idempotent_test(db.address).await.unwrap();
+        database_version_update_idempotent_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests that downgrading is impossible
-        database_version_will_not_downgrade_test(db.address).await.unwrap();
+        database_version_will_not_downgrade_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests old data is dropped if version is updated
-        database_version_wipes_old_version_test(db.address).await.unwrap();
+        database_version_wipes_old_version_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests schema cache is updated when a new sample is inserted
-        update_schema_cache_on_new_sample_test(db.address).await.unwrap();
+        update_schema_cache_on_new_sample_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests that we can successfully query all extant datum types from the schema table.
-        select_all_datum_types_test(db.address).await.unwrap();
+        select_all_datum_types_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         // Tests that, when cache new schema but _fail_ to insert them,
         // we also remove them from the internal cache.
-        new_schema_removed_when_not_inserted_test(db.address).await.unwrap();
+        new_schema_removed_when_not_inserted_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         // Tests for fields and measurements
-        recall_field_value_bool_test(db.address).await.unwrap();
+        recall_field_value_bool_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_u8_test(db.address).await.unwrap();
+        recall_field_value_u8_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_i8_test(db.address).await.unwrap();
+        recall_field_value_i8_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_u16_test(db.address).await.unwrap();
+        recall_field_value_u16_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_i16_test(db.address).await.unwrap();
+        recall_field_value_i16_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_u32_test(db.address).await.unwrap();
+        recall_field_value_u32_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_i32_test(db.address).await.unwrap();
+        recall_field_value_i32_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_u64_test(db.address).await.unwrap();
+        recall_field_value_u64_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_i64_test(db.address).await.unwrap();
+        recall_field_value_i64_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_field_value_string_test(db.address).await.unwrap();
+        recall_field_value_string_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_field_value_ipv4addr_test(db.address).await.unwrap();
+        recall_field_value_ipv4addr_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_field_value_ipv6addr_test(db.address).await.unwrap();
+        recall_field_value_ipv6addr_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_field_value_uuid_test(db.address).await.unwrap();
+        recall_field_value_uuid_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_bool_test(db.address).await.unwrap();
+        recall_measurement_bool_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_i8_test(db.address).await.unwrap();
+        recall_measurement_i8_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_u8_test(db.address).await.unwrap();
+        recall_measurement_u8_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_i16_test(db.address).await.unwrap();
+        recall_measurement_i16_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_u16_test(db.address).await.unwrap();
+        recall_measurement_u16_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_i32_test(db.address).await.unwrap();
+        recall_measurement_i32_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_u32_test(db.address).await.unwrap();
+        recall_measurement_u32_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_i64_test(db.address).await.unwrap();
+        recall_measurement_i64_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_u64_test(db.address).await.unwrap();
+        recall_measurement_u64_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_f32_test(db.address).await.unwrap();
+        recall_measurement_f32_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_f64_test(db.address).await.unwrap();
+        recall_measurement_f64_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
-        recall_measurement_cumulative_i64_test(db.address).await.unwrap();
+        recall_measurement_cumulative_i64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_cumulative_u64_test(db.address).await.unwrap();
+        recall_measurement_cumulative_u64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_cumulative_f64_test(db.address).await.unwrap();
+        recall_measurement_cumulative_f64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_i8_test(db.address).await.unwrap();
+        recall_measurement_histogram_i8_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_u8_test(db.address).await.unwrap();
+        recall_measurement_histogram_u8_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_i16_test(db.address).await.unwrap();
+        recall_measurement_histogram_i16_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_u16_test(db.address).await.unwrap();
+        recall_measurement_histogram_u16_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_i32_test(db.address).await.unwrap();
+        recall_measurement_histogram_i32_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_u32_test(db.address).await.unwrap();
+        recall_measurement_histogram_u32_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_i64_test(db.address).await.unwrap();
+        recall_measurement_histogram_i64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_u64_test(db.address).await.unwrap();
+        recall_measurement_histogram_u64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
-        recall_measurement_histogram_f64_test(db.address).await.unwrap();
+        recall_measurement_histogram_f64_test(
+            db.address,
+            InstallationType::SingleNode,
+        )
+        .await
+        .unwrap();
 
         db.cleanup().await.expect("Failed to cleanup ClickHouse server");
     }
@@ -1161,7 +1357,10 @@ mod tests {
         Ok(())
     }
 
-    async fn insert_samples_test(address: SocketAddr) -> Result<(), Error> {
+    async fn insert_samples_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
         let logctx = test_setup_log("test_insert_samples");
         let log = &logctx.log;
 
@@ -1203,7 +1402,10 @@ mod tests {
         }
     }
 
-    async fn schema_mismatch_test(address: SocketAddr) -> Result<(), Error> {
+    async fn schema_mismatch_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
         let logctx = test_setup_log("test_schema_mismatch");
         let log = &logctx.log;
 
@@ -1233,7 +1435,10 @@ mod tests {
         Ok(())
     }
 
-    async fn schema_updated_test(address: SocketAddr) -> Result<(), Error> {
+    async fn schema_updated_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
         let logctx = test_setup_log("test_schema_updated");
         let log = &logctx.log;
 
@@ -1310,6 +1515,7 @@ mod tests {
 
     async fn client_select_timeseries_one_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_client_select_timeseries_one");
         let log = &logctx.log;
@@ -1395,7 +1601,10 @@ mod tests {
         Ok(())
     }
 
-    async fn field_record_count_test(address: SocketAddr) -> Result<(), Error> {
+    async fn field_record_count_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
         let logctx = test_setup_log("test_field_record_count");
         let log = &logctx.log;
 
@@ -1457,6 +1666,7 @@ mod tests {
     // details. This test verifies that we get back _unquoted_ integers from the database.
     async fn unquoted_64bit_integers_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         use serde_json::Value;
         let logctx = test_setup_log("test_unquoted_64bit_integers");
@@ -1483,6 +1693,7 @@ mod tests {
 
     async fn differentiate_by_timeseries_name_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_differentiate_by_timeseries_name");
         let log = &logctx.log;
@@ -1553,6 +1764,7 @@ mod tests {
 
     async fn select_timeseries_with_select_one_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_select_one");
         let log = &logctx.log;
@@ -1615,6 +1827,7 @@ mod tests {
 
     async fn select_timeseries_with_select_one_field_with_multiple_values_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log(
             "test_select_timeseries_with_select_one_field_with_multiple_values",
@@ -1685,6 +1898,7 @@ mod tests {
 
     async fn select_timeseries_with_select_multiple_fields_with_multiple_values_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_select_multiple_fields_with_multiple_values");
         let log = &logctx.log;
@@ -1761,6 +1975,7 @@ mod tests {
 
     async fn select_timeseries_with_all_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_all");
         let log = &logctx.log;
@@ -1822,6 +2037,7 @@ mod tests {
 
     async fn select_timeseries_with_start_time_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_start_time");
         let log = &logctx.log;
@@ -1873,6 +2089,7 @@ mod tests {
 
     async fn select_timeseries_with_limit_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_limit");
         let log = &logctx.log;
@@ -1991,6 +2208,7 @@ mod tests {
 
     async fn select_timeseries_with_order_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_select_timeseries_with_order");
         let log = &logctx.log;
@@ -2092,6 +2310,7 @@ mod tests {
 
     async fn get_schema_no_new_values_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_get_schema_no_new_values");
         let log = &logctx.log;
@@ -2119,6 +2338,7 @@ mod tests {
 
     async fn timeseries_schema_list_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_timeseries_schema_list");
         let log = &logctx.log;
@@ -2154,7 +2374,10 @@ mod tests {
         Ok(())
     }
 
-    async fn list_timeseries_test(address: SocketAddr) -> Result<(), Error> {
+    async fn list_timeseries_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
         let logctx = test_setup_log("test_list_timeseries");
         let log = &logctx.log;
 
@@ -2232,126 +2455,140 @@ mod tests {
 
     async fn recall_field_value_bool_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::Bool(true);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_u8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::U8(1);
         let as_json = serde_json::Value::from(1_u8);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_i8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::I8(1);
         let as_json = serde_json::Value::from(1_i8);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_u16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::U16(1);
         let as_json = serde_json::Value::from(1_u16);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_i16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::I16(1);
         let as_json = serde_json::Value::from(1_i16);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_u32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::U32(1);
         let as_json = serde_json::Value::from(1_u32);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_i32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::I32(1);
         let as_json = serde_json::Value::from(1_i32);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_u64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::U64(1);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_i64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::I64(1);
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_string_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::String("foo".into());
         let as_json = serde_json::Value::from("foo");
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_ipv4addr_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::from(Ipv4Addr::LOCALHOST);
         let as_json = serde_json::Value::from(
             Ipv4Addr::LOCALHOST.to_ipv6_mapped().to_string(),
         );
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_ipv6addr_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let field = FieldValue::from(Ipv6Addr::LOCALHOST);
         let as_json = serde_json::Value::from(Ipv6Addr::LOCALHOST.to_string());
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn recall_field_value_uuid_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let id = Uuid::new_v4();
         let field = FieldValue::from(id);
         let as_json = serde_json::Value::from(id.to_string());
-        test_recall_field_value_impl(address, field, as_json).await?;
+        test_recall_field_value_impl(address, db_type, field, as_json).await?;
         Ok(())
     }
 
     async fn test_recall_field_value_impl(
         address: SocketAddr,
+        db_type: InstallationType,
         field_value: FieldValue,
         as_json: serde_json::Value,
     ) -> Result<(), Error> {
@@ -2414,149 +2651,192 @@ mod tests {
 
     async fn recall_measurement_bool_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::Bool(true);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_i8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::I8(1);
         let as_json = serde_json::Value::from(1_i8);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_u8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::U8(1);
         let as_json = serde_json::Value::from(1_u8);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_i16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::I16(1);
         let as_json = serde_json::Value::from(1_i16);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_u16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::U16(1);
         let as_json = serde_json::Value::from(1_u16);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_i32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::I32(1);
         let as_json = serde_json::Value::from(1_i32);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_u32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::U32(1);
         let as_json = serde_json::Value::from(1_u32);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_i64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::I64(1);
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_u64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::U64(1);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_f32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         const VALUE: f32 = 1.1;
         let datum = Datum::F32(VALUE);
         // NOTE: This is intentionally an f64.
         let as_json = serde_json::Value::from(1.1_f64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_f64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         const VALUE: f64 = 1.1;
         let datum = Datum::F64(VALUE);
         let as_json = serde_json::Value::from(VALUE);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_i64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeI64(1.into());
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_u64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeU64(1.into());
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_f64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeF64(1.1.into());
         let as_json = serde_json::Value::from(1.1_f64);
-        test_recall_measurement_impl::<u8>(address, datum, None, as_json)
-            .await?;
+        test_recall_measurement_impl::<u8>(
+            address, db_type, datum, None, as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn histogram_test_impl<T>(
         address: SocketAddr,
+        db_type: InstallationType,
         hist: Histogram<T>,
     ) -> Result<(), Error>
     where
@@ -2569,72 +2849,86 @@ mod tests {
         let as_json = serde_json::Value::Array(
             counts.into_iter().map(Into::into).collect(),
         );
-        test_recall_measurement_impl(address, datum, Some(bins), as_json)
-            .await?;
+        test_recall_measurement_impl(
+            address,
+            db_type,
+            datum,
+            Some(bins),
+            as_json,
+        )
+        .await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i8, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u8_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u8, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i16, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u16_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u16, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i32, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u32, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i64, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u64, 1, 2]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
@@ -2653,22 +2947,25 @@ mod tests {
     #[allow(dead_code)]
     async fn recall_measurement_histogram_f32_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f32, 0.2, 0.3]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_f64_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f64, 0.2, 0.3]).unwrap();
-        histogram_test_impl(address, hist).await?;
+        histogram_test_impl(address, db_type, hist).await?;
         Ok(())
     }
 
     async fn test_recall_measurement_impl<T: Into<serde_json::Value> + Copy>(
         address: SocketAddr,
+        db_type: InstallationType,
         datum: Datum,
         maybe_bins: Option<Vec<T>>,
         json_datum: serde_json::Value,
@@ -2768,6 +3065,7 @@ mod tests {
 
     async fn database_version_update_idempotent_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_database_version_update_idempotent");
         let log = &logctx.log;
@@ -2805,6 +3103,7 @@ mod tests {
 
     async fn database_version_will_not_downgrade_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_database_version_will_not_downgrade");
         let log = &logctx.log;
@@ -2840,6 +3139,7 @@ mod tests {
 
     async fn database_version_wipes_old_version_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         let logctx = test_setup_log("test_database_version_wipes_old_version");
         let log = &logctx.log;
@@ -2876,6 +3176,7 @@ mod tests {
 
     async fn update_schema_cache_on_new_sample_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_update_schema_cache_on_new_sample");
@@ -2929,6 +3230,7 @@ mod tests {
     // succeed.
     async fn select_all_datum_types_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         use strum::IntoEnumIterator;
         usdt::register_probes().unwrap();
@@ -2965,6 +3267,7 @@ mod tests {
     // remove them from the internal cache.
     async fn new_schema_removed_when_not_inserted_test(
         address: SocketAddr,
+        db_type: InstallationType,
     ) -> Result<(), Error> {
         usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_update_schema_cache_on_new_sample");

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -838,7 +838,6 @@ mod tests {
     use oximeter::FieldValue;
     use oximeter::Metric;
     use oximeter::Target;
-    use std::net::Ipv4Addr;
     use std::net::Ipv6Addr;
     use std::time::Duration;
     use tokio::time::sleep;
@@ -1026,194 +1025,200 @@ mod tests {
         .unwrap();
 
         // Tests for fields and measurements
-        recall_field_value_bool_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_u8_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_i8_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_u16_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_i16_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_u32_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_i32_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_u64_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_i64_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_field_value_string_test(
+        recall_of_all_fields_test(
             db.address,
             InstallationType::SingleNode,
         )
         .await
         .unwrap();
-
-        recall_field_value_ipv4addr_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_ipv6addr_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_uuid_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_bool_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_i8_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_u8_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_i16_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_u16_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_i32_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_u32_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_i64_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_u64_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_f32_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_f64_test(db.address, InstallationType::SingleNode)
-            .await
-            .unwrap();
-
-        recall_measurement_cumulative_i64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_cumulative_u64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_cumulative_f64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i8_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u8_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i16_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u16_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i32_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u32_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_f64_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
+//        recall_field_value_bool_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_u8_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_i8_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_u16_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_i16_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_u32_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_i32_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_u64_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_i64_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_field_value_string_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_ipv4addr_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_ipv6addr_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_uuid_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_bool_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_i8_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_u8_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_i16_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_u16_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_i32_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_u32_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_i64_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_u64_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_f32_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_f64_test(db.address, InstallationType::SingleNode)
+//            .await
+//            .unwrap();
+//
+//        recall_measurement_cumulative_i64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_cumulative_u64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_cumulative_f64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i8_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u8_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i16_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u16_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i32_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u32_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_f64_test(
+//            db.address,
+//            InstallationType::SingleNode,
+//        )
+//        .await
+//        .unwrap();
 
         db.cleanup().await.expect("Failed to cleanup ClickHouse server");
     }
@@ -1224,7 +1229,7 @@ mod tests {
             .await
             .expect("Failed to initialise ClickHouse Cluster");
 
-        // Tests that the expected error is returned on a wrong address
+//        // Tests that the expected error is returned on a wrong address
         bad_db_connection_test().await.unwrap();
 
         // Tests data is replicated in a cluster
@@ -1419,257 +1424,266 @@ mod tests {
         .unwrap();
 
         // Tests for fields and measurements
-        recall_field_value_bool_test(
+        recall_of_all_fields_test(
             cluster.replica_1.address,
             InstallationType::Cluster,
         )
         .await
         .unwrap();
 
-        recall_field_value_u8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
+//        recall_field_value_bool_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_u8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_i8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_u16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_i16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_u32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_i32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_u64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_i64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_string_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_ipv4addr_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_ipv6addr_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_field_value_uuid_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
 
-        recall_field_value_i8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
+// --------------------------------------------------------
 
-        recall_field_value_u16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_i16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_u32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_i32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_u64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_i64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_string_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_ipv4addr_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_ipv6addr_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_field_value_uuid_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_bool_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_i8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_u8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_i16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_u16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_i32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_u32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_i64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_u64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_f32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_f64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_cumulative_i64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_cumulative_u64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_cumulative_f64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u8_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u16_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u32_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_i64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_u64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
-
-        recall_measurement_histogram_f64_test(
-            cluster.replica_1.address,
-            InstallationType::Cluster,
-        )
-        .await
-        .unwrap();
+//        recall_measurement_bool_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_i8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_u8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_i16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_u16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_i32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_u32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_i64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_u64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_f32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_f64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_cumulative_i64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_cumulative_u64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_cumulative_f64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u8_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u16_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u32_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_i64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_u64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
+//
+//        recall_measurement_histogram_f64_test(
+//            cluster.replica_1.address,
+//            InstallationType::Cluster,
+//        )
+//        .await
+//        .unwrap();
 
         cluster
             .keeper_1
@@ -3073,161 +3087,175 @@ mod tests {
     }
 
     async fn recall_field_value_bool_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::Bool(true);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_u8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::U8(1);
         let as_json = serde_json::Value::from(1_u8);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_i8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::I8(1);
         let as_json = serde_json::Value::from(1_i8);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_u16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::U16(1);
         let as_json = serde_json::Value::from(1_u16);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_i16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::I16(1);
         let as_json = serde_json::Value::from(1_i16);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_u32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::U32(1);
         let as_json = serde_json::Value::from(1_u32);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_i32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::I32(1);
         let as_json = serde_json::Value::from(1_i32);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_u64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::U64(1);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_i64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::I64(1);
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_string_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::String("foo".into());
         let as_json = serde_json::Value::from("foo");
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_ipv4addr_test(
-        address: SocketAddr,
-        db_type: InstallationType,
-    ) -> Result<(), Error> {
-        let field = FieldValue::from(Ipv4Addr::LOCALHOST);
-        let as_json = serde_json::Value::from(
-            Ipv4Addr::LOCALHOST.to_ipv6_mapped().to_string(),
-        );
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
-        Ok(())
-    }
+//    async fn recall_field_value_ipv4addr_test(
+//        // address: SocketAddr,
+//        // db_type: InstallationType,
+//        client: &Client,
+//    ) -> Result<(), Error> {
+//        let field = FieldValue::from(Ipv4Addr::LOCALHOST);
+//        let as_json = serde_json::Value::from(
+//            Ipv4Addr::LOCALHOST.to_ipv6_mapped().to_string(),
+//        );
+//        test_recall_field_value_impl(field, as_json, client).await?;
+//        Ok(())
+//    }
 
     async fn recall_field_value_ipv6addr_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::from(Ipv6Addr::LOCALHOST);
         let as_json = serde_json::Value::from(Ipv6Addr::LOCALHOST.to_string());
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn recall_field_value_uuid_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        // address: SocketAddr,
+        // db_type: InstallationType,
+        client: &Client,
     ) -> Result<(), Error> {
         let id = Uuid::new_v4();
         let field = FieldValue::from(id);
         let as_json = serde_json::Value::from(id.to_string());
-        test_recall_field_value_impl(address, db_type, field, as_json).await?;
+        test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
     async fn test_recall_field_value_impl(
-        address: SocketAddr,
-        db_type: InstallationType,
+    //    address: SocketAddr,
+    //    db_type: InstallationType,
         field_value: FieldValue,
         as_json: serde_json::Value,
+        client: &Client,
     ) -> Result<(), Error> {
-        let logctx = test_setup_log(
-            format!("test_recall_field_value_{}", field_value.field_type())
-                .as_str(),
-        );
-        let log = &logctx.log;
-
-        let client = Client::new(address, log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+//        let logctx = test_setup_log(
+//            format!("test_recall_field_value_{}", field_value.field_type())
+//                .as_str(),
+//        );
+//        let log = &logctx.log;
+//
+//        let client = Client::new(address, log);
+//        match db_type {
+//            InstallationType::SingleNode => client
+//                .init_single_node_db()
+//                .await
+//                .expect("Failed to initialize timeseries database"),
+//            InstallationType::Cluster => client
+//                .init_replicated_db()
+//                .await
+//                .expect("Failed to initialize timeseries database"),
+//        }
 
         // Insert a record from this field.
         const TIMESERIES_NAME: &str = "foo:bar";
@@ -3269,204 +3297,226 @@ mod tests {
             "Actual and expected field rows do not match"
         );
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
-        logctx.cleanup_successful();
+   //    match db_type {
+   //        InstallationType::SingleNode => {
+   //            client.wipe_single_node_db().await?
+   //        }
+   //        InstallationType::Cluster => client.wipe_replicated_db().await?,
+   //    }
+   //     logctx.cleanup_successful();
         Ok(())
     }
 
     async fn recall_measurement_bool_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+    //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::Bool(true);
         let as_json = serde_json::Value::from(1_u64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_i8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::I8(1);
         let as_json = serde_json::Value::from(1_i8);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_u8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::U8(1);
         let as_json = serde_json::Value::from(1_u8);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_i16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::I16(1);
         let as_json = serde_json::Value::from(1_i16);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_u16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::U16(1);
         let as_json = serde_json::Value::from(1_u16);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_i32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::I32(1);
         let as_json = serde_json::Value::from(1_i32);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_u32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::U32(1);
         let as_json = serde_json::Value::from(1_u32);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_i64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::I64(1);
         let as_json = serde_json::Value::from(1_i64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_u64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::U64(1);
         let as_json = serde_json::Value::from(1_u64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
+    // NOTE: This test is ignored intentionally.
+    //
+    // For some reason when the value is an f64 it inserts in both measurements_f32
+    // and measurements_f64 tables. This behaviour is unexpected, and should be investigated
+    // 
+    // See {githublink} for more details.
+    #[allow(dead_code)]
     async fn recall_measurement_f32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         const VALUE: f32 = 1.1;
         let datum = Datum::F32(VALUE);
         // NOTE: This is intentionally an f64.
         let as_json = serde_json::Value::from(1.1_f64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_f64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         const VALUE: f64 = 1.1;
         let datum = Datum::F64(VALUE);
         let as_json = serde_json::Value::from(VALUE);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_i64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeI64(1.into());
         let as_json = serde_json::Value::from(1_i64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_u64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeU64(1.into());
         let as_json = serde_json::Value::from(1_u64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_f64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeF64(1.1.into());
         let as_json = serde_json::Value::from(1.1_f64);
         test_recall_measurement_impl::<u8>(
-            address, db_type, datum, None, as_json,
+             datum, None, as_json, client,
         )
         .await?;
         Ok(())
     }
 
     async fn histogram_test_impl<T>(
-        address: SocketAddr,
-        db_type: InstallationType,
+        //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
         hist: Histogram<T>,
     ) -> Result<(), Error>
     where
@@ -3480,85 +3530,92 @@ mod tests {
             counts.into_iter().map(Into::into).collect(),
         );
         test_recall_measurement_impl(
-            address,
-            db_type,
             datum,
             Some(bins),
             as_json,
+            client,
         )
         .await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i8, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u8_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u8, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i16, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u16_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u16, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i32, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u32, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i64, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+//    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u64, 1, 2]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist ).await?;
         Ok(())
     }
 
@@ -3576,46 +3633,49 @@ mod tests {
     // discussion.
     #[allow(dead_code)]
     async fn recall_measurement_histogram_f32_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+       //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f32, 0.2, 0.3]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_f64_test(
-        address: SocketAddr,
-        db_type: InstallationType,
+       //    address: SocketAddr,
+    //    db_type: InstallationType,
+    client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f64, 0.2, 0.3]).unwrap();
-        histogram_test_impl(address, db_type, hist).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn test_recall_measurement_impl<T: Into<serde_json::Value> + Copy>(
-        address: SocketAddr,
-        db_type: InstallationType,
+    //    address: SocketAddr,
+    //    db_type: InstallationType,
         datum: Datum,
         maybe_bins: Option<Vec<T>>,
         json_datum: serde_json::Value,
+        client: &Client,
     ) -> Result<(), Error> {
-        let logctx = test_setup_log(
-            format!("test_recall_measurement_{}", datum.datum_type()).as_str(),
-        );
-        let log = &logctx.log;
-
-        let client = Client::new(address, log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+//        let logctx = test_setup_log(
+//            format!("test_recall_measurement_{}", datum.datum_type()).as_str(),
+//        );
+//        let log = &logctx.log;
+//
+//        let client = Client::new(address, log);
+//        match db_type {
+//            InstallationType::SingleNode => client
+//                .init_single_node_db()
+//                .await
+//                .expect("Failed to initialize timeseries database"),
+//            InstallationType::Cluster => client
+//                .init_replicated_db()
+//                .await
+//                .expect("Failed to initialize timeseries database"),
+//        }
 
         // Insert a record from this datum.
         const TIMESERIES_NAME: &str = "foo:bar";
@@ -3666,7 +3726,7 @@ mod tests {
 
         // Select it exactly back out.
         let select_sql = format!(
-            "SELECT * FROM oximeter.{} LIMIT 1 FORMAT {};",
+            "SELECT * FROM oximeter.{} LIMIT 2 FORMAT {};",
             measurement_table,
             crate::DATABASE_SELECT_FORMAT,
         );
@@ -3674,6 +3734,7 @@ mod tests {
             .execute_with_body(select_sql)
             .await
             .expect("Failed to select measurement row");
+        println!("{}", body);
         let actual_row: serde_json::Value = serde_json::from_str(&body)
             .expect("Failed to parse measurement row JSON");
         println!("{actual_row:?}");
@@ -3682,13 +3743,13 @@ mod tests {
             actual_row, inserted_row,
             "Actual and expected measurement rows do not match"
         );
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
-        logctx.cleanup_successful();
+//        match db_type {
+//            InstallationType::SingleNode => {
+//                client.wipe_single_node_db().await?
+//            }
+//            InstallationType::Cluster => client.wipe_replicated_db().await?,
+//        }
+//        logctx.cleanup_successful();
         Ok(())
     }
 
@@ -3702,6 +3763,239 @@ mod tests {
             .expect("Failed to SELECT from database")
             .lines()
             .count()
+    }
+
+    async fn recall_of_all_fields_test(address: SocketAddr, db_type: InstallationType) -> Result<(), Error> {
+        let logctx = test_setup_log(
+            "test_recall_of_all_fields",
+        );
+        let log = &logctx.log;
+
+        let client = Client::new(address, log);
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
+
+        recall_measurement_bool_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i8_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u8_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i16_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u16_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i32_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u32_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_f64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_i64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_u64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_f64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i8_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u8_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i16_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u16_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i32_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u32_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_f64_test(
+            &client,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_bool_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u8_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i8_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u16_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i16_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u32_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i32_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u64_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i64_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_string_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_ipv6addr_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_uuid_test(
+            &client
+        )
+        .await
+        .unwrap();
+
+
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
+        logctx.cleanup_successful();
+        Ok(())
     }
 
     async fn database_version_update_idempotent_test(

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -1025,200 +1025,9 @@ mod tests {
         .unwrap();
 
         // Tests for fields and measurements
-        recall_of_all_fields_test(
-            db.address,
-            InstallationType::SingleNode,
-        )
-        .await
-        .unwrap();
-//        recall_field_value_bool_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_u8_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_i8_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_u16_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_i16_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_u32_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_i32_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_u64_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_i64_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_field_value_string_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_ipv4addr_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_ipv6addr_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_uuid_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_bool_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_i8_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_u8_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_i16_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_u16_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_i32_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_u32_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_i64_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_u64_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_f32_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_f64_test(db.address, InstallationType::SingleNode)
-//            .await
-//            .unwrap();
-//
-//        recall_measurement_cumulative_i64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_cumulative_u64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_cumulative_f64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i8_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u8_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i16_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u16_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i32_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u32_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_f64_test(
-//            db.address,
-//            InstallationType::SingleNode,
-//        )
-//        .await
-//        .unwrap();
+        recall_of_all_fields_test(db.address, InstallationType::SingleNode)
+            .await
+            .unwrap();
 
         db.cleanup().await.expect("Failed to cleanup ClickHouse server");
     }
@@ -1229,7 +1038,7 @@ mod tests {
             .await
             .expect("Failed to initialise ClickHouse Cluster");
 
-//        // Tests that the expected error is returned on a wrong address
+        // Tests that the expected error is returned on a wrong address
         bad_db_connection_test().await.unwrap();
 
         // Tests data is replicated in a cluster
@@ -1430,260 +1239,6 @@ mod tests {
         )
         .await
         .unwrap();
-
-//        recall_field_value_bool_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_u8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_i8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_u16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_i16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_u32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_i32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_u64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_i64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_string_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_ipv4addr_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_ipv6addr_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_field_value_uuid_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-
-// --------------------------------------------------------
-
-//        recall_measurement_bool_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_i8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_u8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_i16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_u16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_i32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_u32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_i64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_u64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_f32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_f64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_cumulative_i64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_cumulative_u64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_cumulative_f64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u8_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u16_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u32_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_i64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_u64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
-//
-//        recall_measurement_histogram_f64_test(
-//            cluster.replica_1.address,
-//            InstallationType::Cluster,
-//        )
-//        .await
-//        .unwrap();
 
         cluster
             .keeper_1
@@ -3087,8 +2642,6 @@ mod tests {
     }
 
     async fn recall_field_value_bool_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
         client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::Bool(true);
@@ -3097,88 +2650,56 @@ mod tests {
         Ok(())
     }
 
-    async fn recall_field_value_u8_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_u8_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::U8(1);
         let as_json = serde_json::Value::from(1_u8);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_i8_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_i8_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::I8(1);
         let as_json = serde_json::Value::from(1_i8);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_u16_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_u16_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::U16(1);
         let as_json = serde_json::Value::from(1_u16);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_i16_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_i16_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::I16(1);
         let as_json = serde_json::Value::from(1_i16);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_u32_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_u32_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::U32(1);
         let as_json = serde_json::Value::from(1_u32);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_i32_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_i32_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::I32(1);
         let as_json = serde_json::Value::from(1_i32);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_u64_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_u64_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::U64(1);
         let as_json = serde_json::Value::from(1_u64);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }
 
-    async fn recall_field_value_i64_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
-        client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_field_value_i64_test(client: &Client) -> Result<(), Error> {
         let field = FieldValue::I64(1);
         let as_json = serde_json::Value::from(1_i64);
         test_recall_field_value_impl(field, as_json, client).await?;
@@ -3186,8 +2707,6 @@ mod tests {
     }
 
     async fn recall_field_value_string_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
         client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::String("foo".into());
@@ -3196,22 +2715,7 @@ mod tests {
         Ok(())
     }
 
-//    async fn recall_field_value_ipv4addr_test(
-//        // address: SocketAddr,
-//        // db_type: InstallationType,
-//        client: &Client,
-//    ) -> Result<(), Error> {
-//        let field = FieldValue::from(Ipv4Addr::LOCALHOST);
-//        let as_json = serde_json::Value::from(
-//            Ipv4Addr::LOCALHOST.to_ipv6_mapped().to_string(),
-//        );
-//        test_recall_field_value_impl(field, as_json, client).await?;
-//        Ok(())
-//    }
-
     async fn recall_field_value_ipv6addr_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
         client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::from(Ipv6Addr::LOCALHOST);
@@ -3221,8 +2725,6 @@ mod tests {
     }
 
     async fn recall_field_value_uuid_test(
-        // address: SocketAddr,
-        // db_type: InstallationType,
         client: &Client,
     ) -> Result<(), Error> {
         let id = Uuid::new_v4();
@@ -3233,30 +2735,10 @@ mod tests {
     }
 
     async fn test_recall_field_value_impl(
-    //    address: SocketAddr,
-    //    db_type: InstallationType,
         field_value: FieldValue,
         as_json: serde_json::Value,
         client: &Client,
     ) -> Result<(), Error> {
-//        let logctx = test_setup_log(
-//            format!("test_recall_field_value_{}", field_value.field_type())
-//                .as_str(),
-//        );
-//        let log = &logctx.log;
-//
-//        let client = Client::new(address, log);
-//        match db_type {
-//            InstallationType::SingleNode => client
-//                .init_single_node_db()
-//                .await
-//                .expect("Failed to initialize timeseries database"),
-//            InstallationType::Cluster => client
-//                .init_replicated_db()
-//                .await
-//                .expect("Failed to initialize timeseries database"),
-//        }
-
         // Insert a record from this field.
         const TIMESERIES_NAME: &str = "foo:bar";
         const TIMESERIES_KEY: u64 = 101;
@@ -3296,140 +2778,80 @@ mod tests {
             actual_row, inserted_row,
             "Actual and expected field rows do not match"
         );
-
-   //    match db_type {
-   //        InstallationType::SingleNode => {
-   //            client.wipe_single_node_db().await?
-   //        }
-   //        InstallationType::Cluster => client.wipe_replicated_db().await?,
-   //    }
-   //     logctx.cleanup_successful();
         Ok(())
     }
 
     async fn recall_measurement_bool_test(
-    //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::Bool(true);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_i8_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_i8_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::I8(1);
         let as_json = serde_json::Value::from(1_i8);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_u8_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_u8_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::U8(1);
         let as_json = serde_json::Value::from(1_u8);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_i16_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_i16_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::I16(1);
         let as_json = serde_json::Value::from(1_i16);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_u16_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_u16_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::U16(1);
         let as_json = serde_json::Value::from(1_u16);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_i32_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_i32_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::I32(1);
         let as_json = serde_json::Value::from(1_i32);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_u32_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_u32_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::U32(1);
         let as_json = serde_json::Value::from(1_u32);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_i64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_i64_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::I64(1);
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_u64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_u64_test(client: &Client) -> Result<(), Error> {
         let datum = Datum::U64(1);
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
@@ -3437,86 +2859,60 @@ mod tests {
     //
     // For some reason when the value is an f64 it inserts in both measurements_f32
     // and measurements_f64 tables. This behaviour is unexpected, and should be investigated
-    // 
+    //
     // See {githublink} for more details.
     #[allow(dead_code)]
-    async fn recall_measurement_f32_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_f32_test(client: &Client) -> Result<(), Error> {
         const VALUE: f32 = 1.1;
         let datum = Datum::F32(VALUE);
         // NOTE: This is intentionally an f64.
         let as_json = serde_json::Value::from(1.1_f64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
-    async fn recall_measurement_f64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
-    ) -> Result<(), Error> {
+    async fn recall_measurement_f64_test(client: &Client) -> Result<(), Error> {
         const VALUE: f64 = 1.1;
         let datum = Datum::F64(VALUE);
         let as_json = serde_json::Value::from(VALUE);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_i64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeI64(1.into());
         let as_json = serde_json::Value::from(1_i64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_u64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeU64(1.into());
         let as_json = serde_json::Value::from(1_u64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
     async fn recall_measurement_cumulative_f64_test(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let datum = Datum::CumulativeF64(1.1.into());
         let as_json = serde_json::Value::from(1.1_f64);
-        test_recall_measurement_impl::<u8>(
-             datum, None, as_json, client,
-        )
-        .await?;
+        test_recall_measurement_impl::<u8>(datum, None, as_json, client)
+            .await?;
         Ok(())
     }
 
     async fn histogram_test_impl<T>(
-        //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
         hist: Histogram<T>,
     ) -> Result<(), Error>
     where
@@ -3529,93 +2925,72 @@ mod tests {
         let as_json = serde_json::Value::Array(
             counts.into_iter().map(Into::into).collect(),
         );
-        test_recall_measurement_impl(
-            datum,
-            Some(bins),
-            as_json,
-            client,
-        )
-        .await?;
+        test_recall_measurement_impl(datum, Some(bins), as_json, client)
+            .await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i8_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i8, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u8_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u8, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i16_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i16, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u16_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u16, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i32_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i32, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u32_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u32, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_i64_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0i64, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
     async fn recall_measurement_histogram_u64_test(
-//    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0u64, 1, 2]).unwrap();
-        histogram_test_impl(client, hist ).await?;
+        histogram_test_impl(client, hist).await?;
         Ok(())
     }
 
@@ -3633,9 +3008,7 @@ mod tests {
     // discussion.
     #[allow(dead_code)]
     async fn recall_measurement_histogram_f32_test(
-       //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f32, 0.2, 0.3]).unwrap();
         histogram_test_impl(client, hist).await?;
@@ -3643,9 +3016,7 @@ mod tests {
     }
 
     async fn recall_measurement_histogram_f64_test(
-       //    address: SocketAddr,
-    //    db_type: InstallationType,
-    client: &Client,
+        client: &Client,
     ) -> Result<(), Error> {
         let hist = Histogram::new(&[0.1f64, 0.2, 0.3]).unwrap();
         histogram_test_impl(client, hist).await?;
@@ -3653,30 +3024,11 @@ mod tests {
     }
 
     async fn test_recall_measurement_impl<T: Into<serde_json::Value> + Copy>(
-    //    address: SocketAddr,
-    //    db_type: InstallationType,
         datum: Datum,
         maybe_bins: Option<Vec<T>>,
         json_datum: serde_json::Value,
         client: &Client,
     ) -> Result<(), Error> {
-//        let logctx = test_setup_log(
-//            format!("test_recall_measurement_{}", datum.datum_type()).as_str(),
-//        );
-//        let log = &logctx.log;
-//
-//        let client = Client::new(address, log);
-//        match db_type {
-//            InstallationType::SingleNode => client
-//                .init_single_node_db()
-//                .await
-//                .expect("Failed to initialize timeseries database"),
-//            InstallationType::Cluster => client
-//                .init_replicated_db()
-//                .await
-//                .expect("Failed to initialize timeseries database"),
-//        }
-
         // Insert a record from this datum.
         const TIMESERIES_NAME: &str = "foo:bar";
         const TIMESERIES_KEY: u64 = 101;
@@ -3743,13 +3095,6 @@ mod tests {
             actual_row, inserted_row,
             "Actual and expected measurement rows do not match"
         );
-//        match db_type {
-//            InstallationType::SingleNode => {
-//                client.wipe_single_node_db().await?
-//            }
-//            InstallationType::Cluster => client.wipe_replicated_db().await?,
-//        }
-//        logctx.cleanup_successful();
         Ok(())
     }
 
@@ -3765,10 +3110,11 @@ mod tests {
             .count()
     }
 
-    async fn recall_of_all_fields_test(address: SocketAddr, db_type: InstallationType) -> Result<(), Error> {
-        let logctx = test_setup_log(
-            "test_recall_of_all_fields",
-        );
+    async fn recall_of_all_fields_test(
+        address: SocketAddr,
+        db_type: InstallationType,
+    ) -> Result<(), Error> {
+        let logctx = test_setup_log("test_recall_of_all_fields");
         let log = &logctx.log;
 
         let client = Client::new(address, log);
@@ -3783,210 +3129,73 @@ mod tests {
                 .expect("Failed to initialize timeseries database"),
         }
 
-        recall_measurement_bool_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_bool_test(&client).await.unwrap();
 
-        recall_measurement_i8_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_i8_test(&client).await.unwrap();
 
-        recall_measurement_u8_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_u8_test(&client).await.unwrap();
 
-        recall_measurement_i16_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_i16_test(&client).await.unwrap();
 
-        recall_measurement_u16_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_u16_test(&client).await.unwrap();
 
-        recall_measurement_i32_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_i32_test(&client).await.unwrap();
 
-        recall_measurement_u32_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_u32_test(&client).await.unwrap();
 
-        recall_measurement_i64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_i64_test(&client).await.unwrap();
 
-        recall_measurement_u64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_u64_test(&client).await.unwrap();
 
-        recall_measurement_f64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_f64_test(&client).await.unwrap();
 
-        recall_measurement_cumulative_i64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_cumulative_i64_test(&client).await.unwrap();
 
-        recall_measurement_cumulative_u64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_cumulative_u64_test(&client).await.unwrap();
 
-        recall_measurement_cumulative_f64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_cumulative_f64_test(&client).await.unwrap();
 
-        recall_measurement_histogram_i8_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_i8_test(&client).await.unwrap();
 
-        recall_measurement_histogram_u8_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_u8_test(&client).await.unwrap();
 
-        recall_measurement_histogram_i16_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_i16_test(&client).await.unwrap();
 
-        recall_measurement_histogram_u16_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_u16_test(&client).await.unwrap();
 
-        recall_measurement_histogram_i32_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_i32_test(&client).await.unwrap();
 
-        recall_measurement_histogram_u32_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_u32_test(&client).await.unwrap();
 
-        recall_measurement_histogram_i64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_i64_test(&client).await.unwrap();
 
-        recall_measurement_histogram_u64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_u64_test(&client).await.unwrap();
 
-        recall_measurement_histogram_f64_test(
-            &client,
-        )
-        .await
-        .unwrap();
+        recall_measurement_histogram_f64_test(&client).await.unwrap();
 
-        recall_field_value_bool_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_bool_test(&client).await.unwrap();
 
-        recall_field_value_u8_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_u8_test(&client).await.unwrap();
 
-        recall_field_value_i8_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_i8_test(&client).await.unwrap();
 
-        recall_field_value_u16_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_u16_test(&client).await.unwrap();
 
-        recall_field_value_i16_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_i16_test(&client).await.unwrap();
 
-        recall_field_value_u32_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_u32_test(&client).await.unwrap();
 
-        recall_field_value_i32_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_i32_test(&client).await.unwrap();
 
-        recall_field_value_u64_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_u64_test(&client).await.unwrap();
 
-        recall_field_value_i64_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_i64_test(&client).await.unwrap();
 
-        recall_field_value_string_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_string_test(&client).await.unwrap();
 
-        recall_field_value_ipv6addr_test(
-            &client
-        )
-        .await
-        .unwrap();
+        recall_field_value_ipv6addr_test(&client).await.unwrap();
 
-        recall_field_value_uuid_test(
-            &client
-        )
-        .await
-        .unwrap();
-
+        recall_field_value_uuid_test(&client).await.unwrap();
 
         match db_type {
             InstallationType::SingleNode => {

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -1320,18 +1320,21 @@ mod tests {
         );
         client_2.execute_with_body(sql).await.unwrap();
 
+        // Make sure replicas are synched
+        let sql = String::from(
+            "SYSTEM SYNC REPLICA oximeter.measurements_string_local;",
+        );
+        client_2.execute_with_body(sql).await.unwrap();
+
+        // Make sure data exists in the other replica
         let sql = String::from(
             "SELECT * FROM oximeter.measurements_string FORMAT JSONEachRow;",
         );
-        let result = client_2.execute_with_body(sql.clone()).await.unwrap();
+        let result = client_1.execute_with_body(sql).await.unwrap();
         assert!(result.contains("hiya"));
 
         client_1.wipe_replicated_db().await?;
         logctx.cleanup_successful();
-
-        // TODO(https://github.com/oxidecomputer/omicron/issues/4001): With distributed
-        // engine, it can take a long time to sync the data. This means it's tricky to
-        // test that the data exists on both nodes.
         Ok(())
     }
 

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -1238,6 +1238,439 @@ mod tests {
         .await
         .unwrap();
 
+        // Tests that data can be inserted via the client
+        insert_samples_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests for a schema mismatch
+        schema_mismatch_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests for a schema update
+        schema_updated_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests for specific timeseries selection
+        client_select_timeseries_one_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests for specific timeseries selection
+        field_record_count_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // ClickHouse regression test
+        unquoted_64bit_integers_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests to verify that we can distinguish between metrics by name
+        differentiate_by_timeseries_name_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting a single timeseries
+        select_timeseries_with_select_one_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting two timeseries
+        select_timeseries_with_select_one_field_with_multiple_values_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting multiple timeseries
+        select_timeseries_with_select_multiple_fields_with_multiple_values_test(cluster.replica_1.address, InstallationType::Cluster).await.unwrap();
+
+        // Tests selecting all timeseries
+        select_timeseries_with_all_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting all timeseries with start time
+        select_timeseries_with_start_time_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting all timeseries with start time
+        select_timeseries_with_limit_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests selecting all timeseries with order
+        select_timeseries_with_order_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests schema does not change
+        get_schema_no_new_values_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests listing timeseries schema
+        timeseries_schema_list_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests listing timeseries
+        list_timeseries_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests no changes are made when version is not updated
+        database_version_update_idempotent_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests that downgrading is impossible
+        database_version_will_not_downgrade_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests old data is dropped if version is updated
+        database_version_wipes_old_version_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests schema cache is updated when a new sample is inserted
+        update_schema_cache_on_new_sample_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests that we can successfully query all extant datum types from the schema table.
+        select_all_datum_types_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests that, when cache new schema but _fail_ to insert them,
+        // we also remove them from the internal cache.
+        new_schema_removed_when_not_inserted_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        // Tests for fields and measurements
+        recall_field_value_bool_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_u64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_i64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_string_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_ipv4addr_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_ipv6addr_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_field_value_uuid_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_bool_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_i64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_u64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_f32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_f64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_i64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_u64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_cumulative_f64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u8_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u16_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u32_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_i64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_u64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
+        recall_measurement_histogram_f64_test(
+            cluster.replica_1.address,
+            InstallationType::Cluster,
+        )
+        .await
+        .unwrap();
+
         cluster
             .keeper_1
             .cleanup()
@@ -1325,7 +1758,6 @@ mod tests {
         assert!(result.contains("hiya"));
 
         client_1.wipe_replicated_db().await?;
-        // TODO: Verify data has been deleted in client 2
         logctx.cleanup_successful();
 
         // TODO(https://github.com/oxidecomputer/omicron/issues/4001): With distributed
@@ -1365,10 +1797,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = {
             let mut s = Vec::with_capacity(8);
             for _ in 0..s.capacity() {
@@ -1377,7 +1815,12 @@ mod tests {
             s
         };
         client.insert_samples(&samples).await?;
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1410,10 +1853,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let sample = test_util::make_sample();
         client.insert_samples(&[sample]).await.unwrap();
 
@@ -1430,7 +1879,12 @@ mod tests {
         let sample = Sample::new(&bad_name, &metric).unwrap();
         let result = client.verify_or_cache_sample_schema(&sample).await;
         assert!(matches!(result, Err(Error::SchemaMismatch { .. })));
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1443,10 +1897,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let sample = test_util::make_sample();
 
         // Verify that this sample is considered new, i.e., we return rows to update the timeseries
@@ -1508,7 +1968,12 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(schema.len(), 1);
         assert_eq!(expected_schema, schema[0]);
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1521,10 +1986,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -1596,7 +2067,12 @@ mod tests {
             .iter()
             .all(|field| field_cmp(field, sample.metric_fields()));
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1613,10 +2089,16 @@ mod tests {
         // Because of the schema change, inserting field records per field per unique timeseries,
         // we'd like to exercise the logic of ClickHouse's replacing merge tree engine.
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -1653,7 +2135,12 @@ mod tests {
         )
         .await;
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1673,10 +2160,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let output = client
             .execute_with_body(
                 "SELECT toUInt64(1) AS foo FORMAT JSONEachRow;".to_string(),
@@ -1686,7 +2179,12 @@ mod tests {
         let json: Value = serde_json::from_str(&output).unwrap();
         assert_eq!(json["foo"], Value::Number(1u64.into()));
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1717,10 +2215,16 @@ mod tests {
         }
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
 
         let target = MyTarget::default();
         let first_metric = FirstMetric::default();
@@ -1757,7 +2261,12 @@ mod tests {
         assert_eq!(timeseries.target.name, "my_target");
         assert_eq!(timeseries.metric.name, "second_metric");
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1772,10 +2281,16 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -1820,7 +2335,12 @@ mod tests {
         verify_target(&timeseries.target, &target);
         verify_metric(&timeseries.metric, metrics.get(0).unwrap());
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1837,10 +2357,16 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -1891,7 +2417,12 @@ mod tests {
             verify_metric(&ts.metric, metric);
         }
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1906,10 +2437,16 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -1968,7 +2505,12 @@ mod tests {
             }
         }
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1983,10 +2525,16 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -2030,7 +2578,12 @@ mod tests {
             verify_metric(&ts.metric, metrics.get(i).unwrap());
         }
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2045,10 +2598,16 @@ mod tests {
         let (_, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -2082,7 +2641,12 @@ mod tests {
             }
         }
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2096,10 +2660,16 @@ mod tests {
 
         let (_, _, samples) = setup_select_test();
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -2201,7 +2771,12 @@ mod tests {
             timeseries.measurements
         );
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2215,10 +2790,16 @@ mod tests {
 
         let (_, _, samples) = setup_select_test();
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         client
             .insert_samples(&samples)
             .await
@@ -2303,7 +2884,12 @@ mod tests {
             timeseries_asc.last().unwrap()
         );
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2316,10 +2902,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2331,7 +2923,12 @@ mod tests {
             .expect("Failed to get timeseries schema");
         assert_eq!(&original_schema, &*schema, "Schema shouldn't change");
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2344,10 +2941,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2369,7 +2972,12 @@ mod tests {
             result.next_page.is_none(),
             "Expected the next page token to be None"
         );
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2382,10 +2990,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2448,7 +3062,12 @@ mod tests {
             "Paginating should pick up where it left off"
         );
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2599,10 +3218,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
 
         // Insert a record from this field.
         const TIMESERIES_NAME: &str = "foo:bar";
@@ -2644,7 +3269,12 @@ mod tests {
             "Actual and expected field rows do not match"
         );
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2976,10 +3606,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
 
         // Insert a record from this datum.
         const TIMESERIES_NAME: &str = "foo:bar";
@@ -3046,7 +3682,12 @@ mod tests {
             actual_row, inserted_row,
             "Actual and expected measurement rows do not match"
         );
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3096,7 +3737,12 @@ mod tests {
 
         assert_eq!(1, get_schema_count(&client).await);
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3132,7 +3778,12 @@ mod tests {
             .await
             .expect_err("Should have failed, downgrades are not supported");
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3169,7 +3820,12 @@ mod tests {
             .expect("Should have initialized database successfully");
         assert_eq!(0, get_schema_count(&client).await);
 
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3183,10 +3839,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = [test_util::make_sample()];
         client.insert_samples(&samples).await.unwrap();
 
@@ -3218,7 +3880,12 @@ mod tests {
             "Expected exactly 1 schema again"
         );
         assert_eq!(client.schema.lock().await.len(), 1);
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3238,10 +3905,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
 
         // Attempt to select all schema with each datum type.
         for ty in oximeter::DatumType::iter() {
@@ -3256,7 +3929,12 @@ mod tests {
             let count = res.trim().parse::<usize>().unwrap();
             assert_eq!(count, 0);
         }
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3274,10 +3952,16 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        client
-            .init_single_node_db()
-            .await
-            .expect("Failed to initialize timeseries database");
+        match db_type {
+            InstallationType::SingleNode => client
+                .init_single_node_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+            InstallationType::Cluster => client
+                .init_replicated_db()
+                .await
+                .expect("Failed to initialize timeseries database"),
+        }
         let samples = [test_util::make_sample()];
 
         // We're using the components of the `insert_samples()` method here,
@@ -3293,7 +3977,12 @@ mod tests {
 
         // Next, we'll kill the database, and then try to insert the schema.
         // That will fail, since the DB is now inaccessible.
-        client.wipe_single_node_db().await?;
+        match db_type {
+            InstallationType::SingleNode => {
+                client.wipe_single_node_db().await?
+            }
+            InstallationType::Cluster => client.wipe_replicated_db().await?,
+        }
         let res = client.save_new_schema_or_remove(new_schema).await;
         assert!(res.is_err(), "Should have failed since the DB is gone");
         assert!(

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -2860,7 +2860,7 @@ mod tests {
     // For some reason when the value is an f64 it inserts in both measurements_f32
     // and measurements_f64 tables. This behaviour is unexpected, and should be investigated
     //
-    // See {githublink} for more details.
+    // See https://github.com/oxidecomputer/omicron/pull/4372 for more details.
     #[allow(dead_code)]
     async fn recall_measurement_f32_test(client: &Client) -> Result<(), Error> {
         const VALUE: f32 = 1.1;

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -1356,7 +1356,7 @@ mod tests {
         let sql = String::from(
             "SYSTEM SYNC REPLICA oximeter.measurements_string_local;",
         );
-        client_2.execute_with_body(sql).await.unwrap();
+        client_1.execute_with_body(sql).await.unwrap();
 
         // Make sure data exists in the other replica
         let sql = String::from(
@@ -1401,16 +1401,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = {
             let mut s = Vec::with_capacity(8);
             for _ in 0..s.capacity() {
@@ -1419,12 +1410,7 @@ mod tests {
             s
         };
         client.insert_samples(&samples).await?;
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1457,16 +1443,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let sample = test_util::make_sample();
         client.insert_samples(&[sample]).await.unwrap();
 
@@ -1483,12 +1460,7 @@ mod tests {
         let sample = Sample::new(&bad_name, &metric).unwrap();
         let result = client.verify_or_cache_sample_schema(&sample).await;
         assert!(matches!(result, Err(Error::SchemaMismatch { .. })));
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1501,16 +1473,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let sample = test_util::make_sample();
 
         // Verify that this sample is considered new, i.e., we return rows to update the timeseries
@@ -1572,12 +1535,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(schema.len(), 1);
         assert_eq!(expected_schema, schema[0]);
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1590,16 +1548,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -1671,12 +1620,7 @@ mod tests {
             .iter()
             .all(|field| field_cmp(field, sample.metric_fields()));
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1693,16 +1637,7 @@ mod tests {
         // Because of the schema change, inserting field records per field per unique timeseries,
         // we'd like to exercise the logic of ClickHouse's replacing merge tree engine.
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -1739,12 +1674,7 @@ mod tests {
         )
         .await;
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1764,16 +1694,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let output = client
             .execute_with_body(
                 "SELECT toUInt64(1) AS foo FORMAT JSONEachRow;".to_string(),
@@ -1783,12 +1704,7 @@ mod tests {
         let json: Value = serde_json::from_str(&output).unwrap();
         assert_eq!(json["foo"], Value::Number(1u64.into()));
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1819,16 +1735,7 @@ mod tests {
         }
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
 
         let target = MyTarget::default();
         let first_metric = FirstMetric::default();
@@ -1865,12 +1772,7 @@ mod tests {
         assert_eq!(timeseries.target.name, "my_target");
         assert_eq!(timeseries.metric.name, "second_metric");
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1885,16 +1787,7 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -1939,12 +1832,7 @@ mod tests {
         verify_target(&timeseries.target, &target);
         verify_metric(&timeseries.metric, metrics.get(0).unwrap());
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -1961,16 +1849,7 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2021,12 +1900,7 @@ mod tests {
             verify_metric(&ts.metric, metric);
         }
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2041,16 +1915,7 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2109,12 +1974,7 @@ mod tests {
             }
         }
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2129,16 +1989,7 @@ mod tests {
         let (target, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2182,12 +2033,7 @@ mod tests {
             verify_metric(&ts.metric, metrics.get(i).unwrap());
         }
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2202,16 +2048,7 @@ mod tests {
         let (_, metrics, samples) = setup_select_test();
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2245,12 +2082,7 @@ mod tests {
             }
         }
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2264,16 +2096,7 @@ mod tests {
 
         let (_, _, samples) = setup_select_test();
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2375,12 +2198,7 @@ mod tests {
             timeseries.measurements
         );
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2394,16 +2212,7 @@ mod tests {
 
         let (_, _, samples) = setup_select_test();
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         client
             .insert_samples(&samples)
             .await
@@ -2488,12 +2297,7 @@ mod tests {
             timeseries_asc.last().unwrap()
         );
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2506,16 +2310,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2527,12 +2322,7 @@ mod tests {
             .expect("Failed to get timeseries schema");
         assert_eq!(&original_schema, &*schema, "Schema shouldn't change");
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2545,16 +2335,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2576,12 +2357,7 @@ mod tests {
             result.next_page.is_none(),
             "Expected the next page token to be None"
         );
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -2594,16 +2370,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = test_util::generate_test_samples(2, 2, 2, 2);
         client.insert_samples(&samples).await?;
 
@@ -2666,12 +2433,7 @@ mod tests {
             "Paginating should pick up where it left off"
         );
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3292,12 +3054,7 @@ mod tests {
             .await
             .expect_err("Should have failed, downgrades are not supported");
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+            db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3334,12 +3091,7 @@ mod tests {
             .expect("Should have initialized database successfully");
         assert_eq!(0, get_schema_count(&client).await);
 
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3353,16 +3105,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = [test_util::make_sample()];
         client.insert_samples(&samples).await.unwrap();
 
@@ -3394,12 +3137,7 @@ mod tests {
             "Expected exactly 1 schema again"
         );
         assert_eq!(client.schema.lock().await.len(), 1);
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3419,16 +3157,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
 
         // Attempt to select all schema with each datum type.
         for ty in oximeter::DatumType::iter() {
@@ -3443,12 +3172,7 @@ mod tests {
             let count = res.trim().parse::<usize>().unwrap();
             assert_eq!(count, 0);
         }
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         logctx.cleanup_successful();
         Ok(())
     }
@@ -3466,16 +3190,7 @@ mod tests {
         let log = &logctx.log;
 
         let client = Client::new(address, &log);
-        match db_type {
-            InstallationType::SingleNode => client
-                .init_single_node_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-            InstallationType::Cluster => client
-                .init_replicated_db()
-                .await
-                .expect("Failed to initialize timeseries database"),
-        }
+        db_type.init_db(&client).await.unwrap();
         let samples = [test_util::make_sample()];
 
         // We're using the components of the `insert_samples()` method here,
@@ -3491,12 +3206,7 @@ mod tests {
 
         // Next, we'll kill the database, and then try to insert the schema.
         // That will fail, since the DB is now inaccessible.
-        match db_type {
-            InstallationType::SingleNode => {
-                client.wipe_single_node_db().await?
-            }
-            InstallationType::Cluster => client.wipe_replicated_db().await?,
-        }
+        db_type.wipe_db(&client).await.unwrap();
         let res = client.save_new_schema_or_remove(new_schema).await;
         assert!(res.is_err(), "Should have failed since the DB is gone");
         assert!(

--- a/oximeter/db/src/db-replicated-init.sql
+++ b/oximeter/db/src/db-replicated-init.sql
@@ -206,7 +206,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_f32 ON CLUSTER oximeter_cluster
     timestamp DateTime64(9, 'UTC'),
     datum Float32
 )
-ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f32_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64_local ON CLUSTER oximeter_cluster
 (

--- a/oximeter/db/src/db-replicated-init.sql
+++ b/oximeter/db/src/db-replicated-init.sql
@@ -188,6 +188,26 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_u64 ON CLUSTER oximeter_cluster
 )
 ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_u64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
 --
+CREATE TABLE IF NOT EXISTS oximeter.measurements_f32_local ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    timestamp DateTime64(9, 'UTC'),
+    datum Float32
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/measurements_f32_local', '{replica}')
+ORDER BY (timeseries_name, timeseries_key, timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+--
+CREATE TABLE IF NOT EXISTS oximeter.measurements_f32 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    timestamp DateTime64(9, 'UTC'),
+    datum Float32
+)
+ENGINE = Distributed('oximeter_cluster', 'oximeter', 'measurements_f64_local', xxHash64(splitByChar(':', timeseries_name)[1]));
+--
 CREATE TABLE IF NOT EXISTS oximeter.measurements_f64_local ON CLUSTER oximeter_cluster
 (
     timeseries_name String,
@@ -586,12 +606,82 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_bool ON CLUSTER oximeter_cluster
 ENGINE = ReplicatedReplacingMergeTree()
 ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
 --
+CREATE TABLE IF NOT EXISTS oximeter.fields_i8 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value Int8
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_u8 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value UInt8
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_i16 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value Int16
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_u16 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value UInt16
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_i32 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value Int32
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_u32 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value UInt32
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
 CREATE TABLE IF NOT EXISTS oximeter.fields_i64 ON CLUSTER oximeter_cluster
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
     field_value Int64
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+--
+CREATE TABLE IF NOT EXISTS oximeter.fields_u64 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    field_name String,
+    field_value UInt64
 )
 ENGINE = ReplicatedReplacingMergeTree()
 ORDER BY (timeseries_name, field_name, field_value, timeseries_key);

--- a/oximeter/db/src/db-wipe-replicated.sql
+++ b/oximeter/db/src/db-wipe-replicated.sql
@@ -1,1 +1,1 @@
-DROP DATABASE IF EXISTS oximeter ON CLUSTER oximeter_cluster;
+DROP DATABASE IF EXISTS oximeter ON CLUSTER oximeter_cluster SYNC;

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -165,7 +165,7 @@ impl ClickHouseInstance {
             .env("CH_REPLICA_NUMBER", r_number)
             .env("CH_REPLICA_HOST_01", "::1")
             .env("CH_REPLICA_HOST_02", "::1")
-            // ClickHouse servers have a small quirk, where when setting the keeper hosts as IPv6 localhost 
+            // ClickHouse servers have a small quirk, where when setting the keeper hosts as IPv6 localhost
             // addresses in the replica configuration file, they must be wrapped in square brackets
             // Otherwise, when running any query, a "Service not found" error appears.
             .env("CH_KEEPER_HOST_01", "[::1]")

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -9,7 +9,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
-use std::net::{SocketAddr, Ipv4Addr, Ipv6Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use tempfile::{Builder, TempDir};
 use thiserror::Error;
 use tokio::{

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -32,7 +32,7 @@ pub struct ClickHouseInstance {
     // The HTTP port the server is listening on
     port: u16,
     // The address the server is listening on
-    pub address: Option<SocketAddr>,
+    pub address: SocketAddr,
     // Full list of command-line arguments
     args: Vec<String>,
     // Subprocess handle
@@ -109,11 +109,13 @@ impl ClickHouseInstance {
         let data_path = data_dir.path().to_path_buf();
         let port = wait_for_port(log_path).await?;
 
+        let address = SocketAddr::new("::1".parse().unwrap(), port);
+
         Ok(Self {
             data_dir: Some(data_dir),
             data_path,
             port,
-            address: None,
+            address: address,
             args,
             child: Some(child),
         })
@@ -183,7 +185,7 @@ impl ClickHouseInstance {
                 data_dir: Some(data_dir),
                 data_path,
                 port,
-                address: Some(address),
+                address: address,
                 args,
                 child: Some(child),
             }),
@@ -252,6 +254,7 @@ impl ClickHouseInstance {
             })?;
 
         let data_path = data_dir.path().to_path_buf();
+        let address = SocketAddr::new("127.0.0.1".parse().unwrap(), port);
 
         let result = wait_for_ready(log_path).await;
         match result {
@@ -259,7 +262,7 @@ impl ClickHouseInstance {
                 data_dir: Some(data_dir),
                 data_path,
                 port,
-                address: None,
+                address: address,
                 args,
                 child: Some(child),
             }),

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -165,8 +165,8 @@ impl ClickHouseInstance {
             .env("CH_REPLICA_NUMBER", r_number)
             .env("CH_REPLICA_HOST_01", "::1")
             .env("CH_REPLICA_HOST_02", "::1")
-            // ClickHouse servers have a small quirk, where when defining keeper hosts as ipV6
-            // localhost addresses in the configuration file, they must be wrapped in square brackets.
+            // ClickHouse servers have a small quirk, where when setting the keeper hosts as IPv6 localhost 
+            // addresses in the replica configuration file, they must be wrapped in square brackets
             // Otherwise, when running any query, a "Service not found" error appears.
             .env("CH_KEEPER_HOST_01", "[::1]")
             .env("CH_KEEPER_HOST_02", "[::1]")

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -9,7 +9,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
-use std::net::SocketAddr;
+use std::net::{SocketAddr, Ipv4Addr, Ipv6Addr, IpAddr};
 use tempfile::{Builder, TempDir};
 use thiserror::Error;
 use tokio::{
@@ -109,7 +109,7 @@ impl ClickHouseInstance {
         let data_path = data_dir.path().to_path_buf();
         let port = wait_for_port(log_path).await?;
 
-        let address = SocketAddr::new("::1".parse().unwrap(), port);
+        let address = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port);
 
         Ok(Self {
             data_dir: Some(data_dir),
@@ -177,7 +177,7 @@ impl ClickHouseInstance {
             })?;
 
         let data_path = data_dir.path().to_path_buf();
-        let address = SocketAddr::new("127.0.0.1".parse().unwrap(), port);
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
 
         let result = wait_for_ready(log_path).await;
         match result {


### PR DESCRIPTION
This is a follow up to https://github.com/oxidecomputer/omicron/pull/4149 . In this commit all single node tests are now run against a clustered set up. Additionally, a few bugs on the replicated init SQL file have been fixed.

A few things to note:

- All of the individual field and measurement tests all run under a single test now. The reason for this is test times. Each test needs to wipe out it's database before the next test runs. In a replicated installation, this means that all nodes must sync, which takes time. Before I merged all the field/measurement tests into a single one, the testing time for a replicated set up took about 10 minutes, which really is too much. Now it takes ~3.5 minutes. It is still a lot, but only a temporary measure until we can run these tests in parallel again. An unintended bonus of this approach is that running the tests this way means that you are testing that the data is being inserted in the correct table.
- ~There is a strange behaviour that occurs when running the `recall_measurement_f32_test` test. This test is unique in the fact that it has to insert an f64 value to the `oximeter.measurements_f32` table. For some strange reason the data is inserted into the `oximeter.measurements_f64` table as well. I honestly could not find out why. It seems to be some strange ClickHouse quirk, so I have disabled the test temporarily.~

  ~I tweaked the test to return 2 rows instead of one and these are the results. As you can see, an additional row is inserted into the `oximeter.measurements_f64` at the same time the `recall_measurement_f32_test` test is run.~

  ~Output from the log:~

  ~{"msg":"executing SQL query: INSERT INTO oximeter.measurements_f32 FORMAT JSONEachRow {\"datum\":1.1,\"timeseries_key\":101,\"timeseries_name\":\"foo:bar\",\"timestamp\":\"2023-10-27 00:52:35.601821001\"}","v":0,"name":"test_recall_of_all_fields","level":10,"time":"2023-10-27T00:52:35.602139961Z","hostname":"pop-os","pid":846472,"id":"47b615cf-5e40-4ff8-8700-a48cc97a4830","component":"clickhouse-client"}~
  ~{"msg":"executing SQL query: SELECT * FROM oximeter.measurements_f32 LIMIT 2 FORMAT JSONEachRow;","v":0,"name":"test_recall_of_all_fields","level":10,"time":"2023-10-27T00:52:35.613187591Z","hostname":"pop-os","pid":846472,"id":"47b615cf-5e40-4ff8-8700-a48cc97a4830","component":"clickhouse-client"}~
  ~{"msg":"executing SQL query: INSERT INTO oximeter.measurements_f64 FORMAT JSONEachRow {\"datum\":1.1,\"timeseries_key\":101,\"timeseries_name\":\"foo:bar\",\"timestamp\":\"2023-10-27 00:52:35.614849622\"}","v":0,"name":"test_recall_of_all_fields","level":10,"time":"2023-10-27T00:52:35.614945438Z","hostname":"pop-os","pid":846472,"id":"47b615cf-5e40-4ff8-8700-a48cc97a4830","component":"clickhouse-client"}~
  ~{"msg":"executing SQL query: SELECT * FROM oximeter.measurements_f64 LIMIT 2 FORMAT JSONEachRow;","v":0,"name":"test_recall_of_all_fields","level":10,"time":"2023-10-27T00:52:35.624995473Z","hostname":"pop-os","pid":846472,"id":"47b615cf-5e40-4ff8-8700-a48cc97a4830","component":"clickhouse-client"}~

  ~Test output:~
  ~Object {"datum": Number(1), "timeseries_key": Number(101), "timeseries_name": String("foo:bar"), "timestamp": String("2023-10-27 00:52:35.588811834")}~
  ~Object {"datum": Number(1), "timeseries_key": Number(101), "timeseries_name": String("foo:bar"), "timestamp": String("2023-10-27 00:52:35.588811834")}~
  ~{"timeseries_name":"foo:bar","timeseries_key":101,"timestamp":"2023-10-27 00:52:35.601821001","datum":1.1}~
  
  ~Object {"datum": Number(1.1), "timeseries_key": Number(101), "timeseries_name": String("foo:bar"), "timestamp": String("2023-10-27 00:52:35.601821001")}~
  ~Object {"datum": Number(1.1), "timeseries_key": Number(101), "timeseries_name": String("foo:bar"), "timestamp": String("2023-10-27 00:52:35.601821001")}~
  ~{"timeseries_name":"foo:bar","timeseries_key":101,"timestamp":"2023-10-27 00:52:35.601821001","datum":1.100000023841858}~
  ~{"timeseries_name":"foo:bar","timeseries_key":101,"timestamp":"2023-10-27 00:52:35.614849622","datum":1.1}~

UPDATE: Tyniest of typos in the init sql file was to blame for the above bug

Related: https://github.com/oxidecomputer/omicron/issues/4148
Related: https://github.com/oxidecomputer/omicron/issues/4001