### PR TITLE
Stop panicking when our accounting is wrong

### DIFF
--- a/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
+++ b/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
@@ -124,10 +124,12 @@ impl DataStore {
             .get_result_async(conn)
             .await
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
-        assert!(
-            collection.is_empty(),
-            "Collection deleted while non-empty: {collection:?}"
-        );
+
+        if !collection.is_empty() {
+            return Err(Error::internal_error(&format!(
+                "Collection deleted while non-empty: {collection:?}"
+            )));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Prefer to return a 500 error instead of panicking.

Since this function is already called from a transactional context, we can rely on the rollback mechanism to "undo" the deletion.

Fixes https://github.com/oxidecomputer/omicron/issues/3870