### PR TITLE
[nexus-macros] convert dump tests to snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
 name = "authz-macros"
 version = "0.1.0"
 dependencies = [
+ "expectorate",
  "heck 0.4.1",
  "omicron-workspace-hack",
  "prettyplease",
@@ -1511,6 +1512,7 @@ dependencies = [
 name = "db-macros"
 version = "0.1.0"
 dependencies = [
+ "expectorate",
  "heck 0.4.1",
  "omicron-workspace-hack",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ postgres-protocol = "0.6.6"
 predicates = "3.1.0"
 pretty_assertions = "1.4.0"
 pretty-hex = "0.4.1"
-prettyplease = "0.2.16"
+prettyplease = { version = "0.2.16", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }

--- a/nexus/authz-macros/Cargo.toml
+++ b/nexus/authz-macros/Cargo.toml
@@ -17,4 +17,5 @@ syn.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+expectorate.workspace = true
 prettyplease.workspace = true

--- a/nexus/authz-macros/outputs/instance.txt
+++ b/nexus/authz-macros/outputs/instance.txt
@@ -1,0 +1,79 @@
+///`authz` type for a resource of type InstanceUsed to uniquely identify a resource of type Instance across renames, moves, etc., and to do authorization checks (see  [`crate::context::OpContext::authorize()`]).  See [`crate::authz`] module-level documentation for more information.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Instance {
+    parent: Project,
+    key: (String, String),
+    lookup_type: LookupType,
+}
+impl Instance {
+    /// Makes a new `authz` struct for this resource with the given
+    /// `parent`, unique key `key`, looked up as described by
+    /// `lookup_type`
+    pub fn new(
+        parent: Project,
+        key: SomeCompositeId,
+        lookup_type: LookupType,
+    ) -> Instance {
+        Instance {
+            parent,
+            key: key.into(),
+            lookup_type,
+        }
+    }
+    /// A version of `new` that takes the primary key type directly.
+    /// This is only different from [`Self::new`] if this resource
+    /// uses a different input key type.
+    pub fn with_primary_key(
+        parent: Project,
+        key: (String, String),
+        lookup_type: LookupType,
+    ) -> Instance {
+        Instance {
+            parent,
+            key,
+            lookup_type,
+        }
+    }
+    pub fn id(&self) -> (String, String) {
+        self.key.clone().into()
+    }
+    /// Describes how to register this type with Oso
+    pub(super) fn init() -> Init {
+        use oso::PolarClass;
+        Init {
+            polar_snippet: "\n                resource Instance {\n                    permissions = [\n                        \"list_children\",\n                        \"modify\",\n                        \"read\",\n                        \"create_child\",\n                    ];\n\n                    relations = { containing_project: Project };\n                    \"list_children\" if \"viewer\" on \"containing_project\";\n                    \"read\" if \"viewer\" on \"containing_project\";\n                    \"modify\" if \"collaborator\" on \"containing_project\";\n                    \"create_child\" if \"collaborator\" on \"containing_project\";\n                }\n\n                has_relation(parent: Project, \"containing_project\", child: Instance)\n                        if child.project = parent;\n            ",
+            polar_class: Instance::get_polar_class(),
+        }
+    }
+}
+impl Eq for Instance {}
+impl PartialEq for Instance {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+impl oso::PolarClass for Instance {
+    fn get_polar_class_builder() -> oso::ClassBuilder<Self> {
+        oso::Class::builder()
+            .with_equality_check()
+            .add_method(
+                "has_role",
+                |r: &Instance, actor: AuthenticatedActor, role: String| { false },
+            )
+            .add_attribute_getter("project", |r: &Instance| r.parent.clone())
+    }
+}
+impl ApiResource for Instance {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
+        Some(&self.parent)
+    }
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Instance
+    }
+    fn lookup_type(&self) -> &LookupType {
+        &self.lookup_type
+    }
+    fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles> {
+        None
+    }
+}

--- a/nexus/authz-macros/outputs/organization.txt
+++ b/nexus/authz-macros/outputs/organization.txt
@@ -1,0 +1,75 @@
+///`authz` type for a resource of type OrganizationUsed to uniquely identify a resource of type Organization across renames, moves, etc., and to do authorization checks (see  [`crate::context::OpContext::authorize()`]).  See [`crate::authz`] module-level documentation for more information.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Organization {
+    parent: Fleet,
+    key: Uuid,
+    lookup_type: LookupType,
+}
+impl Organization {
+    /// Makes a new `authz` struct for this resource with the given
+    /// `parent`, unique key `key`, looked up as described by
+    /// `lookup_type`
+    pub fn new(parent: Fleet, key: Uuid, lookup_type: LookupType) -> Organization {
+        Organization {
+            parent,
+            key: key.into(),
+            lookup_type,
+        }
+    }
+    /// A version of `new` that takes the primary key type directly.
+    /// This is only different from [`Self::new`] if this resource
+    /// uses a different input key type.
+    pub fn with_primary_key(
+        parent: Fleet,
+        key: Uuid,
+        lookup_type: LookupType,
+    ) -> Organization {
+        Organization {
+            parent,
+            key,
+            lookup_type,
+        }
+    }
+    pub fn id(&self) -> Uuid {
+        self.key.clone().into()
+    }
+    /// Describes how to register this type with Oso
+    pub(super) fn init() -> Init {
+        use oso::PolarClass;
+        Init {
+            polar_snippet: "",
+            polar_class: Organization::get_polar_class(),
+        }
+    }
+}
+impl Eq for Organization {}
+impl PartialEq for Organization {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+impl oso::PolarClass for Organization {
+    fn get_polar_class_builder() -> oso::ClassBuilder<Self> {
+        oso::Class::builder()
+            .with_equality_check()
+            .add_method(
+                "has_role",
+                |r: &Organization, actor: AuthenticatedActor, role: String| { false },
+            )
+            .add_attribute_getter("fleet", |r: &Organization| r.parent.clone())
+    }
+}
+impl ApiResource for Organization {
+    fn parent(&self) -> Option<&dyn AuthorizedResource> {
+        Some(&self.parent)
+    }
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Organization
+    }
+    fn lookup_type(&self) -> &LookupType {
+        &self.lookup_type
+    }
+    fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles> {
+        None
+    }
+}

