### PR TITLE
add bfd to bootstore and early networking

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -11,7 +11,9 @@ use std::convert::TryFrom;
 use std::hash::Hash;
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use types::{BgpConfig, BgpPeerConfig, PortConfigV1, RouteConfig};
+use types::{
+    BfdPeerConfig, BgpConfig, BgpPeerConfig, PortConfigV1, RouteConfig,
+};
 use uuid::Uuid;
 
 progenitor::generate_api!(
@@ -649,5 +651,18 @@ impl Hash for PortConfigV1 {
         self.switch.hash(state);
         self.uplink_port_fec.hash(state);
         self.uplink_port_speed.hash(state);
+    }
+}
+
+impl Eq for BfdPeerConfig {}
+
+impl Hash for BfdPeerConfig {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.local.hash(state);
+        self.remote.hash(state);
+        self.detection_threshold.hash(state);
+        self.required_rx.hash(state);
+        self.mode.hash(state);
+        self.switch.hash(state);
     }
 }

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2821,6 +2821,25 @@ pub struct BgpImportedRouteIpv4 {
     pub switch: SwitchLocation,
 }
 
+/// BFD connection mode.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BfdMode {
+    SingleHop,
+    MultiHop,
+}
+
 /// A description of an uploaded TUF repository.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct TufRepoDescription {

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -4,7 +4,7 @@
 
 //! Types shared between Nexus and Sled Agent.
 
