### PR TITLE
[update-engine] fix GroupDisplayStats to avoid integer underflow

### DIFF
--- a/update-engine/examples/update-engine-basic/display.rs
+++ b/update-engine/examples/update-engine-basic/display.rs
@@ -88,6 +88,7 @@ async fn display_group(
     slog::info!(log, "setting up display");
 
     let mut display = GroupDisplay::new(
+        log,
         [
             (GroupDisplayKey::Example, "example"),
             (GroupDisplayKey::Other, "other"),

--- a/update-engine/src/buffer.rs
+++ b/update-engine/src/buffer.rs
@@ -1627,6 +1627,16 @@ pub enum TerminalKind {
     Aborted,
 }
 
+impl fmt::Display for TerminalKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
+            Self::Aborted => write!(f, "aborted"),
+        }
+    }
+}
+
 impl ExecutionStatus {
     /// Returns the terminal status and the total amount of time elapsed, or
     /// None if the execution has not reached a terminal state.

--- a/update-engine/src/display/group_display.rs
+++ b/update-engine/src/display/group_display.rs
@@ -163,7 +163,7 @@ impl<K: Eq + Ord, W: std::io::Write, S: StepSpec> GroupDisplay<K, W, S> {
                     "root_total_elapsed" => ?result.root_total_elapsed,
                 );
             } else {
-                slog::debug!(
+                slog::trace!(
                     self.log,
                     "add_event_report called, state did not change";
                     "prefix" => &state.prefix,

--- a/update-engine/src/display/group_display.rs
+++ b/update-engine/src/display/group_display.rs
@@ -149,20 +149,23 @@ impl<K: Eq + Ord, W: std::io::Write, S: StepSpec> GroupDisplay<K, W, S> {
                         TokioSw::with_elapsed_started(root_total_elapsed);
                 }
             }
-            self.log_result(&result);
+
             self.stats.apply_result(result);
+            self.log_result(&state.prefix, &result);
             Ok(())
         } else {
             Err(UnknownReportKey {})
         }
     }
 
