### PR TITLE
planner generated duplicate IPs

### DIFF
--- a/nexus/deployment/src/planner.rs
+++ b/nexus/deployment/src/planner.rs
@@ -154,6 +154,7 @@ mod test {
     use super::Planner;
     use crate::blueprint_builder::test::example;
     use crate::blueprint_builder::test::policy_add_sled;
+    use crate::blueprint_builder::test::verify_blueprint;
     use crate::blueprint_builder::BlueprintBuilder;
     use nexus_inventory::now_db_precision;
     use nexus_types::inventory::OmicronZoneType;
@@ -177,6 +178,7 @@ mod test {
             "the_test",
         )
         .expect("failed to create initial blueprint");
+        verify_blueprint(&blueprint1);
 
         // Now run the planner.  It should do nothing because our initial
         // system didn't have any issues that the planner currently knows how to
@@ -196,6 +198,7 @@ mod test {
         assert_eq!(diff.sleds_added().count(), 0);
         assert_eq!(diff.sleds_removed().count(), 0);
         assert_eq!(diff.sleds_changed().count(), 0);
+        verify_blueprint(&blueprint2);
 
         // Now add a new sled.
         let new_sled_id =
@@ -229,6 +232,7 @@ mod test {
         ));
         assert_eq!(diff.sleds_removed().count(), 0);
         assert_eq!(diff.sleds_changed().count(), 0);
+        verify_blueprint(&blueprint3);
 
         // Check that with no change in inventory, the planner makes no changes.
         // It needs to wait for inventory to reflect the new NTP zone before
@@ -247,6 +251,7 @@ mod test {
         assert_eq!(diff.sleds_added().count(), 0);
         assert_eq!(diff.sleds_removed().count(), 0);
         assert_eq!(diff.sleds_changed().count(), 0);
+        verify_blueprint(&blueprint4);
 
         // Now update the inventory to have the requested NTP zone.
         assert!(collection
@@ -298,6 +303,7 @@ mod test {
                 panic!("unexpectedly added a non-Crucible zone");
             };
         }
+        verify_blueprint(&blueprint5);
 
         // Check that there are no more steps
         let blueprint6 = Planner::new_based_on(
@@ -315,6 +321,7 @@ mod test {
         assert_eq!(diff.sleds_added().count(), 0);
         assert_eq!(diff.sleds_removed().count(), 0);
         assert_eq!(diff.sleds_changed().count(), 0);
+        verify_blueprint(&blueprint6);
 
         logctx.cleanup_successful();
     }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -466,10 +466,11 @@ impl<'a> OmicronZonesDiff<'a> {
         for z in &bbsledzones.zones {
             writeln!(
                 f,
-                "{}         zone {} type {} ({})",
+                "{}         zone {} type {} underlay IP {} ({})",
                 prefix,
                 z.id,
                 z.zone_type.label(),
+                z.underlay_address,
                 label
             )?;
         }
@@ -529,44 +530,65 @@ impl<'a> std::fmt::Display for OmicronZonesDiff<'a> {
                     DiffZoneChangedHow::DetailsChanged => {
                         writeln!(
                             f,
-                            "-         zone {} type {} (changed)",
-                            zone_id, zone_type,
+                            "-         zone {} type {} underlay IP {} \
+                                (changed)",
+                            zone_id,
+                            zone_type,
+                            zone_changes.zone_before.underlay_address,
                         )?;
                         writeln!(
                             f,
-                            "+         zone {} type {} (changed)",
-                            zone_id, zone2_type,
+                            "+         zone {} type {} underlay IP {} \
+                                (changed)",
+                            zone_id,
+                            zone2_type,
+                            zone_changes.zone_after.underlay_address,
                         )?;
                     }
                     DiffZoneChangedHow::RemovedFromService => {
                         writeln!(
                             f,
-                            "-         zone {} type {} (in service)",
-                            zone_id, zone_type,
+                            "-         zone {} type {} underlay IP {} \
+                                (in service)",
+                            zone_id,
+                            zone_type,
+                            zone_changes.zone_before.underlay_address,
                         )?;
                         writeln!(
                             f,
-                            "+         zone {} type {} (removed from service)",
-                            zone_id, zone2_type,
+                            "+         zone {} type {} underlay IP {} \
+                                (removed from service)",
+                            zone_id,
+                            zone2_type,
+                            zone_changes.zone_after.underlay_address,
                         )?;
                     }
                     DiffZoneChangedHow::AddedToService => {
                         writeln!(
                             f,
-                            "-         zone {} type {} (not in service)",
-                            zone_id, zone_type,
+                            "-         zone {} type {} underlay IP {} \
+                                (not in service)",
+                            zone_id,
+                            zone_type,
+                            zone_changes.zone_before.underlay_address,
                         )?;
                         writeln!(
                             f,
-                            "+         zone {} type {} (added to service)",
-                            zone_id, zone2_type,
+                            "+         zone {} type {} underlay IP {} \
+                                (added to service)",
+                            zone_id,
+                            zone2_type,
+                            zone_changes.zone_after.underlay_address,
                         )?;
                     }
                     DiffZoneChangedHow::NoChanges => {
                         writeln!(
                             f,
-                            "         zone {} type {} (unchanged)",
-                            zone_id, zone_type,
+                            "         zone {} type {} underlay IP {} \
+                                (unchanged)",
+                            zone_id,
+                            zone_type,
+                            zone_changes.zone_before.underlay_address,
                         )?;
                     }
                 }
@@ -575,8 +597,9 @@ impl<'a> std::fmt::Display for OmicronZonesDiff<'a> {
             for zone in sled_changes.zones_added() {
                 writeln!(
                     f,
-                    "+        zone {} type {} (added)",
+                    "+        zone {} type {} underlay IP {} (added)",
                     zone.id,
+                    zone.underlay_address,
                     zone.zone_type.label(),
                 )?;
             }


### PR DESCRIPTION
This addresses one of the two problems mentioned in #4990.

For the record: the fix is pretty trivial.  Much of the delta here is:

- I updated the diff output to include IPs so that we could see this particular issue more easily
- I updated the tests to check this condition
- I refactored the way we track Omicron zones as @jgallagher suggested to make this kind of bug harder to introduce