--- a/nexus/authz-macros/src/lib.rs
+++ b/nexus/authz-macros/src/lib.rs
@@ -460,12 +460,17 @@ fn do_authz_resource(
     })
 }
 
-// See the test for lookup_resource.
 #[cfg(test)]
 mod tests {
     use super::*;
+    use expectorate::assert_contents;
+
+    /// Ensures that generated code is as expected.
+    ///
+    /// For more information, see `test_lookup_snapshots` in
+    /// nexus/db-macros/src/lookup.rs.
     #[test]
-    fn test_authz_dump() {
+    fn test_authz_snapshots() {
         let output = do_authz_resource(quote! {
             name = "Organization",
             parent = "Fleet",
@@ -474,7 +479,7 @@ mod tests {
             polar_snippet = Custom,
         })
         .unwrap();
-        println!("{}", pretty_format(output));
+        assert_contents("outputs/organization.txt", &pretty_format(output));
 
         let output = do_authz_resource(quote! {
             name = "Instance",
@@ -487,7 +492,7 @@ mod tests {
             polar_snippet = InProject,
         })
         .unwrap();
-        println!("{}", pretty_format(output));
+        assert_contents("outputs/instance.txt", &pretty_format(output));
     }
 
     fn pretty_format(input: TokenStream) -> String {

--- a/nexus/db-macros/Cargo.toml
+++ b/nexus/db-macros/Cargo.toml
@@ -18,4 +18,5 @@ syn = { workspace = true, features = ["extra-traits"] }
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+expectorate.workspace = true
 prettyplease.workspace = true

--- a/nexus/db-macros/outputs/project.txt
+++ b/nexus/db-macros/outputs/project.txt
@@ -1,0 +1,393 @@
+///Selects a resource of type Project (or any of its children, using the functions on this struct) for lookup or fetch
+pub enum Project<'a> {
+    /// An error occurred while selecting the resource
+    ///
+    /// This error will be returned by any lookup/fetch attempts.
+    Error(Root<'a>, Error),
+    /// We're looking for a resource with the given name in the given
+    /// parent collection
+    Name(Silo<'a>, &'a Name),
+    /// Same as [`Self::Name`], but the name is owned rather than borrowed
+    OwnedName(Silo<'a>, Name),
+    /// We're looking for a resource with the given primary key
+    ///
+    /// This has no parent container -- a by-id lookup is always global
+    PrimaryKey(Root<'a>, Uuid),
+}
+impl<'a> Project<'a> {
+    ///Select a resource of type Disk within this Project, identified by its name
+    pub fn disk_name<'b, 'c>(self, name: &'b Name) -> Disk<'c>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        Disk::Name(self, name)
+    }
+    ///Select a resource of type Disk within this Project, identified by its name
+    pub fn disk_name_owned<'c>(self, name: Name) -> Disk<'c>
+    where
+        'a: 'c,
+    {
+        Disk::OwnedName(self, name)
+    }
+    ///Select a resource of type Instance within this Project, identified by its name
+    pub fn instance_name<'b, 'c>(self, name: &'b Name) -> Instance<'c>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        Instance::Name(self, name)
+    }
+    ///Select a resource of type Instance within this Project, identified by its name
+    pub fn instance_name_owned<'c>(self, name: Name) -> Instance<'c>
+    where
+        'a: 'c,
+    {
+        Instance::OwnedName(self, name)
+    }
+    /// Fetch the record corresponding to the selected resource
+    ///
+    /// This is equivalent to `fetch_for(authz::Action::Read)`.
+    pub async fn fetch(
+        &self,
+    ) -> LookupResult<(authz::Silo, authz::Project, nexus_db_model::Project)> {
+        self.fetch_for(authz::Action::Read).await
+    }
+    /// Turn the Result<T, E> of [`fetch`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch(
+        &self,
+    ) -> LookupResult<Option<(authz::Silo, authz::Project, nexus_db_model::Project)>> {
+        self.optional_fetch_for(authz::Action::Read).await
+    }
+    /// Fetch the record corresponding to the selected resource and
+    /// check whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::Silo, authz::Project, nexus_db_model::Project)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            Project::Error(_, error) => Err(error.clone()),
+            Project::Name(parent, &ref name) | Project::OwnedName(parent, ref name) => {
+                let (authz_silo,) = parent.lookup().await?;
+                let (authz_project, db_row) = Self::fetch_by_name_for(
+                        opctx,
+                        datastore,
+                        &authz_silo,
+                        name,
+                        action,
+                    )
+                    .await?;
+                Ok((authz_silo, authz_project, db_row))
+            }
+            Project::PrimaryKey(_, v0) => {
+                Self::fetch_by_id_for(opctx, datastore, v0, action).await
+            }
+        }
+            .and_then(|input| {
+                let (ref authz_silo, .., ref authz_project, ref _db_row) = &input;
+                Self::silo_check(opctx, authz_silo, authz_project)?;
+                Ok(input)
+            })
+    }
+    /// Turn the Result<T, E> of [`fetch_for`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::Silo, authz::Project, nexus_db_model::Project)>> {
+        let result = self.fetch_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch an `authz` object for the selected resource and check
+    /// whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::Silo, authz::Project)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let (authz_silo, authz_project) = self.lookup().await?;
+        opctx.authorize(action, &authz_project).await?;
+        Ok((authz_silo, authz_project))
+            .and_then(|input| {
+                let (ref authz_silo, .., ref authz_project) = &input;
+                Self::silo_check(opctx, authz_silo, authz_project)?;
+                Ok(input)
+            })
+    }
+    /// Turn the Result<T, E> of [`lookup_for`] into a Result<Option<T>, E>.
+    pub async fn optional_lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::Silo, authz::Project)>> {
+        let result = self.lookup_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch the "authz" objects for the selected resource and all its
+    /// parents
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `lookup_for(authz::Action)`.
+    async fn lookup(&self) -> LookupResult<(authz::Silo, authz::Project)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            Project::Error(_, error) => Err(error.clone()),
+            Project::Name(parent, &ref name) | Project::OwnedName(parent, ref name) => {
+                let (authz_silo,) = parent.lookup().await?;
+                let (authz_project, _) = Self::lookup_by_name_no_authz(
+                        opctx,
+                        datastore,
+                        &authz_silo,
+                        name,
+                    )
+                    .await?;
+                Ok((authz_silo, authz_project))
+            }
+            Project::PrimaryKey(_, v0) => {
+                let (authz_silo, authz_project, _) = Self::lookup_by_id_no_authz(
+                        opctx,
+                        datastore,
+                        v0,
+                    )
+                    .await?;
+                Ok((authz_silo, authz_project))
+            }
+        }
+    }
+    /// Build the `authz` object for this resource
+    fn make_authz(
+        authz_parent: &authz::Silo,
+        db_row: &nexus_db_model::Project,
+        lookup_type: LookupType,
+    ) -> authz::Project {
+        authz::Project::with_primary_key(authz_parent.clone(), db_row.id(), lookup_type)
+    }
+    /// Getting the [`LookupPath`] for this lookup
+    ///
+    /// This is used when we actually query the database.  At that
+    /// point, we need the `OpContext` and `DataStore` that are being
+    /// used for this lookup.
+    fn lookup_root(&self) -> &LookupPath<'a> {
+        match &self {
+            Project::Error(root, ..) => root.lookup_root(),
+            Project::Name(parent, _) | Project::OwnedName(parent, _) => {
+                parent.lookup_root()
+            }
+            Project::PrimaryKey(root, ..) => root.lookup_root(),
+        }
+    }
+    /// For a "siloed" resource (i.e., one that's nested under "Silo" in
+    /// the resource hierarchy), check whether a given resource's Silo
+    /// (given by `authz_silo`) matches the Silo of the actor doing the
+    /// fetch/lookup (given by `opctx`).
+    ///
+    /// This check should not be strictly necessary.  We should never
+    /// wind up hitting the error conditions here.  That's because in
+    /// order to reach this check, we must have done a successful authz
+    /// check.  That check should have failed because there's no way to
+    /// grant users access to resources in other Silos.  So why do this
+    /// check at all?  As a belt-and-suspenders way to make sure we
+    /// never return objects to a user that are from a different Silo
+    /// than the one they're attached to.  But what do we do if the
+    /// check fails?  We definitely want to know about it so that we can
+    /// determine if there's an authz bug here, and if so, fix it.
+    /// That's why we log this at "error" level.  We also override the
+    /// lookup return value with a suitable error indicating the
+    /// resource does not exist or the caller did not supply
+    /// credentials, just as if they didn't have access to the object.
+    fn silo_check(
+        opctx: &OpContext,
+        authz_silo: &authz::Silo,
+        authz_project: &authz::Project,
+    ) -> Result<(), Error> {
+        let log = &opctx.log;
+        let actor_silo_id = match opctx
+            .authn
+            .silo_or_builtin()
+            .internal_context("siloed resource check")
+        {
+            Ok(Some(silo)) => silo.id(),
+            Ok(None) => {
+                trace!(
+                    log,
+                    "successful lookup of siloed resource {:?} \
+                            using built-in user",
+                    "Project",
+                );
+                return Ok(());
+            }
+            Err(error) => {
+                error!(
+                    log,
+                    "unexpected successful lookup of siloed resource \
+                            {:?} with no actor in OpContext",
+                    "Project",
+                );
+                return Err(error);
+            }
+        };
+        let resource_silo_id = authz_silo.id();
+        if resource_silo_id != actor_silo_id {
+            use crate::authz::ApiResource;
+            error!(
+                log,
+                "unexpected successful lookup of siloed resource \
+                        {:?} in a different Silo from current actor (resource \
+                        Silo {}, actor Silo {})",
+                "Project", resource_silo_id, actor_silo_id,
+            );
+            Err(authz_project.not_found())
+        } else {
+            Ok(())
+        }
+    }
+    /// Fetch the database row for a resource by doing a lookup by
+    /// name, possibly within a collection
+    ///
+    /// This function checks whether the caller has permissions to
+    /// read the requested data.  However, it's not intended to be
+    /// used outside this module.  See `fetch_for(authz::Action)`.
+    async fn fetch_by_name_for(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        authz_silo: &authz::Silo,
+        name: &Name,
+        action: authz::Action,
+    ) -> LookupResult<(authz::Project, nexus_db_model::Project)> {
+        let (authz_project, db_row) = Self::lookup_by_name_no_authz(
+                opctx,
+                datastore,
+                authz_silo,
+                name,
+            )
+            .await?;
+        opctx.authorize(action, &authz_project).await?;
+        Ok((authz_project, db_row))
+    }
+    /// Lowest-level function for looking up a resource in the
+    /// database by name, possibly within a collection
+    ///
+    /// This function does not check whether the caller has
+    /// permission to read this information.  That's why it's not
+    /// `pub`.  Outside this module, you want `fetch()` or
+    /// `lookup_for(authz::Action)`.
+    async fn lookup_by_name_no_authz(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        authz_silo: &authz::Silo,
+        name: &Name,
+    ) -> LookupResult<(authz::Project, nexus_db_model::Project)> {
+        use db::schema::project::dsl;
+        dsl::project
+            .filter(dsl::time_deleted.is_null())
+            .filter(dsl::name.eq(name.clone()))
+            .filter(dsl::silo_id.eq(authz_silo.id()))
+            .select(nexus_db_model::Project::as_select())
+            .get_result_async(&*datastore.pool_connection_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::Project,
+                        LookupType::ByName(name.as_str().to_string()),
+                    ),
+                )
+            })
+            .map(|db_row| {
+                (
+                    Self::make_authz(
+                        authz_silo,
+                        &db_row,
+                        LookupType::ByName(name.as_str().to_string()),
+                    ),
+                    db_row,
+                )
+            })
+    }
+    /// Fetch the database row for a resource by doing a lookup by id
+    ///
+    /// This function checks whether the caller has permissions to read
+    /// the requested data.  However, it's not intended to be used
+    /// outside this module.  See `fetch_for(authz::Action)`.
+    async fn fetch_by_id_for(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &Uuid,
+        action: authz::Action,
+    ) -> LookupResult<(authz::Silo, authz::Project, nexus_db_model::Project)> {
+        let (authz_silo, authz_project, db_row) = Self::lookup_by_id_no_authz(
+                opctx,
+                datastore,
+                v0,
+            )
+            .await?;
+        opctx.authorize(action, &authz_project).await?;
+        Ok((authz_silo, authz_project, db_row))
+    }
+    /// Lowest-level function for looking up a resource in the database
+    /// by id
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `fetch()` or `lookup_for(authz::Action)`.
+    async fn lookup_by_id_no_authz(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &Uuid,
+    ) -> LookupResult<(authz::Silo, authz::Project, nexus_db_model::Project)> {
+        use db::schema::project::dsl;
+        let db_row = dsl::project
+            .filter(dsl::time_deleted.is_null())
+            .filter(dsl::id.eq(v0.clone()))
+            .select(nexus_db_model::Project::as_select())
+            .get_result_async(&*datastore.pool_connection_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::Project,
+                        LookupType::ById(v0.clone()),
+                    ),
+                )
+            })?;
+        let (authz_silo, _) = Silo::lookup_by_id_no_authz(
+                opctx,
+                datastore,
+                &db_row.silo_id,
+            )
+            .await?;
+        let authz_project = Self::make_authz(
+            &authz_silo,
+            &db_row,
+            LookupType::ById(v0.clone()),
+        );
+        Ok((authz_silo, authz_project, db_row))
+    }
+}

