### PR TITLE
[update-engine] ensure in-order processing of events

### DIFF
--- a/update-engine/src/context.rs
+++ b/update-engine/src/context.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Mutex;
 use std::{collections::HashMap, fmt};
@@ -11,6 +12,7 @@ use std::{collections::HashMap, fmt};
 use derive_where::derive_where;
 use futures::FutureExt;
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
 
 use crate::errors::NestedEngineError;
 use crate::{
@@ -56,10 +58,13 @@ impl<S: StepSpec> StepContext<S> {
     /// Sends a progress update to the update engine.
     #[inline]
     pub async fn send_progress(&self, progress: StepProgress<S>) {
+        let now = Instant::now();
+        let (done, done_rx) = oneshot::channel::<Infallible>();
         self.payload_sender
-            .send(StepContextPayload::Progress(progress))
+            .send(StepContextPayload::Progress { now, progress, done })
             .await
-            .expect("our code always keeps the receiver open")
+            .expect("our code always keeps the receiver open");
+        _ = done_rx.await;
     }
 
     /// Sends a report from a nested engine, typically one running on a remote
@@ -71,6 +76,8 @@ impl<S: StepSpec> StepContext<S> {
         &self,
         report: EventReport<S2>,
     ) -> Result<(), NestedEngineError<NestedSpec>> {
+        let now = Instant::now();
+
         let mut res = Ok(());
         let delta_report = if let Some(id) = report.root_execution_id {
             let mut nested_buffers = self.nested_buffers.lock().unwrap();
@@ -134,17 +141,32 @@ impl<S: StepSpec> StepContext<S> {
                 }
 
                 self.payload_sender
-                    .send(StepContextPayload::Nested(Event::Step(event)))
+                    .send(StepContextPayload::Nested {
+                        now,
+                        event: Event::Step(event),
+                    })
                     .await
                     .expect("our code always keeps the receiver open");
             }
 
             for event in delta_report.progress_events {
                 self.payload_sender
-                    .send(StepContextPayload::Nested(Event::Progress(event)))
+                    .send(StepContextPayload::Nested {
+                        now,
+                        event: Event::Progress(event),
+                    })
                     .await
                     .expect("our code always keeps the receiver open");
             }
+
+            // Ensure that all reports have been received by the engine before
+            // returning.
+            let (done, done_rx) = oneshot::channel();
+            self.payload_sender
+                .send(StepContextPayload::Sync { done })
+                .await
+                .expect("our code always keeps the receiver open");
+            _ = done_rx.await;
         }
 
         res
@@ -163,58 +185,76 @@ impl<S: StepSpec> StepContext<S> {
         F: FnOnce(&mut UpdateEngine<'a, S2>) -> Result<(), S2::Error> + Send,
         S2: StepSpec + 'a,
     {
-        let (sender, mut receiver) = mpsc::channel(128);
-        let mut engine = UpdateEngine::new(&self.log, sender);
+        // Previously, this code was of the form:
+        //
+        //     let (sender, mut receiver) = mpsc::channel(128);
+        //     let mut engine = UpdateEngine::new(&self.log, sender);
+        //
+        // And there was a loop below that selected over `engine` and
+        // `receiver`.
+        //
+        // That approach was abandoned because it had ordering issues, because
+        // it wasn't guaranteed that events were received in the order they were
+        // processed. For example, consider what happens if:
+        //
+        // 1. User code sent an event E1 through a child (nested) StepContext.
+        // 2. Then in quick succession, the same code sent an event E2 through
+        //    self.
+        //
+        // What users would expect to happen is that E1 is received before E2.
+        // However, what actually happened was that:
+        //
+        // 1. `engine` was driven until the next suspend point. This caused E2
+        //    to be sent.
+        // 2. Then, `receiver` was polled. This caused E1 to be received.
+        //
+        // So the order of events was reversed.
+        //
+        // To fix this, we now use a single channel, and send events through it
+        // both from the nested engine and from self.
+        //
+        // An alternative would be to use a oneshot channel as a synchronization
+        // tool. However, just sharing a channel is easier.
+        let mut engine = UpdateEngine::<S2>::new_nested(
+            &self.log,
+            self.payload_sender.clone(),
+        );
+
         // Create the engine's steps.
         (engine_fn)(&mut engine)
             .map_err(|error| NestedEngineError::Creation { error })?;
 
         // Now run the engine.
         let engine = engine.execute();
-        tokio::pin!(engine);
-
-        let mut result = None;
-        let mut events_done = false;
-
-        loop {
-            tokio::select! {
-                ret = &mut engine, if result.is_none() => {
-                    match ret {
-                        Ok(cx) => {
-                            result = Some(Ok(cx));
-                        }
-                        Err(ExecutionError::EventSendError(_)) => {
-                            unreachable!("we always keep the receiver open")
-                        }
-                        Err(ExecutionError::StepFailed { component, id, description, error }) => {
-                            result = Some(Err(NestedEngineError::StepFailed { component, id, description, error }));
-                        }
-                        Err(ExecutionError::Aborted { component, id, description, message }) => {
-                            result = Some(Err(NestedEngineError::Aborted { component, id, description, message }));
-                        }
-                    }
-                }
-                event = receiver.recv(), if !events_done => {
-                    match event {
-                        Some(event) => {
-                            self.payload_sender.send(
-                                StepContextPayload::Nested(event.into_generic())
-                            )
-                            .await
-                            .expect("we always keep the receiver open");
-                        }
-                        None => {
-                            events_done = true;
-                        }
-                    }
-                }
-                else => {
-                    break;
-                }
+        match engine.await {
+            Ok(cx) => Ok(cx),
+            Err(ExecutionError::EventSendError(_))
+            | Err(ExecutionError::NestedSendError(_)) => {
+                unreachable!("payload_receiver is always kept open")
             }
+            Err(ExecutionError::StepFailed {
+                component,
+                id,
+                description,
+                error,
+            }) => Err(NestedEngineError::StepFailed {
+                component,
+                id,
+                description,
+                error,
+            }),
+            Err(ExecutionError::Aborted {
+                component,
+                id,
+                description,
+                message,
+            }) => Err(NestedEngineError::Aborted {
+                component,
+                id,
+                description,
+                message,
+            }),
         }
-
-        result.expect("the loop only exits if result is set")
     }
 
     /// Retrieves a token used to fetch the value out of a [`StepHandle`].
@@ -249,8 +289,18 @@ impl NestedEventBuffer {
 
 #[derive_where(Debug)]
 pub(crate) enum StepContextPayload<S: StepSpec> {
-    Progress(StepProgress<S>),
-    Nested(Event<NestedSpec>),
+    Progress {
+        now: Instant,
+        progress: StepProgress<S>,
+        done: oneshot::Sender<Infallible>,
+    },
+    Nested {
+        now: Instant,
+        event: Event<NestedSpec>,
+    },
+    Sync {
+        done: oneshot::Sender<Infallible>,
+    },
 }
 
 /// Context for a step's metadata-generation function.

--- a/update-engine/src/engine.rs
+++ b/update-engine/src/engine.rs
@@ -5,7 +5,12 @@
 // Copyright 2023 Oxide Computer Company
 
 use std::{
-    borrow::Cow, fmt, ops::ControlFlow, pin::Pin, sync::Mutex, task::Poll,
+    borrow::Cow,
+    fmt,
+    ops::ControlFlow,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::Poll,
 };
 
 use cancel_safe_futures::coop_cancel;
@@ -64,7 +69,7 @@ pub struct UpdateEngine<'a, S: StepSpec> {
     // be a graph in the future.
     log: slog::Logger,
     execution_id: ExecutionId,
-    sender: mpsc::Sender<Event<S>>,
+    sender: EngineSender<S>,
 
     // This is set to None in Self::execute.
     canceler: Option<coop_cancel::Canceler<String>>,
@@ -82,6 +87,21 @@ pub struct UpdateEngine<'a, S: StepSpec> {
 impl<'a, S: StepSpec + 'a> UpdateEngine<'a, S> {
     /// Creates a new `UpdateEngine`.
     pub fn new(log: &slog::Logger, sender: mpsc::Sender<Event<S>>) -> Self {
+        let sender = Arc::new(DefaultSender { sender });
+        Self::new_impl(log, EngineSender { sender })
+    }
+
+    // See the comment on `StepContext::with_nested_engine` for why this is
+    // necessary.``
+    pub(crate) fn new_nested<S2: StepSpec>(
+        log: &slog::Logger,
+        sender: mpsc::Sender<StepContextPayload<S2>>,
+    ) -> Self {
+        let sender = Arc::new(NestedSender { sender });
+        Self::new_impl(log, EngineSender { sender })
+    }
+
+    fn new_impl(log: &slog::Logger, sender: EngineSender<S>) -> Self {
         let execution_id = ExecutionId(Uuid::new_v4());
         let (canceler, cancel_receiver) = coop_cancel::new_pair();
         Self {
@@ -300,6 +320,88 @@ impl<'a, S: StepSpec + 'a> UpdateEngine<'a, S> {
         reporter.last_step(step_res).await?;
 
         Ok(CompletionContext::new())
+    }
+}
+
+/// Abstraction used to send events to whatever receiver is interested in them.
+///
+/// # Why is this type so weird?
+///
+/// `EngineSender` is a wrapper around a cloneable trait object. Why do we need
+/// that?
+///
+/// `SenderImpl` has two implementations:
+///
+/// 1. `DefaultSender`, which is a wrapper around an `mpsc::Sender<Event<S>>`.
+///    This is used when the receiver is user code.
+/// 2. `NestedSender`, which is a more complex wrapper around an
+///    `mpsc::Sender<StepContextPayload<S>>`.
+///
+/// You might imagine that we could just have `EngineSender` be an enum with
+/// these two variants. But we actually want `NestedSender<S>` to implement
+/// `SenderImpl<S>` for *any* StepSpec, not just `S`, to allow nested engines to
+/// be a different StepSpec than the outer engine.
+///
+/// So we need to use a trait object to achieve type erasure.
+#[derive_where(Clone, Debug)]
+struct EngineSender<S: StepSpec> {
+    sender: Arc<dyn SenderImpl<S>>,
+}
+
+impl<S: StepSpec> EngineSender<S> {
+    async fn send(&self, event: Event<S>) -> Result<(), ExecutionError<S>> {
+        self.sender.send(event).await
+    }
+}
+
+trait SenderImpl<S: StepSpec>: Send + Sync + fmt::Debug {
+    fn send(
+        &self,
+        event: Event<S>,
+    ) -> BoxFuture<'_, Result<(), ExecutionError<S>>>;
+}
+
+#[derive_where(Debug)]
+struct DefaultSender<S: StepSpec> {
+    sender: mpsc::Sender<Event<S>>,
+}
+
+impl<S: StepSpec> SenderImpl<S> for DefaultSender<S> {
+    fn send(
+        &self,
+        event: Event<S>,
+    ) -> BoxFuture<'_, Result<(), ExecutionError<S>>> {
+        self.sender.send(event).map_err(|error| error.into()).boxed()
+    }
+}
+
+#[derive_where(Debug)]
+struct NestedSender<S: StepSpec> {
+    sender: mpsc::Sender<StepContextPayload<S>>,
+}
+
+// Note that NestedSender<S> implements SenderImpl<S2> for any S2: StepSpec.
+// That is to allow nested engines to implement arbitrary StepSpecs.
+impl<S: StepSpec, S2: StepSpec> SenderImpl<S2> for NestedSender<S> {
+    fn send(
+        &self,
+        event: Event<S2>,
+    ) -> BoxFuture<'_, Result<(), ExecutionError<S2>>> {
+        let now = Instant::now();
+        self.sender
+            .send(StepContextPayload::Nested {
+                now,
+                event: event.into_generic(),
+            })
+            .map_err(|error| {
+                // Extract the event from the error.
+                let event = match error.0 {
+                    StepContextPayload::Nested { event, .. } => event,
+                    _ => unreachable!("we just sent a Nested event"),
+                };
+                ExecutionError::NestedSendError(mpsc::error::SendError(event))
+            })
+            .boxed()
     }
 }
 
@@ -868,14 +970,14 @@ struct ExecutionContext<S: StepSpec, F> {
     execution_id: ExecutionId,
     next_event_index: DebugIgnore<F>,
     total_start: Instant,
-    sender: mpsc::Sender<Event<S>>,
+    sender: EngineSender<S>,
 }
 
 impl<S: StepSpec, F> ExecutionContext<S, F> {
     fn new(
         execution_id: ExecutionId,
         next_event_index: F,
-        sender: mpsc::Sender<Event<S>>,
+        sender: EngineSender<S>,
     ) -> Self {
         let total_start = Instant::now();
         Self {
@@ -906,7 +1008,7 @@ struct StepExecutionContext<S: StepSpec, F> {
     next_event_index: DebugIgnore<F>,
     total_start: Instant,
     step_info: StepInfoWithMetadata<S>,
-    sender: mpsc::Sender<Event<S>>,
+    sender: EngineSender<S>,
 }
 
 type StepMetadataFn<'a, S> = Box<
@@ -941,7 +1043,7 @@ struct StepProgressReporter<S: StepSpec, F> {
     step_start: Instant,
     attempt: usize,
     attempt_start: Instant,
-    sender: mpsc::Sender<Event<S>>,
+    sender: EngineSender<S>,
 }
 
 impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
@@ -963,51 +1065,61 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
     async fn handle_payload(
         &mut self,
         payload: StepContextPayload<S>,
-    ) -> Result<(), mpsc::error::SendError<Event<S>>> {
+    ) -> Result<(), ExecutionError<S>> {
         match payload {
-            StepContextPayload::Progress(progress) => {
-                self.handle_progress(progress).await
+            StepContextPayload::Progress { now, progress, done } => {
+                self.handle_progress(now, progress).await?;
+                std::mem::drop(done);
             }
-            StepContextPayload::Nested(Event::Step(event)) => {
+            StepContextPayload::Nested { now, event: Event::Step(event) } => {
                 self.sender
                     .send(Event::Step(StepEvent {
                         spec: S::schema_name(),
                         execution_id: self.execution_id,
                         event_index: (self.next_event_index)(),
-                        total_elapsed: self.total_start.elapsed(),
+                        total_elapsed: now - self.total_start,
                         kind: StepEventKind::Nested {
                             step: self.step_info.clone(),
                             attempt: self.attempt,
                             event: Box::new(event),
-                            step_elapsed: self.step_start.elapsed(),
-                            attempt_elapsed: self.attempt_start.elapsed(),
+                            step_elapsed: now - self.step_start,
+                            attempt_elapsed: now - self.attempt_start,
                         },
                     }))
-                    .await
+                    .await?;
             }
-            StepContextPayload::Nested(Event::Progress(event)) => {
+            StepContextPayload::Nested {
+                now,
+                event: Event::Progress(event),
+            } => {
                 self.sender
                     .send(Event::Progress(ProgressEvent {
                         spec: S::schema_name(),
                         execution_id: self.execution_id,
-                        total_elapsed: self.total_start.elapsed(),
+                        total_elapsed: now - self.total_start,
                         kind: ProgressEventKind::Nested {
                             step: self.step_info.clone(),
                             attempt: self.attempt,
                             event: Box::new(event),
-                            step_elapsed: self.step_start.elapsed(),
-                            attempt_elapsed: self.attempt_start.elapsed(),
+                            step_elapsed: now - self.step_start,
+                            attempt_elapsed: now - self.attempt_start,
                         },
                     }))
-                    .await
+                    .await?;
+            }
+            StepContextPayload::Sync { done } => {
+                std::mem::drop(done);
             }
         }
+
+        Ok(())
     }
 
     async fn handle_progress(
         &mut self,
+        now: Instant,
         progress: StepProgress<S>,
-    ) -> Result<(), mpsc::error::SendError<Event<S>>> {
+    ) -> Result<(), ExecutionError<S>> {
         match progress {
             StepProgress::Progress { progress, metadata } => {
                 // Send the progress to the sender.
@@ -1015,14 +1127,14 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
                     .send(Event::Progress(ProgressEvent {
                         spec: S::schema_name(),
                         execution_id: self.execution_id,
-                        total_elapsed: self.total_start.elapsed(),
+                        total_elapsed: now - self.total_start,
                         kind: ProgressEventKind::Progress {
                             step: self.step_info.clone(),
                             attempt: self.attempt,
                             progress,
                             metadata,
-                            step_elapsed: self.step_start.elapsed(),
-                            attempt_elapsed: self.attempt_start.elapsed(),
+                            step_elapsed: now - self.step_start,
+                            attempt_elapsed: now - self.attempt_start,
                         },
                     }))
                     .await
@@ -1034,13 +1146,13 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
                         spec: S::schema_name(),
                         execution_id: self.execution_id,
                         event_index: (self.next_event_index)(),
-                        total_elapsed: self.total_start.elapsed(),
+                        total_elapsed: now - self.total_start,
                         kind: StepEventKind::ProgressReset {
                             step: self.step_info.clone(),
                             attempt: self.attempt,
                             metadata,
-                            step_elapsed: self.step_start.elapsed(),
-                            attempt_elapsed: self.attempt_start.elapsed(),
+                            step_elapsed: now - self.step_start,
+                            attempt_elapsed: now - self.attempt_start,
                             message,
                         },
                     }))
@@ -1049,7 +1161,7 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
             StepProgress::Retry { message } => {
                 // Retry this step.
                 self.attempt += 1;
-                let attempt_elapsed = self.attempt_start.elapsed();
+                let attempt_elapsed = now - self.attempt_start;
                 self.attempt_start = Instant::now();
 
                 // Send the retry message.
@@ -1058,11 +1170,11 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
                         spec: S::schema_name(),
                         execution_id: self.execution_id,
                         event_index: (self.next_event_index)(),
-                        total_elapsed: self.total_start.elapsed(),
+                        total_elapsed: now - self.total_start,
                         kind: StepEventKind::AttemptRetry {
                             step: self.step_info.clone(),
                             next_attempt: self.attempt,
-                            step_elapsed: self.step_start.elapsed(),
+                            step_elapsed: now - self.step_start,
                             attempt_elapsed,
                             message,
                         },
@@ -1187,7 +1299,7 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
     async fn send_error(
         mut self,
         error: &S::Error,
-    ) -> Result<(), mpsc::error::SendError<Event<S>>> {
+    ) -> Result<(), ExecutionError<S>> {
         // Stringify `error` into a message + list causes; this is written the
         // way it is to avoid `error` potentially living across the `.await`
         // below (which can cause lifetime issues in callers).

--- a/update-engine/src/engine.rs
+++ b/update-engine/src/engine.rs
@@ -1227,7 +1227,7 @@ impl<S: StepSpec, F: FnMut() -> usize> StepProgressReporter<S, F> {
                 description: self.step_info.info.description.clone(),
                 message: message,
             },
-            Err(error) => error.into(),
+            Err(error) => error,
         }
     }
 

--- a/update-engine/src/errors.rs
+++ b/update-engine/src/errors.rs
@@ -11,7 +11,7 @@ use std::{borrow::Cow, collections::VecDeque, error, fmt};
 use derive_where::derive_where;
 use tokio::sync::mpsc;
 
-use crate::{events::Event, AsError, NestedSpec, StepSpec};
+use crate::{events::Event, AsError, StepSpec};
 
 // NOTE: have to hand write `ExecutionError` and `NestedEngineError` impls
 // because #[source] doesn't work for AsError.
@@ -32,7 +32,6 @@ pub enum ExecutionError<S: StepSpec> {
         message: String,
     },
     EventSendError(mpsc::error::SendError<Event<S>>),
-    NestedSendError(mpsc::error::SendError<Event<NestedSpec>>),
 }
 
 impl<S: StepSpec> fmt::Display for ExecutionError<S> {
@@ -51,9 +50,6 @@ impl<S: StepSpec> fmt::Display for ExecutionError<S> {
             Self::EventSendError(_) => {
                 write!(f, "while sending event, event receiver dropped")
             }
-            Self::NestedSendError(_) => {
-                write!(f, "while sending nested event, event receiver dropped")
-            }
         }
     }
 }
@@ -64,9 +60,6 @@ impl<S: StepSpec> error::Error for ExecutionError<S> {
             ExecutionError::StepFailed { error, .. } => Some(error.as_error()),
             ExecutionError::Aborted { .. } => None,
             ExecutionError::EventSendError(error) => {
-                Some(error as &(dyn error::Error + 'static))
-            }
-            ExecutionError::NestedSendError(error) => {
                 Some(error as &(dyn error::Error + 'static))
             }
         }

--- a/update-engine/src/spec.rs
+++ b/update-engine/src/spec.rs
@@ -15,7 +15,7 @@ use serde::{de::DeserializeOwned, Serialize};
 ///
 /// NOTE: `StepSpec` is only required to implement `JsonSchema` to obtain the
 /// name of the schema. This is an upstream limitation in `JsonSchema`.
-pub trait StepSpec: JsonSchema + Send {
+pub trait StepSpec: JsonSchema + Send + 'static {
     /// A component associated with each step.
     type Component: Clone
         + fmt::Debug
@@ -183,7 +183,7 @@ impl AsError for NestedError {
 /// Trait that abstracts over concrete errors and `anyhow::Error`.
 ///
 /// This needs to be manually implemented for any custom error types.
-pub trait AsError: fmt::Debug + Send + Sync {
+pub trait AsError: fmt::Debug + Send + Sync + 'static {
     fn as_error(&self) -> &(dyn std::error::Error + 'static);
 }
 


### PR DESCRIPTION
Previously, there were situations where events could be received out of
order. Solve this in two different ways:

* For nested engines, send data over the payload channel rather than
  having another channel in between.
* For `send_progress` and `send_nested_report`, use a oneshot channel to
  synchronize state before returning. (Trying to use a solution similar
  to the one for nested engines ends up being very difficult--since
  the overall channel is user-controlled, what happens if it errors
  out? Retaining the payload channel makes those errors easier to
  handle.)

Make a couple of other related changes:

* Determine `now` for events as soon as the function is called, and include it in the payload.
* The particular arrangement of code required a bunch of `'static` annotations, so include them. These shouldn't be an issue since `StepSpec`s are typically uninhabited types and errors are almost always `'static`.

The test ensures this -- it was failing before this PR and succeeds
after it.
