### PR TITLE
[ci] update nextest to 0.9.67

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.64", recommended = "0.9.64" }
+nextest-version = { required = "0.9.64", recommended = "0.9.67" }
 
 experimental = ["setup-scripts"]
 

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -7,7 +7,7 @@ set -o xtrace
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.64'
+NEXTEST_VERSION='0.9.67'
 
 cargo --version
 rustc --version


### PR DESCRIPTION
This version of nextest has a fix for
https://github.com/nextest-rs/nextest/issues/1208, which we encountered while
attempting to diagnose #4779.
