### PR TITLE
Revert "fix(deps): update rust crate vsss-rs to 3.4.0 (#5115)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -10322,9 +10322,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vsss-rs"
-version = "3.4.0"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d9b5a415d1bbbf1a9c5982babc0d8054fa10effe9c5b7086cd2fdd36be79d9"
+checksum = "196bbee60607a195bc850e94f0e040bd090e45794ad8df0e9c5a422b9975a00f"
 dependencies = [
  "curve25519-dalek",
  "elliptic-curve",

--- a/bootstore/Cargo.toml
+++ b/bootstore/Cargo.toml
@@ -27,7 +27,7 @@ slog.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-vsss-rs = { version = "3.4.0", features = ["std", "curve25519"] }
+vsss-rs = { version = "3.3.4", features = ["std", "curve25519"] }
 zeroize.workspace = true
 
 # See omicron-rpaths for more about the "pq-sys" dependency.


### PR DESCRIPTION
This reverts commit 6d44cf529c8821e7fc107fe3b15bc2377ba96872.

Hopefully (?) fixes #5254 (@andrewjstone noticed the version bump when I pinged him on the issue). Cc @sunshowers 