### PR TITLE
Add sagas subcommand to omdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5167,6 +5167,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "oximeter-client",
+ "petgraph",
  "pq-sys",
  "regex",
  "serde",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -26,6 +26,7 @@ nexus-db-queries.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true
 oximeter-client.workspace = true
+petgraph.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
 serde.workspace = true
@@ -39,10 +40,10 @@ tokio = { workspace = true, features = [ "full" ] }
 uuid.workspace = true
 ipnetwork.workspace = true
 omicron-workspace-hack.workspace = true
+nexus-test-utils.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true
-nexus-test-utils.workspace = true
 nexus-test-utils-macros.workspace = true
 omicron-nexus.workspace = true
 omicron-test-utils.workspace = true

--- a/nexus/db-model/src/saga_types.rs
+++ b/nexus/db-model/src/saga_types.rs
@@ -21,6 +21,8 @@ use diesel::sql_types;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
 use std::convert::TryFrom;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::io::Write;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -76,7 +78,7 @@ impl From<&SecId> for Uuid {
 /// This exists because Omicron cannot implement foreign traits
 /// for foreign types.
 #[derive(
-    AsExpression, Copy, Clone, Debug, FromSqlRow, PartialEq, PartialOrd,
+    AsExpression, Copy, Clone, Debug, FromSqlRow, PartialEq, PartialOrd, Eq,
 )]
 #[diesel(sql_type = sql_types::Uuid)]
 pub struct SagaId(pub steno::SagaId);
@@ -101,6 +103,12 @@ where
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
         let id = Uuid::from_sql(bytes)?;
         Ok(SagaId(steno::SagaId::from(id)))
+    }
+}
+
+impl Hash for SagaId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0 .0.hash(state);
     }
 }
 

--- a/nexus/db-queries/src/db/mod.rs
+++ b/nexus/db-queries/src/db/mod.rs
@@ -47,3 +47,4 @@ pub use saga_types::SecId;
 pub use sec_store::CockroachDbSecStore;
 
 pub use nexus_types::identity;
+pub use pagination::paginated;


### PR DESCRIPTION
Provide a `sagas` subcommand to omdb:

    $ ./target/debug/omdb db sagas --help
    Print information related to sagas

    Usage: omdb db sagas <COMMAND>

    Commands:
      list         List all sagas
      stuck        List sagas that failed to unwind
      show         Show the execution of a saga
      unwound      List sagas that encountered an error and successfully unwound
      failing      Show any failing nodes
      overlapping  List any sagas which overlap execution with this one
      interleave   Show multiple saga executions along a timeline
      help         Print this message or the help of the given subcommand(s)

    Options:
      -h, --help  Print help

Also, add `region` subcommand:

    $ ./target/debug/omdb db regions --help
    Print information related to regions

    Usage: omdb db regions <COMMAND>

    Commands:
      list     List all regions
      used-by  Find what is using a region
      help     Print this message or the help of the given subcommand(s)

    Options:
      -h, --help  Print help

Fixes #4157.