### PR TITLE
Publish instance vCPU usage statistics to `oximeter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.0",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -490,7 +490,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.46",
+ "syn 2.0.48",
  "which",
 ]
 
@@ -986,7 +986,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1412,7 +1412,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1460,7 +1460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1514,7 +1514,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.0",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1566,7 +1566,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1599,7 +1599,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1619,7 +1619,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1706,7 +1706,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1715,7 +1715,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1958,7 +1958,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.0",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3604,7 +3604,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=dd2b7b0306d3f01fa09170b8884d402209e49244#dd2b7b0306d3f01fa09170b8884d402209e49244"
 dependencies = [
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4007,7 +4007,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4332,7 +4332,7 @@ version = "0.1.0"
 dependencies = [
  "omicron-workspace-hack",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4485,7 +4485,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5204,7 +5204,7 @@ dependencies = [
  "string_cache",
  "subtle",
  "syn 1.0.109",
- "syn 2.0.46",
+ "syn 2.0.48",
  "time",
  "time-macros",
  "tokio",
@@ -5318,7 +5318,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5601,7 +5601,7 @@ dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5741,7 +5741,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.7.5",
  "structmeta",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5887,7 +5887,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5957,7 +5957,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6201,7 +6201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6249,17 +6249,17 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "progenitor"
-version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
+version = "0.5.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2d3b9d0eb50a1907974c0b0ba7ee7893425b3e79"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -6269,8 +6269,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
+version = "0.5.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2d3b9d0eb50a1907974c0b0ba7ee7893425b3e79"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6283,8 +6283,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
+version = "0.5.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2d3b9d0eb50a1907974c0b0ba7ee7893425b3e79"
 dependencies = [
  "getopts",
  "heck 0.4.1",
@@ -6297,7 +6297,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.46",
+ "syn 2.0.48",
  "thiserror",
  "typify",
  "unicode-ident",
@@ -6305,8 +6305,8 @@ dependencies = [
 
 [[package]]
 name = "progenitor-macro"
-version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#9339b57628e1e76b1d7131ef93a6c0db2ab0a762"
+version = "0.5.0"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2d3b9d0eb50a1907974c0b0ba7ee7893425b3e79"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -6317,7 +6317,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream 0.2.0",
  "serde_yaml",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6693,7 +6693,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6940,7 +6940,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.0",
- "syn 2.0.46",
+ "syn 2.0.48",
  "unicode-ident",
 ]
 
@@ -7501,7 +7501,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7562,7 +7562,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7594,7 +7594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7635,7 +7635,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7949,7 +7949,7 @@ source = "git+https://github.com/oxidecomputer/slog-error-chain?branch=main#15f6
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8204,7 +8204,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8301,7 +8301,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8312,7 +8312,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8371,7 +8371,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8419,9 +8419,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8603,7 +8603,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8628,22 +8628,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8830,7 +8830,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -9075,7 +9075,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -9301,8 +9301,8 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "typify"
-version = "0.0.14"
-source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
+version = "0.0.15"
+source = "git+https://github.com/oxidecomputer/typify#1f97f167923f001818d461b1286f8a5242abf8b1"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -9310,8 +9310,8 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.14"
-source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
+version = "0.0.15"
+source = "git+https://github.com/oxidecomputer/typify#1f97f167923f001818d461b1286f8a5242abf8b1"
 dependencies = [
  "heck 0.4.1",
  "log",
@@ -9320,15 +9320,15 @@ dependencies = [
  "regress",
  "schemars",
  "serde_json",
- "syn 2.0.46",
+ "syn 2.0.48",
  "thiserror",
  "unicode-ident",
 ]
 
 [[package]]
 name = "typify-macro"
-version = "0.0.14"
-source = "git+https://github.com/oxidecomputer/typify#c9d6453fc3cf69726d539925b838b267f886cb53"
+version = "0.0.15"
+source = "git+https://github.com/oxidecomputer/typify#1f97f167923f001818d461b1286f8a5242abf8b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9336,7 +9336,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream 0.2.0",
- "syn 2.0.46",
+ "syn 2.0.48",
  "typify-impl",
 ]
 
@@ -9725,7 +9725,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -9759,7 +9759,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10302,7 +10302,7 @@ checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -10313,7 +10313,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -10333,7 +10333,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1e25649e8c2ac274bd04adfe0513dd14a482058c#1e25649e8c2ac274bd04adfe0513dd14a482058c"
+source = "git+https://github.com/oxidecomputer/propolis?branch=vcpu-usage-stats#8ed26acc9a7d06264ed7ac490741b0eea39f2d27"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1e25649e8c2ac274bd04adfe0513dd14a482058c#1e25649e8c2ac274bd04adfe0513dd14a482058c"
+source = "git+https://github.com/oxidecomputer/propolis?branch=vcpu-usage-stats#8ed26acc9a7d06264ed7ac490741b0eea39f2d27"
 dependencies = [
  "libc",
  "strum",
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#711a7490d81416731cfe0f9fef366ed5f266a0ee"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#29ae98d1f909c6832661408a4c03f929e8afa6e9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#711a7490d81416731cfe0f9fef366ed5f266a0ee"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#29ae98d1f909c6832661408a4c03f929e8afa6e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1e25649e8c2ac274bd04adfe0513dd14a482058c#1e25649e8c2ac274bd04adfe0513dd14a482058c"
+source = "git+https://github.com/oxidecomputer/propolis?branch=vcpu-usage-stats#8ed26acc9a7d06264ed7ac490741b0eea39f2d27"
 dependencies = [
  "async-trait",
  "base64",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1e25649e8c2ac274bd04adfe0513dd14a482058c#1e25649e8c2ac274bd04adfe0513dd14a482058c"
+source = "git+https://github.com/oxidecomputer/propolis?branch=vcpu-usage-stats#8ed26acc9a7d06264ed7ac490741b0eea39f2d27"
 dependencies = [
  "anyhow",
  "atty",
@@ -6374,7 +6374,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1e25649e8c2ac274bd04adfe0513dd14a482058c#1e25649e8c2ac274bd04adfe0513dd14a482058c"
+source = "git+https://github.com/oxidecomputer/propolis?branch=vcpu-usage-stats#8ed26acc9a7d06264ed7ac490741b0eea39f2d27"
 dependencies = [
  "schemars",
  "serde",
@@ -9591,9 +9591,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom 0.2.10",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,9 +301,15 @@ prettyplease = "0.2.16"
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
+
+# TODO(ben): Put back to main before merge.
+#bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
+#propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
+#propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "1e25649e8c2ac274bd04adfe0513dd14a482058c" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", branch = "vcpu-usage-stats" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", branch = "vcpu-usage-stats" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", branch = "vcpu-usage-stats" }
+
 proptest = "1.4.0"
 quote = "1.0"
 rand = "0.8.5"

--- a/clients/dns-service-client/src/lib.rs
+++ b/clients/dns-service-client/src/lib.rs
@@ -29,8 +29,10 @@ pub fn is_retryable(error: &DnsConfigError<crate::types::Error>) -> bool {
     let response_value = match error {
         DnsConfigError::CommunicationError(_) => return true,
         DnsConfigError::InvalidRequest(_)
-        | DnsConfigError::InvalidResponsePayload(_)
-        | DnsConfigError::UnexpectedResponse(_) => return false,
+        | DnsConfigError::InvalidResponsePayload(_, _)
+        | DnsConfigError::UnexpectedResponse(_)
+        | DnsConfigError::InvalidUpgrade(_)
+        | DnsConfigError::ResponseBodyError(_) => return false,
         DnsConfigError::ErrorResponse(response_value) => response_value,
     };
 

--- a/common/src/api/external/error.rs
+++ b/common/src/api/external/error.rs
@@ -523,6 +523,7 @@ impl<T: ClientError> From<progenitor::progenitor_client::Error<T>> for Error {
             // our version constraints (i.e. that the call was to a newer
             // service with an incompatible response).
             progenitor::progenitor_client::Error::InvalidResponsePayload(
+                _bytes,
                 ee,
             ) => Error::internal_error(&format!(
                 "InvalidResponsePayload: {}",
@@ -538,6 +539,12 @@ impl<T: ClientError> From<progenitor::progenitor_client::Error<T>> for Error {
                     "UnexpectedResponse: status code {}",
                     r.status(),
                 ))
+            }
+            progenitor::progenitor_client::Error::InvalidUpgrade(e) => {
+                Error::internal_error(&format!("InvalidUpgrade: {e}",))
+            }
+            progenitor::progenitor_client::Error::ResponseBodyError(_) => {
+                Error::internal_error(&format!("ResponseBodyError: {e}",))
             }
         }
     }

--- a/nexus/src/app/sagas/switch_port_settings_apply.rs
+++ b/nexus/src/app/sagas/switch_port_settings_apply.rs
@@ -223,7 +223,7 @@ async fn spa_undo_ensure_switch_port_settings(
     let log = sagactx.user_data().log();
 
     let port_id: PortId = PortId::from_str(&params.switch_port_name)
-        .map_err(|e| external::Error::internal_error(e))?;
+        .map_err(|e| external::Error::internal_error(e.to_string().as_str()))?;
 
     let orig_port_settings_id = sagactx
         .lookup::<Option<Uuid>>("original_switch_port_settings_id")

--- a/nexus/src/app/sagas/switch_port_settings_clear.rs
+++ b/nexus/src/app/sagas/switch_port_settings_clear.rs
@@ -179,7 +179,7 @@ async fn spa_undo_clear_switch_port_settings(
     let log = sagactx.user_data().log();
 
     let port_id: PortId = PortId::from_str(&params.port_name)
-        .map_err(|e| external::Error::internal_error(e))?;
+        .map_err(|e| external::Error::internal_error(e.to_string().as_str()))?;
 
     let orig_port_settings_id = sagactx
         .lookup::<Option<Uuid>>("original_switch_port_settings_id")

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4515,6 +4515,14 @@
               }
             ]
           },
+          "metadata": {
+            "description": "Metadata used to track instance statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMetadata"
+              }
+            ]
+          },
           "propolis_addr": {
             "description": "The address at which this VMM should serve a Propolis server API.",
             "type": "string"
@@ -4536,6 +4544,7 @@
         "required": [
           "hardware",
           "instance_runtime",
+          "metadata",
           "propolis_addr",
           "propolis_id",
           "vmm_runtime"
@@ -4622,6 +4631,24 @@
         },
         "required": [
           "snapshot_id"
+        ]
+      },
+      "InstanceMetadata": {
+        "description": "Metadata used to track statistics about an instance.",
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "project_id",
+          "silo_id"
         ]
       },
       "InstanceMigrationSourceParams": {

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -23,7 +23,6 @@ http-instruments = ["http"]
 datalink = ["dep:kstat-rs"]
 virtual-machine = ["dep:kstat-rs"]
 
-
 [dev-dependencies]
 rand.workspace = true
 slog-async.workspace = true

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -18,9 +18,11 @@ uuid.workspace = true
 omicron-workspace-hack.workspace = true
 
 [features]
-default = ["http-instruments", "kstat"]
+default = ["http-instruments", "datalink", "virtual-machine"]
 http-instruments = ["http"]
-kstat = ["kstat-rs"]
+datalink = ["dep:kstat-rs"]
+virtual-machine = ["dep:kstat-rs"]
+
 
 [dev-dependencies]
 rand.workspace = true

--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -87,8 +87,10 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+#[cfg(feature = "datalink")]
 pub mod link;
 mod sampler;
+#[cfg(feature = "virtual-machine")]
 pub mod virtual_machine;
 
 pub use sampler::CollectionDetails;

--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -89,6 +89,7 @@ use std::time::Duration;
 
 pub mod link;
 mod sampler;
+pub mod virtual_machine;
 
 pub use sampler::CollectionDetails;
 pub use sampler::ExpirationBehavior;

--- a/oximeter/instruments/src/kstat/virtual_machine.rs
+++ b/oximeter/instruments/src/kstat/virtual_machine.rs
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Types for tracking statistics about virtual machine instances.
+
+use crate::kstat::hrtime_to_utc;
+use crate::kstat::ConvertNamedData;
+use crate::kstat::Error;
+use crate::kstat::KstatList;
+use crate::kstat::KstatTarget;
+use chrono::DateTime;
+use chrono::Utc;
+use kstat_rs::Data;
+use kstat_rs::Kstat;
+use kstat_rs::Named;
+use kstat_rs::NamedData;
+use oximeter::types::Cumulative;
+use oximeter::Metric;
+use oximeter::Sample;
+use oximeter::Target;
+use uuid::Uuid;
+
+/// A single virtual machine
+#[derive(Clone, Debug, Target)]
+pub struct VirtualMachine {
+    /// The silo to which the instance belongs.
+    pub silo_id: Uuid,
+    /// The project to which the instance belongs.
+    pub project_id: Uuid,
+    /// The ID of the instance.
+    pub instance_id: Uuid,
+}
+
+/// Metric tracking vCPU usage by state.
+#[derive(Clone, Debug, Metric)]
+pub struct VcpuUsage {
+    /// The vCPU ID.
+    pub vcpu_id: u32,
+    /// The state of the vCPU.
+    pub state: String,
+    /// The cumulative time spent in this state, in nanoseconds.
+    pub datum: Cumulative<u64>,
+}
+
+// The name of the kstat module containing virtual machine kstats.
+const VMM_KSTAT_MODULE_NAME: &str = "vmm";
+
+// The name of the kstat with virtual machine metadata (VM name currently).
+const VM_KSTAT_NAME: &str = "vm";
+
+// The named kstat holding the virtual machine's name. This is currently the
+// UUID assigned by the control plane to the virtual machine instance.
+const VM_NAME_KSTAT: &str = "vm_name";
+
+// The name of kstat containing vCPU usage data.
+const VCPU_KSTAT_PREFIX: &str = "vcpu";
+
+// Prefix for all named data with a valid vCPU microstate that we track.
+const VCPU_MICROSTATE_PREFIX: &str = "time_";
+
+// The number of expected vCPU microstates we track. This isn't load-bearing,
+// and only used to help preallocate an array holding the `VcpuUsage` samples.
+const N_VCPU_MICROSTATES: usize = 6;
+
+impl KstatTarget for VirtualMachine {
+    // The VMM kstats are organized like so:
+    //
+    // - module: vmm
+    // - instance: a kernel-assigned integer
+    // - name: vm -> generic VM info, vcpuX -> info for each vCPU
+    //
+    // At this part of the code, we don't have that kstat instance, only the
+    // virtual machine instance's control plane UUID. However, the VM's "name"
+    // is assigned to be that control plane UUID in the hypervisor. See
+    // https://github.com/oxidecomputer/propolis/blob/759bf4a19990404c135e608afbe0d38b70bfa370/bin/propolis-server/src/lib/vm/mod.rs#L420
+    // for the current code which does that.
+    //
+    // So we need to indicate interest in any VMM-related kstat here, and we are
+    // forced to filter to the right instance by looking up the VM name inside
+    // the `to_samples()` method below.
+    fn interested(&self, kstat: &Kstat<'_>) -> bool {
+        kstat.ks_module == VMM_KSTAT_MODULE_NAME
+    }
+
+    fn to_samples(
+        &self,
+        kstats: KstatList<'_, '_>,
+    ) -> Result<Vec<Sample>, Error> {
+        // First, we need to map the instance's control plane UUID to the
+        // instance ID. We'll find this through the `vmm:<instance>:vm:vm_name`
+        // kstat, which lists the instance's UUID as its name.
+        let instance_id = self.instance_id.to_string();
+        let instance = kstats
+            .iter()
+            .find_map(|(_, kstat, data)| {
+                kstat_instance_from_instance_id(kstat, data, &instance_id)
+            })
+            .ok_or_else(|| Error::NoSuchKstat)?;
+
+        // Armed with the kstat instance, find all relevant metrics related to
+        // this particular VM. For now, we produce only vCPU usage metrics, but
+        // others may be chained in the future.
+        let vcpu_stats = kstats.iter().filter(|(_, kstat, _)| {
+            kstat.ks_instance == instance
+                && kstat.ks_name.starts_with(VCPU_KSTAT_PREFIX)
+        });
+        produce_vcpu_usage(self, vcpu_stats)
+    }
+}
+
+// Given a kstat and an instance's ID, return the kstat instance if it matches.
+pub fn kstat_instance_from_instance_id(
+    kstat: &Kstat<'_>,
+    data: &Data<'_>,
+    instance_id: &str,
+) -> Option<i32> {
+    if kstat.ks_module != VMM_KSTAT_MODULE_NAME {
+        return None;
+    }
+    if kstat.ks_name != VM_KSTAT_NAME {
+        return None;
+    }
+    let Data::Named(named) = data else {
+        return None;
+    };
+    if named.iter().any(|nd| {
+        if nd.name != VM_NAME_KSTAT {
+            return false;
+        }
+        let NamedData::String(name) = &nd.value else {
+            return false;
+        };
+        instance_id == *name
+    }) {
+        return Some(kstat.ks_instance);
+    }
+    None
+}
+
+// Produce `Sample`s for the `VcpuUsage` metric from the relevant kstats.
+pub fn produce_vcpu_usage<'a>(
+    vm: &'a VirtualMachine,
+    vcpu_stats: impl Iterator<Item = &'a (DateTime<Utc>, Kstat<'a>, Data<'a>)> + 'a,
+) -> Result<Vec<Sample>, Error> {
+    let mut out = Vec::with_capacity(N_VCPU_MICROSTATES);
+    for (creation_time, kstat, data) in vcpu_stats {
+        let Data::Named(named) = data else {
+            return Err(Error::ExpectedNamedKstat);
+        };
+        let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
+
+        // Find the vCPU ID, from the relevant named data item.
+        let vcpu_id = named
+            .iter()
+            .find_map(|named| {
+                if named.name == VCPU_KSTAT_PREFIX {
+                    named.value.as_u32().ok()
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| Error::NoSuchKstat)?;
+
+        // We'll track all statistics starting with `time_` as the microstate.
+        for Named { name, value } in named
+            .iter()
+            .filter(|nv| nv.name.starts_with(VCPU_MICROSTATE_PREFIX))
+        {
+            // Safety: We're filtering in the loop on this prefix, so it must
+            // exist.
+            let state =
+                name.strip_prefix(VCPU_MICROSTATE_PREFIX).unwrap().to_string();
+            let datum =
+                Cumulative::with_start_time(*creation_time, value.as_u64()?);
+            let metric = VcpuUsage { vcpu_id, state, datum };
+            let sample =
+                Sample::new_with_timestamp(snapshot_time, vm, &metric)?;
+            out.push(sample);
+        }
+    }
+    Ok(out)
+}

--- a/oximeter/instruments/src/kstat/virtual_machine.rs
+++ b/oximeter/instruments/src/kstat/virtual_machine.rs
@@ -18,13 +18,15 @@ use kstat_rs::Kstat;
 use kstat_rs::Named;
 use kstat_rs::NamedData;
 use oximeter::types::Cumulative;
+use oximeter::FieldType;
+use oximeter::FieldValue;
 use oximeter::Metric;
 use oximeter::Sample;
 use oximeter::Target;
 use uuid::Uuid;
 
-/// A single virtual machine
-#[derive(Clone, Debug, Target)]
+/// A single virtual machine instance.
+#[derive(Clone, Debug)]
 pub struct VirtualMachine {
     /// The silo to which the instance belongs.
     pub silo_id: Uuid,
@@ -32,6 +34,35 @@ pub struct VirtualMachine {
     pub project_id: Uuid,
     /// The ID of the instance.
     pub instance_id: Uuid,
+
+    // This field is not published as part of the target field definitions. It
+    // is needed because the hypervisor currently creates kstats for each vCPU,
+    // regardless of whether they're activated. There is no way to tell from
+    // userland today which vCPU kstats are "real". We include this value here,
+    // and implement `oximeter::Target` manually.
+    pub n_vcpus: u32,
+}
+
+impl Target for VirtualMachine {
+    fn name(&self) -> &'static str {
+        "virtual_machine"
+    }
+
+    fn field_names(&self) -> &'static [&'static str] {
+        &["silo_id", "project_id", "instance_id"]
+    }
+
+    fn field_types(&self) -> Vec<FieldType> {
+        vec![FieldType::Uuid, FieldType::Uuid, FieldType::Uuid]
+    }
+
+    fn field_values(&self) -> Vec<FieldValue> {
+        vec![
+            self.silo_id.into(),
+            self.project_id.into(),
+            self.instance_id.into(),
+        ]
+    }
 }
 
 /// Metric tracking vCPU usage by state.
@@ -92,6 +123,9 @@ impl KstatTarget for VirtualMachine {
         // First, we need to map the instance's control plane UUID to the
         // instance ID. We'll find this through the `vmm:<instance>:vm:vm_name`
         // kstat, which lists the instance's UUID as its name.
+        //
+        // Note that if this code is run from within a Propolis zone, there is
+        // exactly one `vmm` kstat instance in any case.
         let instance_id = self.instance_id.to_string();
         let instance = kstats
             .iter()
@@ -104,8 +138,21 @@ impl KstatTarget for VirtualMachine {
         // this particular VM. For now, we produce only vCPU usage metrics, but
         // others may be chained in the future.
         let vcpu_stats = kstats.iter().filter(|(_, kstat, _)| {
-            kstat.ks_instance == instance
-                && kstat.ks_name.starts_with(VCPU_KSTAT_PREFIX)
+            // Filter out those that don't match our kstat instance.
+            if kstat.ks_instance != instance {
+                return false;
+            }
+
+            // Filter out those which are neither a vCPU stat of any kind, nor
+            // for one of the vCPU IDs we know to be active.
+            let Some(suffix) = kstat.ks_name.strip_prefix(VCPU_KSTAT_PREFIX)
+            else {
+                return false;
+            };
+            let Ok(vcpu_id) = suffix.parse::<u32>() else {
+                return false;
+            };
+            vcpu_id < self.n_vcpus
         });
         produce_vcpu_usage(self, vcpu_stats)
     }

--- a/oximeter/instruments/src/kstat/virtual_machine.rs
+++ b/oximeter/instruments/src/kstat/virtual_machine.rs
@@ -25,6 +25,8 @@ use oximeter::Sample;
 use oximeter::Target;
 use uuid::Uuid;
 
+// TODO(ben): Add tests for changes to the kstat-based schema.
+
 /// A single virtual machine instance.
 #[derive(Clone, Debug)]
 pub struct VirtualMachine {

--- a/oximeter/instruments/src/lib.rs
+++ b/oximeter/instruments/src/lib.rs
@@ -9,5 +9,8 @@
 #[cfg(feature = "http-instruments")]
 pub mod http;
 
-#[cfg(all(feature = "kstat", target_os = "illumos"))]
+#[cfg(all(
+    any(feature = "link", feature = "virtual-machine"),
+    target_os = "illumos"
+))]
 pub mod kstat;

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
     #[error("Error running producer HTTP server: {0}")]
     Server(String),
 
-    #[error("Error registering as metric producer: {0}")]
-    RegistrationError(String),
+    #[error("Error registering as metric producer: {msg}")]
+    RegistrationError { retryable: bool, msg: String },
 
     #[error("Producer registry and config UUIDs do not match")]
     UuidMismatch,
@@ -251,11 +251,19 @@ pub async fn register(
 ) -> Result<(), Error> {
     let client =
         nexus_client::Client::new(&format!("http://{}", address), log.clone());
-    client
-        .cpapi_producers_post(&server_info.into())
-        .await
-        .map(|_| ())
-        .map_err(|msg| Error::RegistrationError(msg.to_string()))
+    client.cpapi_producers_post(&server_info.into()).await.map(|_| ()).map_err(
+        |err| {
+            let retryable = match &err {
+                nexus_client::Error::CommunicationError(..) => true,
+                nexus_client::Error::ErrorResponse(resp) => {
+                    resp.status().is_server_error()
+                }
+                _ => false,
+            };
+            let msg = err.to_string();
+            Error::RegistrationError { retryable, msg }
+        },
+    )
 }
 
 /// Handle a request to pull available metric data from a [`ProducerRegistry`].

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -410,6 +410,7 @@ async fn instance_register(
             body_args.instance_runtime,
             body_args.vmm_runtime,
             body_args.propolis_addr,
+            body_args.metadata,
         )
         .await?,
     ))

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -274,8 +274,10 @@ impl InstanceInner {
                                 ))
                             }
                             nexus_client::Error::InvalidRequest(_)
-                            | nexus_client::Error::InvalidResponsePayload(_)
-                            | nexus_client::Error::UnexpectedResponse(_) => {
+                            | nexus_client::Error::InvalidResponsePayload(..)
+                            | nexus_client::Error::UnexpectedResponse(_)
+                            | nexus_client::Error::InvalidUpgrade(_)
+                            | nexus_client::Error::ResponseBodyError(_) => {
                                 BackoffError::permanent(Error::Notification(
                                     err,
                                 ))

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -6,7 +6,6 @@
 
 use crate::instance::propolis_zone_name;
 use crate::instance::Instance;
-use crate::metrics::MetricsManager;
 use crate::nexus::NexusClientWithResolver;
 use crate::params::InstanceMetadata;
 use crate::params::ZoneBundleMetadata;
@@ -79,7 +78,6 @@ struct InstanceManagerInternal {
     port_manager: PortManager,
     storage: StorageHandle,
     zone_bundler: ZoneBundler,
-    metrics_manager: MetricsManager,
     zone_builder_factory: ZoneBuilderFactory,
 }
 
@@ -89,7 +87,6 @@ pub(crate) struct InstanceManagerServices {
     pub port_manager: PortManager,
     pub storage: StorageHandle,
     pub zone_bundler: ZoneBundler,
-    pub metrics_manager: MetricsManager,
     pub zone_builder_factory: ZoneBuilderFactory,
 }
 
@@ -100,7 +97,6 @@ pub struct InstanceManager {
 
 impl InstanceManager {
     /// Initializes a new [`InstanceManager`] object.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         log: Logger,
         nexus_client: NexusClientWithResolver,
@@ -108,7 +104,6 @@ impl InstanceManager {
         port_manager: PortManager,
         storage: StorageHandle,
         zone_bundler: ZoneBundler,
-        metrics_manager: MetricsManager,
         zone_builder_factory: ZoneBuilderFactory,
     ) -> Result<InstanceManager, Error> {
         Ok(InstanceManager {
@@ -123,7 +118,6 @@ impl InstanceManager {
                 port_manager,
                 storage,
                 zone_bundler,
-                metrics_manager,
                 zone_builder_factory,
             }),
         })
@@ -281,7 +275,6 @@ impl InstanceManager {
                     port_manager: self.inner.port_manager.clone(),
                     storage: self.inner.storage.clone(),
                     zone_bundler: self.inner.zone_bundler.clone(),
-                    metrics_manager: self.inner.metrics_manager.clone(),
                     zone_builder_factory: self
                         .inner
                         .zone_builder_factory

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -217,13 +217,14 @@ impl MetricsManager {
         &self,
         instance_id: &Uuid,
         metadata: &InstanceMetadata,
-        _n_vcpus: u32,
+        n_vcpus: u32,
         interval: Duration,
     ) -> Result<(), Error> {
         let vm = virtual_machine::VirtualMachine {
             silo_id: metadata.silo_id,
             project_id: metadata.project_id,
             instance_id: *instance_id,
+            n_vcpus,
         };
         let details = CollectionDetails::never(interval);
         let id = self

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -217,6 +217,7 @@ impl MetricsManager {
         &self,
         instance_id: &Uuid,
         metadata: &InstanceMetadata,
+        _n_vcpus: u32,
         interval: Duration,
     ) -> Result<(), Error> {
         let vm = virtual_machine::VirtualMachine {
@@ -303,6 +304,7 @@ impl MetricsManager {
         &self,
         _instance_id: &Uuid,
         _metadata: &InstanceMetadata,
+        _n_vcpus: u32,
         _interval: Duration,
     ) -> Result<(), Error> {
         Err(Error::Kstat(anyhow!(

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -88,6 +88,15 @@ pub struct InstanceMetadata {
     pub project_id: Uuid,
 }
 
+impl From<InstanceMetadata> for propolis_client::types::InstanceMetadata {
+    fn from(md: InstanceMetadata) -> propolis_client::types::InstanceMetadata {
+        propolis_client::types::InstanceMetadata {
+            silo_id: md.silo_id,
+            project_id: md.project_id,
+        }
+    }
+}
+
 /// The body of a request to ensure that a instance and VMM are known to a sled
 /// agent.
 #[derive(Serialize, Deserialize, JsonSchema)]

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -81,6 +81,13 @@ pub struct InstanceHardware {
     pub cloud_init_bytes: Option<String>,
 }
 
+/// Metadata used to track statistics about an instance.
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct InstanceMetadata {
+    pub silo_id: Uuid,
+    pub project_id: Uuid,
+}
+
 /// The body of a request to ensure that a instance and VMM are known to a sled
 /// agent.
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -102,6 +109,9 @@ pub struct InstanceEnsureBody {
 
     /// The address at which this VMM should serve a Propolis server API.
     pub propolis_addr: SocketAddr,
+
+    /// Metadata used to track instance statistics.
+    pub metadata: InstanceMetadata,
 }
 
 /// The body of a request to move a previously-ensured instance into a specific

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -95,6 +95,7 @@ async fn instance_register(
             body_args.hardware,
             body_args.instance_runtime,
             body_args.vmm_runtime,
+            body_args.metadata,
         )
         .await?,
     ))

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -237,7 +237,7 @@ impl SledAgent {
         hardware: InstanceHardware,
         instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
-        _metadata: InstanceMetadata,
+        metadata: InstanceMetadata,
     ) -> Result<SledInstanceState, Error> {
         // respond with a fake 500 level failure if asked to ensure an instance
         // with more than 16 CPUs.
@@ -287,6 +287,7 @@ impl SledAgent {
                     id: propolis_id,
                     name: hardware.properties.hostname.clone(),
                     description: "sled-agent-sim created instance".to_string(),
+                    metadata: metadata.into(),
                     image_id: Uuid::default(),
                     bootrom_id: Uuid::default(),
                     memory: hardware.properties.memory.to_whole_mebibytes(),

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -12,9 +12,10 @@ use super::storage::CrucibleData;
 use super::storage::Storage;
 use crate::nexus::NexusClient;
 use crate::params::{
-    DiskStateRequested, InstanceHardware, InstanceMigrationSourceParams,
-    InstancePutStateResponse, InstanceStateRequested,
-    InstanceUnregisterResponse, Inventory, OmicronZonesConfig, SledRole,
+    DiskStateRequested, InstanceHardware, InstanceMetadata,
+    InstanceMigrationSourceParams, InstancePutStateResponse,
+    InstanceStateRequested, InstanceUnregisterResponse, Inventory,
+    OmicronZonesConfig, SledRole,
 };
 use crate::sim::simulatable::Simulatable;
 use crate::updates::UpdateManager;
@@ -236,6 +237,7 @@ impl SledAgent {
         hardware: InstanceHardware,
         instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
+        _metadata: InstanceMetadata,
     ) -> Result<SledInstanceState, Error> {
         // respond with a fake 500 level failure if asked to ensure an instance
         // with more than 16 CPUs.

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -16,10 +16,11 @@ use crate::long_running_tasks::LongRunningTaskHandles;
 use crate::metrics::MetricsManager;
 use crate::nexus::{ConvertInto, NexusClientWithResolver, NexusRequestQueue};
 use crate::params::{
-    DiskStateRequested, InstanceHardware, InstanceMigrationSourceParams,
-    InstancePutStateResponse, InstanceStateRequested,
-    InstanceUnregisterResponse, Inventory, OmicronZonesConfig, SledRole,
-    TimeSync, VpcFirewallRule, ZoneBundleMetadata, Zpool,
+    DiskStateRequested, InstanceHardware, InstanceMetadata,
+    InstanceMigrationSourceParams, InstancePutStateResponse,
+    InstanceStateRequested, InstanceUnregisterResponse, Inventory,
+    OmicronZonesConfig, SledRole, TimeSync, VpcFirewallRule,
+    ZoneBundleMetadata, Zpool,
 };
 use crate::services::{self, ServiceManager};
 use crate::storage_monitor::UnderlayAccess;
@@ -393,6 +394,55 @@ impl SledAgent {
         let underlay_nics = underlay::find_nics(&config.data_links)?;
         illumos_utils::opte::initialize_xde_driver(&log, &underlay_nics)?;
 
+        // Start collecting metric data.
+        //
+        // First, we're creating a shareable type for managing the metrics
+        // themselves early on, so that we can pass it to other components of
+        // the sled agent that need it.
+        //
+        // Then we'll start tracking physical links and register as a producer
+        // with Nexus in the background.
+        let metrics_manager = MetricsManager::new(
+            request.body.id,
+            request.body.rack_id,
+            long_running_task_handles.hardware_manager.baseboard(),
+            log.new(o!("component" => "MetricsManager")),
+        )?;
+
+        // Start tracking the underlay physical links.
+        for nic in underlay::find_nics(&config.data_links)? {
+            let link_name = nic.interface();
+            if let Err(e) = metrics_manager
+                .track_physical_link(
+                    link_name,
+                    crate::metrics::LINK_SAMPLE_INTERVAL,
+                )
+                .await
+            {
+                error!(
+                    log,
+                    "failed to start tracking physical link metrics";
+                    "link_name" => link_name,
+                    "error" => ?e,
+                );
+            }
+        }
+
+        // Spawn a task in the background to register our metric producer with
+        // Nexus. This should not block progress here.
+        let endpoint = ProducerEndpoint {
+            id: request.body.id,
+            kind: ProducerKind::SledAgent,
+            address: sled_address.into(),
+            base_route: String::from("/metrics/collect"),
+            interval: crate::metrics::METRIC_COLLECTION_INTERVAL,
+        };
+        tokio::task::spawn(register_metric_producer_with_nexus(
+            log.clone(),
+            nexus_client.clone(),
+            endpoint,
+        ));
+
         // Create the PortManager to manage all the OPTE ports on the sled.
         let port_manager = PortManager::new(
             parent_log.new(o!("component" => "PortManager")),
@@ -416,6 +466,7 @@ impl SledAgent {
             port_manager.clone(),
             storage_manager.clone(),
             long_running_task_handles.zone_bundler.clone(),
+            metrics_manager.clone(),
             ZoneBuilderFactory::default(),
         )?;
 
@@ -512,47 +563,6 @@ impl SledAgent {
             request.body.rack_id,
             rack_network_config.clone(),
         )?;
-
-        let mut metrics_manager = MetricsManager::new(
-            request.body.id,
-            request.body.rack_id,
-            long_running_task_handles.hardware_manager.baseboard(),
-            log.new(o!("component" => "MetricsManager")),
-        )?;
-
-        // Start tracking the underlay physical links.
-        for nic in underlay::find_nics(&config.data_links)? {
-            let link_name = nic.interface();
-            if let Err(e) = metrics_manager
-                .track_physical_link(
-                    link_name,
-                    crate::metrics::LINK_SAMPLE_INTERVAL,
-                )
-                .await
-            {
-                error!(
-                    log,
-                    "failed to start tracking physical link metrics";
-                    "link_name" => link_name,
-                    "error" => ?e,
-                );
-            }
-        }
-
-        // Spawn a task in the background to register our metric producer with
-        // Nexus. This should not block progress here.
-        let endpoint = ProducerEndpoint {
-            id: request.body.id,
-            kind: ProducerKind::SledAgent,
-            address: sled_address.into(),
-            base_route: String::from("/metrics/collect"),
-            interval: crate::metrics::METRIC_COLLECTION_INTERVAL,
-        };
-        tokio::task::spawn(register_metric_producer_with_nexus(
-            log.clone(),
-            nexus_client.clone(),
-            endpoint,
-        ));
 
         let sled_agent = SledAgent {
             inner: Arc::new(SledAgentInner {
@@ -909,6 +919,7 @@ impl SledAgent {
     /// Idempotently ensures that a given instance is registered with this sled,
     /// i.e., that it can be addressed by future calls to
     /// [`Self::instance_ensure_state`].
+    #[allow(clippy::too_many_arguments)]
     pub async fn instance_ensure_registered(
         &self,
         instance_id: Uuid,
@@ -917,6 +928,7 @@ impl SledAgent {
         instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
         propolis_addr: SocketAddr,
+        metadata: InstanceMetadata,
     ) -> Result<SledInstanceState, Error> {
         self.inner
             .instances
@@ -927,6 +939,7 @@ impl SledAgent {
                 instance_runtime,
                 vmm_runtime,
                 propolis_addr,
+                metadata,
             )
             .await
             .map_err(|e| Error::Instance(e))

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -466,7 +466,6 @@ impl SledAgent {
             port_manager.clone(),
             storage_manager.clone(),
             long_running_task_handles.zone_bundler.clone(),
-            metrics_manager.clone(),
             ZoneBuilderFactory::default(),
         )?;
 

--- a/wicketd/src/preflight_check/uplink.rs
+++ b/wicketd/src/preflight_check/uplink.rs
@@ -161,8 +161,11 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
             |_cx| async {
                 // Check that the port name is valid and that it has no links
                 // configured already.
-                let port_id = PortId::from_str(&uplink.port)
-                    .map_err(UplinkPreflightTerminalError::InvalidPortName)?;
+                let port_id = PortId::from_str(&uplink.port).map_err(|_| {
+                    UplinkPreflightTerminalError::InvalidPortName(
+                        uplink.port.clone(),
+                    )
+                })?;
                 let links = dpd_client
                     .link_list(&port_id)
                     .await
@@ -892,7 +895,7 @@ type DpdError = dpd_client::Error<dpd_client::types::Error>;
 #[derive(Debug, Error)]
 pub(crate) enum UplinkPreflightTerminalError {
     #[error("invalid port name: {0}")]
-    InvalidPortName(&'static str),
+    InvalidPortName(String),
     #[error("failed to connect to dpd to check for current configuration")]
     GetCurrentConfig(#[source] DpdError),
     #[error("uplink already configured - is rack already initialized?")]

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -78,7 +78,7 @@ petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.1.0" }
-proc-macro2 = { version = "1.0.74" }
+proc-macro2 = { version = "1.0.78" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.10.2" }
@@ -98,7 +98,7 @@ spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extra-traits", "fold", "full", "visit"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.46", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.48", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.27", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1.35.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
@@ -182,7 +182,7 @@ petgraph = { version = "0.6.4", features = ["serde-1"] }
 postgres-types = { version = "0.2.6", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 ppv-lite86 = { version = "0.2.17", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.1.0" }
-proc-macro2 = { version = "1.0.74" }
+proc-macro2 = { version = "1.0.78" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.10.2" }
@@ -202,7 +202,7 @@ spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extra-traits", "fold", "full", "visit"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.46", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.48", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.27", features = ["formatting", "local-offset", "macros", "parsing"] }
 time-macros = { version = "0.2.13", default-features = false, features = ["formatting", "parsing"] }
 tokio = { version = "1.35.1", features = ["full", "test-util"] }


### PR DESCRIPTION
- Adds the silo and project IDs to the instance-ensure request from Nexus to the sled-agent. These are used as fields on the instance-related statistics.
- Defines a `VirtualMachine` oximeter target and `VcpuUsage` metric. The latter has a `state` field which corresponds to the named kstats published by the hypervisor that accumulate the time spent in a number of vCPU microstates. The combination of these should allow us to aggregate or break down vCPU usage by silo, project, instance, vCPU ID, and CPU state.
- Adds APIs to the `MetricsManager` for starting / stopping tracking instance-related metrics, and plumbs the type through the `InstanceManager` and `Instance` (and their internal friends), so that new instances can control when data is produced from them. Currently, we'll start producing as soon as we get a non-terminate response from Propolis in the `instance_state_monitor()` task, and stop when the instance is terminated.