### PR TITLE
[nexus] remove views::SledProvisionState::Unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,7 +4179,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_with",
  "steno",
  "strum",
  "uuid",

--- a/nexus/db-model/src/sled_provision_state.rs
+++ b/nexus/db-model/src/sled_provision_state.rs
@@ -34,19 +34,14 @@ impl From<SledProvisionState> for views::SledProvisionState {
     }
 }
 
-impl TryFrom<views::SledProvisionState> for SledProvisionState {
-    type Error = UnknownSledProvisionState;
-
-    fn try_from(state: views::SledProvisionState) -> Result<Self, Self::Error> {
+impl From<views::SledProvisionState> for SledProvisionState {
+    fn from(state: views::SledProvisionState) -> Self {
         match state {
             views::SledProvisionState::Provisionable => {
-                Ok(SledProvisionState::Provisionable)
+                SledProvisionState::Provisionable
             }
             views::SledProvisionState::NonProvisionable => {
-                Ok(SledProvisionState::NonProvisionable)
-            }
-            views::SledProvisionState::Unknown => {
-                Err(UnknownSledProvisionState)
+                SledProvisionState::NonProvisionable
             }
         }
     }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -4504,10 +4504,7 @@ async fn sled_set_provision_state(
 
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
         // Convert the external `SledProvisionState` into our internal data model.
-        let new_state =
-            db::model::SledProvisionState::try_from(provision_state).map_err(
-                |error| HttpError::for_bad_request(None, format!("{error}")),
-            )?;
+        let new_state = db::model::SledProvisionState::from(provision_state);
 
         let sled_lookup = nexus.sled_lookup(&opctx, &path.sled_id)?;
 

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -14,7 +14,6 @@ parse-display.workspace = true
 schemars = { workspace = true, features = ["chrono", "uuid1"] }
 serde.workspace = true
 serde_json.workspace = true
-serde_with.workspace = true
 steno.workspace = true
 strum.workspace = true
 uuid.workspace = true

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -17,7 +17,6 @@ use omicron_common::api::external::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_with::rust::deserialize_ignore_any;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
@@ -311,12 +310,6 @@ pub enum SledProvisionState {
     /// resources will continue to be on this sled unless manually migrated
     /// off.
     NonProvisionable,
-
-    /// This is a state that isn't known yet.
-    ///
-    /// This is defined to avoid API breakage.
-    #[serde(other, deserialize_with = "deserialize_ignore_any")]
-    Unknown,
 }
 
 /// An operator's view of an instance running on a given sled

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -13192,13 +13192,6 @@
             "enum": [
               "non_provisionable"
             ]
-          },
-          {
-            "description": "This is a state that isn't known yet.\n\nThis is defined to avoid API breakage.",
-            "type": "string",
-            "enum": [
-              "unknown"
-            ]
           }
         ]
       },


### PR DESCRIPTION
This doesn't quite work as expected:

* As an input type, if an unknown `SledProvisionState` is specified, we immediately produce an error as soon as we enter the HTTP entrypoint. There's no functional difference between that and producing an error at deserialization time.
* As an output type, progenitor doesn't support `#[serde(other)]` so the unknown type doesn't work.