### PR TITLE
stop splitting the TUF repo on the 1 GiB boundary

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -5,7 +5,7 @@
 #: target = "helios-2.0"
 #: output_rules = [
 #:	"=/work/manifest*.toml",
-#:	"=/work/repo-*.zip.part*",
+#:	"=/work/repo-*.zip",
 #:	"=/work/repo-*.zip.sha256.txt",
 #: ]
 #: access_repos = [
@@ -23,13 +23,8 @@
 #:
 #: [[publish]]
 #: series = "rot-all"
-#: name = "repo.zip.parta"
-#: from_output = "/work/repo-rot-all.zip.parta"
-#:
-#: [[publish]]
-#: series = "rot-all"
-#: name = "repo.zip.partb"
-#: from_output = "/work/repo-rot-all.zip.partb"
+#: name = "repo.zip"
+#: from_output = "/work/repo-rot-all.zip"
 #:
 #: [[publish]]
 #: series = "rot-all"
@@ -201,12 +196,3 @@ add_hubris_artifacts  prod/rel     cert-prod-rel-v1.0.7
 # Build the TUF ZIP.
 /work/tufaceous assemble --no-generate-key /work/manifest.toml /work/repo-rot-all.zip
 digest -a sha256 /work/repo-rot-all.zip > /work/repo-rot-all.zip.sha256.txt
-
-#
-# XXX: There are some issues downloading Buildomat artifacts > 1 GiB, see
-# oxidecomputer/buildomat#36.
-#
-split -a 1 -b 1024m /work/repo-rot-all.zip /work/repo-rot-all.zip.part
-rm /work/repo-rot-all.zip
-# Ensure the build doesn't fail if the repo gets smaller than 1 GiB.
-touch /work/repo-rot-all.zip.partb


### PR DESCRIPTION
Follow-up to #5316, split to prevent breaking various scripts until v7 is out the door.

Per chat and https://github.com/oxidecomputer/omicron/pull/5316#issuecomment-2017325977, Buildomat has supported >1 GiB uploads for a while, but we've seen [issues with downloading files that large](https://github.com/oxidecomputer/buildomat/issues/36). There's now range request support, so retrying failed downloads is no longer catastrophic.

However a lot of scripts are out there that assume we must download a parta/partb. I don't want to prevent people from deploying quickly on dogfood while we're in the run up to a release, unless whoever's on dogfood updates wants to merge this and fix the script.