### PR TITLE
Add a producer kind to oximeter metric producers

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -202,6 +202,19 @@ impl From<&types::InstanceState>
     }
 }
 
+impl From<omicron_common::api::internal::nexus::ProducerKind>
+    for types::ProducerKind
+{
+    fn from(kind: omicron_common::api::internal::nexus::ProducerKind) -> Self {
+        use omicron_common::api::internal::nexus::ProducerKind;
+        match kind {
+            ProducerKind::SledAgent => Self::SledAgent,
+            ProducerKind::Service => Self::Service,
+            ProducerKind::Instance => Self::Instance,
+        }
+    }
+}
+
 impl From<&omicron_common::api::internal::nexus::ProducerEndpoint>
     for types::ProducerEndpoint
 {
@@ -212,6 +225,7 @@ impl From<&omicron_common::api::internal::nexus::ProducerEndpoint>
             address: s.address.to_string(),
             base_route: s.base_route.clone(),
             id: s.id,
+            kind: s.kind.map(Into::into),
             interval: s.interval.into(),
         }
     }

--- a/clients/oximeter-client/src/lib.rs
+++ b/clients/oximeter-client/src/lib.rs
@@ -20,6 +20,19 @@ impl From<std::time::Duration> for types::Duration {
     }
 }
 
+impl From<omicron_common::api::internal::nexus::ProducerKind>
+    for types::ProducerKind
+{
+    fn from(kind: omicron_common::api::internal::nexus::ProducerKind) -> Self {
+        use omicron_common::api::internal::nexus;
+        match kind {
+            nexus::ProducerKind::Service => Self::Service,
+            nexus::ProducerKind::SledAgent => Self::SledAgent,
+            nexus::ProducerKind::Instance => Self::Instance,
+        }
+    }
+}
+
 impl From<&omicron_common::api::internal::nexus::ProducerEndpoint>
     for types::ProducerEndpoint
 {
@@ -30,6 +43,7 @@ impl From<&omicron_common::api::internal::nexus::ProducerEndpoint>
             address: s.address.to_string(),
             base_route: s.base_route.clone(),
             id: s.id,
+            kind: s.kind.map(Into::into),
             interval: s.interval.into(),
         }
     }

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -84,13 +84,34 @@ pub struct SledInstanceState {
 
 // Oximeter producer/collector objects.
 
+/// The kind of metric producer this is.
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProducerKind {
+    /// The producer is a sled-agent.
+    SledAgent,
+    /// The producer is an Omicron-managed service.
+    Service,
+    /// The producer is a Propolis VMM managing a guest instance.
+    Instance,
+}
+
 /// Information announced by a metric server, used so that clients can contact it and collect
 /// available metric data from it.
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
 pub struct ProducerEndpoint {
+    /// A unique ID for this producer.
     pub id: Uuid,
+    /// The kind of producer.
+    pub kind: Option<ProducerKind>,
+    /// The IP address and port at which `oximeter` can collect metrics from the
+    /// producer.
     pub address: SocketAddr,
+    /// The API base route from which `oximeter` can collect metrics.
+    ///
+    /// The full route is `{base_route}/{id}`.
     pub base_route: String,
+    /// The interval on which `oximeter` should collect metrics.
     pub interval: Duration,
 }
 

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1270,7 +1270,7 @@ table! {
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(11, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(12, 0, 0);
 
 allow_tables_to_appear_in_same_query!(
     system_update,

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -399,6 +399,7 @@ table! {
         id -> Uuid,
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
+        kind -> Nullable<crate::ProducerKindEnum>,
         ip -> Inet,
         port -> Int4,
         interval -> Float8,

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -96,6 +96,7 @@ impl DataStore {
             .do_update()
             .set((
                 dsl::time_modified.eq(Utc::now()),
+                dsl::kind.eq(producer.kind),
                 dsl::ip.eq(producer.ip),
                 dsl::port.eq(producer.port),
                 dsl::interval.eq(producer.interval),

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -127,6 +127,9 @@ impl super::Nexus {
             for producer in producers.into_iter() {
                 let producer_info = oximeter_client::types::ProducerEndpoint {
                     id: producer.id(),
+                    kind: producer
+                        .kind
+                        .map(|kind| nexus::ProducerKind::from(kind).into()),
                     address: SocketAddr::new(
                         producer.ip.ip(),
                         producer.port.try_into().unwrap(),
@@ -149,6 +152,7 @@ impl super::Nexus {
     pub(crate) async fn register_as_producer(&self, address: SocketAddr) {
         let producer_endpoint = nexus::ProducerEndpoint {
             id: self.id,
+            kind: Some(nexus::ProducerKind::Service),
             address,
             base_route: String::from("/metrics/collect"),
             interval: Duration::from_secs(10),

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -30,6 +30,7 @@ use omicron_common::address::NEXUS_OPTE_IPV4_SUBNET;
 use omicron_common::api::external::MacAddr;
 use omicron_common::api::external::{IdentityMetadata, Name};
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_common::api::internal::nexus::ProducerKind;
 use omicron_common::api::internal::shared::SwitchLocation;
 use omicron_common::nexus_config;
 use omicron_common::nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
@@ -1092,6 +1093,7 @@ pub async fn start_producer_server(
     let producer_address = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0);
     let server_info = ProducerEndpoint {
         id,
+        kind: Some(ProducerKind::Service),
         address: producer_address,
         base_route: "/collect".to_string(),
         interval: Duration::from_secs(1),

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -9,6 +9,7 @@ use http::StatusCode;
 use nexus_test_interface::NexusServer;
 use nexus_test_utils_macros::nexus_test;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_common::api::internal::nexus::ProducerKind;
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 use oximeter_db::DbWrite;
 use std::collections::BTreeSet;
@@ -360,6 +361,7 @@ async fn test_oximeter_collector_reregistration_gets_all_assignments() {
         ids.insert(id);
         let info = ProducerEndpoint {
             id,
+            kind: Some(ProducerKind::Service),
             address: SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 12345),
             base_route: String::from("/collect"),
             interval: Duration::from_secs(1),

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -4322,17 +4322,34 @@
         "type": "object",
         "properties": {
           "address": {
+            "description": "The IP address and port at which `oximeter` can collect metrics from the producer.",
             "type": "string"
           },
           "base_route": {
+            "description": "The API base route from which `oximeter` can collect metrics.\n\nThe full route is `{base_route}/{id}`.",
             "type": "string"
           },
           "id": {
+            "description": "A unique ID for this producer.",
             "type": "string",
             "format": "uuid"
           },
           "interval": {
-            "$ref": "#/components/schemas/Duration"
+            "description": "The interval on which `oximeter` should collect metrics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "kind": {
+            "nullable": true,
+            "description": "The kind of producer.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProducerKind"
+              }
+            ]
           }
         },
         "required": [
@@ -4340,6 +4357,32 @@
           "base_route",
           "id",
           "interval"
+        ]
+      },
+      "ProducerKind": {
+        "description": "The kind of metric producer this is.",
+        "oneOf": [
+          {
+            "description": "The producer is a sled-agent.",
+            "type": "string",
+            "enum": [
+              "sled_agent"
+            ]
+          },
+          {
+            "description": "The producer is an Omicron-managed service.",
+            "type": "string",
+            "enum": [
+              "service"
+            ]
+          },
+          {
+            "description": "The producer is a Propolis VMM managing a guest instance.",
+            "type": "string",
+            "enum": [
+              "instance"
+            ]
+          }
         ]
       },
       "ProducerResultsItem": {

--- a/openapi/oximeter.json
+++ b/openapi/oximeter.json
@@ -191,17 +191,34 @@
         "type": "object",
         "properties": {
           "address": {
+            "description": "The IP address and port at which `oximeter` can collect metrics from the producer.",
             "type": "string"
           },
           "base_route": {
+            "description": "The API base route from which `oximeter` can collect metrics.\n\nThe full route is `{base_route}/{id}`.",
             "type": "string"
           },
           "id": {
+            "description": "A unique ID for this producer.",
             "type": "string",
             "format": "uuid"
           },
           "interval": {
-            "$ref": "#/components/schemas/Duration"
+            "description": "The interval on which `oximeter` should collect metrics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "kind": {
+            "nullable": true,
+            "description": "The kind of producer.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProducerKind"
+              }
+            ]
           }
         },
         "required": [
@@ -230,6 +247,32 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "ProducerKind": {
+        "description": "The kind of metric producer this is.",
+        "oneOf": [
+          {
+            "description": "The producer is a sled-agent.",
+            "type": "string",
+            "enum": [
+              "sled_agent"
+            ]
+          },
+          {
+            "description": "The producer is an Omicron-managed service.",
+            "type": "string",
+            "enum": [
+              "service"
+            ]
+          },
+          {
+            "description": "The producer is a Propolis VMM managing a guest instance.",
+            "type": "string",
+            "enum": [
+              "instance"
+            ]
+          }
         ]
       }
     },

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -648,6 +648,7 @@ mod tests {
     use hyper::Response;
     use hyper::Server;
     use hyper::StatusCode;
+    use omicron_common::api::internal::nexus::ProducerKind;
     use omicron_test_utils::dev::test_setup_log;
     use std::convert::Infallible;
     use std::net::Ipv6Addr;
@@ -694,6 +695,7 @@ mod tests {
         let interval = Duration::from_secs(1);
         let endpoint = ProducerEndpoint {
             id: Uuid::new_v4(),
+            kind: Some(ProducerKind::Service),
             address,
             base_route: String::from("/"),
             interval,
@@ -752,6 +754,7 @@ mod tests {
         let interval = Duration::from_secs(1);
         let endpoint = ProducerEndpoint {
             id: Uuid::new_v4(),
+            kind: Some(ProducerKind::Service),
             address: SocketAddr::V6(SocketAddrV6::new(
                 Ipv6Addr::LOCALHOST,
                 0,
@@ -840,6 +843,7 @@ mod tests {
         let interval = Duration::from_secs(1);
         let endpoint = ProducerEndpoint {
             id: Uuid::new_v4(),
+            kind: Some(ProducerKind::Service),
             address,
             base_route: String::from("/"),
             interval,

--- a/oximeter/producer/examples/producer.rs
+++ b/oximeter/producer/examples/producer.rs
@@ -15,6 +15,7 @@ use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
 use dropshot::HandlerTaskMode;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_common::api::internal::nexus::ProducerKind;
 use oximeter::types::Cumulative;
 use oximeter::types::ProducerRegistry;
 use oximeter::types::Sample;
@@ -124,6 +125,7 @@ async fn main() -> anyhow::Result<()> {
     registry.register_producer(producer).unwrap();
     let server_info = ProducerEndpoint {
         id: registry.producer_id(),
+        kind: Some(ProducerKind::Service),
         address: args.address,
         base_route: "/collect".to_string(),
         interval: Duration::from_secs(10),

--- a/schema/crdb/12.0.0/up01.sql
+++ b/schema/crdb/12.0.0/up01.sql
@@ -1,0 +1,27 @@
+/*
+ * Drop the entire metric producer assignment table.
+ *
+ * Programs wishing to produce metrics need to register with Nexus. That creates
+ * an assignment of the producer to a collector, which is recorded in this
+ * table. That registration is idempotent, and every _current_ producer will
+ * register when it restarts. For example, `dpd` includes a task that registers
+ * with Nexus, so each time it (re)starts, that registration will happen.
+ *
+ * With that in mind, dropping this table is safe, because as of today, all
+ * software updates reuqire that the whole control plane be offline. We know
+ * that these entries will be recreated shortly, as the services registering
+ * producers are restarted.
+ *
+ * The current metric producers are:
+ *
+ * - `dpd`
+ * - Each `nexus` instance
+ * - Each `sled-agent` instance
+ * - The Propolis server for each guest Instance
+ *
+ * Another reason we're dropping the table is because we will add a new column,
+ * `kind`, in a following update file, but we don't have a good way to backfill
+ * that value for existing rows. We also don't need to, because these services
+ * will soon reregister, and provide us with a value.
+ */
+DROP TABLE IF EXISTS omicron.public.metric_producer;

--- a/schema/crdb/12.0.0/up02.sql
+++ b/schema/crdb/12.0.0/up02.sql
@@ -1,0 +1,11 @@
+/*
+ * The kind of metric producer each record corresponds to.
+ */
+CREATE TYPE IF NOT EXISTS omicron.public.producer_kind AS ENUM (
+    -- A sled agent for an entry in the sled table.
+    'sled_agent',
+    -- A service in the omicron.public.service table
+    'service',
+    -- A Propolis VMM for an instance in the omicron.public.instance table
+    'instance'
+);

--- a/schema/crdb/12.0.0/up03.sql
+++ b/schema/crdb/12.0.0/up03.sql
@@ -1,0 +1,17 @@
+/*
+ * Recreate the metric producer assignment table.
+ *
+ * Note that we're adding the `kind` column here, using the new enum in the
+ * previous update SQL file.
+ */
+CREATE TABLE IF NOT EXISTS omicron.public.metric_producer (
+    id UUID PRIMARY KEY,
+    time_created TIMESTAMPTZ NOT NULL,
+    time_modified TIMESTAMPTZ NOT NULL,
+    kind omicron.public.producer_kind,
+    ip INET NOT NULL,
+    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
+    interval FLOAT NOT NULL,
+    base_route STRING(512) NOT NULL,
+    oximeter_id UUID NOT NULL
+);

--- a/schema/crdb/12.0.0/up04.sql
+++ b/schema/crdb/12.0.0/up04.sql
@@ -1,0 +1,8 @@
+/*
+ * Recreate index to support looking up a producer by its assigned oximeter
+ * collector ID.
+ */
+CREATE UNIQUE INDEX IF NOT EXISTS lookup_producer_by_oximeter ON omicron.public.metric_producer (
+    oximeter_id,
+    id
+);

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1109,12 +1109,25 @@ CREATE TABLE IF NOT EXISTS omicron.public.oximeter (
 );
 
 /*
+ * The kind of metric producer each record corresponds to.
+ */
+CREATE TYPE IF NOT EXISTS omicron.public.producer_kind AS ENUM (
+    -- A sled agent for an entry in the sled table.
+    'sled_agent',
+    -- A service in the omicron.public.service table
+    'service',
+    -- A Propolis VMM for an instance in the omicron.public.instance table
+    'instance'
+);
+
+/*
  * Information about registered metric producers.
  */
 CREATE TABLE IF NOT EXISTS omicron.public.metric_producer (
     id UUID PRIMARY KEY,
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
+    kind omicron.public.producer_kind,
     ip INET NOT NULL,
     port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
     interval FLOAT NOT NULL,
@@ -2906,7 +2919,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '11.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '12.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -17,6 +17,7 @@ use omicron_common::api::external::Generation;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_common::api::internal::nexus::ProducerKind;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
 use propolis_client::types::DiskAttachmentState as PropolisDiskState;
@@ -168,6 +169,7 @@ impl SimDisk {
         let producer_address = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 0);
         let server_info = ProducerEndpoint {
             id,
+            kind: Some(ProducerKind::SledAgent),
             address: producer_address,
             base_route: "/collect".to_string(),
             interval: Duration::from_millis(200),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -43,6 +43,7 @@ use omicron_common::address::{
 };
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
+use omicron_common::api::internal::nexus::ProducerKind;
 use omicron_common::api::internal::nexus::{
     SledInstanceState, VmmRuntimeState,
 };
@@ -504,6 +505,7 @@ impl SledAgent {
         // Nexus. This should not block progress here.
         let endpoint = ProducerEndpoint {
             id: request.body.id,
+            kind: Some(ProducerKind::SledAgent),
             address: sled_address.into(),
             base_route: String::from("/metrics/collect"),
             interval: crate::metrics::METRIC_COLLECTION_INTERVAL,


### PR DESCRIPTION
- Adds the `kind` enum to metric producer information, including DB schema, model, and various client parameter types. This records the supported types of metric producers, and is intended to aid debugging and future work around updates and instance lifecycle management.
- Add schema update files which create the DB enum type and add it as a column to the `metric_producer` table. This currently _drops_ the existing table and recreates it with the new column, rather than adding the column using `ALTER TABLE`. That is intended to remove old entries in bulk, since nothing previously removed the records for Propolis servers when their instance was stopped.

This is the initial PR in a sequence that will eventually make this field _required_ in both the database and API requests. As there are consumers of this API outside of the Omicron repository, this field needs to start as optional, to avoid introducing a commit with incompatible clients. Here are the planned steps:

- This PR introduces an optional `kind` field into the `metric_producer` table and `ProducerEndpoint` registration request body
- A PR in [Crucible](https://github.com/oxidecomputer/crucible/pull/1039) which includes the optional field in its API requests
- A PR in [Dendrite](https://github.com/oxidecomputer/dendrite) which includes the optional field in its API requests
- A PR in [Propolis](https://github.com/oxidecomputer/propolis) which includes the optional field in its API requests
- A PR in Omicron which makes the database and API request fields required, and points to the new versions of the three previous dependencies
- A PR in Dendrite, Crucible, and Propolis which adapts to the new required field from the previous step
- A final PR in Omicron which points to the new versions of the three previous dependencies