### PR TITLE
[test-utils] Give a little hint about running CockroachDB on test failures

### DIFF
--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -641,11 +641,11 @@ impl Drop for CockroachInstance {
                 let path = temp_dir.into_path();
                 eprintln!(
                     "WARN: temporary directory leaked: {path:?}\n\
-                     \tIf you would like to access the database for debugging, run the following:\n\
+                     \tIf you would like to access the database for debugging, run the following:\n\n\
                      \t# Run the database\n\
-                     \tcockroach start-single-node --insecure --store=attrs=ssd,path={data_path:?}\n\
-                     \t# Access the database\n\
-                     \tcockroach sql --host=localhost --insecure",
+                     \tcargo run --bin omicron-dev db-run --no-populate --store-dir {data_path:?}\n\
+                     \t# Access the database. Note the port may change if you run multiple databases.\n\
+                     \tcockroach sql --host=localhost:32221 --insecure",
                      data_path = path.join("data"),
                 );
             }

--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -640,8 +640,13 @@ impl Drop for CockroachInstance {
                 // Do NOT clean up the temporary directory in this case.
                 let path = temp_dir.into_path();
                 eprintln!(
-                    "WARN: temporary directory leaked: {}",
-                    path.display()
+                    "WARN: temporary directory leaked: {path:?}\n\
+                     \tIf you would like to access the database for debugging, run the following:\n\
+                     \t# Run the database\n\
+                     \tcockroach start-single-node --insecure --store=attrs=ssd,path={data_path:?}\n\
+                     \t# Access the database\n\
+                     \tcockroach sql --host=localhost --insecure",
+                     data_path = path.join("data"),
                 );
             }
         }


### PR DESCRIPTION
This is a pattern I use a lot, but I want to help make it more visible to folks during test failures.

Digging into the state of Cockroach after a test failure is a useful debugging tool, so I want to make
it obvious "how to do that".