### PR TITLE
Use the right error conversion to external::Error for service errors

### DIFF
--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -153,8 +153,12 @@ pub enum Error {
 
 impl From<Error> for omicron_common::api::external::Error {
     fn from(err: Error) -> Self {
-        omicron_common::api::external::Error::InternalError {
-            internal_message: err.to_string(),
+        match err {
+            // Service errors can convert themselves into the external error
+            Error::Services(err) => err.into(),
+            _ => omicron_common::api::external::Error::InternalError {
+                internal_message: err.to_string(),
+            },
         }
     }
 }


### PR DESCRIPTION
Service errors already define their own conversion to external errors:

https://github.com/oxidecomputer/omicron/blob/f6efad4126986f72d3bedfdc04cb4ed30a926f0b/sled-agent/src/services.rs#L286

But this conversion was not used by the Sled Agent because it treated ALL `sled_agent::Error` types as internal errors:

https://github.com/oxidecomputer/omicron/blob/f6efad4126986f72d3bedfdc04cb4ed30a926f0b/sled-agent/src/sled_agent.rs#L154-L160

This PR starts converting better error types by enabling dispatch to more specific error converters.