### PR TITLE
[sled-agent] Include error when panicking on start

### DIFF
--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -604,7 +604,7 @@ impl Inner {
                         // This error is unrecoverable, and if returned we'd
                         // end up in maintenance mode anyway.
                         error!(log, "Failed to start sled agent: {err:#}");
-                        panic!("Failed to start sled agent");
+                        panic!("Failed to start sled agent: {err:#}");
                     }
                 };
                 _ = response_tx.send(response);


### PR DESCRIPTION
We build with `panic=abort`, so even though we `error!` log this error immediately prior to panicking, it's very likely the log won't be flushed by the time we abort. Include the error in the panic message itself so we don't have to fish it out of core files.