-    fn log_result(&self, result: &AddEventReportResult) {
+    fn log_result(&self, prefix: &str, result: &AddEventReportResult) {
         slog::debug!(
             self.log,
             "add_event_report called";
+            "prefix" => prefix,
             "before" => %result.before,
             "after" => %result.after,
+            "stats" => ?self.stats,
             "root_total_elapsed" => ?result.root_total_elapsed,
         );
 
@@ -170,8 +173,10 @@ impl<K: Eq + Ord, W: std::io::Write, S: StepSpec> GroupDisplay<K, W, S> {
             slog::info!(
                 self.log,
                 "add_event_report caused state transition";
+                "prefix" => prefix,
                 "before" => %result.before,
                 "after" => %result.after,
+                "stats" => ?self.stats,
                 "root_total_elapsed" => ?result.root_total_elapsed,
             );
         }
@@ -565,6 +570,7 @@ enum SingleStateKind<S: StepSpec> {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct AddEventReportResult {
     before: SingleStateTag,
     after: SingleStateTag,

--- a/update-engine/src/display/group_display.rs
+++ b/update-engine/src/display/group_display.rs
@@ -151,34 +151,31 @@ impl<K: Eq + Ord, W: std::io::Write, S: StepSpec> GroupDisplay<K, W, S> {
             }
 
             self.stats.apply_result(result);
-            self.log_result(&state.prefix, &result);
+
+            if result.before != result.after {
+                slog::info!(
+                    self.log,
+                    "add_event_report caused state transition";
+                    "prefix" => &state.prefix,
+                    "before" => %result.before,
+                    "after" => %result.after,
+                    "current_stats" => ?self.stats,
+                    "root_total_elapsed" => ?result.root_total_elapsed,
+                );
+            } else {
+                slog::debug!(
+                    self.log,
+                    "add_event_report called, state did not change";
+                    "prefix" => &state.prefix,
+                    "state" => %result.before,
+                    "current_stats" => ?self.stats,
+                    "root_total_elapsed" => ?result.root_total_elapsed,
+                );
+            }
+
             Ok(())
         } else {
             Err(UnknownReportKey {})
-        }
-    }
-
-    fn log_result(&self, prefix: &str, result: &AddEventReportResult) {
-        slog::debug!(
-            self.log,
-            "add_event_report called";
-            "prefix" => prefix,
-            "before" => %result.before,
-            "after" => %result.after,
-            "stats" => ?self.stats,
-            "root_total_elapsed" => ?result.root_total_elapsed,
-        );
-
-        if result.before != result.after {
-            slog::info!(
-                self.log,
-                "add_event_report caused state transition";
-                "prefix" => prefix,
-                "before" => %result.before,
-                "after" => %result.after,
-                "stats" => ?self.stats,
-                "root_total_elapsed" => ?result.root_total_elapsed,
-            );
         }
     }
 

--- a/update-engine/src/test_utils.rs
+++ b/update-engine/src/test_utils.rs
@@ -4,9 +4,16 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use anyhow::bail;
+use futures::StreamExt;
 use schemars::JsonSchema;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
 
-use crate::{ExecutionId, StepSpec};
+use crate::{
+    events::{Event, ProgressUnits, StepProgress},
+    EventBuffer, ExecutionId, StepContext, StepSpec, StepSuccess, UpdateEngine,
+};
 
 #[derive(JsonSchema)]
 pub(crate) enum TestSpec {}
@@ -26,4 +33,279 @@ pub(crate) static TEST_EXECUTION_UUID: &str =
 
 pub fn test_execution_id() -> ExecutionId {
     ExecutionId(TEST_EXECUTION_UUID.parse().expect("valid UUID"))
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum GenerateTestEventsKind {
+    Completed,
+    Failed,
+    Aborted,
+}
+
+pub(crate) async fn generate_test_events(
+    log: &slog::Logger,
+    kind: GenerateTestEventsKind,
+) -> Vec<Event<TestSpec>> {
+    // The channel is big enough to contain all possible events.
+    let (sender, receiver) = mpsc::channel(512);
+    let engine = UpdateEngine::new(log, sender);
+
+    match kind {
+        GenerateTestEventsKind::Completed => {
+            define_test_steps(log, &engine, LastStepOutcome::Completed);
+            engine.execute().await.expect("execution successful");
+        }
+        GenerateTestEventsKind::Failed => {
+            define_test_steps(log, &engine, LastStepOutcome::Failed);
+            engine.execute().await.expect_err("execution failed");
+        }
+        GenerateTestEventsKind::Aborted => {
+            // In this case, the last step signals that it has been reached via
+            // sending a message over this channel, and then waits forever. We
+            // abort execution by calling into the AbortHandle.
+            let (sender, receiver) = oneshot::channel();
+            define_test_steps(log, &engine, LastStepOutcome::Aborted(sender));
+            let abort_handle = engine.abort_handle();
+            let mut execute_fut = std::pin::pin!(engine.execute());
+            let mut receiver = std::pin::pin!(receiver);
+            let mut receiver_done = false;
+            loop {
+                tokio::select! {
+                    res = &mut execute_fut => {
+                        res.expect_err("execution should have been aborted, but completed successfully");
+                        break;
+                    }
+                    _ = &mut receiver, if !receiver_done => {
+                        receiver_done = true;
+                        abort_handle
+                            .abort("test engine deliberately aborted")
+                            .expect("engine should still be alive");
+                    }
+                }
+            }
+        }
+    }
+
+    ReceiverStream::new(receiver).collect().await
+}
+
+#[derive(Debug)]
+enum LastStepOutcome {
+    Completed,
+    Failed,
+    Aborted(oneshot::Sender<()>),
+}
+
+#[derive(Debug)]
+enum Never {}
+
+fn define_test_steps(
+    log: &slog::Logger,
+    engine: &UpdateEngine<TestSpec>,
+    last_step_outcome: LastStepOutcome,
+) {
+    engine
+        .new_step("foo".to_owned(), 1, "Step 1", move |_cx| async move {
+            StepSuccess::new(()).into()
+        })
+        .register();
+
+    engine
+        .new_step("bar".to_owned(), 2, "Step 2", move |cx| async move {
+            for _ in 0..20 {
+                cx.send_progress(StepProgress::with_current_and_total(
+                    5,
+                    20,
+                    ProgressUnits::BYTES,
+                    Default::default(),
+                ))
+                .await;
+
+                cx.send_progress(StepProgress::reset(
+                    Default::default(),
+                    "reset step 2",
+                ))
+                .await;
+
+                cx.send_progress(StepProgress::retry("retry step 2")).await;
+            }
+            StepSuccess::new(()).into()
+        })
+        .register();
+
+    engine
+        .new_step(
+            "nested".to_owned(),
+            3,
+            "Step 3 (this is nested)",
+            move |parent_cx| async move {
+                parent_cx
+                    .with_nested_engine(|engine| {
+                        define_nested_engine(&parent_cx, engine);
+                        Ok(())
+                    })
+                    .await
+                    .expect_err("this is expected to fail");
+
+                StepSuccess::new(()).into()
+            },
+        )
+        .register();
+
+    let log = log.clone();
+    engine
+    .new_step(
+        "remote-nested".to_owned(),
+        20,
+        "Step 4 (remote nested)",
+        move |cx| async move {
+            let (sender, mut receiver) = mpsc::channel(16);
+            let mut engine = UpdateEngine::new(&log, sender);
+            define_remote_nested_engine(&mut engine, 20);
+
+            let mut buffer = EventBuffer::default();
+
+            let mut execute_fut = std::pin::pin!(engine.execute());
+            let mut execute_done = false;
+            loop {
+                tokio::select! {
+                    res = &mut execute_fut, if !execute_done => {
+                        res.expect("remote nested engine completed successfully");
+                        execute_done = true;
+                    }
+                    Some(event) = receiver.recv() => {
+                        // Generate complete reports to ensure deduping
+                        // happens within StepContexts.
+                        buffer.add_event(event);
+                        cx.send_nested_report(buffer.generate_report()).await?;
+                    }
+                    else => {
+                        break;
+                    }
+                }
+            }
+
+            StepSuccess::new(()).into()
+        },
+    )
+    .register();
+
+    // The step index here (100) is large enough to be higher than all nested
+    // steps.
+    engine
+        .new_step("baz".to_owned(), 100, "Step 5", move |_cx| async move {
+            match last_step_outcome {
+                LastStepOutcome::Completed => StepSuccess::new(()).into(),
+                LastStepOutcome::Failed => {
+                    bail!("last step failed")
+                }
+                LastStepOutcome::Aborted(sender) => {
+                    sender.send(()).expect("receiver should be alive");
+                    // The driver of the engine is responsible for aborting it
+                    // at this point.
+                    std::future::pending::<Never>().await;
+                    unreachable!("pending future can never resolve");
+                }
+            }
+        })
+        .register();
+}
+
+fn define_nested_engine<'a>(
+    parent_cx: &'a StepContext<TestSpec>,
+    engine: &mut UpdateEngine<'a, TestSpec>,
+) {
+    engine
+        .new_step(
+            "nested-foo".to_owned(),
+            4,
+            "Nested step 1",
+            move |cx| async move {
+                parent_cx
+                    .send_progress(StepProgress::with_current_and_total(
+                        1,
+                        3,
+                        "steps",
+                        Default::default(),
+                    ))
+                    .await;
+                cx.send_progress(StepProgress::progress(Default::default()))
+                    .await;
+                StepSuccess::new(()).into()
+            },
+        )
+        .register();
+
+    engine
+        .new_step::<_, _, ()>(
+            "nested-bar".to_owned(),
+            5,
+            "Nested step 2 (fails)",
+            move |cx| async move {
+                // This is used by NestedProgressCheck below.
+                parent_cx
+                    .send_progress(StepProgress::with_current_and_total(
+                        2,
+                        3,
+                        "steps",
+                        Default::default(),
+                    ))
+                    .await;
+
+                cx.send_progress(StepProgress::with_current(
+                    50,
+                    "units",
+                    Default::default(),
+                ))
+                .await;
+
+                parent_cx
+                    .send_progress(StepProgress::with_current_and_total(
+                        3,
+                        3,
+                        "steps",
+                        Default::default(),
+                    ))
+                    .await;
+
+                bail!("failing step")
+            },
+        )
+        .register();
+}
+
+fn define_remote_nested_engine(
+    engine: &mut UpdateEngine<'_, TestSpec>,
+    start_id: usize,
+) {
+    engine
+        .new_step(
+            "nested-foo".to_owned(),
+            start_id + 1,
+            "Nested step 1",
+            move |cx| async move {
+                cx.send_progress(StepProgress::progress(Default::default()))
+                    .await;
+                StepSuccess::new(()).into()
+            },
+        )
+        .register();
+
+    engine
+        .new_step::<_, _, ()>(
+            "nested-bar".to_owned(),
+            start_id + 2,
+            "Nested step 2",
+            move |cx| async move {
+                cx.send_progress(StepProgress::with_current(
+                    20,
+                    "units",
+                    Default::default(),
+                ))
+                .await;
+
+                StepSuccess::new(()).into()
+            },
+        )
+        .register();
 }

--- a/wicket/src/cli/rack_update.rs
+++ b/wicket/src/cli/rack_update.rs
@@ -174,6 +174,7 @@ async fn do_attach_to_updates(
     output: CommandOutput<'_>,
 ) -> Result<()> {
     let mut display = GroupDisplay::new_with_display(
+        &log,
         update_ids.iter().copied(),
         output.stderr,
     );


### PR DESCRIPTION
This could happen if an empty `EventReport` is passed in -- in that case we'd
transition to `Running` but return `NotStarted`.

Fix this by not transitioning `self.kind` to `Running` if we're going to return
`NotStarted`. This does bloat up the code a little but I think is clearer
overall.

Thanks to @jgallagher for all the help debugging this!

Also clean up some related logic and add tests.

Fixes #4507.