--- a/nexus/db-macros/outputs/silo_user.txt
+++ b/nexus/db-macros/outputs/silo_user.txt
@@ -1,0 +1,183 @@
+///Selects a resource of type SiloUser (or any of its children, using the functions on this struct) for lookup or fetch
+pub enum SiloUser<'a> {
+    /// An error occurred while selecting the resource
+    ///
+    /// This error will be returned by any lookup/fetch attempts.
+    Error(Root<'a>, Error),
+    /// We're looking for a resource with the given primary key
+    ///
+    /// This has no parent container -- a by-id lookup is always global
+    PrimaryKey(Root<'a>, Uuid),
+}
+impl<'a> SiloUser<'a> {
+    /// Fetch the record corresponding to the selected resource
+    ///
+    /// This is equivalent to `fetch_for(authz::Action::Read)`.
+    pub async fn fetch(
+        &self,
+    ) -> LookupResult<(authz::SiloUser, nexus_db_model::SiloUser)> {
+        self.fetch_for(authz::Action::Read).await
+    }
+    /// Turn the Result<T, E> of [`fetch`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch(
+        &self,
+    ) -> LookupResult<Option<(authz::SiloUser, nexus_db_model::SiloUser)>> {
+        self.optional_fetch_for(authz::Action::Read).await
+    }
+    /// Fetch the record corresponding to the selected resource and
+    /// check whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::SiloUser, nexus_db_model::SiloUser)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            SiloUser::Error(_, error) => Err(error.clone()),
+            SiloUser::PrimaryKey(_, v0) => {
+                Self::fetch_by_id_for(opctx, datastore, v0, action).await
+            }
+        }
+    }
+    /// Turn the Result<T, E> of [`fetch_for`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::SiloUser, nexus_db_model::SiloUser)>> {
+        let result = self.fetch_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch an `authz` object for the selected resource and check
+    /// whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::SiloUser,)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let (authz_silo_user,) = self.lookup().await?;
+        opctx.authorize(action, &authz_silo_user).await?;
+        Ok((authz_silo_user,))
+    }
+    /// Turn the Result<T, E> of [`lookup_for`] into a Result<Option<T>, E>.
+    pub async fn optional_lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::SiloUser,)>> {
+        let result = self.lookup_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch the "authz" objects for the selected resource and all its
+    /// parents
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `lookup_for(authz::Action)`.
+    async fn lookup(&self) -> LookupResult<(authz::SiloUser,)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            SiloUser::Error(_, error) => Err(error.clone()),
+            SiloUser::PrimaryKey(_, v0) => {
+                let (authz_silo_user, _) = Self::lookup_by_id_no_authz(
+                        opctx,
+                        datastore,
+                        v0,
+                    )
+                    .await?;
+                Ok((authz_silo_user,))
+            }
+        }
+    }
+    /// Build the `authz` object for this resource
+    fn make_authz(
+        authz_parent: &authz::Fleet,
+        db_row: &nexus_db_model::SiloUser,
+        lookup_type: LookupType,
+    ) -> authz::SiloUser {
+        authz::SiloUser::with_primary_key(authz_parent.clone(), db_row.id(), lookup_type)
+    }
+    /// Getting the [`LookupPath`] for this lookup
+    ///
+    /// This is used when we actually query the database.  At that
+    /// point, we need the `OpContext` and `DataStore` that are being
+    /// used for this lookup.
+    fn lookup_root(&self) -> &LookupPath<'a> {
+        match &self {
+            SiloUser::Error(root, ..) => root.lookup_root(),
+            SiloUser::PrimaryKey(root, ..) => root.lookup_root(),
+        }
+    }
+    /// Fetch the database row for a resource by doing a lookup by id
+    ///
+    /// This function checks whether the caller has permissions to read
+    /// the requested data.  However, it's not intended to be used
+    /// outside this module.  See `fetch_for(authz::Action)`.
+    async fn fetch_by_id_for(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &Uuid,
+        action: authz::Action,
+    ) -> LookupResult<(authz::SiloUser, nexus_db_model::SiloUser)> {
+        let (authz_silo_user, db_row) = Self::lookup_by_id_no_authz(opctx, datastore, v0)
+            .await?;
+        opctx.authorize(action, &authz_silo_user).await?;
+        Ok((authz_silo_user, db_row))
+    }
+    /// Lowest-level function for looking up a resource in the database
+    /// by id
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `fetch()` or `lookup_for(authz::Action)`.
+    async fn lookup_by_id_no_authz(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &Uuid,
+    ) -> LookupResult<(authz::SiloUser, nexus_db_model::SiloUser)> {
+        use db::schema::silo_user::dsl;
+        let db_row = dsl::silo_user
+            .filter(dsl::time_deleted.is_null())
+            .filter(dsl::id.eq(v0.clone()))
+            .select(nexus_db_model::SiloUser::as_select())
+            .get_result_async(&*datastore.pool_connection_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::SiloUser,
+                        LookupType::ById(v0.clone()),
+                    ),
+                )
+            })?;
+        let authz_silo_user = Self::make_authz(
+            &&authz::FLEET,
+            &db_row,
+            LookupType::ById(v0.clone()),
+        );
+        Ok((authz_silo_user, db_row))
+    }
+}

