### PR TITLE
[sled-agent] Ignore zones with invalid storage

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
@@ -960,7 +960,7 @@ fn draw_graph(f: &mut Frame, parent: Rect, graph: &mut Graph, now: u64) {
 
         datasets.push(
             Dataset::default()
-                .name(&s.name)
+                .name(&*s.name)
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(s.color))
                 .data(&s.data),


### PR DESCRIPTION
Partial fix to https://github.com/oxidecomputer/omicron/issues/5002

Implements a solution from @davepacheco : 

> if a zone depends on a U.2 that is not available, we skip it altogether (we treat it as though it's not in the list of zones to start)