### PR TITLE
Move sled-agent contract-reaper thread creation earlier

### DIFF
--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -61,6 +61,15 @@ impl BootstrapAgentStartup {
     pub(super) async fn run(config: Config) -> Result<Self, StartError> {
         let base_log = build_logger(&config)?;
 
+        // Ensure we have a thread that automatically reaps process contracts
+        // when they become empty. See the comments in
+        // illumos-utils/src/running_zone.rs for more detail.
+        //
+        // We're going to start monitoring for hardware below, which could
+        // trigger launching the switch zone, and we need the contract reaper to
+        // exist before entering any zones.
+        illumos_utils::running_zone::ensure_contract_reaper(&base_log);
+
         let log = base_log.new(o!("component" => "BootstrapAgentStartup"));
 
         // Perform several blocking startup tasks first; we move `config` and

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -383,11 +383,6 @@ impl SledAgent {
         info!(log, "Mounting backing filesystems");
         crate::backing_fs::ensure_backing_fs(&parent_log, &boot_disk.1)?;
 
-        // Ensure we have a thread that automatically reaps process contracts
-        // when they become empty. See the comments in
-        // illumos-utils/src/running_zone.rs for more detail.
-        illumos_utils::running_zone::ensure_contract_reaper(&parent_log);
-
         // TODO-correctness Bootstrap-agent already ensures the underlay
         // etherstub and etherstub VNIC exist on startup - could it pass them
         // through to us?


### PR DESCRIPTION
This should ensure the thread before we have any chance to interact with zones:

1. `main` calls [`BootstrapServer::start()`](https://github.com/oxidecomputer/omicron/blob/2349feb36d39804e38539e134a9a3a4462e7d516/sled-agent/src/bin/sled-agent.rs#L91-L93)
2. The first thing `BootstrapServer::start()` does is call [`BoostrapAgentStartup::run()`](https://github.com/oxidecomputer/omicron/blob/2349feb36d39804e38539e134a9a3a4462e7d516/sled-agent/src/bootstrap/server.rs#L169-L183)
3. As of this PR, `BootstrapAgentStartup::run()` creates the reaper thread immediately after building the original sled-agent `Logger`

Fixes #5319.