-use crate::api::external::{self, Name};
+use crate::api::external::{self, BfdMode, Name};
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -87,6 +87,9 @@ pub struct RackNetworkConfigV1 {
     pub ports: Vec<PortConfigV1>,
     /// BGP configurations for connecting the rack to external networks
     pub bgp: Vec<BgpConfig>,
+    /// BFD configuration for connecting the rack to external networks
+    #[serde(default)]
+    pub bfd: Vec<BfdPeerConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
@@ -116,6 +119,16 @@ pub struct BgpPeerConfig {
     pub connect_retry: Option<u64>,
     /// The interval to send keepalive messages at.
     pub keepalive: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+pub struct BfdPeerConfig {
+    pub local: Option<IpAddr>,
+    pub remote: IpAddr,
+    pub detection_threshold: u8,
+    pub required_rx: u64,
+    pub mode: BfdMode,
+    pub switch: SwitchLocation,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]

--- a/nexus/db-model/src/bfd.rs
+++ b/nexus/db-model/src/bfd.rs
@@ -45,13 +45,13 @@ pub struct BfdSession {
     pub time_deleted: Option<DateTime<Utc>>,
 }
 
-impl From<nexus_types::external_api::params::BfdMode> for BfdMode {
-    fn from(value: nexus_types::external_api::params::BfdMode) -> Self {
+impl From<omicron_common::api::external::BfdMode> for BfdMode {
+    fn from(value: omicron_common::api::external::BfdMode) -> Self {
         match value {
-            nexus_types::external_api::params::BfdMode::SingleHop => {
+            omicron_common::api::external::BfdMode::SingleHop => {
                 BfdMode::SingleHop
             }
-            nexus_types::external_api::params::BfdMode::MultiHop => {
+            omicron_common::api::external::BfdMode::MultiHop => {
                 BfdMode::MultiHop
             }
         }

--- a/nexus/src/app/background/sync_switch_configuration.rs
+++ b/nexus/src/app/background/sync_switch_configuration.rs
@@ -900,6 +900,7 @@ impl BackgroundTask for SwitchPortSettingsManager {
                                 let rnc_differs = match (config.body.rack_network_config.clone(), desired_config.body.rack_network_config.clone()) {
                                     (Some(current_rnc), Some(desired_rnc)) => {
                                         !hashset_eq(current_rnc.bgp.clone(), desired_rnc.bgp.clone()) ||
+                                        !hashset_eq(current_rnc.bfd.clone(), desired_rnc.bfd.clone()) ||
                                         !hashset_eq(current_rnc.ports.clone(), desired_rnc.ports.clone()) ||
                                         current_rnc.rack_subnet != desired_rnc.rack_subnet ||
                                         current_rnc.infra_ip_first != desired_rnc.infra_ip_first ||

--- a/nexus/src/app/background/sync_switch_configuration.rs
+++ b/nexus/src/app/background/sync_switch_configuration.rs
@@ -39,7 +39,10 @@ use nexus_types::{external_api::params, identity::Resource};
 use omicron_common::OMICRON_DPD_TAG;
 use omicron_common::{
     address::{get_sled_address, Ipv6Subnet},
-    api::external::{DataPageParams, SwitchLocation},
+    api::{
+        external::{DataPageParams, SwitchLocation},
+        internal::shared::ParseSwitchLocationError,
+    },
 };
 use serde_json::json;
 use sled_agent_client::types::{
@@ -209,6 +212,56 @@ impl SwitchPortSettingsManager {
         }
 
         Ok(set)
+    }
+
+    async fn bfd_peer_configs_from_db<'a>(
+        &'a mut self,
+        opctx: &OpContext,
+    ) -> Result<
+        Vec<sled_agent_client::types::BfdPeerConfig>,
+        omicron_common::api::external::Error,
+    > {
+        let db_data = self
+            .datastore
+            .bfd_session_list(opctx, &DataPageParams::max_page())
+            .await?;
+
+        let mut result = Vec::new();
+        for spec in db_data.into_iter() {
+            let config = sled_agent_client::types::BfdPeerConfig {
+                local: spec.local.map(|x| x.ip()),
+                remote: spec.remote.ip(),
+                detection_threshold: spec.detection_threshold.0.try_into().map_err(|_| {
+                    omicron_common::api::external::Error::InternalError {
+                        internal_message: format!(
+                            "db_bfd_peer_configs: detection threshold overflow: {}",
+                            spec.detection_threshold.0,
+                        ),
+                    }
+                })?,
+                required_rx: spec.required_rx.0.into(),
+                mode: match spec.mode {
+                    nexus_db_model::BfdMode::SingleHop => {
+                        sled_agent_client::types::BfdMode::SingleHop
+                    }
+                    nexus_db_model::BfdMode::MultiHop => {
+                        sled_agent_client::types::BfdMode::MultiHop
+                    }
+                },
+                switch: spec.switch.parse().map_err(|e: ParseSwitchLocationError| {
+                    omicron_common::api::external::Error::InternalError {
+                        internal_message: format!(
+                            "db_bfd_peer_configs: failed to parse switch name: {}: {:?}",
+                            spec.switch,
+                            e,
+                        ),
+                    }
+                })?,
+            };
+            result.push(config);
+        }
+
+        Ok(result)
     }
 }
 
@@ -799,6 +852,14 @@ impl BackgroundTask for SwitchPortSettingsManager {
                 ;
 
 
+                let bfd = match self.bfd_peer_configs_from_db(opctx).await {
+                    Ok(bfd) => bfd,
+                    Err(e) => {
+                        error!(log, "error fetching bfd config from db"; "error" => %e);
+                        continue;
+                    }
+                };
+
                 let mut desired_config = EarlyNetworkConfig {
                     generation: 0,
                     schema_version: 1,
@@ -810,6 +871,7 @@ impl BackgroundTask for SwitchPortSettingsManager {
                             infra_ip_last,
                             ports,
                             bgp,
+                            bfd,
                         }),
                     },
                 };

--- a/nexus/src/app/bfd.rs
+++ b/nexus/src/app/bfd.rs
@@ -42,6 +42,10 @@ impl super::Nexus {
         self.background_tasks
             .driver
             .activate(&self.background_tasks.bfd_manager);
+        // for timely propagation to bootstore
+        self.background_tasks
+            .driver
+            .activate(&self.background_tasks.task_switch_port_settings_manager);
         Ok(())
     }
 
@@ -56,6 +60,10 @@ impl super::Nexus {
         self.background_tasks
             .driver
             .activate(&self.background_tasks.bfd_manager);
+        // for timely propagation to bootstore
+        self.background_tasks
+            .driver
+            .activate(&self.background_tasks.task_switch_port_settings_manager);
         Ok(())
     }
 

--- a/nexus/src/app/bfd.rs
+++ b/nexus/src/app/bfd.rs
@@ -93,10 +93,10 @@ impl super::Nexus {
                     required_rx: info.config.required_rx,
                     mode: match info.config.mode {
                         mg_admin_client::types::SessionMode::SingleHop => {
-                            params::BfdMode::SingleHop
+                            omicron_common::api::external::BfdMode::SingleHop
                         }
                         mg_admin_client::types::SessionMode::MultiHop => {
-                            params::BfdMode::MultiHop
+                            omicron_common::api::external::BfdMode::MultiHop
                         }
                     },
                 })

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -302,6 +302,7 @@ impl nexus_test_interface::NexusServer for Server {
                         infra_ip_last: Ipv4Addr::UNSPECIFIED,
                         ports: Vec::new(),
                         bgp: Vec::new(),
+                        bfd: Vec::new(),
                     },
                 },
             )

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -595,7 +595,7 @@ pub static DEMO_BFD_ENABLE: Lazy<params::BfdSessionEnable> =
         detection_threshold: 3,
         required_rx: 1000000,
         switch: "switch0".parse().unwrap(),
-        mode: params::BfdMode::MultiHop,
+        mode: omicron_common::api::external::BfdMode::MultiHop,
     });
 
 pub static DEMO_BFD_DISABLE: Lazy<params::BfdSessionDisable> =

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -9,7 +9,7 @@ use crate::external_api::shared;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use omicron_common::api::external::{
-    AddressLotKind, ByteCount, Hostname, IdentityMetadataCreateParams,
+    AddressLotKind, BfdMode, ByteCount, Hostname, IdentityMetadataCreateParams,
     IdentityMetadataUpdateParams, InstanceCpuCount, IpNet, Ipv4Net, Ipv6Net,
     Name, NameOrId, PaginationOrder, RouteDestination, RouteTarget,
     SemverVersion,
@@ -1812,24 +1812,6 @@ pub struct BgpConfigCreate {
 pub struct BgpStatusSelector {
     /// A name or id of the BGP configuration to get status for
     pub name_or_id: NameOrId,
-}
-
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Deserialize,
-    Serialize,
-    JsonSchema,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-)]
-#[serde(rename_all = "snake_case")]
-pub enum BfdMode {
-    SingleHop,
-    MultiHop,
 }
 
 /// Information about a bidirectional forwarding detection (BFD) session.

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -17,8 +17,7 @@ use strum::EnumIter;
 use uuid::Uuid;
 
 pub use omicron_common::address::{IpRange, Ipv4Range, Ipv6Range};
-
-use super::params::BfdMode;
+pub use omicron_common::api::external::BfdMode;
 
 /// Maximum number of role assignments allowed on any one resource
 // Today's implementation assumes a relatively small number of role assignments

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -229,6 +229,51 @@
           }
         ]
       },
