### PR TITLE
[tufaceous-lib] add fake artifacts with an mtime of zero

### DIFF
--- a/tufaceous-lib/src/artifact.rs
+++ b/tufaceous-lib/src/artifact.rs
@@ -19,8 +19,10 @@ use crate::oxide_metadata;
 mod composite;
 
 pub use composite::CompositeControlPlaneArchiveBuilder;
+pub use composite::CompositeEntry;
 pub use composite::CompositeHostArchiveBuilder;
 pub use composite::CompositeRotArchiveBuilder;
+pub use composite::MtimeSource;
 
 /// The location a artifact will be obtained from.
 #[derive(Clone, Debug)]

--- a/tufaceous-lib/src/oxide_metadata.rs
+++ b/tufaceous-lib/src/oxide_metadata.rs
@@ -10,10 +10,7 @@
  * Copyright 2023 Oxide Computer Company
  */
 
-use std::{
-    collections::HashMap,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::collections::HashMap;
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -52,8 +49,9 @@ impl Metadata {
         let mut b = serde_json::to_vec(self)?;
         b.push(b'\n');
 
-        let mtime =
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        // XXX This was changed from upstream to add oxide.json with a zero
+        // timestamp, to ensure stability of fake manifests.
+        let mtime = 0;
 
         let mut h = tar::Header::new_ustar();
         h.set_entry_type(tar::EntryType::Regular);

--- a/update-common/src/artifacts/update_plan.rs
+++ b/update-common/src/artifacts/update_plan.rs
@@ -859,6 +859,7 @@ mod tests {
     use omicron_test_utils::dev::test_setup_log;
     use rand::{distributions::Standard, thread_rng, Rng};
     use sha2::{Digest, Sha256};
+    use tufaceous_lib::{CompositeEntry, MtimeSource};
 
     fn make_random_bytes() -> Vec<u8> {
         thread_rng().sample_iter(Standard).take(128).collect()
@@ -877,8 +878,18 @@ mod tests {
         let phase2 = make_random_bytes();
 
         let mut builder = CompositeHostArchiveBuilder::new(Vec::new()).unwrap();
-        builder.append_phase_1(phase1.len(), phase1.as_slice()).unwrap();
-        builder.append_phase_2(phase2.len(), phase2.as_slice()).unwrap();
+        builder
+            .append_phase_1(CompositeEntry {
+                data: &phase1,
+                mtime_source: MtimeSource::Zero,
+            })
+            .unwrap();
+        builder
+            .append_phase_2(CompositeEntry {
+                data: &phase2,
+                mtime_source: MtimeSource::Zero,
+            })
+            .unwrap();
 
         let tarball = builder.finish().unwrap();
 
@@ -903,10 +914,16 @@ mod tests {
 
         let mut builder = CompositeRotArchiveBuilder::new(Vec::new()).unwrap();
         builder
-            .append_archive_a(archive_a.len(), archive_a.as_slice())
+            .append_archive_a(CompositeEntry {
+                data: &archive_a,
+                mtime_source: MtimeSource::Zero,
+            })
             .unwrap();
         builder
-            .append_archive_b(archive_b.len(), archive_b.as_slice())
+            .append_archive_b(CompositeEntry {
+                data: &archive_b,
+                mtime_source: MtimeSource::Zero,
+            })
             .unwrap();
 
         let tarball = builder.finish().unwrap();

--- a/update-common/src/artifacts/update_plan.rs
+++ b/update-common/src/artifacts/update_plan.rs
@@ -877,7 +877,9 @@ mod tests {
         let phase1 = make_random_bytes();
         let phase2 = make_random_bytes();
 
-        let mut builder = CompositeHostArchiveBuilder::new(Vec::new()).unwrap();
+        let mut builder =
+            CompositeHostArchiveBuilder::new(Vec::new(), MtimeSource::Zero)
+                .unwrap();
         builder
             .append_phase_1(CompositeEntry {
                 data: &phase1,
@@ -912,7 +914,9 @@ mod tests {
         let archive_a = make_random_bytes();
         let archive_b = make_random_bytes();
 
-        let mut builder = CompositeRotArchiveBuilder::new(Vec::new()).unwrap();
+        let mut builder =
+            CompositeRotArchiveBuilder::new(Vec::new(), MtimeSource::Zero)
+                .unwrap();
         builder
             .append_archive_a(CompositeEntry {
                 data: &archive_a,


### PR DESCRIPTION
In #4690 I'd like to be able to generate a tufaceous repo twice and expect that each artifact has the same hash.

Writing tests for this is a bit annoying at the moment because at the moment the overall repo has a different hash when generated again (because TUF bakes timestamps into its format), but each artifact has the same hash. #4690 has other work going on which makes writing this test quite simple, so I'll include the test there.