### PR TITLE
Better error message when there's no default IP pool

### DIFF
--- a/nexus/db-queries/src/authz/policy_test/resource_builder.rs
+++ b/nexus/db-queries/src/authz/policy_test/resource_builder.rs
@@ -92,7 +92,7 @@ impl<'a> ResourceBuilder<'a> {
                 // (e.g., "fleet").
                 resource.resource_type().to_string().to_lowercase()
             }
-            LookupType::BySessionToken(_) | LookupType::ByCompositeId(_) => {
+            LookupType::ByCompositeId(_) | LookupType::ByOther(_) => {
                 panic!("test resources must be given names");
             }
         };
@@ -212,7 +212,7 @@ where
             LookupType::ByName(name) => format!("{:?}", name),
             LookupType::ById(id) => format!("id {:?}", id.to_string()),
             LookupType::ByCompositeId(id) => format!("id {:?}", id),
-            LookupType::BySessionToken(_) => {
+            LookupType::ByOther(_) => {
                 unimplemented!()
             }
         };

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -134,12 +134,8 @@ impl DataStore {
         //     .authorize(authz::Action::ListChildren, &authz::IP_POOL_LIST)
         //     .await?;
 
-        // join ip_pool to ip_pool_resource and filter
-
-        // used in both success and error outcomes
-        let lookup_type = LookupType::ByCompositeId(
-            "Default pool for current silo".to_string(),
-        );
+        let lookup_type =
+            LookupType::ByOther("default IP pool for current silo".to_string());
 
         ip_pool::table
             .inner_join(ip_pool_resource::table)
@@ -161,9 +157,6 @@ impl DataStore {
             )
             .await
             .map_err(|e| {
-                // janky to do this manually, but this is an unusual kind of
-                // lookup in that it is by (silo_id, is_default=true), which is
-                // arguably a composite ID.
                 public_error_from_diesel_lookup(
                     e,
                     ResourceType::IpPool,

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -3838,8 +3838,7 @@ async fn test_instance_ephemeral_ip_no_default_pool_error(
     let url = format!("/v1/instances?project={}", PROJECT_NAME);
     let error =
         object_create_error(client, &url, &body, StatusCode::NOT_FOUND).await;
-    let msg = "not found: ip-pool with id \"Default pool for current silo\""
-        .to_string();
+    let msg = "not found: default IP pool for current silo".to_string();
     assert_eq!(error.message, msg);
 
     // same deal if you specify a pool that doesn't exist


### PR DESCRIPTION
Closes #4864 

This is a bad error message to get when the problem is that there is no default IP pool configured for your current silo:

```
not found: ip-pool with id "Default pool for current silo"
```

"Default pool for current silo" is not an id, so why would we call it one? This is better:

```
not found: default IP pool for current silo
```

This PR is just making that possible.