### PR TITLE
Added dtrace_user and dtrace_proc permissions for oxz_ zones

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1260,11 +1260,14 @@ impl ServiceManager {
     // Check the services intended to run in the zone to determine whether any
     // additional privileges need to be enabled for the zone.
     fn privs_needed(zone_args: &ZoneArgs<'_>) -> Vec<String> {
-        let mut needed = Vec::new();
+        let mut needed = vec![
+            "default".to_string(),
+            "dtrace_user".to_string(),
+            "dtrace_proc".to_string(),
+        ];
         for svc_details in zone_args.sled_local_services() {
             match svc_details {
                 SwitchService::Tfport { .. } => {
-                    needed.push("default".to_string());
                     needed.push("sys_dl_config".to_string());
                 }
                 _ => (),
@@ -1275,7 +1278,6 @@ impl ServiceManager {
             match omicron_zone_type {
                 OmicronZoneType::BoundaryNtp { .. }
                 | OmicronZoneType::InternalNtp { .. } => {
-                    needed.push("default".to_string());
                     needed.push("sys_time".to_string());
                     needed.push("proc_priocntl".to_string());
                 }


### PR DESCRIPTION
This allows dtrace inside the oxz_ zones created by Omicron.
Partial fix for https://github.com/oxidecomputer/omicron/issues/4731

The update to allow dtrace_kernel will come in a later PR, as that requires
coordination with another repo.