### PR TITLE
[omdb] Add `db network list-vnics` and expand output of `db network list-eips`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1788,7 +1788,7 @@ async fn cmd_db_eips(
             }
         }
 
-        fn description(&self) -> String {
+        fn name(&self) -> String {
             match self {
                 Self::Instance { project, name, .. } => {
                     format!("{project}/{name}")
@@ -1809,7 +1809,7 @@ async fn cmd_db_eips(
         state: IpAttachState,
         owner_kind: &'static str,
         owner_id: String,
-        owner_description: String,
+        owner_name: String,
     }
 
     if verbose {
@@ -1920,7 +1920,7 @@ async fn cmd_db_eips(
             kind: ip.kind,
             owner_kind: owner.kind(),
             owner_id: owner.id(),
-            owner_description: owner.description(),
+            owner_name: owner.name(),
         };
         rows.push(row);
     }

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -254,8 +254,9 @@ Print information about the network
 Usage: omdb db network [OPTIONS] <COMMAND>
 
 Commands:
-  list-eips  List external IPs
-  help       Print this message or the help of the given subcommand(s)
+  list-eips   List external IPs
+  list-vnics  List virtual network interfaces
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
       --verbose  Print out raw data structures from the data store


### PR DESCRIPTION
This PR has some omdb commands I wanted during dev/debug of #5045. It expands the output of `list-vnics` to include the parent's ID (particularly useful when trying to determine the external IP of a specific Nexus instance, for example):

```
 IP                PORTS        KIND       STATE     OWNER_KIND  OWNER_ID                              OWNER_DESCRIPTION
 10.1.1.3/32       0/65535      floating   Attached  instance    4e6fb33a-7ba2-4a5e-abc5-dc9b047c01e0  v6/some-vm2
 10.1.1.4/32       0/16383      SNAT       Attached  instance    4e6fb33a-7ba2-4a5e-abc5-dc9b047c01e0  v6/some-vm2
 10.1.1.5/32       0/65535      ephemeral  Attached  instance    4e6fb33a-7ba2-4a5e-abc5-dc9b047c01e0  v6/some-vm2
 172.20.26.1/32    0/65535      floating   Attached  service     edd99650-5df1-4241-815d-253e4ef2399c  ExternalDns
 172.20.26.2/32    0/65535      floating   Attached  service     f500d564-c40a-4eca-ac8a-a26b435f2037  ExternalDns
 172.20.26.3/32    0/65535      floating   Attached  service     65a11c18-7f59-41ac-b9e7-680627f996e7  Nexus
 172.20.26.4/32    0/65535      floating   Attached  service     20b100d0-84c3-4119-aa9b-0c632b0b6a3a  Nexus
 172.20.26.5/32    0/65535      floating   Attached  service     2898657e-4141-4c05-851b-147bffc6bbbd  Nexus
 172.20.26.6/32    0/16383      SNAT       Attached  service     c3ec3d1a-3172-4d36-bfd3-f54a04d5ba55  Ntp
```

and adds a `list-vnics` command to show allocated vnics:

```
 IP                 MAC                SLOT  PRIMARY  KIND      SUBNET           PARENT_ID                             DESCRIPTION
 172.30.0.5/32      A8:40:25:F8:A5:8C  1     true     instance  172.30.0.0/22    2a4afdda-e269-48bc-913f-01ad57c50543  default primary interface for p4
 172.30.0.5/32      A8:40:25:F5:AF:F0  1     true     instance  172.30.0.0/22    be705808-d507-4693-9a97-186c92970e7b  default primary interface for updateinst
 172.30.0.5/32      A8:40:25:F7:3B:00  1     true     instance  172.30.0.0/22    0ab1939f-af6e-4ea2-a155-71f210e937fc  a sample nic
 172.30.1.5/32      A8:40:25:FF:B0:9C  1     true     service   172.30.1.0/24    edd99650-5df1-4241-815d-253e4ef2399c  external_dns service vNIC
 172.30.1.6/32      A8:40:25:FF:D0:B4  1     true     service   172.30.1.0/24    f500d564-c40a-4eca-ac8a-a26b435f2037  external_dns service vNIC
 172.30.2.5/32      A8:40:25:FF:A6:83  1     true     service   172.30.2.0/24    65a11c18-7f59-41ac-b9e7-680627f996e7  nexus service vNIC
 172.30.2.6/32      A8:40:25:FF:B4:C1  1     true     service   172.30.2.0/24    20b100d0-84c3-4119-aa9b-0c632b0b6a3a  nexus service vNIC
 172.30.2.7/32      A8:40:25:FF:C6:59  0     true     service   172.30.2.0/24    2898657e-4141-4c05-851b-147bffc6bbbd  nexus service vNIC
 172.30.3.5/32      A8:40:25:FF:B2:52  1     true     service   172.30.3.0/24    c3ec3d1a-3172-4d36-bfd3-f54a04d5ba55  ntp service vNIC
 172.30.3.6/32      A8:40:25:FF:A0:F9  1     true     service   172.30.3.0/24    6ea2684c-115e-48a6-8453-ab52d1cecd73  ntp service vNIC
```

(This command immediately revealed issues with the slot number recording on dogfood, which led to opening #5056.)