### PR TITLE
[nix flake] add `rust-src` component

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,11 @@
         system = "x86_64-linux";
       };
       # use the Rust toolchain defined in the `rust-toolchain.toml` file.
-      rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      rustToolchain = (pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+        extensions = [
+          "rust-src" # for rust-analyzer
+        ];
+      };
 
       buildInputs = with pkgs; [
         # libs


### PR DESCRIPTION
Currently, when using the Nix flake managed Rust toolchain, `rust-analyzer` complains that it can't expand proc macros, because it can't find the sysroot. Adding the `rust-src` Rustup component fixes this. This PR adds the `rust-src` component to the flake's Rust toolchain.