### PR TITLE
[wicketd] fix additional race with test_update_races

### DIFF
--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -818,6 +818,7 @@ impl AbortUpdateError {
 struct UpdateDriver {}
 
 impl UpdateDriver {
+    #![allow(clippy::too_many_arguments)]
     async fn run(
         self,
         plan: UpdatePlan,


### PR DESCRIPTION
The issue here was that we'd send a notification to the test that the task was
finished, as the last thing in the task. This meant that there was a period
where `task.is_finished()` was false but the test thought the task had finished
and proceeded accordingly.

To fix this, use an `Arc<AtomicBool>` to indicate that the task is finished.

Fixes #4668.
