### PR TITLE
Pare down nexus-client dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,8 +3934,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sled-hardware",
- "sled-storage",
  "slog",
  "uuid",
 ]

--- a/clients/nexus-client/Cargo.toml
+++ b/clients/nexus-client/Cargo.toml
@@ -10,8 +10,6 @@ futures.workspace = true
 ipnetwork.workspace = true
 omicron-common.workspace = true
 omicron-passwords.workspace = true
-sled-hardware.workspace = true
-sled-storage.workspace = true
 progenitor.workspace = true
 regress.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -388,36 +388,3 @@ impl From<omicron_common::api::internal::shared::ExternalPortDiscovery>
         }
     }
 }
-
-impl From<sled_hardware::DiskVariant> for types::PhysicalDiskKind {
-    fn from(value: sled_hardware::DiskVariant) -> Self {
-        match value {
-            sled_hardware::DiskVariant::U2 => types::PhysicalDiskKind::U2,
-            sled_hardware::DiskVariant::M2 => types::PhysicalDiskKind::M2,
-        }
-    }
-}
-
-impl From<sled_hardware::Baseboard> for types::Baseboard {
-    fn from(b: sled_hardware::Baseboard) -> types::Baseboard {
-        types::Baseboard {
-            serial_number: b.identifier().to_string(),
-            part_number: b.model().to_string(),
-            revision: b.revision(),
-        }
-    }
-}
-
-impl From<sled_storage::dataset::DatasetKind> for types::DatasetKind {
-    fn from(k: sled_storage::dataset::DatasetKind) -> Self {
-        use sled_storage::dataset::DatasetKind::*;
-        match k {
-            CockroachDb => Self::Cockroach,
-            Crucible => Self::Crucible,
-            Clickhouse => Self::Clickhouse,
-            ClickhouseKeeper => Self::ClickhouseKeeper,
-            ExternalDns => Self::ExternalDns,
-            InternalDns => Self::InternalDns,
-        }
-    }
-}

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -154,3 +154,51 @@ fn d2n_record(
         }
     }
 }
+
+// Although it is a bit awkward to define these conversions here, it frees us
+// from depending on sled_storage/sled_hardware in the nexus_client crate.
+
+pub(crate) trait ConvertInto<T>: Sized {
+    fn convert(self) -> T;
+}
+
+impl ConvertInto<nexus_client::types::PhysicalDiskKind>
+    for sled_hardware::DiskVariant
+{
+    fn convert(self) -> nexus_client::types::PhysicalDiskKind {
+        use nexus_client::types::PhysicalDiskKind;
+
+        match self {
+            sled_hardware::DiskVariant::U2 => PhysicalDiskKind::U2,
+            sled_hardware::DiskVariant::M2 => PhysicalDiskKind::M2,
+        }
+    }
+}
+
+impl ConvertInto<nexus_client::types::Baseboard> for sled_hardware::Baseboard {
+    fn convert(self) -> nexus_client::types::Baseboard {
+        nexus_client::types::Baseboard {
+            serial_number: self.identifier().to_string(),
+            part_number: self.model().to_string(),
+            revision: self.revision(),
+        }
+    }
+}
+
+impl ConvertInto<nexus_client::types::DatasetKind>
+    for sled_storage::dataset::DatasetKind
+{
+    fn convert(self) -> nexus_client::types::DatasetKind {
+        use nexus_client::types::DatasetKind;
+        use sled_storage::dataset::DatasetKind::*;
+
+        match self {
+            CockroachDb => DatasetKind::Cockroach,
+            Crucible => DatasetKind::Crucible,
+            Clickhouse => DatasetKind::Clickhouse,
+            ClickhouseKeeper => DatasetKind::ClickhouseKeeper,
+            ExternalDns => DatasetKind::ExternalDns,
+            InternalDns => DatasetKind::InternalDns,
+        }
+    }
+}

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -63,7 +63,7 @@ use crate::bootstrap::early_networking::{
 use crate::bootstrap::params::BootstrapAddressDiscovery;
 use crate::bootstrap::params::StartSledAgentRequest;
 use crate::bootstrap::rss_handle::BootstrapAgentHandle;
-use crate::nexus::d2n_params;
+use crate::nexus::{d2n_params, ConvertInto};
 use crate::params::{
     AutonomousServiceOnlyError, ServiceType, ServiceZoneRequest,
     ServiceZoneService, TimeSync, ZoneType,
@@ -564,7 +564,7 @@ impl ServiceInner {
                         dataset_id: dataset.id,
                         request: NexusTypes::DatasetPutRequest {
                             address: dataset.service_address.to_string(),
-                            kind: dataset.name.dataset().clone().into(),
+                            kind: dataset.name.dataset().clone().convert(),
                         },
                     })
                 }

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::instance_manager::{InstanceManager, ReservoirMode};
 use crate::long_running_tasks::LongRunningTaskHandles;
 use crate::metrics::MetricsManager;
-use crate::nexus::{NexusClientWithResolver, NexusRequestQueue};
+use crate::nexus::{ConvertInto, NexusClientWithResolver, NexusRequestQueue};
 use crate::params::{
     DiskStateRequested, InstanceHardware, InstanceMigrationSourceParams,
     InstancePutStateResponse, InstanceStateRequested,
@@ -607,9 +607,7 @@ impl SledAgent {
         let nexus_client = self.inner.nexus_client.clone();
         let sled_address = self.inner.sled_address();
         let is_scrimlet = self.inner.hardware.is_scrimlet();
-        let baseboard = nexus_client::types::Baseboard::from(
-            self.inner.hardware.baseboard(),
-        );
+        let baseboard = self.inner.hardware.baseboard().convert();
         let usable_hardware_threads =
             self.inner.hardware.online_processor_count();
         let usable_physical_ram =

--- a/sled-agent/src/storage_monitor.rs
+++ b/sled-agent/src/storage_monitor.rs
@@ -7,7 +7,7 @@
 //! code.
 
 use crate::dump_setup::DumpSetup;
-use crate::nexus::NexusClientWithResolver;
+use crate::nexus::{ConvertInto, NexusClientWithResolver};
 use derive_more::From;
 use futures::stream::FuturesOrdered;
 use futures::FutureExt;
@@ -338,7 +338,7 @@ fn compute_resource_diffs(
                         model: disk_id.model.clone(),
                         serial: disk_id.serial.clone(),
                         vendor: disk_id.vendor.clone(),
-                        variant: updated_disk.variant().into(),
+                        variant: updated_disk.variant().convert(),
                     });
                 }
                 if pool != updated_pool {
@@ -363,7 +363,7 @@ fn compute_resource_diffs(
                 model: disk_id.model.clone(),
                 serial: disk_id.serial.clone(),
                 vendor: disk_id.vendor.clone(),
-                variant: updated_disk.variant().into(),
+                variant: updated_disk.variant().convert(),
             });
             put_pool(disk_id, updated_pool);
         }


### PR DESCRIPTION
Adding sled-hardware and sled-storage as dependencies to nexus-client bring in a large portion of unrelated crates, all in service of some (albeit convenient) type conversion routines.  For the sake of nexus-client consumers outside of omicron, we can manually implement those few conversions in sled-agent where they are consumed.