### PR TITLE
[oxlog] add sigpipe::reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6293,6 +6293,7 @@ dependencies = [
  "chrono",
  "clap 4.5.1",
  "omicron-workspace-hack",
+ "sigpipe",
  "uuid 1.7.0",
 ]
 
@@ -8664,6 +8665,15 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "sigpipe"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5584bfb3e0d348139d8210285e39f6d2f8a1902ac06de343e06357d1d763d8e6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,6 +378,7 @@ sha3 = "0.10.8"
 shell-words = "1.1.0"
 signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
+sigpipe = "0.1.3"
 similar-asserts = "1.5.0"
 sled = "0.34"
 sled-agent-client = { path = "clients/sled-agent-client" }

--- a/dev-tools/oxlog/Cargo.toml
+++ b/dev-tools/oxlog/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 camino.workspace = true
 chrono.workspace = true
 clap.workspace = true
+sigpipe.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
 

--- a/dev-tools/oxlog/src/bin/oxlog.rs
+++ b/dev-tools/oxlog/src/bin/oxlog.rs
@@ -57,6 +57,8 @@ struct FilterArgs {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    sigpipe::reset();
+
     let cli = Cli::parse();
 
     match cli.command {


### PR DESCRIPTION
We have a number of CLI tools that panic when piped to things like `head`
instead of quietly exiting.  There's a long history about this within the Rust
community (see https://github.com/rust-lang/rust/issues/62569), but the long
and short of it is that SIGPIPE really should be set to its default handler
(`SIG_DFL`, terminate the process) for CLI tools.

Because oxlog doesn't make any network requests, reset the SIGPIPE handler to
`SIG_DFL`.

I looked at also potentially doing this for some of our other CLI tools that
wait on network services. This should be fine to do if and only if whenever we
send data over a socket, the `MSG_NOSIGNAL` flag is set. (This causes an
`EPIPE` error to be returned, but no `SIGPIPE` signal to be generated.)

Rust does set this flag [here]. **However, as of Rust 1.77 this flag is not
set on illumos.** That's a bug and I'll fix it in Rust upstream.

[here]: https://github.com/rust-lang/rust/blob/877d36b1928b5a4f7d193517b48290ecbe404d71/library/std/src/sys_common/net.rs#L32
