### PR TITLE
[nexus] Endpoint to list IP pools for silo, add `is_default` to silo-scoped IP pools list

### DIFF
--- a/end-to-end-tests/src/bin/bootstrap.rs
+++ b/end-to-end-tests/src/bin/bootstrap.rs
@@ -4,7 +4,7 @@ use end_to_end_tests::helpers::{generate_name, get_system_ip_pool};
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 use oxide_client::types::{
     ByteCount, DeviceAccessTokenRequest, DeviceAuthRequest, DeviceAuthVerify,
-    DiskCreate, DiskSource, IpPoolCreate, IpPoolSiloLink, IpRange, Ipv4Range,
+    DiskCreate, DiskSource, IpPoolCreate, IpPoolLinkSilo, IpRange, Ipv4Range,
     NameOrId, SiloQuotasUpdate,
 };
 use oxide_client::{
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
     client
         .ip_pool_silo_link()
         .pool(pool_name)
-        .body(IpPoolSiloLink {
+        .body(IpPoolLinkSilo {
             silo: NameOrId::Name(params.silo_name().parse().unwrap()),
             is_default: true,
         })

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -97,7 +97,7 @@ pub struct IpPoolResource {
     pub is_default: bool,
 }
 
-impl From<IpPoolResource> for views::IpPoolSilo {
+impl From<IpPoolResource> for views::IpPoolSiloLink {
     fn from(assoc: IpPoolResource) -> Self {
         Self {
             ip_pool_id: assoc.ip_pool_id,

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -78,7 +78,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pagparams: &PaginatedBy<'_>,
-    ) -> ListResultVec<db::model::IpPool> {
+    ) -> ListResultVec<(db::model::IpPool, db::model::IpPoolResource)> {
         self.db_datastore.current_silo_ip_pool_list(opctx, pagparams).await
     }
 

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -128,7 +128,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pool_lookup: &lookup::IpPool<'_>,
-        silo_link: &params::IpPoolSiloLink,
+        silo_link: &params::IpPoolLinkSilo,
     ) -> CreateResult<db::model::IpPoolResource> {
         let (authz_pool,) =
             pool_lookup.lookup_for(authz::Action::Modify).await?;

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -74,12 +74,12 @@ impl super::Nexus {
     }
 
     /// List IP pools in current silo
-    pub(crate) async fn silo_ip_pools_list(
+    pub(crate) async fn current_silo_ip_pool_list(
         &self,
         opctx: &OpContext,
         pagparams: &PaginatedBy<'_>,
     ) -> ListResultVec<db::model::IpPool> {
-        self.db_datastore.silo_ip_pools_list(opctx, pagparams).await
+        self.db_datastore.current_silo_ip_pool_list(opctx, pagparams).await
     }
 
     // Look up pool by name or ID, but only return it if it's linked to the
@@ -101,6 +101,7 @@ impl super::Nexus {
         Ok(pool)
     }
 
+    /// List silos for a given pool
     pub(crate) async fn ip_pool_silo_list(
         &self,
         opctx: &OpContext,
@@ -110,6 +111,18 @@ impl super::Nexus {
         let (.., authz_pool) =
             pool_lookup.lookup_for(authz::Action::ListChildren).await?;
         self.db_datastore.ip_pool_silo_list(opctx, &authz_pool, pagparams).await
+    }
+
+    // List pools for a given silo
+    pub(crate) async fn silo_ip_pool_list(
+        &self,
+        opctx: &OpContext,
+        silo_lookup: &lookup::Silo<'_>,
+        pagparams: &DataPageParams<'_, Uuid>,
+    ) -> ListResultVec<(db::model::IpPool, db::model::IpPoolResource)> {
+        let (.., authz_silo) =
+            silo_lookup.lookup_for(authz::Action::Read).await?;
+        self.db_datastore.silo_ip_pool_list(opctx, &authz_silo, pagparams).await
     }
 
     pub(crate) async fn ip_pool_link_silo(

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -117,7 +117,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         silo_lookup: &lookup::Silo<'_>,
-        pagparams: &DataPageParams<'_, Uuid>,
+        pagparams: &PaginatedBy<'_>,
     ) -> ListResultVec<(db::model::IpPool, db::model::IpPoolResource)> {
         let (.., authz_silo) =
             silo_lookup.lookup_for(authz::Action::Read).await?;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1546,7 +1546,7 @@ async fn ip_pool_silo_list(
     // whatever the thing is. Still... all we'd have to do to make this usable
     // in both places would be to make it { ...IpPool, silo_id, silo_name,
     // is_default }
-) -> Result<HttpResponseOk<ResultsPage<views::IpPoolSilo>>, HttpError> {
+) -> Result<HttpResponseOk<ResultsPage<views::IpPoolSiloLink>>, HttpError> {
     let apictx = rqctx.context();
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
@@ -1568,7 +1568,7 @@ async fn ip_pool_silo_list(
         Ok(HttpResponseOk(ScanById::results_page(
             &query,
             assocs,
-            &|_, x: &views::IpPoolSilo| x.silo_id,
+            &|_, x: &views::IpPoolSiloLink| x.silo_id,
         )?))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -1583,8 +1583,8 @@ async fn ip_pool_silo_list(
 async fn ip_pool_silo_link(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<params::IpPoolPath>,
-    resource_assoc: TypedBody<params::IpPoolSiloLink>,
-) -> Result<HttpResponseCreated<views::IpPoolSilo>, HttpError> {
+    resource_assoc: TypedBody<params::IpPoolLinkSilo>,
+) -> Result<HttpResponseCreated<views::IpPoolSiloLink>, HttpError> {
     let apictx = rqctx.context();
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
@@ -1638,7 +1638,7 @@ async fn ip_pool_silo_update(
     rqctx: RequestContext<Arc<ServerContext>>,
     path_params: Path<params::IpPoolSiloPath>,
     update: TypedBody<params::IpPoolSiloUpdate>,
-) -> Result<HttpResponseOk<views::IpPoolSilo>, HttpError> {
+) -> Result<HttpResponseOk<views::IpPoolSiloLink>, HttpError> {
     let apictx = rqctx.context();
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -246,9 +246,9 @@ pub async fn link_ip_pool(
     is_default: bool,
 ) {
     let link =
-        params::IpPoolSiloLink { silo: NameOrId::Id(*silo_id), is_default };
+        params::IpPoolLinkSilo { silo: NameOrId::Id(*silo_id), is_default };
     let url = format!("/v1/system/ip-pools/{pool_name}/silos");
-    object_create::<params::IpPoolSiloLink, views::IpPoolSilo>(
+    object_create::<params::IpPoolLinkSilo, views::IpPoolSiloLink>(
         client, &url, &link,
     )
     .await;

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -629,8 +629,8 @@ pub static DEMO_IP_POOL_UPDATE: Lazy<params::IpPoolUpdate> =
     });
 pub static DEMO_IP_POOL_SILOS_URL: Lazy<String> =
     Lazy::new(|| format!("{}/silos", *DEMO_IP_POOL_URL));
-pub static DEMO_IP_POOL_SILOS_BODY: Lazy<params::IpPoolSiloLink> =
-    Lazy::new(|| params::IpPoolSiloLink {
+pub static DEMO_IP_POOL_SILOS_BODY: Lazy<params::IpPoolLinkSilo> =
+    Lazy::new(|| params::IpPoolLinkSilo {
         silo: NameOrId::Id(DEFAULT_SILO.identity().id),
         is_default: true, // necessary for demo instance create to go through
     });

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -80,6 +80,8 @@ pub static DEMO_SILO_NAME: Lazy<Name> =
     Lazy::new(|| "demo-silo".parse().unwrap());
 pub static DEMO_SILO_URL: Lazy<String> =
     Lazy::new(|| format!("/v1/system/silos/{}", *DEMO_SILO_NAME));
+pub static DEMO_SILO_IP_POOLS_URL: Lazy<String> =
+    Lazy::new(|| format!("{}/ip-pools", *DEMO_SILO_URL));
 pub static DEMO_SILO_POLICY_URL: Lazy<String> =
     Lazy::new(|| format!("/v1/system/silos/{}/policy", *DEMO_SILO_NAME));
 pub static DEMO_SILO_QUOTAS_URL: Lazy<String> =
@@ -1108,6 +1110,14 @@ pub static VERIFY_ENDPOINTS: Lazy<Vec<VerifyEndpoint>> = Lazy::new(|| {
             allowed_methods: vec![
                 AllowedMethod::Get,
                 AllowedMethod::Delete,
+            ],
+        },
+        VerifyEndpoint {
+            url: &DEMO_SILO_IP_POOLS_URL,
+            visibility: Visibility::Protected,
+            unprivileged_access: UnprivilegedAccess::None,
+            allowed_methods: vec![
+                AllowedMethod::Get,
             ],
         },
         VerifyEndpoint {

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3657,7 +3657,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     );
 
     // make pool2 default and create instance with default pool. check that it now it comes from pool2
-    let _: views::IpPoolSilo = object_put(
+    let _: views::IpPoolSiloLink = object_put(
         client,
         &format!("/v1/system/ip-pools/pool2/silos/{}", DEFAULT_SILO.id()),
         &params::IpPoolSiloUpdate { is_default: true },
@@ -3788,11 +3788,11 @@ async fn test_instance_ephemeral_ip_from_orphan_pool(
 
     // associate the pool with a different silo and we should get the same
     // error on instance create
-    let params = params::IpPoolSiloLink {
+    let params = params::IpPoolLinkSilo {
         silo: NameOrId::Name(cptestctx.silo_name.clone()),
         is_default: false,
     };
-    let _: views::IpPoolSilo =
+    let _: views::IpPoolSiloLink =
         object_create(client, "/v1/system/ip-pools/orphan-pool/silos", &params)
             .await;
 

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -42,6 +42,7 @@ use nexus_types::external_api::views::IpPool;
 use nexus_types::external_api::views::IpPoolRange;
 use nexus_types::external_api::views::IpPoolSilo;
 use nexus_types::external_api::views::Silo;
+use nexus_types::external_api::views::SiloIpPool;
 use nexus_types::identity::Resource;
 use omicron_common::api::external::IdentityMetadataUpdateParams;
 use omicron_common::api::external::NameOrId;
@@ -933,12 +934,14 @@ async fn test_ip_pool_list_in_silo(cptestctx: &ControlPlaneTestContext) {
     );
     create_ip_pool(client, otherpool_name, Some(otherpool_range)).await;
 
-    let list =
-        objects_list_page_authz::<IpPool>(client, "/v1/ip-pools").await.items;
+    let list = objects_list_page_authz::<SiloIpPool>(client, "/v1/ip-pools")
+        .await
+        .items;
 
     // only mypool shows up because it's linked to my silo
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].identity.name.to_string(), mypool_name);
+    assert!(list[0].is_default);
 
     // fetch the pool directly too
     let url = format!("/v1/ip-pools/{}", mypool_name);

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -945,8 +945,9 @@ async fn test_ip_pool_list_in_silo(cptestctx: &ControlPlaneTestContext) {
 
     // fetch the pool directly too
     let url = format!("/v1/ip-pools/{}", mypool_name);
-    let pool: IpPool = object_get(client, &url).await;
+    let pool = object_get::<SiloIpPool>(client, &url).await;
     assert_eq!(pool.identity.name.as_str(), mypool_name);
+    assert!(pool.is_default);
 
     // fetching the other pool directly 404s
     let url = format!("/v1/ip-pools/{}", otherpool_name);

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -185,6 +185,7 @@ saml_identity_provider_view              GET      /v1/system/identity-providers/
 silo_create                              POST     /v1/system/silos
 silo_delete                              DELETE   /v1/system/silos/{silo}
 silo_identity_provider_list              GET      /v1/system/identity-providers
+silo_ip_pool_list                        GET      /v1/system/silos/{silo}/ip-pools
 silo_list                                GET      /v1/system/silos
 silo_policy_update                       PUT      /v1/system/silos/{silo}/policy
 silo_policy_view                         GET      /v1/system/silos/{silo}/policy

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -855,7 +855,7 @@ pub struct IpPoolSiloPath {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct IpPoolSiloLink {
+pub struct IpPoolLinkSilo {
     pub silo: NameOrId,
     /// When a pool is the default for a silo, floating IPs and instance
     /// ephemeral IPs will come from that pool when no other pool is specified.

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -315,13 +315,10 @@ pub struct SiloIpPool {
     pub is_default: bool,
 }
 
-// TODO: rename IpPoolSilo or get rid of it somehow. we cannot have both
-// IpPoolSilo and SiloIpPool. come on
-
 /// A link between an IP pool and a silo that allows one to allocate IPs from
 /// the pool within the silo
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct IpPoolSilo {
+pub struct IpPoolSiloLink {
     pub ip_pool_id: Uuid,
     pub silo_id: Uuid,
     /// When a pool is the default for a silo, floating IPs and instance

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -303,6 +303,22 @@ pub struct IpPool {
     pub identity: IdentityMetadata,
 }
 
+/// A collection of IP ranges. If a pool is linked to a silo, IP addresses from
+/// the pool can be allocated within that silo
+#[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SiloIpPool {
+    #[serde(flatten)]
+    pub identity: IdentityMetadata,
+
+    /// When a pool is the default for a silo, floating IPs and instance
+    /// ephemeral IPs will come from that pool when no other pool is specified.
+    /// There can be at most one default for a given silo.
+    pub is_default: bool,
+}
+
+// TODO: rename IpPoolSilo or get rid of it somehow. we cannot have both
+// IpPoolSilo and SiloIpPool. come on
+
 /// A link between an IP pool and a silo that allows one to allocate IPs from
 /// the pool within the silo
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -303,8 +303,7 @@ pub struct IpPool {
     pub identity: IdentityMetadata,
 }
 
-/// A collection of IP ranges. If a pool is linked to a silo, IP addresses from
-/// the pool can be allocated within that silo
+/// An IP pool in the context of a silo
 #[derive(ObjectIdentity, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SiloIpPool {
     #[serde(flatten)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6580,7 +6580,7 @@
           "system/silos"
         ],
         "summary": "Fetch a silo",
-        "description": "Fetch a silo by name.",
+        "description": "Fetch a silo by name or ID.",
         "operationId": "silo_view",
         "parameters": [
           {
@@ -6640,6 +6640,74 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
+        }
+      }
+    },
+    "/v1/system/silos/{silo}/ip-pools": {
+      "get": {
+        "tags": [
+          "system/silos"
+        ],
+        "summary": "List IP pools available within silo",
+        "operationId": "silo_ip_pool_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "silo",
+            "description": "Name or ID of the silo",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiloIpPoolResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
         }
       }
     },
@@ -13800,6 +13868,72 @@
               "local_only"
             ]
           }
+        ]
+      },
+      "SiloIpPool": {
+        "description": "A collection of IP ranges. If a pool is linked to a silo, IP addresses from the pool can be allocated within that silo",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "is_default": {
+            "description": "When a pool is the default for a silo, floating IPs and instance ephemeral IPs will come from that pool when no other pool is specified. There can be at most one default for a given silo.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "is_default",
+          "name",
+          "time_created",
+          "time_modified"
+        ]
+      },
+      "SiloIpPoolResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiloIpPool"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "SiloQuotas": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5039,7 +5039,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IpPoolSiloResultsPage"
+                  "$ref": "#/components/schemas/IpPoolSiloLinkResultsPage"
                 }
               }
             }
@@ -5076,7 +5076,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/IpPoolSiloLink"
+                "$ref": "#/components/schemas/IpPoolLinkSilo"
               }
             }
           },
@@ -5088,7 +5088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IpPoolSilo"
+                  "$ref": "#/components/schemas/IpPoolSiloLink"
                 }
               }
             }
@@ -5144,7 +5144,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IpPoolSilo"
+                  "$ref": "#/components/schemas/IpPoolSiloLink"
                 }
               }
             }
@@ -6684,7 +6684,7 @@
             "in": "query",
             "name": "sort_by",
             "schema": {
-              "$ref": "#/components/schemas/IdSortMode"
+              "$ref": "#/components/schemas/NameOrIdSortMode"
             }
           }
         ],
@@ -12565,6 +12565,22 @@
           "name"
         ]
       },
+      "IpPoolLinkSilo": {
+        "type": "object",
+        "properties": {
+          "is_default": {
+            "description": "When a pool is the default for a silo, floating IPs and instance ephemeral IPs will come from that pool when no other pool is specified. There can be at most one default for a given silo.",
+            "type": "boolean"
+          },
+          "silo": {
+            "$ref": "#/components/schemas/NameOrId"
+          }
+        },
+        "required": [
+          "is_default",
+          "silo"
+        ]
+      },
       "IpPoolRange": {
         "type": "object",
         "properties": {
@@ -12633,7 +12649,7 @@
           "items"
         ]
       },
-      "IpPoolSilo": {
+      "IpPoolSiloLink": {
         "description": "A link between an IP pool and a silo that allows one to allocate IPs from the pool within the silo",
         "type": "object",
         "properties": {
@@ -12656,23 +12672,7 @@
           "silo_id"
         ]
       },
-      "IpPoolSiloLink": {
-        "type": "object",
-        "properties": {
-          "is_default": {
-            "description": "When a pool is the default for a silo, floating IPs and instance ephemeral IPs will come from that pool when no other pool is specified. There can be at most one default for a given silo.",
-            "type": "boolean"
-          },
-          "silo": {
-            "$ref": "#/components/schemas/NameOrId"
-          }
-        },
-        "required": [
-          "is_default",
-          "silo"
-        ]
-      },
-      "IpPoolSiloResultsPage": {
+      "IpPoolSiloLinkResultsPage": {
         "description": "A single page of results",
         "type": "object",
         "properties": {
@@ -12680,7 +12680,7 @@
             "description": "list of items on this page of results",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IpPoolSilo"
+              "$ref": "#/components/schemas/IpPoolSiloLink"
             }
           },
           "next_page": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2191,7 +2191,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IpPoolResultsPage"
+                  "$ref": "#/components/schemas/SiloIpPoolResultsPage"
                 }
               }
             }
