### PR TITLE
Rename `ssh_keys` to `ssh_public_keys` in instance create

### DIFF
--- a/end-to-end-tests/src/instance_launch.rs
+++ b/end-to-end-tests/src/instance_launch.rs
@@ -73,7 +73,7 @@ async fn instance_launch() -> Result<()> {
             network_interfaces: InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![ExternalIpCreate::Ephemeral { pool: None }],
             user_data: String::new(),
-            ssh_keys: Some(vec![oxide_client::types::NameOrId::Name(
+            ssh_public_keys: Some(vec![oxide_client::types::NameOrId::Name(
                 ssh_key_name.clone(),
             )]),
             start: true,

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -999,7 +999,7 @@ mod tests {
                 ncpus: InstanceCpuCount(omicron_common::api::external::InstanceCpuCount(1)).into(),
                 memory: ByteCount(omicron_common::api::external::ByteCount::from_gibibytes_u32(1)).into(),
                 hostname: "test".into(),
-                ssh_keys: None,
+                ssh_public_keys: None,
                 user_data: vec![],
                 network_interfaces: Default::default(),
                 external_ips: vec![],

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -1740,7 +1740,7 @@ mod tests {
             memory: ByteCount::from_gibibytes_u32(4),
             hostname: "inst".to_string(),
             user_data: vec![],
-            ssh_keys: Some(Vec::new()),
+            ssh_public_keys: Some(Vec::new()),
             network_interfaces: InstanceNetworkInterfaceAttachment::None,
             external_ips: vec![],
             disks: vec![],

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -330,7 +330,7 @@ impl super::Nexus {
             .lookup_for(authz::Action::ListChildren)
             .await?;
 
-        let ssh_keys = match &params.ssh_keys {
+        let ssh_keys = match &params.ssh_public_keys {
             Some(keys) => Some(
                 self.db_datastore
                     .ssh_keys_batch_lookup(opctx, &authz_user, keys)
@@ -354,7 +354,7 @@ impl super::Nexus {
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),
             project_id: authz_project.id(),
             create_params: params::InstanceCreate {
-                ssh_keys,
+                ssh_public_keys: ssh_keys,
                 ..params.clone()
             },
             boundary_switches: self

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -331,7 +331,7 @@ async fn sic_associate_ssh_keys(
             &opctx,
             &authz_user,
             instance_id,
-            &saga_params.create_params.ssh_keys.map(|k| {
+            &saga_params.create_params.ssh_public_keys.map(|k| {
                 // Before the instance_create saga is kicked off all entries
                 // in `ssh_keys` are validated and converted to `Uuids`.
                 k.iter()
@@ -1104,7 +1104,7 @@ pub mod test {
                 memory: ByteCount::from_gibibytes_u32(4),
                 hostname: String::from("inst"),
                 user_data: vec![],
-                ssh_keys: None,
+                ssh_public_keys: None,
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::Default,
                 external_ips: vec![params::ExternalIpCreate::Ephemeral {

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -237,7 +237,7 @@ mod test {
             memory: ByteCount::from_gibibytes_u32(4),
             hostname: String::from("inst"),
             user_data: vec![],
-            ssh_keys: Some(Vec::new()),
+            ssh_public_keys: Some(Vec::new()),
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![params::ExternalIpCreate::Ephemeral {

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -570,7 +570,7 @@ mod tests {
                 memory: ByteCount::from_gibibytes_u32(2),
                 hostname: String::from(INSTANCE_NAME),
                 user_data: b"#cloud-config".to_vec(),
-                ssh_keys: Some(Vec::new()),
+                ssh_public_keys: Some(Vec::new()),
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::None,
                 external_ips: vec![],

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -749,7 +749,7 @@ mod test {
                 memory: ByteCount::from_gibibytes_u32(2),
                 hostname: String::from(INSTANCE_NAME),
                 user_data: b"#cloud-config".to_vec(),
-                ssh_keys: Some(Vec::new()),
+                ssh_public_keys: Some(Vec::new()),
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::None,
                 external_ips: vec![],

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1944,7 +1944,7 @@ mod test {
                 user_data:
                     b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                         .to_vec(),
-                ssh_keys:  Some(Vec::new()),
+                ssh_public_keys:  Some(Vec::new()),
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::None,
                 disks: disks_to_attach,

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -522,7 +522,7 @@ pub async fn create_instance_with(
             user_data:
                 b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                     .to_vec(),
-            ssh_keys: Some(Vec::new()),
+            ssh_public_keys: Some(Vec::new()),
             network_interfaces: nics.clone(),
             external_ips,
             disks,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -423,7 +423,7 @@ pub static DEMO_INSTANCE_CREATE: Lazy<params::InstanceCreate> =
         memory: ByteCount::from_gibibytes_u32(16),
         hostname: String::from("demo-instance"),
         user_data: vec![],
-        ssh_keys: Some(Vec::new()),
+        ssh_public_keys: Some(Vec::new()),
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
             pool: Some(DEMO_IP_POOL_NAME.clone().into()),

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -249,7 +249,7 @@ async fn test_instances_create_reboot_halt(
                 memory: instance.memory,
                 hostname: instance.hostname.clone(),
                 user_data: vec![],
-                ssh_keys: None,
+                ssh_public_keys: None,
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::Default,
                 external_ips: vec![],
@@ -1222,7 +1222,7 @@ async fn test_instances_create_stopped_start(
             memory: ByteCount::from_gibibytes_u32(1),
             hostname: String::from("the_host"),
             user_data: vec![],
-            ssh_keys: None,
+            ssh_public_keys: None,
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![],
@@ -1390,7 +1390,7 @@ async fn test_instance_using_image_from_other_project_fails(
                 memory: ByteCount::from_gibibytes_u32(1),
                 hostname: "stolen".into(),
                 user_data: vec![],
-                ssh_keys: None,
+                ssh_public_keys: None,
                 network_interfaces:
                     params::InstanceNetworkInterfaceAttachment::Default,
                 external_ips: vec![],
@@ -1465,7 +1465,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("inst"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: interface_params.clone(),
         external_ips: vec![],
         disks: vec![],
@@ -1493,7 +1493,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("inst2"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: interface_params,
         external_ips: vec![],
         disks: vec![],
@@ -1582,7 +1582,7 @@ async fn test_instance_with_single_explicit_ip_address(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nic-test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: interface_params,
         external_ips: vec![],
         disks: vec![],
@@ -1696,7 +1696,7 @@ async fn test_instance_with_new_custom_network_interfaces(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nic-test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: interface_params,
         external_ips: vec![],
         disks: vec![],
@@ -1810,7 +1810,7 @@ async fn test_instance_create_delete_network_interface(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nic-test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::None,
         external_ips: vec![],
         disks: vec![],
@@ -2051,7 +2051,7 @@ async fn test_instance_update_network_interfaces(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nic-test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::None,
         external_ips: vec![],
         disks: vec![],
@@ -2444,7 +2444,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nic-test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: interface_params,
         external_ips: vec![],
         disks: vec![],
@@ -2510,7 +2510,7 @@ async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![params::InstanceDiskAttachment::Attach(
@@ -2570,7 +2570,7 @@ async fn test_instance_create_attach_disks(
         memory: ByteCount::from_gibibytes_u32(3),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![
@@ -2667,7 +2667,7 @@ async fn test_instance_create_attach_disks_undo(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![
@@ -2752,7 +2752,7 @@ async fn test_attach_eight_disks_to_instance(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: (0..8)
@@ -2833,7 +2833,7 @@ async fn test_cannot_attach_nine_disks_to_instance(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: (0..9)
@@ -2928,7 +2928,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: (0..8)
@@ -3012,7 +3012,7 @@ async fn test_disks_detached_when_instance_destroyed(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfs"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: (0..8)
@@ -3103,7 +3103,7 @@ async fn test_disks_detached_when_instance_destroyed(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("nfsv2"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: (0..8)
@@ -3165,7 +3165,7 @@ async fn test_instances_memory_rejected_less_than_min_memory_size(
         user_data:
             b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                 .to_vec(),
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![],
@@ -3215,7 +3215,7 @@ async fn test_instances_memory_not_divisible_by_min_memory_size(
         user_data:
             b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                 .to_vec(),
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![],
@@ -3265,7 +3265,7 @@ async fn test_instances_memory_greater_than_max_size(
         user_data:
             b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                 .to_vec(),
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![],
@@ -3345,7 +3345,7 @@ async fn test_instance_create_with_ssh_keys(
         ncpus: InstanceCpuCount::try_from(2).unwrap(),
         memory: ByteCount::from_gibibytes_u32(4),
         // By default should transfer all profile keys
-        ssh_keys: None,
+        ssh_public_keys: None,
         start: false,
         hostname: instance_name.to_string(),
         user_data: vec![],
@@ -3391,7 +3391,7 @@ async fn test_instance_create_with_ssh_keys(
         ncpus: InstanceCpuCount::try_from(2).unwrap(),
         memory: ByteCount::from_gibibytes_u32(4),
         // Should only transfer the first key
-        ssh_keys: Some(vec![user_keys[0].identity.name.clone().into()]),
+        ssh_public_keys: Some(vec![user_keys[0].identity.name.clone().into()]),
         start: false,
         hostname: instance_name.to_string(),
         user_data: vec![],
@@ -3436,7 +3436,7 @@ async fn test_instance_create_with_ssh_keys(
         ncpus: InstanceCpuCount::try_from(2).unwrap(),
         memory: ByteCount::from_gibibytes_u32(4),
         // Should transfer no keys
-        ssh_keys: Some(vec![]),
+        ssh_public_keys: Some(vec![]),
         start: false,
         hostname: instance_name.to_string(),
         user_data: vec![],
@@ -3558,7 +3558,7 @@ async fn test_cannot_provision_instance_beyond_cpu_capacity(
             memory: ByteCount::from_gibibytes_u32(1),
             hostname: config.0.to_string(),
             user_data: vec![],
-            ssh_keys: None,
+            ssh_public_keys: None,
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![],
@@ -3612,7 +3612,7 @@ async fn test_cannot_provision_instance_beyond_cpu_limit(
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("test"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![],
         disks: vec![],
@@ -3664,7 +3664,7 @@ async fn test_cannot_provision_instance_beyond_ram_capacity(
             memory: ByteCount::try_from(config.1).unwrap(),
             hostname: config.0.to_string(),
             user_data: vec![],
-            ssh_keys: None,
+            ssh_public_keys: None,
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::Default,
             external_ips: vec![],
@@ -3919,7 +3919,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
             pool: Some("pool1".parse::<Name>().unwrap().into()),
         }],
-        ssh_keys: None,
+        ssh_public_keys: None,
         disks: vec![],
         start: true,
     };
@@ -3984,7 +3984,7 @@ async fn test_instance_ephemeral_ip_from_orphan_pool(
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
             pool: Some("orphan-pool".parse::<Name>().unwrap().into()),
         }],
-        ssh_keys: None,
+        ssh_public_keys: None,
         disks: vec![],
         start: true,
     };
@@ -4045,7 +4045,7 @@ async fn test_instance_ephemeral_ip_no_default_pool_error(
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
             pool: None, // <--- the only important thing here
         }],
-        ssh_keys: None,
+        ssh_public_keys: None,
         disks: vec![],
         start: true,
     };
@@ -4176,7 +4176,7 @@ async fn test_instance_allow_only_one_ephemeral_ip(
         user_data:
             b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                 .to_vec(),
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![ephemeral_create.clone(), ephemeral_create],
         disks: vec![],
@@ -4302,7 +4302,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         memory: ByteCount::from_gibibytes_u32(4),
         hostname: String::from("inst"),
         user_data: vec![],
-        ssh_keys: None,
+        ssh_public_keys: None,
         network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
         external_ips: vec![params::ExternalIpCreate::Ephemeral {
             pool: Some("default".parse::<Name>().unwrap().into()),

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -157,7 +157,7 @@ async fn test_project_deletion_with_instance(
             memory: ByteCount::from_gibibytes_u32(1),
             hostname: String::from("the_host"),
             user_data: b"none".to_vec(),
-            ssh_keys: Some(Vec::new()),
+            ssh_public_keys: Some(Vec::new()),
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::None,
             external_ips: vec![],

--- a/nexus/tests/integration_tests/quotas.rs
+++ b/nexus/tests/integration_tests/quotas.rs
@@ -81,7 +81,7 @@ impl ResourceAllocator {
                 hostname: "host".to_string(),
                 user_data: b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                     .to_vec(),
-                ssh_keys:  Some(Vec::new()),
+                ssh_public_keys:  Some(Vec::new()),
                 network_interfaces: params::InstanceNetworkInterfaceAttachment::Default,
                 external_ips: Vec::<params::ExternalIpCreate>::new(),
                 disks: Vec::<params::InstanceDiskAttachment>::new(),

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -123,7 +123,7 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
             user_data:
                 b"#cloud-config\nsystem_info:\n  default_user:\n    name: oxide"
                     .to_vec(),
-            ssh_keys: Some(Vec::new()),
+            ssh_public_keys: Some(Vec::new()),
             network_interfaces:
                 params::InstanceNetworkInterfaceAttachment::None,
             disks: vec![params::InstanceDiskAttachment::Attach(

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -58,7 +58,7 @@ async fn create_instance_expect_failure(
         memory: ByteCount::from_gibibytes_u32(1),
         hostname: name.to_string(),
         user_data: vec![],
-        ssh_keys: Some(Vec::new()),
+        ssh_public_keys: Some(Vec::new()),
         network_interfaces,
         external_ips: vec![],
         disks: vec![],

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1042,7 +1042,7 @@ pub struct InstanceCreate {
     /// If not provided, all SSH public keys from the user's profile will be sent.
     /// If an empty list is provided, no public keys will be transmitted to the
     /// instance.
-    pub ssh_keys: Option<Vec<NameOrId>>,
+    pub ssh_public_keys: Option<Vec<NameOrId>>,
 
     /// Should this instance be started upon creation; true by default.
     #[serde(default = "bool_true")]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12430,7 +12430,7 @@
               }
             ]
           },
-          "ssh_keys": {
+          "ssh_public_keys": {
             "nullable": true,
             "description": "An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation.\n\nIf not provided, all SSH public keys from the user's profile will be sent. If an empty list is provided, no public keys will be transmitted to the instance.",
             "type": "array",


### PR DESCRIPTION
Fixes #4866 