### PR TITLE
some initial blueprints could just be empty

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -1339,17 +1339,9 @@ mod tests {
         let mut db = test_setup_database(&logctx.log).await;
         let (opctx, datastore) = datastore_test(&logctx, &db).await;
 
-        // Create an empty collection and a blueprint from it
-        let collection =
-            nexus_inventory::CollectionBuilder::new("test").build();
-        let blueprint1 = BlueprintBuilder::build_initial_from_collection(
-            &collection,
-            Generation::new(),
-            Generation::new(),
-            &EMPTY_POLICY,
-            "test",
-        )
-        .unwrap();
+        // Create an empty blueprint.
+        let blueprint1 =
+            BlueprintBuilder::build_initial_empty(&EMPTY_POLICY, "test");
         let authz_blueprint = authz_blueprint_from_id(blueprint1.id);
 
         // Trying to read it from the database should fail with the relevant
@@ -1368,7 +1360,7 @@ mod tests {
         let blueprint_read = datastore
             .blueprint_read(&opctx, &authz_blueprint)
             .await
-            .expect("failed to read collection back");
+            .expect("failed to read blueprint back");
         assert_eq!(blueprint1, blueprint_read);
         assert_eq!(
             blueprint_list_all_ids(&opctx, &datastore).await,
@@ -1615,16 +1607,8 @@ mod tests {
         // Create three blueprints:
         // * `blueprint1` has no parent
         // * `blueprint2` and `blueprint3` both have `blueprint1` as parent
-        let collection =
-            nexus_inventory::CollectionBuilder::new("test").build();
-        let blueprint1 = BlueprintBuilder::build_initial_from_collection(
-            &collection,
-            Generation::new(),
-            Generation::new(),
-            &EMPTY_POLICY,
-            "test1",
-        )
-        .unwrap();
+        let blueprint1 =
+            BlueprintBuilder::build_initial_empty(&EMPTY_POLICY, "test1");
         let blueprint2 = BlueprintBuilder::new_based_on(
             &logctx.log,
             &blueprint1,
@@ -1772,16 +1756,8 @@ mod tests {
         let (opctx, datastore) = datastore_test(&logctx, &db).await;
 
         // Create an initial blueprint and a child.
-        let collection =
-            nexus_inventory::CollectionBuilder::new("test").build();
-        let blueprint1 = BlueprintBuilder::build_initial_from_collection(
-            &collection,
-            Generation::new(),
-            Generation::new(),
-            &EMPTY_POLICY,
-            "test1",
-        )
-        .unwrap();
+        let blueprint1 =
+            BlueprintBuilder::build_initial_empty(&EMPTY_POLICY, "test1");
         let blueprint2 = BlueprintBuilder::new_based_on(
             &logctx.log,
             &blueprint1,

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -496,10 +496,9 @@ mod test {
     use nexus_db_queries::authz;
     use nexus_db_queries::context::OpContext;
     use nexus_db_queries::db::DataStore;
-    use nexus_inventory::CollectionBuilder;
     use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
     use nexus_reconfigurator_planning::blueprint_builder::EnsureMultiple;
-    use nexus_reconfigurator_planning::example::example;
+    use nexus_reconfigurator_planning::example::ExampleSystem;
     use nexus_reconfigurator_preparation::policy_from_db;
     use nexus_test_utils::resource_helpers::create_silo;
     use nexus_test_utils_macros::nexus_test;
@@ -546,21 +545,12 @@ mod test {
         nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
 
     fn blueprint_empty() -> Blueprint {
-        let builder = CollectionBuilder::new("test-suite");
-        let collection = builder.build();
         let policy = Policy {
             sleds: BTreeMap::new(),
             service_ip_pool_ranges: vec![],
             target_nexus_zone_count: 3,
         };
-        BlueprintBuilder::build_initial_from_collection(
-            &collection,
-            Generation::new(),
-            Generation::new(),
-            &policy,
-            "test-suite",
-        )
-        .expect("failed to generate empty blueprint")
+        BlueprintBuilder::build_initial_empty(&policy, "test-suite")
     }
 
     fn dns_config_empty() -> DnsConfigParams {
@@ -864,16 +854,8 @@ mod test {
     async fn test_blueprint_external_dns_basic() {
         static TEST_NAME: &str = "test_blueprint_external_dns_basic";
         let logctx = test_setup_log(TEST_NAME);
-        let (collection, policy) = example(&logctx.log, TEST_NAME, 5);
-        let initial_external_dns_generation = Generation::new();
-        let blueprint = BlueprintBuilder::build_initial_from_collection(
-            &collection,
-            Generation::new(),
-            initial_external_dns_generation,
-            &policy,
-            "test suite",
-        )
-        .expect("failed to generate initial blueprint");
+        let example = ExampleSystem::new(&logctx.log, TEST_NAME, 5);
+        let blueprint = example.blueprint;
 
         let my_silo = Silo::new(params::SiloCreate {
             identity: IdentityMetadataCreateParams {

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -12,7 +12,6 @@ use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::Policy;
 use nexus_types::inventory::Collection;
 use omicron_common::api::external::Generation;
-use sled_agent_client::types::OmicronZonesConfig;
 use typed_rng::UuidRng;
 
 pub struct ExampleSystem {
@@ -44,36 +43,11 @@ impl ExampleSystem {
         }
 
         let policy = system.to_policy().expect("failed to make policy");
-        let mut inventory_builder =
-            system.to_collection_builder().expect("failed to build collection");
-
-        // For each sled, have it report 0 zones in the initial inventory.
-        // This will enable us to build a blueprint from the initial
-        // inventory, which we can then use to build new blueprints.
-        for sled_id in &sled_ids {
-            inventory_builder
-                .found_sled_omicron_zones(
-                    "fake sled agent",
-                    *sled_id,
-                    OmicronZonesConfig {
-                        generation: Generation::new(),
-                        zones: vec![],
-                    },
-                )
-                .expect("recording Omicron zones");
-        }
-
-        let empty_zone_inventory = inventory_builder.build();
-        let initial_blueprint =
-            BlueprintBuilder::build_initial_from_collection_seeded(
-                &empty_zone_inventory,
-                Generation::new(),
-                Generation::new(),
-                &policy,
-                "test suite",
-                (test_name, "ExampleSystem initial"),
-            )
-            .unwrap();
+        let initial_blueprint = BlueprintBuilder::build_initial_empty_seeded(
+            &policy,
+            "test suite",
+            (test_name, "ExampleSystem initial"),
+        );
 
         // Now make a blueprint and collection with some zones on each sled.
         let mut builder = BlueprintBuilder::new_based_on(

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -335,6 +335,11 @@ pub struct BlueprintZonesConfig {
 }
 
 impl BlueprintZonesConfig {
+    /// Constructs an empty [`BlueprintZonesConfig`]
+    pub fn empty() -> Self {
+        BlueprintZonesConfig { generation: Generation::new(), zones: vec![] }
+    }
+
     /// Constructs a new [`BlueprintZonesConfig`] from a collection's zones.
     ///
     /// For the initial blueprint, all zones within a collection are assumed to


### PR DESCRIPTION
With an eye towards removing `BlueprintBuilder::build_initial_from_collection()`, this adds `BlueprintBuilder::build_initial_empty()` and uses that from several places we were using the other function.

This already eliminates some yak shaving in a few tests and I think that will improve further when fewer things create a collection just so they can construct the blueprint they want.