### PR TITLE
Floating IP attach fix: fip by ID + instance by name and vice versa

### DIFF
--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -146,20 +146,20 @@ impl super::Nexus {
     ) -> UpdateResult<views::FloatingIp> {
         match target.kind {
             params::FloatingIpParentKind::Instance => {
-                // This is surprisingly complicated in order to handle the
-                // case where floating IP is specified by name (and therefore
-                // a project is given) but instance is specified by ID (and
-                // therefore the lookup doesn't want a project), as well as
-                // the converse: floating IP specified by ID (and no project
+                // Handle the case where floating IP is specified by name (and
+                // therefore a project is given) but instance is specified by
+                // ID (and therefore the lookup doesn't want a project), as well
+                // as the converse: floating IP specified by ID (and no project
                 // given) but instance specified by name, and therefore needs
                 // a project. In the latter case, we have to fetch the floating
                 // IP by its ID in order to get the project to include with
                 // the instance.
-                let project = match target.parent {
-                    NameOrId::Id(_) => None,
-                    NameOrId::Name(_) => match fip_selector.project {
-                        Some(p) => Some(p),
-                        None => {
+                let project =
+                    match (target.parent.clone(), fip_selector.clone().project)
+                    {
+                        (NameOrId::Id(_), _) => None,
+                        (NameOrId::Name(_), Some(p)) => Some(p),
+                        (NameOrId::Name(_), None) => {
                             let fip_lookup = self.floating_ip_lookup(
                                 opctx,
                                 fip_selector.clone(),
@@ -167,8 +167,7 @@ impl super::Nexus {
                             let (.., fip) = fip_lookup.fetch().await?;
                             Some(fip.project_id.into())
                         }
-                    },
-                };
+                    };
 
                 let instance_selector = params::InstanceSelector {
                     project,

--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -147,7 +147,12 @@ impl super::Nexus {
         match target.kind {
             params::FloatingIpParentKind::Instance => {
                 let instance_selector = params::InstanceSelector {
-                    project: fip_selector.project,
+                    // only include the project if the instance is specified by
+                    // name. lookup by ID fails if project if present
+                    project: match target.parent {
+                        NameOrId::Name(_) => fip_selector.project,
+                        NameOrId::Id(_) => None,
+                    },
                     instance: target.parent,
                 };
                 let instance =

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -202,7 +202,7 @@ impl super::Nexus {
                 ..
             } => {
                 Err(Error::invalid_request(
-                    "when providing instance as an ID project should not be specified",
+                    "when providing instance as an ID, project should not be specified",
                 ))
             }
             _ => {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -167,7 +167,7 @@ pub struct OptionalProjectSelector {
     pub project: Option<NameOrId>,
 }
 
-#[derive(Deserialize, JsonSchema)]
+#[derive(Deserialize, JsonSchema, Clone)]
 pub struct FloatingIpSelector {
     /// Name or ID of the project, only required if `floating_ip` is provided as a `Name`
     pub project: Option<NameOrId>,


### PR DESCRIPTION
When I tried attaching a floating IP to an instance in the web console on dogfood, I got this error from the API.

<img src="https://github.com/oxidecomputer/omicron/assets/3612203/0c7b6a2f-f31e-44d1-bc21-07c5f1926ef7" width="400">


It turns out we were taking the project as specified for determining the floating IP and jamming it into the instance selector, regardless of whether it needed it (selecting instance by name) or not (selecting instance by ID). I added a bit to the floating IP attach test and confirmed that it fails without the fix and passes with the fix.

Even with this fix in place, there is still one more loose end to tie up: if the floating IP is specified by ID, and therefore does not have the project, but the _instance_ is specified by name, this will fail because there is no project to include for instance specification purposes. The only way I can see of making this work without asking the user to somehow specify the project for the instance is to fetch the floating IP and pull the project off of that to include on the instance selector. This makes sense because you can only ever attach a floating IP to an instance in the same project.

Edit: did that in 6c144e82e04e1a64da9bd1a6ccc6026efb76f98e. Kinda sad to do an extra DB fetch, but I don't see another way to preserve the ability to do name or ID on the instance.