### PR TITLE
Update Sidecar-lite, ignore ARP hostnames in SoftNPU init

### DIFF
--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -63,7 +63,7 @@ function ensure_softnpu_zone {
             --omicron-zone \
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0 \
-            --sidecar-lite-commit 45ed98fea5824feb4d42f45bbf218e597dc9fc58 \
+            --sidecar-lite-commit 6007a1b0ffe57ee738222867c343bde7e47bbf60 \
             --softnpu-commit dbab082dfa89da5db5ca2325c257089d2f130092
      }
     "$SOURCE_DIR"/scrimlet/softnpu-init.sh

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -63,7 +63,7 @@ function ensure_softnpu_zone {
             --omicron-zone \
             --ports sc0_0,tfportrear0_0 \
             --ports sc0_1,tfportqsfp0_0 \
-            --sidecar-lite-commit 6007a1b0ffe57ee738222867c343bde7e47bbf60 \
+            --sidecar-lite-commit e3ea4b495ba0a71801ded0776ae4bbd31df57e26 \
             --softnpu-commit dbab082dfa89da5db5ca2325c257089d2f130092
      }
     "$SOURCE_DIR"/scrimlet/softnpu-init.sh

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -31,7 +31,7 @@ fi
 # Add an extrac space at the end of the search pattern passed to `grep`, so that
 # we can be sure we're matching the exact $GATEWAY_IP, and not something that
 # shares the same string prefix.
-GATEWAY_MAC=${GATEWAY_MAC:=$(arp -a | grep "$GATEWAY_IP " | awk -F ' ' '{print $NF}')}
+GATEWAY_MAC=${GATEWAY_MAC:=$(arp -an | grep "$GATEWAY_IP " | awk -F ' ' '{print $NF}')}
 
 # Check that the MAC appears to be exactly one MAC address.
 COUNT=$(grep -c -E '^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$' <(echo "$GATEWAY_MAC"))


### PR DESCRIPTION
Bumps to the most recent sidecar-lite, which includes a minor fix for manually added routes, and adds the `-n` flag when checking `arp` for the gateway's MAC address during SoftNPU init. This is really only needed if the gateway is also acting as a DNS server and names itself something cutesy, but it can come up:

```
kyle@farme:~/gits/omicron$ arp -a
Net to Media Table: IPv4
Device   IP Address               Mask      Flags      Phys Addr
------ -------------------- --------------- -------- ---------------
rge0   hub.home.arpa        255.255.255.255          b8:6a:f1:28:cd:00

...

kyle@farme:~/gits/omicron$ arp -an
Net to Media Table: IPv4
Device   IP Address               Mask      Flags      Phys Addr
------ -------------------- --------------- -------- ---------------
rge0   10.0.0.1             255.255.255.255          b8:6a:f1:28:cd:00
```