### PR TITLE
[sled agent] fail requests for non-NTP zones if time is not synchronized

### DIFF
--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -18,6 +18,7 @@ use crate::long_running_tasks::{
     spawn_all_longrunning_tasks, LongRunningTaskHandles,
 };
 use crate::services::ServiceManager;
+use crate::services::TimeSyncConfig;
 use crate::sled_agent::SledAgent;
 use crate::storage_monitor::UnderlayAccess;
 use camino::Utf8PathBuf;
@@ -127,12 +128,18 @@ impl BootstrapAgentStartup {
         let global_zone_bootstrap_ip =
             startup_networking.global_zone_bootstrap_ip;
 
+        let time_sync = if let Some(true) = config.skip_timesync {
+            TimeSyncConfig::Skip
+        } else {
+            TimeSyncConfig::Normal
+        };
+
         let service_manager = ServiceManager::new(
             &base_log,
             ddm_admin_localhost_client.clone(),
             startup_networking,
             sled_mode,
-            config.skip_timesync,
+            time_sync,
             config.sidecar_revision.clone(),
             config.switch_zone_maghemite_links.clone(),
             long_running_task_handles.storage_manager.clone(),

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -202,6 +202,11 @@ pub enum Error {
     #[error("NTP zone not ready")]
     NtpZoneNotReady,
 
+    // This isn't exactly "NtpZoneNotReady" -- it can happen when the NTP zone
+    // is up, but time is still in the process of synchronizing.
+    #[error("Time not yet synchronized")]
+    TimeNotSynchronized,
+
     #[error("Execution error: {0}")]
     ExecutionError(#[from] illumos_utils::ExecutionError),
 
@@ -252,6 +257,9 @@ impl From<Error> for omicron_common::api::external::Error {
             err @ Error::RequestedConfigOutdated { .. } => {
                 omicron_common::api::external::Error::conflict(&err.to_string())
             }
+            err @ Error::TimeNotSynchronized => {
+                omicron_common::api::external::Error::unavail(&err.to_string())
+            }
             _ => omicron_common::api::external::Error::InternalError {
                 internal_message: err.to_string(),
             },
@@ -274,28 +282,25 @@ fn display_zone_init_errors(errors: &[(String, Box<Error>)]) -> String {
     output
 }
 
-/// Answers the question: "Do these zones require time synchronization before
-/// they are initialized?"
-///
-/// This function is somewhat conservative - the set of services
-/// that can be launched before timesync has completed is intentionally kept
-/// small, since it would be easy to add a service that expects time to be
-/// reasonably synchronized.
-pub fn zones_require_timesync(requested_zones: &OmicronZonesConfig) -> bool {
-    requested_zones.zones.iter().any(|zone_config| {
-        match zone_config.zone_type {
-            // These zones can be initialized and started before time has been
-            // synchronized. For the NTP zones, this should be self-evident --
-            // we need the NTP zone to actually perform time synchronization!
-            //
-            // The DNS zone is a bit of an exception here, since the NTP zone
-            // itself may rely on DNS lookups as a dependency.
-            OmicronZoneType::BoundaryNtp { .. }
-            | OmicronZoneType::InternalNtp { .. }
-            | OmicronZoneType::InternalDns { .. } => false,
-            _ => true,
-        }
-    })
+// Does this zone require time synchronization before it is initialized?"
+//
+// This function is somewhat conservative - the set of services
+// that can be launched before timesync has completed is intentionally kept
+// small, since it would be easy to add a service that expects time to be
+// reasonably synchronized.
+fn zone_requires_timesync(zone_type: &OmicronZoneType) -> bool {
+    match zone_type {
+        // These zones can be initialized and started before time has been
+        // synchronized. For the NTP zones, this should be self-evident --
+        // we need the NTP zone to actually perform time synchronization!
+        //
+        // The DNS zone is a bit of an exception here, since the NTP zone
+        // itself may rely on DNS lookups as a dependency.
+        OmicronZoneType::BoundaryNtp { .. }
+        | OmicronZoneType::InternalNtp { .. }
+        | OmicronZoneType::InternalDns { .. } => false,
+        _ => true,
+    }
 }
 
 /// Configuration parameters which modify the [`ServiceManager`]'s behavior.
@@ -528,18 +533,20 @@ enum SledLocalZone {
     },
 }
 
+type ZoneMap = BTreeMap<String, RunningZone>;
+
 /// Manages miscellaneous Sled-local services.
 pub struct ServiceManagerInner {
     log: Logger,
     global_zone_bootstrap_link_local_address: Ipv6Addr,
     switch_zone: Mutex<SledLocalZone>,
     sled_mode: SledMode,
-    skip_timesync: Option<bool>,
+    time_sync_config: TimeSyncConfig,
     time_synced: AtomicBool,
     switch_zone_maghemite_links: Vec<PhysicalLink>,
     sidecar_revision: SidecarRevision,
     // Zones representing running services
-    zones: Mutex<BTreeMap<String, RunningZone>>,
+    zones: Mutex<ZoneMap>,
     underlay_vnic_allocator: VnicAllocator<Etherstub>,
     underlay_vnic: EtherstubVnic,
     bootstrap_vnic_allocator: VnicAllocator<Etherstub>,
@@ -564,6 +571,16 @@ struct SledAgentInfo {
     rack_network_config: Option<RackNetworkConfig>,
 }
 
+pub(crate) enum TimeSyncConfig {
+    // Waits for NTP to confirm that time has been synchronized.
+    Normal,
+    // Skips timesync unconditionally.
+    Skip,
+    // Fails timesync unconditionally.
+    #[cfg(test)]
+    Fail,
+}
+
 #[derive(Clone)]
 pub struct ServiceManager {
     inner: Arc<ServiceManagerInner>,
@@ -578,7 +595,7 @@ impl ServiceManager {
     /// - `bootstrap_networking`: Collection of etherstubs/VNICs set up when
     ///    bootstrap agent begins
     /// - `sled_mode`: The sled's mode of operation (Gimlet vs Scrimlet).
-    /// - `skip_timesync`: If true, the sled always reports synced time.
+    /// - `time_sync_config`: Describes how the sled awaits synced time.
     /// - `sidecar_revision`: Rev of attached sidecar, if present.
     /// - `switch_zone_maghemite_links`: List of physical links on which
     ///    maghemite should listen.
@@ -589,7 +606,7 @@ impl ServiceManager {
         ddmd_client: DdmAdminClient,
         bootstrap_networking: BootstrapNetworking,
         sled_mode: SledMode,
-        skip_timesync: Option<bool>,
+        time_sync_config: TimeSyncConfig,
         sidecar_revision: SidecarRevision,
         switch_zone_maghemite_links: Vec<PhysicalLink>,
         storage: StorageHandle,
@@ -606,7 +623,7 @@ impl ServiceManager {
                 // Load the switch zone if it already exists?
                 switch_zone: Mutex::new(SledLocalZone::Disabled),
                 sled_mode,
-                skip_timesync,
+                time_sync_config,
                 time_synced: AtomicBool::new(false),
                 sidecar_revision,
                 switch_zone_maghemite_links,
@@ -2821,6 +2838,16 @@ impl ServiceManager {
             }
         }
 
+        // Check time synchronization; we'll need to check this bool for each of
+        // the new zone types.
+        let time_is_synchronized =
+            match self.timesync_get_locked(&existing_zones).await {
+                // Time is synchronized
+                Ok(TimeSync { sync: true, .. }) => true,
+                // Time is not synchronized, or we can't check
+                _ => false,
+            };
+
         // Create zones that should be running
         let all_u2_roots = self
             .inner
@@ -2859,6 +2886,17 @@ impl ServiceManager {
                         }
                     }
                 }
+            }
+
+            // For each new zone request, ensure that we've sufficiently
+            // synchronized time.
+            //
+            // NOTE: This imposes a constraint, during initial setup, cold boot,
+            // etc, that NTP and the internal DNS system it depends on MUST be
+            // initialized prior to other zones.
+            if zone_requires_timesync(&zone.zone_type) && !time_is_synchronized
+            {
+                return Err(Error::TimeNotSynchronized);
             }
 
             // For each new zone request, we pick an arbitrary U.2 to store
@@ -2984,8 +3022,24 @@ impl ServiceManager {
 
     pub async fn timesync_get(&self) -> Result<TimeSync, Error> {
         let existing_zones = self.inner.zones.lock().await;
+        self.timesync_get_locked(&existing_zones).await
+    }
 
-        if let Some(true) = self.inner.skip_timesync {
+    async fn timesync_get_locked(
+        &self,
+        existing_zones: &tokio::sync::MutexGuard<'_, ZoneMap>,
+    ) -> Result<TimeSync, Error> {
+        let skip_timesync = match &self.inner.time_sync_config {
+            TimeSyncConfig::Normal => false,
+            TimeSyncConfig::Skip => true,
+            #[cfg(test)]
+            TimeSyncConfig::Fail => {
+                info!(self.inner.log, "Configured to fail timesync checks");
+                return Err(Error::TimeNotSynchronized);
+            }
+        };
+
+        if skip_timesync {
             info!(self.inner.log, "Configured to skip timesync checks");
             self.boottime_rewrite();
             return Ok(TimeSync {
@@ -3569,7 +3623,6 @@ mod test {
         svc,
         zone::MockZones,
     };
-    use omicron_common::address::OXIMETER_PORT;
     use sled_storage::disk::{RawDisk, SyntheticDisk};
 
     use sled_storage::manager::{FakeStorageManager, StorageHandle};
@@ -3582,6 +3635,7 @@ mod test {
     const SWITCH_ZONE_BOOTSTRAP_IP: Ipv6Addr = Ipv6Addr::LOCALHOST;
 
     const EXPECTED_ZONE_NAME_PREFIX: &str = "oxz_oximeter";
+    const EXPECTED_PORT: u16 = 12223;
 
     fn make_bootstrap_networking_config() -> BootstrapNetworking {
         BootstrapNetworking {
@@ -3599,7 +3653,9 @@ mod test {
     }
 
     // Returns the expectations for a new service to be created.
-    fn expect_new_service() -> Vec<Box<dyn std::any::Any>> {
+    fn expect_new_service(
+        expected_zone_name_prefix: &str,
+    ) -> Vec<Box<dyn std::any::Any>> {
         illumos_utils::USE_MOCKS.store(true, Ordering::SeqCst);
         // Create a VNIC
         let create_vnic_ctx = MockDladm::create_vnic_context();
@@ -3611,15 +3667,19 @@ mod test {
         );
         // Install the Omicron Zone
         let install_ctx = MockZones::install_omicron_zone_context();
-        install_ctx.expect().return_once(|_, _, name, _, _, _, _, _, _| {
-            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
-            Ok(())
-        });
+        let prefix = expected_zone_name_prefix.to_string();
+        install_ctx.expect().return_once(
+            move |_, _, name, _, _, _, _, _, _| {
+                assert!(name.starts_with(&prefix));
+                Ok(())
+            },
+        );
 
         // Boot the zone.
         let boot_ctx = MockZones::boot_context();
-        boot_ctx.expect().return_once(|name| {
-            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
+        let prefix = expected_zone_name_prefix.to_string();
+        boot_ctx.expect().return_once(move |name| {
+            assert!(name.starts_with(&prefix));
             Ok(())
         });
 
@@ -3627,8 +3687,9 @@ mod test {
         // up the zone ID for the booted zone. This goes through
         // `MockZone::id` to find the zone and get its ID.
         let id_ctx = MockZones::id_context();
-        id_ctx.expect().return_once(|name| {
-            assert!(name.starts_with(EXPECTED_ZONE_NAME_PREFIX));
+        let prefix = expected_zone_name_prefix.to_string();
+        id_ctx.expect().return_once(move |name| {
+            assert!(name.starts_with(&prefix));
             Ok(Some(1))
         });
 
@@ -3744,19 +3805,35 @@ mod test {
         id: Uuid,
         generation: Generation,
     ) {
-        let _expectations = expect_new_service();
         let address =
-            SocketAddrV6::new(Ipv6Addr::LOCALHOST, OXIMETER_PORT, 0, 0);
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, EXPECTED_PORT, 0, 0);
+        try_new_service_of_type(
+            mgr,
+            id,
+            generation,
+            OmicronZoneType::Oximeter { address },
+        )
+        .await
+        .expect("Could not create service");
+    }
+
+    async fn try_new_service_of_type(
+        mgr: &ServiceManager,
+        id: Uuid,
+        generation: Generation,
+        zone_type: OmicronZoneType,
+    ) -> Result<(), Error> {
+        let zone_prefix = format!("oxz_{}", zone_type.zone_type_str());
+        let _expectations = expect_new_service(&zone_prefix);
         mgr.ensure_all_omicron_zones_persistent(OmicronZonesConfig {
             generation,
             zones: vec![OmicronZoneConfig {
                 id,
                 underlay_address: Ipv6Addr::LOCALHOST,
-                zone_type: OmicronZoneType::Oximeter { address },
+                zone_type,
             }],
         })
         .await
-        .unwrap();
     }
 
     // Prepare to call "ensure" for a service which already exists. We should
@@ -3767,7 +3844,7 @@ mod test {
         generation: Generation,
     ) {
         let address =
-            SocketAddrV6::new(Ipv6Addr::LOCALHOST, OXIMETER_PORT, 0, 0);
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, EXPECTED_PORT, 0, 0);
         mgr.ensure_all_omicron_zones_persistent(OmicronZonesConfig {
             generation,
             zones: vec![OmicronZoneConfig {
@@ -3826,6 +3903,7 @@ mod test {
             // files.
             std::fs::write(dir.join("oximeter.tar.gz"), "Not a real file")
                 .unwrap();
+            std::fs::write(dir.join("ntp.tar.gz"), "Not a real file").unwrap();
         }
     }
 
@@ -3881,13 +3959,20 @@ mod test {
         }
 
         fn new_service_manager(self) -> ServiceManager {
+            self.new_service_manager_with_timesync(TimeSyncConfig::Skip)
+        }
+
+        fn new_service_manager_with_timesync(
+            self,
+            time_sync_config: TimeSyncConfig,
+        ) -> ServiceManager {
             let log = &self.log;
             let mgr = ServiceManager::new(
                 log,
                 self.ddmd_client,
                 make_bootstrap_networking_config(),
                 SledMode::Auto,
-                Some(true),
+                time_sync_config,
                 SidecarRevision::Physical("rev-test".to_string()),
                 vec![],
                 self.storage_handle,
@@ -3952,6 +4037,63 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_ensure_service_before_timesync() {
+        let logctx = omicron_test_utils::dev::test_setup_log(
+            "test_ensure_service_before_timesync",
+        );
+        let test_config = TestConfig::new().await;
+        let helper =
+            LedgerTestHelper::new(logctx.log.clone(), &test_config).await;
+
+        let mgr =
+            helper.new_service_manager_with_timesync(TimeSyncConfig::Fail);
+        LedgerTestHelper::sled_agent_started(&logctx.log, &test_config, &mgr);
+
+        let v1 = Generation::new();
+        let found =
+            mgr.omicron_zones_list().await.expect("failed to list zones");
+        assert_eq!(found.generation, v1);
+        assert!(found.zones.is_empty());
+
+        let v2 = v1.next();
+        let id = Uuid::new_v4();
+
+        // Should fail: time has not yet synchronized.
+        let address =
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, EXPECTED_PORT, 0, 0);
+        let result = try_new_service_of_type(
+            &mgr,
+            id,
+            v2,
+            OmicronZoneType::Oximeter { address },
+        )
+        .await;
+        assert_matches::assert_matches!(
+            result,
+            Err(Error::TimeNotSynchronized)
+        );
+
+        // Should succeed: we don't care that time has not yet synchronized (for
+        // this specific service).
+        try_new_service_of_type(
+            &mgr,
+            id,
+            v2,
+            OmicronZoneType::InternalNtp {
+                address,
+                ntp_servers: vec![],
+                dns_servers: vec![],
+                domain: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        drop_service_manager(mgr);
+        logctx.cleanup_successful();
+    }
+
+    #[tokio::test]
     async fn test_ensure_service_which_already_exists() {
         let logctx = omicron_test_utils::dev::test_setup_log(
             "test_ensure_service_which_already_exists",
@@ -3999,7 +4141,7 @@ mod test {
 
         // Before we re-create the service manager - notably, using the same
         // config file! - expect that a service gets initialized.
-        let _expectations = expect_new_service();
+        let _expectations = expect_new_service(EXPECTED_ZONE_NAME_PREFIX);
         let mgr = helper.new_service_manager();
         LedgerTestHelper::sled_agent_started(&logctx.log, &test_config, &mgr);
 
@@ -4073,7 +4215,7 @@ mod test {
 
         let _expectations = expect_new_services();
         let address =
-            SocketAddrV6::new(Ipv6Addr::LOCALHOST, OXIMETER_PORT, 0, 0);
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, EXPECTED_PORT, 0, 0);
         let mut zones = vec![OmicronZoneConfig {
             id: id1,
             underlay_address: Ipv6Addr::LOCALHOST,
@@ -4265,7 +4407,7 @@ mod test {
 
         let _expectations = expect_new_services();
         let address =
-            SocketAddrV6::new(Ipv6Addr::LOCALHOST, OXIMETER_PORT, 0, 0);
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, EXPECTED_PORT, 0, 0);
         let mut zones =
             migrated_ledger.data().clone().to_omicron_zones_config().zones;
         zones.push(OmicronZoneConfig {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -140,9 +140,6 @@ pub enum Error {
     #[error("Failed to deserialize early network config: {0}")]
     EarlyNetworkDeserialize(serde_json::Error),
 
-    #[error("Time not yet synchronized")]
-    TimeNotSynchronized,
-
     #[error("Zone bundle error: {0}")]
     ZoneBundle(#[from] BundleError),
 
@@ -212,10 +209,6 @@ impl From<Error> for dropshot::HttpError {
                 }
                 _ => HttpError::for_internal_error(err.to_string()),
             },
-            Error::TimeNotSynchronized => HttpError::for_unavail(
-                Some(String::from("TimeNotSynchronized")),
-                String::from("Time synchronization is not complete"),
-            ),
             e => HttpError::for_internal_error(e.to_string()),
         }
     }
@@ -859,17 +852,6 @@ impl SledAgent {
         &self,
         requested_zones: OmicronZonesConfig,
     ) -> Result<(), Error> {
-        // If the requested set of zones need time synchronization,
-        // check that it has occurred.
-        if crate::services::zones_require_timesync(&requested_zones) {
-            match self.inner.services.timesync_get().await {
-                // Time is synchronized
-                Ok(TimeSync { sync: true, .. }) => {}
-                // Time is not synchronized, or we can't check
-                _ => return Err(Error::TimeNotSynchronized),
-            }
-        }
-
         // TODO:
         // - If these are the set of filesystems, we should also consider
         // removing the ones which are not listed here.


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/4776