### PR TITLE
Prune `inv_zpool` when pruning collections

### DIFF
--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -1096,6 +1096,7 @@ impl DataStore {
             nsled_agent_zones,
             nzones,
             nnics,
+            nzpools,
             nerrors,
         ) = conn
             .transaction_async(|conn| async move {
@@ -1206,6 +1207,16 @@ impl DataStore {
                     .await?
                 };
 
+                let nzpools = {
+                    use db::schema::inv_zpool::dsl;
+                    diesel::delete(
+                        dsl::inv_zpool
+                            .filter(dsl::inv_collection_id.eq(collection_id)),
+                    )
+                    .execute_async(&conn)
+                    .await?
+                };
+
                 // Remove rows for errors encountered.
                 let nerrors = {
                     use db::schema::inv_collection_error::dsl;
@@ -1228,6 +1239,7 @@ impl DataStore {
                     nsled_agent_zones,
                     nzones,
                     nnics,
+                    nzpools,
                     nerrors,
                 ))
             })
@@ -1251,6 +1263,7 @@ impl DataStore {
             "nsled_agent_zones" => nsled_agent_zones,
             "nzones" => nzones,
             "nnics" => nnics,
+            "nzpools" => nzpools,
             "nerrors" => nerrors,
         );
 


### PR DESCRIPTION
Noticed this while investigating #5299; I am unsure whether this will actually resolve #5299 though.

I made this same mistake the first time I added something new to inventory; @davepacheco and I discussed the issues with trying to test for this at https://github.com/oxidecomputer/omicron/pull/4496#discussion_r1393108135. I'm not sure anything has materially changed there, but maybe testing this warrants a closer look.