### PR TITLE
[nexus][sled-agent] Try more to load firewall rules during service bringup

### DIFF
--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -44,7 +44,7 @@ impl super::Nexus {
     // unless the DNS lookups at sled-agent are only for rack-local nexuses.
     pub(crate) async fn upsert_sled(
         &self,
-        opctx: &OpContext,
+        _opctx: &OpContext,
         id: Uuid,
         info: SledAgentStartupInfo,
     ) -> Result<(), Error> {
@@ -73,10 +73,16 @@ impl super::Nexus {
         );
         self.db_datastore.sled_upsert(sled).await?;
 
-        // Make sure any firewall rules for serices that may
-        // be running on this sled get plumbed
-        self.plumb_service_firewall_rules(opctx, &[id]).await?;
+        Ok(())
+    }
 
+    pub(crate) async fn sled_request_firewall_rules(
+        &self,
+        opctx: &OpContext,
+        id: Uuid,
+    ) -> Result<(), Error> {
+        info!(self.log, "requesting firewall rules"; "sled_uuid" => id.to_string());
+        self.plumb_service_firewall_rules(opctx, &[id]).await?;
         Ok(())
     }
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -835,6 +835,34 @@
         }
       }
     },
+    "/sled-agents/{sled_id}/firewall-rules-update": {
+      "post": {
+        "summary": "Request a new set of firewall rules for a sled.",
+        "operationId": "sled_firewall_rules_request",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sled_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/sled-agents/{sled_id}/zpools/{zpool_id}": {
       "put": {
         "summary": "Report that a pool for a specified sled has come online.",

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -838,6 +838,7 @@
     "/sled-agents/{sled_id}/firewall-rules-update": {
       "post": {
         "summary": "Request a new set of firewall rules for a sled.",
+        "description": "This causes Nexus to read the latest set of rules for the sled, and call a Sled endpoint which applies the rules to all OPTE ports that happen to exist.",
         "operationId": "sled_firewall_rules_request",
         "parameters": [
           {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -669,9 +669,11 @@ impl SledAgent {
         Ok(())
     }
 
-    /// Sends a request to Nexus informing it that the current sled exists.
+    /// Sends a request to Nexus informing it that the current sled exists,
+    /// with information abou the existing set of hardware.
     ///
-    /// Does not block for neux being available.
+    /// Does not block until Nexus is available -- the future created by this
+    /// function is retried in a queue that is polled in the background.
     pub(crate) fn notify_nexus_about_self(&self, log: &Logger) {
         let sled_id = self.inner.id;
         let nexus_client = self.inner.nexus_client.clone();


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/5053 , with this solution implemented:

> Nexus Internal Endpoint to Ask for FW Rules, Triggered After Individual Zones Launch. Rather than waiting for "all zones to launch", the Sled Agent could just re-apply firewall rules after any zones that need FW rules come up.

I used a bit of a brute-force solution here -- "just do it each time we try to launch a set of zones". This could certainly be more fine-grained, but it gets the job done.