### PR TITLE
Support Omicron development on NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,8 @@ PATH_add out/cockroachdb/bin
 PATH_add out/clickhouse
 PATH_add out/dendrite-stub/bin
 PATH_add out/mgd/root/opt/oxide/mgd/bin
+
+if nix flake show &> /dev/null
+then
+    use flake;
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ debug.out
 rusty-tags.vi
 *.sw*
 tags
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706371002,
+        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706634984,
+        "narHash": "sha256-xn7lGPE8gRGBe3Lt8ESoN/uUHm7IrbiV7siupwjHX1o=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "883b84c426107a8ec020e7124f263d7c35a5bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,10 @@
               LIBCLANG_PATH = "${libclang.lib}/lib";
               OPENSSL_DIR = "${openssl.dev}";
               OPENSSL_LIB_DIR = "${openssl.out}/lib";
+
+              # Needed by rustfmt-wrapper, see:
+              # https://github.com/oxidecomputer/rustfmt-wrapper/blob/main/src/lib.rs
+              RUSTFMT = "${rustToolchain}/bin/rustfmt";
             };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -52,11 +52,8 @@
               name = "omicron";
               DEP_PQ_LIBDIRS = " ${postgresql.lib}/lib";
               LIBCLANG_PATH = "${libclang.lib}/lib";
-              LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-              LC_ALL = "en_US.UTF-8";
               OPENSSL_DIR = "${openssl.dev}";
               OPENSSL_LIB_DIR = "${openssl.out}/lib";
-              CARGO_TERM_COLOR = "always";
             };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "Development environment for Omicron";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          # use the Rust toolchain defined in the `rust-toolchain.toml` file.
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          nativeBuildInputs = with pkgs; [
+            rustToolchain
+            cmake
+            stdenv
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            # libs
+            openssl
+            postgresql
+            xmlsec
+            sqlite
+            libclang
+            libxml2
+          ];
+        in
+        with pkgs;
+        {
+          devShells.default = mkShell.override
+            {
+              # use Clang as the C compiler for all C libraries
+              stdenv = clangStdenv;
+            }
+            {
+              inherit buildInputs nativeBuildInputs;
+
+              name = "omicron";
+              DEP_PQ_LIBDIRS = " ${postgresql.lib}/lib";
+              LIBCLANG_PATH = "${libclang.lib}/lib";
+              LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+              LC_ALL = "en_US.UTF-8";
+              OPENSSL_DIR = "${openssl.dev}";
+              OPENSSL_LIB_DIR = "${openssl.out}/lib";
+              CARGO_TERM_COLOR = "always";
+            };
+        }
+      );
+}

--- a/tools/build-global-zone-packages.sh
+++ b/tools/build-global-zone-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/tools/build-host-image.sh
+++ b/tools/build-host-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail

--- a/tools/build-trampoline-global-zone-packages.sh
+++ b/tools/build-trampoline-global-zone-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/tools/ci_check_opte_ver.sh
+++ b/tools/ci_check_opte_ver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 source tools/opte_version_override

--- a/tools/ci_download_clickhouse
+++ b/tools/ci_download_clickhouse
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_clickhouse: fetches the appropriate ClickHouse binary tarball

--- a/tools/ci_download_cockroachdb
+++ b/tools/ci_download_cockroachdb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_cockroachdb: fetches the appropriate CockroachDB binary tarball

--- a/tools/ci_download_console
+++ b/tools/ci_download_console
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_console: fetches the appropriate Console assets.

--- a/tools/ci_download_dendrite_openapi
+++ b/tools/ci_download_dendrite_openapi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_dendrite_openapi: fetches the appropriate dendrite openapi spec.

--- a/tools/ci_download_dendrite_stub
+++ b/tools/ci_download_dendrite_stub
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_dendrite_stub: fetches the appropriate Dendrite binary tarball

--- a/tools/ci_download_maghemite_mgd
+++ b/tools/ci_download_maghemite_mgd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_maghemite_mgd: fetches the maghemite mgd binary tarball, unpacks

