### PR TITLE
move the cockroachdb http console to localhost

### DIFF
--- a/smf/cockroachdb/method_script.sh
+++ b/smf/cockroachdb/method_script.sh
@@ -44,6 +44,7 @@ fi
 args=(
   '--insecure'
   '--listen-addr' "[$LISTEN_ADDR]:$LISTEN_PORT"
+  '--http-addr' '127.0.0.1:8080'
   '--store' "$DATASTORE"
   '--join' "$JOIN_ADDRS"
 )


### PR DESCRIPTION
I can't find any use of the HTTP console or any of its endpoints for anything, so let's move it off the underlay network.

I have not tested this on hardware myself, but the logs for the deploy job here indicate that the `webui` has in fact moved to 127.0.0.1.

I couldn't find a way to completely disable the HTTP console, but I think even if I did I would prefer this, as it still lets us access it for in-situ debugging (although I'm not well-versed enough with zones to understand how you would write an SSH forward to get to it with this change).