### PR TITLE
Fix bad service NIC slots

### DIFF
--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -13,7 +13,7 @@ use omicron_common::api::external::SemverVersion;
 ///
 /// This should be updated whenever the schema is changed. For more details,
 /// refer to: schema/crdb/README.adoc
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(34, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(35, 0, 0);
 
 table! {
     disk (id) {

--- a/nexus/db-queries/src/db/mod.rs
+++ b/nexus/db-queries/src/db/mod.rs
@@ -35,6 +35,11 @@ pub mod subquery;
 pub(crate) mod true_or_cast_error;
 mod update_and_check;
 
+/// Batch statement to disable full table scans.
+// This is `pub` so tests that don't go through our connection pool can disable
+// full table scans the same way pooled connections do.
+pub use pool_connection::DISALLOW_FULL_TABLE_SCAN_SQL;
+
 #[cfg(test)]
 mod test_utils;
 

--- a/nexus/db-queries/src/db/pool_connection.rs
+++ b/nexus/db-queries/src/db/pool_connection.rs
@@ -78,7 +78,7 @@ static CUSTOM_TYPE_KEYS: &'static [&'static str] = &[
 ];
 const CUSTOM_TYPE_SCHEMA: &'static str = "public";
 
-const DISALLOW_FULL_TABLE_SCAN_SQL: &str =
+pub const DISALLOW_FULL_TABLE_SCAN_SQL: &str =
     "set disallow_full_table_scans = on; set large_full_scan_rows = 0;";
 
 #[derive(Debug)]

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -10,6 +10,7 @@ use nexus_db_model::schema::SCHEMA_VERSION as LATEST_SCHEMA_VERSION;
 use nexus_db_queries::db::datastore::{
     all_sql_for_version_migration, EARLIEST_SUPPORTED_VERSION,
 };
+use nexus_db_queries::db::DISALLOW_FULL_TABLE_SCAN_SQL;
 use nexus_test_utils::{db, load_test_config, ControlPlaneTestContextBuilder};
 use omicron_common::api::external::SemverVersion;
 use omicron_common::api::internal::shared::SwitchLocation;
@@ -117,6 +118,11 @@ async fn apply_update(
     info!(log, "Performing upgrade");
 
     let client = crdb.connect().await.expect("failed to connect");
+
+    client
+        .batch_execute(DISALLOW_FULL_TABLE_SCAN_SQL)
+        .await
+        .expect("failed to disallow full table scans");
 
     // We skip this for the earliest supported version because these tables
     // might not exist yet.

--- a/schema/crdb/35.0.0/up.sql
+++ b/schema/crdb/35.0.0/up.sql
@@ -1,0 +1,6 @@
+-- This isn't realy a schema migration, but is instead a one-off fix for
+-- incorrect data (https://github.com/oxidecomputer/omicron/issues/5056) after
+-- the root cause for the incorrect data has been addressed.
+UPDATE omicron.public.network_interface
+    SET slot = 0
+    WHERE kind = 'service' AND time_deleted IS NULL;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3515,7 +3515,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '34.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '35.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
This is the second half of the fix for #5056. #5065 (already merged) fixed _how_ we were getting service NICs with nonzero slot values, and this PR adds a schema migration to apply a one-time fix to any existing service NICs with nonzero slot values. This matters to the Reconfigurator, because currently the NICs sled-agent thinks it has don't match the NICs recorded in CRDB (differing only by slot number).

Closes #5056.