### PR TITLE
Fetch all entries when listing assigned producers

### DIFF
--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -748,7 +748,6 @@ impl OximeterAgent {
 // A task which periodically updates our list of producers from Nexus.
 async fn refresh_producer_list(agent: OximeterAgent, resolver: Resolver) {
     let mut interval = tokio::time::interval(agent.refresh_interval);
-    let page_size = Some(NonZeroU32::new(100).unwrap());
     loop {
         interval.tick().await;
         info!(agent.log, "refreshing list of producers from Nexus");
@@ -758,7 +757,9 @@ async fn refresh_producer_list(agent: OximeterAgent, resolver: Resolver) {
         let client = nexus_client::Client::new(&url, agent.log.clone());
         let mut stream = client.cpapi_assigned_producers_list_stream(
             &agent.id,
-            page_size,
+            // This is a _total_ limit, not a page size, so `None` means "get
+            // all entries".
+            None,
             Some(IdSortMode::IdAscending),
         );
         let mut expected_producers = BTreeMap::new();

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -36,7 +36,6 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
-use std::num::NonZeroU32;
 use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;


### PR DESCRIPTION
This works around a confusing interface in Progenitor, which lists the second argument to the `*_stream()` methods as a `limit`, but which describes it as a page size. It currently is the former, a total limit on all entries, so this change ensures we refresh our producer entire producer list.