### PR TITLE
[meta] update whoami to 1.5.0, remove patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,12 +884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,18 +4620,6 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.4.0",
- "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -10270,12 +10252,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
-source = "git+https://github.com/oxidecomputer/whoami?branch=use-nix#da2a26e695849f1ffc394627ba27a6a473650705"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "nix 0.28.0",
+ "redox_syscall 0.4.1",
  "wasite",
- "wasm-bindgen",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -621,11 +621,6 @@ opt-level = 3
 git = 'https://github.com/oxidecomputer/pq-sys'
 branch = "oxide/omicron"
 
-# See https://github.com/oxidecomputer/security-operations/issues/43.
-[patch.crates-io.whoami]
-git = "https://github.com/oxidecomputer/whoami"
-branch = "use-nix"
-
 # Using the workspace-hack via this patch directive means that it only applies
 # while building within this workspace. If another workspace imports a crate
 # from here via a git dependency, it will not have the workspace-hack applied


### PR DESCRIPTION
whoami 1.5.0 contains the fix for https://github.com/oxidecomputer/security-operations/issues/43.