### PR TITLE
[direnv] make nix flake opt-in

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,7 +6,7 @@ PATH_add out/clickhouse
 PATH_add out/dendrite-stub/bin
 PATH_add out/mgd/root/opt/oxide/mgd/bin
 
-if nix flake show &> /dev/null
+if [ "$OMICRON_USE_FLAKE" = 1 ] && nix flake show &> /dev/null
 then
     use flake;
 fi


### PR DESCRIPTION
On a non-NixOS platform I'm seeing issues building both on main and on #4961,
of the form shown at https://github.com/oxidecomputer/omicron/pull/4961#issuecomment-1930996559. Fix this by making use of the flake opt-in for now.