--- a/tools/ci_download_maghemite_openapi
+++ b/tools/ci_download_maghemite_openapi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_maghemite_openapi: fetches the appropriate maghemite openapi spec.

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script fetches the following from CI
 #

--- a/tools/ci_download_transceiver_control
+++ b/tools/ci_download_transceiver_control
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # ci_download_transceiver_control: fetches the appropriate transceiver-control

--- a/tools/create_gimlet_virtual_hardware.sh
+++ b/tools/create_gimlet_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Make me a Gimlet!
 #

--- a/tools/create_scrimlet_virtual_hardware.sh
+++ b/tools/create_scrimlet_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Make me a Scrimlet!
 #

--- a/tools/create_self_signed_cert.sh
+++ b/tools/create_self_signed_cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Creates a self-signed certificate.
 #

--- a/tools/create_virtual_hardware.sh
+++ b/tools/create_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Make me a Gimlet!
 #

--- a/tools/delete-reservoir.sh
+++ b/tools/delete-reservoir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 size=`pfexec /usr/lib/rsrvrctl -q | grep Free | awk '{print $3}'`
 let x=$size/1024

--- a/tools/destroy_gimlet_virtual_hardware.sh
+++ b/tools/destroy_gimlet_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unmake me a Gimlet!
 #

--- a/tools/destroy_scrimlet_virtual_hardware.sh
+++ b/tools/destroy_scrimlet_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unmake me a Scrimlet!
 #

--- a/tools/destroy_virtual_hardware.sh
+++ b/tools/destroy_virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unmake me a Gimlet!
 #

--- a/tools/ensure_buildomat_artifact.sh
+++ b/tools/ensure_buildomat_artifact.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Ensure a buildomat artifact is downloaded and available locally.
 

--- a/tools/generate-nexus-api.sh
+++ b/tools/generate-nexus-api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./target/debug/nexus nexus/examples/config.toml -O > openapi/nexus.json
 ./target/debug/nexus nexus/examples/config.toml -I > openapi/nexus-internal.json

--- a/tools/generate-sled-agent-api.sh
+++ b/tools/generate-sled-agent-api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./target/debug/sled-agent openapi bootstrap > openapi/bootstrap-agent.json
 ./target/debug/sled-agent openapi sled > openapi/sled-agent.json

--- a/tools/generate-wicketd-api.sh
+++ b/tools/generate-wicketd-api.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./target/debug/wicketd openapi > openapi/wicketd.json

