### PR TITLE
inventory builder could better distinguish runtime errors from API misuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "regex",
  "slog",
  "strum",
+ "thiserror",
  "tokio",
  "uuid",
 ]

--- a/nexus/inventory/Cargo.toml
+++ b/nexus/inventory/Cargo.toml
@@ -13,6 +13,7 @@ gateway-messages.workspace = true
 nexus-types.workspace = true
 slog.workspace = true
 strum.workspace = true
+thiserror.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
 

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -108,11 +108,7 @@ impl CollectionBuilder {
     pub fn build(self) -> Collection {
         Collection {
             id: Uuid::new_v4(),
-            errors: self
-                .errors
-                .into_iter()
-                .map(|e| e.to_string())
-                .collect(),
+            errors: self.errors.into_iter().map(|e| e.to_string()).collect(),
             time_started: self.time_started,
             time_done: now(),
             collector: self.collector,

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -44,7 +44,7 @@ impl std::fmt::Display for InventoryError {
     }
 }
 
-/// Describes a mis-use of the [`Builder`] object
+/// Describes a mis-use of the [`CollectionBuilder`] object
 ///
 /// Example: reporting information about a caboose when the caller has not
 /// already reported information about the corresopnding baseboard.

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -5,6 +5,7 @@
 //! Collection of inventory from Omicron components
 
 use crate::builder::CollectionBuilder;
+use crate::builder::InventoryError;
 use anyhow::Context;
 use gateway_client::types::GetCfpaParams;
 use gateway_client::types::RotCfpaSlot;
@@ -93,7 +94,7 @@ impl Collector {
         // being able to identify this particular condition.
         let sps = match ignition_result {
             Err(error) => {
-                self.in_progress.found_error(error);
+                self.in_progress.found_error(InventoryError::from(error));
                 return;
             }
 
@@ -129,7 +130,7 @@ impl Collector {
                 });
             let sp_state = match result {
                 Err(error) => {
-                    self.in_progress.found_error(error);
+                    self.in_progress.found_error(InventoryError::from(error));
                     continue;
                 }
                 Ok(response) => response.into_inner(),
@@ -179,7 +180,8 @@ impl Collector {
                     });
                 let caboose = match result {
                     Err(error) => {
-                        self.in_progress.found_error(error);
+                        self.in_progress
+                            .found_error(InventoryError::from(error));
                         continue;
                     }
                     Ok(response) => response.into_inner(),
@@ -257,7 +259,8 @@ impl Collector {
 
                 let page = match result {
                     Err(error) => {
-                        self.in_progress.found_error(error);
+                        self.in_progress
+                            .found_error(InventoryError::from(error));
                         continue;
                     }
                     Ok(data_base64) => RotPage { data_base64 },

--- a/nexus/inventory/src/lib.rs
+++ b/nexus/inventory/src/lib.rs
@@ -23,5 +23,7 @@ pub mod examples;
 
 // only exposed for test code to construct collections
 pub use builder::CollectionBuilder;
+pub use builder::CollectorBug;
+pub use builder::InventoryError;
 
 pub use collector::Collector;


### PR DESCRIPTION
The inventory builder has two forms of error reporting: `found_error()` is used to report things that are really part of the collection itself: a failure to collect some important information, or unexpected data, etc.  Returned errors are used to signal to the caller that they've done something wrong.  (These could as well be panics, except that the program state is not so wrong that it's dangerous to proceed.)  This PR changes these to use simple newtypes.  More could probably be done here (maybe in terms of making some of the `CollectorBug`s actual compile errors) but I think this is a useful step.