### PR TITLE
[nexus] simplify BackgroundTask trait

### DIFF
--- a/nexus/src/app/background/common.rs
+++ b/nexus/src/app/background/common.rs
@@ -153,13 +153,10 @@ use tokio::time::MissedTickBehavior;
 ///
 /// See module-level documentation for details.
 pub trait BackgroundTask: Send + Sync {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c;
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value>;
 }
 
 /// Drives the execution of background tasks
@@ -499,14 +496,10 @@ mod test {
     }
 
     impl BackgroundTask for ReportingTask {
-        fn activate<'a, 'b, 'c>(
+        fn activate<'a>(
             &'a mut self,
-            _: &'b OpContext,
-        ) -> BoxFuture<'c, serde_json::Value>
-        where
-            'a: 'c,
-            'b: 'c,
-        {
+            _: &'a OpContext,
+        ) -> BoxFuture<'a, serde_json::Value> {
             async {
                 let count = self.counter;
                 self.counter += 1;
@@ -684,14 +677,10 @@ mod test {
     }
 
     impl BackgroundTask for PausingTask {
-        fn activate<'a, 'b, 'c>(
+        fn activate<'a>(
             &'a mut self,
-            _: &'b OpContext,
-        ) -> BoxFuture<'c, serde_json::Value>
-        where
-            'a: 'c,
-            'b: 'c,
-        {
+            _: &'a OpContext,
+        ) -> BoxFuture<'a, serde_json::Value> {
             async {
                 let count = self.counter;
                 self.counter += 1;

--- a/nexus/src/app/background/dns_config.rs
+++ b/nexus/src/app/background/dns_config.rs
@@ -43,14 +43,10 @@ impl DnsConfigWatcher {
 }
 
 impl BackgroundTask for DnsConfigWatcher {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             // Set up a logger for this activation that includes metadata about
             // the current generation.

--- a/nexus/src/app/background/dns_propagation.rs
+++ b/nexus/src/app/background/dns_propagation.rs
@@ -36,14 +36,10 @@ impl DnsPropagator {
 }
 
 impl BackgroundTask for DnsPropagator {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             // Read the DNS configuration and server list from the other
             // background tasks that assemble these.  Clone them because

--- a/nexus/src/app/background/dns_servers.rs
+++ b/nexus/src/app/background/dns_servers.rs
@@ -57,14 +57,10 @@ impl DnsServersWatcher {
 }
 
 impl BackgroundTask for DnsServersWatcher {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             // Set up a logger for this activation that includes metadata about
             // the current generation.

--- a/nexus/src/app/background/external_endpoints.rs
+++ b/nexus/src/app/background/external_endpoints.rs
@@ -42,14 +42,10 @@ impl ExternalEndpointsWatcher {
 }
 
 impl BackgroundTask for ExternalEndpointsWatcher {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             let log = &opctx.log;
 

--- a/nexus/src/app/background/inventory_collection.rs
+++ b/nexus/src/app/background/inventory_collection.rs
@@ -51,14 +51,10 @@ impl InventoryCollector {
 }
 
 impl BackgroundTask for InventoryCollector {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             match inventory_activate(
                 opctx,

--- a/nexus/src/app/background/nat_cleanup.rs
+++ b/nexus/src/app/background/nat_cleanup.rs
@@ -32,14 +32,10 @@ impl Ipv4NatGarbageCollector {
 }
 
 impl BackgroundTask for Ipv4NatGarbageCollector {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             let log = &opctx.log;
 

--- a/nexus/src/app/background/phantom_disks.rs
+++ b/nexus/src/app/background/phantom_disks.rs
@@ -37,14 +37,10 @@ impl PhantomDiskDetector {
 }
 
 impl BackgroundTask for PhantomDiskDetector {
-    fn activate<'a, 'b, 'c>(
+    fn activate<'a>(
         &'a mut self,
-        opctx: &'b OpContext,
-    ) -> BoxFuture<'c, serde_json::Value>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
         async {
             let log = &opctx.log;
             warn!(&log, "phantom disk task started");


### PR DESCRIPTION
Just using `'a` everywhere is semantically identical to the current pattern
because all the lifetime parameters are covariant.
