### PR TITLE
Set version to 5.0.0

### DIFF
--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -37,7 +37,7 @@ rustc --version
 # trampoline global zone images.
 #
 COMMIT=$(git rev-parse HEAD)
-VERSION="1.0.4-0.ci+git${COMMIT:0:11}"
+VERSION="5.0.0-0.ci+git${COMMIT:0:11}"
 echo "$VERSION" >/work/version.txt
 
 ptime -m ./tools/install_builder_prerequisites.sh -yp


### PR DESCRIPTION
[Last time around I raised a concern about jumping to x.0.0](https://github.com/oxidecomputer/omicron/pull/4437#issuecomment-1793652280) but we resolved that in the next updates meeting, and decided it's fine for all the inner control plane components to be versioned this way too for the time being. The actual updates system will rely less on implied semver semantics and will instead be more explicit, probably on ranges of versions.