### PR TITLE
Remove missed cleanup in deploy.sh

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -34,9 +34,6 @@ _exit_trap() {
 	local status=$?
 	[[ $status -eq 0 ]] && exit 0
 
-    # XXX paranoia
-    pfexec cp /tmp/opteadm /opt/oxide/opte/bin/opteadm
-
 	set +o errexit
 	set -o xtrace
 	banner evidence


### PR DESCRIPTION
This PR removes code that should have been cleaned up when the following was previously removed:
https://github.com/oxidecomputer/omicron/blob/978cf08adfc1fb6ec4fdf39814d625eba46447eb/.github/buildomat/jobs/deploy.sh#L104-L115