### PR TITLE
Update dropshot and openapiv3 deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "pretty-hex 0.3.0",
  "schemars",
  "serde",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fa728d07970824fd5f3bd57a3d4dc0fdbea09bfd"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff87a0175a6c8ce4462cfe7486edd7000f01be6e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2128,7 +2128,7 @@ dependencies = [
  "hyper",
  "indexmap 2.1.0",
  "multer",
- "openapiv3",
+ "openapiv3 2.0.0-rc.1",
  "paste",
  "percent-encoding",
  "proc-macro2",
@@ -2147,7 +2147,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-rustls",
- "toml 0.7.8",
+ "toml 0.8.8",
  "usdt",
  "uuid",
  "version_check",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#fa728d07970824fd5f3bd57a3d4dc0fdbea09bfd"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff87a0175a6c8ce4462cfe7486edd7000f01be6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3527,7 +3527,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "schemars",
  "serde",
  "serde_json",
@@ -4392,7 +4392,7 @@ dependencies = [
  "omicron-sled-agent",
  "omicron-test-utils",
  "omicron-workspace-hack",
- "openapiv3",
+ "openapiv3 1.0.3",
  "openssl",
  "oso",
  "oximeter 0.1.0",
@@ -4992,7 +4992,7 @@ dependencies = [
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "schemars",
  "serde",
  "serde_json",
@@ -5068,7 +5068,7 @@ dependencies = [
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "openssl",
  "oxide-client",
  "oximeter 0.1.0",
@@ -5278,7 +5278,7 @@ dependencies = [
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "opte-ioctl",
  "oximeter 0.1.0",
  "oximeter-instruments",
@@ -5409,7 +5409,6 @@ dependencies = [
  "num-iter",
  "num-traits",
  "once_cell",
- "openapiv3",
  "petgraph",
  "postgres-types",
  "ppv-lite86",
@@ -5508,7 +5507,7 @@ dependencies = [
  "heck 0.4.1",
  "indexmap 2.1.0",
  "lazy_static",
- "openapiv3",
+ "openapiv3 1.0.3",
  "regex",
 ]
 
@@ -5517,6 +5516,17 @@ name = "openapiv3"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e56d5c441965b6425165b7e3223cc933ca469834f4a8b4786817a1f9dc4f13"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "openapiv3"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25316406f0191559189c56d99731b63130775de7284d98df5e976ce67882ca8a"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -5752,7 +5762,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "oximeter 0.1.0",
  "oximeter-client",
  "oximeter-db",
@@ -6551,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -6592,7 +6602,7 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "indexmap 2.1.0",
- "openapiv3",
+ "openapiv3 1.0.3",
  "proc-macro2",
  "quote",
  "regex",
@@ -6610,7 +6620,7 @@ name = "progenitor-macro"
 version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/progenitor?branch=main#5c941c0b41b0235031f3ade33a9c119945f1fd51"
 dependencies = [
- "openapiv3",
+ "openapiv3 1.0.3",
  "proc-macro2",
  "progenitor-impl",
  "quote",
@@ -7774,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -7821,9 +7831,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8003,9 +8013,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -9550,7 +9560,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -10205,7 +10215,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "openapi-lint",
- "openapiv3",
+ "openapiv3 1.0.3",
  "rand 0.8.5",
  "reqwest",
  "schemars",

--- a/internal-dns/tests/output/test-server.json
+++ b/internal-dns/tests/output/test-server.json
@@ -33,18 +33,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "Error": {
         "description": "Error information from a response.",
@@ -64,6 +52,18 @@
           "message",
           "request_id"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/nexus/tests/output/cmd-nexus-noargs-stderr
+++ b/nexus/tests/output/cmd-nexus-noargs-stderr
@@ -1,6 +1,13 @@
-error: the following required arguments were not provided:
-  <CONFIG_FILE_PATH>
+See README.adoc for more information
 
-Usage: nexus <CONFIG_FILE_PATH>
+Usage: nexus [OPTIONS] [CONFIG_FILE_PATH]
 
-For more information, try '--help'.
+Arguments:
+  [CONFIG_FILE_PATH]  
+
+Options:
+  -O, --openapi           Print the external OpenAPI Spec document and exit
+  -I, --openapi-internal  Print the internal OpenAPI Spec document and exit
+  -h, --help              Print help
+
+nexus: CONFIG_FILE_PATH is required

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -160,18 +160,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "Baseboard": {
         "description": "Describes properties that should uniquely identify a Gimlet.",
@@ -976,6 +964,18 @@
       "UserId": {
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID though they may contain a UUID.",
         "type": "string"
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/dns-server.json
+++ b/openapi/dns-server.json
@@ -54,18 +54,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "DnsConfig": {
         "type": "object",
@@ -250,6 +238,18 @@
           "target",
           "weight"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -1393,18 +1393,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "Duration": {
         "type": "object",
@@ -3108,6 +3096,18 @@
           "power_off",
           "power_reset"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/installinator-artifactd.json
+++ b/openapi/installinator-artifactd.json
@@ -95,18 +95,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "Duration": {
         "type": "object",
@@ -2322,6 +2310,18 @@
           "slots_attempted",
           "slots_written"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -679,18 +679,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "ActivationReason": {
         "description": "Describes why a background task was activated\n\nThis is only used for debugging.  This is deliberately not made available to the background task itself.  See \"Design notes\" in the module-level documentation for details.",
@@ -5409,6 +5397,18 @@
             ]
           }
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7838,18 +7838,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "Address": {
         "description": "An address tied to an address lot.",
@@ -16057,6 +16045,18 @@
             ]
           }
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   },

--- a/openapi/oximeter.json
+++ b/openapi/oximeter.json
@@ -134,18 +134,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "CollectorInfo": {
         "type": "object",
@@ -243,6 +231,18 @@
         "required": [
           "items"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -991,18 +991,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "AddSledRequest": {
         "description": "A request to Add a given sled after rack initialization has occurred",
@@ -6479,6 +6467,18 @@
         "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
         "type": "string",
         "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -677,18 +677,6 @@
     }
   },
   "components": {
-    "responses": {
-      "Error": {
-        "description": "Error",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "AbortUpdateOptions": {
         "type": "object",
@@ -4705,6 +4693,18 @@
           "power_off",
           "power_reset"
         ]
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
       }
     }
   }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -66,12 +66,11 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
-openapiv3 = { version = "1.0.3", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
-proc-macro2 = { version = "1.0.67" }
+proc-macro2 = { version = "1.0.69" }
 rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
 rand_chacha = { version = "0.3.1" }
 regex = { version = "1.10.2" }
@@ -81,7 +80,7 @@ reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.188", features = ["alloc", "derive", "rc"] }
+serde = { version = "1.0.192", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.108", features = ["raw_value"] }
 sha2 = { version = "0.10.8", features = ["oid"] }
 signature = { version = "2.1.0", default-features = false, features = ["digest", "rand_core", "std"] }
@@ -162,12 +161,11 @@ num-bigint = { version = "0.4.4", features = ["rand"] }
 num-integer = { version = "0.1.45", features = ["i128"] }
 num-iter = { version = "0.1.43", default-features = false, features = ["i128"] }
 num-traits = { version = "0.2.16", features = ["i128", "libm"] }
-openapiv3 = { version = "1.0.3", default-features = false, features = ["skip_serializing_defaults"] }
 petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.0.4" }
-proc-macro2 = { version = "1.0.67" }
+proc-macro2 = { version = "1.0.69" }
 rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
 rand_chacha = { version = "0.3.1" }
 regex = { version = "1.10.2" }
@@ -178,7 +176,7 @@ reqwest = { version = "0.11.20", features = ["blocking", "json", "rustls-tls", "
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.13", features = ["bytes", "chrono", "uuid1"] }
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.188", features = ["alloc", "derive", "rc"] }
+serde = { version = "1.0.192", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.108", features = ["raw_value"] }
 sha2 = { version = "0.10.8", features = ["oid"] }
 signature = { version = "2.1.0", default-features = false, features = ["digest", "rand_core", "std"] }


### PR DESCRIPTION
The json specification generated by the updated openapiv3 is ordered slightly differently, but not in a way that matters to anything but "brute force" diff checks like expectorate.  This updates the dependency and applies the reordering to the recorded OpenAPI specs.