### PR TITLE
sled-agent-client doesn't depend on sled-storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,7 +7764,6 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
- "sled-storage",
  "slog",
  "uuid",
 ]

--- a/clients/sled-agent-client/Cargo.toml
+++ b/clients/sled-agent-client/Cargo.toml
@@ -15,6 +15,5 @@ reqwest = { workspace = true, features = [ "json", "rustls-tls", "stream" ] }
 schemars.workspace = true
 serde.workspace = true
 slog.workspace = true
-sled-storage.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true


### PR DESCRIPTION
If someone is incrementally working on certain parts of sled agent, poking at something fully unrelated to the API, they’ll need to rebuild all of Nexus. Why?

We have the following dependencies:
- Nexus depends on sled_agent_client
- sled_agent_client depends on sled_storage
… so if you poke at sled_storage, you gotta rebuild Nexus.

This PR removes that (not actually needed) dependency -- now, updates to sled-storage do not cause Nexus to rebuild