### PR TITLE
Update Crucible (51a3121) and Propolis (8ad2d4f)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=54398875a2125227d13827d4236dce943c019b1c#54398875a2125227d13827d4236dce943c019b1c"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=54398875a2125227d13827d4236dce943c019b1c#54398875a2125227d13827d4236dce943c019b1c"
 dependencies = [
  "libc",
  "strum",
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=54398875a2125227d13827d4236dce943c019b1c#54398875a2125227d13827d4236dce943c019b1c"
 dependencies = [
  "async-trait",
  "base64 0.21.5",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=54398875a2125227d13827d4236dce943c019b1c#54398875a2125227d13827d4236dce943c019b1c"
 dependencies = [
  "anyhow",
  "atty",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=54398875a2125227d13827d4236dce943c019b1c#54398875a2125227d13827d4236dce943c019b1c"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 dependencies = [
  "libc",
  "strum",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
+source = "git+https://github.com/oxidecomputer/crucible?rev=51a3121c8318fc7ac97d74f917ce1d37962e785f#51a3121c8318fc7ac97d74f917ce1d37962e785f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1286,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
+source = "git+https://github.com/oxidecomputer/crucible?rev=51a3121c8318fc7ac97d74f917ce1d37962e785f#51a3121c8318fc7ac97d74f917ce1d37962e785f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da534e73380f3cc53ca0de073e1ea862ae32109b#da534e73380f3cc53ca0de073e1ea862ae32109b"
+source = "git+https://github.com/oxidecomputer/crucible?rev=51a3121c8318fc7ac97d74f917ce1d37962e785f#51a3121c8318fc7ac97d74f917ce1d37962e785f"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 dependencies = [
  "async-trait",
  "base64 0.21.5",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 dependencies = [
  "anyhow",
  "atty",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=5ed82315541271e2734746a9ca79e39f35c12283#5ed82315541271e2734746a9ca79e39f35c12283"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2#8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,9 +169,9 @@ cookie = "0.16"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "da534e73380f3cc53ca0de073e1ea862ae32109b" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "51a3121c8318fc7ac97d74f917ce1d37962e785f" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "51a3121c8318fc7ac97d74f917ce1d37962e785f" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "51a3121c8318fc7ac97d74f917ce1d37962e785f" }
 curve25519-dalek = "4"
 datatest-stable = "0.2.3"
 display-error-chain = "0.2.0"
@@ -290,9 +290,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "5ed82315541271e2734746a9ca79e39f35c12283" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
 proptest = "1.3.1"
 quote = "1.0"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,9 +290,9 @@ pretty-hex = "0.3.0"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "54398875a2125227d13827d4236dce943c019b1c" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "54398875a2125227d13827d4236dce943c019b1c" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "54398875a2125227d13827d4236dce943c019b1c" }
 proptest = "1.3.1"
 quote = "1.0"
 rand = "0.8.5"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -409,10 +409,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
+source.commit = "54398875a2125227d13827d4236dce943c019b1c"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "1a7b0d8d20c7a0044b9f972f4d33a6e046fca862a54439e83617f2202468b396"
+source.sha256 = "01b8563db6626f90ee3fb6d97e7921b0a680373d843c1bea7ebf46fcea4f7b28"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -384,10 +384,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "da534e73380f3cc53ca0de073e1ea862ae32109b"
+source.commit = "51a3121c8318fc7ac97d74f917ce1d37962e785f"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "572ac3b19e51b4e476266a62c2b7e06eff81c386cb48247c4b9f9b1e2ee81895"
+source.sha256 = "897d0fd6c0b82db42256a63a13c228152e1117434afa2681f649b291e3c6f46d"
 output.type = "zone"
 
 [package.crucible-pantry]
@@ -395,10 +395,10 @@ service_name = "crucible_pantry"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "da534e73380f3cc53ca0de073e1ea862ae32109b"
+source.commit = "51a3121c8318fc7ac97d74f917ce1d37962e785f"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "812269958e18f54d72bc10bb4fb81f26c084cf762da7fd98e63d58c689be9ad1"
+source.sha256 = "fe545de7ac4f15454d7827927149c5f0fc68ce9545b4f1ef96aac9ac8039805a"
 output.type = "zone"
 
 # Refer to
@@ -409,10 +409,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "4019eb10fc2f4ba9bf210d0461dc6292b68309c2"
+source.commit = "8ad2d4fe9bb21d7a8989dc5f556a66d19ba796a2"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "aa1d9dc5c9117c100f9636901e8eec6679d7dfbf869c46b7f2873585f94a1b89"
+source.sha256 = "1a7b0d8d20c7a0044b9f972f4d33a6e046fca862a54439e83617f2202468b396"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -30,8 +30,8 @@ skip_timesync = false
 zpools = [
   "oxi_a462a7f7-b628-40fe-80ff-4e4189e2d62b",
   "oxi_b462a7f7-b628-40fe-80ff-4e4189e2d62b",
-  "oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b",
-  "oxp_e4b4dc87-ab46-49fb-a4b4-d361ae214c03",
+#  "oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b",
+#  "oxp_e4b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_f4b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_14b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_24b4dc87-ab46-49fb-a4b4-d361ae214c03",
@@ -62,7 +62,7 @@ swap_device_size_gb = 64
 #
 # If empty, this will be equivalent to the first result from:
 # $ dladm show-phys -p -o LINK
-# data_link = "igb0"
+data_link = "igb0"
 
 # On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
 # to configure routes between sleds.  This runs over the Sidecar's rear ports

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -30,8 +30,8 @@ skip_timesync = false
 zpools = [
   "oxi_a462a7f7-b628-40fe-80ff-4e4189e2d62b",
   "oxi_b462a7f7-b628-40fe-80ff-4e4189e2d62b",
-#  "oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b",
-#  "oxp_e4b4dc87-ab46-49fb-a4b4-d361ae214c03",
+  "oxp_d462a7f7-b628-40fe-80ff-4e4189e2d62b",
+  "oxp_e4b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_f4b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_14b4dc87-ab46-49fb-a4b4-d361ae214c03",
   "oxp_24b4dc87-ab46-49fb-a4b4-d361ae214c03",
@@ -62,7 +62,7 @@ swap_device_size_gb = 64
 #
 # If empty, this will be equivalent to the first result from:
 # $ dladm show-phys -p -o LINK
-data_link = "igb0"
+# data_link = "igb0"
 
 # On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
 # to configure routes between sleds.  This runs over the Sidecar's rear ports


### PR DESCRIPTION
Crucible changes:
test-crudd can collect more info, test_up can be gentle (#997) 
Decrypt without holding the downstairs lock (#1021) 
Add raw file backend (#991)
Don't hold the Downstairs lock while doing encryption (#1019) 
Antagonize the Crucible Agent (#1011)
The Pantry should reject non-block sized writes (#1013)

Propolis changes:
make headroom for linux virtio/9p client impl (#565)
Guarantee Tokio access for Entity methods