### PR TITLE
Update to USDT 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "getrandom 0.2.10",
  "once_cell",
  "version_check",
- "zerocopy 0.7.31",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -1691,12 +1691,12 @@ dependencies = [
 
 [[package]]
 name = "diesel-dtrace"
-version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#c1252df734b52b4e1243e0ca2bd5f00b17730408"
+version = "0.3.0"
+source = "git+https://github.com/oxidecomputer/diesel-dtrace?branch=main#62ef5ca0fe243a0929791bb9efbb7ed9c32c5368"
 dependencies = [
  "diesel",
  "serde",
- "usdt",
+ "usdt 0.5.0",
  "uuid",
  "version_check",
 ]
@@ -1876,6 +1876,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dof"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558e5396321b677a59d2c43b3cc3bc44683109c63ac49275f3bbbf41c0ecd002"
+dependencies = [
+ "goblin",
+ "pretty-hex 0.4.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "zerocopy 0.7.32",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,7 +1961,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "toml 0.8.8",
- "usdt",
+ "usdt 0.3.5",
  "uuid",
  "version_check",
  "waitgroup",
@@ -1970,6 +1984,17 @@ name = "dtrace-parser"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed110893a7f9f4ceb072e166354a09f6cb4cc416eec5b5e5e8ee367442d434b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "thiserror",
+]
+
+[[package]]
+name = "dtrace-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71734e3eb68cd4df338d04dffdcc024f89eb0b238150cc95b826fbfad756452b"
 dependencies = [
  "pest",
  "pest_derive",
@@ -2571,7 +2596,7 @@ dependencies = [
  "thiserror",
  "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc.git?branch=main)",
  "tokio",
- "usdt",
+ "usdt 0.3.5",
  "uuid",
  "version_check",
  "zip",
@@ -2670,6 +2695,17 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -3970,6 +4006,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,7 +4328,7 @@ dependencies = [
  "term",
  "thiserror",
  "tokio",
- "usdt",
+ "usdt 0.5.0",
  "uuid",
 ]
 
@@ -4832,7 +4878,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-tokio",
  "slog",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "slog-error-chain",
  "sp-sim",
  "subprocess",
@@ -4941,7 +4987,7 @@ dependencies = [
  "sled-agent-client",
  "slog",
  "slog-async",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "slog-error-chain",
  "slog-term",
  "sp-sim",
@@ -5135,7 +5181,7 @@ dependencies = [
  "sled-storage",
  "slog",
  "slog-async",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "slog-term",
  "smf",
  "static_assertions",
@@ -5148,7 +5194,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml 0.8.8",
- "usdt",
+ "usdt 0.5.0",
  "uuid",
  "zeroize",
  "zone",
@@ -5184,7 +5230,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "usdt",
+ "usdt 0.5.0",
  "walkdir",
 ]
 
@@ -5218,6 +5264,7 @@ dependencies = [
  "der",
  "diesel",
  "digest",
+ "dof 0.3.0",
  "either",
  "elliptic-curve",
  "errno",
@@ -5298,10 +5345,11 @@ dependencies = [
  "trust-dns-proto",
  "unicode-bidi",
  "unicode-normalization",
- "usdt",
+ "usdt 0.3.5",
+ "usdt-impl 0.5.0",
  "uuid",
  "yasna",
- "zerocopy 0.7.31",
+ "zerocopy 0.7.32",
  "zeroize",
  "zip",
 ]
@@ -5531,7 +5579,7 @@ dependencies = [
  "poptrie",
  "serde",
  "smoltcp 0.11.0",
- "zerocopy 0.7.31",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -5601,7 +5649,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "slog-term",
  "strum",
  "subprocess",
@@ -5641,7 +5689,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "slog-term",
  "sqlformat",
  "sqlparser",
@@ -5650,7 +5698,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "usdt",
+ "usdt 0.5.0",
  "uuid",
 ]
 
@@ -5700,7 +5748,7 @@ dependencies = [
  "schemars",
  "serde",
  "slog",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "thiserror",
  "tokio",
  "uuid",
@@ -5952,19 +6000,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.2"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5972,9 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.2"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5985,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.2"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
 dependencies = [
  "once_cell",
  "pest",
@@ -6091,6 +6140,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platforms"
@@ -6461,7 +6516,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-bunyan",
- "slog-dtrace",
+ "slog-dtrace 0.2.3",
  "slog-term",
  "thiserror",
  "tokio",
@@ -7467,6 +7522,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8014,7 +8089,21 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "usdt",
+ "usdt 0.3.5",
+ "version_check",
+]
+
+[[package]]
+name = "slog-dtrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c4003e4582bc29415fcbf94f53346c9c379d5dafac45d4bafaa39c7f0453ac"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "slog",
+ "usdt 0.5.0",
  "version_check",
 ]
 
@@ -8216,7 +8305,7 @@ dependencies = [
  "omicron-workspace-hack",
  "serde",
  "slog",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "sprockets-rot",
  "thiserror",
  "tokio",
@@ -9649,11 +9738,27 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b4c48f9e522b977bbe938a0d7c4d36633d267ba0155aaa253fb57d0531be0fb"
 dependencies = [
- "dtrace-parser",
+ "dtrace-parser 0.1.14",
  "serde",
- "usdt-attr-macro",
- "usdt-impl",
- "usdt-macro",
+ "usdt-attr-macro 0.3.5",
+ "usdt-impl 0.3.5",
+ "usdt-macro 0.3.5",
+]
+
+[[package]]
+name = "usdt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5c47fb471a0bff3d7b17a250817bba8c6cc99b0492abaefe5b3bb99045f02"
+dependencies = [
+ "dof 0.3.0",
+ "dtrace-parser 0.2.0",
+ "goblin",
+ "memmap",
+ "serde",
+ "usdt-attr-macro 0.5.0",
+ "usdt-impl 0.5.0",
+ "usdt-macro 0.5.0",
 ]
 
 [[package]]
@@ -9662,12 +9767,26 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e6ae4f982ae74dcbaa8eb17baf36ca0d464a3abc8a7172b3bd74c73e9505d6"
 dependencies = [
- "dtrace-parser",
+ "dtrace-parser 0.1.14",
  "proc-macro2",
  "quote",
  "serde_tokenstream 0.1.7",
  "syn 1.0.109",
- "usdt-impl",
+ "usdt-impl 0.3.5",
+]
+
+[[package]]
+name = "usdt-attr-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025161fff40db24774e7757f75df74ecc47e93d7e11e0f6cdfc31b40eacfe136"
+dependencies = [
+ "dtrace-parser 0.2.0",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream 0.2.0",
+ "syn 2.0.48",
+ "usdt-impl 0.5.0",
 ]
 
 [[package]]
@@ -9677,8 +9796,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f53b4ca0b33aae466dc47b30b98adc4f88454928837af8010b6ed02d18474cb1"
 dependencies = [
  "byteorder",
- "dof",
- "dtrace-parser",
+ "dof 0.1.5",
+ "dtrace-parser 0.1.14",
  "libc",
  "proc-macro2",
  "quote",
@@ -9691,17 +9810,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "usdt-impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f925814e5942ebb87af2d9fcf4c3f8665e37903f741eb11f0fa2396c6ef5f7b1"
+dependencies = [
+ "byteorder",
+ "dof 0.3.0",
+ "dtrace-parser 0.2.0",
+ "libc",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.48",
+ "thiserror",
+ "thread-id",
+ "version_check",
+]
+
+[[package]]
 name = "usdt-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb093f9653dc91632621c754f9ed4ee25d14e46e0239b6ccaf74a6c0c2788bd"
 dependencies = [
- "dtrace-parser",
+ "dtrace-parser 0.1.14",
  "proc-macro2",
  "quote",
  "serde_tokenstream 0.1.7",
  "syn 1.0.109",
- "usdt-impl",
+ "usdt-impl 0.3.5",
+]
+
+[[package]]
+name = "usdt-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ddd86f8f3abac0b7c87f59fe82446fc96a3854a413f176dd2797ed686b7af4c"
+dependencies = [
+ "dtrace-parser 0.2.0",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream 0.2.0",
+ "syn 2.0.48",
+ "usdt-impl 0.5.0",
 ]
 
 [[package]]
@@ -10085,7 +10238,7 @@ dependencies = [
  "sha2",
  "sled-hardware",
  "slog",
- "slog-dtrace",
+ "slog-dtrace 0.3.0",
  "snafu",
  "subprocess",
  "tar",
@@ -10402,12 +10555,12 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.31",
+ "zerocopy-derive 0.7.32",
 ]
 
 [[package]]
@@ -10434,9 +10587,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ sled-hardware = { path = "sled-hardware" }
 sled-storage = { path = "sled-storage" }
 slog = { version = "2.7", features = [ "dynamic-keys", "max_level_trace", "release_max_level_debug" ] }
 slog-async = "2.8"
-slog-dtrace = "0.2"
+slog-dtrace = "0.3"
 slog-envlogger = "2.2"
 slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain", branch = "main", features = ["derive"] }
 slog-term = "2.9"
@@ -400,7 +400,7 @@ tui-tree-widget = "0.16.0"
 unicode-width = "0.1.11"
 update-common = { path = "update-common" }
 update-engine = { path = "update-engine" }
-usdt = "0.3"
+usdt = "0.5.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 walkdir = "2.4"
 wicket = { path = "wicket" }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -331,9 +331,8 @@ pub async fn start_server(
             .map_err(|message| format!("initializing logger: {}", message))?,
     );
     let log = slog::Logger::root(drain.fuse(), slog::o!(FileKv));
-    if let slog_dtrace::ProbeRegistration::Failed(e) = registration {
-        let err = InlineErrorChain::new(&e);
-        error!(log, "failed to register DTrace probes"; &err);
+    if let slog_dtrace::ProbeRegistration::Failed(err) = registration {
+        error!(log, "failed to register DTrace probes"; "err" => &err);
         return Err(format!("failed to register DTrace probes: {err}"));
     } else {
         debug!(log, "registered DTrace probes");

--- a/nexus/db-queries/src/lib.rs
+++ b/nexus/db-queries/src/lib.rs
@@ -19,7 +19,7 @@ extern crate newtype_derive;
 #[macro_use]
 extern crate diesel;
 
-#[usdt::provider(provider = "nexus__db__queries")]
+#[usdt::provider(provider = "nexus_db_queries")]
 mod probes {
     // Fires before we start a search over a range for a VNI.
     //

--- a/oximeter/db/src/client.rs
+++ b/oximeter/db/src/client.rs
@@ -50,7 +50,7 @@ use tokio::fs;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-#[usdt::provider(provider = "clickhouse__client")]
+#[usdt::provider(provider = "clickhouse_client")]
 mod probes {
     fn query__start(_: &usdt::UniqueId, sql: &str) {}
     fn query__done(_: &usdt::UniqueId) {}

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -61,8 +61,8 @@ pub enum StartError {
     #[error("Failed to initialize logger")]
     InitLogger(#[source] io::Error),
 
-    #[error("Failed to register DTrace probes")]
-    RegisterDTraceProbes(#[source] usdt::Error),
+    #[error("Failed to register DTrace probes: {0}")]
+    RegisterDTraceProbes(String),
 
     #[error("Failed to find address objects for maghemite")]
     FindMaghemiteAddrObjs(#[source] underlay::Error),

--- a/tools/dtrace/aggregate-query-latency.d
+++ b/tools/dtrace/aggregate-query-latency.d
@@ -7,14 +7,14 @@ dtrace:::BEGIN
     printf("Tracing database query latency by connection ID for nexus PID %d, use Ctrl-C to exit\n", $target);
 }
 
-diesel-db$target:::query-start
+diesel_db$target:::query-start
 {
     @total_queries = count();
     this->conn_id = json(copyinstr(arg1), "ok");
     self->ts[this->conn_id] = timestamp;
 }
 
-diesel-db$target:::query-done
+diesel_db$target:::query-done
 /self->ts[json(copyinstr(arg1), "ok")] != 0/
 {
     this->conn_id = json(copyinstr(arg1), "ok");

--- a/tools/dtrace/slowest-queries.d
+++ b/tools/dtrace/slowest-queries.d
@@ -9,7 +9,7 @@ dtrace:::BEGIN
     printf("Tracing slowest queries for nexus PID %d, use Ctrl-C to exit\n", $target);
 }
 
-diesel-db$target:::query-start
+diesel_db$target:::query-start
 {
     this->conn_id = json(copyinstr(arg1), "ok");
     ts[this->conn_id] = timestamp;
@@ -17,12 +17,12 @@ diesel-db$target:::query-start
 }
 
 
-diesel-db$target:::query-done
+diesel_db$target:::query-done
 {
     this->conn_id = json(copyinstr(arg1), "ok");
 }
 
-diesel-db$target:::query-done
+diesel_db$target:::query-done
 /ts[this->conn_id]/
 {
     this->latency = timestamp - ts[this->conn_id];

--- a/tools/dtrace/trace-db-queries.d
+++ b/tools/dtrace/trace-db-queries.d
@@ -9,19 +9,19 @@ dtrace:::BEGIN
     printf("Tracing all database queries for nexus PID %d, use Ctrl-C to exit\n", $target);
 }
 
-diesel-db$target:::query-start
+diesel_db$target:::query-start
 {
     this->conn_id = json(copyinstr(arg1), "ok");
     ts[this->conn_id] = timestamp;
     query[this->conn_id] = copyinstr(arg2);
 }
 
-diesel-db$target:::query-done
+diesel_db$target:::query-done
 {
     this->conn_id = json(copyinstr(arg1), "ok");
 }
 
-diesel-db$target:::query-done
+diesel_db$target:::query-done
 /ts[this->conn_id]/
 {
     this->latency = (timestamp - ts[this->conn_id]) / 1000;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -114,9 +114,10 @@ trust-dns-proto = { version = "0.22.0" }
 unicode-bidi = { version = "0.3.13" }
 unicode-normalization = { version = "0.1.22" }
 usdt = { version = "0.3.5" }
+usdt-impl = { version = "0.5.0", default-features = false, features = ["asm", "des"] }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 yasna = { version = "0.5.2", features = ["bit-vec", "num-bigint", "std", "time"] }
-zerocopy = { version = "0.7.31", features = ["derive", "simd"] }
+zerocopy = { version = "0.7.32", features = ["derive", "simd"] }
 zeroize = { version = "1.7.0", features = ["std", "zeroize_derive"] }
 zip = { version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
 
@@ -222,20 +223,23 @@ trust-dns-proto = { version = "0.22.0" }
 unicode-bidi = { version = "0.3.13" }
 unicode-normalization = { version = "0.1.22" }
 usdt = { version = "0.3.5" }
+usdt-impl = { version = "0.5.0", default-features = false, features = ["asm", "des"] }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 yasna = { version = "0.5.2", features = ["bit-vec", "num-bigint", "std", "time"] }
-zerocopy = { version = "0.7.31", features = ["derive", "simd"] }
+zerocopy = { version = "0.7.32", features = ["derive", "simd"] }
 zeroize = { version = "1.7.0", features = ["std", "zeroize_derive"] }
 zip = { version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["std"] }
+dof = { version = "0.3.0", default-features = false, features = ["des"] }
 mio = { version = "0.8.9", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 rustix = { version = "0.38.30", features = ["fs", "termios"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["std"] }
+dof = { version = "0.3.0", default-features = false, features = ["des"] }
 mio = { version = "0.8.9", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
 rustix = { version = "0.38.30", features = ["fs", "termios"] }
@@ -270,6 +274,7 @@ rustix = { version = "0.38.30", features = ["fs", "termios"] }
 
 [target.x86_64-unknown-illumos.dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["std"] }
+dof = { version = "0.3.0", default-features = false, features = ["des"] }
 errno = { version = "0.3.8", default-features = false, features = ["std"] }
 mio = { version = "0.8.9", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }
@@ -279,6 +284,7 @@ toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", featu
 
 [target.x86_64-unknown-illumos.build-dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.4.0", default-features = false, features = ["std"] }
+dof = { version = "0.3.0", default-features = false, features = ["des"] }
 errno = { version = "0.3.8", default-features = false, features = ["std"] }
 mio = { version = "0.8.9", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0", features = ["unstable"] }


### PR DESCRIPTION
- Update diesel-dtrace
- Update usdt
- Handle API change in how providers are named, since dunders are no longer translated to dashes.