### PR TITLE
Concurrent disk creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7838,6 +7838,7 @@ dependencies = [
  "camino-tempfile",
  "cfg-if",
  "derive_more",
+ "futures",
  "glob",
  "illumos-utils",
  "key-manager",

--- a/sled-storage/Cargo.toml
+++ b/sled-storage/Cargo.toml
@@ -8,6 +8,7 @@ async-trait.workspace = true
 camino.workspace = true
 cfg-if.workspace = true
 derive_more.workspace = true
+futures.workspace = true
 glob.workspace = true
 illumos-utils.workspace = true
 key-manager.workspace = true

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -391,7 +391,7 @@ impl StorageManager {
     // and wait for the next retry window to re-call this method. If we hit a
     // permanent error we log it, but we continue inserting queued disks.
     //
-    // Return true if updates should be sent to watchers, false otherwise
+    // Return true if updates should be sent to watchers, false otherwise.
     async fn add_queued_disks(&mut self) -> bool {
         info!(
             self.log,
@@ -582,7 +582,7 @@ impl StorageManager {
         for raw_disk in raw_disks {
             let disk_id = raw_disk.identity().clone();
             match raw_disk.variant() {
-                DiskVariant::M2 => match self.add_disk(raw_disk).await {
+                DiskVariant::M2 => match self.add_m2_disk(raw_disk).await {
                     Ok(AddDiskResult::DiskInserted) => should_update = true,
                     Ok(_) => (),
                     Err(err) => {
@@ -600,7 +600,7 @@ impl StorageManager {
         }
 
         // Add the newly queued U.2 drives unless we are not ready. If we are
-        // not ready, the storage manager will try again later.
+        // not ready the storage manager will try again later.
         if self.state == StorageManagerState::Normal {
             should_update = should_update | self.add_queued_disks().await;
         }

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -440,7 +440,13 @@ impl StorageManager {
                     Ok(AddDiskResult::DiskAlreadyInserted) => {
                         self.queued_u2_drives.remove(&raw_disk);
                     }
-                    Ok(AddDiskResult::DiskQueued) => (),
+                    Ok(AddDiskResult::DiskQueued) => {
+                        error!(
+                            self.log,
+                            "Disks cannot be queued by `StorageResources::insert`";
+                            "disk_id" => ?raw_disk.identity()
+                        );
+                    }
                 },
                 Err(err @ DiskError::Dataset(DatasetError::KeyManager(_))) => {
                     warn!(

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -823,7 +823,7 @@ mod tests {
             manager.run().await;
         });
 
-        // Queue up a disks, as we haven't told the `StorageManager` that
+        // Queue up a disk, as we haven't told the `StorageManager` that
         // the `KeyManager` is ready yet.
         let zpool_name = ZpoolName::new_external(Uuid::new_v4());
         let dir = tempdir().unwrap();
@@ -861,7 +861,7 @@ mod tests {
         // Spawn the key_manager so that it will respond to requests for encryption keys
         tokio::spawn(async move { key_manager.run().await });
 
-        // Queue up a disks, as we haven't told the `StorageManager` that
+        // Queue up a disk, as we haven't told the `StorageManager` that
         // the `KeyManager` is ready yet.
         let zpool_name = ZpoolName::new_external(Uuid::new_v4());
         let dir = tempdir().unwrap();


### PR DESCRIPTION
Make any sequential for loops for U.2 disk additions concurrent inside the storage manager. Now that we have some data migration going on during disk creation, we don't want to wait for each of the 10 disks in a sled to make progress before moving on. 

I believe the existing tests cover these changes well, as the external behavior of queuing and adding should not have changed.