### PR TITLE
Update crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
+source = "git+https://github.com/oxidecomputer/crucible?rev=16f16478f4af1502b25ddcd79d307b3f116f13f6#16f16478f4af1502b25ddcd79d307b3f116f13f6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
+source = "git+https://github.com/oxidecomputer/crucible?rev=16f16478f4af1502b25ddcd79d307b3f116f13f6#16f16478f4af1502b25ddcd79d307b3f116f13f6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
+source = "git+https://github.com/oxidecomputer/crucible?rev=16f16478f4af1502b25ddcd79d307b3f116f13f6#16f16478f4af1502b25ddcd79d307b3f116f13f6"
 dependencies = [
  "crucible-workspace-hack",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,9 +192,9 @@ cookie = "0.18"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "952c7d60d22be5198b892bec8d92f4291b9160c2" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "952c7d60d22be5198b892bec8d92f4291b9160c2" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "952c7d60d22be5198b892bec8d92f4291b9160c2" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "16f16478f4af1502b25ddcd79d307b3f116f13f6" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "16f16478f4af1502b25ddcd79d307b3f116f13f6" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "16f16478f4af1502b25ddcd79d307b3f116f13f6" }
 csv = "1.3.0"
 curve25519-dalek = "4"
 datatest-stable = "0.2.3"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -492,10 +492,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "952c7d60d22be5198b892bec8d92f4291b9160c2"
+source.commit = "16f16478f4af1502b25ddcd79d307b3f116f13f6"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "af200d930e6d658bdd1688a032747da7c2bafa0e6ab1b53bda7b7f571d8a19c6"
+source.sha256 = "ce186a1a1243ea618755ae341844795cff0ce2c1415c6bd770360b3330dc664b"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -504,10 +504,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "952c7d60d22be5198b892bec8d92f4291b9160c2"
+source.commit = "16f16478f4af1502b25ddcd79d307b3f116f13f6"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "1a40e24b176e8179cc7f74ef6922cd2ee51d5eca9bfa7057fc37994cf5c4678e"
+source.sha256 = "8920622255fa0317ce312d0127c94b8fef647a85be4c8abaf861be560fe43194"
 output.type = "zone"
 output.intermediate_only = true
 


### PR DESCRIPTION
Bump crucible rev to pick up:

- Return *410 Gone* if volume is inactive
- Update Rust crate opentelemetry to 0.22.0
- Update Rust crate base64 to 0.22.0
- Update Rust crate async-recursion to 1.1.0
- Minor cleanups to extent implementations
- Update Rust crate http to 0.2.12
- Update Rust crate reedline to 0.30.0
- Update Rust crate rayon to 1.9.0
- Update Rust crate nix to 0.28
- Update Rust crate async-trait to 0.1.78
- Various buffer optimizations
- Add low-level test for message encoding
- Don't let df failures ruin the buildomat tests
- Activate the NBD server's psuedo file