--- a/tools/include/force-git-over-https.sh
+++ b/tools/include/force-git-over-https.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # The token authentication mechanism that affords us access to other private
 # repositories requires that we use HTTPS URLs for GitHub, rather than SSH.

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -105,6 +105,12 @@ HOST_OS=$(uname -s)
 
 function install_packages {
   if [[ "${HOST_OS}" == "Linux" ]]; then
+    # If Nix is in use, we don't need to install any packagess here,
+    # as they're provided by the Nix flake. 
+    if nix flake show &> /dev/null; then
+      return
+    fi
+
     packages=(
       'libpq-dev'
       'pkg-config'

--- a/tools/install_opte.sh
+++ b/tools/install_opte.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Small tool to install OPTE and the xde kernel driver and ONU bits.
 

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/tools/opte_version_override
+++ b/tools/opte_version_override
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # only set this if you want to override the version of opte/xde installed by the
 # install_opte.sh script

--- a/tools/populate/populate-alpine.sh
+++ b/tools/populate/populate-alpine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Simple script to install the alpine image included with propolis.
 
 if ! oxide api /v1/images > /dev/null; then

--- a/tools/populate/populate-images.sh
+++ b/tools/populate/populate-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Populate an Oxide host running Omicron with images from server catacomb.
 #
 # Note that the default tunnel IP of `fd00:...` will only be available _after_

--- a/tools/reflector/helpers.sh
+++ b/tools/reflector/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/renovate-post-upgrade.sh
+++ b/tools/renovate-post-upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is run after Renovate upgrades dependencies or lock files.
 

--- a/tools/scrimlet/create-softnpu-zone.sh
+++ b/tools/scrimlet/create-softnpu-zone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 set -e

--- a/tools/scrimlet/destroy-softnpu-zone.sh
+++ b/tools/scrimlet/destroy-softnpu-zone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 set -e

--- a/tools/scrimlet/softnpu-init.sh
+++ b/tools/scrimlet/softnpu-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/tools/uninstall_opte.sh
+++ b/tools/uninstall_opte.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Small tool to _uninstall_ OPTE and the xde kernel driver and ONU bits.
 #

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/update_dendrite.sh
+++ b/tools/update_dendrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/update_helpers.sh
+++ b/tools/update_helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/update_maghemite.sh
+++ b/tools/update_maghemite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/update_propolis.sh
+++ b/tools/update_propolis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/update_transceiver_control.sh
+++ b/tools/update_transceiver_control.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 set -o errexit

--- a/tools/virtual_hardware.sh
+++ b/tools/virtual_hardware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MARKER=/etc/opt/oxide/NO_INSTALL
 if [[ -f "$MARKER" ]]; then


### PR DESCRIPTION
I use NixOS on my dev machine, and I'd like to be able to do some
development tasks locally (such as `cargo check`, running
`rust-analyzer`, et cetera). This branch makes the following changes to
better support Omicron development on NixOS:

- **Add `flake.nix` for Nix users** (484323c)

  In order to build Omicron, including running `cargo check` or
  `rust-analyzer`, a number of non-Rust dependencies must be present.
  This commit adds a [Nix flake] file which users of the Nix package
  manager can [use to enter a dev shell][nix-develop] that contains
  those dependencies, making it easy for Nix and NixOS users to develop
  Omicron on NixOS.

  The Nix flake configured here creates a build environment with `clang`
  as the C compiler toolchain, and ensures that the following libraries
  are available:

  - `libclang` (of a version matching the `clang` C toolchain)
  - `libpq`
  - `libxml2`
  - `libxmlsec`
  - `openssl`
  - `sqlite`

  In addition, it provides `pkg-config`, `cmake`, and `rustup`, and
  ensures that the various environment variables that the Rust bindings
  for these libraries use to find the libraries are set correctly.

  This makes it possible to run `cargo check`, `cargo build`, and
  `rust-analyzer` on NixOS.

  I've also added to the `.envrc` file so that `direnv` will
  automatically use the Nix flake's dev environment, if a `nix` binary
  is present on the user's system and that `nix` binary supports flakes.

  [Nix flake]: https://nixos.wiki/wiki/Flakes
  [nix-develop]:
      https://nixos.wiki/wiki/Development_environment_with_nix-shell#nix_develop

- **Use `/usr/bin/env bash` rather than `/bin/bash`** (9b438c1)

  On some operating systems, such as [NixOS][1], there may not be a
  `bash` executable in `/bin`, but a `bash` executable may be located
  elsewhere. Using a `#!/bin/bash` shebang line in scripts may not work
  correctly on these systems.

  Instead, a `#!/usr/bin/env bash` shebang is [generally considered][2]
  the preferable way to write portable shell scripts that use Bash.
  Therefore, this commit changes the shell scripts in `tools/` to use
  `#!/usr/bin/env bash` shebang lines, rather than `#!/bin/bash`.

  [1]: https://discourse.nixos.org/t/shebang-locations/28992
  [2]:
      https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html
      
Hopefully, checking config files for supporting specific dev tools and
environments into Git is considered acceptable. Nix flakes require the
flake and its lockfile be tracked in Git, as Git revisions are used for
caching. And, I believe a few other folks at Oxide also use Nix, so I
thought having the flake in Git would be helpful for them as well.
However, if people object to this being checked into Git, I can also use
an (untracked) legacy `shell.nix` configuration for `nix-shell`, instead
(which I'd be happy to share with other Nix users).