### PR TITLE
Restore larger max request body size

### DIFF
--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -72,6 +72,10 @@ impl Server {
 
         let dropshot_config = dropshot::ConfigDropshot {
             bind_address: SocketAddr::V6(sled_address),
+
+            // bump up size to handle large POSTs
+            request_body_max_bytes: 1024 * 1024,
+
             ..config.dropshot
         };
         let dropshot_log = log.new(o!("component" => "dropshot (SledAgent)"));


### PR DESCRIPTION
76b835d5d68657265564f40a4667e8ffc7026091 removed the dropshot configuration that bumped the sled agent's max request size to 1M. The sled agent needs to be able to handler larger POSTs, so restore that parameter.