### PR TITLE
Unbreak the build (ratatui x omdb)

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
@@ -960,7 +960,7 @@ fn draw_graph(f: &mut Frame, parent: Rect, graph: &mut Graph, now: u64) {
 
         datasets.push(
             Dataset::default()
-                .name(&s.name)
+                .name(&*s.name)
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(s.color))
                 .data(&s.data),


### PR DESCRIPTION
I suspect we had a race condition in our merge-queue-less world, where ratatui was updated to `0.26.0`, and needed slightly different parameters. This PR fixes that compatibility error.