### PR TITLE
add way to edit and upload blueprints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7423,6 +7423,7 @@ name = "reconfigurator-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "camino",
  "camino-tempfile",
  "clap 4.5.1",

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -9,6 +9,7 @@ use crate::db::DbUrlOptions;
 use crate::Omdb;
 use anyhow::bail;
 use anyhow::Context;
+use camino::Utf8PathBuf;
 use chrono::DateTime;
 use chrono::SecondsFormat;
 use chrono::Utc;
@@ -23,6 +24,7 @@ use nexus_client::types::LastResult;
 use nexus_client::types::SledSelector;
 use nexus_client::types::UninitializedSledId;
 use nexus_db_queries::db::lookup::LookupPath;
+use nexus_types::deployment::Blueprint;
 use nexus_types::inventory::BaseboardId;
 use reedline::DefaultPrompt;
 use reedline::DefaultPromptSegment;
@@ -94,6 +96,8 @@ enum BlueprintsCommands {
     GenerateFromCollection(CollectionIdArgs),
     /// Generate a new blueprint
     Regenerate,
+    /// Import a blueprint
+    Import(BlueprintImportArgs),
 }
 
 #[derive(Debug, Args)]
@@ -154,6 +158,12 @@ enum BlueprintTargetSetEnabled {
     Disabled,
     /// use the enabled setting from the parent blueprint
     Inherit,
+}
+
+#[derive(Debug, Args)]
+struct BlueprintImportArgs {
+    /// path to a file containing a JSON-serialized blueprint
+    input: Utf8PathBuf,
 }
 
 #[derive(Debug, Args)]
@@ -300,6 +310,12 @@ impl NexusArgs {
                     &client, args, token,
                 )
                 .await