+      "BfdMode": {
+        "description": "BFD connection mode.",
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdPeerConfig": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "remote": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "$ref": "#/components/schemas/SwitchLocation"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
       "BgpConfig": {
         "type": "object",
         "properties": {
@@ -691,6 +736,14 @@
         "description": "Initial network configuration",
         "type": "object",
         "properties": {
+          "bfd": {
+            "description": "BFD configuration for connecting the rack to external networks",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BfdPeerConfig"
+            }
+          },
           "bgp": {
             "description": "BGP configurations for connecting the rack to external networks",
             "type": "array",

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1502,6 +1502,51 @@
           "serial"
         ]
       },
+      "BfdMode": {
+        "description": "BFD connection mode.",
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdPeerConfig": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "remote": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "$ref": "#/components/schemas/SwitchLocation"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
       "BgpConfig": {
         "type": "object",
         "properties": {
@@ -6342,6 +6387,14 @@
         "description": "Initial network configuration",
         "type": "object",
         "properties": {
+          "bfd": {
+            "description": "BFD configuration for connecting the rack to external networks",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BfdPeerConfig"
+            }
+          },
           "bgp": {
             "description": "BGP configurations for connecting the rack to external networks",
             "type": "array",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9010,6 +9010,7 @@
         ]
       },
       "BfdMode": {
+        "description": "BFD connection mode.",
         "type": "string",
         "enum": [
           "single_hop",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1361,6 +1361,51 @@
           "serial_number"
         ]
       },
+      "BfdMode": {
+        "description": "BFD connection mode.",
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdPeerConfig": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "remote": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "$ref": "#/components/schemas/SwitchLocation"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
       "BgpConfig": {
         "type": "object",
         "properties": {
@@ -6432,6 +6477,14 @@
         "description": "Initial network configuration",
         "type": "object",
         "properties": {
+          "bfd": {
+            "description": "BFD configuration for connecting the rack to external networks",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BfdPeerConfig"
+            }
+          },
           "bgp": {
             "description": "BGP configurations for connecting the rack to external networks",
             "type": "array",

--- a/schema/rss-sled-plan.json
+++ b/schema/rss-sled-plan.json
@@ -91,6 +91,53 @@
         }
       ]
     },
+    "BfdMode": {
+      "description": "BFD connection mode.",
+      "type": "string",
+      "enum": [
+        "single_hop",
+        "multi_hop"
+      ]
+    },
+    "BfdPeerConfig": {
+      "type": "object",
+      "required": [
+        "detection_threshold",
+        "mode",
+        "remote",
+        "required_rx",
+        "switch"
+      ],
+      "properties": {
+        "detection_threshold": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "local": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "ip"
+        },
+        "mode": {
+          "$ref": "#/definitions/BfdMode"
+        },
+        "remote": {
+          "type": "string",
+          "format": "ip"
+        },
+        "required_rx": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "switch": {
+          "$ref": "#/definitions/SwitchLocation"
+        }
+      }
+    },
     "BgpConfig": {
       "type": "object",
       "required": [
@@ -558,6 +605,14 @@
         "rack_subnet"
       ],
       "properties": {
+        "bfd": {
+          "description": "BFD configuration for connecting the rack to external networks",
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BfdPeerConfig"
+          }
+        },
         "bgp": {
           "description": "BGP configurations for connecting the rack to external networks",
           "type": "array",

--- a/sled-agent/src/bootstrap/early_networking.rs
+++ b/sled-agent/src/bootstrap/early_networking.rs
@@ -557,6 +557,9 @@ impl<'a> EarlyNetworkSetup<'a> {
 
         // BFD config
         for spec in &rack_network_config.bfd {
+            if spec.switch != switch_location {
+                continue;
+            }
             let cfg = BfdPeerConfig {
                 detection_threshold: spec.detection_threshold,
                 listen: spec.local.unwrap_or(Ipv4Addr::UNSPECIFIED.into()),

--- a/sled-agent/src/bootstrap/params.rs
+++ b/sled-agent/src/bootstrap/params.rs
@@ -493,6 +493,7 @@ mod tests {
                 infra_ip_last: Ipv4Addr::LOCALHOST,
                 ports: Vec::new(),
                 bgp: Vec::new(),
+                bfd: Vec::new(),
             },
         };
 

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -127,6 +127,7 @@ mod test {
                 infra_ip_last: Ipv4Addr::LOCALHOST,
                 ports: Vec::new(),
                 bgp: Vec::new(),
+                bfd: Vec::new(),
             },
         };
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -1169,6 +1169,7 @@ mod tests {
                 infra_ip_last: Ipv4Addr::LOCALHOST,
                 ports: Vec::new(),
                 bgp: Vec::new(),
+                bfd: Vec::new(),
             },
         };
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -660,6 +660,25 @@ impl ServiceInner {
                         originate: config.originate.clone(),
                     })
                     .collect(),
+                bfd: config
+                    .bfd
+                    .iter()
+                    .map(|spec| NexusTypes::BfdPeerConfig {
+                        detection_threshold: spec.detection_threshold,
+                        local: spec.local,
+                        mode: match spec.mode {
+                            omicron_common::api::external::BfdMode::SingleHop => {
+                                nexus_client::types::BfdMode::SingleHop
+                            }
+                            omicron_common::api::external::BfdMode::MultiHop => {
+                                nexus_client::types::BfdMode::MultiHop
+                            }
+                        },
+                        remote: spec.remote,
+                        required_rx: spec.required_rx,
+                        switch: spec.switch.into(),
+                    })
+                    .collect(),
             }
         };
 

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -407,6 +407,7 @@ async fn read_network_bootstore_config(
                 infra_ip_last: Ipv4Addr::UNSPECIFIED,
                 ports: Vec::new(),
                 bgp: Vec::new(),
+                bfd: Vec::new(),
             }),
         },
     };

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -516,6 +516,7 @@ pub async fn run_standalone_server(
             infra_ip_last: Ipv4Addr::LOCALHOST,
             ports: Vec::new(),
             bgp: Vec::new(),
+            bfd: Vec::new(),
         },
     };
 

--- a/sled-agent/tests/integration_tests/early_network.rs
+++ b/sled-agent/tests/integration_tests/early_network.rs
@@ -146,6 +146,7 @@ fn current_config_example() -> (&'static str, EarlyNetworkConfig) {
                     asn: 20000,
                     originate: vec!["192.168.0.0/24".parse().unwrap()],
                 }],
+                bfd: vec![],
             }),
         },
     };

--- a/sled-agent/tests/output/new-rss-sled-plans/madrid-rss-sled-plan.json
+++ b/sled-agent/tests/output/new-rss-sled-plans/madrid-rss-sled-plan.json
@@ -158,7 +158,8 @@
           "autoneg": false
         }
       ],
-      "bgp": []
+      "bgp": [],
+      "bfd": []
     }
   }
 }

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -560,6 +560,8 @@ fn validate_rack_network_config(
                 originate: config.originate.clone(),
             })
             .collect(),
+        //TODO(ry) bfd config in wicket
+        bfd: vec![],
     })
 }
 


### PR DESCRIPTION
BFD information is not currently in the bootstore, and early networking is not BFD aware. This means early networking will not set up BFD during upgrades for systems that have BFD configured, or during scrimlet cold-boot situations.