### PR TITLE
Deserialize pre-6.0.0 RegionSnapshot objects

### DIFF
--- a/nexus/db-model/src/region_snapshot.rs
+++ b/nexus/db-model/src/region_snapshot.rs
@@ -27,12 +27,16 @@ pub struct RegionSnapshot {
     pub region_id: Uuid,
     pub snapshot_id: Uuid,
 
-    // used for identifying volumes that reference this
+    /// used for identifying volumes that reference this
     pub snapshot_addr: String,
 
-    // how many volumes reference this?
+    /// how many volumes reference this?
     pub volume_references: i64,
 
-    // true if part of a volume's `resources_to_clean_up` already
+    /// true if part of a volume's `resources_to_clean_up` already
+    // this column was added in `schema/crdb/6.0.0/up1.sql` with a default of
+    // false, so instruct serde to deserialize default as false if an old
+    // serialized version of RegionSnapshot is being deserialized.
+    #[serde(default)]
     pub deleting: bool,
 }


### PR DESCRIPTION
Schema update 6.0.0 added the `deleted` column to the region_snapshot table and added the `deleted` field to the RegionSnapshot object. If an old RegionSnapshot was serialized before this schema update (as part of a volume delete) into the `resources_to_clean_up` column of the volume table, _and_ if that volume delete failed and unwound, Nexus will fail to deserialize that column after that schema update + model change if there is another request to delete that volume.

Add `#[serde(default)]` to RegionSnapshot's deleting field so that Nexus can deserialize pre-6.0.0 RegionSnapshot objects. This will default to `false` which matches what the ALTER COLUMN's default setting was in the 6.0.0 schema upgrade.

Fixes oxidecomputer/customer-support#72