### PR TITLE
Rework {Sp,Rot,HostPhase1}Updater tests to be less flaky 

### DIFF
--- a/nexus/tests/integration_tests/host_phase1_updater.rs
+++ b/nexus/tests/integration_tests/host_phase1_updater.rs
@@ -6,7 +6,7 @@
 //! MGS to SP.
 
 use gateway_client::types::SpType;
-use gateway_messages::{SpPort, UpdateInProgressStatus, UpdateStatus};
+use gateway_messages::SpPort;
 use gateway_test_utils::setup as mgs_setup;
 use omicron_nexus::app::test_interfaces::{
     HostPhase1Updater, MgsClients, UpdateProgress,

--- a/nexus/tests/integration_tests/host_phase1_updater.rs
+++ b/nexus/tests/integration_tests/host_phase1_updater.rs
@@ -403,6 +403,7 @@ async fn test_host_phase1_updater_delivers_progress() {
     let target_host_slot = 0;
     let update_id = Uuid::new_v4();
     let phase1_data = make_fake_host_phase1_image();
+    let target_sp = &mgstestctx.simrack.gimlets[sp_slot as usize];
 
     let host_phase1_updater = HostPhase1Updater::new(
         sp_type,
@@ -413,18 +414,10 @@ async fn test_host_phase1_updater_delivers_progress() {
         &mgstestctx.logctx.log,
     );
 
-    let phase1_data_len = phase1_data.len() as u32;
-
     // Subscribe to update progress, and check that there is no status yet; we
     // haven't started the update.
     let mut progress = host_phase1_updater.progress_watcher();
     assert_eq!(*progress.borrow_and_update(), None);
-
-    // Install a semaphore on the requests our target SP will receive so we can
-    // inspect progress messages without racing.
-    let target_sp = &mgstestctx.simrack.gimlets[sp_slot as usize];
-    let sp_accept_sema = target_sp.install_udp_accept_semaphore().await;
-    let mut sp_responses = target_sp.responses_sent_count().unwrap();
 
     // Spawn the update on a background task so we can watch `progress` as it is
     // applied.
@@ -432,137 +425,46 @@ async fn test_host_phase1_updater_delivers_progress() {
         host_phase1_updater.update(&mut mgs_clients).await
     });
 
-    // Allow the SP to respond to 2 messages: the message to activate the target
-    // flash slot and the "prepare update" messages that triggers the start of an
-    // update, then ensure we see the "started" progress.
-    sp_accept_sema.send(2).unwrap();
-    progress.changed().await.unwrap();
-    assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Started));
-
-    // Ensure our simulated SP is in the state we expect: it's prepared for an
-    // update but has not yet received any data.
-    assert_eq!(
-        target_sp.current_update_status().await,
-        UpdateStatus::InProgress(UpdateInProgressStatus {
-            id: update_id.into(),
-            bytes_received: 0,
-            total_size: phase1_data_len,
-        })
-    );
-
-    // Record the number of responses the SP has sent; we'll use
-    // `sp_responses.changed()` in the loop below, and want to mark whatever
-    // value this watch channel currently has as seen.
-    sp_responses.borrow_and_update();
-
-    // At this point, there are two clients racing each other to talk to our
-    // simulated SP:
-    //
-    // 1. MGS is trying to deliver the update
-    // 2. `host_phase1_updater` is trying to poll (via MGS) for update status
-    //
-    // and we want to ensure that we see any relevant progress reports from
-    // `host_phase1_updater`. We'll let one MGS -> SP message through at a time
-    // (waiting until our SP has responded by waiting for a change to
-    // `sp_responses`) then check its update state: if it changed, the packet we
-    // let through was data from MGS; otherwise, it was a status request from
-    // `host_phase1_updater`.
-    //
-    // This loop will continue until either:
-    //
-    // 1. We see an `UpdateStatus::InProgress` message indicating 100% delivery,
-    //    at which point we break out of the loop
-    // 2. We time out waiting for the previous step (by timing out for either
-    //    the SP to process a request or `host_phase1_updater` to realize
-    //    there's been progress), at which point we panic and fail this test.
-    let mut prev_bytes_received = 0;
-    let mut expect_progress_change = false;
-    loop {
-        // Allow the SP to accept and respond to a single UDP packet.
-        sp_accept_sema.send(1).unwrap();
-
-        // Wait until the SP has sent a response, with a safety rail that we
-        // haven't screwed up our untangle-the-race logic: if we don't see the
-        // SP process any new messages after several seconds, our test is
-        // broken, so fail.
-        tokio::time::timeout(Duration::from_secs(10), sp_responses.changed())
-            .await
-            .expect("timeout waiting for SP response count to change")
-            .expect("sp response count sender dropped");
-
-        // Inspec the SP's in-memory update state; we expect only `InProgress`
-        // or `Complete`, and in either case we note whether we expect to see
-        // status changes from `host_phase1_updater`.
-        match target_sp.current_update_status().await {
-            UpdateStatus::InProgress(sp_progress) => {
-                if sp_progress.bytes_received > prev_bytes_received {
-                    prev_bytes_received = sp_progress.bytes_received;
-                    expect_progress_change = true;
-                    continue;
+    // Loop until we see `UpdateProgress::Complete`, ensuring that any
+    // intermediate progress messages we see are in order.
+    let mut saw_started = false;
+    let mut prev_progress = 0.0;
+    let log = mgstestctx.logctx.log.clone();
+    tokio::time::timeout(
+        Duration::from_secs(20),
+        tokio::spawn(async move {
+            loop {
+                progress.changed().await.unwrap();
+                let status = progress
+                    .borrow_and_update()
+                    .clone()
+                    .expect("progress changed but still None");
+                debug!(log, "saw new progress status"; "status" => ?status);
+                match status {
+                    UpdateProgress::Started => {
+                        assert!(!saw_started, "saw Started multiple times");
+                        saw_started = true;
+                    }
+                    UpdateProgress::InProgress { progress: Some(value) } => {
+                        // even if we didn't see the explicit `Started` message,
+                        // getting `InProgress` means we're past that point.
+                        saw_started = true;
+                        assert!(
+                            value >= prev_progress,
+                            "new progress {value} \
+                             less than previous progress {prev_progress}"
+                        );
+                        prev_progress = value;
+                    }
+                    UpdateProgress::Complete => break,
+                    _ => panic!("unexpected progress status {status:?}"),
                 }
             }
-            UpdateStatus::Complete(_) => {
-                if prev_bytes_received < phase1_data_len {
-                    break;
-                }
-            }
-            status @ (UpdateStatus::None
-            | UpdateStatus::Preparing(_)
-            | UpdateStatus::SpUpdateAuxFlashChckScan { .. }
-            | UpdateStatus::Aborted(_)
-            | UpdateStatus::Failed { .. }
-            | UpdateStatus::RotError { .. }) => {
-                panic!("unexpected status {status:?}");
-            }
-        }
-
-        // If we get here, the most recent packet did _not_ change the SP's
-        // internal update state, so it was a status request from
-        // `host_phase1_updater`. If we expect the updater to see new progress,
-        // wait for that change here.
-        if expect_progress_change {
-            // Safety rail that we haven't screwed up our untangle-the-race
-            // logic: if we don't see a new progress after several seconds, our
-            // test is broken, so fail.
-            tokio::time::timeout(Duration::from_secs(10), progress.changed())
-                .await
-                .expect("progress timeout")
-                .expect("progress watch sender dropped");
-            let status = progress.borrow_and_update().clone().unwrap();
-            expect_progress_change = false;
-
-            assert!(
-                matches!(status, UpdateProgress::InProgress { .. }),
-                "unexpected progress status {status:?}"
-            );
-        }
-    }
-
-    // We know the SP has received a complete update, but `HostPhase1Updater`
-    // may still need to request status to realize that; release the socket
-    // semaphore so the SP can respond.
-    sp_accept_sema.send(usize::MAX).unwrap();
-
-    // Unlike the SP and RoT cases, there are no MGS/SP steps in between the
-    // update completing and `HostPhase1Updater` sending
-    // `UpdateProgress::Complete`. Therefore, it's a race whether we'll see
-    // some number of `InProgress` status before `Complete`, but we should
-    // quickly move to `Complete`.
-    loop {
-        tokio::time::timeout(Duration::from_secs(10), progress.changed())
-            .await
-            .expect("progress timeout")
-            .expect("progress watch sender dropped");
-        let status = progress.borrow_and_update().clone().unwrap();
-        match status {
-            UpdateProgress::Complete => break,
-            UpdateProgress::InProgress { .. } => continue,
-            _ => panic!("unexpected progress status {status:?}"),
-        }
-    }
-
-    // drop our progress receiver so `do_update_task` can complete
-    mem::drop(progress);
+        }),
+    )
+    .await
+    .expect("timeout waiting for update completion")
+    .expect("task panic");
 
     do_update_task.await.expect("update task panicked").expect("update failed");
 

--- a/nexus/tests/integration_tests/rot_updater.rs
+++ b/nexus/tests/integration_tests/rot_updater.rs
@@ -5,7 +5,7 @@
 //! Tests `RotUpdater`'s delivery of updates to RoTs via MGS
 
 use gateway_client::types::{RotSlot, SpType};
-use gateway_messages::{SpPort, UpdateInProgressStatus, UpdateStatus};
+use gateway_messages::SpPort;
 use gateway_test_utils::setup as mgs_setup;
 use hubtools::RawHubrisArchive;
 use hubtools::{CabooseBuilder, HubrisArchiveBuilder};
@@ -461,6 +461,7 @@ async fn test_rot_updater_delivers_progress() {
     let update_id = Uuid::new_v4();
     let hubris_archive = make_fake_rot_image();
     let target_rot_slot = RotSlot::B;
+    let target_sp = &mgstestctx.simrack.gimlets[sp_slot as usize];
 
     let rot_updater = RotUpdater::new(
         sp_type,
@@ -472,144 +473,57 @@ async fn test_rot_updater_delivers_progress() {
     );
 
     let hubris_archive = RawHubrisArchive::from_vec(hubris_archive).unwrap();
-    let rot_image_len = hubris_archive.image.data.len() as u32;
 
     // Subscribe to update progress, and check that there is no status yet; we
     // haven't started the update.
     let mut progress = rot_updater.progress_watcher();
     assert_eq!(*progress.borrow_and_update(), None);
 
-    // Install a semaphore on the requests our target SP will receive so we can
-    // inspect progress messages without racing.
-    let target_sp = &mgstestctx.simrack.gimlets[sp_slot as usize];
-    let sp_accept_sema = target_sp.install_udp_accept_semaphore().await;
-    let mut sp_responses = target_sp.responses_sent_count().unwrap();
-
     // Spawn the update on a background task so we can watch `progress` as it is
     // applied.
     let do_update_task =
         tokio::spawn(async move { rot_updater.update(&mut mgs_clients).await });
 
-    // Allow the SP to respond to 1 message: the "prepare update" messages that
-    // triggers the start of an update, then ensure we see the "started"
-    // progress.
-    sp_accept_sema.send(1).unwrap();
-    progress.changed().await.unwrap();
-    assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Started));
-
-    // Ensure our simulated SP is in the state we expect: it's prepared for an
-    // update but has not yet received any data.
-    assert_eq!(
-        target_sp.current_update_status().await,
-        UpdateStatus::InProgress(UpdateInProgressStatus {
-            id: update_id.into(),
-            bytes_received: 0,
-            total_size: rot_image_len,
-        })
-    );
-
-    // Record the number of responses the SP has sent; we'll use
-    // `sp_responses.changed()` in the loop below, and want to mark whatever
-    // value this watch channel currently has as seen.
-    sp_responses.borrow_and_update();
-
-    // At this point, there are two clients racing each other to talk to our
-    // simulated SP:
-    //
-    // 1. MGS is trying to deliver the update
-    // 2. `rot_updater` is trying to poll (via MGS) for update status
-    //
-    // and we want to ensure that we see any relevant progress reports from
-    // `rot_updater`. We'll let one MGS -> SP message through at a time (waiting
-    // until our SP has responded by waiting for a change to `sp_responses`)
-    // then check its update state: if it changed, the packet we let through was
-    // data from MGS; otherwise, it was a status request from `rot_updater`.
-    //
-    // This loop will continue until either:
-    //
-    // 1. We see an `UpdateStatus::InProgress` message indicating 100% delivery,
-    //    at which point we break out of the loop
-    // 2. We time out waiting for the previous step (by timing out for either
-    //    the SP to process a request or `rot_updater` to realize there's been
-    //    progress), at which point we panic and fail this test.
-    let mut prev_bytes_received = 0;
-    let mut expect_progress_change = false;
-    loop {
-        // Allow the SP to accept and respond to a single UDP packet.
-        sp_accept_sema.send(1).unwrap();
-
-        // Wait until the SP has sent a response, with a safety rail that we
-        // haven't screwed up our untangle-the-race logic: if we don't see the
-        // SP process any new messages after several seconds, our test is
-        // broken, so fail.
-        tokio::time::timeout(Duration::from_secs(10), sp_responses.changed())
-            .await
-            .expect("timeout waiting for SP response count to change")
-            .expect("sp response count sender dropped");
-
-        // Inspec the SP's in-memory update state; we expect only `InProgress`
-        // or `Complete`, and in either case we note whether we expect to see
-        // status changes from `rot_updater`.
-        match target_sp.current_update_status().await {
-            UpdateStatus::InProgress(rot_progress) => {
-                if rot_progress.bytes_received > prev_bytes_received {
-                    prev_bytes_received = rot_progress.bytes_received;
-                    expect_progress_change = true;
-                    continue;
+    // Loop until we see `UpdateProgress::Complete`, ensuring that any
+    // intermediate progress messages we see are in order.
+    let mut saw_started = false;
+    let mut prev_progress = 0.0;
+    let log = mgstestctx.logctx.log.clone();
+    tokio::time::timeout(
+        Duration::from_secs(20),
+        tokio::spawn(async move {
+            loop {
+                progress.changed().await.unwrap();
+                let status = progress
+                    .borrow_and_update()
+                    .clone()
+                    .expect("progress changed but still None");
+                debug!(log, "saw new progress status"; "status" => ?status);
+                match status {
+                    UpdateProgress::Started => {
+                        assert!(!saw_started, "saw Started multiple times");
+                        saw_started = true;
+                    }
+                    UpdateProgress::InProgress { progress: Some(value) } => {
+                        // even if we didn't see the explicit `Started` message,
+                        // getting `InProgress` means we're past that point.
+                        saw_started = true;
+                        assert!(
+                            value >= prev_progress,
+                            "new progress {value} \
+                             less than previous progress {prev_progress}"
+                        );
+                        prev_progress = value;
+                    }
+                    UpdateProgress::Complete => break,
+                    _ => panic!("unexpected progress status {status:?}"),
                 }
             }
-            UpdateStatus::Complete(_) => {
-                if prev_bytes_received < rot_image_len {
-                    prev_bytes_received = rot_image_len;
-                }
-            }
-            status @ (UpdateStatus::None
-            | UpdateStatus::Preparing(_)
-            | UpdateStatus::SpUpdateAuxFlashChckScan { .. }
-            | UpdateStatus::Aborted(_)
-            | UpdateStatus::Failed { .. }
-            | UpdateStatus::RotError { .. }) => {
-                panic!("unexpected status {status:?}");
-            }
-        }
-
-        // If we get here, the most recent packet did _not_ change the SP's
-        // internal update state, so it was a status request from `rot_updater`.
-        // If we expect the updater to see new progress, wait for that change
-        // here.
-        if expect_progress_change || prev_bytes_received == rot_image_len {
-            // Safety rail that we haven't screwed up our untangle-the-race
-            // logic: if we don't see a new progress after several seconds, our
-            // test is broken, so fail.
-            tokio::time::timeout(Duration::from_secs(10), progress.changed())
-                .await
-                .expect("progress timeout")
-                .expect("progress watch sender dropped");
-            let status = progress.borrow_and_update().clone().unwrap();
-            expect_progress_change = false;
-
-            // We're done if we've observed the final progress message.
-            if let UpdateProgress::InProgress { progress: Some(value) } = status
-            {
-                if value == 1.0 {
-                    break;
-                }
-            } else {
-                panic!("unexpected progerss status {status:?}");
-            }
-        }
-    }
-
-    // The update has been fully delivered to the SP, but we don't see an
-    // `UpdateStatus::Complete` message until the RoT is reset. Release the SP
-    // semaphore since we're no longer racing to observe intermediate progress,
-    // and wait for the completion message.
-    sp_accept_sema.send(usize::MAX).unwrap();
-    progress.changed().await.unwrap();
-    assert_eq!(*progress.borrow_and_update(), Some(UpdateProgress::Complete));
-
-    // drop our progress receiver so `do_update_task` can complete
-    mem::drop(progress);
+        }),
+    )
+    .await
+    .expect("timeout waiting for update completion")
+    .expect("task panic");
 
     do_update_task.await.expect("update task panicked").expect("update failed");
 

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -488,6 +488,7 @@ struct UdpTask {
 }
 
 impl UdpTask {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         servers: [UdpServer; 2],
         components: Vec<SpComponentConfig>,

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -57,6 +57,22 @@ use tokio::task::{self, JoinHandle};
 
 pub const SIM_GIMLET_BOARD: &str = "SimGimletSp";
 
+/// Type of request most recently handled by a simulated SP.
+///
+/// Many request types are not covered by this enum. This only exists to enable
+/// certain particular tests.
+// If you need an additional request type to be reported by this enum, feel free
+// to add it and update the appropriate `Handler` function below (see
+// `update_status()`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimSpHandledRequest {
+    /// The most recent request was for the update status of a component.
+    ComponentUpdateStatus(SpComponent),
+    /// The most recent request was some other type that is currently not
+    /// implemented in this tracker.
+    NotImplemented,
+}
+
 pub struct Gimlet {
     rot: Mutex<RotSprocket>,
     manufacturing_public_key: Ed25519PublicKey,
@@ -66,6 +82,7 @@ pub struct Gimlet {
     commands: mpsc::UnboundedSender<Command>,
     inner_tasks: Vec<JoinHandle<()>>,
     responses_sent_count: Option<watch::Receiver<usize>>,
+    last_request_handled: Arc<Mutex<Option<SimSpHandledRequest>>>,
 }
 
 impl Drop for Gimlet {
@@ -168,6 +185,7 @@ impl Gimlet {
         let mut serial_console_addrs = HashMap::new();
         let mut inner_tasks = Vec::new();
         let (commands, commands_rx) = mpsc::unbounded_channel();
+        let last_request_handled = Arc::default();
 
         let (manufacturing_public_key, rot) =
             RotSprocket::bootstrap_from_config(&gimlet.common);
@@ -185,6 +203,7 @@ impl Gimlet {
                 commands,
                 inner_tasks,
                 responses_sent_count: None,
+                last_request_handled,
             });
         };
 
@@ -257,6 +276,7 @@ impl Gimlet {
             gimlet.common.serial_number.clone(),
             incoming_console_tx,
             commands_rx,
+            Arc::clone(&last_request_handled),
             log,
         );
         inner_tasks
@@ -271,11 +291,16 @@ impl Gimlet {
             commands,
             inner_tasks,
             responses_sent_count: Some(responses_sent_count),
+            last_request_handled,
         })
     }
 
     pub fn serial_console_addr(&self, component: &str) -> Option<SocketAddrV6> {
         self.serial_console_addrs.get(component).copied()
+    }
+
+    pub fn last_request_handled(&self) -> Option<SimSpHandledRequest> {
+        *self.last_request_handled.lock().unwrap()
     }
 }
 
@@ -459,6 +484,7 @@ struct UdpTask {
     handler: Arc<TokioMutex<Handler>>,
     commands: mpsc::UnboundedReceiver<Command>,
     responses_sent_count: watch::Sender<usize>,
+    last_request_handled: Arc<Mutex<Option<SimSpHandledRequest>>>,
 }
 
 impl UdpTask {
@@ -469,6 +495,7 @@ impl UdpTask {
         serial_number: String,
         incoming_serial_console: HashMap<SpComponent, UnboundedSender<Vec<u8>>>,
         commands: mpsc::UnboundedReceiver<Command>,
+        last_request_handled: Arc<Mutex<Option<SimSpHandledRequest>>>,
         log: Logger,
     ) -> (Self, Arc<TokioMutex<Handler>>, watch::Receiver<usize>) {
         let [udp0, udp1] = servers;
@@ -488,6 +515,7 @@ impl UdpTask {
                 handler: Arc::clone(&handler),
                 commands,
                 responses_sent_count,
+                last_request_handled,
             },
             handler,
             responses_sent_count_rx,
@@ -513,16 +541,27 @@ impl UdpTask {
                 }
 
                 recv0 = self.udp0.recv_from(), if throttle_count > 0 => {
-                    if let Some((resp, addr)) = server::handle_request(
-                        &mut *self.handler.lock().await,
-                        recv0,
-                        &mut out_buf,
-                        responsiveness,
-                        SpPort::One,
-                    ).await? {
+                    let (result, handled_request) = {
+                        let mut handler = self.handler.lock().await;
+                        handler.last_request_handled = None;
+                        let result = server::handle_request(
+                            &mut *handler,
+                            recv0,
+                            &mut out_buf,
+                            responsiveness,
+                            SpPort::One,
+                        ).await?;
+                        (result,
+                         handler.last_request_handled.unwrap_or(
+                             SimSpHandledRequest::NotImplemented,
+                        ))
+                    };
+                    if let Some((resp, addr)) = result {
                         throttle_count -= 1;
                         self.udp0.send_to(resp, addr).await?;
                         self.responses_sent_count.send_modify(|n| *n += 1);
+                        *self.last_request_handled.lock().unwrap() =
+                            Some(handled_request);
                     }
                 }
 
@@ -594,6 +633,8 @@ struct Handler {
     update_state: SimSpUpdate,
     reset_pending: Option<SpComponent>,
 
+    last_request_handled: Option<SimSpHandledRequest>,
+
     // To simulate an SP reset, we should (after doing whatever housekeeping we
     // need to track the reset) intentionally _fail_ to respond to the request,
     // simulating a `-> !` function on the SP that triggers a reset. To provide
@@ -635,6 +676,7 @@ impl Handler {
             startup_options: StartupOptions::empty(),
             update_state: SimSpUpdate::default(),
             reset_pending: None,
+            last_request_handled: None,
             should_fail_to_respond_signal: None,
         }
     }
@@ -1003,6 +1045,8 @@ impl SpHandler for Handler {
             "port" => ?port,
             "component" => ?component,
         );
+        self.last_request_handled =
+            Some(SimSpHandledRequest::ComponentUpdateStatus(component));
         Ok(self.update_state.status())
     }
 

--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 pub use config::Config;
 use gateway_messages::SpPort;
 pub use gimlet::Gimlet;
+pub use gimlet::SimSpHandledRequest;
 pub use gimlet::SIM_GIMLET_BOARD;
 pub use server::logger;
 pub use sidecar::Sidecar;


### PR DESCRIPTION
There were three tests that were mostly copy/pasted, that all tried to tame an inherent race between two tokio tasks: one is delivering an update to the simulated SP, and the other is polling that simulated SP for the progress of that update. The taming was by throttling the simulated SP to only reply to a single message at a time, then checking some internal state to infer what kind of message the SP had just received, and using that inference to check some invariants. The inference was typically right, but as evidenced by the name of this PR, not perfect.

I took a fairly big hammer to the Rot and HostPhase1 updater tests: they now just loop waiting to see the "Complete" progress message, and no longer try to single-step through messages. Under normal conditions (e.g., not heavily-loaded-CI systems), it's likely these tests will skip from "no progress" to "complete", but that's ok.

I tried to rework the SpUpdater test to keep the same "single-step through messages" to carefully check the progress reports by adding more details to the simulated SP, so the test can know exactly when the specific message it was trying to infer (i.e., `SpUpdater`'s requests for the update status) arrives. This should fix the flake; if it doesn't, we can replace this one with the same impl that the Rot and HostPhase1 tests now have.

Fixes https://github.com/oxidecomputer/omicron/issues/4911