### PR TITLE
sled-agent needs to deal with SSD overprovisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,6 +3859,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnvme"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/libnvme?rev=6fffcc81d2c423ed2d2e6c5c2827485554c4ecbe#6fffcc81d2c423ed2d2e6c5c2827485554c4ecbe"
+dependencies = [
+ "libnvme-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "libnvme-sys"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/libnvme?rev=6fffcc81d2c423ed2d2e6c5c2827485554c4ecbe#6fffcc81d2c423ed2d2e6c5c2827485554c4ecbe"
+
+[[package]]
 name = "libsw"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8187,6 +8201,7 @@ dependencies = [
  "illumos-utils",
  "libc",
  "libefi-illumos",
+ "libnvme",
  "macaddr",
  "omicron-common",
  "omicron-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ itertools = "0.12.1"
 key-manager = { path = "key-manager" }
 kstat-rs = "0.2.3"
 libc = "0.2.153"
+libnvme = { git = "https://github.com/oxidecomputer/libnvme", rev = "6fffcc81d2c423ed2d2e6c5c2827485554c4ecbe" }
 linear-map = "1.2.0"
 macaddr = { version = "1.0.1", features = ["serde_std"] }
 maplit = "1.0.2"

--- a/sled-hardware/Cargo.toml
+++ b/sled-hardware/Cargo.toml
@@ -28,6 +28,7 @@ omicron-workspace-hack.workspace = true
 [target.'cfg(target_os = "illumos")'.dependencies]
 illumos-devinfo = { git = "https://github.com/oxidecomputer/illumos-devinfo", branch = "main" }
 libefi-illumos = { git = "https://github.com/oxidecomputer/libefi-illumos", branch = "master" }
+libnvme.workspace = true
 
 [dev-dependencies]
 illumos-utils = { workspace = true, features = ["testing"] }

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -26,7 +26,7 @@ mod gpt;
 mod partitions;
 mod sysconf;
 
-pub use partitions::ensure_partition_layout;
+pub use partitions::{ensure_partition_layout, NvmeFormattingError};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -256,7 +256,7 @@ fn ensure_size_and_formatting(
         preferred_nvme_device_settings().get(identity.model.as_str())
     {
         let nvme = Nvme::new()?;
-        for controller in nvme.controller_discovery()?.into_iter() {
+        for controller in nvme.controller_discovery()? {
             let controller = controller?.write_lock().map_err(|(_, e)| e)?;
             let controller_info = controller.get_info()?;
             // Make sure we are operating on the correct NVMe device.
@@ -304,7 +304,6 @@ fn ensure_size_and_formatting(
                 .unwrap_or(DEFAULT_NVME_LBA_DATA_SIZE);
             let desired_lba = controller_info
                 .lba_formats()
-                .into_iter()
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 .find(|lba| {

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -276,8 +276,10 @@ fn ensure_size_and_formatting(
             // Safe because verified there is exactly one namespace.
             let namespace = namespaces.into_iter().next().unwrap();
 
-            // TODO we need to abstract this detail awway if/when future devices
-            // are not from WDC.
+            // NB: Only some vendors such as WDC support adjusting the size
+            // of the disk to deal with overprovisioning. This will need to be
+            // abstracted away if/when we ever start using another vendor with
+            // this capability.
             let size = controller.wdc_resize_get()?;
 
             // First we need to detach blkdev from the namespace.
@@ -287,7 +289,6 @@ fn ensure_size_and_formatting(
             // durability level in terms of drive writes per day.
             if let Some(wanted_size) = nvme_settings.size {
                 if size != wanted_size {
-                    // TODO this also needs to be abstracted away.
                     controller.wdc_resize_set(wanted_size)?;
                     info!(
                         log,
@@ -328,7 +329,8 @@ fn ensure_size_and_formatting(
 
                 info!(
                     log,
-                    "Formatted {} using LBA with data size of {wanted_data_size}",
+                    "Formatted disk with serial {} to an LBA with data size \
+                    {wanted_data_size}",
                     identity.serial,
                 );
             }
@@ -340,7 +342,7 @@ fn ensure_size_and_formatting(
         info!(
             log,
             "There are no preferred NVMe settings for disk model {}; nothing to\
-            do for disk with serial {}",
+             do for disk with serial {}",
             identity.model,
             identity.serial
         );

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -56,7 +56,6 @@ fn preferred_nvme_device_settings(
 }
 
 #[derive(Debug, thiserror::Error)]
-#[cfg(target_os = "illumos")]
 pub enum NvmeFormattingError {
     #[error(transparent)]
     NvmeInit(#[from] libnvme::NvmeInitError),
@@ -70,13 +69,6 @@ pub enum NvmeFormattingError {
     InfoError(#[from] libnvme::controller_info::NvmeInfoError),
     #[error("Could not find NVMe controller for disk with serial {0}")]
     NoController(String),
-}
-
-#[derive(Debug, thiserror::Error)]
-#[cfg(not(target_os = "illumos"))]
-pub enum NvmeFormattingError {
-    #[error("NVMe formatting is unsupported on this platform")]
-    UnsupportedPlatform,
 }
 
 // The expected layout of an M.2 device within the Oxide rack.
@@ -225,7 +217,6 @@ fn internal_ensure_partition_layout<GPT: gpt::LibEfiGpt>(
     }
 }
 
-#[cfg(target_os = "illumos")]
 fn ensure_size_and_formatting(
     log: &Logger,
     identity: &DiskIdentity,
@@ -325,14 +316,6 @@ fn ensure_size_and_formatting(
         return Err(NvmeFormattingError::NoController(identity.serial.clone()));
     }
 
-    Ok(())
-}
-
-#[cfg(not(target_os = "illumos"))]
-fn ensure_size_and_formatting(
-    log: &Logger,
-    identity: &DiskIdentity,
-) -> Result<(), NvmeFormattingError> {
     Ok(())
 }
 

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -348,7 +348,7 @@ mod test {
     use crate::DiskPaths;
     use camino::Utf8PathBuf;
     use illumos_utils::zpool::MockZpool;
-    use omicron_test_utils::dev::{mock_device_identity, test_setup_log};
+    use omicron_test_utils::dev::{mock_disk_identity, test_setup_log};
     use std::path::Path;
 
     struct FakePartition {
@@ -384,7 +384,7 @@ mod test {
             &log,
             &DiskPaths { devfs_path, dev_path: None },
             DiskVariant::U2,
-            &mock_device_identity(),
+            &mock_disk_identity(),
         );
         match result {
             Err(PooledDiskError::CannotFormatMissingDevPath { .. }) => {}
@@ -418,7 +418,7 @@ mod test {
                 dev_path: Some(Utf8PathBuf::from(DEV_PATH)),
             },
             DiskVariant::U2,
-            &mock_device_identity(),
+            &mock_disk_identity(),
         )
         .expect("Should have succeeded partitioning disk");
 
@@ -443,7 +443,7 @@ mod test {
                 dev_path: Some(Utf8PathBuf::from(DEV_PATH))
             },
             DiskVariant::M2,
-            &mock_device_identity(),
+            &mock_disk_identity(),
         )
         .is_err());
 
@@ -481,7 +481,7 @@ mod test {
                 dev_path: Some(Utf8PathBuf::from(DEV_PATH)),
             },
             DiskVariant::U2,
-            &mock_device_identity(),
+            &mock_disk_identity(),
         )
         .expect("Should be able to parse disk");
 
@@ -524,7 +524,7 @@ mod test {
                 dev_path: Some(Utf8PathBuf::from(DEV_PATH)),
             },
             DiskVariant::M2,
-            &mock_device_identity(),
+            &mock_disk_identity(),
         )
         .expect("Should be able to parse disk");
 
@@ -564,7 +564,7 @@ mod test {
                     dev_path: Some(Utf8PathBuf::from(DEV_PATH)),
                 },
                 DiskVariant::M2,
-                &mock_device_identity(),
+                &mock_disk_identity(),
             )
             .expect_err("Should have failed parsing empty GPT"),
             PooledDiskError::BadPartitionLayout { .. }
@@ -590,7 +590,7 @@ mod test {
                     dev_path: Some(Utf8PathBuf::from(DEV_PATH)),
                 },
                 DiskVariant::U2,
-                &mock_device_identity(),
+                &mock_disk_identity(),
             )
             .expect_err("Should have failed parsing empty GPT"),
             PooledDiskError::BadPartitionLayout { .. }

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -6,9 +6,16 @@ use crate::disk::{
     DiskPaths, DiskVariant, Partition, PooledDiskError, UnparsedDisk,
 };
 use crate::{Baseboard, SledMode};
+use omicron_common::disk::DiskIdentity;
 use slog::Logger;
 use std::collections::HashSet;
 use tokio::sync::broadcast;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NvmeFormattingError {
+    #[error("NVMe formatting is unsupported on this platform")]
+    UnsupportedPlatform,
+}
 
 /// An unimplemented, stub representation of the underlying hardware.
 ///
@@ -59,6 +66,7 @@ pub fn ensure_partition_layout(
     _log: &Logger,
     _paths: &DiskPaths,
     _variant: DiskVariant,
+    _identity: &DiskIdentity,
 ) -> Result<Vec<Partition>, PooledDiskError> {
     unimplemented!("Accessing hardware unsupported on non-illumos");
 }

--- a/test-utils/src/dev/mod.rs
+++ b/test-utils/src/dev/mod.rs
@@ -149,7 +149,7 @@ pub fn process_running(pid: u32) -> bool {
 
 /// Returns a DiskIdentity that can be passed to ensure_partition_layout when
 /// not operating on a real disk.
-pub fn mock_device_identity() -> DiskIdentity {
+pub fn mock_disk_identity() -> DiskIdentity {
     DiskIdentity {
         vendor: "MockVendor".to_string(),
         serial: "MOCKSERIAL".to_string(),

--- a/test-utils/src/dev/mod.rs
+++ b/test-utils/src/dev/mod.rs
@@ -20,6 +20,7 @@ pub use dropshot::test_util::LogContext;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingIfExists;
 use dropshot::ConfigLoggingLevel;
+use omicron_common::disk::DiskIdentity;
 use slog::Logger;
 use std::io::BufReader;
 
@@ -144,4 +145,14 @@ pub fn process_running(pid: u32) -> bool {
     // It should be okay to invoke this syscall with these arguments.  This
     // only checks whether the process is running.
     0 == (unsafe { libc::kill(pid as libc::pid_t, 0) })
+}
+
+/// Returns a DiskIdentity that can be passed to ensure_partition_layout when
+/// not operating on a real disk.
+pub fn mock_device_identity() -> DiskIdentity {
+    DiskIdentity {
+        vendor: "MockVendor".to_string(),
+        serial: "MOCKSERIAL".to_string(),
+        model: "MOCKMODEL".to_string(),
+    }
 }


### PR DESCRIPTION
This introduces the ability for omicron's storage manager to resize and format NVMe disks based upon a lookup table keyed off of model number to preferred settings. 

Fixes #4619

