### PR TITLE
Update `how-to-run.adoc` post-BGP

### DIFF
--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -274,6 +274,8 @@ You will also need to update route information if your `$GATEWAY_IP` differs fro
 # outside.  This block assumes that you're following option (2) above: putting
 # your Oxide system on an existing network that you control.
 [rack_network_config]
+# An internal-only IPv6 address block which contains AZ-wide services.
+# This does not need to be changed.
 rack_subnet = "fd00:1122:3344:01::/56"
 # A range of IP addresses used by Boundary Services on the network.  In a real
 # system, these would be addresses of the uplink ports on the Sidecar.  With
@@ -282,6 +284,10 @@ infra_ip_first = "192.168.1.30"
 infra_ip_last = "192.168.1.30"
 
 # Configurations for BGP routers to run on the scrimlets.
+# This array can typically be safely left empty for home/local use,
+# otherwise this is a list of { asn: u32, originate: ["<v4 subnet>"] }
+# structs which will be be inserted when Nexus is started by sled-agent.
+# see: common/src/api/internal/shared.rs – BgpConfig
 bgp = []
 
 [[rack_network_config.ports]]

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -266,26 +266,44 @@ last = "192.168.1.29"
 
 This is a range of IP addresses on your external network that Omicron can assign to externally-facing services (like DNS and the API).  You'll need to change these if you've picked different addresses for your external network.  See <<_external_networking>> above for more on this.
 
+You will also need to update route information if your `$GATEWAY_IP` differs from the default:
+
 [source,toml]
 ----
 # Configuration to bring up boundary services and make Nexus reachable from the
 # outside.  This block assumes that you're following option (2) above: putting
 # your Oxide system on an existing network that you control.
 [rack_network_config]
-# The gateway for the external network
-gateway_ip = "192.168.1.199"
+rack_subnet = "fd00:1122:3344:01::/56"
 # A range of IP addresses used by Boundary Services on the network.  In a real
 # system, these would be addresses of the uplink ports on the Sidecar.  With
 # softnpu, only one address is used.
 infra_ip_first = "192.168.1.30"
 infra_ip_last = "192.168.1.30"
-# Name of the port.  This should always be "qsfp0" when using softnpu.
-uplink_port = "qsfp0"
-uplink_port_speed = "40G"
-uplink_port_fec="none"
+
+# Configurations for BGP routers to run on the scrimlets.
+bgp = []
+
+[[rack_network_config.ports]]
+# Routes associated with this port.
+# NOTE: The below `nexthop` should be set to $GATEWAY_IP for your configuration
+routes = [{nexthop = "192.168.1.199", destination = "0.0.0.0/0"}]
+# Addresses associated with this port.
 # For softnpu, an address within the "infra" block above that will be used for
 # the softnpu uplink port.  You can just pick the first address in that pool.
-uplink_ip = "192.168.1.30"
+addresses = ["192.168.1.30/32"]
+# Name of the uplink port.  This should always be "qsfp0" when using softnpu.
+port = "qsfp0"
+# The speed of this port.
+uplink_port_speed = "40G"
+# The forward error correction mode for this port.
+uplink_port_fec="none"
+# Switch to use for the uplink. For single-rack deployments this can be
+# "switch0" (upper slot) or "switch1" (lower slot). For single-node softnpu
+# and dendrite stub environments, use "switch0"
+switch = "switch0"
+# Neighbors we expect to peer with over BGP on this port.
+bgp_peers = []
 ----
 
 In some configurations (not the one described here), it may be necessary to update `smf/sled-agent/$MACHINE/config.toml`:

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -266,7 +266,8 @@ last = "192.168.1.29"
 
 This is a range of IP addresses on your external network that Omicron can assign to externally-facing services (like DNS and the API).  You'll need to change these if you've picked different addresses for your external network.  See <<_external_networking>> above for more on this.
 
-You will also need to update route information if your `$GATEWAY_IP` differs from the default:
+You will also need to update route information if your `$GATEWAY_IP` differs from the default.
+The below example demonstrates a single static gateway route; in-depth explanations for testing with BGP can be found https://docs.oxide.computer/guides/system/network-preparations#_rack_switch_configuration_with_bgp[in the Network Preparations guide] and https://docs.oxide.computer/guides/operator/configuring-bgp[the Configuring BGP guide]:
 
 [source,toml]
 ----
@@ -287,8 +288,7 @@ infra_ip_last = "192.168.1.30"
 # This array can typically be safely left empty for home/local use,
 # otherwise this is a list of { asn: u32, originate: ["<v4 network>"] }
 # structs which will be be inserted when Nexus is started by sled-agent.
-# These prefixes will be advertised to peers set below.
-# see: common/src/api/internal/shared.rs – BgpConfig
+# See the 'Network Preparations' guide linked above.
 bgp = []
 
 [[rack_network_config.ports]]

--- a/docs/how-to-run.adoc
+++ b/docs/how-to-run.adoc
@@ -285,8 +285,9 @@ infra_ip_last = "192.168.1.30"
 
 # Configurations for BGP routers to run on the scrimlets.
 # This array can typically be safely left empty for home/local use,
-# otherwise this is a list of { asn: u32, originate: ["<v4 subnet>"] }
+# otherwise this is a list of { asn: u32, originate: ["<v4 network>"] }
 # structs which will be be inserted when Nexus is started by sled-agent.
+# These prefixes will be advertised to peers set below.
 # see: common/src/api/internal/shared.rs – BgpConfig
 bgp = []
 
@@ -309,6 +310,7 @@ uplink_port_fec="none"
 # and dendrite stub environments, use "switch0"
 switch = "switch0"
 # Neighbors we expect to peer with over BGP on this port.
+# see: common/src/api/internal/shared.rs – BgpPeerConfig
 bgp_peers = []
 ----
 


### PR DESCRIPTION
Small edits needed to bring this in line with how routes are configured now. `gateway_ip` is no longer explicitly named as such, so I've added an explicit comment to signpost how $GATEWAY_IP should be used w.r.t. the default route.