### PR TITLE
[easy] [update-engine] change an info to a debug

### DIFF
--- a/update-engine/src/display/group_display.rs
+++ b/update-engine/src/display/group_display.rs
@@ -153,7 +153,7 @@ impl<K: Eq + Ord, W: std::io::Write, S: StepSpec> GroupDisplay<K, W, S> {
             self.stats.apply_result(result);
 
             if result.before != result.after {
-                slog::info!(
+                slog::debug!(
                     self.log,
                     "add_event_report caused state transition";
                     "prefix" => &state.prefix,


### PR DESCRIPTION
Saw `wicket rack-update` print out this info message even though the group
displayer would show a corresponding message anyway.
