### PR TITLE
Add `omdb sled-agent bootstore status`

### DIFF
--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -62,6 +62,15 @@ pub enum NodeRequestError {
     },
 }
 
+impl From<NodeRequestError> for omicron_common::api::external::Error {
+    fn from(error: NodeRequestError) -> Self {
+        omicron_common::api::external::Error::internal_error(&format!(
+            "{:#}",
+            error
+        ))
+    }
+}
+
 /// A request sent to the `Node` task from the `NodeHandle`
 pub enum NodeApiRequest {
     /// Initialize a rack at the behest of RSS running on the same scrimlet as

--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -65,8 +65,7 @@ pub enum NodeRequestError {
 impl From<NodeRequestError> for omicron_common::api::external::Error {
     fn from(error: NodeRequestError) -> Self {
         omicron_common::api::external::Error::internal_error(&format!(
-            "{:#}",
-            error
+            "{error}"
         ))
     }
 }

--- a/dev-tools/omdb/src/bin/omdb/sled_agent.rs
+++ b/dev-tools/omdb/src/bin/omdb/sled_agent.rs
@@ -129,6 +129,40 @@ async fn cmd_bootstore_status(
     client: &sled_agent_client::Client,
 ) -> Result<(), anyhow::Error> {
     let status = client.bootstore_status().await.context("bootstore status")?;
-    println!("{status}");
+    println!("fsm ledger generation: {}", status.fsm_ledger_generation);
+    println!(
+        "network config ledger generation: {:?}",
+        status.network_config_ledger_generation
+    );
+    println!("fsm state: {}", status.fsm_state);
+    println!("peers (found by ddmd):");
+    if status.peers.is_empty() {
+        println!("    <none>");
+    }
+    for peer in status.peers.iter() {
+        println!("    {peer}");
+    }
+    println!("established connections:");
+    if status.established_connections.is_empty() {
+        println!("    <none>");
+    }
+    for c in status.established_connections.iter() {
+        println!("     {:?} : {}", c.baseboard, c.addr);
+    }
+    println!("accepted connections:");
+    if status.accepted_connections.is_empty() {
+        println!("    <none>");
+    }
+    for addr in status.accepted_connections.iter() {
+        println!("    {addr}");
+    }
+    println!("negotiating connections:");
+    if status.negotiating_connections.is_empty() {
+        println!("    <none>");
+    }
+    for addr in status.negotiating_connections.iter() {
+        println!("    {addr}");
+    }
+
     Ok(())
 }

--- a/dev-tools/omdb/src/bin/omdb/sled_agent.rs
+++ b/dev-tools/omdb/src/bin/omdb/sled_agent.rs
@@ -31,6 +31,10 @@ enum SledAgentCommands {
     /// print information about zpools
     #[clap(subcommand)]
     Zpools(ZpoolCommands),
+
+    /// print information about the local bootstore node
+    #[clap(subcommand)]
+    Bootstore(BootstoreCommands),
 }
 
 #[derive(Debug, Subcommand)]
@@ -43,6 +47,12 @@ enum ZoneCommands {
 enum ZpoolCommands {
     /// Print list of all zpools managed by the sled agent
     List,
+}
+
+#[derive(Debug, Subcommand)]
+enum BootstoreCommands {
+    /// Show the internal state of the local bootstore node
+    Status,
 }
 
 impl SledAgentArgs {
@@ -69,6 +79,9 @@ impl SledAgentArgs {
             }
             SledAgentCommands::Zpools(ZpoolCommands::List) => {
                 cmd_zpools_list(&client).await
+            }
+            SledAgentCommands::Bootstore(BootstoreCommands::Status) => {
+                cmd_bootstore_status(&client).await
             }
         }
     }
@@ -108,5 +121,14 @@ async fn cmd_zpools_list(
         println!("    {:?}", zpool);
     }
 
+    Ok(())
+}
+
+/// Runs `omdb sled-agent bootstore status`
+async fn cmd_bootstore_status(
+    client: &sled_agent_client::Client,
+) -> Result<(), anyhow::Error> {
+    let status = client.bootstore_status().await.context("bootstore status")?;
+    println!("{status}");
     Ok(())
 }

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -331,9 +331,10 @@ Debug a specific Sled
 Usage: omdb sled-agent [OPTIONS] <COMMAND>
 
 Commands:
-  zones   print information about zones
-  zpools  print information about zpools
-  help    Print this message or the help of the given subcommand(s)
+  zones      print information about zones
+  zpools     print information about zpools
+  bootstore  print information about the local bootstore node
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
       --sled-agent-url <SLED_AGENT_URL>  URL of the Sled internal API [env: OMDB_SLED_AGENT_URL=]

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -136,6 +136,31 @@
         }
       }
     },
