### PR TITLE
Add Error::not_found variant

### DIFF
--- a/common/src/api/external/error.rs
+++ b/common/src/api/external/error.rs
@@ -311,7 +311,7 @@ impl Error {
     /// This is used in cases where a generic 404 is required. For cases where
     /// there is a ResourceType, use a function that produces
     /// [`Error::ObjectNotFound`] instead.
-    pub fn not_found(message: impl Into<String>) -> Error {
+    pub fn non_resourcetype_not_found(message: impl Into<String>) -> Error {
         Error::NotFound { message: MessagePair::new(message.into()) }
     }
 

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -156,7 +156,8 @@ impl super::Nexus {
                 | Error::ServiceUnavailable { .. }
                 | Error::InsufficientCapacity { .. }
                 | Error::TypeVersionMismatch { .. }
-                | Error::Conflict { .. } => {
+                | Error::Conflict { .. }
+                | Error::NotFound { .. } => {
                     Reason::UnknownError { source: error }
                 }
             })?;


### PR DESCRIPTION
Add a variant to our external Error so that a 404 can be returned without requiring a ResourceType - adding one may not make sense for a particular endpoint.