### PR TITLE
Groundwork for oximeter instance vCPU metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#711a7490d81416731cfe0f9fef366ed5f266a0ee"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#29ae98d1f909c6832661408a4c03f929e8afa6e9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2009,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#711a7490d81416731cfe0f9fef366ed5f266a0ee"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#29ae98d1f909c6832661408a4c03f929e8afa6e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4708,6 +4708,14 @@
               }
             ]
           },
+          "metadata": {
+            "description": "Metadata used to track instance statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMetadata"
+              }
+            ]
+          },
           "propolis_addr": {
             "description": "The address at which this VMM should serve a Propolis server API.",
             "type": "string"
@@ -4729,6 +4737,7 @@
         "required": [
           "hardware",
           "instance_runtime",
+          "metadata",
           "propolis_addr",
           "propolis_id",
           "vmm_runtime"
@@ -4858,6 +4867,24 @@
         },
         "required": [
           "snapshot_id"
+        ]
+      },
+      "InstanceMetadata": {
+        "description": "Metadata used to track statistics about an instance.",
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "project_id",
+          "silo_id"
         ]
       },
       "InstanceMigrationSourceParams": {

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -5,27 +5,48 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-cfg-if.workspace = true
-chrono.workspace = true
-dropshot.workspace = true
-futures.workspace = true
+cfg-if = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+dropshot = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-oximeter.workspace = true
-slog.workspace = true
-tokio.workspace = true
-thiserror.workspace = true
-uuid.workspace = true
-omicron-workspace-hack.workspace = true
+oximeter = { workspace = true, optional = true }
+slog = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+omicron-workspace-hack = { workspace = true, optional = true }
 
 [features]
-default = ["http-instruments", "kstat"]
-http-instruments = ["http"]
-kstat = ["kstat-rs"]
+default = ["http-instruments", "datalink"]
+http-instruments = [
+    "dep:chrono",
+    "dep:dropshot",
+    "dep:futures",
+    "dep:http",
+    "dep:omicron-workspace-hack",
+    "dep:oximeter",
+    "dep:uuid"
+]
+kstat = [
+    "dep:cfg-if",
+    "dep:chrono",
+    "dep:futures",
+    "dep:kstat-rs",
+    "dep:omicron-workspace-hack",
+    "dep:oximeter",
+    "dep:slog",
+    "dep:tokio",
+    "dep:thiserror",
+    "dep:uuid"
+]
+datalink = ["kstat"]
 
 [dev-dependencies]
 rand.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
+oximeter.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 kstat-rs = { workspace = true, optional = true }

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -15,7 +15,7 @@ slog = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
-omicron-workspace-hack = { workspace = true, optional = true }
+omicron-workspace-hack.workspace = true
 
 [features]
 default = ["http-instruments", "datalink"]
@@ -24,7 +24,6 @@ http-instruments = [
     "dep:dropshot",
     "dep:futures",
     "dep:http",
-    "dep:omicron-workspace-hack",
     "dep:oximeter",
     "dep:uuid"
 ]
@@ -33,7 +32,6 @@ kstat = [
     "dep:chrono",
     "dep:futures",
     "dep:kstat-rs",
-    "dep:omicron-workspace-hack",
     "dep:oximeter",
     "dep:slog",
     "dep:tokio",

--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! Types for publishing kernel statistics via oximeter.
 //!
@@ -87,6 +87,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+#[cfg(any(feature = "datalink", test))]
 pub mod link;
 mod sampler;
 
@@ -206,9 +207,9 @@ pub fn hrtime_to_utc(hrtime: i64) -> Result<DateTime<Utc>, Error> {
     }
 }
 
-// Helper trait for converting a `NamedData` item into a specific contained data
-// type, if possible.
-pub(crate) trait ConvertNamedData {
+/// Helper trait for converting a `NamedData` item into a specific contained data
+/// type, if possible.
+pub trait ConvertNamedData {
     fn as_i32(&self) -> Result<i32, Error>;
     fn as_u32(&self) -> Result<u32, Error>;
     fn as_i64(&self) -> Result<i64, Error>;

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -671,7 +671,7 @@ impl KstatSamplerWorker {
         let n_current_samples = current_samples.len();
         let n_total_samples = n_new_samples + n_current_samples;
         let n_overflow_samples =
-            n_total_samples.checked_sub(self.sample_limit).unwrap_or(0);
+            n_total_samples.saturating_sub(self.sample_limit);
         if n_overflow_samples > 0 {
             warn!(
                 self.log,
@@ -788,7 +788,7 @@ impl KstatSamplerWorker {
                         // or the time we added the kstat if not.
                         let start = sampled_kstat
                             .time_of_last_collection
-                            .unwrap_or_else(|| sampled_kstat.time_added);
+                            .unwrap_or(sampled_kstat.time_added);
                         let expire_at = start + duration;
                         cfg_if::cfg_if! {
                             if #[cfg(test)] {

--- a/oximeter/instruments/src/lib.rs
+++ b/oximeter/instruments/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! General-purpose types for instrumenting code to producer oximeter metrics.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 #[cfg(feature = "http-instruments")]
 pub mod http;

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
     #[error("Error running producer HTTP server: {0}")]
     Server(String),
 
-    #[error("Error registering as metric producer: {0}")]
-    RegistrationError(String),
+    #[error("Error registering as metric producer: {msg}")]
+    RegistrationError { retryable: bool, msg: String },
 
     #[error("Producer registry and config UUIDs do not match")]
     UuidMismatch,
@@ -251,11 +251,19 @@ pub async fn register(
 ) -> Result<(), Error> {
     let client =
         nexus_client::Client::new(&format!("http://{}", address), log.clone());
-    client
-        .cpapi_producers_post(&server_info.into())
-        .await
-        .map(|_| ())
-        .map_err(|msg| Error::RegistrationError(msg.to_string()))
+    client.cpapi_producers_post(&server_info.into()).await.map(|_| ()).map_err(
+        |err| {
+            let retryable = match &err {
+                nexus_client::Error::CommunicationError(..) => true,
+                nexus_client::Error::ErrorResponse(resp) => {
+                    resp.status().is_server_error()
+                }
+                _ => false,
+            };
+            let msg = err.to_string();
+            Error::RegistrationError { retryable, msg }
+        },
+    )
 }
 
 /// Handle a request to pull available metric data from a [`ProducerRegistry`].

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -413,6 +413,7 @@ async fn instance_register(
             body_args.instance_runtime,
             body_args.vmm_runtime,
             body_args.propolis_addr,
+            body_args.metadata,
         )
         .await?,
     ))

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -15,7 +15,7 @@ use crate::nexus::NexusClientWithResolver;
 use crate::params::ZoneBundleMetadata;
 use crate::params::{InstanceExternalIpBody, ZoneBundleCause};
 use crate::params::{
-    InstanceHardware, InstanceMigrationSourceParams,
+    InstanceHardware, InstanceMetadata, InstanceMigrationSourceParams,
     InstanceMigrationTargetParams, InstancePutStateResponse,
     InstanceStateRequested, InstanceUnregisterResponse, VpcFirewallRule,
 };
@@ -310,6 +310,11 @@ struct InstanceRunner {
 
     // Properties visible to Propolis
     properties: propolis_client::types::InstanceProperties,
+
+    // This is currently unused, but will be sent to Propolis as part of the
+    // work tracked in https://github.com/oxidecomputer/omicron/issues/4851. It
+    // will be included in the InstanceProperties above, most likely.
+    _metadata: InstanceMetadata,
 
     // The ID of the Propolis server (and zone) running this instance
     propolis_id: Uuid,
@@ -928,6 +933,7 @@ impl Instance {
         ticket: InstanceTicket,
         state: InstanceInitialState,
         services: InstanceManagerServices,
+        metadata: InstanceMetadata,
     ) -> Result<Self, Error> {
         info!(log, "initializing new Instance";
               "instance_id" => %id,
@@ -1005,6 +1011,9 @@ impl Instance {
                 // InstanceCpuCount here, to avoid any casting...
                 vcpus: hardware.properties.ncpus.0 as u8,
             },
+            // This will be used in a follow up, tracked under
+            // https://github.com/oxidecomputer/omicron/issues/4851.
+            _metadata: metadata,
             propolis_id,
             propolis_addr,
             vnic_allocator,

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -8,6 +8,7 @@ use oximeter::types::MetricsError;
 use oximeter::types::ProducerRegistry;
 use sled_hardware::Baseboard;
 use slog::Logger;
+use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -19,6 +20,7 @@ cfg_if::cfg_if! {
         use oximeter_instruments::kstat::KstatSampler;
         use oximeter_instruments::kstat::TargetId;
         use std::collections::BTreeMap;
+        use std::sync::Mutex;
     } else {
         use anyhow::anyhow;
     }
@@ -46,6 +48,21 @@ pub enum Error {
 
     #[error("Failed to fetch hostname")]
     Hostname(#[source] std::io::Error),
+
+    #[error("Non-UTF8 hostname")]
+    NonUtf8Hostname,
+
+    #[error("Missing NULL byte in hostname")]
+    HostnameMissingNull,
+}
+
+// Basic metadata about the sled agent used when publishing metrics.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(target_os = "illumos"), allow(dead_code))]
+struct SledIdentifiers {
+    sled_id: Uuid,
+    rack_id: Uuid,
+    baseboard: Baseboard,
 }
 
 /// Type managing all oximeter metrics produced by the sled-agent.
@@ -61,10 +78,7 @@ pub enum Error {
 // the name of fields that are not yet used.
 #[cfg_attr(not(target_os = "illumos"), allow(dead_code))]
 pub struct MetricsManager {
-    sled_id: Uuid,
-    rack_id: Uuid,
-    baseboard: Baseboard,
-    hostname: Option<String>,
+    metadata: Arc<SledIdentifiers>,
     _log: Logger,
     #[cfg(target_os = "illumos")]
     kstat_sampler: KstatSampler,
@@ -78,7 +92,7 @@ pub struct MetricsManager {
     // namespace them internally, e.g., `"datalink:{link_name}"` would be the
     // real key.
     #[cfg(target_os = "illumos")]
-    tracked_links: BTreeMap<String, TargetId>,
+    tracked_links: Arc<Mutex<BTreeMap<String, TargetId>>>,
     registry: ProducerRegistry,
 }
 
@@ -101,14 +115,11 @@ impl MetricsManager {
                 registry
                     .register_producer(kstat_sampler.clone())
                     .map_err(Error::Registry)?;
-                let tracked_links = BTreeMap::new();
+                let tracked_links = Arc::new(Mutex::new(BTreeMap::new()));
             }
         }
         Ok(Self {
-            sled_id,
-            rack_id,
-            baseboard,
-            hostname: None,
+            metadata: Arc::new(SledIdentifiers { sled_id, rack_id, baseboard }),
             _log: log,
             #[cfg(target_os = "illumos")]
             kstat_sampler,
@@ -128,14 +139,14 @@ impl MetricsManager {
 impl MetricsManager {
     /// Track metrics for a physical datalink.
     pub async fn track_physical_link(
-        &mut self,
+        &self,
         link_name: impl AsRef<str>,
         interval: Duration,
     ) -> Result<(), Error> {
-        let hostname = self.hostname().await?;
+        let hostname = hostname()?;
         let link = link::PhysicalDataLink {
-            rack_id: self.rack_id,
-            sled_id: self.sled_id,
+            rack_id: self.metadata.rack_id,
+            sled_id: self.metadata.sled_id,
             serial: self.serial_number(),
             hostname,
             link_name: link_name.as_ref().to_string(),
@@ -146,7 +157,10 @@ impl MetricsManager {
             .add_target(link, details)
             .await
             .map_err(Error::Kstat)?;
-        self.tracked_links.insert(link_name.as_ref().to_string(), id);
+        self.tracked_links
+            .lock()
+            .unwrap()
+            .insert(link_name.as_ref().to_string(), id);
         Ok(())
     }
 
@@ -155,10 +169,12 @@ impl MetricsManager {
     /// This works for both physical and virtual links.
     #[allow(dead_code)]
     pub async fn stop_tracking_link(
-        &mut self,
+        &self,
         link_name: impl AsRef<str>,
     ) -> Result<(), Error> {
-        if let Some(id) = self.tracked_links.remove(link_name.as_ref()) {
+        let maybe_id =
+            self.tracked_links.lock().unwrap().remove(link_name.as_ref());
+        if let Some(id) = maybe_id {
             self.kstat_sampler.remove_target(id).await.map_err(Error::Kstat)
         } else {
             Ok(())
@@ -174,8 +190,8 @@ impl MetricsManager {
         interval: Duration,
     ) -> Result<(), Error> {
         let link = link::VirtualDataLink {
-            rack_id: self.rack_id,
-            sled_id: self.sled_id,
+            rack_id: self.metadata.rack_id,
+            sled_id: self.metadata.sled_id,
             serial: self.serial_number(),
             hostname: hostname.as_ref().to_string(),
             link_name: link_name.as_ref().to_string(),
@@ -190,32 +206,11 @@ impl MetricsManager {
 
     // Return the serial number out of the baseboard, if one exists.
     fn serial_number(&self) -> String {
-        match &self.baseboard {
+        match &self.metadata.baseboard {
             Baseboard::Gimlet { identifier, .. } => identifier.clone(),
             Baseboard::Unknown => String::from("unknown"),
             Baseboard::Pc { identifier, .. } => identifier.clone(),
         }
-    }
-
-    // Return the system's hostname.
-    //
-    // If we've failed to get it previously, we try again. If _that_ fails,
-    // return an error.
-    //
-    // TODO-cleanup: This will become much simpler once
-    // `OnceCell::get_or_try_init` is stabilized.
-    async fn hostname(&mut self) -> Result<String, Error> {
-        if let Some(hn) = &self.hostname {
-            return Ok(hn.clone());
-        }
-        let hn = tokio::process::Command::new("hostname")
-            .env_clear()
-            .output()
-            .await
-            .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
-            .map_err(Error::Hostname)?;
-        self.hostname.replace(hn.clone());
-        Ok(hn)
     }
 }
 
@@ -223,7 +218,7 @@ impl MetricsManager {
 impl MetricsManager {
     /// Track metrics for a physical datalink.
     pub async fn track_physical_link(
-        &mut self,
+        &self,
         _link_name: impl AsRef<str>,
         _interval: Duration,
     ) -> Result<(), Error> {
@@ -237,7 +232,7 @@ impl MetricsManager {
     /// This works for both physical and virtual links.
     #[allow(dead_code)]
     pub async fn stop_tracking_link(
-        &mut self,
+        &self,
         _link_name: impl AsRef<str>,
     ) -> Result<(), Error> {
         Err(Error::Kstat(anyhow!(
@@ -256,5 +251,30 @@ impl MetricsManager {
         Err(Error::Kstat(anyhow!(
             "kstat metrics are not supported on this platform"
         )))
+    }
+}
+
+// Return the current hostname if possible.
+#[cfg(target_os = "illumos")]
+fn hostname() -> Result<String, Error> {
+    // See netdb.h
+    const MAX_LEN: usize = 256;
+    let mut out = vec![0u8; MAX_LEN + 1];
+    if unsafe {
+        libc::gethostname(out.as_mut_ptr() as *mut libc::c_char, MAX_LEN)
+    } == 0
+    {
+        // Split into subslices by NULL bytes.
+        //
+        // We should have a NULL byte, since we've asked for no more than 255
+        // bytes in a 256 byte buffer, but you never know.
+        let Some(chunk) = out.split(|x| *x == 0).next() else {
+            return Err(Error::HostnameMissingNull);
+        };
+        let s = std::ffi::CString::new(chunk)
+            .map_err(|_| Error::NonUtf8Hostname)?;
+        s.into_string().map_err(|_| Error::NonUtf8Hostname)
+    } else {
+        Err(std::io::Error::last_os_error()).map_err(|_| Error::NonUtf8Hostname)
     }
 }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -82,6 +82,17 @@ pub struct InstanceHardware {
     pub cloud_init_bytes: Option<String>,
 }
 
+/// Metadata used to track statistics about an instance.
+///
+// NOTE: The instance ID is not here, since it's already provided in other
+// pieces of the instance-related requests. It is pulled from there when
+// publishing metrics for the instance.
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct InstanceMetadata {
+    pub silo_id: Uuid,
+    pub project_id: Uuid,
+}
+
 /// The body of a request to ensure that a instance and VMM are known to a sled
 /// agent.
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -103,6 +114,9 @@ pub struct InstanceEnsureBody {
 
     /// The address at which this VMM should serve a Propolis server API.
     pub propolis_addr: SocketAddr,
+
+    /// Metadata used to track instance statistics.
+    pub metadata: InstanceMetadata,
 }
 
 /// The body of a request to move a previously-ensured instance into a specific

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -98,6 +98,7 @@ async fn instance_register(
             body_args.hardware,
             body_args.instance_runtime,
             body_args.vmm_runtime,
+            body_args.metadata,
         )
         .await?,
     ))

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -13,7 +13,7 @@ use super::storage::Storage;
 use crate::nexus::NexusClient;
 use crate::params::{
     DiskStateRequested, InstanceExternalIpBody, InstanceHardware,
-    InstanceMigrationSourceParams, InstancePutStateResponse,
+    InstanceMetadata, InstanceMigrationSourceParams, InstancePutStateResponse,
     InstanceStateRequested, InstanceUnregisterResponse, Inventory,
     OmicronZonesConfig, SledRole,
 };
@@ -239,6 +239,9 @@ impl SledAgent {
         hardware: InstanceHardware,
         instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
+        // This is currently unused, but will be included as part of work
+        // tracked in https://github.com/oxidecomputer/omicron/issues/4851.
+        _metadata: InstanceMetadata,
     ) -> Result<SledInstanceState, Error> {
         // respond with a fake 500 level failure if asked to ensure an instance
         // with more than 16 CPUs.


### PR DESCRIPTION
- Adds the silo and project IDs to the instance-ensure request from Nexus to the sled-agent. These are used as fields on the instance-related statistics. This metadata is currently unused, but will be forwarded to Propolis in the instance-ensure request once the server is updated to accept it.
- Defines a `VirtualMachine` oximeter target and `VcpuUsage` metric. The latter has a `state` field which corresponds to the named kstats published by the hypervisor that accumulate the time spent in a number of vCPU microstates. The combination of these should allow us to aggregate or break down vCPU usage by silo, project, instance, vCPU ID, and CPU state. Adds some simple mocks and tests for these.
- Adds more fine-grained feature flags to the `oximeter-instruments` crate.