### PR TITLE
patch samael crate to include njaremko/samael#41

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,14 +32,6 @@ jobs:
     - name: Disable packages.microsoft.com repo
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-    # https://github.com/oxidecomputer/omicron/issues/4920
-    - name: Pin libxmlsec1 to 1.3.2
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      run: |
-        curl -fLOsS --retry 5 https://raw.githubusercontent.com/Homebrew/homebrew-core/081149b0d2720c2759b6ac8253e33b27f6d6c1cd/Formula/lib/libxmlsec1.rb
-        brew install ./libxmlsec1.rb
-        brew pin libxmlsec1
-        rm -f libxmlsec1.rb
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ github.event.pull_request.head.sha }} # see omicron#4461

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7623,8 +7623,7 @@ dependencies = [
 [[package]]
 name = "samael"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75583aad4a51c50fc0af69c230d18078c9d5a69a98d0f6013d01053acf744f4"
+source = "git+https://github.com/oxidecomputer/samael?branch=oxide/omicron#9e609a8f6fa0dd84e3bb8f579f46bd780c8be62b"
 dependencies = [
  "base64",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -614,3 +614,8 @@ branch = "oxide/omicron"
 # to it.
 [patch.crates-io.omicron-workspace-hack]
 path = "workspace-hack"
+
+# Pulls in https://github.com/njaremko/samael/pull/41
+[patch.crates-io.samael]
+git = "https://github.com/oxidecomputer/samael"
+branch = "oxide/omicron"


### PR DESCRIPTION
Points cargo at https://github.com/oxidecomputer/samael/tree/oxide/omicron, which has njaremko/samael#41 merged in.

Fixes #4920, reverts #5007, supersedes #5019.