### PR TITLE
Exclude non-discoverable silos from IP pool silos list

### DIFF
--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1511,7 +1511,12 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(ip_pool_range, ip_pool, ip_pool_resource);
+allow_tables_to_appear_in_same_query!(
+    ip_pool_range,
+    ip_pool,
+    ip_pool_resource,
+    silo
+);
 joinable!(ip_pool_range -> ip_pool (ip_pool_id));
 joinable!(ip_pool_resource -> ip_pool (ip_pool_id));
 

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -330,6 +330,7 @@ impl DataStore {
     ) -> ListResultVec<IpPoolResource> {
         use db::schema::ip_pool;
         use db::schema::ip_pool_resource;
+        use db::schema::silo;
 
         paginated(
             ip_pool_resource::table,
@@ -337,8 +338,11 @@ impl DataStore {
             pagparams,
         )
         .inner_join(ip_pool::table)
+        .inner_join(silo::table.on(silo::id.eq(ip_pool_resource::resource_id)))
         .filter(ip_pool::id.eq(authz_pool.id()))
         .filter(ip_pool::time_deleted.is_null())
+        .filter(silo::time_deleted.is_null())
+        .filter(silo::discoverable.eq(true))
         .select(IpPoolResource::as_select())
         .load_async::<IpPoolResource>(
             &*self.pool_connection_authorized(opctx).await?,

--- a/schema/crdb/23.0.0/up4.sql
+++ b/schema/crdb/23.0.0/up4.sql
@@ -36,6 +36,7 @@ CROSS JOIN omicron.public.silo AS s
 WHERE p.time_deleted IS null 
   AND p.silo_id IS null -- means it's a fleet pool
   AND s.time_deleted IS null
+  -- TODO: AND NOT s.discoverable ???
 -- this makes it idempotent
 ON CONFLICT (ip_pool_id, resource_type, resource_id)
 DO NOTHING;

--- a/schema/crdb/23.0.0/up4.sql
+++ b/schema/crdb/23.0.0/up4.sql
@@ -36,7 +36,6 @@ CROSS JOIN omicron.public.silo AS s
 WHERE p.time_deleted IS null 
   AND p.silo_id IS null -- means it's a fleet pool
   AND s.time_deleted IS null
-  -- TODO: AND NOT s.discoverable ???
 -- this makes it idempotent
 ON CONFLICT (ip_pool_id, resource_type, resource_id)
 DO NOTHING;


### PR DESCRIPTION
They're still linkable, just like they're still GETable by name or ID. They just don't show up in lists.

Closes https://github.com/oxidecomputer/omicron/issues/4955