### PR TITLE
bump external API version number

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
@@ -960,7 +960,7 @@ fn draw_graph(f: &mut Frame, parent: Rect, graph: &mut Graph, now: u64) {
 
         datasets.push(
             Dataset::default()
-                .name(&s.name)
+                .name(&*s.name)
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(s.color))
                 .data(&s.data),

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -47,7 +47,7 @@ extern crate slog;
 /// to stdout.
 pub fn run_openapi_external() -> Result<(), String> {
     external_api()
-        .openapi("Oxide Region API", "0.0.1")
+        .openapi("Oxide Region API", "0.0.6")
         .description("API for interacting with the Oxide control plane")
         .contact_url("https://oxide.computer")
         .contact_email("api@oxide.computer")

--- a/nexus/tests/integration_tests/commands.rs
+++ b/nexus/tests/integration_tests/commands.rs
@@ -109,7 +109,7 @@ fn test_nexus_openapi() {
         .expect("stdout was not valid OpenAPI");
     assert_eq!(spec.openapi, "3.0.3");
     assert_eq!(spec.info.title, "Oxide Region API");
-    assert_eq!(spec.info.version, "0.0.1");
+    assert_eq!(spec.info.version, "0.0.6");
 
     // Spot check a couple of items.
     assert!(!spec.paths.paths.is_empty());

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "0.0.1"
+    "version": "0.0.6"
   },
   "paths": {
     "/device/auth": {


### PR DESCRIPTION
This is a semi-cowardly approach. Rather than actually implementing the non-integer we [determined](https://rfd.shared.oxide.computer/rfd/0299#_determinations), this moves us from 0.0.1 to 0.0.6 (6 for release 6). This is to dry run the oxide.rs [versioned release process](https://github.com/oxidecomputer/oxide.rs?tab=readme-ov-file#determine-the-version-number).