--- a/nexus/db-macros/outputs/update_artifact.txt
+++ b/nexus/db-macros/outputs/update_artifact.txt
@@ -1,0 +1,206 @@
+///Selects a resource of type UpdateArtifact (or any of its children, using the functions on this struct) for lookup or fetch
+pub enum UpdateArtifact<'a> {
+    /// An error occurred while selecting the resource
+    ///
+    /// This error will be returned by any lookup/fetch attempts.
+    Error(Root<'a>, Error),
+    /// We're looking for a resource with the given primary key
+    ///
+    /// This has no parent container -- a by-id lookup is always global
+    PrimaryKey(Root<'a>, String, i64, KnownArtifactKind),
+}
+impl<'a> UpdateArtifact<'a> {
+    /// Fetch the record corresponding to the selected resource
+    ///
+    /// This is equivalent to `fetch_for(authz::Action::Read)`.
+    pub async fn fetch(
+        &self,
+    ) -> LookupResult<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)> {
+        self.fetch_for(authz::Action::Read).await
+    }
+    /// Turn the Result<T, E> of [`fetch`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch(
+        &self,
+    ) -> LookupResult<Option<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)>> {
+        self.optional_fetch_for(authz::Action::Read).await
+    }
+    /// Fetch the record corresponding to the selected resource and
+    /// check whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            UpdateArtifact::Error(_, error) => Err(error.clone()),
+            UpdateArtifact::PrimaryKey(_, v0, v1, v2) => {
+                Self::fetch_by_id_for(opctx, datastore, v0, v1, v2, action).await
+            }
+        }
+    }
+    /// Turn the Result<T, E> of [`fetch_for`] into a Result<Option<T>, E>.
+    pub async fn optional_fetch_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)>> {
+        let result = self.fetch_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch an `authz` object for the selected resource and check
+    /// whether the caller is allowed to do the specified `action`
+    ///
+    /// The return value is a tuple that also includes the `authz`
+    /// objects for all resources along the path to this one (i.e., all
+    /// parent resources) and the authz object for this resource itself.
+    /// These objects are useful for identifying those resources by
+    /// id, for doing other authz checks, or for looking up related
+    /// objects.
+    pub async fn lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<(authz::UpdateArtifact,)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let (authz_update_artifact,) = self.lookup().await?;
+        opctx.authorize(action, &authz_update_artifact).await?;
+        Ok((authz_update_artifact,))
+    }
+    /// Turn the Result<T, E> of [`lookup_for`] into a Result<Option<T>, E>.
+    pub async fn optional_lookup_for(
+        &self,
+        action: authz::Action,
+    ) -> LookupResult<Option<(authz::UpdateArtifact,)>> {
+        let result = self.lookup_for(action).await;
+        match result {
+            Err(Error::ObjectNotFound { type_name: _, lookup_type: _ }) => Ok(None),
+            _ => Ok(Some(result?)),
+        }
+    }
+    /// Fetch the "authz" objects for the selected resource and all its
+    /// parents
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `lookup_for(authz::Action)`.
+    async fn lookup(&self) -> LookupResult<(authz::UpdateArtifact,)> {
+        let lookup = self.lookup_root();
+        let opctx = &lookup.opctx;
+        let datastore = &lookup.datastore;
+        match &self {
+            UpdateArtifact::Error(_, error) => Err(error.clone()),
+            UpdateArtifact::PrimaryKey(_, v0, v1, v2) => {
+                let (authz_update_artifact, _) = Self::lookup_by_id_no_authz(
+                        opctx,
+                        datastore,
+                        v0,
+                        v1,
+                        v2,
+                    )
+                    .await?;
+                Ok((authz_update_artifact,))
+            }
+        }
+    }
+    /// Build the `authz` object for this resource
+    fn make_authz(
+        authz_parent: &authz::Fleet,
+        db_row: &nexus_db_model::UpdateArtifact,
+        lookup_type: LookupType,
+    ) -> authz::UpdateArtifact {
+        authz::UpdateArtifact::with_primary_key(
+            authz_parent.clone(),
+            db_row.id(),
+            lookup_type,
+        )
+    }
+    /// Getting the [`LookupPath`] for this lookup
+    ///
+    /// This is used when we actually query the database.  At that
+    /// point, we need the `OpContext` and `DataStore` that are being
+    /// used for this lookup.
+    fn lookup_root(&self) -> &LookupPath<'a> {
+        match &self {
+            UpdateArtifact::Error(root, ..) => root.lookup_root(),
+            UpdateArtifact::PrimaryKey(root, ..) => root.lookup_root(),
+        }
+    }
+    /// Fetch the database row for a resource by doing a lookup by id
+    ///
+    /// This function checks whether the caller has permissions to read
+    /// the requested data.  However, it's not intended to be used
+    /// outside this module.  See `fetch_for(authz::Action)`.
+    async fn fetch_by_id_for(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &String,
+        v1: &i64,
+        v2: &KnownArtifactKind,
+        action: authz::Action,
+    ) -> LookupResult<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)> {
+        let (authz_update_artifact, db_row) = Self::lookup_by_id_no_authz(
+                opctx,
+                datastore,
+                v0,
+                v1,
+                v2,
+            )
+            .await?;
+        opctx.authorize(action, &authz_update_artifact).await?;
+        Ok((authz_update_artifact, db_row))
+    }
+    /// Lowest-level function for looking up a resource in the database
+    /// by id
+    ///
+    /// This function does not check whether the caller has permission
+    /// to read this information.  That's why it's not `pub`.  Outside
+    /// this module, you want `fetch()` or `lookup_for(authz::Action)`.
+    async fn lookup_by_id_no_authz(
+        opctx: &OpContext,
+        datastore: &DataStore,
+        v0: &String,
+        v1: &i64,
+        v2: &KnownArtifactKind,
+    ) -> LookupResult<(authz::UpdateArtifact, nexus_db_model::UpdateArtifact)> {
+        use db::schema::update_artifact::dsl;
+        let db_row = dsl::update_artifact
+            .filter(dsl::name.eq(v0.clone()))
+            .filter(dsl::version.eq(v1.clone()))
+            .filter(dsl::kind.eq(v2.clone()))
+            .select(nexus_db_model::UpdateArtifact::as_select())
+            .get_result_async(&*datastore.pool_connection_authorized(opctx).await?)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::UpdateArtifact,
+                        LookupType::ByCompositeId(
+                            format!(
+                                "name = {:?}, version = {:?}, kind = {:?}", v0, v1, v2,
+                            ),
+                        ),
+                    ),
+                )
+            })?;
+        let authz_update_artifact = Self::make_authz(
+            &&authz::FLEET,
+            &db_row,
+            LookupType::ByCompositeId(
+                format!("name = {:?}, version = {:?}, kind = {:?}", v0, v1, v2,),
+            ),
+        );
+        Ok((authz_update_artifact, db_row))
+    }
+}

