### PR TITLE
[Trivial] Fix wording and comments

### DIFF
--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -111,8 +111,8 @@ impl Host {
 ///
 /// `DnsConfigBuilder` provides a much simpler interface for constructing DNS
 /// zone data than using `DnsConfig` directly.  That's because it makes a number
-/// of assumptions that are true of the control plane DNS zone (all described in
-/// RFD 248), but not true in general about DNS zones:
+/// of assumptions that are true of the control plane DNS zones (all described
+/// in RFD 248), but not true in general about DNS zones:
 ///
 /// - We assume that there are only two kinds of hosts: a "sled" (an illumos
 ///   global zone) or a "zone" (an illumos non-global zone).  (Both of these are

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -191,11 +191,11 @@ impl RackSetupService {
     /// Arguments:
     /// - `log`: The logger.
     /// - `config`: The config file, which is used to setup the rack.
-    /// - `storage_resources`: All the disks and zpools managed by this sled
+    /// - `storage_manager`: A handle for interacting with the storage manager
+    ///   task
     /// - `local_bootstrap_agent`: Communication channel by which we can send
-    ///   commands to our local bootstrap-agent (e.g., to initialize sled
+    ///   commands to our local bootstrap-agent (e.g., to start sled-agents)
     /// - `bootstore` - A handle to call bootstore APIs
-    ///   agents).
     pub(crate) fn new(
         log: Logger,
         config: Config,
@@ -1082,10 +1082,6 @@ impl ServiceInner {
             nexus_address,
         )
         .await?;
-
-        // TODO Questions to consider:
-        // - What if a sled comes online *right after* this setup? How does
-        // it get a /64?
 
         Ok(())
     }


### PR DESCRIPTION
The comment about sled address allocation was removed because it was implemented in https://github.com/oxidecomputer/omicron/pull/4545