### PR TITLE
sled agent client could use some primitives from omicron_common

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -25,6 +25,9 @@ progenitor::generate_api!(
     //TODO trade the manual transformations later in this file for the
     //     replace directives below?
     replace = {
+        ByteCount = omicron_common::api::external::ByteCount,
+        Generation = omicron_common::api::external::Generation,
+        Name = omicron_common::api::external::Name,
         SwitchLocation = omicron_common::api::external::SwitchLocation,
         Ipv6Network = ipnetwork::Ipv6Network,
         IpNetwork = ipnetwork::IpNetwork,
@@ -80,7 +83,7 @@ impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
             propolis_id: s.propolis_id,
             dst_propolis_id: s.dst_propolis_id,
             migration_id: s.migration_id,
-            gen: s.gen.into(),
+            gen: s.gen,
             time_updated: s.time_updated,
         }
     }
@@ -114,18 +117,6 @@ impl From<omicron_common::api::external::InstanceCpuCount>
     }
 }
 
-impl From<omicron_common::api::external::ByteCount> for types::ByteCount {
-    fn from(s: omicron_common::api::external::ByteCount) -> Self {
-        Self(s.to_bytes())
-    }
-}
-
-impl From<omicron_common::api::external::Generation> for types::Generation {
-    fn from(s: omicron_common::api::external::Generation) -> Self {
-        Self(i64::from(&s) as u64)
-    }
-}
-
 impl From<types::InstanceRuntimeState>
     for omicron_common::api::internal::nexus::InstanceRuntimeState
 {
@@ -134,7 +125,7 @@ impl From<types::InstanceRuntimeState>
             propolis_id: s.propolis_id,
             dst_propolis_id: s.dst_propolis_id,
             migration_id: s.migration_id,
-            gen: s.gen.into(),
+            gen: s.gen,
             time_updated: s.time_updated,
         }
     }
@@ -144,11 +135,7 @@ impl From<types::VmmRuntimeState>
     for omicron_common::api::internal::nexus::VmmRuntimeState
 {
     fn from(s: types::VmmRuntimeState) -> Self {
-        Self {
-            state: s.state.into(),
-            gen: s.gen.into(),
-            time_updated: s.time_updated,
-        }
+        Self { state: s.state.into(), gen: s.gen, time_updated: s.time_updated }
     }
 }
 
@@ -192,25 +179,13 @@ impl From<types::InstanceCpuCount>
     }
 }
 
-impl From<types::ByteCount> for omicron_common::api::external::ByteCount {
-    fn from(s: types::ByteCount) -> Self {
-        Self::try_from(s.0).unwrap_or_else(|e| panic!("{}: {}", s.0, e))
-    }
-}
-
-impl From<types::Generation> for omicron_common::api::external::Generation {
-    fn from(s: types::Generation) -> Self {
-        Self::try_from(s.0 as i64).unwrap()
-    }
-}
-
 impl From<omicron_common::api::internal::nexus::DiskRuntimeState>
     for types::DiskRuntimeState
 {
     fn from(s: omicron_common::api::internal::nexus::DiskRuntimeState) -> Self {
         Self {
             disk_state: s.disk_state.into(),
-            gen: s.gen.into(),
+            gen: s.gen,
             time_updated: s.time_updated,
         }
     }
@@ -242,7 +217,7 @@ impl From<types::DiskRuntimeState>
     fn from(s: types::DiskRuntimeState) -> Self {
         Self {
             disk_state: s.disk_state.into(),
-            gen: s.gen.into(),
+            gen: s.gen,
             time_updated: s.time_updated,
         }
     }
@@ -265,19 +240,6 @@ impl From<types::DiskState> for omicron_common::api::external::DiskState {
             Destroyed => Self::Destroyed,
             Faulted => Self::Faulted,
         }
-    }
-}
-
-impl From<&omicron_common::api::external::Name> for types::Name {
-    fn from(s: &omicron_common::api::external::Name) -> Self {
-        Self::try_from(<&str>::from(s))
-            .unwrap_or_else(|e| panic!("{}: {}", s, e))
-    }
-}
-
-impl From<types::Name> for omicron_common::api::external::Name {
-    fn from(s: types::Name) -> Self {
-        Self::try_from(s.as_str().to_owned()).unwrap()
     }
 }
 
@@ -541,7 +503,7 @@ impl From<omicron_common::api::internal::shared::NetworkInterface>
         Self {
             id: s.id,
             kind: s.kind.into(),
-            name: (&s.name).into(),
+            name: s.name,
             ip: s.ip,
             mac: s.mac.into(),
             subnet: s.subnet.into(),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2738,7 +2738,7 @@ fn inv_collection_print_sleds(collection: &Collection) {
             );
             println!(
                 "    zones generation: {} (count: {})",
-                *zones.zones.generation,
+                zones.zones.generation,
                 zones.zones.zones.len()
             );
 

--- a/nexus/db-model/src/bytecount.rs
+++ b/nexus/db-model/src/bytecount.rs
@@ -53,12 +53,6 @@ where
     }
 }
 
-impl From<ByteCount> for sled_agent_client::types::ByteCount {
-    fn from(b: ByteCount) -> Self {
-        Self(b.to_bytes())
-    }
-}
-
 impl From<BlockSize> for ByteCount {
     fn from(bs: BlockSize) -> Self {
         Self(bs.to_bytes().into())

--- a/nexus/db-model/src/generation.rs
+++ b/nexus/db-model/src/generation.rs
@@ -60,9 +60,3 @@ where
             .map_err(|e| e.into())
     }
 }
