### PR TITLE
Add PEM encoded certificate to external api response

### DIFF
--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -82,6 +82,16 @@ impl TryFrom<Certificate> for views::Certificate {
         Ok(Self {
             identity: cert.identity(),
             service: cert.service.try_into()?,
+            cert: String::from_utf8(cert.cert)
+                .map_err(|err| {
+                    Error::InternalError {
+                        internal_message: format!(
+                            "Failed to construct string from stored certificate: {}",
+                            err
+                        )
+                    }
+                }
+            )?,
         })
     }
 }

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -86,11 +86,8 @@ impl TryFrom<Certificate> for views::Certificate {
             // database with PEM encoding which are essentially bundles of Base64 encoded text.
             // The only cases in which this conversion should fail is when our internal database
             // representation of the certificate is invalid.
-            cert: String::from_utf8(cert.cert).map_err(|err| {
-                Error::internal_error(&format!(
-                    "Failed to construct string from stored certificate: {}",
-                    err
-                ))
+            cert: String::from_utf8(cert.cert).map_err(|_| {
+                Error::internal_error("Certificate is not valid UTF-8")
             })?,
         })
     }

--- a/nexus/db-model/src/certificate.rs
+++ b/nexus/db-model/src/certificate.rs
@@ -82,16 +82,16 @@ impl TryFrom<Certificate> for views::Certificate {
         Ok(Self {
             identity: cert.identity(),
             service: cert.service.try_into()?,
-            cert: String::from_utf8(cert.cert)
-                .map_err(|err| {
-                    Error::InternalError {
-                        internal_message: format!(
-                            "Failed to construct string from stored certificate: {}",
-                            err
-                        )
-                    }
-                }
-            )?,
+            // This is expected to succeed in normal circumstances. Certificates are stored in the
+            // database with PEM encoding which are essentially bundles of Base64 encoded text.
+            // The only cases in which this conversion should fail is when our internal database
+            // representation of the certificate is invalid.
+            cert: String::from_utf8(cert.cert).map_err(|err| {
+                Error::internal_error(&format!(
+                    "Failed to construct string from stored certificate: {}",
+                    err
+                ))
+            })?,
         })
     }
 }

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -177,7 +177,10 @@ pub struct Project {
 pub struct Certificate {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
+    /// The service using this certificate
     pub service: ServiceUsingCertificate,
+    /// PEM-formatted string containing public certificate chain
+    pub cert: String,
 }
 
 // IMAGES

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11021,6 +11021,10 @@
         "description": "View of a Certificate",
         "type": "object",
         "properties": {
+          "cert": {
+            "description": "PEM-formatted string containing public certificate chain",
+            "type": "string"
+          },
           "description": {
             "description": "human-readable free-form text about a resource",
             "type": "string"
@@ -11039,7 +11043,12 @@
             ]
           },
           "service": {
-            "$ref": "#/components/schemas/ServiceUsingCertificate"
+            "description": "The service using this certificate",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ServiceUsingCertificate"
+              }
+            ]
           },
           "time_created": {
             "description": "timestamp when this resource was created",
@@ -11053,6 +11062,7 @@
           }
         },
         "required": [
+          "cert",
           "description",
           "id",
           "name",


### PR DESCRIPTION
* Add pem encoded certificate to certificate list and view endpoints

When managing multiple silos, it quickly becomes desirable to be able to use the oxide cli and/or sdk to manage them. Handling certificate rotation currently requires storing external state about what certificate is registered with which silo as our external API only returns identity metadata about the certificate. This PR proposes adding the the public certificate to the fields returned for a certificate.

This initial implementation tries to take the simplest approach to this:
1. Return the exact representation that we store in the database (PEM-encoded string)
2. Returns the certificate on both list and view endpoints

An alternative approach may be to only return the full certificate as a part of the view endpoint, but I'm not sure if that is a pattern that we use.

The other consideration is how this should handle the failure to construct a String from the bytes form of a certificate. Currently it is very disruptive, and hard to debug if bad data were to be stored in the database.
