### PR TITLE
Add a show-empty option to oxlog

### DIFF
--- a/dev-tools/oxlog/src/bin/oxlog.rs
+++ b/dev-tools/oxlog/src/bin/oxlog.rs
@@ -4,7 +4,7 @@
 
 //! Tool for discovering oxide related logfiles on sleds
 
-use clap::{Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand};
 use oxlog::{Filter, LogFile, Zones};
 
 #[derive(Debug, Parser)]
@@ -50,6 +50,10 @@ struct FilterArgs {
     // Print only the extra log files
     #[arg(short, long)]
     extra: bool,
+
+    /// Show log files even if they are empty
+    #[arg(short, long, action=ArgAction::SetFalse)]
+    show_empty: bool,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -68,6 +72,7 @@ fn main() -> Result<(), anyhow::Error> {
                 current: filter.current,
                 archived: filter.archived,
                 extra: filter.extra,
+                show_empty: filter.show_empty,
             };
             let print_metadata = |f: &LogFile| {
                 println!(

--- a/dev-tools/oxlog/src/bin/oxlog.rs
+++ b/dev-tools/oxlog/src/bin/oxlog.rs
@@ -52,7 +52,7 @@ struct FilterArgs {
     extra: bool,
 
     /// Show log files even if they are empty
-    #[arg(short, long, action=ArgAction::SetFalse)]
+    #[arg(short, long, action=ArgAction::SetTrue)]
     show_empty: bool,
 }
 

--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -75,6 +75,9 @@ pub struct Filter {
     /// standard paths or don't follow the naming conventions of SMF service
     /// files. e.g. `/pool/ext/e12f29b8-1ab8-431e-bc96-1c1298947980/crypt/zone/oxz_cockroachdb_8bbea076-ff60-4330-8302-383e18140ef3/root/data/logs/cockroach.log`
     pub extra: bool,
+
+    /// Show a log file even if is has zero size.
+    pub show_empty: bool,
 }
 
 /// Path and metadata about a logfile
@@ -264,17 +267,21 @@ impl Zones {
         // 'archived'. These files have not yet been migrated into the debug
         // directory.
         if filter.current || filter.archived {
-            load_svc_logs(paths.primary.clone(), &mut output);
+            load_svc_logs(
+                paths.primary.clone(),
+                &mut output,
+                filter.show_empty,
+            );
         }
 
         if filter.archived {
             for dir in paths.debug.clone() {
-                load_svc_logs(dir, &mut output);
+                load_svc_logs(dir, &mut output, filter.show_empty);
             }
         }
         if filter.extra {
             for (svc_name, dir) in paths.extra.clone() {
-                load_extra_logs(dir, svc_name, &mut output);
+                load_extra_logs(dir, svc_name, &mut output, filter.show_empty);
             }
         }
         output
@@ -320,7 +327,11 @@ pub fn oxide_smf_service_name_from_log_file_name(
 
 // Given a directory, find all oxide specific SMF service logs and return them
 // mapped to their inferred service name.
-fn load_svc_logs(dir: Utf8PathBuf, logs: &mut BTreeMap<ServiceName, SvcLogs>) {
+fn load_svc_logs(
+    dir: Utf8PathBuf,
+    logs: &mut BTreeMap<ServiceName, SvcLogs>,
+    show_empty: bool,
+) {
     let Ok(entries) = dir.read_dir_utf8() else {
         return;
     };
@@ -344,7 +355,7 @@ fn load_svc_logs(dir: Utf8PathBuf, logs: &mut BTreeMap<ServiceName, SvcLogs>) {
             };
 
             logfile.read_metadata(&entry);
-            if logfile.size == Some(0) {
+            if logfile.size == Some(0) && show_empty {
                 // skip 0 size files
                 continue;
             }
@@ -368,6 +379,7 @@ fn load_extra_logs(
     dir: Utf8PathBuf,
     svc_name: &str,
     logs: &mut BTreeMap<ServiceName, SvcLogs>,
+    show_empty: bool,
 ) {
     let Ok(entries) = dir.read_dir_utf8() else {
         return;
@@ -384,7 +396,7 @@ fn load_extra_logs(
         path.push(filename);
         let mut logfile = LogFile::new(path);
         logfile.read_metadata(&entry);
-        if logfile.size == Some(0) {
+        if logfile.size == Some(0) && show_empty {
             // skip 0 size files
             continue;
         }

--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -355,7 +355,7 @@ fn load_svc_logs(
             };
 
             logfile.read_metadata(&entry);
-            if logfile.size == Some(0) && show_empty {
+            if logfile.size == Some(0) && !show_empty {
                 // skip 0 size files
                 continue;
             }
@@ -396,7 +396,7 @@ fn load_extra_logs(
         path.push(filename);
         let mut logfile = LogFile::new(path);
         logfile.read_metadata(&entry);
-        if logfile.size == Some(0) && show_empty {
+        if logfile.size == Some(0) && !show_empty {
             // skip 0 size files
             continue;
         }


### PR DESCRIPTION
This adds an option flag (off by default) that will show matching log files even if they are
zero length.

By default, if the log file is empty, you won't see any output:
```
root@EVT22200005:/alan# /alan/bin/oxlog logs --current oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e
root@EVT22200005:/alan#
```

But, sometimes you want really want to know there is a log file that is indeed empty.
If so, add the `--show-empty` option, and volia, you can see the empty files:
```
root@EVT22200005:/alan# /alan/bin/oxlog logs --current --show-empty  oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e
/pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-agent:default.log
/pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-downstairs:downstairs-7b0f29d1-642c-4c60-bbc2-eddb6ace34a9.log
/pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-zone-network-setup:default.log
root@EVT22200005:/alan# ls -l /pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-agent:default.log
-rw-r--r--   1 root     root           0 Mar  3 01:45 /pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-agent:default.log
root@EVT22200005:/alan# ls -l /pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-downstairs:downstairs-7b0f29d1-642c-4c60-bbc2-eddb6ace34a9.log
-rw-r--r--   1 root     root           0 Mar  3 01:45 /pool/ext/616b26df-e62a-4c68-b506-f4a923d8aaf7/crypt/zone/oxz_crucible_b2136649-3b43-4bd9-827d-127fe5fe757e/root/var/svc/log/oxide-crucible-downstairs:downstairs-7b0f29d1-642c-4c60-bbc2-eddb6ace34a9.log
```