### PR TITLE
[wicketd] move shared update-related code into a new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9123,6 +9123,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "update-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "camino-tempfile",
+ "display-error-chain",
+ "dropshot",
+ "futures",
+ "hex",
+ "hubtools",
+ "omicron-common",
+ "omicron-test-utils",
+ "omicron-workspace-hack",
+ "rand 0.8.5",
+ "sha2",
+ "slog",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tough",
+ "tufaceous-lib",
+]
+
+[[package]]
 name = "update-engine"
 version = "0.1.0"
 dependencies = [
@@ -9624,6 +9650,7 @@ dependencies = [
  "trust-dns-resolver",
  "tufaceous",
  "tufaceous-lib",
+ "update-common",
  "update-engine",
  "uuid",
  "wicket",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9130,6 +9130,8 @@ dependencies = [
  "bytes",
  "camino",
  "camino-tempfile",
+ "clap 4.4.3",
+ "debug-ignore",
  "display-error-chain",
  "dropshot",
  "futures",
@@ -9145,6 +9147,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tough",
+ "tufaceous",
  "tufaceous-lib",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "test-utils",
     "tufaceous-lib",
     "tufaceous",
+    "update-common",
     "update-engine",
     "wicket-common",
     "wicket-dbg",
@@ -130,6 +131,7 @@ default-members = [
     "test-utils",
     "tufaceous-lib",
     "tufaceous",
+    "update-common",
     "update-engine",
     "wicket-common",
     "wicket-dbg",
@@ -381,6 +383,7 @@ trybuild = "1.0.85"
 tufaceous = { path = "tufaceous" }
 tufaceous-lib = { path = "tufaceous-lib" }
 unicode-width = "0.1.11"
+update-common = { path = "update-common" }
 update-engine = { path = "update-engine" }
 usdt = "0.3"
 uuid = { version = "1.6.1", features = ["serde", "v4"] }

--- a/update-common/Cargo.toml
+++ b/update-common/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 bytes.workspace = true
 camino.workspace = true
 camino-tempfile.workspace = true
+debug-ignore.workspace = true
 display-error-chain.workspace = true
 dropshot.workspace = true
 futures.workspace = true
@@ -25,5 +26,7 @@ tufaceous-lib.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+clap.workspace = true
 omicron-test-utils.workspace = true
 rand.workspace = true
+tufaceous.workspace = true

--- a/update-common/Cargo.toml
+++ b/update-common/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "update-common"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+anyhow.workspace = true
+bytes.workspace = true
+camino.workspace = true
+camino-tempfile.workspace = true
+display-error-chain.workspace = true
+dropshot.workspace = true
+futures.workspace = true
+hex.workspace = true
+hubtools.workspace = true
+omicron-common.workspace = true
+sha2.workspace = true
+slog.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tough.workspace = true
+tufaceous-lib.workspace = true
+omicron-workspace-hack.workspace = true
+
+[dev-dependencies]
+omicron-test-utils.workspace = true
+rand.workspace = true

--- a/update-common/src/artifacts/artifact_types.rs
+++ b/update-common/src/artifacts/artifact_types.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! General types for artifacts that don't quite fit into the other modules.
+
+use std::borrow::Borrow;
+
+use omicron_common::update::ArtifactId;
+
+use super::ExtractedArtifactDataHandle;
+
+/// A pair containing both the ID of an artifact and a handle to its data.
+///
+/// Note that cloning an `ArtifactIdData` will clone the handle, which has
+/// implications on temporary directory cleanup. See
+/// [`ExtractedArtifactDataHandle`] for details.
+#[derive(Debug, Clone)]
+pub struct ArtifactIdData {
+    pub id: ArtifactId,
+    pub data: ExtractedArtifactDataHandle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Board(pub String);
+
+impl Borrow<String> for Board {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}

--- a/update-common/src/artifacts/artifacts_with_plan.rs
+++ b/update-common/src/artifacts/artifacts_with_plan.rs
@@ -2,6 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::ExtractedArtifactDataHandle;
+use super::UpdatePlan;
+use super::UpdatePlanBuilder;
+use crate::errors::RepositoryError;
 use camino_tempfile::Utf8TempDir;
 use debug_ignore::DebugIgnore;
 use omicron_common::update::ArtifactHash;
@@ -15,14 +19,10 @@ use std::io;
 use tough::TargetName;
 use tufaceous_lib::ArchiveExtractor;
 use tufaceous_lib::OmicronRepo;
-use update_common::artifacts::ExtractedArtifactDataHandle;
-use update_common::artifacts::UpdatePlan;
-use update_common::artifacts::UpdatePlanBuilder;
-use update_common::errors::RepositoryError;
 
 /// A collection of artifacts along with an update plan using those artifacts.
 #[derive(Debug)]
-pub(super) struct ArtifactsWithPlan {
+pub struct ArtifactsWithPlan {
     // Map of top-level artifact IDs (present in the TUF repo) to the actual
     // artifacts we're serving (e.g., a top-level RoT artifact will map to two
     // artifact hashes: one for each of the A and B images).
@@ -50,7 +50,7 @@ pub(super) struct ArtifactsWithPlan {
 }
 
 impl ArtifactsWithPlan {
-    pub(super) async fn from_zip<T>(
+    pub async fn from_zip<T>(
         zip_data: T,
         log: &Logger,
     ) -> Result<Self, RepositoryError>
@@ -164,7 +164,7 @@ impl ArtifactsWithPlan {
         Ok(Self { by_id, by_hash: by_hash.into(), plan: artifacts })
     }
 
-    pub(super) fn by_id(&self) -> &BTreeMap<ArtifactId, Vec<ArtifactHashId>> {
+    pub fn by_id(&self) -> &BTreeMap<ArtifactId, Vec<ArtifactHashId>> {
         &self.by_id
     }
 
@@ -175,11 +175,11 @@ impl ArtifactsWithPlan {
         &self.by_hash
     }
 
-    pub(super) fn plan(&self) -> &UpdatePlan {
+    pub fn plan(&self) -> &UpdatePlan {
         &self.plan
     }
 
-    pub(super) fn get_by_hash(
+    pub fn get_by_hash(
         &self,
         id: &ArtifactHashId,
     ) -> Option<ExtractedArtifactDataHandle> {

--- a/update-common/src/artifacts/mod.rs
+++ b/update-common/src/artifacts/mod.rs
@@ -2,9 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod artifacts_with_plan;
-mod server;
-mod store;
+//! Types to represent update artifacts.
 
-pub(crate) use self::server::WicketdArtifactServer;
-pub(crate) use self::store::WicketdArtifactStore;
+mod artifact_types;
+mod extracted_artifacts;
+mod update_plan;
+
+pub use artifact_types::*;
+pub use extracted_artifacts::*;
+pub use update_plan::*;

--- a/update-common/src/artifacts/mod.rs
+++ b/update-common/src/artifacts/mod.rs
@@ -5,9 +5,11 @@
 //! Types to represent update artifacts.
 
 mod artifact_types;
+mod artifacts_with_plan;
 mod extracted_artifacts;
 mod update_plan;
 
 pub use artifact_types::*;
+pub use artifacts_with_plan::*;
 pub use extracted_artifacts::*;
 pub use update_plan::*;

--- a/update-common/src/errors.rs
+++ b/update-common/src/errors.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Error types for this crate.
+
 use camino::Utf8PathBuf;
 use display_error_chain::DisplayErrorChain;
 use dropshot::HttpError;
@@ -12,7 +14,7 @@ use slog::error;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub(super) enum RepositoryError {
+pub enum RepositoryError {
     #[error("error opening archive")]
     OpenArchive(#[source] anyhow::Error),
 
@@ -129,7 +131,7 @@ pub(super) enum RepositoryError {
 }
 
 impl RepositoryError {
-    pub(super) fn to_http_error(&self) -> HttpError {
+    pub fn to_http_error(&self) -> HttpError {
         let message = DisplayErrorChain::new(self).to_string();
 
         match self {

--- a/update-common/src/lib.rs
+++ b/update-common/src/lib.rs
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod artifacts_with_plan;
-mod server;
-mod store;
+//! Common update types and code shared between wicketd and Nexus.
 
-pub(crate) use self::server::WicketdArtifactServer;
-pub(crate) use self::store::WicketdArtifactStore;
+pub mod artifacts;
+pub mod errors;

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -56,6 +56,7 @@ omicron-common.workspace = true
 omicron-passwords.workspace = true
 sled-hardware.workspace = true
 tufaceous-lib.workspace = true
+update-common.workspace = true
 update-engine.workspace = true
 wicket-common.workspace = true
 wicketd-client.workspace = true

--- a/wicketd/src/artifacts.rs
+++ b/wicketd/src/artifacts.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod artifacts_with_plan;
 mod server;
 mod store;
 

--- a/wicketd/src/artifacts/store.rs
+++ b/wicketd/src/artifacts/store.rs
@@ -3,8 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::artifacts_with_plan::ArtifactsWithPlan;
-use super::ExtractedArtifactDataHandle;
-use super::UpdatePlan;
 use crate::http_entrypoints::InstallableArtifacts;
 use dropshot::HttpError;
 use omicron_common::api::external::SemverVersion;
@@ -13,6 +11,8 @@ use slog::Logger;
 use std::io;
 use std::sync::Arc;
 use std::sync::Mutex;
+use update_common::artifacts::ExtractedArtifactDataHandle;
+use update_common::artifacts::UpdatePlan;
 
 /// The artifact store for wicketd.
 ///

--- a/wicketd/src/artifacts/store.rs
+++ b/wicketd/src/artifacts/store.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::artifacts_with_plan::ArtifactsWithPlan;
 use crate::http_entrypoints::InstallableArtifacts;
 use dropshot::HttpError;
 use omicron_common::api::external::SemverVersion;
@@ -11,6 +10,7 @@ use slog::Logger;
 use std::io;
 use std::sync::Arc;
 use std::sync::Mutex;
+use update_common::artifacts::ArtifactsWithPlan;
 use update_common::artifacts::ExtractedArtifactDataHandle;
 use update_common::artifacts::UpdatePlan;
 

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -4,8 +4,6 @@
 
 // Copyright 2023 Oxide Computer Company
 
-use crate::artifacts::ArtifactIdData;
-use crate::artifacts::UpdatePlan;
 use crate::artifacts::WicketdArtifactStore;
 use crate::helpers::sps_to_string;
 use crate::http_entrypoints::ClearUpdateStateResponse;
@@ -64,6 +62,8 @@ use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::io::StreamReader;
+use update_common::artifacts::ArtifactIdData;
+use update_common::artifacts::UpdatePlan;
 use update_engine::events::ProgressUnits;
 use update_engine::AbortHandle;
 use update_engine::StepSpec;


### PR DESCRIPTION
Introduce a new crate called "update-common" which consists of update-related code shared
between Nexus and wicketd.

This sits above tufaceous-lib and below wicketd (and soon Nexus).