@@ -2232,7 +2232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IpPool"
+                  "$ref": "#/components/schemas/SiloIpPool"
                 }
               }
             }
@@ -13871,7 +13871,7 @@
         ]
       },
       "SiloIpPool": {
-        "description": "A collection of IP ranges. If a pool is linked to a silo, IP addresses from the pool can be allocated within that silo",
+        "description": "An IP pool in the context of a silo",
         "type": "object",
         "properties": {
           "description": {


### PR DESCRIPTION
Fixes #4752
Fixes #4763 

The main trick here is introducing `views::SiloIpPool`, which is the same as `views::IpPool` except it also has `is_default` on it. It only makes sense in the context of a particular silo because `is_default` is only defined for a (pool, silo) pair, not for a pool alone. 

- [x] Add `GET /v1/system/silos/{silo}/ip-pools`
- [x] `/v1/ip-pools` and `/v1/ip-pools/{pool}` should return `SiloIpPool` too
- [x] Tests for `/v1/system/silos/{silo}/ip-pools`
- [x] We can't have both `SiloIpPool` and `IpPoolSilo`, cleaned up by changing:
  - `views::IpPoolSilo` -> `views::SiloIpSiloLink`
  - `params::IpPoolSiloLink` -> `views::IpPoolLinkSilo`