### PR TITLE
[update-engine] make last_seen a mutable cursor

### DIFF
--- a/update-engine/src/context.rs
+++ b/update-engine/src/context.rs
@@ -242,8 +242,7 @@ impl NestedEventBuffer {
         report: EventReport<S>,
     ) -> EventReport<NestedSpec> {
         self.buffer.add_event_report(report.into_generic());
-        let ret = self.buffer.generate_report_since(self.last_seen);
-        self.last_seen = ret.last_seen;
+        let ret = self.buffer.generate_report_since(&mut self.last_seen);
         ret
     }
 }


### PR DESCRIPTION
All correct uses of incremental report generation must update the external `last_seen` cursor. To guarantee that, make last_seen be `&mut Option<usize>`, and effectively an inout parameter.