-
-impl From<Generation> for sled_agent_client::types::Generation {
-    fn from(g: Generation) -> Self {
-        Self(i64::from(&g.0) as u64)
-    }
-}

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -675,7 +675,7 @@ impl InvSledOmicronZones {
             time_collected: zones_found.time_collected,
             source: zones_found.source.clone(),
             sled_id: zones_found.sled_id,
-            generation: Generation(zones_found.zones.generation.clone().into()),
+            generation: Generation(zones_found.zones.generation),
         }
     }
 
@@ -687,7 +687,7 @@ impl InvSledOmicronZones {
             source: self.source,
             sled_id: self.sled_id,
             zones: nexus_types::inventory::OmicronZonesConfig {
-                generation: self.generation.0.into(),
+                generation: *self.generation,
                 zones: Vec::new(),
             },
         }
@@ -1123,11 +1123,7 @@ impl InvOmicronZoneNic {
                 Ok(Some(InvOmicronZoneNic {
                     inv_collection_id,
                     id: nic.id,
-                    name: Name::from(
-                        omicron_common::api::external::Name::from(
-                            nic.name.clone(),
-                        ),
-                    ),
+                    name: Name::from(nic.name.clone()),
                     ip: IpNetwork::from(nic.ip),
                     mac: MacAddr::from(
                         omicron_common::api::external::MacAddr::from(
@@ -1155,7 +1151,7 @@ impl InvOmicronZoneNic {
                 zone_id,
             ),
             mac: (*self.mac).into(),
-            name: (&(*self.name)).into(),
+            name: self.name.into(),
             primary: self.is_primary,
             slot: *self.slot,
             vni: nexus_types::inventory::Vni::from(*self.vni),

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -76,7 +76,7 @@ impl From<NicInfo> for sled_client_types::NetworkInterface {
         sled_client_types::NetworkInterface {
             id: nic.id,
             kind,
-            name: sled_client_types::Name::from(&nic.name.0),
+            name: nic.name.into(),
             ip: nic.ip.ip(),
             mac: sled_client_types::MacAddr::from(nic.mac.0),
             subnet: sled_client_types::IpNet::from(ip_subnet),

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -26,7 +26,6 @@ use nexus_types::inventory::RotPageWhich;
 use nexus_types::inventory::RotState;
 use nexus_types::inventory::ServiceProcessor;
 use nexus_types::inventory::SledAgent;
-use omicron_common::api::external::ByteCount;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -455,8 +454,8 @@ impl CollectionBuilder {
             sled_role: inventory.sled_role,
             baseboard_id,
             usable_hardware_threads: inventory.usable_hardware_threads,
-            usable_physical_ram: ByteCount::from(inventory.usable_physical_ram),
-            reservoir_size: ByteCount::from(inventory.reservoir_size),
+            usable_physical_ram: inventory.usable_physical_ram,
+            reservoir_size: inventory.reservoir_size,
             time_collected: now(),
             sled_id,
         };

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -374,6 +374,7 @@ mod test {
     use crate::StaticSledAgentEnumerator;
     use gateway_messages::SpPort;
     use nexus_types::inventory::Collection;
+    use omicron_common::api::external::Generation;
     use omicron_sled_agent::sim;
     use std::fmt::Write;
     use std::net::Ipv6Addr;
@@ -540,7 +541,7 @@ mod test {
         let zone_address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 123, 0, 0);
         client
             .omicron_zones_put(&sled_agent_client::types::OmicronZonesConfig {
-                generation: sled_agent_client::types::Generation::from(3),
+                generation: Generation::from(3),
                 zones: vec![sled_agent_client::types::OmicronZoneConfig {
                     id: zone_id,
                     underlay_address: *zone_address.ip(),

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -19,6 +19,7 @@ use nexus_types::inventory::RotPageWhich;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use uuid::Uuid;
+use omicron_common::api::external::ByteCount;
 
 /// Returns an example Collection used for testing
 ///
@@ -441,13 +442,11 @@ pub fn sled_agent(
 ) -> sled_agent_client::types::Inventory {
     sled_agent_client::types::Inventory {
         baseboard,
-        reservoir_size: sled_agent_client::types::ByteCount::from(1024),
+        reservoir_size: ByteCount::from(1024),
         sled_role,
         sled_agent_address: "[::1]:56792".parse().unwrap(),
         sled_id,
         usable_hardware_threads: 10,
-        usable_physical_ram: sled_agent_client::types::ByteCount::from(
-            1024 * 1024,
-        ),
+        usable_physical_ram: ByteCount::from(1024 * 1024),
     }
 }

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -16,10 +16,10 @@ use nexus_types::inventory::CabooseWhich;
 use nexus_types::inventory::OmicronZonesConfig;
 use nexus_types::inventory::RotPage;
 use nexus_types::inventory::RotPageWhich;
+use omicron_common::api::external::ByteCount;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use uuid::Uuid;
-use omicron_common::api::external::ByteCount;
 
 /// Returns an example Collection used for testing
 ///

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -298,7 +298,7 @@ pub struct OmicronZonesConfig {
 impl From<OmicronZonesConfig> for sled_agent_client::types::OmicronZonesConfig {
     fn from(local: OmicronZonesConfig) -> Self {
         Self {
-            generation: local.generation.into(),
+            generation: local.generation,
             zones: local.zones.into_iter().map(|s| s.into()).collect(),
         }
     }


### PR DESCRIPTION
sled_agent_client generates types like `Generation` and `ByteCount` that ultimately come from omicron_common.  These are more like primitive types than API-specific types.  I think it makes more sense to re-use the omicron_common ones here.

There are a bunch of other types here from omicron_common that could get the same treatment: all the instance, disk, and net-related ones.  I have _not_ done that here.  These seem like the sorts of things we might well expect to evolve over time and we do want to be more careful about them, not just assume our local copy matches the server's.