### PR TITLE
[omicron-dev] increase test timeout to 30 seconds

### DIFF
--- a/dev-tools/omicron-dev/tests/test_omicron_dev.rs
+++ b/dev-tools/omicron-dev/tests/test_omicron_dev.rs
@@ -27,7 +27,7 @@ use subprocess::Redirection;
 const CMD_OMICRON_DEV: &str = env!("CARGO_BIN_EXE_omicron-dev");
 
 /// timeout used for various things that should be pretty quick
-const TIMEOUT: Duration = Duration::from_secs(15);
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 fn path_to_omicron_dev() -> PathBuf {
     path_to_executable(CMD_OMICRON_DEV)


### PR DESCRIPTION
On my machine (Ryzen 7950X) I saw that under load (32 tests running at the same
time), the timeout would quite reliably be hit likely because cockroach was
starved. Increasing it seems pretty harmless.
