### PR TITLE
don't enable chrony in the gz, it runs in the ntp zone

### DIFF
--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -120,8 +120,6 @@ function install_packages {
       exit "$rc"
     fi
 
-    pfexec svcadm enable chrony
-
     pkg list -v "${packages[@]}"
   elif [[ "${HOST_OS}" == "Linux" ]]; then
     packages=(


### PR DESCRIPTION
When chrony runs in both the gz and in the ntp zone, they fight each other and time becomes unstable, causing issues for subsystems like CRDB that depend on stable time. This PR removes enablement of chrony in the gz in the prerequisites install script.