--- a/nexus/db-macros/outputs/update_artifact.txt
+++ b/nexus/db-macros/outputs/update_artifact.txt
@@ -188,7 +188,10 @@ impl<'a> UpdateArtifact<'a> {
                         ResourceType::UpdateArtifact,
                         LookupType::ByCompositeId(
                             format!(
-                                "name = {:?}, version = {:?}, kind = {:?}", v0, v1, v2,
+                                "name = {:?}, version = {:?}, kind = {:?}",
+                                v0,
+                                v1,
+                                v2,
                             ),
                         ),
                     ),
@@ -198,7 +201,7 @@ impl<'a> UpdateArtifact<'a> {
             &&authz::FLEET,
             &db_row,
             LookupType::ByCompositeId(
-                format!("name = {:?}, version = {:?}, kind = {:?}", v0, v1, v2,),
+                format!("name = {:?}, version = {:?}, kind = {:?}", v0, v1, v2),
             ),
         );
         Ok((authz_update_artifact, db_row))

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -913,22 +913,24 @@ fn generate_database_functions(config: &Config) -> TokenStream {
     }
 }
 
-// This isn't so much a test (although it does make sure we don't panic on some
-// basic cases).  This is a way to dump the output of the macro for some common
-// inputs.  This is invaluable for debugging.  If there's a bug where the macro
-// generates syntactically invalid Rust, `cargo expand` will often not print the
-// macro's output.  Instead, you can paste the output of this test into
-// lookup.rs, replacing the call to the macro, then reformat the file, and then
-// build it in order to see the compiler error in context.
 #[cfg(test)]
 mod test {
     use super::lookup_resource;
+    use expectorate::assert_contents;
     use proc_macro2::TokenStream;
     use quote::quote;
 
+    /// Ensure that generated code is as expected.
+    ///
+    /// This is both a test, and a way to dump the output of the macro for some
+    /// common inputs.  This is invaluable for debugging.  If there's a bug
+    /// where the macro generates syntactically invalid Rust, `cargo expand`
+    /// will often not print the macro's output.  Instead, you can paste the
+    /// output of this test into lookup.rs, replacing the call to the macro,
+    /// then reformat the file, and then build it in order to see the compiler
+    /// error in context.
     #[test]
-    #[ignore]
-    fn test_lookup_dump() {
+    fn test_lookup_snapshots() {
         let output = lookup_resource(quote! {
             name = "Project",
             ancestors = ["Silo"],
@@ -938,7 +940,7 @@ mod test {
             primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
         })
         .unwrap();
-        println!("{}", pretty_format(output));
+        assert_contents("outputs/project.txt", &pretty_format(output));
 
         let output = lookup_resource(quote! {
             name = "SiloUser",
@@ -949,7 +951,7 @@ mod test {
             primary_key_columns = [ { column_name = "id", rust_type = Uuid } ]
         })
         .unwrap();
-        println!("{}", pretty_format(output));
+        assert_contents("outputs/silo_user.txt", &pretty_format(output));
 
         let output = lookup_resource(quote! {
             name = "UpdateArtifact",
@@ -964,7 +966,7 @@ mod test {
             ]
         })
         .unwrap();
-        println!("{}", pretty_format(output));
+        assert_contents("outputs/update_artifact.txt", &pretty_format(output));
     }
 
     fn pretty_format(input: TokenStream) -> String {


### PR DESCRIPTION
Currently, these "dump" tests are mainly for debugging. However, the output of
these macros is expected to be stable, so we can turn them into snapshot tests.

(Ordinarily I'd use cargo-insta for snapshot tests, but we use expectorate
which works fine.)