+    "/bootstore/status": {
+      "get": {
+        "summary": "Get the internal state of the local bootstore node",
+        "operationId": "bootstore_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "String",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/cockroachdb": {
       "post": {
         "summary": "Initializes a CockroachDB cluster",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -146,8 +146,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "String",
-                  "type": "string"
+                  "$ref": "#/components/schemas/BootstoreStatus"
                 }
               }
             }
@@ -2556,6 +2555,60 @@
           }
         ]
       },
+      "BootstoreStatus": {
+        "type": "object",
+        "properties": {
+          "accepted_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "established_connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EstablishedConnection"
+            }
+          },
+          "fsm_ledger_generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "fsm_state": {
+            "type": "string"
+          },
+          "negotiating_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "network_config_ledger_generation": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "peers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "accepted_connections",
+          "established_connections",
+          "fsm_ledger_generation",
+          "fsm_state",
+          "negotiating_connections",
+          "peers"
+        ]
+      },
       "BundleUtilization": {
         "description": "The portion of a debug dataset used for zone bundles.",
         "type": "object",
@@ -3870,6 +3923,21 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "EstablishedConnection": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          }
+        },
+        "required": [
+          "addr",
+          "baseboard"
         ]
       },
       "Field": {

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -8,7 +8,7 @@ use super::sled_agent::SledAgent;
 use crate::bootstrap::early_networking::EarlyNetworkConfig;
 use crate::bootstrap::params::AddSledRequest;
 use crate::params::{
-    CleanupContextUpdate, DiskEnsureBody, InstanceEnsureBody,
+    BootstoreStatus, CleanupContextUpdate, DiskEnsureBody, InstanceEnsureBody,
     InstanceExternalIpBody, InstancePutMigrationIdsBody, InstancePutStateBody,
     InstancePutStateResponse, InstanceUnregisterResponse, Inventory,
     OmicronZonesConfig, SledRole, TimeSync, VpcFirewallRulesEnsureBody,
@@ -981,15 +981,15 @@ async fn inventory(
 }]
 async fn bootstore_status(
     request_context: RequestContext<SledAgent>,
-) -> Result<HttpResponseOk<String>, HttpError> {
+) -> Result<HttpResponseOk<BootstoreStatus>, HttpError> {
     let sa = request_context.context();
     let bootstore = sa.bootstore();
-    let status = bootstore.get_status().await.map_err(|e| {
-        HttpError::from(omicron_common::api::external::Error::from(e))
-    })?;
-    // Status is full of maps with non-string keys, and using `serde_as`
-    // doesn't work with JSON. Since this is just used for omdb right now,
-    // return a string.
-    let status_str = format!("{status:#?}");
-    Ok(HttpResponseOk(status_str))
+    let status = bootstore
+        .get_status()
+        .await
+        .map_err(|e| {
+            HttpError::from(omicron_common::api::external::Error::from(e))
+        })?
+        .into();
+    Ok(HttpResponseOk(status))
 }


### PR DESCRIPTION
I ended up creating an API type, `BootstoreStatus`, that is suitable for JSON / OpenAPI.

Fixes #4295 and #3722