### PR TITLE
Implement ClickHouse replicated cluster option for simulated omicron

### DIFF
--- a/dev-tools/omicron-dev/src/bin/omicron-dev.rs
+++ b/dev-tools/omicron-dev/src/bin/omicron-dev.rs
@@ -338,12 +338,11 @@ async fn start_replicated_cluster() -> Result<(), anyhow::Error> {
     let mut signal_stream = signals.fuse();
 
     // Start the database server and keeper processes
-    let cur_dir = std::env::current_dir().unwrap();
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let replica_config =
-        cur_dir.as_path().join("oximeter/db/src/configs/replica_config.xml");
-    let cur_dir = std::env::current_dir().unwrap();
+        manifest_dir.as_path().join("../../oximeter/db/src/configs/replica_config.xml");
     let keeper_config =
-        cur_dir.as_path().join("oximeter/db/src/configs/keeper_config.xml");
+        manifest_dir.as_path().join("../../oximeter/db/src/configs/keeper_config.xml");
 
     let mut cluster =
         dev::clickhouse::ClickHouseCluster::new(replica_config, keeper_config)
@@ -356,7 +355,8 @@ async fn start_replicated_cluster() -> Result<(), anyhow::Error> {
     );
     let pid_error_msg = "Failed to get process PID, it may not have started";
     println!(
-        "omicron-dev: ClickHouse cluster is running with PIDs: {}, {}, {}, {}, {}",
+        "omicron-dev: ClickHouse cluster is running with: server PIDs = [{}, {}] \
+        and keeper PIDs = [{}, {}, {}]",
         cluster.replica_1
             .pid()
             .expect(pid_error_msg),

--- a/dev-tools/omicron-dev/src/bin/omicron-dev.rs
+++ b/dev-tools/omicron-dev/src/bin/omicron-dev.rs
@@ -339,10 +339,12 @@ async fn start_replicated_cluster() -> Result<(), anyhow::Error> {
 
     // Start the database server and keeper processes
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let replica_config =
-        manifest_dir.as_path().join("../../oximeter/db/src/configs/replica_config.xml");
-    let keeper_config =
-        manifest_dir.as_path().join("../../oximeter/db/src/configs/keeper_config.xml");
+    let replica_config = manifest_dir
+        .as_path()
+        .join("../../oximeter/db/src/configs/replica_config.xml");
+    let keeper_config = manifest_dir
+        .as_path()
+        .join("../../oximeter/db/src/configs/keeper_config.xml");
 
     let mut cluster =
         dev::clickhouse::ClickHouseCluster::new(replica_config, keeper_config)

--- a/dev-tools/omicron-dev/src/bin/omicron-dev.rs
+++ b/dev-tools/omicron-dev/src/bin/omicron-dev.rs
@@ -288,7 +288,7 @@ async fn start_single_node(port: u16) -> Result<(), anyhow::Error> {
     let mut db_instance =
         dev::clickhouse::ClickHouseInstance::new_single_node(port).await?;
     println!(
-        "\nomicron-dev: running ClickHouse with full command:\n\"clickhouse {}\"",
+        "omicron-dev: running ClickHouse with full command:\n\"clickhouse {}\"",
         db_instance.cmdline().join(" ")
     );
     println!(
@@ -349,14 +349,14 @@ async fn start_replicated_cluster() -> Result<(), anyhow::Error> {
         dev::clickhouse::ClickHouseCluster::new(replica_config, keeper_config)
             .await?;
     println!(
-        "\nomicron-dev: running ClickHouse cluster with configuration files:\n \
-        replicas: {}\n keepers: {}\n",
+        "omicron-dev: running ClickHouse cluster with configuration files:\n \
+        replicas: {}\n keepers: {}",
         cluster.replica_config_path().display(),
         cluster.keeper_config_path().display()
     );
     let pid_error_msg = "Failed to get process PID, it may not have started";
     println!(
-        "omicron-dev: ClickHouse cluster is running with PIDs: {}, {}, {}, {}, {}\n",
+        "omicron-dev: ClickHouse cluster is running with PIDs: {}, {}, {}, {}, {}",
         cluster.replica_1
             .pid()
             .expect(pid_error_msg),
@@ -374,15 +374,9 @@ async fn start_replicated_cluster() -> Result<(), anyhow::Error> {
             .expect(pid_error_msg),
     );
     println!(
-        "omicron-dev: ClickHouse HTTP servers listening on ports: {}, {}\n",
+        "omicron-dev: ClickHouse HTTP servers listening on ports: {}, {}",
         cluster.replica_1.port(),
         cluster.replica_2.port()
-    );
-    println!(
-        "omicron-dev: ClickHouse keepers listening on ports: {}, {}, {}\n",
-        cluster.keeper_1.port(),
-        cluster.keeper_2.port(),
-        cluster.keeper_3.port()
     );
     println!(
         "omicron-dev: using {} and {} for ClickHouse data storage",

--- a/docs/how-to-run-simulated.adoc
+++ b/docs/how-to-run-simulated.adoc
@@ -159,6 +159,20 @@ $ cargo run --bin omicron-dev -- ch-run
 omicron-dev: running ClickHouse (PID: 2463), full command is "clickhouse server --log-file /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot/clickhouse-server.log --errorlog-file /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot/clickhouse-server.errlog -- --http_port 8123 --path /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot"
 omicron-dev: using /var/folders/67/2tlym22x1r3d2kwbh84j298w0000gn/T/.tmpJ5nhot for ClickHouse data storage
 ----
++
+If you wish to start a ClickHouse replicated cluster instead of a single node, run the following instead:
+[source,text]
+---
+$ cargo run --bin omicron-dev -- ch-run --replicated
+    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
+     Running `target/debug/omicron-dev ch-run --replicated`
+omicron-dev: running ClickHouse cluster with configuration files:
+ replicas: /home/{user}/src/omicron/oximeter/db/src/configs/replica_config.xml
+ keepers: /home/{user}/src/omicron/oximeter/db/src/configs/keeper_config.xml
+omicron-dev: ClickHouse cluster is running with PIDs: 1113482, 1113681, 1113387, 1113451, 1113419
+omicron-dev: ClickHouse HTTP servers listening on ports: 8123, 8124
+omicron-dev: using /tmp/.tmpFH6v8h and /tmp/.tmpkUjDji for ClickHouse data storage
+---
 
 . `nexus` requires a configuration file to run.  You can use `nexus/examples/config.toml` to start with.  Build and run it like this:
 +

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -1064,7 +1064,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_replicated() {
-        let mut cluster = ClickHouseCluster::new()
+        let cur_dir = std::env::current_dir().unwrap();
+        let replica_config =
+            cur_dir.as_path().join("src/configs/replica_config.xml");
+        let cur_dir = std::env::current_dir().unwrap();
+        let keeper_config =
+            cur_dir.as_path().join("src/configs/keeper_config.xml");
+
+        let mut cluster = ClickHouseCluster::new(replica_config, keeper_config)
             .await
             .expect("Failed to initialise ClickHouse Cluster");
 

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -340,12 +340,12 @@ impl ClickHouseCluster {
         // Start all Keeper coordinator nodes
         let keeper_amount = 3;
         let mut keepers =
-            Self::new_keeper_set(keeper_amount, keeper_config.clone()).await?;
+            Self::new_keeper_set(keeper_amount, &keeper_config).await?;
 
         // Start all replica nodes
         let replica_amount = 2;
         let mut replicas =
-            Self::new_replica_set(replica_amount, replica_config.clone())
+            Self::new_replica_set(replica_amount, &replica_config)
                 .await?;
 
         let r1 = replicas.swap_remove(0);
@@ -367,7 +367,7 @@ impl ClickHouseCluster {
 
     pub async fn new_keeper_set(
         keeper_amount: u16,
-        config_path: PathBuf,
+        config_path: &PathBuf,
     ) -> Result<Vec<ClickHouseInstance>, anyhow::Error> {
         let mut keepers = vec![];
 
@@ -392,7 +392,7 @@ impl ClickHouseCluster {
 
     pub async fn new_replica_set(
         replica_amount: u16,
-        config_path: PathBuf,
+        config_path: &PathBuf,
     ) -> Result<Vec<ClickHouseInstance>, anyhow::Error> {
         let mut replicas = vec![];
 

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -39,16 +39,6 @@ pub struct ClickHouseInstance {
     child: Option<tokio::process::Child>,
 }
 
-/// A `ClickHouseCluster` is used to start and manage a 2 replica 3 keeper ClickHouse cluster.
-#[derive(Debug)]
-pub struct ClickHouseCluster {
-    pub replica_1: ClickHouseInstance,
-    pub replica_2: ClickHouseInstance,
-    pub keeper_1: ClickHouseInstance,
-    pub keeper_2: ClickHouseInstance,
-    pub keeper_3: ClickHouseInstance,
-}
-
 #[derive(Debug, Error)]
 pub enum ClickHouseError {
     #[error("Failed to open ClickHouse log file")]
@@ -330,25 +320,33 @@ impl Drop for ClickHouseInstance {
     }
 }
 
-impl ClickHouseCluster {
-    pub async fn new() -> Result<Self, anyhow::Error> {
-        // Start all Keeper coordinator nodes
-        let cur_dir = std::env::current_dir().unwrap();
-        let keeper_config =
-            cur_dir.as_path().join("src/configs/keeper_config.xml");
+/// A `ClickHouseCluster` is used to start and manage a 2 replica 3 keeper ClickHouse cluster.
+#[derive(Debug)]
+pub struct ClickHouseCluster {
+    pub replica_1: ClickHouseInstance,
+    pub replica_2: ClickHouseInstance,
+    pub keeper_1: ClickHouseInstance,
+    pub keeper_2: ClickHouseInstance,
+    pub keeper_3: ClickHouseInstance,
+    pub replica_config_path: PathBuf,
+    pub keeper_config_path: PathBuf,
+}
 
+impl ClickHouseCluster {
+    pub async fn new(
+        replica_config: PathBuf,
+        keeper_config: PathBuf,
+    ) -> Result<Self, anyhow::Error> {
+        // Start all Keeper coordinator nodes
         let keeper_amount = 3;
         let mut keepers =
-            Self::new_keeper_set(keeper_amount, keeper_config).await?;
+            Self::new_keeper_set(keeper_amount, keeper_config.clone()).await?;
 
         // Start all replica nodes
-        let cur_dir = std::env::current_dir().unwrap();
-        let replica_config =
-            cur_dir.as_path().join("src/configs/replica_config.xml");
-
         let replica_amount = 2;
         let mut replicas =
-            Self::new_replica_set(replica_amount, replica_config).await?;
+            Self::new_replica_set(replica_amount, replica_config.clone())
+                .await?;
 
         let r1 = replicas.swap_remove(0);
         let r2 = replicas.swap_remove(0);
@@ -362,6 +360,8 @@ impl ClickHouseCluster {
             keeper_1: k1,
             keeper_2: k2,
             keeper_3: k3,
+            replica_config_path: replica_config,
+            keeper_config_path: keeper_config,
         })
     }
 
@@ -418,6 +418,14 @@ impl ClickHouseCluster {
         }
 
         Ok(replicas)
+    }
+
+    pub fn replica_config_path(&self) -> &Path {
+        &self.replica_config_path
+    }
+
+    pub fn keeper_config_path(&self) -> &Path {
+        &self.keeper_config_path
     }
 }
 

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -345,8 +345,7 @@ impl ClickHouseCluster {
         // Start all replica nodes
         let replica_amount = 2;
         let mut replicas =
-            Self::new_replica_set(replica_amount, &replica_config)
-                .await?;
+            Self::new_replica_set(replica_amount, &replica_config).await?;
 
         let r1 = replicas.swap_remove(0);
         let r2 = replicas.swap_remove(0);


### PR DESCRIPTION
New `--replicated` flag for the `omicron-dev ch-run` command. This will allow us to spin up a ClickHouse replicated cluster containing 2 replicas and 3 keepers.

```console
$ cargo run --bin omicron-dev -- ch-run --replicated
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/omicron-dev ch-run --replicated`
omicron-dev: running ClickHouse cluster with configuration files:
 replicas: /home/{user}/src/omicron/oximeter/db/src/configs/replica_config.xml
 keepers: /home/{user}/src/omicron/oximeter/db/src/configs/keeper_config.xml
omicron-dev: ClickHouse cluster is running with PIDs: 1113482, 1113681, 1113387, 1113451, 1113419
omicron-dev: ClickHouse HTTP servers listening on ports: 8123, 8124
omicron-dev: using /tmp/.tmpFH6v8h and /tmp/.tmpkUjDji for ClickHouse data storage
```

Related: https://github.com/oxidecomputer/omicron/issues/4148