### PR TITLE
[nexus] mark schema tests as heavy, increase timeout for one of them

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,11 @@ clickhouse-cluster = { max-threads = 1 }
 filter = 'package(oximeter-db) and test(replicated)'
 test-group = 'clickhouse-cluster'
 
+[[profile.default.overrides]]
+# These tests can time out under heavy contention.
+filter = 'binary_id(omicron-nexus::test_all) and test(::schema::)'
+threads-required = 4
+
 [[profile.ci.overrides]]
 filter = 'binary_id(omicron-nexus::test_all)'
 # As of 2023-01-08, the slowest test in test_all takes 196s on a Ryzen 7950X.

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -479,10 +479,14 @@ async fn nexus_applies_update_on_boot() {
     // Start Nexus. It should auto-format itself to the latest version,
     // upgrading through each intermediate update.
     //
+    // The timeout here is a bit longer than usual (120s vs 60s) because if
+    // lots of tests are running at the same time, there can be contention
+    // here.
+    //
     // NOTE: If this grows excessively, we could break it into several smaller
     // tests.
     assert!(
-        timeout(Duration::from_secs(60), builder.start_nexus_internal())
+        timeout(Duration::from_secs(120), builder.start_nexus_internal())
             .await
             .is_ok(),
         "Nexus should have started"


### PR DESCRIPTION
On my Linux machine, when running the tests in test_all, I'm starting to see
`integration_tests::schema::nexus_applies_update_on_boot`
fail because of a 60s timeout waiting for nexus to start. The failure is caused
due to contention -- the logs just seem to indicate each schema version taking
5-15 seconds to apply.

To address this, do two things:

1. Mark the tests as heavy so that they run with less contention.
2. Increase the timeout for this specific test to 120s.

In the future, we may want to do something more clever like breaking this test
up into several smaller ones.

Error message:

```
thread 'integration_tests::schema::nexus_applies_update_on_boot' panicked at nexus/tests/integration_tests/schema.rs:484:5:
Nexus should have started
```

Logs: https://gist.github.com/sunshowers/39ee99badc5f75c2a3154ea602aa95aa