### PR TITLE
Update propolis mock-server and client deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,21 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,12 +71,6 @@ checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -191,16 +170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "api_identity"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,17 +257,6 @@ dependencies = [
  "diesel",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -495,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -505,19 +457,10 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
 dependencies = [
  "libc",
  "strum",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -559,12 +502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,26 +520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitstruct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b10c3912af09af44ea1dafe307edb5ed374b2a32658eb610e372270c9017b4"
-dependencies = [
- "bitstruct_derive",
-]
-
-[[package]]
-name = "bitstruct_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fd19022c2b750d14eb9724c204d08ab7544570105b3b466d8a9f2f3feded27"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -678,7 +595,7 @@ dependencies = [
  "derive_more",
  "hex",
  "hkdf",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-rpaths",
  "omicron-test-utils",
  "omicron-workspace-hack",
@@ -705,7 +622,7 @@ name = "bootstrap-agent-client"
 version = "0.1.0"
 dependencies = [
  "ipnetwork",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -907,7 +824,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -1113,26 +1029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
-name = "const_format"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,18 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cpuid_profile_config"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "propolis",
- "serde",
- "serde_derive",
- "thiserror",
- "toml 0.7.8",
 ]
 
 [[package]]
@@ -1384,51 +1268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible"
-version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "aes-gcm-siv",
- "anyhow",
- "async-recursion",
- "async-trait",
- "base64 0.21.5",
- "bytes",
- "chrono",
- "crucible-client-types",
- "crucible-common",
- "crucible-protocol",
- "crucible-workspace-hack",
- "dropshot",
- "futures",
- "futures-core",
- "itertools 0.11.0",
- "libc",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reqwest",
- "ringbuffer",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-dtrace",
- "slog-term",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "toml 0.8.8",
- "tracing",
- "usdt",
- "uuid",
- "version_check",
-]
-
-[[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
 source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
@@ -1445,47 +1284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crucible-client-types"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "base64 0.21.5",
- "crucible-workspace-hack",
- "schemars",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "crucible-common"
-version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "anyhow",
- "atty",
- "crucible-workspace-hack",
- "nix 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite",
- "rustls-pemfile",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-bunyan",
- "slog-dtrace",
- "slog-term",
- "tempfile",
- "thiserror",
- "tokio-rustls",
- "toml 0.8.8",
- "twox-hash",
- "uuid",
- "vergen",
-]
-
-[[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
 source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
@@ -1499,23 +1297,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "crucible-protocol"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "crucible-common",
- "crucible-workspace-hack",
- "num_enum 0.7.0",
- "schemars",
- "serde",
- "tokio-util",
  "uuid",
 ]
 
@@ -1735,7 +1516,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "progenitor",
@@ -1971,22 +1752,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f77af9e75578c1ab34f5f04545a8b05be0c36fbd7a9bb3cf2d2a971e435fdbb9"
 
 [[package]]
-name = "dladm"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
- "strum",
-]
-
-[[package]]
 name = "dlpi"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0b960559c76d475d2"
 dependencies = [
  "libc",
  "libdlpi-sys",
- "num_enum 0.5.11",
+ "num_enum",
  "pretty-hex 0.2.1",
  "thiserror",
  "tokio",
@@ -2000,7 +1772,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap 4.4.3",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "expectorate",
  "http",
@@ -2042,22 +1814,6 @@ dependencies = [
  "schemars",
  "serde",
  "slog",
-]
-
-[[package]]
-name = "dns-service-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "http",
- "progenitor",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
- "slog",
- "uuid",
 ]
 
 [[package]]
@@ -2306,19 +2062,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -2333,15 +2076,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "erased-serde"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837c0466252947ada828b975e12daf82e18bb5444e4df87be6038d4469e2a3d2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "errno"
@@ -2380,12 +2114,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2691,7 +2419,7 @@ dependencies = [
  "futures",
  "gateway-client",
  "gateway-messages",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "reqwest",
  "serde",
@@ -2753,7 +2481,7 @@ dependencies = [
  "hubpack 0.1.2",
  "hubtools",
  "lru-cache",
- "nix 0.26.2 (git+https://github.com/jgallagher/nix?branch=r0.26-illumos)",
+ "nix",
  "once_cell",
  "paste",
  "serde",
@@ -2847,19 +2575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "git2"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,19 +2658,6 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
-dependencies = [
- "hashbrown 0.14.2",
-]
 
 [[package]]
 name = "headers"
@@ -3339,7 +3041,7 @@ source = "git+https://github.com/oxidecomputer/illumos-devinfo?branch=main#4323b
 dependencies = [
  "anyhow",
  "libc",
- "num_enum 0.5.11",
+ "num_enum",
 ]
 
 [[package]]
@@ -3363,7 +3065,7 @@ dependencies = [
  "libc",
  "macaddr",
  "mockall",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "opte-ioctl",
  "oxide-vpc",
@@ -3472,7 +3174,7 @@ dependencies = [
  "ipcc-key-value",
  "itertools 0.11.0",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "partial-io",
@@ -3524,7 +3226,7 @@ dependencies = [
  "expectorate",
  "hyper",
  "installinator-common",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
@@ -3570,12 +3272,12 @@ dependencies = [
  "assert_matches",
  "chrono",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "expectorate",
  "futures",
  "hyper",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "progenitor",
@@ -3592,33 +3294,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "internal-dns"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "anyhow",
- "chrono",
- "dns-service-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "futures",
- "hyper",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "reqwest",
- "slog",
- "thiserror",
- "trust-dns-proto",
- "trust-dns-resolver",
- "uuid",
-]
-
-[[package]]
 name = "internal-dns-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.4.3",
  "dropshot",
- "internal-dns 0.1.0",
- "omicron-common 0.1.0",
+ "internal-dns",
+ "omicron-common",
  "omicron-workspace-hack",
  "slog",
  "tokio",
@@ -3642,7 +3325,7 @@ version = "0.1.0"
 dependencies = [
  "ciborium",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "proptest",
  "serde",
@@ -3721,15 +3404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,7 +3427,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "hkdf",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "secrecy",
  "sha3",
@@ -3854,18 +3528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b024e211b1b371da58cd69e4fb8fa4ed16915edcc0e2e1fb04ac4bad61959f25"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.15.2+1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3891,23 +3553,13 @@ dependencies = [
  "colored",
  "dlpi",
  "libc",
- "num_enum 0.5.11",
+ "num_enum",
  "nvpair",
  "nvpair-sys",
  "rusty-doors",
  "socket2 0.4.9",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3936,18 +3588,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe73cdec2bcb36d25a9fe3f607ffcd44bb8907ca0100c4098d1aa342d1e7bec"
 dependencies = [
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -4013,7 +3653,7 @@ dependencies = [
  "const-oid",
  "crc-any",
  "der",
- "env_logger 0.10.0",
+ "env_logger",
  "hex",
  "log",
  "lpc55_areas",
@@ -4122,7 +3762,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "progenitor",
@@ -4285,8 +3925,8 @@ dependencies = [
  "chrono",
  "futures",
  "ipnetwork",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -4296,26 +3936,6 @@ dependencies = [
  "serde_json",
  "sled-hardware",
  "sled-storage",
- "slog",
- "uuid",
-]
-
-[[package]]
-name = "nexus-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "futures",
- "ipnetwork",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-passwords 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "progenitor",
- "regress",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
  "slog",
  "uuid",
 ]
@@ -4336,11 +3956,11 @@ dependencies = [
  "nexus-defaults",
  "nexus-types",
  "omicron-certificates",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-workspace-hack",
- "parse-display 0.8.2",
+ "parse-display",
  "pq-sys",
  "rand 0.8.5",
  "ref-cast",
@@ -4379,7 +3999,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "lazy_static",
@@ -4389,8 +4009,8 @@ dependencies = [
  "nexus-inventory",
  "nexus-test-utils",
  "nexus-types",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -4398,7 +4018,7 @@ dependencies = [
  "openapiv3 1.0.3",
  "openssl",
  "oso",
- "oximeter 0.1.0",
+ "oximeter",
  "paste",
  "pem 1.1.1",
  "petgraph",
@@ -4432,7 +4052,7 @@ version = "0.1.0"
 dependencies = [
  "ipnetwork",
  "lazy_static",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "rand 0.8.5",
  "serde_json",
@@ -4463,7 +4083,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "slog",
  "uuid",
@@ -4480,25 +4100,25 @@ dependencies = [
  "chrono",
  "crucible-agent-client",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dropshot",
  "gateway-messages",
  "gateway-test-utils",
  "headers",
  "http",
  "hyper",
- "internal-dns 0.1.0",
+ "internal-dns",
  "nexus-db-queries",
  "nexus-test-interface",
  "nexus-types",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-sled-agent",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-collector",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4521,17 +4141,17 @@ name = "nexus-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "base64 0.21.5",
  "chrono",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "futures",
  "gateway-client",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
  "openssl",
- "parse-display 0.8.2",
+ "parse-display",
  "schemars",
  "serde",
  "serde_json",
@@ -4547,20 +4167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec 1.11.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -4728,16 +4334,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
-dependencies = [
- "num_enum_derive 0.7.0",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -4750,18 +4347,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -4832,7 +4417,7 @@ version = "0.1.0"
 dependencies = [
  "display-error-chain",
  "foreign-types 0.3.2",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openssl",
@@ -4846,7 +4431,7 @@ name = "omicron-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api_identity 0.1.0",
+ "api_identity",
  "async-trait",
  "backoff",
  "camino",
@@ -4862,7 +4447,7 @@ dependencies = [
  "libc",
  "macaddr",
  "omicron-workspace-hack",
- "parse-display 0.8.2",
+ "parse-display",
  "progenitor",
  "proptest",
  "rand 0.8.5",
@@ -4882,46 +4467,6 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "toml 0.8.8",
- "uuid",
-]
-
-[[package]]
-name = "omicron-common"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "anyhow",
- "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "async-trait",
- "backoff",
- "camino",
- "chrono",
- "dropshot",
- "futures",
- "hex",
- "http",
- "hyper",
- "ipnetwork",
- "lazy_static",
- "macaddr",
- "parse-display 0.7.0",
- "progenitor",
- "rand 0.8.5",
- "reqwest",
- "ring 0.16.20",
- "schemars",
- "semver 1.0.20",
- "serde",
- "serde_derive",
- "serde_human_bytes",
- "serde_json",
- "serde_with",
- "slog",
- "strum",
- "thiserror",
- "tokio",
- "tokio-postgres",
- "toml 0.7.8",
  "uuid",
 ]
 
@@ -4955,7 +4500,7 @@ dependencies = [
  "libc",
  "nexus-test-interface",
  "nexus-test-utils",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-nexus",
  "omicron-rpaths",
  "omicron-test-utils",
@@ -4990,7 +4535,7 @@ dependencies = [
  "hyper",
  "illumos-utils",
  "ipcc-key-value",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
@@ -5031,7 +4576,7 @@ dependencies = [
  "crucible-pantry-client",
  "diesel",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -5047,7 +4592,7 @@ dependencies = [
  "hubtools",
  "hyper",
  "hyper-rustls",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "lazy_static",
@@ -5063,8 +4608,8 @@ dependencies = [
  "nexus-test-utils-macros",
  "nexus-types",
  "num-integer",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-rpaths",
  "omicron-sled-agent",
  "omicron-test-utils",
@@ -5074,12 +4619,12 @@ dependencies = [
  "openapiv3 1.0.3",
  "openssl",
  "oxide-client",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-db",
  "oximeter-instruments",
- "oximeter-producer 0.1.0",
- "parse-display 0.8.2",
+ "oximeter-producer",
+ "parse-display",
  "paste",
  "pem 1.1.1",
  "petgraph",
@@ -5137,15 +4682,15 @@ dependencies = [
  "gateway-messages",
  "gateway-test-utils",
  "humantime",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
- "nexus-client 0.1.0",
+ "nexus-client",
  "nexus-db-model",
  "nexus-db-queries",
  "nexus-test-utils",
  "nexus-test-utils-macros",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-nexus",
  "omicron-rpaths",
  "omicron-test-utils",
@@ -5215,19 +4760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "omicron-passwords"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "argon2",
- "rand 0.8.5",
- "schemars",
- "serde",
- "serde_with",
- "thiserror",
-]
-
-[[package]]
 name = "omicron-rpaths"
 version = "0.1.0"
 dependencies = [
@@ -5252,11 +4784,10 @@ dependencies = [
  "chrono",
  "clap 4.4.3",
  "crucible-agent-client",
- "crucible-client-types",
  "ddm-admin-client",
  "derive_more",
  "dns-server",
- "dns-service-client 0.1.0",
+ "dns-service-client",
  "dpd-client",
  "dropshot",
  "expectorate",
@@ -5268,27 +4799,27 @@ dependencies = [
  "hyper",
  "hyper-staticfile",
  "illumos-utils",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "key-manager",
  "libc",
  "macaddr",
  "mg-admin-client",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
  "openapiv3 1.0.3",
  "opte-ioctl",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-instruments",
- "oximeter-producer 0.1.0",
+ "oximeter-producer",
  "pretty_assertions",
  "propolis-client",
- "propolis-server",
+ "propolis-mock-server",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
@@ -5335,7 +4866,7 @@ dependencies = [
  "hex",
  "http",
  "libc",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "pem 1.1.1",
  "rcgen",
@@ -5362,12 +4893,10 @@ dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
  "bitflags 2.4.0",
- "bitvec",
  "bstr 0.2.17",
  "bstr 1.6.0",
  "byteorder",
  "bytes",
- "cc",
  "chrono",
  "cipher",
  "clap 4.4.3",
@@ -5393,7 +4922,6 @@ dependencies = [
  "generic-array",
  "getrandom 0.2.10",
  "hashbrown 0.13.2",
- "hashbrown 0.14.2",
  "hex",
  "hyper",
  "hyper-rustls",
@@ -5413,6 +4941,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "once_cell",
+ "openapiv3 2.0.0-rc.1",
  "petgraph",
  "postgres-types",
  "ppv-lite86",
@@ -5422,7 +4951,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "regex",
  "regex-automata 0.4.3",
- "regex-syntax 0.6.29",
  "regex-syntax 0.8.2",
  "reqwest",
  "ring 0.16.20",
@@ -5453,7 +4981,6 @@ dependencies = [
  "trust-dns-proto",
  "unicode-bidi",
  "unicode-normalization",
- "unicode-xid",
  "usdt",
  "uuid",
  "yasna",
@@ -5706,9 +5233,9 @@ dependencies = [
  "bytes",
  "chrono",
  "num",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
- "oximeter-macro-impl 0.1.0",
+ "oximeter-macro-impl",
  "rstest",
  "schemars",
  "serde",
@@ -5719,28 +5246,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "bytes",
- "chrono",
- "num-traits",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "schemars",
- "serde",
- "thiserror",
- "uuid",
-]
-
-[[package]]
 name = "oximeter-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "reqwest",
@@ -5761,15 +5272,15 @@ dependencies = [
  "expectorate",
  "futures",
  "hyper",
- "internal-dns 0.1.0",
- "nexus-client 0.1.0",
+ "internal-dns",
+ "nexus-client",
  "nexus-types",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
  "openapiv3 1.0.3",
- "oximeter 0.1.0",
+ "oximeter",
  "oximeter-client",
  "oximeter-db",
  "rand 0.8.5",
@@ -5804,10 +5315,10 @@ dependencies = [
  "expectorate",
  "highway",
  "itertools 0.11.0",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "regex",
  "reqwest",
  "schemars",
@@ -5836,7 +5347,7 @@ dependencies = [
  "http",
  "kstat-rs",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
+ "oximeter",
  "rand 0.8.5",
  "slog",
  "slog-async",
@@ -5857,16 +5368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oximeter-macro-impl"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "oximeter-producer"
 version = "0.1.0"
 dependencies = [
@@ -5874,30 +5375,10 @@ dependencies = [
  "chrono",
  "clap 4.4.3",
  "dropshot",
- "nexus-client 0.1.0",
- "omicron-common 0.1.0",
+ "nexus-client",
+ "omicron-common",
  "omicron-workspace-hack",
- "oximeter 0.1.0",
- "schemars",
- "serde",
- "slog",
- "slog-dtrace",
- "thiserror",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "oximeter-producer"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3dcc8d2eb648c87b42454882a2ce024b409cbb8c"
-dependencies = [
- "chrono",
- "dropshot",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "reqwest",
+ "oximeter",
  "schemars",
  "serde",
  "slog",
@@ -5990,39 +5471,13 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b32f6c8212838b74c0f5ba412194e88897923020810d9bec72d3594c2588d"
-dependencies = [
- "once_cell",
- "parse-display-derive 0.7.0",
- "regex",
-]
-
-[[package]]
-name = "parse-display"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
 dependencies = [
  "once_cell",
- "parse-display-derive 0.8.2",
+ "parse-display-derive",
  "regex",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6ec9ab2477935d04fcdf7c51c9ee94a1be988938886de3239aed40980b7180"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax 0.6.29",
- "structmeta 0.1.6",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6036,7 +5491,7 @@ dependencies = [
  "quote",
  "regex",
  "regex-syntax 0.7.5",
- "structmeta 0.2.0",
+ "structmeta",
  "syn 2.0.32",
 ]
 
@@ -6577,8 +6032,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -6588,8 +6043,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6602,14 +6057,14 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
 dependencies = [
  "getopts",
  "heck 0.4.1",
  "http",
  "indexmap 2.1.0",
- "openapiv3 1.0.3",
+ "openapiv3 2.0.0-rc.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -6624,10 +6079,10 @@ dependencies = [
 
 [[package]]
 name = "progenitor-macro"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
 dependencies = [
- "openapiv3 1.0.3",
+ "openapiv3 2.0.0-rc.1",
  "proc-macro2",
  "progenitor-impl",
  "quote",
@@ -6640,52 +6095,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "anyhow",
- "bhyve_api",
- "bitflags 2.4.0",
- "bitstruct",
- "byteorder",
- "crucible",
- "crucible-client-types",
- "dladm",
- "erased-serde",
- "futures",
- "lazy_static",
- "libc",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "propolis_types",
- "rfb",
- "serde",
- "serde_arrays",
- "serde_json",
- "slog",
- "strum",
- "thiserror",
- "tokio",
- "usdt",
- "uuid",
- "viona_api",
-]
-
-[[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
 dependencies = [
  "async-trait",
  "base64 0.21.5",
- "crucible-client-types",
  "futures",
  "progenitor",
- "propolis_types",
  "rand 0.8.5",
  "reqwest",
- "ring 0.16.20",
  "schemars",
  "serde",
  "serde_json",
@@ -6697,73 +6116,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis-server"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+name = "propolis-mock-server"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
 dependencies = [
  "anyhow",
- "async-trait",
  "atty",
  "base64 0.21.5",
- "bit_field",
- "bitvec",
- "bytes",
- "cfg-if 1.0.0",
- "chrono",
  "clap 4.4.3",
- "const_format",
- "crucible-client-types",
  "dropshot",
- "erased-serde",
  "futures",
- "http",
  "hyper",
- "internal-dns 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "lazy_static",
- "nexus-client 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "oximeter-producer 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
- "propolis",
- "propolis-client",
- "propolis-server-config",
- "rfb",
- "ron 0.7.1",
+ "progenitor",
+ "propolis_types",
+ "rand 0.8.5",
+ "reqwest",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "slog",
  "slog-async",
  "slog-bunyan",
  "slog-dtrace",
  "slog-term",
- "strum",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.20.1",
- "tokio-util",
- "toml 0.7.8",
- "usdt",
  "uuid",
-]
-
-[[package]]
-name = "propolis-server-config"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "cpuid_profile_config",
- "serde",
- "serde_derive",
- "thiserror",
- "toml 0.7.8",
 ]
 
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
 dependencies = [
  "schemars",
  "serde",
@@ -7156,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -7184,6 +6569,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -7206,21 +6592,6 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
-]
-
-[[package]]
-name = "rfb"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rfb?rev=0cac8d9c25eb27acfa35df80f3b9d371de98ab3b#0cac8d9c25eb27acfa35df80f3b9d371de98ab3b"
-dependencies = [
- "ascii",
- "async-trait",
- "bitflags 1.3.2",
- "env_logger 0.9.3",
- "futures",
- "log",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -7250,23 +6621,6 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ringbuffer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
-
-[[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "serde",
 ]
 
 [[package]]
@@ -7353,20 +6707,6 @@ checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
-dependencies = [
- "bitflags 2.4.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -7828,15 +7168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_arrays"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8178,7 +7509,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ipnetwork",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -8202,7 +7533,7 @@ dependencies = [
  "libc",
  "libefi-illumos",
  "macaddr",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "rand 0.8.5",
@@ -8228,7 +7559,7 @@ dependencies = [
  "glob",
  "illumos-utils",
  "key-manager",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "rand 0.8.5",
@@ -8455,7 +7786,7 @@ dependencies = [
  "futures",
  "gateway-messages",
  "hex",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-gateway",
  "omicron-workspace-hack",
  "serde",
@@ -8600,37 +7931,14 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structmeta"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive 0.1.6",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "structmeta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta-derive 0.2.0",
+ "structmeta-derive",
  "syn 2.0.32",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8770,6 +8078,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tabled"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8892,7 +8221,7 @@ checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "structmeta 0.2.0",
+ "structmeta",
  "syn 2.0.32",
 ]
 
@@ -9075,7 +8404,7 @@ name = "tlvc-text"
 version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/tlvc.git#e644a21a7ca973ed31499106ea926bd63ebccc6f"
 dependencies = [
- "ron 0.8.1",
+ "ron",
  "serde",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git)",
  "zerocopy 0.6.4",
@@ -9492,7 +8821,7 @@ dependencies = [
  "datatest-stable",
  "fs-err",
  "humantime",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "predicates 3.0.4",
@@ -9521,7 +8850,7 @@ dependencies = [
  "hex",
  "hubtools",
  "itertools 0.11.0",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "rand 0.8.5",
@@ -9587,17 +8916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 0.1.10",
- "rand 0.8.5",
- "static_assertions",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9605,8 +8923,8 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "typify"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -9614,8 +8932,8 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
 dependencies = [
  "heck 0.4.1",
  "log",
@@ -9631,8 +8949,8 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#de16c4238a2b34400d0fece086a6469951c3236b"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9881,40 +9199,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "vergen"
-version = "8.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
-dependencies = [
- "anyhow",
- "git2",
- "rustc_version 0.4.0",
- "rustversion",
- "time",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "viona_api"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
- "viona_api_sys",
-]
-
-[[package]]
-name = "viona_api_sys"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4019eb10fc2f4ba9bf210d0461dc6292b68309c2#4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "vsss-rs"
@@ -10135,8 +9423,8 @@ dependencies = [
  "indexmap 2.1.0",
  "indicatif",
  "itertools 0.11.0",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-workspace-hack",
  "once_cell",
  "owo-colors",
@@ -10172,7 +9460,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "gateway-client",
- "omicron-common 0.1.0",
+ "omicron-common",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -10237,13 +9525,13 @@ dependencies = [
  "installinator-artifact-client",
  "installinator-artifactd",
  "installinator-common",
- "internal-dns 0.1.0",
+ "internal-dns",
  "ipnetwork",
  "itertools 0.11.0",
  "maplit",
  "omicron-certificates",
- "omicron-common 0.1.0",
- "omicron-passwords 0.1.0",
+ "omicron-common",
+ "omicron-passwords",
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
 crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
 crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
 curve25519-dalek = "4"
@@ -291,9 +290,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2", features = [ "generated-migration" ] }
-propolis-server = { git = "https://github.com/oxidecomputer/propolis", rev = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2", default-features = false, features = ["mock-only"] }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
 proptest = "1.3.1"
 quote = "1.0"
 rand = "0.8.5"
@@ -547,9 +546,9 @@ opt-level = 3
 #steno = { path = "../steno" }
 #[patch."https://github.com/oxidecomputer/propolis"]
 #propolis-client = { path = "../propolis/lib/propolis-client" }
+#propolis-mock-server = { path = "../propolis/bin/mock-server" }
 #[patch."https://github.com/oxidecomputer/crucible"]
 #crucible-agent-client = { path = "../crucible/agent-client" }
-#crucible-client-types = { path = "../crucible/crucible-client-types" }
 #crucible-pantry-client = { path = "../crucible/pantry-client" }
 #crucible-smf = { path = "../crucible/smf" }
 #[patch.crates-io]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -19,7 +19,6 @@ cfg-if.workspace = true
 chrono.workspace = true
 clap.workspace = true
 # Only used by the simulated sled agent.
-crucible-client-types.workspace = true
 crucible-agent-client.workspace = true
 ddm-admin-client.workspace = true
 derive_more.workspace = true
@@ -47,8 +46,8 @@ once_cell.workspace = true
 oximeter.workspace = true
 oximeter-instruments.workspace = true
 oximeter-producer.workspace = true
-propolis-client = { workspace = true, features = [ "generated-migration" ] }
-propolis-server.workspace = true # Only used by the simulated sled agent
+propolis-client.workspace = true
+propolis-mock-server.workspace = true # Only used by the simulated sled agent
 rand = { workspace = true, features = ["getrandom"] }
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
 schemars = { workspace = true, features = [ "chrono", "uuid1" ] }

--- a/sled-agent/src/common/disk.rs
+++ b/sled-agent/src/common/disk.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
-use propolis_client::api::DiskAttachmentState as PropolisDiskState;
+use propolis_client::types::DiskAttachmentState as PropolisDiskState;
 use uuid::Uuid;
 
 /// Action to be taken on behalf of state transition.

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -10,8 +10,9 @@ use omicron_common::api::external::InstanceState as ApiInstanceState;
 use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, SledInstanceState, VmmRuntimeState,
 };
-use propolis_client::api::{
+use propolis_client::types::{
     InstanceState as PropolisApiState, InstanceStateMonitorResponse,
+    MigrationState,
 };
 use uuid::Uuid;
 
@@ -36,7 +37,7 @@ impl From<PropolisApiState> for PropolisInstanceState {
 
 impl From<PropolisInstanceState> for ApiInstanceState {
     fn from(value: PropolisInstanceState) -> Self {
-        use propolis_client::api::InstanceState as State;
+        use propolis_client::types::InstanceState as State;
         match value.0 {
             // Nexus uses the VMM state as the externally-visible instance state
             // when an instance has an active VMM. A Propolis that is "creating"
@@ -119,7 +120,6 @@ impl ObservedPropolisState {
                 (Some(this_id), Some(propolis_migration))
                     if this_id == propolis_migration.migration_id =>
                 {
-                    use propolis_client::api::MigrationState;
                     match propolis_migration.state {
                         MigrationState::Finish => {
                             ObservedMigrationStatus::Succeeded
@@ -510,7 +510,7 @@ mod test {
     use chrono::Utc;
     use omicron_common::api::external::Generation;
     use omicron_common::api::internal::nexus::InstanceRuntimeState;
-    use propolis_client::api::InstanceState as Observed;
+    use propolis_client::types::InstanceState as Observed;
     use uuid::Uuid;
 
     fn make_instance() -> InstanceStates {

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -71,8 +71,8 @@ pub struct InstanceHardware {
     pub external_ips: Vec<IpAddr>,
     pub firewall_rules: Vec<VpcFirewallRule>,
     pub dhcp_config: DhcpConfig,
-    // TODO: replace `propolis_client::handmade::*` with locally-modeled request type
-    pub disks: Vec<propolis_client::handmade::api::DiskRequest>,
+    // TODO: replace `propolis_client::*` with locally-modeled request type
+    pub disks: Vec<propolis_client::types::DiskRequest>,
     pub cloud_init_bytes: Option<String>,
 }
 

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -19,7 +19,7 @@ use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
-use propolis_client::api::DiskAttachmentState as PropolisDiskState;
+use propolis_client::types::DiskAttachmentState as PropolisDiskState;
 use std::net::{Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;

--- a/sled-agent/src/sim/http_entrypoints_pantry.rs
+++ b/sled-agent/src/sim/http_entrypoints_pantry.rs
@@ -4,11 +4,11 @@
 
 //! HTTP entrypoint functions for simulating the crucible pantry API.
 
-use crucible_client_types::VolumeConstructionRequest;
 use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseDeleted, HttpResponseOk,
     HttpResponseUpdatedNoContent, Path as TypedPath, RequestContext, TypedBody,
 };
+use propolis_client::types::VolumeConstructionRequest;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -19,9 +19,10 @@ use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, SledInstanceState,
 };
-use propolis_client::api::InstanceMigrateStatusResponse as PropolisMigrateStatus;
-use propolis_client::api::InstanceState as PropolisInstanceState;
-use propolis_client::api::InstanceStateMonitorResponse;
+use propolis_client::types::{
+    InstanceMigrateStatusResponse as PropolisMigrateStatus,
+    InstanceState as PropolisInstanceState, InstanceStateMonitorResponse,
+};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -131,11 +132,11 @@ impl SimInstanceInner {
                     });
                 self.queue_migration_status(PropolisMigrateStatus {
                     migration_id,
-                    state: propolis_client::api::MigrationState::Sync,
+                    state: propolis_client::types::MigrationState::Sync,
                 });
                 self.queue_migration_status(PropolisMigrateStatus {
                     migration_id,
-                    state: propolis_client::api::MigrationState::Finish,
+                    state: propolis_client::types::MigrationState::Finish,
                 });
                 self.queue_propolis_state(PropolisInstanceState::Running);
             }

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -16,13 +16,13 @@ use chrono::prelude::*;
 use crucible_agent_client::types::{
     CreateRegion, Region, RegionId, RunningSnapshot, Snapshot, State,
 };
-use crucible_client_types::VolumeConstructionRequest;
 use dropshot::HandlerTaskMode;
 use dropshot::HttpError;
 use futures::lock::Mutex;
 use nexus_client::types::{
     ByteCount, PhysicalDiskKind, PhysicalDiskPutRequest, ZpoolPutRequest,
 };
+use propolis_client::types::VolumeConstructionRequest;
 use slog::Logger;
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -21,7 +21,6 @@ PACKAGES=(
 
 CRATES=(
   "crucible-agent-client"
-  "crucible-client-types"
   "crucible-pantry-client"
   "crucible-smf"
 )

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -19,7 +19,6 @@ bit-set = { version = "0.5.3" }
 bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["serde"] }
-bitvec = { version = "1.0.1" }
 bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2.17" }
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1.6.0" }
 byteorder = { version = "1.5.0" }
@@ -48,8 +47,7 @@ futures-util = { version = "0.3.29", features = ["channel", "io", "sink"] }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.2", features = ["raw"] }
-hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13.2" }
+hashbrown = { version = "0.13.2" }
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
@@ -66,17 +64,18 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
+openapiv3 = { version = "2.0.0-rc.1", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
 proc-macro2 = { version = "1.0.69" }
-rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
-rand_chacha = { version = "0.3.1" }
+rand = { version = "0.8.5" }
+rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.10.2" }
 regex-automata = { version = "0.4.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax-c38e5c1d305a1b54 = { package = "regex-syntax", version = "0.8.2" }
-reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "stream"] }
+regex-syntax = { version = "0.8.2" }
+reqwest = { version = "0.11.22", features = ["blocking", "json", "rustls-tls", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
@@ -113,12 +112,10 @@ bit-set = { version = "0.5.3" }
 bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["serde"] }
-bitvec = { version = "1.0.1" }
 bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2.17" }
 bstr-dff4ba8e3ae991db = { package = "bstr", version = "1.6.0" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.5.0", features = ["serde"] }
-cc = { version = "1.0.83", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.31", features = ["alloc", "serde"] }
 cipher = { version = "0.4.4", default-features = false, features = ["block-padding", "zeroize"] }
 clap = { version = "4.4.3", features = ["derive", "env", "wrap_help"] }
@@ -143,8 +140,7 @@ futures-util = { version = "0.3.29", features = ["channel", "io", "sink"] }
 gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "2739c18e80697aa6bc235c935176d14b4d757ee9", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom = { version = "0.2.10", default-features = false, features = ["js", "rdrand", "std"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14.2", features = ["raw"] }
-hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13.2" }
+hashbrown = { version = "0.13.2" }
 hex = { version = "0.4.3", features = ["serde"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
@@ -161,18 +157,18 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
+openapiv3 = { version = "2.0.0-rc.1", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
 proc-macro2 = { version = "1.0.69" }
-rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
-rand_chacha = { version = "0.3.1" }
+rand = { version = "0.8.5" }
+rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.10.2" }
 regex-automata = { version = "0.4.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6.29" }
-regex-syntax-c38e5c1d305a1b54 = { package = "regex-syntax", version = "0.8.2" }
-reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "stream"] }
+regex-syntax = { version = "0.8.2" }
+reqwest = { version = "0.11.22", features = ["blocking", "json", "rustls-tls", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
@@ -198,7 +194,6 @@ tracing = { version = "0.1.37", features = ["log"] }
 trust-dns-proto = { version = "0.22.0" }
 unicode-bidi = { version = "0.3.13" }
 unicode-normalization = { version = "0.1.22" }
-unicode-xid = { version = "0.2.4" }
 usdt = { version = "0.3.5" }
 uuid = { version = "1.5.0", features = ["serde", "v4"] }
 yasna = { version = "0.5.2", features = ["bit-vec", "num-bigint", "std", "time"] }


### PR DESCRIPTION
With the propolis mock-server split out from the "real" propolis-server, and the handmade types cleaned out of the propolis-client library, we can now free ourselves of the somewhat circular dependency situation.