### PR TITLE
"expensive operation" check was too aggressive

### DIFF
--- a/nexus/db-queries/src/context.rs
+++ b/nexus/db-queries/src/context.rs
@@ -303,10 +303,17 @@ impl OpContext {
     ///   either.  Clients and proxies often don't expect long requests and
     ///   apply aggressive timeouts.  Depending on the HTTP version, a
     ///   long-running request can tie up the TCP connection.
+    ///
+    /// We shouldn't allow these in either internal or external API handlers,
+    /// but we currently have some internal APIs for exercising some expensive
+    /// blueprint operations and so we allow these cases here.
     pub fn check_complex_operations_allowed(&self) -> Result<(), Error> {
         let api_handler = match self.kind {
-            OpKind::ExternalApiRequest | OpKind::InternalApiRequest => true,
-            OpKind::Saga | OpKind::Background | OpKind::Test => false,
+            OpKind::ExternalApiRequest => true,
+            OpKind::InternalApiRequest
+            | OpKind::Saga
+            | OpKind::Background
+            | OpKind::Test => false,
         };
         if api_handler {
             Err(Error::internal_error(


### PR DESCRIPTION
See #5111.  In #4989 I added a check so that we couldn't list all sleds in the rack (or do other expensive things) from an API handler.  But right now, blueprint planning always happens inside an internal API handler.  So for now I'm suggesting we relax this constraint to prevent it only from the external API.