### PR TITLE
Fix: prevent cross-project floating IP attach

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -37,12 +37,12 @@ use chrono::Utc;
 use diesel::prelude::*;
 use nexus_db_model::Instance;
 use nexus_db_model::IpAttachState;
-use nexus_types::external_api::params;
 use nexus_types::identity::Resource;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;
+use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::ResourceType;
@@ -227,7 +227,8 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         project_id: Uuid,
-        params: params::FloatingIpCreate,
+        identity: IdentityMetadataCreateParams,
+        ip: Option<IpAddr>,
         pool: Option<authz::IpPool>,
     ) -> CreateResult<ExternalIp> {
         let ip_id = Uuid::new_v4();
@@ -256,11 +257,11 @@ impl DataStore {
 
         let pool_id = pool.id();
 
-        let data = if let Some(ip) = params.ip {
+        let data = if let Some(ip) = ip {
             IncompleteExternalIp::for_floating_explicit(
                 ip_id,
-                &Name(params.identity.name),
-                &params.identity.description,
+                &Name(identity.name),
+                &identity.description,
                 project_id,
                 ip,
                 pool_id,
@@ -268,8 +269,8 @@ impl DataStore {
         } else {
             IncompleteExternalIp::for_floating(
                 ip_id,
-                &Name(params.identity.name),
-                &params.identity.description,
+                &Name(identity.name),
+                &identity.description,
                 project_id,
                 pool_id,
             )

--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -109,9 +109,11 @@ impl super::Nexus {
         let (.., authz_project) =
             project_lookup.lookup_for(authz::Action::CreateChild).await?;
 
-        let pool = match &params.pool {
+        let params::FloatingIpCreate { identity, pool, ip } = params;
+
+        let pool = match pool {
             Some(pool) => Some(
-                self.ip_pool_lookup(opctx, pool)?
+                self.ip_pool_lookup(opctx, &pool)?
                     .lookup_for(authz::Action::Read)
                     .await?
                     .0,
@@ -121,7 +123,7 @@ impl super::Nexus {
 
         Ok(self
             .db_datastore
-            .allocate_floating_ip(opctx, authz_project.id(), params, pool)
+            .allocate_floating_ip(opctx, authz_project.id(), identity, ip, pool)
             .await?
             .try_into()
             .unwrap())

--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -158,16 +158,11 @@ impl super::Nexus {
                 // given) but instance specified by name, and therefore needs
                 // a project. In the latter case, we need to place the floating
                 // IP's project ID into the instance selector.
-                let project = match (&target.parent, fip_selector.project) {
-                    (NameOrId::Id(_), _) => None,
-                    (NameOrId::Name(_), Some(p)) => Some(p),
-                    (NameOrId::Name(_), None) => {
-                        Some(authz_project.id().into())
-                    }
-                };
-
                 let instance_selector = params::InstanceSelector {
-                    project,
+                    project: match &target.parent {
+                        NameOrId::Id(_) => None,
+                        NameOrId::Name(_) => Some(authz_project.id().into()),
+                    },
                     instance: target.parent,
                 };
 

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -49,6 +49,7 @@ use propolis_client::support::tungstenite::Message as WebSocketMessage;
 use propolis_client::support::InstanceSerialConsoleHelper;
 use propolis_client::support::WSClientOffset;
 use propolis_client::support::WebSocketStream;
+use sagas::instance_common::ExternalIpAttach;
 use sled_agent_client::types::InstanceMigrationSourceParams;
 use sled_agent_client::types::InstanceMigrationTargetParams;
 use sled_agent_client::types::InstanceProperties;
@@ -201,7 +202,7 @@ impl super::Nexus {
                 ..
             } => {
                 Err(Error::invalid_request(
-                    "when providing instance as an ID, project should not be specified",
+                    "when providing instance as an ID project should not be specified",
                 ))
             }
             _ => {
@@ -1952,20 +1953,63 @@ impl super::Nexus {
         Ok(())
     }
 
-    /// Attach an external IP to an instance.
-    pub(crate) async fn instance_attach_external_ip(
+    /// Attach an ephemeral IP to an instance.
+    pub(crate) async fn instance_attach_ephemeral_ip(
         self: &Arc<Self>,
         opctx: &OpContext,
         instance_lookup: &lookup::Instance<'_>,
-        ext_ip: &params::ExternalIpCreate,
+        pool: Option<NameOrId>,
     ) -> UpdateResult<views::ExternalIp> {
         let (.., authz_project, authz_instance) =
             instance_lookup.lookup_for(authz::Action::Modify).await?;
 
+        self.instance_attach_external_ip(
+            opctx,
+            authz_instance,
+            authz_project.id(),
+            ExternalIpAttach::Ephemeral { pool },
+        )
+        .await
+    }
+
+    /// Attach an ephemeral IP to an instance.
+    pub(crate) async fn instance_attach_floating_ip(
+        self: &Arc<Self>,
+        opctx: &OpContext,
+        instance_lookup: &lookup::Instance<'_>,
+        authz_fip: authz::FloatingIp,
+        authz_fip_project: authz::Project,
+    ) -> UpdateResult<views::ExternalIp> {
+        let (.., authz_project, authz_instance) =
+            instance_lookup.lookup_for(authz::Action::Modify).await?;
+
+        if authz_fip_project.id() != authz_project.id() {
+            return Err(Error::invalid_request(
+                "floating IP must be in the same project as the instance",
+            ));
+        }
+
+        self.instance_attach_external_ip(
+            opctx,
+            authz_instance,
+            authz_project.id(),
+            ExternalIpAttach::Floating { floating_ip: authz_fip },
+        )
+        .await
+    }
+
+    /// Attach an external IP to an instance.
+    pub(crate) async fn instance_attach_external_ip(
+        self: &Arc<Self>,
+        opctx: &OpContext,
+        authz_instance: authz::Instance,
+        project_id: Uuid,
+        ext_ip: ExternalIpAttach,
+    ) -> UpdateResult<views::ExternalIp> {
         let saga_params = sagas::instance_ip_attach::Params {
             create_params: ext_ip.clone(),
             authz_instance,
-            project_id: authz_project.id(),
+            project_id,
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),
         };
 

--- a/nexus/src/app/sagas/instance_common.rs
+++ b/nexus/src/app/sagas/instance_common.rs
@@ -16,8 +16,8 @@ use nexus_db_queries::authz;
 use nexus_db_queries::db::lookup::LookupPath;
 use nexus_db_queries::db::queries::external_ip::SAFE_TRANSIENT_INSTANCE_STATES;
 use nexus_db_queries::{authn, context::OpContext, db, db::DataStore};
-use omicron_common::api::external::Error;
 use omicron_common::api::external::InstanceState;
+use omicron_common::api::external::{Error, NameOrId};
 use serde::{Deserialize, Serialize};
 use steno::ActionError;
 use uuid::Uuid;
@@ -468,4 +468,10 @@ pub async fn instance_ip_remove_opte(
         })?;
 
     Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ExternalIpAttach {
+    Ephemeral { pool: Option<NameOrId> },
+    Floating { floating_ip: authz::FloatingIp },
 }

--- a/nexus/src/app/sagas/instance_ip_detach.rs
+++ b/nexus/src/app/sagas/instance_ip_detach.rs
@@ -357,6 +357,8 @@ pub(crate) mod test {
             .project_name(&proj_name)
             .instance_name(&inst_name);
 
+        let (.., authz_proj, authz_instance, _) = lookup.fetch().await.unwrap();
+
         for use_float in [false, true] {
             let params = instance_ip_attach::test::new_test_params(
                 opctx, datastore, use_float,
@@ -365,8 +367,9 @@ pub(crate) mod test {
             nexus
                 .instance_attach_external_ip(
                     opctx,
-                    &lookup,
-                    &params.create_params,
+                    authz_instance.clone(),
+                    authz_proj.id(),
+                    params.create_params,
                 )
                 .await
                 .unwrap();

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -24,7 +24,7 @@ pub mod disk_create;
 pub mod disk_delete;
 pub mod finalize_disk;
 pub mod image_delete;
-mod instance_common;
+pub(crate) mod instance_common;
 pub mod instance_create;
 pub mod instance_delete;
 pub mod instance_ip_attach;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -4088,12 +4088,10 @@ async fn instance_ephemeral_ip_attach(
         let instance_lookup =
             nexus.instance_lookup(&opctx, instance_selector)?;
         let ip = nexus
-            .instance_attach_external_ip(
+            .instance_attach_ephemeral_ip(
                 &opctx,
                 &instance_lookup,
-                &params::ExternalIpCreate::Ephemeral {
-                    pool: ip_to_create.into_inner().pool,
-                },
+                ip_to_create.into_inner().pool,
             )
             .await?;
         Ok(HttpResponseAccepted(ip))


### PR DESCRIPTION
This PR ensures that attached FIPs have the same project ID as their target instance, and prevents double lookup of a FIP in the `FIP [name + project] + Instance [ID]` attach case.