### PR TITLE
Fix reflector-bot merge conflict handling

### DIFF
--- a/.github/workflows/update-dendrite.yml
+++ b/.github/workflows/update-dendrite.yml
@@ -39,7 +39,7 @@ jobs:
           . ./tools/reflector/helpers.sh
 
           PATHS=("tools")
-          merge $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} $PATHS
+          merge $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} "${PATHS[@]}"
 
       - name: Update dendrite versions
         run: |

--- a/.github/workflows/update-maghemite.yml
+++ b/.github/workflows/update-maghemite.yml
@@ -39,7 +39,7 @@ jobs:
           . ./tools/reflector/helpers.sh
 
           PATHS=("tools")
-          merge $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} $PATHS
+          merge $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} "${PATHS[@]}"
 
       - name: Update maghemite versions
         run: |

--- a/tools/reflector/helpers.sh
+++ b/tools/reflector/helpers.sh
@@ -19,7 +19,7 @@ function merge {
   local TARGET_BRANCH="$1"
   local INTEGRATION_BRANCH="$2"
   local BOT_ID="$3"
-  local -n CHECKOUT_PATHS=$4
+  local CHECKOUT_PATHS=$4
 
   set_reflector_bot "$BOT_ID"
 


### PR DESCRIPTION
The update workflows for dendrite and maghemite are currently failing to merge main into their respective integration branches. The intended behavior is that the workflows start by merging main to pick up any new changes, and overwriting any changes to the `*_openapi_version` files that had been made on the integration branches with the versions from main (in the event of a conflict). This gets the integration branch into a clean spot which it can then apply the update scripts to.

The workflows as is though are not correctly passing the list of paths for which the the main branch should be preferred. This leaves the integration branch with a conflict causing the action to fail.

These changes should fix that and allow merges to complete cleanly.