### PR TITLE
trigger inventory collection after blueprint execution

### DIFF
--- a/nexus/src/app/background/blueprint_execution.rs
+++ b/nexus/src/app/background/blueprint_execution.rs
@@ -21,7 +21,6 @@ pub struct BlueprintExecutor {
     rx_blueprint: watch::Receiver<Option<Arc<(BlueprintTarget, Blueprint)>>>,
     nexus_label: String,
     tx: watch::Sender<usize>,
-    count: usize,
 }
 
 impl BlueprintExecutor {
@@ -33,7 +32,7 @@ impl BlueprintExecutor {
         nexus_label: String,
     ) -> BlueprintExecutor {
         let (tx, _) = watch::channel(0);
-        BlueprintExecutor { datastore, rx_blueprint, nexus_label, tx, count: 0 }
+        BlueprintExecutor { datastore, rx_blueprint, nexus_label, tx }
     }
 
     pub fn watcher(&self) -> watch::Receiver<usize> {
@@ -79,8 +78,7 @@ impl BackgroundTask for BlueprintExecutor {
             .await;
 
             // Trigger anybody waiting for this to finish.
-            self.count = self.count + 1;
-            self.tx.send(self.count);
+            self.tx.send_modify(|count| *count = *count + 1);
 
             // Return the result as a `serde_json::Value`
             match result {

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -170,30 +170,6 @@ impl BackgroundTasks {
             )
         };
 
-        // Background task: inventory collector
-        let task_inventory_collection = {
-            let collector = inventory_collection::InventoryCollector::new(
-                datastore.clone(),
-                resolver,
-                &nexus_id.to_string(),
-                config.inventory.nkeep,
-                config.inventory.disable,
-            );
-            let task = driver.register(
-                String::from("inventory_collection"),
-                String::from(
-                    "collects hardware and software inventory data from the \
-                    whole system",
-                ),
-                config.inventory.period_secs,
-                Box::new(collector),
-                opctx.child(BTreeMap::new()),
-                vec![],
-            );
-
-            task
-        };
-
         // Background task: phantom disk detection
         let task_phantom_disks = {
             let detector =
@@ -230,6 +206,7 @@ impl BackgroundTasks {
             rx_blueprint.clone(),
             nexus_id.to_string(),
         );
+        let rx_blueprint_exec = blueprint_executor.watcher();
         let task_blueprint_executor = driver.register(
             String::from("blueprint_executor"),
             String::from("Executes the target blueprint"),
@@ -238,6 +215,37 @@ impl BackgroundTasks {
             opctx.child(BTreeMap::new()),
             vec![Box::new(rx_blueprint)],
         );
+
+        // Background task: inventory collector
+        //
+        // This currently depends on the "output" of the blueprint executor in
+        // order to automatically trigger inventory collection whenever the
+        // blueprint executor runs.  In the limit, this could become a problem
+        // because the blueprint executor might also depend indirectly on the
+        // inventory collector.  In that case, we may need to do something more
+        // complicated.  But for now, this works.
+        let task_inventory_collection = {
+            let collector = inventory_collection::InventoryCollector::new(
+                datastore.clone(),
+                resolver,
+                &nexus_id.to_string(),
+                config.inventory.nkeep,
+                config.inventory.disable,
+            );
+            let task = driver.register(
+                String::from("inventory_collection"),
+                String::from(
+                    "collects hardware and software inventory data from the \
+                    whole system",
+                ),
+                config.inventory.period_secs,
+                Box::new(collector),
+                opctx.child(BTreeMap::new()),
+                vec![Box::new(rx_blueprint_exec)],
+            );
+
+            task
+        };
 
         let task_service_zone_nat_tracker = {
             driver.register(


### PR DESCRIPTION
This came up in the context of #5111 and [here in particular](https://github.com/oxidecomputer/omicron/issues/5111#issuecomment-1959346002):

> > FWIW, there were 2 periods where I ended up waiting on a collection:
> 
>     * After add sled, as discussed above and we now understand
> 
>     * In between making the blueprint that added an NTP zone to the new sled and regenerating the next blueprint
> 
> 
> In the second case, even though the sled had already started the NTP zone and successfully timesync'd, I was still waiting for an inventory collection because the planner [won't add anything else to the sled until the latest collection shows the NTP zone](https://github.com/oxidecomputer/omicron/blob/42844311eb688e63ea23361dfb4279b44e65f792/nexus/deployment/src/planner.rs#L106-L139). I'm not sure where we could trigger a collection here, though - if sled-agent told us in the response whether the `PUT /omicron-zones` actually started new zones, could the reconfigurator task trigger a collection if new zones were added?

I figured that more generally, any time we execute a blueprint, successfully or otherwise, we may have made some changes and we ought to re-collect inventory.