### PR TITLE
Unquarantine clickhouse binary on mac

### DIFF
--- a/tools/ci_download_clickhouse
+++ b/tools/ci_download_clickhouse
@@ -84,6 +84,12 @@ function main
 	# Unpack the tarball into a local directory
 	do_untar "$TARBALL_FILE" "$DEST_DIR"
 
+	# on macOS, we need to take the binary out of quarantine after download
+	# https://github.com/ClickHouse/clickhouse-docs/blob/08d7a329d/knowledgebase/fix-developer-verification-error-in-macos.md
+	if [[ $CIDL_OS == darwin* ]]; then
+		xattr -d com.apple.quarantine "$DEST_DIR/clickhouse"
+	fi
+
 	# Run the binary as a sanity-check.
 	"$DEST_DIR/clickhouse" server --version
 }


### PR DESCRIPTION
After #5127 (I assume, because this problem came up immediately after that) macOS Gatekeeper is putting the `clickhouse` binary in quarantine after download, which means we can't execute it unless we take it out of quarantine. This is apparently a new thing, as [this doc](https://github.com/ClickHouse/clickhouse-docs/blob/08d7a329d/knowledgebase/fix-developer-verification-error-in-macos.md) about how to do that was only [added Jan 9](https://github.com/ClickHouse/clickhouse-docs/pull/1835).

Here I am doing it in the simplest way possible: if mac, then remove quarantine attr. If anyone has a better way, I'm all ears.