### PR TITLE
[sled-agent] Ignore zone order when checking for changes

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -2799,7 +2799,7 @@ impl ServiceManager {
     /// boot.
     pub async fn ensure_all_omicron_zones_persistent(
         &self,
-        request: OmicronZonesConfig,
+        mut request: OmicronZonesConfig,
     ) -> Result<(), Error> {
         let log = &self.inner.log;
 
@@ -2838,11 +2838,26 @@ impl ServiceManager {
 
         // If the generation is the same as what we're running, but the contents
         // aren't, that's a problem, too.
-        if ledger_zone_config.omicron_generation == request.generation
-            && ledger_zone_config.clone().to_omicron_zones_config().zones
-                != request.zones
-        {
-            return Err(Error::RequestedConfigConflicts(request.generation));
+        if ledger_zone_config.omicron_generation == request.generation {
+            // Nexus should send us consistent zone orderings; however, we may
+            // reorder the zone list inside `ensure_all_omicron_zones`. To avoid
+            // equality checks failing only because the two lists are ordered
+            // differently, sort them both here before comparing.
+            let mut ledger_zones =
+                ledger_zone_config.clone().to_omicron_zones_config().zones;
+
+            // We sort by ID because we assume no two zones have the same ID. If
+            // that assumption is wrong, we may return an error here where the
+            // conflict is soley the list orders, but in such a case that's the
+            // least of our problems.
+            ledger_zones.sort_by_key(|z| z.id);
+            request.zones.sort_by_key(|z| z.id);
+
+            if ledger_zones != request.zones {
+                return Err(Error::RequestedConfigConflicts(
+                    request.generation,
+                ));
+            }
         }
 
         let new_config = self


### PR DESCRIPTION
This addresses one of two problems mentioned in #4990. sled-agent's `PUT /omicron-zones` endpoint is expected to be idempotent, and it checks that if it receives a zone config with the same generation as it currently has, that the contents are identical. This check was just a straight equality check between two `Vec`s, because we have been careful on the Nexus side to always sort the zone list consistently, but on #4990 we see an error caused solely by the ordering of these `Vec`s.

When sled-agent receives a config with a new generation number, sled-agent itself may reorder the zone list between receiving it from Nexus and storing it in its ledger. This will cause the first `PUT` of the new generation to succeed, but any subsequent `PUT`s with identical contents to fail the equality check.

Instead of trying ensure that sled-agent sorts the zone list in its ledger consistently with how Nexus sorts them, this PR changes the comparison to explicitly sort both the incoming list and the list loaded from the ledger prior to comparing them.