### PR TITLE
[omdb] typo fix in error message

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2477,7 +2477,7 @@ async fn cmd_db_inventory_collections_show(
         eprintln!(
             "warning: {} collection error{} {} reported above",
             nerrors,
-            if nerrors == 1 { "" } else { "s" }
+            if nerrors == 1 { "" } else { "s" },
             if nerrors == 1 { "was" } else { "were" },
         );
     }

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2477,8 +2477,8 @@ async fn cmd_db_inventory_collections_show(
         eprintln!(
             "warning: {} collection error{} {} reported above",
             nerrors,
-            if nerrors == 1 { "was" } else { "were" },
             if nerrors == 1 { "" } else { "s" }
+            if nerrors == 1 { "was" } else { "were" },
         );
     }
 


### PR DESCRIPTION
Noticed this while investigating #4621:

```
warning: 16 collection errorwere s reported above
```
