### PR TITLE
Various volume management fixes

### DIFF
--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -457,7 +457,7 @@ impl DataStore {
     /// snapshots.
     pub async fn find_deleted_volume_regions(
         &self,
-    ) -> ListResultVec<(Dataset, Region, Volume)> {
+    ) -> ListResultVec<(Dataset, Region, Option<RegionSnapshot>, Volume)> {
         use db::schema::dataset::dsl as dataset_dsl;
         use db::schema::region::dsl as region_dsl;
         use db::schema::region_snapshot::dsl;
@@ -494,6 +494,7 @@ impl DataStore {
             .select((
                 Dataset::as_select(),
                 Region::as_select(),
+                Option::<RegionSnapshot>::as_select(),
                 Volume::as_select(),
             ))
             .load_async(&*self.pool_connection_unauthorized().await?)

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -252,27 +252,23 @@ pub(super) async fn delete_crucible_region(
             match region.state {
                 RegionState::Tombstoned => {
                     Err(BackoffError::transient(WaitError::Transient(anyhow!(
-                        "region {} not deleted yet",
-                        region_id.to_string(),
+                        "region {region_id} not deleted yet",
                     ))))
                 }
 
                 RegionState::Destroyed => {
-                    info!(log, "region {} deleted", region_id.to_string(),);
+                    info!(log, "region {region_id} deleted");
 
                     Ok(())
                 }
 
-                _ => {
-                    Err(BackoffError::transient(WaitError::Transient(anyhow!(
-                        "region {} unexpected state",
-                        region_id.to_string(),
-                    ))))
-                }
+                _ => Err(BackoffError::transient(WaitError::Transient(
+                    anyhow!("region {region_id} unexpected state"),
+                ))),
             }
         },
         |e: WaitError, delay| {
-            info!(log, "{:?}, trying again in {:?}", e, delay,);
+            info!(log, "{:?}, trying again in {:?}", e, delay);
         },
     )
     .await
@@ -409,9 +405,7 @@ pub(super) async fn delete_crucible_running_snapshot(
                 Some(running_snapshot) => {
                     info!(
                         log,
-                        "region {} snapshot {} running_snapshot is Some, state is {}",
-                        region_id.to_string(),
-                        snapshot_id.to_string(),
+                        "region {region_id} snapshot {snapshot_id} running_snapshot is Some, state is {}",
                         running_snapshot.state.to_string(),
                     );
 
@@ -419,9 +413,7 @@ pub(super) async fn delete_crucible_running_snapshot(
                         RegionState::Tombstoned => {
                             Err(BackoffError::transient(
                                 WaitError::Transient(anyhow!(
-                                    "region {} snapshot {} running_snapshot not deleted yet",
-                                    region_id.to_string(),
-                                    snapshot_id.to_string(),
+                                    "region {region_id} snapshot {snapshot_id} running_snapshot not deleted yet",
                                 )
                             )))
                         }
@@ -429,9 +421,7 @@ pub(super) async fn delete_crucible_running_snapshot(
                         RegionState::Destroyed => {
                             info!(
                                 log,
-                                "region {} snapshot {} running_snapshot deleted",
-                                region_id.to_string(),
-                                snapshot_id.to_string(),
+                                "region {region_id} snapshot {snapshot_id} running_snapshot deleted",
                             );
 
                             Ok(())
@@ -440,9 +430,7 @@ pub(super) async fn delete_crucible_running_snapshot(
                         _ => {
                             Err(BackoffError::transient(
                                 WaitError::Transient(anyhow!(
-                                    "region {} snapshot {} running_snapshot unexpected state",
-                                    region_id.to_string(),
-                                    snapshot_id.to_string(),
+                                    "region {region_id} snapshot {snapshot_id} running_snapshot unexpected state",
                                 )
                             )))
                         }
@@ -453,9 +441,7 @@ pub(super) async fn delete_crucible_running_snapshot(
                     // deleted?
                     info!(
                         log,
-                        "region {} snapshot {} running_snapshot is None",
-                        region_id.to_string(),
-                        snapshot_id.to_string(),
+                        "region {region_id} snapshot {snapshot_id} running_snapshot is None",
                     );
 
                     // break here - it's possible that the running snapshot
@@ -500,12 +486,7 @@ pub(super) async fn delete_crucible_snapshot(
     // effect right away. Wait until the snapshot no longer appears in the list
     // of region snapshots, meaning it was not returned from `zfs list`.
 
-    info!(
-        log,
-        "deleting region {} snapshot {}",
-        region_id.to_string(),
-        snapshot_id.to_string(),
-    );
+    info!(log, "deleting region {region_id} snapshot {snapshot_id}");
 
     retry_until_known_result(log, || async {
         client
@@ -588,22 +569,16 @@ pub(super) async fn delete_crucible_snapshot(
             {
                 info!(
                     log,
-                    "region {} snapshot {} still exists, waiting",
-                    region_id.to_string(),
-                    snapshot_id.to_string(),
+                    "region {region_id} snapshot {snapshot_id} still exists, waiting",
                 );
 
                 Err(BackoffError::transient(WaitError::Transient(anyhow!(
-                    "region {} snapshot {} not deleted yet",
-                    region_id.to_string(),
-                    snapshot_id.to_string(),
+                    "region {region_id} snapshot {snapshot_id} not deleted yet",
                 ))))
             } else {
                 info!(
                     log,
-                    "region {} snapshot {} deleted",
-                    region_id.to_string(),
-                    snapshot_id.to_string(),
+                    "region {region_id} snapshot {snapshot_id} deleted",
                 );
 
                 Ok(())
@@ -744,10 +719,8 @@ pub(crate) async fn call_pantry_attach_for_disk(
 
     info!(
         log,
-        "sending attach for disk {} volume {} to endpoint {}",
-        disk_id,
+        "sending attach for disk {disk_id} volume {} to endpoint {endpoint}",
         disk.volume_id,
-        endpoint,
     );
 
     let volume_construction_request: crucible_pantry_client::types::VolumeConstructionRequest =
@@ -783,7 +756,7 @@ pub(crate) async fn call_pantry_detach_for_disk(
 ) -> Result<(), ActionError> {
     let endpoint = format!("http://{}", pantry_address);
 
-    info!(log, "sending detach for disk {} to endpoint {}", disk_id, endpoint,);
+    info!(log, "sending detach for disk {disk_id} to endpoint {endpoint}");
 
     let client = crucible_pantry_client::Client::new(&endpoint);
 

--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -406,9 +406,6 @@ async fn svd_delete_crucible_snapshot_records(
 async fn svd_delete_freed_crucible_regions(
     sagactx: NexusActionContext,
 ) -> Result<(), ActionError> {
-    // bail!
-    return Ok(());
-
     let log = sagactx.user_data().log();
     let osagactx = sagactx.user_data();
 


### PR DESCRIPTION
This commit bundles up a few fixes related to volume management:

- `find_deleted_volume_regions` now returns the `Option<RegionSnapshot>` that resulted from the `left_join` in the query for freed regions. This is then consulted to see if sending a DELETE for that region is safe: if the `Option` is `Some`, then the region snapshot has not been deleted yet, and sending a region DELETE will surely result in a `must delete snapshots first` error from the corresponding Crucible agent.

- Fix a few typos in nexus/src/app/sagas/common_storage.rs

- Nexus now waits for the Agent's `zfs destroy` of a snapshot to take place. Otherwise if illumos doesn't immediately remove the snapshot it may be returned by a subsequent `zfs list` later.

- Either `decrease_crucible_resource_count_and_soft_delete_volume` or `volume_hard_delete` should be called when unwinding a saga, calling both is not required.

- In the snapshot deletion saga, use `append_parallel` for the two volume delete sub sagas: in order to _not_ orphan Crucible resources, it's important that both volumes be soft deleted, and that failing to delete one volume's Crucible resources does not cause the other to _not_ be soft deleted.

- Also fix a very confusing typo when building the destination volume delete sub saga.