### PR TITLE
zone bundle tests fail on ZFS pool with 4K sectors (ashift=12)

### DIFF
--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -2014,6 +2014,7 @@ mod tests {
     use super::ZoneBundleMetadata;
     use chrono::TimeZone;
     use chrono::Utc;
+    use rand::RngCore;
 
     #[test]
     fn test_sort_zone_bundle_cause() {
@@ -2176,7 +2177,9 @@ mod illumos_tests {
     use super::ZoneBundler;
     use super::ZFS;
     use anyhow::Context;
+    use chrono::DateTime;
     use chrono::TimeZone;
+    use chrono::Timelike;
     use chrono::Utc;
     use illumos_utils::zpool::ZpoolName;
     use sled_storage::disk::RawDisk;
@@ -2185,6 +2188,43 @@ mod illumos_tests {
     use slog::Drain;
     use slog::Logger;
     use tokio::process::Command;
+
+    /// An iterator that returns the date of consecutive days beginning with 1st
+    /// January 2020. The time portion of each returned date will be fixed at
+    /// midnight in UTC.
+    struct DaysOfOurBundles {
+        next: DateTime<Utc>,
+    }
+
+    impl DaysOfOurBundles {
+        fn new() -> DaysOfOurBundles {
+            DaysOfOurBundles {
+                next: Utc
+                    // Set the start date to 1st January 2020:
+                    .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+                    .single()
+                    .unwrap(),
+            }
+        }
+    }
+
+    impl Iterator for DaysOfOurBundles {
+        type Item = DateTime<Utc>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let out = self.next;
+
+            // We promise that all returned dates are aligned with midnight UTC:
+            assert_eq!(out.hour(), 0);
+            assert_eq!(out.minute(), 0);
+            assert_eq!(out.second(), 0);
+
+            self.next =
+                self.next.checked_add_days(chrono::Days::new(1)).unwrap();
+
+            Some(out)
+        }
+    }
 
     #[tokio::test]
     async fn test_zfs_quota() {
@@ -2327,9 +2367,14 @@ mod illumos_tests {
 
     // Quota applied to test datasets.
     //
-    // This needs to be at least this big lest we get "out of space" errors when
-    // creating. Not sure where those come from, but could be ZFS overhead.
-    const TEST_QUOTA: u64 = 1024 * 32;
+    // ZFS will not allow a quota to be set that is smaller than the bytes
+    // presently stored for that dataset, either at dataset creation time or
+    // later by setting the "quota" property.  The exact minimum number of bytes
+    // depends on many factors, including the block size of the underlying pool;
+    // i.e., the "ashift" value.  An empty dataset is unlikely to contain more
+    // than one megabyte of overhead, so use that as a conservative test size to
+    // avoid issues.
+    const TEST_QUOTA: u64 = 1024 * 1024;
 
     async fn create_test_dataset(
         id: &Uuid,
@@ -2441,9 +2486,7 @@ mod illumos_tests {
         // back.
         let info = insert_fake_bundle(
             &paths[0],
-            2020,
-            1,
-            1,
+            DaysOfOurBundles::new().next().unwrap(),
             ZoneBundleCause::ExplicitRequest,
         )
         .await?;
@@ -2514,7 +2557,7 @@ mod illumos_tests {
             .await
             .context("failed to update cleanup context")?;
 
-        let mut day = 1;
+        let mut days = DaysOfOurBundles::new();
         let mut info = Vec::new();
         let mut utilization = ctx.bundler.utilization().await?;
         loop {
@@ -2527,13 +2570,10 @@ mod illumos_tests {
             }
             let it = insert_fake_bundle(
                 &ctx.resource_wrapper.dirs[0],
-                2020,
-                1,
-                day,
+                days.next().unwrap(),
                 ZoneBundleCause::ExplicitRequest,
             )
             .await?;
-            day += 1;
             info.push(it);
             utilization = ctx.bundler.utilization().await?;
         }
@@ -2581,20 +2621,17 @@ mod illumos_tests {
     async fn test_list_with_filter_body(
         ctx: CleanupTestContext,
     ) -> anyhow::Result<()> {
-        let mut day = 1;
+        let mut days = DaysOfOurBundles::new();
         let mut info = Vec::new();
         const N_BUNDLES: usize = 3;
         for i in 0..N_BUNDLES {
             let it = insert_fake_bundle_with_zone_name(
                 &ctx.resource_wrapper.dirs[0],
-                2020,
-                1,
-                day,
+                days.next().unwrap(),
                 ZoneBundleCause::ExplicitRequest,
                 format!("oxz_whatever_{i}").as_str(),
             )
             .await?;
-            day += 1;
             info.push(it);
         }
 
@@ -2641,16 +2678,12 @@ mod illumos_tests {
 
     async fn insert_fake_bundle(
         dir: &Utf8Path,
-        year: i32,
-        month: u32,
-        day: u32,
+        time_created: DateTime<Utc>,
         cause: ZoneBundleCause,
     ) -> anyhow::Result<ZoneBundleInfo> {
         insert_fake_bundle_with_zone_name(
             dir,
-            year,
-            month,
-            day,
+            time_created,
             cause,
             "oxz_whatever",
         )
@@ -2659,21 +2692,20 @@ mod illumos_tests {
 
     async fn insert_fake_bundle_with_zone_name(
         dir: &Utf8Path,
-        year: i32,
-        month: u32,
-        day: u32,
+        time_created: DateTime<Utc>,
         cause: ZoneBundleCause,
         zone_name: &str,
     ) -> anyhow::Result<ZoneBundleInfo> {
+        assert_eq!(time_created.hour(), 0);
+        assert_eq!(time_created.minute(), 0);
+        assert_eq!(time_created.second(), 0);
+
         let metadata = ZoneBundleMetadata {
             id: ZoneBundleId {
                 zone_name: String::from(zone_name),
                 bundle_id: uuid::Uuid::new_v4(),
             },
-            time_created: Utc
-                .with_ymd_and_hms(year, month, day, 0, 0, 0)
-                .single()
-                .context("invalid year/month/day")?,
+            time_created,
             cause,
             version: 0,
         };
@@ -2704,6 +2736,13 @@ mod illumos_tests {
             super::ZONE_BUNDLE_METADATA_FILENAME,
             contents.as_bytes(),
         )?;
+
+        // Inject some ~incompressible ballast to ensure the bundles are, though
+        // fake, not also microscopic:
+        let mut ballast = vec![0; 64 * 1024];
+        rand::thread_rng().fill_bytes(&mut ballast);
+        super::insert_data(&mut builder, "ballast.bin", &ballast)?;
+
         let _ = builder.into_inner().context("failed to finish tarball")?;
         let bytes = tokio::fs::metadata(&path).await?.len();
         Ok(ZoneBundleInfo { metadata, path, bytes })

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -2014,7 +2014,6 @@ mod tests {
     use super::ZoneBundleMetadata;
     use chrono::TimeZone;
     use chrono::Utc;
-    use rand::RngCore;
 
     #[test]
     fn test_sort_zone_bundle_cause() {
@@ -2188,6 +2187,7 @@ mod illumos_tests {
     use slog::Drain;
     use slog::Logger;
     use tokio::process::Command;
+    use rand::RngCore;
 
     /// An iterator that returns the date of consecutive days beginning with 1st
     /// January 2020. The time portion of each returned date will be fixed at

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -2181,13 +2181,13 @@ mod illumos_tests {
     use chrono::Timelike;
     use chrono::Utc;
     use illumos_utils::zpool::ZpoolName;
+    use rand::RngCore;
     use sled_storage::disk::RawDisk;
     use sled_storage::disk::SyntheticDisk;
     use sled_storage::manager::{FakeStorageManager, StorageHandle};
     use slog::Drain;
     use slog::Logger;
     use tokio::process::Command;
-    use rand::RngCore;
 
     /// An iterator that returns the date of consecutive days beginning with 1st
     /// January 2020. The time portion of each returned date will be fixed at


### PR DESCRIPTION
There is a subtle and somewhat tedious to debug failure in the zone bundle tests due to our attempt to set a vanishingly small (32KB!) quota on a dataset.  This appears to work on a system with a ZFS pool that has an **ashift** value of **9** (i.e., 512 byte sectors); it fails catastrophically on a pool with an **ashift** of **12**, though.

The original test was trying to do this:

```
/usr/sbin/zfs create \
    -o quota=32768 \
    -o mountpoint=/pool/int/0aafdcd5-03ed-4d3f-ae3f-6a94cd313025/debug/bundle/zone \
     rpool/0aafdcd5-03ed-4d3f-ae3f-6a94cd313025
```

Dataset creation would fail with this error message:

```
cannot create 'rpool/0aafdcd5-03ed-4d3f-ae3f-6a94cd313025': out of space
```

This is clearly not accurate, as the pool was indeed mostly empty at the time.  If one were instead to create the dataset _without_ a quota, but then apply a quota as a second step, the error message is more revealing:

```
cannot set property for 'rpool/0aafdcd5-03ed-4d3f-ae3f-6a94cd313025': size is less than current used or reserved space
```

There is clearly room for improvement in the error message of `zfs create`, but at least we know what's wrong.  Bumping the quota to a much larger value will mean we don't see this error regardless of any sector size we are likely to see for a long time.

(I found this a few months ago as part of trying to get CI moved from AWS onto Propolis running on bench Gimlets, and am finally getting it cleaned up for integration.)