### PR TITLE
pin libxmlsec1 1.3.2 in CI on macOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,16 @@ jobs:
     steps:
     # This repo is unstable and unnecessary: https://github.com/microsoft/linux-package-repositories/issues/34
     - name: Disable packages.microsoft.com repo
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+    # https://github.com/oxidecomputer/omicron/issues/4920
+    - name: Pin libxmlsec1 to 1.3.2
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: |
+        curl -fLOsS --retry 5 https://raw.githubusercontent.com/Homebrew/homebrew-core/081149b0d2720c2759b6ac8253e33b27f6d6c1cd/Formula/lib/libxmlsec1.rb
+        brew install ./libxmlsec1.rb
+        brew pin libxmlsec1
+        rm -f libxmlsec1.rb
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ github.event.pull_request.head.sha }} # see omicron#4461


### PR DESCRIPTION
A [temporary](https://xkcd.com/2730/) hack to keep the macOS job mildly happy while I muster the energy to fix this upstream in samael.