### PR TITLE
Update Floating IP field name from address to ip

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -256,7 +256,7 @@ impl DataStore {
 
         let pool_id = pool.id();
 
-        let data = if let Some(ip) = params.address {
+        let data = if let Some(ip) = params.ip {
             IncompleteExternalIp::for_floating_explicit(
                 ip_id,
                 &Name(params.identity.name),

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -267,7 +267,7 @@ pub async fn create_floating_ip(
     client: &ClientTestContext,
     fip_name: &str,
     project: &str,
-    address: Option<IpAddr>,
+    ip: Option<IpAddr>,
     parent_pool_name: Option<&str>,
 ) -> FloatingIp {
     object_create(
@@ -278,7 +278,7 @@ pub async fn create_floating_ip(
                 name: fip_name.parse().unwrap(),
                 description: String::from("a floating ip"),
             },
-            address,
+            ip,
             pool: parent_pool_name.map(|v| NameOrId::Name(v.parse().unwrap())),
         },
     )

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -768,7 +768,7 @@ pub static DEMO_FLOAT_IP_CREATE: Lazy<params::FloatingIpCreate> =
             name: DEMO_FLOAT_IP_NAME.clone(),
             description: String::from("a new IP pool"),
         },
-        address: Some(std::net::Ipv4Addr::new(10, 0, 0, 141).into()),
+        ip: Some(std::net::Ipv4Addr::new(10, 0, 0, 141).into()),
         pool: None,
     });
 

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -189,7 +189,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
             name: fip_name.parse().unwrap(),
             description: String::from("a floating ip"),
         },
-        address: None,
+        ip: None,
         pool: Some(NameOrId::Name("other-pool".parse().unwrap())),
     };
     let url = format!("/v1/floating-ips?project={}", project.identity.name);
@@ -259,7 +259,7 @@ async fn test_floating_ip_create_fails_in_other_silo_pool(
             name: fip_name.parse().unwrap(),
             description: String::from("a floating ip"),
         },
-        address: None,
+        ip: None,
         pool: Some(NameOrId::Name("external-silo-pool".parse().unwrap())),
     };
 
@@ -316,7 +316,7 @@ async fn test_floating_ip_create_ip_in_use(
                 name: FIP_NAMES[1].parse().unwrap(),
                 description: "another fip".into(),
             },
-            address: Some(contested_ip),
+            ip: Some(contested_ip),
             pool: None,
         }))
         .expect_status(Some(StatusCode::BAD_REQUEST)),
@@ -364,7 +364,7 @@ async fn test_floating_ip_create_name_in_use(
                 name: contested_name.parse().unwrap(),
                 description: "another fip".into(),
             },
-            address: None,
+            ip: None,
             pool: None,
         }))
         .expect_status(Some(StatusCode::BAD_REQUEST)),

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -883,7 +883,7 @@ pub struct FloatingIpCreate {
     /// An IP address to reserve for use as a floating IP. This field is
     /// optional: when not set, an address will be automatically chosen from
     /// `pool`. If set, then the IP must be available in the resolved `pool`.
-    pub address: Option<IpAddr>,
+    pub ip: Option<IpAddr>,
 
     /// The parent IP pool that a floating IP is pulled from. If unset, the
     /// default pool is selected.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11864,7 +11864,7 @@
         "description": "Parameters for creating a new floating IP address for instances.",
         "type": "object",
         "properties": {
-          "address": {
+          "ip": {
             "nullable": true,
             "description": "An IP address to reserve for use as a floating IP. This field is optional: when not set, an address will be automatically chosen from `pool`. If set, then the IP must be available in the resolved `pool`.",
             "type": "string",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11864,14 +11864,14 @@
         "description": "Parameters for creating a new floating IP address for instances.",
         "type": "object",
         "properties": {
+          "description": {
+            "type": "string"
+          },
           "ip": {
             "nullable": true,
             "description": "An IP address to reserve for use as a floating IP. This field is optional: when not set, an address will be automatically chosen from `pool`. If set, then the IP must be available in the resolved `pool`.",
             "type": "string",
             "format": "ip"
-          },
-          "description": {
-            "type": "string"
           },
           "name": {
             "$ref": "#/components/schemas/Name"


### PR DESCRIPTION
Fixes #5046

Our API for Floating IPs currently has an `address` field, though in a few other places we use `ip`. This PR just makes the API more consistent across the API (and DB).