### PR TITLE
[rust] update to Rust 1.74.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,5 +4,5 @@
 #
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.74.0"
+channel = "1.74.1"
 profile = "default"


### PR DESCRIPTION
I'm hitting an ICE with 1.74.0 that appears to be fixed with 1.74.1. (Will wait
until the next release is cut to land this.)
