### PR TITLE
Don't constrain baseboard when adding sled

### DIFF
--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -871,36 +871,15 @@ impl super::Nexus {
             )
             .await?;
 
-        // Grab the SPs from the last collection
-        let collection =
-            self.db_datastore.inventory_get_latest_collection(opctx).await?;
-
-        // If there isn't a collection, we don't know about the sled
-        let Some(collection) = collection else {
-            return Err(Error::unavail("no inventory data available"));
-        };
-
-        // Find the revision
-        let Some(sp) = collection.sps.get(&baseboard_id) else {
-            return Err(Error::ObjectNotFound {
-                type_name: ResourceType::Sled,
-                lookup_type:
-                    omicron_common::api::external::LookupType::ByCompositeId(
-                        format!("{sled:?}"),
-                    ),
-            });
-        };
-
-        // Convert the baseboard as necessary
-        let baseboard = sled_agent_client::types::Baseboard::Gimlet {
-            identifier: sled.serial.clone(),
-            model: sled.part.clone(),
-            revision: sp.baseboard_revision.into(),
+        // Convert `UninitializedSledId` to the sled-agent type
+        let baseboard_id = sled_agent_client::types::BaseboardId {
+            serial_number: sled.serial.clone(),
+            part_number: sled.part.clone(),
         };
 
         // Make the call to sled-agent
         let req = AddSledRequest {
-            sled_id: baseboard,
+            sled_id: baseboard_id,
             start_request: StartSledAgentRequest {
                 generation: 0,
                 schema_version: 1,

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -52,7 +52,6 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::Name;
 use omicron_common::api::external::NameOrId;
-use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::shared::ExternalPortDiscovery;
 use sled_agent_client::types::AddSledRequest;
 use sled_agent_client::types::EarlyNetworkConfigBody;

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1240,7 +1240,7 @@
         "type": "object",
         "properties": {
           "sled_id": {
-            "$ref": "#/components/schemas/Baseboard"
+            "$ref": "#/components/schemas/BaseboardId"
           },
           "start_request": {
             "$ref": "#/components/schemas/StartSledAgentRequest"
@@ -1317,6 +1317,24 @@
               "type"
             ]
           }
+        ]
+      },
+      "BaseboardId": {
+        "description": "A representation of a Baseboard ID as used in the inventory subsystem This type is essentially the same as a `Baseboard` except it doesn't have a revision or HW type (Gimlet, PC, Unknown).",
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "description": "Oxide Part Number",
+            "type": "string"
+          },
+          "serial_number": {
+            "description": "Serial number (unique for a given part number)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "part_number",
+          "serial_number"
         ]
       },
       "BgpConfig": {

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -174,10 +174,21 @@ impl TryFrom<UnvalidatedRackInitializeRequest> for RackInitializeRequest {
 pub type Certificate = nexus_client::types::Certificate;
 pub type RecoverySiloConfig = nexus_client::types::RecoverySiloConfig;
 
+/// A representation of a Baseboard ID as used in the inventory subsystem
+/// This type is essentially the same as a `Baseboard` except it doesn't have a
+/// revision or HW type (Gimlet, PC, Unknown).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
+pub struct BaseboardId {
+    /// Oxide Part Number
+    pub part_number: String,
+    /// Serial number (unique for a given part number)
+    pub serial_number: String,
+}
+
 /// A request to Add a given sled after rack initialization has occurred
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct AddSledRequest {
-    pub sled_id: Baseboard,
+    pub sled_id: BaseboardId,
     pub start_request: StartSledAgentRequest,
 }
 
@@ -255,9 +266,6 @@ pub struct StartSledAgentRequestBody {
     /// true.
     pub is_lrtq_learner: bool,
 
-    // Note: The order of these fields is load bearing, because we serialize
-    // `SledAgentRequest`s as toml. `subnet` serializes as a TOML table, so it
-    // must come after non-table fields.
     /// Portion of the IP space to be managed by the Sled Agent.
     pub subnet: Ipv6Subnet<SLED_PREFIX>,
 }


### PR DESCRIPTION
We were artificially limiting how we added sleds to a rack by forcing them to be of type `Baseboard::Gimlet`. Instead of constructing a `Baseboard` inside nexus, we instead send down the serial and part numbers and use those to uniquely identify the sled. We ignore whether it's a PC or Gimlet as long as the ids match. This is similar to how the inventory works and allows adding a sled to a rack on the falcon a4x2 testbed.