### PR TITLE
[omdb] Add `db rack list`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -160,6 +160,8 @@ pub struct DbFetchOptions {
 /// Subcommands that query or update the database
 #[derive(Debug, Subcommand)]
 enum DbCommands {
+    /// Print information about the rack
+    Rack(RackArgs),
     /// Print information about disks
     Disks(DiskArgs),
     /// Print information about internal and external DNS
@@ -178,6 +180,18 @@ enum DbCommands {
     Snapshots(SnapshotArgs),
     /// Validate the contents of the database
     Validate(ValidateArgs),
+}
+
+#[derive(Debug, Args)]
+struct RackArgs {
+    #[command(subcommand)]
+    command: RackCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum RackCommands {
+    /// Summarize current racks
+    List,
 }
 
 #[derive(Debug, Args)]
@@ -406,6 +420,9 @@ impl DbArgs {
 
         let opctx = OpContext::for_tests(log.clone(), datastore.clone());
         match &self.command {
+            DbCommands::Rack(RackArgs { command: RackCommands::List }) => {
+                cmd_db_rack_list(&opctx, &datastore, &self.fetch_opts).await
+            }
             DbCommands::Disks(DiskArgs {
                 command: DiskCommands::Info(uuid),
             }) => cmd_db_disk_info(&opctx, &datastore, uuid).await,
@@ -609,6 +626,50 @@ async fn cmd_db_disk_list(
             None => "-".to_string(),
         },
     });
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}
+
+/// Run `omdb db rack info`.
+async fn cmd_db_rack_list(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    fetch_opts: &DbFetchOptions,
+) -> Result<(), anyhow::Error> {
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct RackRow {
+        id: String,
+        initialized: bool,
+        tuf_base_url: String,
+        rack_subnet: String,
+    }
+
+    let ctx = || "listing racks".to_string();
+
+    let limit = fetch_opts.fetch_limit;
+    let rack_list = datastore
+        .rack_list(opctx, &first_page(limit))
+        .await
+        .context("listing racks")?;
+    check_limit(&rack_list, limit, ctx);
+
+    let rows = rack_list.into_iter().map(|rack| RackRow {
+        id: rack.id().to_string(),
+        initialized: rack.initialized,
+        tuf_base_url: rack.tuf_base_url.unwrap_or_else(|| "-".to_string()),
+        rack_subnet: rack
+            .rack_subnet
+            .map(|subnet| subnet.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+    });
+
     let table = tabled::Table::new(rows)
         .with(tabled::settings::Style::empty())
         .with(tabled::settings::Padding::new(0, 1, 0, 0))

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -90,6 +90,7 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
+  rack       Print information about the rack
   disks      Print information about disks
   dns        Print information about internal and external DNS
   inventory  Print information about collected hardware/software inventory
@@ -118,6 +119,7 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
+  rack       Print information about the rack
   disks      Print information about disks
   dns        Print information about internal and external DNS
   inventory  Print information about collected hardware/software inventory


### PR DESCRIPTION
In the context of #5009, it would be good to be able to quickly confirm whether a rack has the correct or incorrect subnet recorded in CRDB.

Madrid is incorrect (as expected):

```
root@oxz_switch1:~# /var/tmp/john/omdb db rack list
ID                                   INITIALIZED TUF_BASE_URL RACK_SUBNET
ed6bcf59-9620-491d-8ebd-4a4eebf2e136 true        -            fd00:1122:3344:1::/56
```

Rack2 is correct (not surprising, since this would've been set after RSS ran, which means it wouldn't hit #5009, although I don't know _exactly_ how this did get set in practice):

```
root@oxz_switch1:~# /var/tmp/john/omdb db rack list
ID                                   INITIALIZED TUF_BASE_URL RACK_SUBNET
de608e01-b8e4-4d93-b972-a7dbed36dd22 true        -            fd00:1122:3344:100::/56
```