### PR TITLE
Add LLDP

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -50,6 +50,7 @@ pub const CLICKHOUSE_PORT: u16 = 8123;
 pub const CLICKHOUSE_KEEPER_PORT: u16 = 9181;
 pub const OXIMETER_PORT: u16 = 12223;
 pub const DENDRITE_PORT: u16 = 12224;
+pub const LLDP_PORT: u16 = 12230;
 pub const MGD_PORT: u16 = 4676;
 pub const DDMD_PORT: u16 = 8000;
 pub const MGS_PORT: u16 = 12225;

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -553,6 +553,15 @@ source.sha256 = "151aeb26414989cad571b3886786efbeeafd91c41a93a747c784cdc654d5876
 output.type = "zone"
 output.intermediate_only = true
 
+[package.lldp]
+service_name = "lldp"
+source.type = "prebuilt"
+source.repo = "lldp"
+source.commit = "e165090e393df90874329265799480e221884236"
+source.sha256 = "004a6488a948d894fa203222aa42e159e1ae12c13751607852302d111e2c58e6"
+output.type = "zone"
+output.intermediate_only = true
+
 [package.dendrite-stub]
 service_name = "dendrite"
 only_for_targets.switch = "stub"
@@ -648,6 +657,7 @@ source.type = "composite"
 source.packages = [
   "omicron-gateway-asic.tar.gz",
   "dendrite-asic.tar.gz",
+  "lldp.tar.gz",
   "wicketd.tar.gz",
   "wicket.tar.gz",
   "mg-ddm.tar.gz",
@@ -671,6 +681,7 @@ source.type = "composite"
 source.packages = [
   "omicron-gateway-stub.tar.gz",
   "dendrite-stub.tar.gz",
+  "lldp.tar.gz",
   "wicketd.tar.gz",
   "wicket.tar.gz",
   "mg-ddm.tar.gz",
@@ -694,6 +705,7 @@ source.type = "composite"
 source.packages = [
   "omicron-gateway-softnpu.tar.gz",
   "dendrite-softnpu.tar.gz",
+  "lldp.tar.gz",
   "wicketd.tar.gz",
   "wicket.tar.gz",
   "mg-ddm.tar.gz",

--- a/tools/update_lldp.sh
+++ b/tools/update_lldp.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -o errexit
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+function usage {
+    echo "usage: $0 [-c COMMIT] [-n]"
+    echo
+    echo "  -c COMMIT   Ask to update Lldp to a specific commit."
+    echo "              If this is unset, Github is queried."
+    echo "  -n          Dry-run"
+    exit 1
+}
+
+PACKAGES=(
+  "lldp"
+)
+
+CRATES=(
+  "lldp"
+)
+
+REPO="oxidecomputer/lldp"
+
+. "$SOURCE_DIR/update_helpers.sh"
+
+function main {
+    TARGET_COMMIT=""
+    DRY_RUN=""
+    while getopts "c:n" o; do
+      case "${o}" in
+        c)
+          TARGET_COMMIT="$OPTARG"
+          ;;
+        n)
+          DRY_RUN="yes"
+          ;;
+        *)
+          usage
+          ;;
+      esac
+    done
+
+    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    install_toml2json
+    do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
+    do_update_crates "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${CRATES[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
This adds the `lldp` daemon and CLI to the switch zone and updates `sled-agent` to do the basic configuration and enablement of the service.

On its own, this change will not cause the switch zone to advertise or receive `lldp` packets, as no interfaces are configured.  That can be done using the CLI in the switch zone for testing on `dogfood` and/or the colo.  Adding runtime configuration by `nexus` will be follow-on work.