### PR TITLE
Fix paths for reflector updates

### DIFF
--- a/.github/workflows/update-maghemite.yml
+++ b/.github/workflows/update-maghemite.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Extract new maghemite package version
         run: |
-          eval $(cat tools/maghemite_openapi_version | grep COMMIT)
+          eval $(cat tools/maghemite_mg_openapi_version | grep COMMIT)
           echo "version=${COMMIT:0:7}" >> $GITHUB_OUTPUT
         id: updated
 
@@ -55,7 +55,7 @@ jobs:
         run: |
           . ./tools/reflector/helpers.sh
 
-          PATHS=("tools/maghemite_openapi_version")
+          PATHS=("tools/maghemite_ddm_openapi_version" "tools/maghemite_mg_openapi_version" "tools/maghemite_mgd_checksums")
           CHANGES=()
           commit $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} PATHS CHANGES
 


### PR DESCRIPTION
Fixes the paths that maghemite reflector updates should look at when detecting changes. This should fix the missing commit id in the PR titles and bodies