### PR TITLE
Fix typo in printing blueprint diff

### DIFF
--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -615,8 +615,8 @@ impl<'a> std::fmt::Display for OmicronZonesDiff<'a> {
                     f,
                     "+        zone {} type {} underlay IP {} (added)",
                     zone.id,
-                    zone.underlay_address,
                     zone.zone_type.label(),
+                    zone.underlay_address,
                 )?;
             }
         }


### PR DESCRIPTION
This seems weird! :)

```
         zone faa4010d-9979-47d3-b104-7c269def8cbb type crucible underlay IP fd00:1122:3344:101::c (unchanged)
         zone fb81a9cc-267e-48d8-bdb3-32dc6225a04f type crucible underlay IP fd00:1122:3344:101::8 (unchanged)
+        zone d86f17d2-e1a5-4744-85c7-8bb3d989ac76 type fd00:1122:3344:101::21 underlay IP nexus (added)
```