### PR TITLE
[nexus] Add `HostPhase1Updater`

### DIFF
--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -10,6 +10,7 @@ use sled_agent_client::Client as SledAgentClient;
 use std::sync::Arc;
 use uuid::Uuid;
 
+pub use super::update::HostPhase1Updater;
 pub use super::update::MgsClients;
 pub use super::update::RotUpdater;
 pub use super::update::SpUpdater;

--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -11,9 +11,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub use super::update::MgsClients;
-pub use super::update::RotUpdateError;
 pub use super::update::RotUpdater;
-pub use super::update::SpUpdateError;
 pub use super::update::SpUpdater;
 pub use super::update::UpdateProgress;
 pub use gateway_client::types::SpType;

--- a/nexus/src/app/update/common_sp_update.rs
+++ b/nexus/src/app/update/common_sp_update.rs
@@ -63,6 +63,10 @@ pub(super) trait SpComponentUpdater {
     fn update_id(&self) -> Uuid;
 
     /// The update payload data to send to MGS.
+    // TODO-performance This has to be convertible into a `reqwest::Body`, so we
+    // return an owned Vec. That requires all our implementors to clone the data
+    // at least once; maybe we should use `Bytes` instead (which is cheap to
+    // clone and also convertible into a reqwest::Body)?
     fn update_data(&self) -> Vec<u8>;
 
     /// The sending half of the watch channel to report update progress.

--- a/nexus/src/app/update/common_sp_update.rs
+++ b/nexus/src/app/update/common_sp_update.rs
@@ -1,0 +1,235 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Module containing implementation details shared amongst all MGS-to-SP-driven
+//! updates.
+
+use super::MgsClients;
+use super::UpdateProgress;
+use gateway_client::types::SpType;
+use gateway_client::types::SpUpdateStatus;
+use slog::Logger;
+use std::time::Duration;
+use tokio::sync::watch;
+use uuid::Uuid;
+
+type GatewayClientError = gateway_client::Error<gateway_client::types::Error>;
+
+/// Error type returned when an update to a component managed by the SP fails.
+///
+/// Note that the SP manages itself, as well, so "SP component" here includes
+/// the SP.
+#[derive(Debug, thiserror::Error)]
+pub enum SpComponentUpdateError {
+    #[error("error communicating with MGS")]
+    MgsCommunication(#[from] GatewayClientError),
+    #[error("different update is now preparing ({0})")]
+    DifferentUpdatePreparing(Uuid),
+    #[error("different update is now in progress ({0})")]
+    DifferentUpdateInProgress(Uuid),
+    #[error("different update is now complete ({0})")]
+    DifferentUpdateComplete(Uuid),
+    #[error("different update is now aborted ({0})")]
+    DifferentUpdateAborted(Uuid),
+    #[error("different update failed ({0})")]
+    DifferentUpdateFailed(Uuid),
+    #[error("update status lost (did the SP reset?)")]
+    UpdateStatusLost,
+    #[error("update was aborted")]
+    UpdateAborted,
+    #[error("update failed (error code {0})")]
+    UpdateFailedWithCode(u32),
+    #[error("update failed (error message {0})")]
+    UpdateFailedWithMessage(String),
+}
+
+pub(super) trait SpComponentUpdater {
+    /// The target component.
+    ///
+    /// Should be produced via `SpComponent::const_as_str()`.
+    fn component(&self) -> &'static str;
+
+    /// The type of the target SP.
+    fn target_sp_type(&self) -> SpType;
+
+    /// The slot number of the target SP.
+    fn target_sp_slot(&self) -> u32;
+
+    /// The target firmware slot for the component.
+    fn firmware_slot(&self) -> u16;
+
+    /// The ID of this update.
+    fn update_id(&self) -> Uuid;
+
+    /// The update payload data to send to MGS.
+    fn update_data(&self) -> Vec<u8>;
+
+    /// The sending half of the watch channel to report update progress.
+    fn progress(&self) -> &watch::Sender<Option<UpdateProgress>>;
+
+    /// Logger to use while performing this update.
+    fn logger(&self) -> &Logger;
+}
+
+pub(super) async fn deliver_update(
+    updater: &(dyn SpComponentUpdater + Send + Sync),
+    mgs_clients: &mut MgsClients,
+) -> Result<(), SpComponentUpdateError> {
+    // How frequently do we poll MGS for the update progress?
+    const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+    // Start the update.
+    mgs_clients
+        .try_all_serially(updater.logger(), |client| async move {
+            client
+                .sp_component_update(
+                    updater.target_sp_type(),
+                    updater.target_sp_slot(),
+                    updater.component(),
+                    updater.firmware_slot(),
+                    &updater.update_id(),
+                    reqwest::Body::from(updater.update_data()),
+                )
+                .await?;
+            updater.progress().send_replace(Some(UpdateProgress::Started));
+            info!(
+                updater.logger(), "update started";
+                "mgs_addr" => client.baseurl(),
+            );
+            Ok(())
+        })
+        .await?;
+
+    // Wait for the update to complete.
+    loop {
+        let status = mgs_clients
+            .try_all_serially(updater.logger(), |client| async move {
+                let update_status = client
+                    .sp_component_update_status(
+                        updater.target_sp_type(),
+                        updater.target_sp_slot(),
+                        updater.component(),
+                    )
+                    .await?;
+
+                debug!(
+                    updater.logger(), "got update status";
+                    "mgs_addr" => client.baseurl(),
+                    "status" => ?update_status,
+                );
+
+                Ok(update_status)
+            })
+            .await?;
+
+        if status_is_complete(
+            status.into_inner(),
+            updater.update_id(),
+            updater.progress(),
+            updater.logger(),
+        )? {
+            updater.progress().send_replace(Some(UpdateProgress::InProgress {
+                progress: Some(1.0),
+            }));
+            return Ok(());
+        }
+
+        tokio::time::sleep(STATUS_POLL_INTERVAL).await;
+    }
+}
+
+fn status_is_complete(
+    status: SpUpdateStatus,
+    update_id: Uuid,
+    progress_tx: &watch::Sender<Option<UpdateProgress>>,
+    log: &Logger,
+) -> Result<bool, SpComponentUpdateError> {
+    match status {
+        // For `Preparing` and `InProgress`, we could check the progress
+        // information returned by these steps and try to check that
+        // we're still _making_ progress, but every Nexus instance needs
+        // to do that anyway in case we (or the MGS instance delivering
+        // the update) crash, so we'll omit that check here. Instead, we
+        // just sleep and we'll poll again shortly.
+        SpUpdateStatus::Preparing { id, progress } => {
+            if id == update_id {
+                let progress = progress.and_then(|progress| {
+                    if progress.current > progress.total {
+                        warn!(
+                            log, "nonsense preparing progress";
+                            "current" => progress.current,
+                            "total" => progress.total,
+                        );
+                        None
+                    } else if progress.total == 0 {
+                        None
+                    } else {
+                        Some(
+                            f64::from(progress.current)
+                                / f64::from(progress.total),
+                        )
+                    }
+                });
+                progress_tx
+                    .send_replace(Some(UpdateProgress::Preparing { progress }));
+                Ok(false)
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdatePreparing(id))
+            }
+        }
+        SpUpdateStatus::InProgress { id, bytes_received, total_bytes } => {
+            if id == update_id {
+                let progress = if bytes_received > total_bytes {
+                    warn!(
+                        log, "nonsense update progress";
+                        "bytes_received" => bytes_received,
+                        "total_bytes" => total_bytes,
+                    );
+                    None
+                } else if total_bytes == 0 {
+                    None
+                } else {
+                    Some(f64::from(bytes_received) / f64::from(total_bytes))
+                };
+                progress_tx.send_replace(Some(UpdateProgress::InProgress {
+                    progress,
+                }));
+                Ok(false)
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdateInProgress(id))
+            }
+        }
+        SpUpdateStatus::Complete { id } => {
+            if id == update_id {
+                Ok(true)
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdateComplete(id))
+            }
+        }
+        SpUpdateStatus::None => Err(SpComponentUpdateError::UpdateStatusLost),
+        SpUpdateStatus::Aborted { id } => {
+            if id == update_id {
+                Err(SpComponentUpdateError::UpdateAborted)
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdateAborted(id))
+            }
+        }
+        SpUpdateStatus::Failed { code, id } => {
+            if id == update_id {
+                Err(SpComponentUpdateError::UpdateFailedWithCode(code))
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdateFailed(id))
+            }
+        }
+        SpUpdateStatus::RotError { id, message } => {
+            if id == update_id {
+                Err(SpComponentUpdateError::UpdateFailedWithMessage(format!(
+                    "rot error: {message}"
+                )))
+            } else {
+                Err(SpComponentUpdateError::DifferentUpdateFailed(id))
+            }
+        }
+    }
+}

