### PR TITLE
Disable incremental builds on CI

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -51,6 +51,7 @@ export RUSTFLAGS="-D warnings"
 export RUSTDOCFLAGS="-D warnings"
 export TMPDIR=$TEST_TMPDIR
 export RUST_BACKTRACE=1
+export CARGO_INCREMENTAL=0
 ptime -m cargo test --locked --verbose --no-run
 
 #

--- a/.github/buildomat/jobs/ci-tools.sh
+++ b/.github/buildomat/jobs/ci-tools.sh
@@ -28,6 +28,7 @@ banner end-to-end-tests
 #
 export CARGO_PROFILE_DEV_DEBUG=1
 export CARGO_PROFILE_TEST_DEBUG=1
+export CARGO_INCREMENTAL=0
 
 ptime -m cargo build --locked -p end-to-end-tests --tests --bin bootstrap \
 	--message-format json-render-diagnostics >/tmp/output.end-to-end.json

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -28,5 +28,6 @@ banner prerequisites
 ptime -m bash ./tools/install_builder_prerequisites.sh -y
 
 banner clippy
+export CARGO_INCREMENTAL=0
 ptime -m cargo xtask clippy
 ptime -m cargo doc

--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -44,6 +44,7 @@ ptime -m ./tools/install_builder_prerequisites.sh -yp
 ptime -m ./tools/ci_download_softnpu_machinery
 
 # Build the test target
+export CARGO_INCREMENTAL=0
 ptime -m cargo run --locked --release --bin omicron-package -- \
   -t test target create -i standard -m non-gimlet -s softnpu -r single-sled
 ptime -m cargo run --locked --release --bin omicron-package -- \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
 
   check-omicron-deployment:
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_INCREMENTAL: 0
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +51,8 @@ jobs:
   # of our code.
   clippy-lint:
     runs-on: ubuntu-22.04
+    env:
+      CARGO_INCREMENTAL: 0
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
@@ -75,6 +79,8 @@ jobs:
   # the separate "rustdocs" repo.
   build-docs:
     runs-on: ubuntu-22.04
+    env:
+      CARGO_INCREMENTAL: 0
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo


### PR DESCRIPTION
With the intent to speed up CI times, this follows the advice of: https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow

> Disable incremental compilation. CI builds often are closer to from-scratch builds, as changes are typically much bigger than from a local edit-compile cycle. For from-scratch builds, incremental adds an extra dependency-tracking overhead. It also significantly increases the amount of IO and the size of ./target, which make caching less effective.