+            }
+            NexusCommands::Blueprints(BlueprintsArgs {
+                command: BlueprintsCommands::Import(args),
+            }) => {
+                let token = omdb.check_allow_destructive()?;
+                cmd_nexus_blueprints_import(&client, token, args).await
             }
 
             NexusCommands::Sleds(SledsArgs {
@@ -1087,6 +1103,24 @@ async fn cmd_nexus_blueprints_regenerate(
     let blueprint =
         client.blueprint_regenerate().await.context("generating blueprint")?;
     eprintln!("generated new blueprint {}", blueprint.id);
+    Ok(())
+}
+
+async fn cmd_nexus_blueprints_import(
+    client: &nexus_client::Client,
+    _destruction_token: DestructiveOperationToken,
+    args: &BlueprintImportArgs,
+) -> Result<(), anyhow::Error> {
+    let input_path = &args.input;
+    let file = std::fs::File::open(input_path)
+        .with_context(|| format!("open {:?}", input_path))?;
+    let blueprint: Blueprint = serde_json::from_reader(file)
+        .with_context(|| format!("read {:?}", input_path))?;
+    client
+        .blueprint_import(&blueprint)
+        .await
+        .with_context(|| format!("upload {:?}", input_path))?;
+    eprintln!("uploaded new blueprint {}", blueprint.id);
     Ok(())
 }
 

--- a/dev-tools/reconfigurator-cli/Cargo.toml
+++ b/dev-tools/reconfigurator-cli/Cargo.toml
@@ -9,6 +9,7 @@ omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+assert_matches.workspace = true
 camino.workspace = true
 clap.workspace = true
 dns-service-client.workspace = true

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -351,7 +351,11 @@ struct BlueprintEditArgs {
     /// id of the blueprint to edit
     blueprint_id: Uuid,
     /// "creator" field for the new blueprint
+    #[arg(long)]
     creator: Option<String>,
+    /// "comment" field for the new blueprint
+    #[arg(long)]
+    comment: Option<String>,
     #[command(subcommand)]
     edit_command: BlueprintEditCommands,
 }
@@ -718,6 +722,10 @@ fn cmd_blueprint_edit(
         creator,
     )
     .context("creating blueprint builder")?;
+
+    if let Some(comment) = args.comment {
+        builder.comment(comment);
+    }
 
     let label = match args.edit_command {
         BlueprintEditCommands::AddNexus { sled_id } => {
@@ -1137,7 +1145,7 @@ fn cmd_load(
         let blueprint_id = blueprint.id;
         match sim.blueprint_insert_loaded(blueprint) {
             Ok(_) => {
-                swriteln!(s, "blueprint {}: loaded", blueprint_id);
+                swriteln!(s, "blueprint {} loaded", blueprint_id);
             }
             Err(error) => {
                 swriteln!(

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -709,9 +709,6 @@ fn cmd_blueprint_edit(
     let blueprint_id = args.blueprint_id;
     let blueprint = sim.blueprint_lookup(blueprint_id)?;
     let creator = args.creator.as_deref().unwrap_or("reconfigurator-cli");
-    // XXX-dap for this to work, the UnstableReconfiguratorState needs to
-    // include the service IP pool ranges so that we can stuff that into the
-    // Policy to allocate addresses correctly
     let policy = sim.system.to_policy().context("assembling policy")?;
     let mut builder = BlueprintBuilder::new_based_on(
         &sim.log,
@@ -1157,6 +1154,10 @@ fn cmd_load(
             }
         }
     }
+
+    let ranges = format!("{:?}", loaded.policy.service_ip_pool_ranges);
+    sim.system.service_ip_pool_ranges(loaded.policy.service_ip_pool_ranges);
+    swriteln!(s, "loaded service IP pool ranges: {:?}", ranges);
 
     sim.internal_dns = loaded.internal_dns;
     sim.external_dns = loaded.external_dns;

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -271,4 +271,13 @@ impl super::Nexus {
         self.blueprint_add(&opctx, &blueprint).await?;
         Ok(blueprint)
     }
+
+    pub async fn blueprint_import(
+        &self,
+        opctx: &OpContext,
+        blueprint: Blueprint,
+    ) -> Result<(), Error> {
+        let _ = self.blueprint_add(&opctx, &blueprint).await?;
+        Ok(())
+    }
 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -110,6 +110,7 @@ pub(crate) fn internal_api() -> NexusApiDescription {
         api.register(blueprint_target_set_enabled)?;
         api.register(blueprint_generate_from_collection)?;
         api.register(blueprint_regenerate)?;
+        api.register(blueprint_import)?;
 
         api.register(sled_list_uninitialized)?;
         api.register(sled_add)?;
@@ -1077,6 +1078,28 @@ async fn blueprint_regenerate(
         let nexus = &apictx.nexus;
         let result = nexus.blueprint_create_regenerate(&opctx).await?;
         Ok(HttpResponseOk(result))
+    };
+    apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+/// Imports a client-provided blueprint
+///
+/// This is intended for development and support, not end users or operators.
+#[endpoint {
+    method = POST,
+    path = "/deployment/blueprints/import",
+}]
+async fn blueprint_import(
+    rqctx: RequestContext<Arc<ServerContext>>,
+    blueprint: TypedBody<Blueprint>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let apictx = rqctx.context();
+    let handler = async {
+        let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
+        let nexus = &apictx.nexus;
+        let blueprint = blueprint.into_inner();
+        nexus.blueprint_import(&opctx, blueprint).await?;
+        Ok(HttpResponseUpdatedNoContent())
     };
     apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -489,6 +489,34 @@
         }
       }
     },
+    "/deployment/blueprints/import": {
+      "post": {
+        "summary": "Imports a client-provided blueprint",
+        "description": "This is intended for development and support, not end users or operator.",
+        "operationId": "blueprint_import",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Blueprint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/deployment/blueprints/regenerate": {
       "post": {
         "summary": "Generates a new blueprint for the current system, re-evaluating anything",


### PR DESCRIPTION
This PR adds:

- `reconfigurator-cli` command `blueprint-edit` to edit an existing blueprint.  This creates a new blueprint.  The only supported editing operation right now is to add a Nexus zone to a specific sled.
- `reconfigurator-cli` command `blueprint-save` to save an existing blueprint to a file
- internal API + `omdb nexus blueprints import` to upload a blueprint that's stored in a file

Together with the existing tooling, this should let someone take an existing deployed system, fetch the reconfigurator state with `omdb`, edit the latest blueprint as desired, diff it against the latest to see what it will do, then import it back into the deployed system, set it as the target, and carry out that change.  I have not tested this end-to-end on a real system yet.