--- a/nexus/src/app/update/host_phase1_updater.rs
+++ b/nexus/src/app/update/host_phase1_updater.rs
@@ -84,7 +84,7 @@ impl HostPhase1Updater {
         // TODO-correctness Should we be doing this, or should a higher level
         // executor set this up before calling us?
         mgs_clients
-            .try_all(&self.log, |client| async move {
+            .try_all_serially(&self.log, |client| async move {
                 me.mark_target_slot_active(&client).await
             })
             .await?;

--- a/nexus/src/app/update/host_phase1_updater.rs
+++ b/nexus/src/app/update/host_phase1_updater.rs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Module containing types for updating host OS phase1 images via MGS.
+
+use super::common_sp_update::deliver_update;
+use super::common_sp_update::SpComponentUpdater;
+use super::MgsClients;
+use super::SpComponentUpdateError;
+use super::UpdateProgress;
+use gateway_client::types::SpType;
+use gateway_client::SpComponent;
+use slog::Logger;
+use tokio::sync::watch;
+use uuid::Uuid;
+
+pub struct HostPhase1Updater {
+    log: Logger,
+    progress: watch::Sender<Option<UpdateProgress>>,
+    sp_type: SpType,
+    sp_slot: u32,
+    target_host_slot: u16,
+    update_id: Uuid,
+    // TODO-clarity maybe a newtype for this? TBD how we get this from
+    // wherever it's stored, which might give us a stronger type already.
+    phase1_data: Vec<u8>,
+}
+
+impl HostPhase1Updater {
+    pub fn new(
+        sp_type: SpType,
+        sp_slot: u32,
+        target_host_slot: u16,
+        update_id: Uuid,
+        phase1_data: Vec<u8>,
+        log: &Logger,
+    ) -> Self {
+        let log = log.new(slog::o!(
+            "component" => "HostPhase1Updater",
+            "sp_type" => format!("{sp_type:?}"),
+            "sp_slot" => sp_slot,
+            "target_host_slot" => target_host_slot,
+            "update_id" => format!("{update_id}"),
+        ));
+        let progress = watch::Sender::new(None);
+        Self {
+            log,
+            progress,
+            sp_type,
+            sp_slot,
+            target_host_slot,
+            update_id,
+            phase1_data,
+        }
+    }
+
+    pub fn progress_watcher(&self) -> watch::Receiver<Option<UpdateProgress>> {
+        self.progress.subscribe()
+    }
+
+    /// Drive this host phase 1 update to completion (or failure).
+    ///
+    /// Only one MGS instance is required to drive an update; however, if
+    /// multiple MGS instances are available and passed to this method and an
+    /// error occurs communicating with one instance, `HostPhase1Updater` will
+    /// try the remaining instances before failing.
+    pub async fn update(
+        mut self,
+        mgs_clients: &mut MgsClients,
+    ) -> Result<(), SpComponentUpdateError> {
+        // Deliver and drive the update to completion
+        deliver_update(&mut self, mgs_clients).await?;
+
+        // wait for any progress watchers to be dropped before we return;
+        // otherwise, they'll get `RecvError`s when trying to check the current
+        // status
+        self.progress.closed().await;
+
+        Ok(())
+    }
+}
+
+impl SpComponentUpdater for HostPhase1Updater {
+    fn component(&self) -> &'static str {
+        SpComponent::HOST_CPU_BOOT_FLASH.const_as_str()
+    }
+
+    fn target_sp_type(&self) -> SpType {
+        self.sp_type
+    }
+
+    fn target_sp_slot(&self) -> u32 {
+        self.sp_slot
+    }
+
+    fn firmware_slot(&self) -> u16 {
+        self.target_host_slot
+    }
+
+    fn update_id(&self) -> Uuid {
+        self.update_id
+    }
+
+    fn update_data(&self) -> Vec<u8> {
+        self.phase1_data.clone()
+    }
+
+    fn progress(&self) -> &watch::Sender<Option<UpdateProgress>> {
+        &self.progress
+    }
+
+    fn logger(&self) -> &Logger {
+        &self.log
+    }
+}

--- a/nexus/src/app/update/mgs_clients.rs
+++ b/nexus/src/app/update/mgs_clients.rs
@@ -5,52 +5,13 @@
 //! Module providing support for handling failover between multiple MGS clients
 
 use futures::Future;
-use gateway_client::types::SpType;
-use gateway_client::types::SpUpdateStatus;
 use gateway_client::Client;
 use slog::Logger;
 use std::collections::VecDeque;
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub(super) type GatewayClientError =
     gateway_client::Error<gateway_client::types::Error>;
-
-pub(super) enum PollUpdateStatus {
-    Preparing { progress: Option<f64> },
-    InProgress { progress: Option<f64> },
-    Complete,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum UpdateStatusError {
-    #[error("different update is now preparing ({0})")]
-    DifferentUpdatePreparing(Uuid),
-    #[error("different update is now in progress ({0})")]
-    DifferentUpdateInProgress(Uuid),
-    #[error("different update is now complete ({0})")]
-    DifferentUpdateComplete(Uuid),
-    #[error("different update is now aborted ({0})")]
-    DifferentUpdateAborted(Uuid),
-    #[error("different update failed ({0})")]
-    DifferentUpdateFailed(Uuid),
-    #[error("update status lost (did the SP reset?)")]
-    UpdateStatusLost,
-    #[error("update was aborted")]
-    UpdateAborted,
-    #[error("update failed (error code {0})")]
-    UpdateFailedWithCode(u32),
-    #[error("update failed (error message {0})")]
-    UpdateFailedWithMessage(String),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(super) enum PollUpdateStatusError {
-    #[error(transparent)]
-    StatusError(#[from] UpdateStatusError),
-    #[error(transparent)]
-    ClientError(#[from] GatewayClientError),
-}
 
 #[derive(Debug, Clone)]
 pub struct MgsClients {
@@ -129,112 +90,5 @@ impl MgsClients {
         // The only way to get here is if all clients failed with communication
         // errors. Return the error from the last MGS we tried.
         Err(GatewayClientError::CommunicationError(last_err.unwrap()))
-    }
-
-    /// Poll for the status of an expected-to-be-in-progress update.
-    pub(super) async fn poll_update_status(
-        &mut self,
-        sp_type: SpType,
-        sp_slot: u32,
-        component: &'static str,
-        update_id: Uuid,
-        log: &Logger,
-    ) -> Result<PollUpdateStatus, PollUpdateStatusError> {
-        let update_status = self
-            .try_all_serially(log, |client| async move {
-                let update_status = client
-                    .sp_component_update_status(sp_type, sp_slot, component)
-                    .await?;
-
-                debug!(
-                    log, "got update status";
-                    "mgs_addr" => client.baseurl(),
-                    "status" => ?update_status,
-                );
-
-                Ok(update_status)
-            })
-            .await?
-            .into_inner();
-
-        match update_status {
-            SpUpdateStatus::Preparing { id, progress } => {
-                if id == update_id {
-                    let progress = progress.and_then(|progress| {
-                        if progress.current > progress.total {
-                            warn!(
-                                log, "nonsense preparing progress";
-                                "current" => progress.current,
-                                "total" => progress.total,
-                            );
-                            None
-                        } else if progress.total == 0 {
-                            None
-                        } else {
-                            Some(
-                                f64::from(progress.current)
-                                    / f64::from(progress.total),
-                            )
-                        }
-                    });
-                    Ok(PollUpdateStatus::Preparing { progress })
-                } else {
-                    Err(UpdateStatusError::DifferentUpdatePreparing(id).into())
-                }
-            }
-            SpUpdateStatus::InProgress { id, bytes_received, total_bytes } => {
-                if id == update_id {
-                    let progress = if bytes_received > total_bytes {
-                        warn!(
-                            log, "nonsense update progress";
-                            "bytes_received" => bytes_received,
-                            "total_bytes" => total_bytes,
-                        );
-                        None
-                    } else if total_bytes == 0 {
-                        None
-                    } else {
-                        Some(f64::from(bytes_received) / f64::from(total_bytes))
-                    };
-                    Ok(PollUpdateStatus::InProgress { progress })
-                } else {
-                    Err(UpdateStatusError::DifferentUpdateInProgress(id).into())
-                }
-            }
-            SpUpdateStatus::Complete { id } => {
-                if id == update_id {
-                    Ok(PollUpdateStatus::Complete)
-                } else {
-                    Err(UpdateStatusError::DifferentUpdateComplete(id).into())
-                }
-            }
-            SpUpdateStatus::None => {
-                Err(UpdateStatusError::UpdateStatusLost.into())
-            }
-            SpUpdateStatus::Aborted { id } => {
-                if id == update_id {
-                    Err(UpdateStatusError::UpdateAborted.into())
-                } else {
-                    Err(UpdateStatusError::DifferentUpdateAborted(id).into())
-                }
-            }
-            SpUpdateStatus::Failed { code, id } => {
-                if id == update_id {
-                    Err(UpdateStatusError::UpdateFailedWithCode(code).into())
-                } else {
-                    Err(UpdateStatusError::DifferentUpdateFailed(id).into())
-                }
-            }
-            SpUpdateStatus::RotError { id, message } => {
-                if id == update_id {
-                    Err(UpdateStatusError::UpdateFailedWithMessage(format!(
-                        "rot error: {message}"
-                    ))
-                    .into())
-                } else {
-                    Err(UpdateStatusError::DifferentUpdateFailed(id).into())
-                }
-            }
-        }
     }
 }

--- a/nexus/src/app/update/mod.rs
+++ b/nexus/src/app/update/mod.rs
@@ -26,13 +26,15 @@ use std::path::Path;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
+mod common_sp_update;
 mod mgs_clients;
 mod rot_updater;
 mod sp_updater;
 
-pub use mgs_clients::{MgsClients, UpdateStatusError};
-pub use rot_updater::{RotUpdateError, RotUpdater};
-pub use sp_updater::{SpUpdateError, SpUpdater};
+pub use common_sp_update::SpComponentUpdateError;
+pub use mgs_clients::MgsClients;
+pub use rot_updater::RotUpdater;
+pub use sp_updater::SpUpdater;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum UpdateProgress {

--- a/nexus/src/app/update/mod.rs
+++ b/nexus/src/app/update/mod.rs
@@ -27,11 +27,13 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 mod common_sp_update;
+mod host_phase1_updater;
 mod mgs_clients;
 mod rot_updater;
 mod sp_updater;
 
 pub use common_sp_update::SpComponentUpdateError;
+pub use host_phase1_updater::HostPhase1Updater;
 pub use mgs_clients::MgsClients;
 pub use rot_updater::RotUpdater;
 pub use sp_updater::SpUpdater;

--- a/nexus/src/app/update/rot_updater.rs
+++ b/nexus/src/app/update/rot_updater.rs
@@ -79,7 +79,7 @@ impl RotUpdater {
         deliver_update(&mut self, mgs_clients).await?;
 
         // The async blocks below want `&self` references, but we take `self`
-        // for API clarity (to start a RoT update, the caller should construct a
+        // for API clarity (to start a new update, the caller should construct a
         // new updater). Create a `&self` ref that we use through the remainder
         // of this method.
         let me = &self;

--- a/nexus/src/app/update/rot_updater.rs
+++ b/nexus/src/app/update/rot_updater.rs
@@ -118,7 +118,7 @@ impl RotUpdater {
             .sp_component_active_slot_set(
                 self.sp_type,
                 self.sp_slot,
-                SpComponent::ROT.const_as_str(),
+                self.component(),
                 persist,
                 &SpComponentFirmwareSlot { slot },
             )
@@ -142,11 +142,7 @@ impl RotUpdater {
         client: &gateway_client::Client,
     ) -> Result<(), GatewayClientError> {
         client
-            .sp_component_reset(
-                self.sp_type,
-                self.sp_slot,
-                SpComponent::ROT.const_as_str(),
-            )
+            .sp_component_reset(self.sp_type, self.sp_slot, self.component())
             .await?;
 
         self.progress.send_replace(Some(UpdateProgress::Complete));

--- a/nexus/src/app/update/rot_updater.rs
+++ b/nexus/src/app/update/rot_updater.rs
@@ -4,39 +4,20 @@
 
 //! Module containing types for updating RoTs via MGS.
 
-use super::mgs_clients::PollUpdateStatusError;
+use super::common_sp_update::deliver_update;
+use super::common_sp_update::SpComponentUpdater;
 use super::MgsClients;
+use super::SpComponentUpdateError;
 use super::UpdateProgress;
-use super::UpdateStatusError;
-use crate::app::update::mgs_clients::PollUpdateStatus;
 use gateway_client::types::RotSlot;
 use gateway_client::types::SpComponentFirmwareSlot;
 use gateway_client::types::SpType;
 use gateway_client::SpComponent;
 use slog::Logger;
-use std::time::Duration;
 use tokio::sync::watch;
 use uuid::Uuid;
 
 type GatewayClientError = gateway_client::Error<gateway_client::types::Error>;
-
-#[derive(Debug, thiserror::Error)]
-pub enum RotUpdateError {
-    #[error("error communicating with MGS")]
-    MgsCommunication(#[from] GatewayClientError),
-
-    #[error("failed checking update status: {0}")]
-    PollUpdateStatus(#[from] UpdateStatusError),
-}
-
-impl From<PollUpdateStatusError> for RotUpdateError {
-    fn from(err: PollUpdateStatusError) -> Self {
-        match err {
-            PollUpdateStatusError::StatusError(err) => err.into(),
-            PollUpdateStatusError::ClientError(err) => err.into(),
-        }
-    }
-}
 
 pub struct RotUpdater {
     log: Logger,
@@ -89,34 +70,29 @@ impl RotUpdater {
     /// error occurs communicating with one instance, `RotUpdater` will try the
     /// remaining instances before failing.
     pub async fn update(
-        self,
-        mut mgs_clients: MgsClients,
-    ) -> Result<(), RotUpdateError> {
+        mut self,
+        mgs_clients: &mut MgsClients,
+    ) -> Result<(), SpComponentUpdateError> {
+        // Deliver and drive the update to "completion" (which isn't really
+        // complete for the RoT, since we still have to do the steps below after
+        // the delivery of the update completes).
+        deliver_update(&mut self, mgs_clients).await?;
+
         // The async blocks below want `&self` references, but we take `self`
-        // for API clarity (to start a new update, the caller should construct a
+        // for API clarity (to start a RoT update, the caller should construct a
         // new updater). Create a `&self` ref that we use through the remainder
         // of this method.
         let me = &self;
 
         mgs_clients
             .try_all_serially(&self.log, |client| async move {
-                me.start_update_one_mgs(&client).await
-            })
-            .await?;
-
-        // `wait_for_update_completion` uses `try_all_mgs_clients` internally,
-        // so we don't wrap it here.
-        me.wait_for_update_completion(&mut mgs_clients).await?;
-
-        mgs_clients
-            .try_all_serially(&self.log, |client| async move {
-                me.mark_target_slot_active_one_mgs(&client).await
+                me.mark_target_slot_active(&client).await
             })
             .await?;
 
         mgs_clients
             .try_all_serially(&self.log, |client| async move {
-                me.finalize_update_via_reset_one_mgs(&client).await
+                me.finalize_update_via_reset(&client).await
             })
             .await?;
 
@@ -128,82 +104,7 @@ impl RotUpdater {
         Ok(())
     }
 
-    async fn start_update_one_mgs(
-        &self,
-        client: &gateway_client::Client,
-    ) -> Result<(), GatewayClientError> {
-        let firmware_slot = self.target_rot_slot.as_u16();
-
-        // Start the update.
-        client
-            .sp_component_update(
-                self.sp_type,
-                self.sp_slot,
-                SpComponent::ROT.const_as_str(),
-                firmware_slot,
-                &self.update_id,
-                reqwest::Body::from(self.rot_hubris_archive.clone()),
-            )
-            .await?;
-
-        self.progress.send_replace(Some(UpdateProgress::Started));
-
-        info!(
-            self.log, "RoT update started";
-            "mgs_addr" => client.baseurl(),
-        );
-
-        Ok(())
-    }
-
-    async fn wait_for_update_completion(
-        &self,
-        mgs_clients: &mut MgsClients,
-    ) -> Result<(), RotUpdateError> {
-        // How frequently do we poll MGS for the update progress?
-        const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
-
-        loop {
-            let status = mgs_clients
-                .poll_update_status(
-                    self.sp_type,
-                    self.sp_slot,
-                    SpComponent::ROT.const_as_str(),
-                    self.update_id,
-                    &self.log,
-                )
-                .await?;
-
-            // For `Preparing` and `InProgress`, we could check the progress
-            // information returned by these steps and try to check that
-            // we're still _making_ progress, but every Nexus instance needs
-            // to do that anyway in case we (or the MGS instance delivering
-            // the update) crash, so we'll omit that check here. Instead, we
-            // just sleep and we'll poll again shortly.
-            match status {
-                PollUpdateStatus::Preparing { progress } => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::Preparing { progress },
-                    ));
-                }
-                PollUpdateStatus::InProgress { progress } => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::InProgress { progress },
-                    ));
-                }
-                PollUpdateStatus::Complete => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::InProgress { progress: Some(1.0) },
-                    ));
-                    return Ok(());
-                }
-            }
-
-            tokio::time::sleep(STATUS_POLL_INTERVAL).await;
-        }
-    }
-
-    async fn mark_target_slot_active_one_mgs(
+    async fn mark_target_slot_active(
         &self,
         client: &gateway_client::Client,
     ) -> Result<(), GatewayClientError> {
@@ -211,7 +112,7 @@ impl RotUpdater {
         // tell it to persist our choice.
         let persist = true;
 
-        let slot = self.target_rot_slot.as_u16();
+        let slot = self.firmware_slot();
 
         client
             .sp_component_active_slot_set(
@@ -236,7 +137,7 @@ impl RotUpdater {
         Ok(())
     }
 
-    async fn finalize_update_via_reset_one_mgs(
+    async fn finalize_update_via_reset(
         &self,
         client: &gateway_client::Client,
     ) -> Result<(), GatewayClientError> {
@@ -258,15 +159,39 @@ impl RotUpdater {
     }
 }
 
-trait RotSlotAsU16 {
-    fn as_u16(&self) -> u16;
-}
+impl SpComponentUpdater for RotUpdater {
+    fn component(&self) -> &'static str {
+        SpComponent::ROT.const_as_str()
+    }
 
-impl RotSlotAsU16 for RotSlot {
-    fn as_u16(&self) -> u16 {
-        match self {
+    fn target_sp_type(&self) -> SpType {
+        self.sp_type
+    }
+
+    fn target_sp_slot(&self) -> u32 {
+        self.sp_slot
+    }
+
+    fn firmware_slot(&self) -> u16 {
+        match self.target_rot_slot {
             RotSlot::A => 0,
             RotSlot::B => 1,
         }
+    }
+
+    fn update_id(&self) -> Uuid {
+        self.update_id
+    }
+
+    fn update_data(&self) -> Vec<u8> {
+        self.rot_hubris_archive.clone()
+    }
+
+    fn progress(&self) -> &watch::Sender<Option<UpdateProgress>> {
+        &self.progress
+    }
+
+    fn logger(&self) -> &Logger {
+        &self.log
     }
 }

--- a/nexus/src/app/update/sp_updater.rs
+++ b/nexus/src/app/update/sp_updater.rs
@@ -4,38 +4,18 @@
 
 //! Module containing types for updating SPs via MGS.
 
-use crate::app::update::mgs_clients::PollUpdateStatus;
-
-use super::mgs_clients::PollUpdateStatusError;
+use super::common_sp_update::deliver_update;
+use super::common_sp_update::SpComponentUpdater;
 use super::MgsClients;
+use super::SpComponentUpdateError;
 use super::UpdateProgress;
-use super::UpdateStatusError;
 use gateway_client::types::SpType;
 use gateway_client::SpComponent;
 use slog::Logger;
-use std::time::Duration;
 use tokio::sync::watch;
 use uuid::Uuid;
 
 type GatewayClientError = gateway_client::Error<gateway_client::types::Error>;
-
-#[derive(Debug, thiserror::Error)]
-pub enum SpUpdateError {
-    #[error("error communicating with MGS")]
-    MgsCommunication(#[from] GatewayClientError),
-
-    #[error("failed checking update status: {0}")]
-    PollUpdateStatus(#[from] UpdateStatusError),
-}
-
-impl From<PollUpdateStatusError> for SpUpdateError {
-    fn from(err: PollUpdateStatusError) -> Self {
-        match err {
-            PollUpdateStatusError::StatusError(err) => err.into(),
-            PollUpdateStatusError::ClientError(err) => err.into(),
-        }
-    }
-}
 
 pub struct SpUpdater {
     log: Logger,
@@ -77,10 +57,15 @@ impl SpUpdater {
     /// error occurs communicating with one instance, `SpUpdater` will try the
     /// remaining instances before failing.
     pub async fn update(
-        self,
-        mut mgs_clients: MgsClients,
-    ) -> Result<(), SpUpdateError> {
-        // The async blocks below want `&self` references, but we take `self`
+        mut self,
+        mgs_clients: &mut MgsClients,
+    ) -> Result<(), SpComponentUpdateError> {
+        // Deliver and drive the update to "completion" (which isn't really
+        // complete for the SP, since we still have to reset it after the
+        // delivery of the update completes).
+        deliver_update(&mut self, mgs_clients).await?;
+
+        // The async block below wants a `&self` reference, but we take `self`
         // for API clarity (to start a new SP update, the caller should
         // construct a new `SpUpdater`). Create a `&self` ref that we use
         // through the remainder of this method.
@@ -88,17 +73,7 @@ impl SpUpdater {
 
         mgs_clients
             .try_all_serially(&self.log, |client| async move {
-                me.start_update_one_mgs(&client).await
-            })
-            .await?;
-
-        // `wait_for_update_completion` uses `try_all_mgs_clients` internally,
-        // so we don't wrap it here.
-        me.wait_for_update_completion(&mut mgs_clients).await?;
-
-        mgs_clients
-            .try_all_serially(&self.log, |client| async move {
-                me.finalize_update_via_reset_one_mgs(&client).await
+                me.finalize_update_via_reset(&client).await
             })
             .await?;
 
@@ -110,85 +85,7 @@ impl SpUpdater {
         Ok(())
     }
 
-    async fn start_update_one_mgs(
-        &self,
-        client: &gateway_client::Client,
-    ) -> Result<(), GatewayClientError> {
-        // The SP has two firmware slots, but they're aren't individually
-        // labled. We always request an update to slot 0, which means "the
-        // inactive slot".
-        let firmware_slot = 0;
-
-        // Start the update.
-        client
-            .sp_component_update(
-                self.sp_type,
-                self.sp_slot,
-                SpComponent::SP_ITSELF.const_as_str(),
-                firmware_slot,
-                &self.update_id,
-                reqwest::Body::from(self.sp_hubris_archive.clone()),
-            )
-            .await?;
-
-        self.progress.send_replace(Some(UpdateProgress::Started));
-
-        info!(
-            self.log, "SP update started";
-            "mgs_addr" => client.baseurl(),
-        );
-
-        Ok(())
-    }
-
-    async fn wait_for_update_completion(
-        &self,
-        mgs_clients: &mut MgsClients,
-    ) -> Result<(), SpUpdateError> {
-        // How frequently do we poll MGS for the update progress?
-        const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(3);
-
-        loop {
-            let status = mgs_clients
-                .poll_update_status(
-                    self.sp_type,
-                    self.sp_slot,
-                    SpComponent::SP_ITSELF.const_as_str(),
-                    self.update_id,
-                    &self.log,
-                )
-                .await?;
-
-            // For `Preparing` and `InProgress`, we could check the progress
-            // information returned by these steps and try to check that
-            // we're still _making_ progress, but every Nexus instance needs
-            // to do that anyway in case we (or the MGS instance delivering
-            // the update) crash, so we'll omit that check here. Instead, we
-            // just sleep and we'll poll again shortly.
-            match status {
-                PollUpdateStatus::Preparing { progress } => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::Preparing { progress },
-                    ));
-                }
-                PollUpdateStatus::InProgress { progress } => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::InProgress { progress },
-                    ));
-                }
-                PollUpdateStatus::Complete => {
-                    self.progress.send_replace(Some(
-                        UpdateProgress::InProgress { progress: Some(1.0) },
-                    ));
-                    return Ok(());
-                }
-            }
-
-            tokio::time::sleep(STATUS_POLL_INTERVAL).await;
-        }
-    }
-
-    async fn finalize_update_via_reset_one_mgs(
+    async fn finalize_update_via_reset(
         &self,
         client: &gateway_client::Client,
     ) -> Result<(), GatewayClientError> {
@@ -207,5 +104,42 @@ impl SpUpdater {
         );
 
         Ok(())
+    }
+}
+
+impl SpComponentUpdater for SpUpdater {
+    fn component(&self) -> &'static str {
+        SpComponent::SP_ITSELF.const_as_str()
+    }
+
+    fn target_sp_type(&self) -> SpType {
+        self.sp_type
+    }
+
+    fn target_sp_slot(&self) -> u32 {
+        self.sp_slot
+    }
+
+    fn firmware_slot(&self) -> u16 {
+        // The SP has two firmware slots, but they're aren't individually
+        // labled. We always request an update to slot 0, which means "the
+        // inactive slot".
+        0
+    }
+
+    fn update_id(&self) -> Uuid {
+        self.update_id
+    }
+
+    fn update_data(&self) -> Vec<u8> {
+        self.sp_hubris_archive.clone()
+    }
+
+    fn progress(&self) -> &watch::Sender<Option<UpdateProgress>> {
+        &self.progress
+    }
+
+    fn logger(&self) -> &Logger {
+        &self.log
     }
 }

--- a/nexus/src/app/update/sp_updater.rs
+++ b/nexus/src/app/update/sp_updater.rs
@@ -90,11 +90,7 @@ impl SpUpdater {
         client: &gateway_client::Client,
     ) -> Result<(), GatewayClientError> {
         client
-            .sp_component_reset(
-                self.sp_type,
-                self.sp_slot,
-                SpComponent::SP_ITSELF.const_as_str(),
-            )
+            .sp_component_reset(self.sp_type, self.sp_slot, self.component())
             .await?;
 
         self.progress.send_replace(Some(UpdateProgress::Complete));

--- a/nexus/tests/integration_tests/host_phase1_updater.rs
+++ b/nexus/tests/integration_tests/host_phase1_updater.rs
@@ -2,18 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Tests `RotUpdater`'s delivery of updates to RoTs via MGS
+//! Tests `HostPhase1Updater`'s delivery of updates to host phase 1 flash via
+//! MGS to SP.
 
-use gateway_client::types::{RotSlot, SpType};
+use gateway_client::types::SpType;
 use gateway_messages::{SpPort, UpdateInProgressStatus, UpdateStatus};
 use gateway_test_utils::setup as mgs_setup;
-use hubtools::RawHubrisArchive;
-use hubtools::{CabooseBuilder, HubrisArchiveBuilder};
 use omicron_nexus::app::test_interfaces::{
-    MgsClients, RotUpdater, UpdateProgress,
+    HostPhase1Updater, MgsClients, UpdateProgress,
 };
+use rand::RngCore;
 use sp_sim::SimulatedSp;
-use sp_sim::SIM_ROT_BOARD;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -24,127 +23,74 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-fn make_fake_rot_image() -> Vec<u8> {
-    let caboose = CabooseBuilder::default()
-        .git_commit("fake-git-commit")
-        .board(SIM_ROT_BOARD)
-        .version("0.0.0")
-        .name("fake-name")
-        .build();
-
-    let mut builder = HubrisArchiveBuilder::with_fake_image();
-    builder.write_caboose(caboose.as_slice()).unwrap();
-    builder.build_to_vec().unwrap()
+fn make_fake_host_phase1_image() -> Vec<u8> {
+    let mut image = vec![0; 128];
+    rand::thread_rng().fill_bytes(&mut image);
+    image
 }
 
 #[tokio::test]
-async fn test_rot_updater_updates_sled() {
-    // Start MGS + Sim SP.
-    let mgstestctx =
-        mgs_setup::test_setup("test_rot_updater_updates_sled", SpPort::One)
-            .await;
-
-    // Configure an MGS client.
-    let mut mgs_clients =
-        MgsClients::from_clients([gateway_client::Client::new(
-            &mgstestctx.client.url("/").to_string(),
-            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
-        )]);
-
-    // Configure and instantiate an `RotUpdater`.
-    let sp_type = SpType::Sled;
-    let sp_slot = 0;
-    let update_id = Uuid::new_v4();
-    let hubris_archive = make_fake_rot_image();
-    let target_rot_slot = RotSlot::B;
-
-    let rot_updater = RotUpdater::new(
-        sp_type,
-        sp_slot,
-        target_rot_slot,
-        update_id,
-        hubris_archive.clone(),
-        &mgstestctx.logctx.log,
-    );
-
-    // Run the update.
-    rot_updater.update(&mut mgs_clients).await.expect("update failed");
-
-    // Ensure the RoT received the complete update.
-    let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
-        .last_rot_update_data()
-        .await
-        .expect("simulated RoT did not receive an update");
-
-    let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
-
-    assert_eq!(
-        hubris_archive.image.data.as_slice(),
-        &*last_update_image,
-        "simulated RoT update contents (len {}) \
-         do not match test generated fake image (len {})",
-        last_update_image.len(),
-        hubris_archive.image.data.len()
-    );
-
-    mgstestctx.teardown().await;
-}
-
-#[tokio::test]
-async fn test_rot_updater_updates_switch() {
-    // Start MGS + Sim SP.
-    let mgstestctx =
-        mgs_setup::test_setup("test_rot_updater_updates_switch", SpPort::One)
-            .await;
-
-    // Configure an MGS client.
-    let mut mgs_clients =
-        MgsClients::from_clients([gateway_client::Client::new(
-            &mgstestctx.client.url("/").to_string(),
-            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
-        )]);
-
-    let sp_type = SpType::Switch;
-    let sp_slot = 0;
-    let update_id = Uuid::new_v4();
-    let hubris_archive = make_fake_rot_image();
-    let target_rot_slot = RotSlot::B;
-
-    let rot_updater = RotUpdater::new(
-        sp_type,
-        sp_slot,
-        target_rot_slot,
-        update_id,
-        hubris_archive.clone(),
-        &mgstestctx.logctx.log,
-    );
-
-    rot_updater.update(&mut mgs_clients).await.expect("update failed");
-
-    let last_update_image = mgstestctx.simrack.sidecars[sp_slot as usize]
-        .last_rot_update_data()
-        .await
-        .expect("simulated RoT did not receive an update");
-
-    let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
-
-    assert_eq!(
-        hubris_archive.image.data.as_slice(),
-        &*last_update_image,
-        "simulated RoT update contents (len {}) \
-         do not match test generated fake image (len {})",
-        last_update_image.len(),
-        hubris_archive.image.data.len()
-    );
-
-    mgstestctx.teardown().await;
-}
-
-#[tokio::test]
-async fn test_rot_updater_remembers_successful_mgs_instance() {
+async fn test_host_phase1_updater_updates_sled() {
     // Start MGS + Sim SP.
     let mgstestctx = mgs_setup::test_setup(
-        "test_rot_updater_remembers_successful_mgs_instance",
+        "test_host_phase1_updater_updates_sled",
+        SpPort::One,
+    )
+    .await;
+
+    // Configure an MGS client.
+    let mut mgs_clients =
+        MgsClients::from_clients([gateway_client::Client::new(
+            &mgstestctx.client.url("/").to_string(),
+            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
+        )]);
+
+    for target_host_slot in [0, 1] {
+        // Configure and instantiate an `HostPhase1Updater`.
+        let sp_type = SpType::Sled;
+        let sp_slot = 0;
+        let update_id = Uuid::new_v4();
+        let phase1_data = make_fake_host_phase1_image();
+
+        let host_phase1_updater = HostPhase1Updater::new(
+            sp_type,
+            sp_slot,
+            target_host_slot,
+            update_id,
+            phase1_data.clone(),
+            &mgstestctx.logctx.log,
+        );
+
+        // Run the update.
+        host_phase1_updater
+            .update(&mut mgs_clients)
+            .await
+            .expect("update failed");
+
+        // Ensure the SP received the complete update.
+        let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
+            .last_host_phase1_update_data(target_host_slot)
+            .await
+            .expect("simulated host phase1 did not receive an update");
+
+        assert_eq!(
+            phase1_data.as_slice(),
+            &*last_update_image,
+            "simulated host phase1 update contents (len {}) \
+         do not match test generated fake image (len {})",
+            last_update_image.len(),
+            phase1_data.len(),
+        );
+    }
+
+    mgstestctx.teardown().await;
+}
+
+#[tokio::test]
+async fn test_host_phase1_updater_remembers_successful_mgs_instance() {
+    // Start MGS + Sim SP.
+    let mgstestctx = mgs_setup::test_setup(
+        "test_host_phase1_updater_remembers_successful_mgs_instance",
         SpPort::One,
     )
     .await;
@@ -152,7 +98,8 @@ async fn test_rot_updater_remembers_successful_mgs_instance() {
     // Also start a local TCP server that we will claim is an MGS instance, but
     // it will close connections immediately after accepting them. This will
     // allow us to count how many connections it receives, while simultaneously
-    // causing errors in the RotUpdater when it attempts to use this "MGS".
+    // causing errors in the HostPhase1Updater when it attempts to use this
+    // "MGS".
     let (failing_mgs_task, failing_mgs_addr, failing_mgs_conn_counter) = {
         let socket = TcpListener::bind("[::1]:0").await.unwrap();
         let addr = socket.local_addr().unwrap();
@@ -173,12 +120,12 @@ async fn test_rot_updater_remembers_successful_mgs_instance() {
     };
 
     // Order the MGS clients such that the bogus MGS that immediately closes
-    // connections comes first. `RotUpdater` should remember that the second MGS
-    // instance succeeds, and only send subsequent requests to it: we should
-    // only see a single attempted connection to the bogus MGS, even though
-    // delivering an update requires a bare minimum of three requests (start the
-    // update, query the status, reset the RoT) and often more (if repeated
-    // queries are required to wait for completion).
+    // connections comes first. `HostPhase1Updater` should remember that the
+    // second MGS instance succeeds, and only send subsequent requests to it: we
+    // should only see a single attempted connection to the bogus MGS, even
+    // though delivering an update requires a bare minimum of three requests
+    // (start the update, query the status, reset the SP) and often more (if
+    // repeated queries are required to wait for completion).
     let mut mgs_clients = MgsClients::from_clients([
         gateway_client::Client::new(
             &format!("http://{failing_mgs_addr}"),
@@ -192,40 +139,38 @@ async fn test_rot_updater_remembers_successful_mgs_instance() {
 
     let sp_type = SpType::Sled;
     let sp_slot = 0;
+    let target_host_slot = 0;
     let update_id = Uuid::new_v4();
-    let hubris_archive = make_fake_rot_image();
-    let target_rot_slot = RotSlot::B;
+    let phase1_data = make_fake_host_phase1_image();
 
-    let rot_updater = RotUpdater::new(
+    let host_phase1_updater = HostPhase1Updater::new(
         sp_type,
         sp_slot,
-        target_rot_slot,
+        target_host_slot,
         update_id,
-        hubris_archive.clone(),
+        phase1_data.clone(),
         &mgstestctx.logctx.log,
     );
 
-    rot_updater.update(&mut mgs_clients).await.expect("update failed");
+    host_phase1_updater.update(&mut mgs_clients).await.expect("update failed");
 
     let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
-        .last_rot_update_data()
+        .last_host_phase1_update_data(target_host_slot)
         .await
-        .expect("simulated RoT did not receive an update");
-
-    let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
+        .expect("simulated host phase1 did not receive an update");
 
     assert_eq!(
-        hubris_archive.image.data.as_slice(),
+        phase1_data.as_slice(),
         &*last_update_image,
-        "simulated RoT update contents (len {}) \
+        "simulated host phase1 update contents (len {}) \
          do not match test generated fake image (len {})",
         last_update_image.len(),
-        hubris_archive.image.data.len()
+        phase1_data.len(),
     );
 
     // Check that our bogus MGS only received a single connection attempt.
-    // (After RotUpdater failed to talk to this instance, it should have fallen
-    // back to the valid one for all further requests.)
+    // (After HostPhase1Updater failed to talk to this instance, it should have
+    // fallen back to the valid one for all further requests.)
     assert_eq!(
         failing_mgs_conn_counter.load(Ordering::SeqCst),
         1,
@@ -237,7 +182,7 @@ async fn test_rot_updater_remembers_successful_mgs_instance() {
 }
 
 #[tokio::test]
-async fn test_rot_updater_switches_mgs_instances_on_failure() {
+async fn test_host_phase1_updater_switches_mgs_instances_on_failure() {
     enum MgsProxy {
         One(TcpStream),
         Two(TcpStream),
@@ -245,7 +190,7 @@ async fn test_rot_updater_switches_mgs_instances_on_failure() {
 
     // Start MGS + Sim SP.
     let mgstestctx = mgs_setup::test_setup(
-        "test_rot_updater_switches_mgs_instances_on_failure",
+        "test_host_phase1_updater_switches_mgs_instances_on_failure",
         SpPort::One,
     )
     .await;
@@ -312,22 +257,23 @@ async fn test_rot_updater_switches_mgs_instances_on_failure() {
 
     let sp_type = SpType::Sled;
     let sp_slot = 0;
+    let target_host_slot = 0;
     let update_id = Uuid::new_v4();
-    let hubris_archive = make_fake_rot_image();
-    let target_rot_slot = RotSlot::B;
+    let phase1_data = make_fake_host_phase1_image();
 
-    let rot_updater = RotUpdater::new(
+    let host_phase1_updater = HostPhase1Updater::new(
         sp_type,
         sp_slot,
-        target_rot_slot,
+        target_host_slot,
         update_id,
-        hubris_archive.clone(),
+        phase1_data.clone(),
         &mgstestctx.logctx.log,
     );
 
     // Spawn the actual update task.
-    let mut update_task =
-        tokio::spawn(async move { rot_updater.update(&mut mgs_clients).await });
+    let mut update_task = tokio::spawn(async move {
+        host_phase1_updater.update(&mut mgs_clients).await
+    });
 
     // Loop over incoming requests. We expect this sequence:
     //
@@ -364,10 +310,10 @@ async fn test_rot_updater_switches_mgs_instances_on_failure() {
                     }
                 };
 
-                // Should we trigger `RotUpdater` to swap to the other MGS
-                // (proxy)? If so, do that by dropping this connection (which
-                // will cause a client failure) and note that we expect the next
-                // incoming request to come on the other proxy.
+                // Should we trigger `HostPhase1Updater` to swap to the other
+                // MGS (proxy)? If so, do that by dropping this connection
+                // (which will cause a client failure) and note that we expect
+                // the next incoming request to come on the other proxy.
                 if should_swap {
                     mem::drop(stream);
                     expected_proxy ^= 1;
@@ -394,20 +340,18 @@ async fn test_rot_updater_switches_mgs_instances_on_failure() {
         }
     }
 
-    // An RoT update requires a minimum of 4 requests to MGS: post the update,
-    // check the status, post to mark the new target slot active, and post an
-    // RoT reset. There may be more requests if the update is not yet complete
-    // when the status is checked, but we can just check that each of our
-    // proxies received at least 2 incoming requests; based on our outline
-    // above, if we got the minimum of 4 requests, it would look like this:
+    // An SP update requires a minimum of 3 requests to MGS: post the update,
+    // check the status, and post an SP reset. There may be more requests if the
+    // update is not yet complete when the status is checked, but we can just
+    // check that each of our proxies received at least 2 incoming requests;
+    // based on our outline above, if we got the minimum of 3 requests, it would
+    // look like this:
     //
     // 1. POST update -> first proxy (success)
     // 2. GET status -> first proxy (fail)
     // 3. GET status retry -> second proxy (success)
-    // 4. POST new target slot -> second proxy (fail)
-    // 5. POST new target slot -> first proxy (success)
-    // 6. POST reset -> first proxy (fail)
-    // 7. POST reset -> second proxy (success)
+    // 4. POST reset -> second proxy (fail)
+    // 5. POST reset -> first proxy (success)
     //
     // This pattern would repeat if multiple status requests were required, so
     // we always expect the first proxy to see exactly one more connection
@@ -422,29 +366,27 @@ async fn test_rot_updater_switches_mgs_instances_on_failure() {
     );
 
     let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
-        .last_rot_update_data()
+        .last_host_phase1_update_data(target_host_slot)
         .await
-        .expect("simulated RoT did not receive an update");
-
-    let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
+        .expect("simulated host phase1 did not receive an update");
 
     assert_eq!(
-        hubris_archive.image.data.as_slice(),
+        phase1_data.as_slice(),
         &*last_update_image,
-        "simulated RoT update contents (len {}) \
+        "simulated host phase1 update contents (len {}) \
          do not match test generated fake image (len {})",
         last_update_image.len(),
-        hubris_archive.image.data.len()
+        phase1_data.len(),
     );
 
     mgstestctx.teardown().await;
 }
 
 #[tokio::test]
-async fn test_rot_updater_delivers_progress() {
+async fn test_host_phase1_updater_delivers_progress() {
     // Start MGS + Sim SP.
     let mgstestctx = mgs_setup::test_setup(
-        "test_rot_updater_delivers_progress",
+        "test_host_phase1_updater_delivers_progress",
         SpPort::One,
     )
     .await;
@@ -458,25 +400,24 @@ async fn test_rot_updater_delivers_progress() {
 
     let sp_type = SpType::Sled;
     let sp_slot = 0;
+    let target_host_slot = 0;
     let update_id = Uuid::new_v4();
-    let hubris_archive = make_fake_rot_image();
-    let target_rot_slot = RotSlot::B;
+    let phase1_data = make_fake_host_phase1_image();
 
-    let rot_updater = RotUpdater::new(
+    let host_phase1_updater = HostPhase1Updater::new(
         sp_type,
         sp_slot,
-        target_rot_slot,
+        target_host_slot,
         update_id,
-        hubris_archive.clone(),
+        phase1_data.clone(),
         &mgstestctx.logctx.log,
     );
 
-    let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
-    let rot_image_len = hubris_archive.image.data.len() as u32;
+    let phase1_data_len = phase1_data.len() as u32;
 
     // Subscribe to update progress, and check that there is no status yet; we
     // haven't started the update.
-    let mut progress = rot_updater.progress_watcher();
+    let mut progress = host_phase1_updater.progress_watcher();
     assert_eq!(*progress.borrow_and_update(), None);
 
     // Install a semaphore on the requests our target SP will receive so we can
@@ -487,13 +428,14 @@ async fn test_rot_updater_delivers_progress() {
 
     // Spawn the update on a background task so we can watch `progress` as it is
     // applied.
-    let do_update_task =
-        tokio::spawn(async move { rot_updater.update(&mut mgs_clients).await });
+    let do_update_task = tokio::spawn(async move {
+        host_phase1_updater.update(&mut mgs_clients).await
+    });
 
-    // Allow the SP to respond to 1 message: the "prepare update" messages that
-    // trigger the start of an update, then ensure we see the "started"
-    // progress.
-    sp_accept_sema.send(1).unwrap();
+    // Allow the SP to respond to 2 messages: the caboose check and the "prepare
+    // update" messages that trigger the start of an update, then ensure we see
+    // the "started" progress.
+    sp_accept_sema.send(2).unwrap();
     progress.changed().await.unwrap();
     assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Started));
 
@@ -504,7 +446,7 @@ async fn test_rot_updater_delivers_progress() {
         UpdateStatus::InProgress(UpdateInProgressStatus {
             id: update_id.into(),
             bytes_received: 0,
-            total_size: rot_image_len,
+            total_size: phase1_data_len,
         })
     );
 
@@ -517,21 +459,22 @@ async fn test_rot_updater_delivers_progress() {
     // simulated SP:
     //
     // 1. MGS is trying to deliver the update
-    // 2. `rot_updater` is trying to poll (via MGS) for update status
+    // 2. `host_phase1_updater` is trying to poll (via MGS) for update status
     //
     // and we want to ensure that we see any relevant progress reports from
-    // `rot_updater`. We'll let one MGS -> SP message through at a time (waiting
-    // until our SP has responded by waiting for a change to `sp_responses`)
-    // then check its update state: if it changed, the packet we let through was
-    // data from MGS; otherwise, it was a status request from `rot_updater`.
+    // `host_phase1_updater`. We'll let one MGS -> SP message through at a time
+    // (waiting until our SP has responded by waiting for a change to
+    // `sp_responses`) then check its update state: if it changed, the packet we
+    // let through was data from MGS; otherwise, it was a status request from
+    // `host_phase1_updater`.
     //
     // This loop will continue until either:
     //
     // 1. We see an `UpdateStatus::InProgress` message indicating 100% delivery,
     //    at which point we break out of the loop
     // 2. We time out waiting for the previous step (by timing out for either
-    //    the SP to process a request or `rot_updater` to realize there's been
-    //    progress), at which point we panic and fail this test.
+    //    the SP to process a request or `host_phase1_updater` to realize
+    //    there's been progress), at which point we panic and fail this test.
     let mut prev_bytes_received = 0;
     let mut expect_progress_change = false;
     loop {
@@ -549,18 +492,18 @@ async fn test_rot_updater_delivers_progress() {
 
         // Inspec the SP's in-memory update state; we expect only `InProgress`
         // or `Complete`, and in either case we note whether we expect to see
-        // status changes from `rot_updater`.
+        // status changes from `host_phase1_updater`.
         match target_sp.current_update_status().await {
-            UpdateStatus::InProgress(rot_progress) => {
-                if rot_progress.bytes_received > prev_bytes_received {
-                    prev_bytes_received = rot_progress.bytes_received;
+            UpdateStatus::InProgress(sp_progress) => {
+                if sp_progress.bytes_received > prev_bytes_received {
+                    prev_bytes_received = sp_progress.bytes_received;
                     expect_progress_change = true;
                     continue;
                 }
             }
             UpdateStatus::Complete(_) => {
-                if prev_bytes_received < rot_image_len {
-                    prev_bytes_received = rot_image_len;
+                if prev_bytes_received < phase1_data_len {
+                    break;
                 }
             }
             status @ (UpdateStatus::None
@@ -574,10 +517,10 @@ async fn test_rot_updater_delivers_progress() {
         }
 
         // If we get here, the most recent packet did _not_ change the SP's
-        // internal update state, so it was a status request from `rot_updater`.
-        // If we expect the updater to see new progress, wait for that change
-        // here.
-        if expect_progress_change || prev_bytes_received == rot_image_len {
+        // internal update state, so it was a status request from
+        // `host_phase1_updater`. If we expect the updater to see new progress,
+        // wait for that change here.
+        if expect_progress_change {
             // Safety rail that we haven't screwed up our untangle-the-race
             // logic: if we don't see a new progress after several seconds, our
             // test is broken, so fail.
@@ -588,25 +531,35 @@ async fn test_rot_updater_delivers_progress() {
             let status = progress.borrow_and_update().clone().unwrap();
             expect_progress_change = false;
 
-            // We're done if we've observed the final progress message.
-            if let UpdateProgress::InProgress { progress: Some(value) } = status
-            {
-                if value == 1.0 {
-                    break;
-                }
-            } else {
-                panic!("unexpected progerss status {status:?}");
-            }
+            assert!(
+                matches!(status, UpdateProgress::InProgress { .. }),
+                "unexpected progress status {status:?}"
+            );
         }
     }
 
-    // The update has been fully delivered to the SP, but we don't see an
-    // `UpdateStatus::Complete` message until the RoT is reset. Release the SP
-    // semaphore since we're no longer racing to observe intermediate progress,
-    // and wait for the completion message.
+    // We know the SP has received a complete update, but `HostPhase1Updater`
+    // may still need to request status to realize that; release the socket
+    // semaphore so the SP can respond.
     sp_accept_sema.send(usize::MAX).unwrap();
-    progress.changed().await.unwrap();
-    assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Complete));
+
+    // Unlike the SP and RoT cases, there are no MGS/SP steps in between the
+    // update completing and `HostPhase1Updater` sending
+    // `UpdateProgress::Complete`. Therefore, it's a race whether we'll see
+    // some number of `InProgress` status before `Complete`, but we should
+    // quickly move to `Complete`.
+    loop {
+        tokio::time::timeout(Duration::from_secs(10), progress.changed())
+            .await
+            .expect("progress timeout")
+            .expect("progress watch sender dropped");
+        let status = progress.borrow_and_update().clone().unwrap();
+        match status {
+            UpdateProgress::Complete => break,
+            UpdateProgress::InProgress { .. } => continue,
+            _ => panic!("unexpected progress status {status:?}"),
+        }
+    }
 
     // drop our progress receiver so `do_update_task` can complete
     mem::drop(progress);
@@ -614,17 +567,17 @@ async fn test_rot_updater_delivers_progress() {
     do_update_task.await.expect("update task panicked").expect("update failed");
 
     let last_update_image = target_sp
-        .last_rot_update_data()
+        .last_host_phase1_update_data(target_host_slot)
         .await
-        .expect("simulated RoT did not receive an update");
+        .expect("simulated host phase1 did not receive an update");
 
     assert_eq!(
-        hubris_archive.image.data.as_slice(),
+        phase1_data.as_slice(),
         &*last_update_image,
-        "simulated RoT update contents (len {}) \
+        "simulated host phase1 update contents (len {}) \
          do not match test generated fake image (len {})",
         last_update_image.len(),
-        hubris_archive.image.data.len()
+        phase1_data.len(),
     );
 
     mgstestctx.teardown().await;

--- a/nexus/tests/integration_tests/host_phase1_updater.rs
+++ b/nexus/tests/integration_tests/host_phase1_updater.rs
@@ -340,12 +340,12 @@ async fn test_host_phase1_updater_switches_mgs_instances_on_failure() {
         }
     }
 
-    // An SP update requires a minimum of 3 requests to MGS: post the update,
-    // check the status, and post an SP reset. There may be more requests if the
-    // update is not yet complete when the status is checked, but we can just
-    // check that each of our proxies received at least 2 incoming requests;
-    // based on our outline above, if we got the minimum of 3 requests, it would
-    // look like this:
+    // A host flash update requires a minimum of 3 requests to MGS: set the
+    // active flash slot, post the update, and check the status. There may be
+    // more requests if the update is not yet complete when the status is
+    // checked, but we can just check that each of our proxies received at least
+    // 2 incoming requests; based on our outline above, if we got the minimum of
+    // 3 requests, it would look like this:
     //
     // 1. POST update -> first proxy (success)
     // 2. GET status -> first proxy (fail)
@@ -432,9 +432,9 @@ async fn test_host_phase1_updater_delivers_progress() {
         host_phase1_updater.update(&mut mgs_clients).await
     });
 
-    // Allow the SP to respond to 2 messages: the caboose check and the "prepare
-    // update" messages that trigger the start of an update, then ensure we see
-    // the "started" progress.
+    // Allow the SP to respond to 2 messages: the message to activate the target
+    // flash slot and the "prepare update" messages that triggers the start of an
+    // update, then ensure we see the "started" progress.
     sp_accept_sema.send(2).unwrap();
     progress.changed().await.unwrap();
     assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Started));

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -12,6 +12,7 @@ mod commands;
 mod console_api;
 mod device_auth;
 mod disks;
+mod host_phase1_updater;
 mod images;
 mod initialization;
 mod instances;

--- a/nexus/tests/integration_tests/rot_updater.rs
+++ b/nexus/tests/integration_tests/rot_updater.rs
@@ -491,7 +491,7 @@ async fn test_rot_updater_delivers_progress() {
         tokio::spawn(async move { rot_updater.update(&mut mgs_clients).await });
 
     // Allow the SP to respond to 1 message: the "prepare update" messages that
-    // trigger the start of an update, then ensure we see the "started"
+    // triggers the start of an update, then ensure we see the "started"
     // progress.
     sp_accept_sema.send(1).unwrap();
     progress.changed().await.unwrap();

--- a/nexus/tests/integration_tests/sp_updater.rs
+++ b/nexus/tests/integration_tests/sp_updater.rs
@@ -46,10 +46,11 @@ async fn test_sp_updater_updates_sled() {
             .await;
 
     // Configure an MGS client.
-    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
-        &mgstestctx.client.url("/").to_string(),
-        mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
-    )]);
+    let mut mgs_clients =
+        MgsClients::from_clients([gateway_client::Client::new(
+            &mgstestctx.client.url("/").to_string(),
+            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
+        )]);
 
     // Configure and instantiate an `SpUpdater`.
     let sp_type = SpType::Sled;
@@ -96,10 +97,11 @@ async fn test_sp_updater_updates_switch() {
             .await;
 
     // Configure an MGS client.
-    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
-        &mgstestctx.client.url("/").to_string(),
-        mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
-    )]);
+    let mut mgs_clients =
+        MgsClients::from_clients([gateway_client::Client::new(
+            &mgstestctx.client.url("/").to_string(),
+            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
+        )]);
 
     let sp_type = SpType::Switch;
     let sp_slot = 0;
@@ -317,7 +319,8 @@ async fn test_sp_updater_switches_mgs_instances_on_failure() {
     );
 
     // Spawn the actual update task.
-    let mut update_task = tokio::spawn(async move { sp_updater.update(&mut mgs_clients).await });
+    let mut update_task =
+        tokio::spawn(async move { sp_updater.update(&mut mgs_clients).await });
 
     // Loop over incoming requests. We expect this sequence:
     //
@@ -436,10 +439,11 @@ async fn test_sp_updater_delivers_progress() {
             .await;
 
     // Configure an MGS client.
-    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
-        &mgstestctx.client.url("/").to_string(),
-        mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
-    )]);
+    let mut mgs_clients =
+        MgsClients::from_clients([gateway_client::Client::new(
+            &mgstestctx.client.url("/").to_string(),
+            mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
+        )]);
 
     let sp_type = SpType::Sled;
     let sp_slot = 0;
@@ -470,9 +474,8 @@ async fn test_sp_updater_delivers_progress() {
 
     // Spawn the update on a background task so we can watch `progress` as it is
     // applied.
-    let do_update_task = tokio::spawn(async move {
-        sp_updater.update(&mut mgs_clients).await
-    });
+    let do_update_task =
+        tokio::spawn(async move { sp_updater.update(&mut mgs_clients).await });
 
     // Allow the SP to respond to 2 messages: the caboose check and the "prepare
     // update" messages that trigger the start of an update, then ensure we see

--- a/nexus/tests/integration_tests/sp_updater.rs
+++ b/nexus/tests/integration_tests/sp_updater.rs
@@ -46,7 +46,7 @@ async fn test_sp_updater_updates_sled() {
             .await;
 
     // Configure an MGS client.
-    let mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
+    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
         &mgstestctx.client.url("/").to_string(),
         mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
     )]);
@@ -66,7 +66,7 @@ async fn test_sp_updater_updates_sled() {
     );
 
     // Run the update.
-    sp_updater.update(mgs_clients).await.expect("update failed");
+    sp_updater.update(&mut mgs_clients).await.expect("update failed");
 
     // Ensure the SP received the complete update.
     let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
@@ -96,7 +96,7 @@ async fn test_sp_updater_updates_switch() {
             .await;
 
     // Configure an MGS client.
-    let mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
+    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
         &mgstestctx.client.url("/").to_string(),
         mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
     )]);
@@ -114,7 +114,7 @@ async fn test_sp_updater_updates_switch() {
         &mgstestctx.logctx.log,
     );
 
-    sp_updater.update(mgs_clients).await.expect("update failed");
+    sp_updater.update(&mut mgs_clients).await.expect("update failed");
 
     let last_update_image = mgstestctx.simrack.sidecars[sp_slot as usize]
         .last_sp_update_data()
@@ -174,7 +174,7 @@ async fn test_sp_updater_remembers_successful_mgs_instance() {
     // delivering an update requires a bare minimum of three requests (start the
     // update, query the status, reset the SP) and often more (if repeated
     // queries are required to wait for completion).
-    let mgs_clients = MgsClients::from_clients([
+    let mut mgs_clients = MgsClients::from_clients([
         gateway_client::Client::new(
             &format!("http://{failing_mgs_addr}"),
             mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient1")),
@@ -198,7 +198,7 @@ async fn test_sp_updater_remembers_successful_mgs_instance() {
         &mgstestctx.logctx.log,
     );
 
-    sp_updater.update(mgs_clients).await.expect("update failed");
+    sp_updater.update(&mut mgs_clients).await.expect("update failed");
 
     let last_update_image = mgstestctx.simrack.gimlets[sp_slot as usize]
         .last_sp_update_data()
@@ -290,7 +290,7 @@ async fn test_sp_updater_switches_mgs_instances_on_failure() {
         reqwest::Client::builder().pool_max_idle_per_host(0).build().unwrap();
 
     // Configure two MGS clients pointed at our two proxy tasks.
-    let mgs_clients = MgsClients::from_clients([
+    let mut mgs_clients = MgsClients::from_clients([
         gateway_client::Client::new_with_client(
             &format!("http://{mgs_proxy_one_addr}"),
             client.clone(),
@@ -317,7 +317,7 @@ async fn test_sp_updater_switches_mgs_instances_on_failure() {
     );
 
     // Spawn the actual update task.
-    let mut update_task = tokio::spawn(sp_updater.update(mgs_clients));
+    let mut update_task = tokio::spawn(async move { sp_updater.update(&mut mgs_clients).await });
 
     // Loop over incoming requests. We expect this sequence:
     //
@@ -436,7 +436,7 @@ async fn test_sp_updater_delivers_progress() {
             .await;
 
     // Configure an MGS client.
-    let mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
+    let mut mgs_clients = MgsClients::from_clients([gateway_client::Client::new(
         &mgstestctx.client.url("/").to_string(),
         mgstestctx.logctx.log.new(slog::o!("component" => "MgsClient")),
     )]);
@@ -470,7 +470,9 @@ async fn test_sp_updater_delivers_progress() {
 
     // Spawn the update on a background task so we can watch `progress` as it is
     // applied.
-    let do_update_task = tokio::spawn(sp_updater.update(mgs_clients));
+    let do_update_task = tokio::spawn(async move {
+        sp_updater.update(&mut mgs_clients).await
+    });
 
     // Allow the SP to respond to 2 messages: the caboose check and the "prepare
     // update" messages that trigger the start of an update, then ensure we see

--- a/nexus/tests/integration_tests/sp_updater.rs
+++ b/nexus/tests/integration_tests/sp_updater.rs
@@ -545,7 +545,6 @@ async fn test_sp_updater_delivers_progress() {
             UpdateStatus::Complete(_) => {
                 if prev_bytes_received < sp_image_len {
                     prev_bytes_received = sp_image_len;
-                    continue;
                 }
             }
             status @ (UpdateStatus::None

--- a/nexus/tests/integration_tests/sp_updater.rs
+++ b/nexus/tests/integration_tests/sp_updater.rs
@@ -478,7 +478,7 @@ async fn test_sp_updater_delivers_progress() {
         tokio::spawn(async move { sp_updater.update(&mut mgs_clients).await });
 
     // Allow the SP to respond to 2 messages: the caboose check and the "prepare
-    // update" messages that trigger the start of an update, then ensure we see
+    // update" messages that triggers the start of an update, then ensure we see
     // the "started" progress.
     sp_accept_sema.send(2).unwrap();
     progress.changed().await.unwrap();

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -68,6 +68,12 @@ pub trait SimulatedSp {
     /// Only returns data after a simulated reset of the RoT.
     async fn last_rot_update_data(&self) -> Option<Box<[u8]>>;
 
+    /// Get the last completed update delivered to the host phase1 flash slot.
+    async fn last_host_phase1_update_data(
+        &self,
+        slot: u16,
+    ) -> Option<Box<[u8]>>;
+
     /// Get the current update status, just as would be returned by an MGS
     /// request to get the update status.
     async fn current_update_status(&self) -> gateway_messages::UpdateStatus;

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -134,6 +134,14 @@ impl SimulatedSp for Sidecar {
         handler.update_state.last_rot_update_data()
     }
 
+    async fn last_host_phase1_update_data(
+        &self,
+        _slot: u16,
+    ) -> Option<Box<[u8]>> {
+        // sidecars do not have attached hosts
+        None
+    }
+
     async fn current_update_status(&self) -> gateway_messages::UpdateStatus {
         let Some(handler) = self.handler.as_ref() else {
             return gateway_messages::UpdateStatus::None;

--- a/sp-sim/src/update.rs
+++ b/sp-sim/src/update.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::mem;
 
@@ -15,6 +16,8 @@ pub(crate) struct SimSpUpdate {
     state: UpdateState,
     last_sp_update_data: Option<Box<[u8]>>,
     last_rot_update_data: Option<Box<[u8]>>,
+    last_host_phase1_update_data: BTreeMap<u16, Box<[u8]>>,
+    active_host_slot: Option<u16>,
 }
 
 impl Default for SimSpUpdate {
@@ -23,6 +26,13 @@ impl Default for SimSpUpdate {
             state: UpdateState::NotPrepared,
             last_sp_update_data: None,
             last_rot_update_data: None,
+            last_host_phase1_update_data: BTreeMap::new(),
+
+            // In the real SP, there is always _some_ active host slot. We could
+            // emulate that by always defaulting to slot 0, but instead we'll
+            // ensure any tests that expect to read or write a particular slot
+            // set that slot as active first.
+            active_host_slot: None,
         }
     }
 }
@@ -43,9 +53,20 @@ impl SimSpUpdate {
             UpdateState::NotPrepared
             | UpdateState::Aborted(_)
             | UpdateState::Completed { .. } => {
+                let slot = if component == SpComponent::HOST_CPU_BOOT_FLASH {
+                    match self.active_host_slot {
+                        Some(slot) => slot,
+                        None => return Err(SpError::InvalidSlotForComponent),
+                    }
+                } else {
+                    // We don't manage SP or RoT slots, so just use 0
+                    0
+                };
+
                 self.state = UpdateState::Prepared {
                     component,
                     id,
+                    slot,
                     data: Cursor::new(vec![0u8; total_size].into_boxed_slice()),
                 };
                 Ok(())
@@ -63,7 +84,7 @@ impl SimSpUpdate {
         chunk_data: &[u8],
     ) -> Result<(), SpError> {
         match &mut self.state {
-            UpdateState::Prepared { component, id, data } => {
+            UpdateState::Prepared { component, id, slot, data } => {
                 // Ensure that the update ID and target component are correct.
                 if chunk.id != *id || chunk.component != *component {
                     return Err(SpError::InvalidUpdateId { sp_update_id: *id });
@@ -84,10 +105,17 @@ impl SimSpUpdate {
                 if data.position() == data.get_ref().len() as u64 {
                     let mut stolen = Cursor::new(Box::default());
                     mem::swap(data, &mut stolen);
+                    let data = stolen.into_inner();
+
+                    if *component == SpComponent::HOST_CPU_BOOT_FLASH {
+                        self.last_host_phase1_update_data
+                            .insert(*slot, data.clone());
+                    }
+
                     self.state = UpdateState::Completed {
                         component: *component,
                         id: *id,
-                        data: stolen.into_inner(),
+                        data,
                     };
                 }
 
@@ -150,6 +178,17 @@ impl SimSpUpdate {
     pub(crate) fn last_rot_update_data(&self) -> Option<Box<[u8]>> {
         self.last_rot_update_data.clone()
     }
+
+    pub(crate) fn last_host_phase1_update_data(
+        &self,
+        slot: u16,
+    ) -> Option<Box<[u8]>> {
+        self.last_host_phase1_update_data.get(&slot).cloned()
+    }
+
+    pub(crate) fn set_active_host_slot(&mut self, slot: u16) {
+        self.active_host_slot = Some(slot);
+    }
 }
 
 enum UpdateState {
@@ -157,6 +196,7 @@ enum UpdateState {
     Prepared {
         component: SpComponent,
         id: UpdateId,
+        slot: u16,
         // data would ordinarily be a Cursor<Vec<u8>>, but that can grow and
         // reallocate. We want to ensure that we don't receive any more data
         // than originally promised, so use a Cursor<Box<[u8]>> to ensure that


### PR DESCRIPTION
Continues the work from #4427 and #4502 adding types to Nexus that can deliver updates to components managed by the SP, and contains a similar amount of duplication from those two. Non-duplication changes are mostly refactoring:

* Removed component-specific error types in favor of `SpComponentUpdateError`
* Extracted the "start the update and poll MGS until it's done" logic into a new `common_sp_update` module

The `test_host_phase1_updater_delivers_progress` is subtly different from the RoT/SP versions of the same test, but not in a way that's particularly interesting (see the "Unlike the SP and RoT cases" comment for details). 