### PR TITLE
Add gimlet-f to TUF repo

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -71,7 +71,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-ALL_BOARDS=(gimlet-{c..e} psc-{b..c} sidecar-{b..c})
+ALL_BOARDS=(gimlet-{c..f} psc-{b..c} sidecar-{b..c})
 
 TOP=$PWD
 VERSION=$(< /input/package/work/version.txt)

--- a/tools/hubris_checksums
+++ b/tools/hubris_checksums
@@ -1,6 +1,7 @@
 e1b3dc5c7da643b27c0dd5bf8e915d13661446e711bfdeb1d8274eed63fa5843  build-gimlet-c-image-default-v1.0.6.zip
 3002444307047429531ef862435a034c64b89a698921bf19794ac97b777a2f95  build-gimlet-d-image-default-v1.0.6.zip
 9e783bc92fb1c8a91f4b117241ed4c0ff2818f32f46c5193cdcdbbe02d56af9a  build-gimlet-e-image-default-v1.0.6.zip
+458c4f02310fe79f27841ce87b2a7c163494f0196890e6420fac17dc4803b51c  build-gimlet-f-image-default-v1.0.6.zip
 dece7d39f7fcd2f15dc62d91e94046b1f438a3e0fd2c804efd5f67e12ce0dd58  build-psc-b-image-default-v1.0.6.zip
 7e94035b52f1dcb137b477750bf9e215d4fcd07fe95b2cfdbbc0d7fada79eb28  build-psc-c-image-default-v1.0.6.zip
 ccf09dc7c9c2a946b89bcfafb391100504880fa395c9079dfb7a3b28635a4abb  build-sidecar-b-image-default-v1.0.6.zip


### PR DESCRIPTION
As of https://github.com/oxidecomputer/hubris/commit/1fcb6ce375a6b10e4f0ba40745da688748deff39 Hubris now has Gimlet F images.