### PR TITLE
[buildomat] Capture per-crate build timing as build-timings.json

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -20,8 +20,12 @@ curl -sSfL --retry 10 https://get.nexte.st/"$NEXTEST_VERSION"/"$1" | gunzip | ta
 # we can check later whether we left detritus around.
 #
 TEST_TMPDIR='/var/tmp/omicron_tmp'
-echo "tests will store output in $TEST_TMPDIR" >&2
+echo "tests will store ephemeral output in $TEST_TMPDIR" >&2
 mkdir "$TEST_TMPDIR"
+
+OUTPUT_DIR='/work/'
+echo "tests will store non-ephemeral output in $OUTPUT_DIR" >&2
+mkdir "$OUTPUT_DIR"
 
 #
 # Set up our PATH for the test suite.
@@ -70,7 +74,7 @@ export RUSTC_BOOTSTRAP=1
 
 # Build all the packages and tests, and keep track of how long each took to build.
 # We report build progress to stderr, and the "--timings=json" output goes to stdout.
-ptime -m cargo build -Z unstable-options --timings=json --workspace --tests --locked --verbose 1> "$TEST_TMPDIR/crate-build-timings.json"
+ptime -m cargo build -Z unstable-options --timings=json --workspace --tests --locked --verbose 1> "$OUTPUT_DIR/crate-build-timings.json"
 
 #
 # We apply our own timeout to ensure that we get a normal failure on timeout

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -70,11 +70,7 @@ export RUSTC_BOOTSTRAP=1
 
 # Build all the packages and tests, and keep track of how long each took to build.
 # We report build progress to stderr, and the "--timings=json" output goes to stdout.
-ptime -m cargo build -Z unstable-options --timings=json --workspace --tests --locked --verbose 1> build-timings.json
-
-# Sort the build timings by "slowest to build first", then emit emit it from the build
-# phase so it's saved.
-jq build-timings.json -c -s 'sort_by(.duration)' > "$TEST_TMPDIR/build-timings.json"
+ptime -m cargo build -Z unstable-options --timings=json --workspace --tests --locked --verbose 1> "$TEST_TMPDIR/crate-build-timings.json"
 
 #
 # We apply our own timeout to ensure that we get a normal failure on timeout

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -23,9 +23,9 @@ TEST_TMPDIR='/var/tmp/omicron_tmp'
 echo "tests will store ephemeral output in $TEST_TMPDIR" >&2
 mkdir "$TEST_TMPDIR"
 
-OUTPUT_DIR='/work/'
+OUTPUT_DIR='/work'
 echo "tests will store non-ephemeral output in $OUTPUT_DIR" >&2
-mkdir "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
 
 #
 # Set up our PATH for the test suite.

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -5,6 +5,7 @@
 #: target = "helios-2.0"
 #: rust_toolchain = "1.72.1"
 #: output_rules = [
+#:	"%/work/*",
 #:	"%/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -5,6 +5,7 @@
 #: target = "ubuntu-22.04"
 #: rust_toolchain = "1.72.1"
 #: output_rules = [
+#:	"%/work/*",
 #:	"%/var/tmp/omicron_tmp/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/omicron/issues/4471

Captures the per-crate build timing information in a JSON file