### PR TITLE
Configure bash environment for NGZ root.

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -69,6 +69,7 @@ service_name = "overlay"
 source.type = "composite"
 source.packages = [
   "logadm.tar.gz",
+  "profile.tar.gz",
 ]
 output.type = "zone"
 
@@ -80,6 +81,18 @@ source.type = "local"
 source.paths = [
   { from = "smf/logadm/crontab.root", to = "/var/spool/cron/crontabs/root" },
   { from = "smf/logadm/logadm.conf", to = "/etc/logadm.conf" },
+]
+output.type = "zone"
+output.intermediate_only = true
+#
+# The profile package is an overlay for all non-global zones to configure
+# root's bash environment.
+[package.profile]
+service_name = "profile"
+source.type = "local"
+source.paths = [
+  { from = "smf/profile/profile", to = "/root/.profile" },
+  { from = "smf/profile/bashrc", to = "/root/.bashrc" },
 ]
 output.type = "zone"
 output.intermediate_only = true
@@ -335,7 +348,6 @@ source.paths = [
   { from = "smf/switch_zone_setup/manifest.xml", to = "/var/svc/manifest/site/switch_zone_setup/manifest.xml" },
   { from = "smf/switch_zone_setup/switch_zone_setup", to = "/opt/oxide/bin/switch_zone_setup" },
   { from = "smf/switch_zone_setup/support_authorized_keys", to = "/opt/oxide/support/authorized_keys" },
-  { from = "smf/switch_zone_setup/root.profile", to = "/root/.profile" },
 ]
 output.type = "zone"
 output.intermediate_only = true

--- a/smf/profile/bashrc
+++ b/smf/profile/bashrc
@@ -1,0 +1,42 @@
+
+C_RED='\[\033[01;31m\]'
+C_GREEN='\[\033[01;32m\]'
+C_CYAN='\[\033[01;36m\]'
+C_BLD='\[\033[1m\]'
+C_NUL='\[\033[00m\]'
+
+typeset _hst="$HOSTNAME"
+typeset _hstc="$C_RED$HOSTNAME"
+case "$_hst" in
+    oxz_switch)
+	# Try to determine which switch zone we are
+	_switchid=$(curl -s http://localhost:12225/local/switch-id \
+	    | /opt/ooce/bin/jq -r .slot)
+	if (( $? == 0 )) && [[ -n "$_switchid" ]]; then
+		_hst+="$_switchid"
+		_hstc+="$C_CYAN$_switchid"
+	fi
+	;;
+    oxz_*-*)
+	# Shorten the hostname by truncating the UUID so that the prompt
+	# doesn't take up an excessive amount of width
+	_hst="${HOSTNAME%%-*}"
+	_hstc="$C_RED${HOSTNAME%%-*}"
+	;;
+esac
+
+if [[ -n $SSH_CLIENT ]]; then
+	echo -ne "\033]0;${_hst} \007"
+	export PROMPT_COMMAND='history -a'
+fi
+
+case "$TERM" in
+xterm*|rxvt*|screen*|sun-color)
+	PS1="$C_GREEN\\u$C_NUL@$_hstc$C_NUL:$C_RED\\w$C_NUL$C_BLD\\\$$C_NUL "
+        ;;
+*)
+	PS1="\\u@$_hst:\\w\\$ "
+esac
+
+export PS1
+

--- a/smf/profile/profile
+++ b/smf/profile/profile
@@ -1,0 +1,24 @@
+
+PATH+=:/opt/ooce/bin
+
+case "$HOSTNAME" in
+    oxz_switch)
+	# Add tools like xcvradm, swadm & ddmadm to the PATH by default
+	PATH+=:/opt/oxide/bin:/opt/oxide/dendrite/bin:/opt/oxide/mg-ddm/bin
+	;;
+    oxz_cockroachdb*)
+	PATH+=:/opt/oxide/cockroachdb/bin
+	;;
+    oxz_crucible*)
+	PATH+=:/opt/oxide/crucible/bin
+	;;
+    oxz_clockhouse*)
+	PATH+=:/opt/oxide/clickhouse
+	;;
+    oxz_external_dns*|oxz_internal_dns*)
+	PATH+=:/opt/oxide/dns-server/bin
+	;;
+esac
+
+[ -f ~/.bashrc ] && . ~/.bashrc
+

--- a/smf/switch_zone_setup/root.profile
+++ b/smf/switch_zone_setup/root.profile
@@ -1,3 +1,0 @@
-# Add tools like xcvradm, swadm & ddmadm to the PATH by default
-export PATH=$PATH:/opt/oxide/bin:/opt/oxide/dendrite/bin:/opt/oxide/mg-ddm/bin
-


### PR DESCRIPTION
This removes the special case for the switch zone and deploys a consistent profile and bashrc to all non-global zones.

While understanding this is subjective, improvements here are:
 * A switch zone prompt includes the local switch number (0/1) if it can be determined;
 * PATH is configured to include additional directories useful within the zone;
 * The hostname part of the prompt is truncated in zones which have UUIDs as part of their name;
 * Coloured prompt, as per the GZ.

Pretty much everyone has their own preferred prompt format, so consensus is unlikely here, but this is a step forward in having consistency and a better PATH. In the limit, nobody will be logging into these zones outside of a development environment anyway.