### PR TITLE
`tools/install_builder_prerequisites.sh`: Don't cause problems on non-Debian distros

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -105,6 +105,12 @@ HOST_OS=$(uname -s)
 
 function install_packages {
   if [[ "${HOST_OS}" == "Linux" ]]; then
+    if ! grep -q -e 'ID=debian' -e 'ID_LIKE=.*debian.*' /etc/os-release; then
+      echo "This script doesn't yet support $(grep ^ID /etc/os-release)"
+      echo "We assume you know what you're doing!"
+      return
+    fi
+
     packages=(
       'libpq-dev'
       'pkg-config'
@@ -162,7 +168,7 @@ function install_packages {
     confirm "Install (or update) [${packages[*]}]?" && brew install "${packages[@]}"
   else
     echo "Unsupported OS: ${HOST_OS}"
-    exit 1
+    echo "We assume you know what you're doing!"
   fi
 }
 


### PR DESCRIPTION
The `install_packages` function in `tools/install_builder_prerequisites.sh` is specific to Debian-like Linux distros, Helios, and macOS. This script is run in CI for those three platforms (or maybe just the first two now?), so those still need to work. But this script is also convenient for pulling down artifacts (e.g. Cockroach DB) to build the rest of the control plane.

Attempting to have a list of every command needed for every Linux distribution to install the correct packages is probably intractable (especially for distros with _multiple separate tools_ depending on user preference), so we should print a message and assume the user knows what they're doing if they're using Gentoo.

(I also got rid of the `exit 1` in the branch that runs if `uname -s` returns something other than Linux, SunOS, or Darwin. The script is far less likely to work in that situation but we again assume the user knows what they're doing more than the script does.)