### PR TITLE
[wicketd] replace snafu with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10291,7 +10291,6 @@ dependencies = [
  "sled-hardware",
  "slog",
  "slog-dtrace",
- "snafu",
  "subprocess",
  "tar",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -354,7 +354,6 @@ slog-envlogger = "2.2"
 slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain", branch = "main", features = ["derive"] }
 slog-term = "2.9"
 smf = "0.2"
-snafu = "0.7"
 sp-sim = { path = "sp-sim" }
 sprockets-common = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }
 sprockets-host = { git = "http://github.com/oxidecomputer/sprockets", rev = "77df31efa5619d0767ffc837ef7468101608aee9" }

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -42,7 +42,6 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tough.workspace = true
 trust-dns-resolver.workspace = true
-snafu.workspace = true
 toml.workspace = true
 uuid.workspace = true
 

--- a/wicketd/src/config.rs
+++ b/wicketd/src/config.rs
@@ -4,11 +4,10 @@
 
 //! Configuration related types used by wicketd
 
+use camino::{Utf8Path, Utf8PathBuf};
 use dropshot::ConfigLogging;
 use serde::{Deserialize, Serialize};
-use snafu::prelude::*;
-use std::path::Path;
-use std::path::PathBuf;
+use thiserror::Error;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
@@ -19,17 +18,32 @@ impl Config {
     /// Load a `Config` from the given TOML file
     ///
     /// This config object can be used to create a wicketd server.
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
+    pub fn from_file<P: AsRef<Utf8Path>>(
+        path: P,
+    ) -> Result<Config, ConfigError> {
         let path = path.as_ref();
-        let data = std::fs::read_to_string(path).context(IoSnafu { path })?;
-        toml::from_str(&data).context(ParseSnafu { path })
+        let data = std::fs::read_to_string(path).map_err(|error| {
+            ConfigError::Io { error, path: path.to_owned() }
+        })?;
+        toml::from_str(&data).map_err(|error| ConfigError::Parse {
+            error,
+            path: path.to_owned(),
+        })
     }
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Error)]
 pub enum ConfigError {
-    #[snafu(display("Failed to read config file: {}", path.display()))]
-    Io { source: std::io::Error, path: PathBuf },
-    #[snafu(display("Failed to parse config file: {}", path.display()))]
-    Parse { source: toml::de::Error, path: PathBuf },
+    #[error("Failed to read config file: {path}")]
+    Io {
+        #[source]
+        error: std::io::Error,
+        path: Utf8PathBuf,
+    },
+    #[error("Failed to parse config file: {path}")]
+    Parse {
+        #[source]
+        error: toml::de::Error,
+        path: Utf8PathBuf,
+    },
 }


### PR DESCRIPTION
This is currently the only use of snafu in omicron (outside of transitive
deps), and I figure it is simple enough that we can replace it with thiserror,
reducing use of a direct dependency.

This was the first time I'd encountered snafu so I read a bit about it. As far
as I understand, the main benefit of snafu is that it pushes you heavily
towards an error-per-module pattern. However, thiserror does permit that
pattern as well, and in practice it is only a little more verbose than snafu to
do right (`map_err` vs `context`, though `snafu` introduces new types that
aren't in the source code like `IoSnafu` and `ParseSnafu`).

I'd love to get your take on it though @andrewjstone.
