### PR TITLE
[tests] time out tests in test_all after a duration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.59", recommended = "0.9.64" }
+nextest-version = { required = "0.9.64", recommended = "0.9.64" }
 
 experimental = ["setup-scripts"]
 
@@ -30,5 +30,11 @@ command = 'cargo run -p crdb-seed --profile test'
 clickhouse-cluster = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'package(oximeter-db) and test(replicated)'
+filter = 'binary_id(oximeter-db::replicated)'
 test-group = 'clickhouse-cluster'
+
+[[profile.default.overrides]]
+filter = 'binary_id(omicron-nexus::test_all)'
+# As of 2023-01-08, the slowest test in test_all takes 196s on a Ryzen 7950X.
+# 900s is a good upper limit that adds a comfortable buffer.
+slow-timeout = { period = '60s', terminate-after = 15 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -30,7 +30,7 @@ command = 'cargo run -p crdb-seed --profile test'
 clickhouse-cluster = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary_id(oximeter-db::replicated)'
+filter = 'package(oximeter-db) and test(replicated)'
 test-group = 'clickhouse-cluster'
 
 [[profile.ci.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,7 +33,7 @@ clickhouse-cluster = { max-threads = 1 }
 filter = 'binary_id(oximeter-db::replicated)'
 test-group = 'clickhouse-cluster'
 
-[[profile.default.overrides]]
+[[profile.ci.overrides]]
 filter = 'binary_id(omicron-nexus::test_all)'
 # As of 2023-01-08, the slowest test in test_all takes 196s on a Ryzen 7950X.
 # 900s is a good upper limit that adds a comfortable buffer.


### PR DESCRIPTION
We're seeing some tests in `test_all` hang forever (#4779). Set a reasonable
upper bound on test duration.

This will also cause stdout and stderr for failing tests to be printed. Doing
so on SIGTERM in general is tracked at
https://github.com/nextest-rs/nextest/issues/1208.

Also, bump up the required nextest version to 0.9.64 to make use of the
`binary_id` predicate.