### PR TITLE
`/lookup/*` route for console

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -700,6 +700,7 @@ macro_rules! console_page_wildcard {
 console_page_wildcard!(console_projects, "/projects/{path:.*}");
 console_page_wildcard!(console_settings_page, "/settings/{path:.*}");
 console_page_wildcard!(console_system_page, "/system/{path:.*}");
+console_page_wildcard!(console_lookup, "/lookup/{path:.*}");
 console_page!(console_root, "/");
 console_page!(console_projects_new, "/projects-new");
 console_page!(console_silo_images, "/images");

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -332,6 +332,7 @@ pub(crate) fn external_api() -> NexusApiDescription {
         api.register(console_api::login_saml)?;
         api.register(console_api::logout)?;
 
+        api.register(console_api::console_lookup)?;
         api.register(console_api::console_projects)?;
         api.register(console_api::console_projects_new)?;
         api.register(console_api::console_silo_images)?;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -209,6 +209,8 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
         "/images",
         "/utilization",
         "/access",
+        "/lookup/",
+        "/lookup/abc",
     ];
 
     for path in console_paths {


### PR DESCRIPTION
Needed to make https://github.com/oxidecomputer/console/pull/1944 work. Adding one top-level route `/lookup/*` so we can freely add more routes under it in the console without adding anything here.

Will hold on merging until after the release is finalized.