### PR TITLE
Include enums in `dbinit_equal_sum_of_all_up` test

### DIFF
--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1243,7 +1243,7 @@ table! {
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(9, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(10, 0, 0);
 
 allow_tables_to_appear_in_same_query!(
     system_update,

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -628,7 +628,9 @@ impl InformationSchema {
         similar_asserts::assert_eq!(
             self.enums,
             other.enums,
-            "Enums did not match. Members must have the same order in dbinit.sql and migrations. If a migration adds a member, it should be added at the end of the definition in dbinit.sql."
+            "Enums did not match. Members must have the same order in dbinit.sql and \
+            migrations. If a migration adds a member, it should use BEFORE or AFTER \
+            to add it in the same order as dbinit.sql."
         );
         similar_asserts::assert_eq!(self.views, other.views);
         similar_asserts::assert_eq!(

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -354,7 +354,7 @@ async fn crdb_list_enums(crdb: &CockroachInstance) -> Vec<Row> {
 
     // https://www.cockroachlabs.com/docs/stable/show-enums
     let rows = client
-        .query(&"show enums;".to_string(), &[])
+        .query("show enums;", &[])
         .await
         .unwrap_or_else(|_| panic!("failed to list enums"));
     client.cleanup().await.expect("cleaning up after wipe");

--- a/schema/crdb/10.0.0/README.md
+++ b/schema/crdb/10.0.0/README.md
@@ -1,0 +1,12 @@
+# Why?
+
+This migration is part of a PR that adds a check to the schema tests ensuring that the order of enum members is the same when starting from scratch with `dbinit.sql` as it is when building up from existing deployments by running the migrations. The problem: there were already two enums, `dataset_kind` and `service_kind`, where the order did not match, so we have to fix that by putting the enums in the "right" order even on an existing deployment where the order is wrong. To do that, for each of those enums, we:
+
+1. add `clickhouse_keeper2` member
+1. change existing uses of `clickhouse_keeper` to `clickhouse_keeper2`
+1. drop `clickhouse_keeper` member
+1. add `clickhouse_keeper` back in the right order using `AFTER 'clickhouse'`
+1. change uses of `clickhouse_keeper2` back to `clickhouse_keeper`
+1. drop `clickhouse_keeper2`
+
+As there are 6 steps here and two different enums to do them for, there are 12 `up*.sql` files.

--- a/schema/crdb/10.0.0/up01.sql
+++ b/schema/crdb/10.0.0/up01.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind ADD VALUE IF NOT EXISTS 'clickhouse_keeper2' AFTER 'clickhouse';

--- a/schema/crdb/10.0.0/up02.sql
+++ b/schema/crdb/10.0.0/up02.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.service_kind ADD VALUE IF NOT EXISTS 'clickhouse_keeper2' AFTER 'clickhouse';

--- a/schema/crdb/10.0.0/up03.sql
+++ b/schema/crdb/10.0.0/up03.sql
@@ -1,3 +1,5 @@
+set local disallow_full_table_scans = off;
+
 UPDATE omicron.public.dataset
 SET kind = 'clickhouse_keeper2'
 WHERE kind = 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up03.sql
+++ b/schema/crdb/10.0.0/up03.sql
@@ -1,0 +1,3 @@
+UPDATE omicron.public.dataset
+SET kind = 'clickhouse_keeper2'
+WHERE kind = 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up04.sql
+++ b/schema/crdb/10.0.0/up04.sql
@@ -1,3 +1,5 @@
+set local disallow_full_table_scans = off;
+
 UPDATE omicron.public.service
 SET kind = 'clickhouse_keeper2'
 WHERE kind = 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up04.sql
+++ b/schema/crdb/10.0.0/up04.sql
@@ -1,0 +1,3 @@
+UPDATE omicron.public.service
+SET kind = 'clickhouse_keeper2'
+WHERE kind = 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up05.sql
+++ b/schema/crdb/10.0.0/up05.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind DROP VALUE 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up06.sql
+++ b/schema/crdb/10.0.0/up06.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.service_kind DROP VALUE 'clickhouse_keeper';

--- a/schema/crdb/10.0.0/up07.sql
+++ b/schema/crdb/10.0.0/up07.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind ADD VALUE 'clickhouse_keeper' AFTER 'clickhouse';

--- a/schema/crdb/10.0.0/up08.sql
+++ b/schema/crdb/10.0.0/up08.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.service_kind ADD VALUE 'clickhouse_keeper' AFTER 'clickhouse';

--- a/schema/crdb/10.0.0/up09.sql
+++ b/schema/crdb/10.0.0/up09.sql
@@ -1,0 +1,3 @@
+UPDATE omicron.public.dataset
+SET kind = 'clickhouse_keeper'
+WHERE kind = 'clickhouse_keeper2';

--- a/schema/crdb/10.0.0/up09.sql
+++ b/schema/crdb/10.0.0/up09.sql
@@ -1,3 +1,5 @@
+set local disallow_full_table_scans = off;
+
 UPDATE omicron.public.dataset
 SET kind = 'clickhouse_keeper'
 WHERE kind = 'clickhouse_keeper2';

--- a/schema/crdb/10.0.0/up10.sql
+++ b/schema/crdb/10.0.0/up10.sql
@@ -1,0 +1,3 @@
+UPDATE omicron.public.service
+SET kind = 'clickhouse_keeper'
+WHERE kind = 'clickhouse_keeper2';

--- a/schema/crdb/10.0.0/up10.sql
+++ b/schema/crdb/10.0.0/up10.sql
@@ -1,3 +1,5 @@
+set local disallow_full_table_scans = off;
+
 UPDATE omicron.public.service
 SET kind = 'clickhouse_keeper'
 WHERE kind = 'clickhouse_keeper2';

--- a/schema/crdb/10.0.0/up11.sql
+++ b/schema/crdb/10.0.0/up11.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind DROP VALUE 'clickhouse_keeper2';

--- a/schema/crdb/10.0.0/up12.sql
+++ b/schema/crdb/10.0.0/up12.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.service_kind DROP VALUE 'clickhouse_keeper2';

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -191,6 +191,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lookup_switch_by_rack ON omicron.public.switch
 
 CREATE TYPE IF NOT EXISTS omicron.public.service_kind AS ENUM (
   'clickhouse',
+  'clickhouse_keeper',
   'cockroach',
   'crucible',
   'crucible_pantry',
@@ -201,7 +202,6 @@ CREATE TYPE IF NOT EXISTS omicron.public.service_kind AS ENUM (
   'ntp',
   'oximeter',
   'tfport',
-  'clickhouse_keeper',
   'mgd'
 );
 
@@ -402,9 +402,9 @@ CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'crucible',
   'cockroach',
   'clickhouse',
+  'clickhouse_keeper',
   'external_dns',
-  'internal_dns',
-  'clickhouse_keeper'
+  'internal_dns'
 );
 
 /*
@@ -2838,7 +2838,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '9.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '10.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -191,7 +191,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS lookup_switch_by_rack ON omicron.public.switch
 
 CREATE TYPE IF NOT EXISTS omicron.public.service_kind AS ENUM (
   'clickhouse',
-  'clickhouse_keeper',
   'cockroach',
   'crucible',
   'crucible_pantry',
@@ -202,6 +201,7 @@ CREATE TYPE IF NOT EXISTS omicron.public.service_kind AS ENUM (
   'ntp',
   'oximeter',
   'tfport',
+  'clickhouse_keeper',
   'mgd'
 );
 
@@ -402,9 +402,9 @@ CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'crucible',
   'cockroach',
   'clickhouse',
-  'clickhouse_keeper',
   'external_dns',
-  'internal_dns'
+  'internal_dns',
+  'clickhouse_keeper'
 );
 
 /*


### PR DESCRIPTION
While working on #4261 I ~~ran into~~ created a situation where the order of items in a DB enum matters because I want to sort by it. In this case it's about specificity — the type is `silo` or `fleet` and I want to sort by it to ensure I get the most "specific" thing first. @zephraph noticed I had an order mismatch between my migration adding the enum and the copy in `dbinit.sql`, and it wasn't caught by the tests.

So, here I've added the list of user-defined enums to the set of things we compare when we ask whether the result of our migrations matches the contents of `dbinit.sql`. There were two existing enums that failed the test because the copy in `dbinit.sql` was sorted alphabetically, but a migration added a new item at the end of the list. Very easy to fix, though now are enums aren't sorted nicely, which is sad.

The question is: should we enforce enum order? Seems like we might as well if it doesn't cost us much. But should we write application logic like #4261 that relies on enum order? In that case, at least, I have a reasonable alternative because the list of things I'm sorting is at most 2 long, so I can easily get the whole list and pick the element I want in app code instead of doing an `order by` + `limit 1` in SQL. It is made quite clear in a comment, but it still feels a little dicey.