### PR TITLE
more specific address reservation errors

### DIFF
--- a/nexus/db-model/src/ipv4net.rs
+++ b/nexus/db-model/src/ipv4net.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::vpc_subnet::RequestAddressError;
 use diesel::backend::Backend;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
@@ -32,18 +33,30 @@ NewtypeDeref! { () pub struct Ipv4Net(external::Ipv4Net); }
 
 impl Ipv4Net {
     /// Check if an address is a valid user-requestable address for this subnet
-    pub fn check_requestable_addr(&self, addr: Ipv4Addr) -> bool {
-        self.contains(addr)
-            && (
-                // First N addresses are reserved
-                self.iter()
-                    .take(NUM_INITIAL_RESERVED_IP_ADDRESSES)
-                    .all(|this| this != addr)
-            )
-            && (
-                // Last address in the subnet is reserved
-                addr != self.broadcast()
-            )
+    pub fn check_requestable_addr(
+        &self,
+        addr: Ipv4Addr,
+    ) -> Result<(), RequestAddressError> {
+        if !self.contains(addr) {
+            return Err(RequestAddressError::OutsideSubnet(
+                addr.into(),
+                self.0 .0.into(),
+            ));
+        }
+        // Only the first N addresses are reserved
+        if self
+            .iter()
+            .take(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+            .any(|this| this == addr)
+        {
+            return Err(RequestAddressError::Reserved);
+        }
+        // Last address in the subnet is reserved
+        if addr == self.broadcast() {
+            return Err(RequestAddressError::Broadcast);
+        }
+
+        Ok(())
     }
 }
 

--- a/nexus/db-model/src/ipv6net.rs
+++ b/nexus/db-model/src/ipv6net.rs
@@ -15,6 +15,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::net::Ipv6Addr;
 
+use crate::RequestAddressError;
+
 #[derive(
     Clone,
     Copy,
@@ -83,13 +85,25 @@ impl Ipv6Net {
     }
 
     /// Check if an address is a valid user-requestable address for this subnet
-    pub fn check_requestable_addr(&self, addr: Ipv6Addr) -> bool {
+    pub fn check_requestable_addr(
+        &self,
+        addr: Ipv6Addr,
+    ) -> Result<(), RequestAddressError> {
+        if !self.contains(addr) {
+            return Err(RequestAddressError::OutsideSubnet(
+                addr.into(),
+                self.0 .0.into(),
+            ));
+        }
         // Only the first N addresses are reserved
-        self.contains(addr)
-            && self
-                .iter()
-                .take(NUM_INITIAL_RESERVED_IP_ADDRESSES)
-                .all(|this| this != addr)
+        if self
+            .iter()
+            .take(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+            .any(|this| this == addr)
+        {
+            return Err(RequestAddressError::Reserved);
+        }
+        Ok(())
     }
 }
 

--- a/nexus/db-model/src/lib.rs
+++ b/nexus/db-model/src/lib.rs
@@ -407,10 +407,13 @@ impl DatabaseString for ProjectRole {
 
 #[cfg(test)]
 mod tests {
+    use crate::RequestAddressError;
+
     use super::VpcSubnet;
     use ipnetwork::Ipv4Network;
     use ipnetwork::Ipv6Network;
     use omicron_common::api::external::IdentityMetadataCreateParams;
+    use omicron_common::api::external::IpNet;
     use omicron_common::api::external::Ipv4Net;
     use omicron_common::api::external::Ipv6Net;
     use std::net::IpAddr;
@@ -515,18 +518,37 @@ mod tests {
     #[test]
     fn test_ip_subnet_check_requestable_address() {
         let subnet = super::Ipv4Net(Ipv4Net("192.168.0.0/16".parse().unwrap()));
-        assert!(subnet.check_requestable_addr("192.168.0.10".parse().unwrap()));
-        assert!(subnet.check_requestable_addr("192.168.1.0".parse().unwrap()));
-        assert!(!subnet.check_requestable_addr("192.168.0.0".parse().unwrap()));
-        assert!(subnet.check_requestable_addr("192.168.0.255".parse().unwrap()));
-        assert!(
-            !subnet.check_requestable_addr("192.168.255.255".parse().unwrap())
+        subnet.check_requestable_addr("192.168.0.10".parse().unwrap()).unwrap();
+        subnet.check_requestable_addr("192.168.1.0".parse().unwrap()).unwrap();
+        let addr = "192.178.0.10".parse().unwrap();
+        assert_eq!(
+            subnet.check_requestable_addr(addr),
+            Err(RequestAddressError::OutsideSubnet(
+                addr.into(),
+                IpNet::from(subnet.0).into()
+            ))
+        );
+        assert_eq!(
+            subnet.check_requestable_addr("192.168.0.0".parse().unwrap()),
+            Err(RequestAddressError::Reserved)
+        );
+
+        subnet
+            .check_requestable_addr("192.168.0.255".parse().unwrap())
+            .unwrap();
+
+        assert_eq!(
+            subnet.check_requestable_addr("192.168.255.255".parse().unwrap()),
+            Err(RequestAddressError::Broadcast)
         );
 
         let subnet = super::Ipv6Net(Ipv6Net("fd00::/64".parse().unwrap()));
-        assert!(subnet.check_requestable_addr("fd00::a".parse().unwrap()));
-        assert!(!subnet.check_requestable_addr("fd00::1".parse().unwrap()));
-        assert!(subnet.check_requestable_addr("fd00::1:1".parse().unwrap()));
+        subnet.check_requestable_addr("fd00::a".parse().unwrap()).unwrap();
+        assert_eq!(
+            subnet.check_requestable_addr("fd00::1".parse().unwrap()),
+            Err(RequestAddressError::Reserved)
+        );
+        subnet.check_requestable_addr("fd00::1:1".parse().unwrap()).unwrap();
     }
 
     /// Does some basic smoke checks on an impl of `DatabaseString`

--- a/nexus/db-model/src/vpc_subnet.rs
+++ b/nexus/db-model/src/vpc_subnet.rs
@@ -14,6 +14,7 @@ use nexus_types::external_api::params;
 use nexus_types::external_api::views;
 use nexus_types::identity::Resource;
 use omicron_common::api::external;
+use omicron_common::nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::IpAddr;
@@ -73,25 +74,25 @@ impl VpcSubnet {
         &self,
         addr: IpAddr,
     ) -> Result<(), external::Error> {
-        let subnet = match addr {
-            IpAddr::V4(addr) => {
-                if self.ipv4_block.check_requestable_addr(addr) {
-                    return Ok(());
-                }
-                ipnetwork::IpNetwork::V4(self.ipv4_block.0 .0)
-            }
-            IpAddr::V6(addr) => {
-                if self.ipv6_block.check_requestable_addr(addr) {
-                    return Ok(());
-                }
-                ipnetwork::IpNetwork::V6(self.ipv6_block.0 .0)
-            }
-        };
-        Err(external::Error::invalid_request(&format!(
-            "Address '{}' not in subnet '{}' or is reserved for rack services",
-            addr, subnet,
-        )))
+        match addr {
+            IpAddr::V4(addr) => self.ipv4_block.check_requestable_addr(addr),
+            IpAddr::V6(addr) => self.ipv6_block.check_requestable_addr(addr),
+        }
+        .map_err(|e| external::Error::invalid_request(e.to_string()))
     }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum RequestAddressError {
+    #[error("{} is outside subnet {}", .0, .1)]
+    OutsideSubnet(IpAddr, ipnetwork::IpNetwork),
+    #[error(
+        "The first {} addresses of a subnet are reserved",
+        NUM_INITIAL_RESERVED_IP_ADDRESSES
+    )]
+    Reserved,
+    #[error("Cannot request a broadcast address")]
+    Broadcast,
 }
 
 impl From<VpcSubnet> for views::VpcSubnet {


### PR DESCRIPTION
I was trying to use the rack today to do some dev/test. I started by creating a VM with the requested address `10.0.0.2` and was greeted with this error.

```
Address 10.0.0.2 not in subnet 10.0.0.0/24 or is reserved for rack services
```

The former is not true, which leaves me with the latter. Then the question is, what addresses are reserved for rack services? This PR changes the error message to be more direct and specific about the issue at hand.

Possible errors are now

```rust
pub enum RequestAddressError {
    #[error("{} is outside subnet {}", .0, .1)]
    OutsideSubnet(IpAddr, ipnetwork::IpNetwork),
    #[error(
        "The first {} addresses of a subnet are reserved",
        NUM_INITIAL_RESERVED_IP_ADDRESSES
    )]
    Reserved,
    #[error("Cannot request a broadcast address")]
    Broadcast,
}
```

