### PR TITLE
Bootstore related log message adjustments

### DIFF
--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -647,7 +647,7 @@ impl Node {
             .iter()
             .filter(|(id, _)| Some(*id) != excluded_peer)
         {
-            debug!(
+            info!(
                 self.log,
                 "Sending network config with generation {} to {id}",
                 network_config.generation
@@ -684,7 +684,7 @@ impl Node {
             if let Some(conn_handle) =
                 self.established_connections.get(&envelope.to)
             {
-                debug!(
+                info!(
                     self.log,
                     "Sending {:?} to {}", envelope.msg, envelope.to
                 );
@@ -924,6 +924,7 @@ impl Node {
                 self.fsm.on_disconnected(&peer_id);
             }
             ConnToMainMsgInner::Received { from, msg } => {
+                info!(self.log, "Received {msg:?} from {from}");
                 match self.fsm.handle_msg(Instant::now().into(), from, msg) {
                     Ok(None) => (),
                     Ok(Some(api_output)) => {

--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -15,7 +15,7 @@ use crate::trust_quorum::RackSecret;
 use camino::Utf8PathBuf;
 use derive_more::From;
 use sled_hardware::Baseboard;
-use slog::{debug, error, info, o, warn, Logger};
+use slog::{error, info, o, warn, Logger};
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{SocketAddr, SocketAddrV6};
 use std::time::Duration;

--- a/clients/ddm-admin-client/src/lib.rs
+++ b/clients/ddm-admin-client/src/lib.rs
@@ -132,7 +132,6 @@ impl Client {
         interfaces: &'a [BootstrapInterface],
     ) -> Result<impl Iterator<Item = Ipv6Addr> + 'a, DdmError> {
         let prefixes = self.inner.get_prefixes().await?.into_inner();
-        info!(self.log, "Received prefixes from ddmd"; "prefixes" => ?prefixes);
         Ok(prefixes.into_iter().flat_map(|(_, prefixes)| {
             prefixes.into_iter().flat_map(|prefix| {
                 let mut segments = prefix.destination.addr.segments();


### PR DESCRIPTION
Actual bootstore messages sent and received were not logged. We now log them. These messages are quite infrequent, but have massive debugging value.

We also get rid of logging bootstrap network prefixes everytime we look at them. This happens constantly, since bootstore polls them every few seconds indefinitely so it can discover new nodes. It's also unnecessary for bootstore in particular, because bootstore will already log when the prefixes change.

The method the log is removed from is used in a few other places, including installinator and wicketd, but there are enough logs and related contexts to debug things there. In any case, failure there is a support scenario and we can use ddm-admin to debug. Additional contextual logs can also be added as needed.