### PR TITLE
[nexus] Improve logging when transactions retry

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -413,7 +413,7 @@ impl DbArgs {
         // here.  We will then check the schema version explicitly and warn the
         // user if it doesn't match.
         let datastore = Arc::new(
-            DataStore::new_unchecked(pool)
+            DataStore::new_unchecked(log.clone(), pool)
                 .map_err(|e| anyhow!(e).context("creating datastore"))?,
         );
         check_schema_version(&datastore).await;

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -150,6 +150,7 @@ pub type DataStoreConnection<'a> =
     bb8::PooledConnection<'a, ConnectionManager<DbConnection>>;
 
 pub struct DataStore {
+    log: Logger,
     pool: Arc<Pool>,
     virtual_provisioning_collection_producer: crate::provisioning::Producer,
     transaction_retry_producer: crate::transaction_retry::Producer,
@@ -164,8 +165,9 @@ impl DataStore {
     /// Ignores the underlying DB version. Should be used with caution, as usage
     /// of this method can construct a Datastore which does not understand
     /// the underlying CockroachDB schema. Data corruption could result.
-    pub fn new_unchecked(pool: Arc<Pool>) -> Result<Self, String> {
+    pub fn new_unchecked(log: Logger, pool: Arc<Pool>) -> Result<Self, String> {
         let datastore = DataStore {
+            log,
             pool,
             virtual_provisioning_collection_producer:
                 crate::provisioning::Producer::new(),
@@ -184,7 +186,8 @@ impl DataStore {
         pool: Arc<Pool>,
         config: Option<&SchemaConfig>,
     ) -> Result<Self, String> {
-        let datastore = Self::new_unchecked(pool)?;
+        let datastore =
+            Self::new_unchecked(log.new(o!("component" => "datastore")), pool)?;
 
         // Keep looping until we find that the schema matches our expectation.
         const EXPECTED_VERSION: SemverVersion =
@@ -230,6 +233,7 @@ impl DataStore {
         name: &'static str,
     ) -> crate::transaction_retry::RetryHelper {
         crate::transaction_retry::RetryHelper::new(
+            &self.log,
             &self.transaction_retry_producer,
             name,
         )

--- a/nexus/src/bin/schema-updater.rs
+++ b/nexus/src/bin/schema-updater.rs
@@ -76,7 +76,8 @@ async fn main() -> anyhow::Result<()> {
 
     // We use the unchecked constructor of the datastore because we
     // don't want to block on someone else applying an upgrade.
-    let datastore = DataStore::new_unchecked(pool).map_err(|e| anyhow!(e))?;
+    let datastore =
+        DataStore::new_unchecked(log.clone(), pool).map_err(|e| anyhow!(e))?;
 
     match args.cmd {
         Cmd::List => {


### PR DESCRIPTION
I was trying to determine whether or not transaction retries spiked alongside a CRDB crash, and found that the current mechanism of tracking "which transactions did we retry" could use a little improvement.

Although we do send these retry attempts to Clickhouse (and I'm able to see them for historical data) this doesn't help us if Nexus crashes before those queries can be pulled by Oximeter.

This PR adds logging for these cases:
- It logs with `warn` if we retry at all
- It logs with `info` if a retried transaction completes