### PR TITLE
Fix FIP creation being able to access IP Pools in other silos

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -147,22 +147,34 @@ impl DataStore {
     ) -> CreateResult<ExternalIp> {
         let ip_id = Uuid::new_v4();
 
-        let pool_id = match params.pool {
-            Some(NameOrId::Name(name)) => {
-                LookupPath::new(opctx, self)
-                    .ip_pool_name(&Name(name))
-                    .fetch_for(authz::Action::Read)
-                    .await?
-                    .1
+        // See `allocate_instance_ephemeral_ip`: we're replicating
+        // its strucutre to prevent cross-silo pool access.
+        let pool_id = if let Some(name_or_id) = params.pool {
+            let (.., authz_pool, pool) = match name_or_id {
+                NameOrId::Name(name) => {
+                    LookupPath::new(opctx, self)
+                        .ip_pool_name(&Name(name))
+                        .fetch_for(authz::Action::CreateChild)
+                        .await?
+                }
+                NameOrId::Id(id) => {
+                    LookupPath::new(opctx, self)
+                        .ip_pool_id(id)
+                        .fetch_for(authz::Action::CreateChild)
+                        .await?
+                }
+            };
+
+            let authz_silo_id = opctx.authn.silo_required()?.id();
+            if let Some(pool_silo_id) = pool.silo_id {
+                if pool_silo_id != authz_silo_id {
+                    return Err(authz_pool.not_found());
+                }
             }
-            Some(NameOrId::Id(id)) => {
-                LookupPath::new(opctx, self)
-                    .ip_pool_id(id)
-                    .fetch_for(authz::Action::Read)
-                    .await?
-                    .1
-            }
-            None => self.ip_pools_fetch_default(opctx).await?,
+
+            pool
+        } else {
+            self.ip_pools_fetch_default(opctx).await?
         }
         .id();
 

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -854,7 +854,7 @@ pub(crate) mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_ip_pool(&client, "p0", None).await;
+        create_ip_pool(&client, "p0", None, None).await;
         let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -202,7 +202,7 @@ pub(crate) mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_ip_pool(&client, "p0", None).await;
+        create_ip_pool(&client, "p0", None, None).await;
         let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1786,7 +1786,7 @@ mod test {
     const INSTANCE_NAME: &str = "base-instance";
 
     async fn create_org_project_and_disk(client: &ClientTestContext) -> Uuid {
-        create_ip_pool(&client, "p0", None).await;
+        create_ip_pool(&client, "p0", None, None).await;
         create_project(client, PROJECT_NAME).await;
         create_disk(client, PROJECT_NAME, DISK_NAME).await.identity.id
     }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -134,6 +134,7 @@ pub async fn create_ip_pool(
     client: &ClientTestContext,
     pool_name: &str,
     ip_range: Option<IpRange>,
+    silo: Option<Uuid>,
 ) -> (IpPool, IpPoolRange) {
     let pool = object_create(
         client,
@@ -143,7 +144,7 @@ pub async fn create_ip_pool(
                 name: pool_name.parse().unwrap(),
                 description: String::from("an ip pool"),
             },
-            silo: None,
+            silo: silo.map(|id| NameOrId::Id(id)),
             is_default: false,
         },
     )

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3563,7 +3563,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
         .unwrap(),
     );
     populate_ip_pool(&client, "default", Some(default_pool_range)).await;
-    create_ip_pool(&client, "other-pool", Some(other_pool_range)).await;
+    create_ip_pool(&client, "other-pool", Some(other_pool_range), None).await;
 
     // Create an instance with pool name blank, expect IP from default pool
     create_instance_with_pool(client, "default-pool-inst", None).await;


### PR DESCRIPTION
As raised in Matrix, this backports a fix from #4261 where a new floating IP can be allocated using the name or ID of an IP pool which is bound to another silo.