### PR TITLE
async-await-ifying DumpSetup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,7 +491,7 @@ wicket-common = { path = "wicket-common" }
 wicketd-client = { path = "clients/wicketd-client" }
 zeroize = { version = "1.7.0", features = ["zeroize_derive", "std"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate","bzip2"] }
-zone = { version = "0.3", default-features = false, features = ["async", "sync"] }
+zone = { version = "0.3", default-features = false, features = ["async"] }
 
 # newtype-uuid is set to default-features = false because we don't want to
 # depend on std in omicron-uuid-kinds (in case a no-std library wants to access

--- a/sled-agent/src/dump_setup.rs
+++ b/sled-agent/src/dump_setup.rs
@@ -118,13 +118,13 @@ struct DebugDataset(Utf8PathBuf);
 #[derive(AsRef, Clone, Debug, Eq, From, Hash, Ord, PartialEq, PartialOrd)]
 struct CoreDataset(Utf8PathBuf);
 
-#[derive(AsRef, Clone, From)]
+#[derive(AsRef, Clone, Debug, From)]
 pub(super) struct CoreZpool {
     mount_config: MountConfig,
     name: ZpoolName,
 }
 
-#[derive(AsRef, Clone, From)]
+#[derive(AsRef, Clone, Debug, From)]
 pub(super) struct DebugZpool {
     mount_config: MountConfig,
     name: ZpoolName,

--- a/sled-agent/src/dump_setup.rs
+++ b/sled-agent/src/dump_setup.rs
@@ -546,9 +546,15 @@ impl DumpSetupWorker {
         debug_datasets: Vec<DebugZpool>,
         core_datasets: Vec<CoreZpool>,
     ) {
+        info!(
+            self.log,
+            "Updated view of disks";
+            "core_datasets" => %core_datasets.len(),
+            "debug_datasets" => %debug_datasets.len(),
+            "dump_slices" => %dump_slices.len(),
+        );
         self.core_dataset_names = core_datasets;
         self.debug_dataset_names = debug_datasets;
-
         self.known_dump_slices = dump_slices;
     }
 

--- a/sled-agent/src/dump_setup.rs
+++ b/sled-agent/src/dump_setup.rs
@@ -82,6 +82,7 @@
 //! rotated log files having the same modified time to the second), the
 //! number is incremented by 1 until no conflict remains.
 
+use async_trait::async_trait;
 use camino::Utf8PathBuf;
 use derive_more::{AsRef, From};
 use illumos_utils::coreadm::{CoreAdm, CoreFileOption};
@@ -97,8 +98,8 @@ use slog::Logger;
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Weak};
 use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use tokio::sync::mpsc::Receiver;
 use zone::{Zone, ZoneError};
 
 const ZFS_PROP_USED: &str = "used";
@@ -118,13 +119,13 @@ struct DebugDataset(Utf8PathBuf);
 struct CoreDataset(Utf8PathBuf);
 
 #[derive(AsRef, Clone, From)]
-struct CoreZpool {
+pub(super) struct CoreZpool {
     mount_config: MountConfig,
     name: ZpoolName,
 }
 
 #[derive(AsRef, Clone, From)]
-struct DebugZpool {
+pub(super) struct DebugZpool {
     mount_config: MountConfig,
     name: ZpoolName,
 }
@@ -167,6 +168,16 @@ trait GetMountpoint: AsRef<ZpoolName> {
         }
     }
 }
+
+#[derive(Debug)]
+enum DumpSetupCmd {
+    UpdateDumpdevSetup {
+        dump_slices: Vec<DumpSlicePath>,
+        debug_datasets: Vec<DebugZpool>,
+        core_datasets: Vec<CoreZpool>,
+    },
+}
+
 struct DumpSetupWorker {
     core_dataset_names: Vec<CoreZpool>,
     debug_dataset_names: Vec<DebugZpool>,
@@ -182,33 +193,33 @@ struct DumpSetupWorker {
     savecored_slices: HashSet<DumpSlicePath>,
 
     log: Logger,
+    rx: Receiver<DumpSetupCmd>,
     coredumpadm_invoker: Box<dyn CoreDumpAdmInvoker + Send + Sync>,
     zfs_invoker: Box<dyn ZfsInvoker + Send + Sync>,
     zone_invoker: Box<dyn ZoneInvoker + Send + Sync>,
 }
 
 pub struct DumpSetup {
-    worker: Arc<std::sync::Mutex<DumpSetupWorker>>,
+    tx: tokio::sync::mpsc::Sender<DumpSetupCmd>,
     mount_config: MountConfig,
-    _poller: std::thread::JoinHandle<()>,
+    _poller: tokio::task::JoinHandle<()>,
     log: Logger,
 }
 
 impl DumpSetup {
     pub fn new(log: &Logger, mount_config: MountConfig) -> Self {
-        let worker = Arc::new(std::sync::Mutex::new(DumpSetupWorker::new(
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let worker = DumpSetupWorker::new(
             Box::new(RealCoreDumpAdm {}),
             Box::new(RealZfs {}),
             Box::new(RealZone {}),
             log.new(o!("component" => "DumpSetup-worker")),
-        )));
-        let worker_weak = Arc::downgrade(&worker);
-        let log_poll = log.new(o!("component" => "DumpSetup-archival"));
-        let _poller = std::thread::spawn(move || {
-            Self::poll_file_archival(worker_weak, log_poll)
-        });
+            rx,
+        );
+        let _poller =
+            tokio::spawn(async move { worker.poll_file_archival().await });
         let log = log.new(o!("component" => "DumpSetup"));
-        Self { worker, mount_config, _poller, log }
+        Self { tx, mount_config, _poller, log }
     }
 
     pub(crate) async fn update_dumpdev_setup(
@@ -268,55 +279,16 @@ impl DumpSetup {
             }
         }
 
-        let savecore_lock = self.worker.clone();
-        let log_tmp = log.new(o!("component" => "DumpSetup-mutex"));
-        tokio::task::spawn_blocking(move || match savecore_lock.lock() {
-            Ok(mut guard) => {
-                guard.update_disk_loadout(
-                    m2_dump_slices,
-                    u2_debug_datasets,
-                    m2_core_datasets,
-                );
-            }
-            Err(err) => {
-                error!(log_tmp, "DumpSetup mutex poisoned: {err:?}");
-            }
-        });
-    }
-
-    fn poll_file_archival(
-        worker: Weak<std::sync::Mutex<DumpSetupWorker>>,
-        log: Logger,
-    ) {
-        info!(log, "DumpSetup poll loop started.");
-        loop {
-            if let Some(mutex) = worker.upgrade() {
-                match mutex.lock() {
-                    Ok(mut guard) => {
-                        guard.reevaluate_choices();
-                        if let Err(err) = guard.archive_files() {
-                            error!(
-                                log,
-                                "Failed to archive debug/dump files: {err:?}"
-                            );
-                        }
-                    }
-                    Err(err) => {
-                        error!(
-                            log,
-                            "DumpSetup mutex poisoned in poll thread: {err:?}"
-                        );
-                        break;
-                    }
-                }
-            } else {
-                info!(
-                    log,
-                    "DumpSetup weak pointer dropped, leaving poll loop."
-                );
-                break;
-            }
-            std::thread::sleep(ARCHIVAL_INTERVAL);
+        if let Err(err) = self
+            .tx
+            .send(DumpSetupCmd::UpdateDumpdevSetup {
+                dump_slices: m2_dump_slices,
+                debug_datasets: u2_debug_datasets,
+                core_datasets: m2_core_datasets,
+            })
+            .await
+        {
+            error!(log, "DumpSetup channel closed: {:?}", err.0);
         }
     }
 }
@@ -331,9 +303,10 @@ enum ZfsGetError {
     Parse(#[from] std::num::ParseIntError),
 }
 
+#[async_trait]
 trait CoreDumpAdmInvoker {
     fn coreadm(&self, core_dir: &Utf8PathBuf) -> Result<(), ExecutionError>;
-    fn dumpadm(
+    async fn dumpadm(
         &self,
         dump_slice: &Utf8PathBuf,
         savecore_dir: Option<&Utf8PathBuf>,
@@ -378,14 +351,16 @@ trait ZfsInvoker {
     ) -> Utf8PathBuf;
 }
 
+#[async_trait]
 trait ZoneInvoker {
-    fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError>;
+    async fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError>;
 }
 
 struct RealCoreDumpAdm {}
 struct RealZfs {}
 struct RealZone {}
 
+#[async_trait]
 impl CoreDumpAdmInvoker for RealCoreDumpAdm {
     fn coreadm(&self, core_dir: &Utf8PathBuf) -> Result<(), ExecutionError> {
         let mut cmd = CoreAdm::new();
@@ -414,7 +389,7 @@ impl CoreDumpAdmInvoker for RealCoreDumpAdm {
     // function also invokes `savecore(8)` to save it into that directory.
     // On success, returns Ok(Some(stdout)) if `savecore(8)` was invoked, or
     // Ok(None) if it wasn't.
-    fn dumpadm(
+    async fn dumpadm(
         &self,
         dump_slice: &Utf8PathBuf,
         savecore_dir: Option<&Utf8PathBuf>,
@@ -427,7 +402,7 @@ impl CoreDumpAdmInvoker for RealCoreDumpAdm {
             // which is in the ramdisk pool), because dumpadm refuses to do what
             // we ask otherwise.
             let tmp_crash = "/tmp/crash";
-            std::fs::create_dir_all(tmp_crash).map_err(|err| {
+            tokio::fs::create_dir_all(tmp_crash).await.map_err(|err| {
                 ExecutionError::ExecutionStart {
                     command: format!("mkdir {tmp_crash:?}"),
                     err,
@@ -457,7 +432,7 @@ impl CoreDumpAdmInvoker for RealCoreDumpAdm {
         if savecore_dir.is_some() {
             // and does the dump slice have one to save off
             if let Ok(true) =
-                illumos_utils::dumpadm::dump_flag_is_valid(dump_slice)
+                illumos_utils::dumpadm::dump_flag_is_valid(dump_slice).await
             {
                 return illumos_utils::dumpadm::SaveCore.execute();
             }
@@ -490,9 +465,11 @@ impl ZfsInvoker for RealZfs {
     }
 }
 
+#[async_trait]
 impl ZoneInvoker for RealZone {
-    fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError> {
-        Ok(zone::Adm::list_blocking()?
+    async fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError> {
+        Ok(zone::Adm::list()
+            .await?
             .into_iter()
             .filter(|z| z.global() || z.name().starts_with(ZONE_PREFIX))
             .collect::<Vec<_>>())
@@ -505,6 +482,7 @@ impl DumpSetupWorker {
         zfs_invoker: Box<dyn ZfsInvoker + Send + Sync>,
         zone_invoker: Box<dyn ZoneInvoker + Send + Sync>,
         log: Logger,
+        rx: Receiver<DumpSetupCmd>,
     ) -> Self {
         Self {
             core_dataset_names: vec![],
@@ -517,9 +495,48 @@ impl DumpSetupWorker {
             known_core_dirs: vec![],
             savecored_slices: Default::default(),
             log,
+            rx,
             coredumpadm_invoker,
             zfs_invoker,
             zone_invoker,
+        }
+    }
+
+    async fn poll_file_archival(mut self) {
+        info!(self.log, "DumpSetup poll loop started.");
+        loop {
+            match tokio::time::timeout(ARCHIVAL_INTERVAL, self.rx.recv()).await
+            {
+                Ok(Some(DumpSetupCmd::UpdateDumpdevSetup {
+                    dump_slices,
+                    debug_datasets,
+                    core_datasets,
+                })) => {
+                    self.update_disk_loadout(
+                        dump_slices,
+                        debug_datasets,
+                        core_datasets,
+                    );
+                }
+                Ok(None) => {
+                    warn!(
+                        self.log,
+                        "Control channel closed, no more dump archival!"
+                    );
+                    break;
+                }
+                Err(_elapsed) => {
+                    // no new disks, just pump cores/logs with what we've got
+                }
+            }
+            // regardless of whether we updated disks,
+            // at least every ARCHIVAL_INTERVAL,
+            // figure out if we should change our target volumes...
+            self.reevaluate_choices().await;
+            // and then do the actual archiving.
+            if let Err(err) = self.archive_files().await {
+                error!(self.log, "Failed to archive debug/dump files: {err:?}");
+            }
         }
     }
 
@@ -533,8 +550,6 @@ impl DumpSetupWorker {
         self.debug_dataset_names = debug_datasets;
 
         self.known_dump_slices = dump_slices;
-
-        self.reevaluate_choices();
     }
 
     // only allow mounted zfs datasets into 'known_*_dirs',
@@ -554,7 +569,7 @@ impl DumpSetupWorker {
             .collect();
     }
 
-    fn reevaluate_choices(&mut self) {
+    async fn reevaluate_choices(&mut self) {
         self.update_mounted_dirs();
 
         self.known_dump_slices.sort();
@@ -609,7 +624,7 @@ impl DumpSetupWorker {
                             self.chosen_debug_dir = None;
                         } else {
                             warn!(self.log, "All candidate debug/dump dirs are over usage threshold, removing older archived files");
-                            if let Err(err) = self.cleanup() {
+                            if let Err(err) = self.cleanup().await {
                                 error!(self.log, "Couldn't clean up any debug/dump dirs, may hit dataset quota in {x:?}: {err:?}");
                             } else {
                                 self.chosen_debug_dir = None;
@@ -665,7 +680,9 @@ impl DumpSetupWorker {
                     // Let's try to see if it appears to have a kernel dump already
                     match illumos_utils::dumpadm::dump_flag_is_valid(
                         dump_slice.as_ref(),
-                    ) {
+                    )
+                    .await
+                    {
                         Ok(true) => {
                             debug!(self.log, "Dump slice {dump_slice:?} appears to have a valid header; will attempt to savecore");
                         }
@@ -676,7 +693,9 @@ impl DumpSetupWorker {
                             debug!(self.log, "Dump slice {dump_slice:?} appears to be unused: {err:?}");
                         }
                     }
-                    if let Ok(saved) = self.dumpadm_and_savecore(&dump_slice) {
+                    if let Ok(saved) =
+                        self.dumpadm_and_savecore(&dump_slice).await
+                    {
                         if let Some(out) = saved {
                             info!(self.log, "Previous dump on slice {dump_slice:?} saved, configured slice as target for new dumps. {out:?}");
                         }
@@ -691,13 +710,16 @@ impl DumpSetupWorker {
                 for dump_slice in &self.known_dump_slices {
                     match illumos_utils::dumpadm::dump_flag_is_valid(
                         dump_slice.as_ref(),
-                    ) {
+                    )
+                    .await
+                    {
                         Ok(false) => {
                             // Have dumpadm write the config for crash dumps to be
                             // on this slice, at least, until a U.2 comes along.
                             match self
                                 .coredumpadm_invoker
                                 .dumpadm(dump_slice.as_ref(), None)
+                                .await
                             {
                                 Ok(_) => {
                                     info!(self.log, "Using dump device {dump_slice:?} with no savecore destination (no U.2 debug zvol yet)");
@@ -731,7 +753,7 @@ impl DumpSetupWorker {
                     changed_slice = true;
                     // temporarily changes the system's dump slice so savecore(8)
                     // can update the header in the slice when it finishes...
-                    match self.dumpadm_and_savecore(&dump_slice) {
+                    match self.dumpadm_and_savecore(&dump_slice).await {
                         Ok(saved) => {
                             if let Some(stdout) = &saved {
                                 info!(
@@ -759,6 +781,7 @@ impl DumpSetupWorker {
                     if let Err(err) = self
                         .coredumpadm_invoker
                         .dumpadm(dump_slice.as_ref(), None)
+                        .await
                     {
                         error!(self.log, "Could not restore dump slice to {dump_slice:?}: {err:?}");
                     }
@@ -767,7 +790,7 @@ impl DumpSetupWorker {
         }
     }
 
-    fn archive_files(&self) -> std::io::Result<()> {
+    async fn archive_files(&self) -> tokio::io::Result<()> {
         if let Some(debug_dir) = &self.chosen_debug_dir {
             if self.known_core_dirs.is_empty() {
                 info!(self.log, "No core dump locations yet known.");
@@ -780,6 +803,7 @@ impl DumpSetupWorker {
 
                             if let Err(err) =
                                 Self::copy_sync_and_remove(&entry.path(), &dest)
+                                    .await
                             {
                                 error!(
                                     self.log,
@@ -804,7 +828,7 @@ impl DumpSetupWorker {
             );
         }
 
-        if let Err(err) = self.archive_logs() {
+        if let Err(err) = self.archive_logs().await {
             if !matches!(err, ArchiveLogsError::NoDebugDirYet) {
                 error!(
                     self.log,
@@ -816,32 +840,32 @@ impl DumpSetupWorker {
         Ok(())
     }
 
-    fn copy_sync_and_remove(
+    async fn copy_sync_and_remove(
         source: impl AsRef<Path>,
         dest: impl AsRef<Path>,
-    ) -> std::io::Result<()> {
+    ) -> tokio::io::Result<()> {
         let source = source.as_ref();
         let dest = dest.as_ref();
-        let mut dest_f = std::fs::File::create(&dest)?;
-        let mut src_f = std::fs::File::open(&source)?;
+        let mut dest_f = tokio::fs::File::create(&dest).await?;
+        let mut src_f = tokio::fs::File::open(&source).await?;
 
-        std::io::copy(&mut src_f, &mut dest_f)?;
+        tokio::io::copy(&mut src_f, &mut dest_f).await?;
 
-        dest_f.sync_all()?;
+        dest_f.sync_all().await?;
 
         drop(src_f);
         drop(dest_f);
 
-        std::fs::remove_file(source)?;
+        tokio::fs::remove_file(source).await?;
         Ok(())
     }
 
-    fn archive_logs(&self) -> Result<(), ArchiveLogsError> {
+    async fn archive_logs(&self) -> Result<(), ArchiveLogsError> {
         let debug_dir = self
             .chosen_debug_dir
             .as_ref()
             .ok_or(ArchiveLogsError::NoDebugDirYet)?;
-        let oxz_zones = self.zone_invoker.get_zones()?;
+        let oxz_zones = self.zone_invoker.get_zones().await?;
         for zone in oxz_zones {
             let logdir = if zone.global() {
                 PathBuf::from("/var/svc/log")
@@ -849,12 +873,12 @@ impl DumpSetupWorker {
                 zone.path().join("root/var/svc/log")
             };
             let zone_name = zone.name();
-            self.archive_logs_inner(debug_dir, logdir, zone_name)?;
+            self.archive_logs_inner(debug_dir, logdir, zone_name).await?;
         }
         Ok(())
     }
 
-    fn archive_logs_inner(
+    async fn archive_logs_inner(
         &self,
         debug_dir: &DebugDataset,
         logdir: PathBuf,
@@ -873,7 +897,7 @@ impl DumpSetupWorker {
         }
         let dest_dir = debug_dir.as_ref().join(zone_name).into_std_path_buf();
         if !rotated_log_files.is_empty() {
-            std::fs::create_dir_all(&dest_dir)?;
+            tokio::fs::create_dir_all(&dest_dir).await?;
             let count = rotated_log_files.len();
             info!(
                 self.log,
@@ -903,7 +927,7 @@ impl DumpSetupWorker {
                     break;
                 }
             }
-            if let Err(err) = Self::copy_sync_and_remove(&entry, dest) {
+            if let Err(err) = Self::copy_sync_and_remove(&entry, dest).await {
                 warn!(self.log, "Failed to archive {entry:?}: {err:?}");
             }
         }
@@ -919,7 +943,7 @@ impl DumpSetupWorker {
     // for savecore to behave the way we want (i.e. clear the flag
     // after succeeding), we could hypothetically miss a dump if
     // the kernel crashes again while savecore is still running.
-    fn dumpadm_and_savecore(
+    async fn dumpadm_and_savecore(
         &mut self,
         dump_slice: &DumpSlicePath,
     ) -> Result<Option<OsString>, ExecutionError> {
@@ -931,6 +955,7 @@ impl DumpSetupWorker {
         match self
             .coredumpadm_invoker
             .dumpadm(dump_slice.as_ref(), Some(&savecore_dir))
+            .await
         {
             Ok(saved) => {
                 self.savecored_slices.insert(dump_slice.clone());
@@ -940,10 +965,10 @@ impl DumpSetupWorker {
         }
     }
 
-    fn cleanup(&self) -> Result<(), CleanupError> {
+    async fn cleanup(&self) -> Result<(), CleanupError> {
         let mut dir_info = Vec::new();
         for dir in &self.known_debug_dirs {
-            match self.scope_dir_for_cleanup(dir) {
+            match self.scope_dir_for_cleanup(dir).await {
                 Ok(info) => {
                     dir_info.push((info, dir));
                 }
@@ -967,7 +992,7 @@ impl DumpSetupWorker {
                 // the i/o error *may* be an issue with the underlying disk, so
                 // we continue to the dataset with the next-oldest average age
                 // of files-to-delete in the sorted list.
-                if let Err(err) = std::fs::remove_file(&path) {
+                if let Err(err) = tokio::fs::remove_file(&path).await {
                     error!(self.log, "Couldn't delete {path:?} from debug dataset, skipping {dir:?}. {err:?}");
                     continue 'outer;
                 }
@@ -980,7 +1005,7 @@ impl DumpSetupWorker {
         Ok(())
     }
 
-    fn scope_dir_for_cleanup(
+    async fn scope_dir_for_cleanup(
         &self,
         debug_dir: &DebugDataset,
     ) -> Result<CleanupDirInfo, CleanupError> {
@@ -999,7 +1024,7 @@ impl DumpSetupWorker {
         for path in
             glob::glob(debug_dir.as_ref().join("**/*").as_str())?.flatten()
         {
-            let meta = std::fs::metadata(&path)?;
+            let meta = tokio::fs::metadata(&path).await?;
             // we need this to be a Duration rather than SystemTime so we can
             // do math to it later.
             let time = meta.modified()?.duration_since(UNIX_EPOCH)?;
@@ -1033,7 +1058,7 @@ impl DumpSetupWorker {
 #[derive(thiserror::Error, Debug)]
 pub enum ArchiveLogsError {
     #[error("I/O error: {0}")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] tokio::io::Error),
     #[error("Error calling zoneadm: {0}")]
     Zoneadm(#[from] ZoneError),
     #[error("Non-UTF8 zone path for zone {0}")]
@@ -1053,7 +1078,7 @@ enum CleanupError {
     #[error("Failed to query ZFS properties: {0}")]
     ZfsError(#[from] ZfsGetError),
     #[error("I/O error: {0}")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] tokio::io::Error),
     #[error("Glob pattern invalid: {0}")]
     Glob(#[from] glob::PatternError),
     #[error("A file's observed modified time was before the Unix epoch: {0}")]
@@ -1103,6 +1128,7 @@ mod tests {
         pub zones: Vec<Zone>,
     }
 
+    #[async_trait]
     impl CoreDumpAdmInvoker for FakeCoreDumpAdm {
         fn coreadm(
             &self,
@@ -1111,7 +1137,7 @@ mod tests {
             Ok(())
         }
 
-        fn dumpadm(
+        async fn dumpadm(
             &self,
             _dump_slice: &Utf8PathBuf,
             _savecore_dir: Option<&Utf8PathBuf>,
@@ -1168,8 +1194,9 @@ mod tests {
             .join(mountpoint)
         }
     }
+    #[async_trait]
     impl ZoneInvoker for FakeZone {
-        fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError> {
+        async fn get_zones(&self) -> Result<Vec<Zone>, ArchiveLogsError> {
             Ok(self.zones.clone())
         }
     }
@@ -1193,6 +1220,7 @@ mod tests {
             }),
             Box::<FakeZone>::default(),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
 
         // nothing when no disks
@@ -1266,6 +1294,7 @@ mod tests {
             }),
             Box::<FakeZone>::default(),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
 
         // something when there's one that's ready!
@@ -1330,6 +1359,7 @@ mod tests {
             Box::<FakeZfs>::default(),
             Box::<FakeZone>::default(),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
         let tempdir = TempDir::new().unwrap();
         let (occupied, _) = populate_tempdir_with_fake_dumps(&tempdir);
@@ -1356,6 +1386,7 @@ mod tests {
             Box::<FakeZfs>::default(),
             Box::<FakeZone>::default(),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
         let tempdir = TempDir::new().unwrap();
         let (occupied, vacant) = populate_tempdir_with_fake_dumps(&tempdir);
@@ -1395,6 +1426,7 @@ mod tests {
             }),
             Box::<FakeZone>::default(),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
         let tempdir = TempDir::new().unwrap();
         let (occupied, _) = populate_tempdir_with_fake_dumps(&tempdir);
@@ -1416,8 +1448,8 @@ mod tests {
         logctx.cleanup_successful();
     }
 
-    #[test]
-    fn test_archives_rotated_logs_and_cores() {
+    #[tokio::test]
+    async fn test_archives_rotated_logs_and_cores() {
         let logctx = omicron_test_utils::dev::test_setup_log(
             "test_archives_rotated_logs_and_cores",
         );
@@ -1465,6 +1497,7 @@ mod tests {
             }),
             Box::new(FakeZone { zones: vec![zone.clone()] }),
             logctx.log.clone(),
+            tokio::sync::mpsc::channel(1).1,
         );
 
         std::fs::create_dir_all(&core_dir).unwrap();
@@ -1498,7 +1531,7 @@ mod tests {
             vec![mounted_debug_zpool],
             vec![mounted_core_zpool],
         );
-        worker.archive_files().unwrap();
+        worker.archive_files().await.unwrap();
 
         // it'll be renamed to use an epoch timestamp instead of .0
         let log_glob =


### PR DESCRIPTION
Replace the std::thread + Mutex originally used in DumpSetup with a tokio task and message-passing.
(Verified cores and kernel dumps and logs all getting archived appropriately on a bench gimlet)