### PR TITLE
[nexus] Allow silo admins to upload new certs

### DIFF
--- a/nexus/src/app/certificate.rs
+++ b/nexus/src/app/certificate.rs
@@ -54,9 +54,9 @@ impl super::Nexus {
         // Looking up DNS names requires reading the DNS configuration of the
         // _rack_, which this user may not be able to do (even if they have
         // permission to upload new certs, which almost certainly implies a
-        // silo-level admin. We'll use our `opctx_external_authn()` context,
+        // silo-level admin). We'll use our `opctx_external_authn()` context,
         // which is the same context used to create a silo. This is a higher
-        // privelege than the current user may have, but we believe it does not
+        // privilege than the current user may have, but we believe it does not
         // leak any information that a silo admin doesn't already know (the
         // external DNS name(s) of the rack, which leads to their silo's DNS
         // name(s)).

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::integration_tests::saml::SAML_IDP_DESCRIPTOR;
+use dropshot::ResultsPage;
 use nexus_db_queries::authn::silos::{
     AuthenticatedSubject, IdentityProviderType,
 };
@@ -19,6 +20,7 @@ use nexus_test_utils::resource_helpers::{
     objects_list_page_authz, projects_list,
 };
 use nexus_test_utils_macros::nexus_test;
+use nexus_types::external_api::views::Certificate;
 use nexus_types::external_api::views::{
     self, IdentityProvider, Project, SamlIdentityProvider, Silo,
 };
@@ -27,6 +29,7 @@ use omicron_common::api::external::ObjectIdentity;
 use omicron_common::api::external::{
     IdentityMetadataCreateParams, LookupType, Name,
 };
+use omicron_test_utils::certificates::CertificateChain;
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -2436,4 +2439,86 @@ async fn check_fleet_privileges(
             .await
             .unwrap();
     }
+}
+
+// Test that a silo admin can create new certificates for their silo
+//
+// Internally, the certificate validation check requires the `authz::DNS_CONFIG`
+// resource (to check that the certificate is valid for
+// `{silo_name}.{external_dns_zone_name}`), which silo admins may not have. We
+// have to use an alternate, elevated context to perform that check, and this
+// test confirms we do so.
+//
+// Ensures no regression on
+// https://github.com/oxidecomputer/omicron/issues/4532.
+#[nexus_test]
+async fn test_silo_admin_can_create_certs(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+    let certs_url = "/v1/certificates";
+
+    // Create a silo with an admin user
+    let silo = create_silo(
+        client,
+        "silo-name",
+        true,
+        shared::SiloIdentityMode::LocalOnly,
+    )
+    .await;
+
+    let new_silo_user_id = create_local_user(
+        client,
+        &silo,
+        &"admin".parse().unwrap(),
+        params::UserPassword::LoginDisallowed,
+    )
+    .await
+    .id;
+
+    grant_iam(
+        client,
+        "/v1/system/silos/silo-name",
+        SiloRole::Admin,
+        new_silo_user_id,
+        AuthnMode::PrivilegedUser,
+    )
+    .await;
+
+    // The user should be able to create certs for this silo
+    let chain = CertificateChain::new(cptestctx.wildcard_silo_dns_name());
+    let (cert, key) =
+        (chain.cert_chain_as_pem(), chain.end_cert_private_key_as_pem());
+
+    let cert: Certificate = NexusRequest::objects_post(
+        client,
+        certs_url,
+        &params::CertificateCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "test-cert".parse().unwrap(),
+                description: "the test cert".to_string(),
+            },
+            cert,
+            key,
+            service: shared::ServiceUsingCertificate::ExternalApi,
+        },
+    )
+    .authn_as(AuthnMode::SiloUser(new_silo_user_id))
+    .execute()
+    .await
+    .expect("failed to create certificate")
+    .parsed_body()
+    .unwrap();
+
+    // The cert should exist when listing the silo's certs as the silo admin
+    let silo_certs =
+        NexusRequest::object_get(client, &format!("{certs_url}?limit=10"))
+            .authn_as(AuthnMode::SiloUser(new_silo_user_id))
+            .execute()
+            .await
+            .expect("failed to list certificates")
+            .parsed_body::<ResultsPage<Certificate>>()
+            .expect("failed to parse body as ResultsPage<Certificate>")
+            .items;
+
+    assert_eq!(silo_certs.len(), 1);
+    assert_eq!(silo_certs[0].identity.id, cert.identity.id);
 }

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -2448,9 +2448,6 @@ async fn check_fleet_privileges(
 // `{silo_name}.{external_dns_zone_name}`), which silo admins may not have. We
 // have to use an alternate, elevated context to perform that check, and this
 // test confirms we do so.
-//
-// Ensures no regression on
-// https://github.com/oxidecomputer/omicron/issues/4532.
 #[nexus_test]
 async fn test_silo_admin_can_create_certs(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;


### PR DESCRIPTION
The additional cert validation added in #4100 broke the ability for silo admins to upload new certs, because it introduced a call to fetch the rack DNS configuration (in order to assemble the FQDNs for the silo to check that the cert is valid for them). This PR fixes that by using an elevated internal privilege for that DNS config lookup.

Fixes #4532.

~~TODO before merging~~ Done:

- [x] ~~confirm fix on madrid (the integration test makes me think this is _probably_ not necessary, but I'd rather be sure)~~ Tested on madrid; was able to use the CLI `oxide certificate create` command while logged in as a silo admin, which 403'd prior to this PR