### PR TITLE
net-rpw: ignore v6 loopback addrs not created by nexus

### DIFF
--- a/nexus/src/app/background/sync_switch_configuration.rs
+++ b/nexus/src/app/background/sync_switch_configuration.rs
@@ -1143,7 +1143,8 @@ async fn switch_loopback_addresses(
                 .insert((*location, IpAddr::V4(entry.addr)));
         }
 
-        for entry in ipv6_loopbacks.iter() {
+        for entry in ipv6_loopbacks.iter().filter(|x| x.tag == OMICRON_DPD_TAG)
+        {
             current_loopback_addresses
                 .insert((*location, IpAddr::V6(entry.addr)));
         }


### PR DESCRIPTION
Maghemite creates randomized IPv6 tunnel addresses for tunnel routing endpoints on the underlay network. The network RPW detects these loopback addresses created by maghemite, does not see them in the nexus-tracked state, and determines that they must be destroyed. These addresses are required for egress traffic leaving the rack (see RFD 404 for more details).

This patch has the network RPW ignore loopback addresses that it did not create by filtering on the dpd tag it uses to create loopback addresses.