### PR TITLE
New crucible and propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2#9b2deee64874b315427962b1c7fccceef99436b2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f#84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 dependencies = [
- "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2)",
+ "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f)",
  "libc",
  "strum 0.26.1",
 ]
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2#9b2deee64874b315427962b1c7fccceef99436b2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f#84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 dependencies = [
  "libc",
  "strum 0.26.1",
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=09bcfa6b9201f75891a5413928bb088cc150d319#09bcfa6b9201f75891a5413928bb088cc150d319"
+source = "git+https://github.com/oxidecomputer/crucible?rev=4661c23b248da18862012cf55af21b17b79a468e#4661c23b248da18862012cf55af21b17b79a468e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=09bcfa6b9201f75891a5413928bb088cc150d319#09bcfa6b9201f75891a5413928bb088cc150d319"
+source = "git+https://github.com/oxidecomputer/crucible?rev=4661c23b248da18862012cf55af21b17b79a468e#4661c23b248da18862012cf55af21b17b79a468e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=09bcfa6b9201f75891a5413928bb088cc150d319#09bcfa6b9201f75891a5413928bb088cc150d319"
+source = "git+https://github.com/oxidecomputer/crucible?rev=4661c23b248da18862012cf55af21b17b79a468e#4661c23b248da18862012cf55af21b17b79a468e"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -3539,7 +3539,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2)",
+ "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f)",
  "byteorder",
  "camino",
  "camino-tempfile",
@@ -5462,7 +5462,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f)",
  "rand 0.8.5",
  "rcgen",
  "ref-cast",
@@ -5674,7 +5674,7 @@ dependencies = [
  "oximeter-instruments",
  "oximeter-producer",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f)",
  "propolis-mock-server",
  "rand 0.8.5",
  "rcgen",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2#9b2deee64874b315427962b1c7fccceef99436b2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f#84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2#9b2deee64874b315427962b1c7fccceef99436b2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f#84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 dependencies = [
  "anyhow",
  "atty",
@@ -7146,7 +7146,7 @@ dependencies = [
  "futures",
  "hyper 0.14.28",
  "progenitor",
- "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2)",
+ "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f)",
  "rand 0.8.5",
  "reqwest",
  "schemars",
@@ -7187,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=9b2deee64874b315427962b1c7fccceef99436b2#9b2deee64874b315427962b1c7fccceef99436b2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=84e423bfd3bf84ebb04acb95cf7600731e9f361f#84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,9 +197,9 @@ cookie = "0.18"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "09bcfa6b9201f75891a5413928bb088cc150d319" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "09bcfa6b9201f75891a5413928bb088cc150d319" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "09bcfa6b9201f75891a5413928bb088cc150d319" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "4661c23b248da18862012cf55af21b17b79a468e" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "4661c23b248da18862012cf55af21b17b79a468e" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "4661c23b248da18862012cf55af21b17b79a468e" }
 csv = "1.3.0"
 curve25519-dalek = "4"
 datatest-stable = "0.2.3"
@@ -339,9 +339,9 @@ prettyplease = { version = "0.2.16", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "9b2deee64874b315427962b1c7fccceef99436b2" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "9b2deee64874b315427962b1c7fccceef99436b2" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "9b2deee64874b315427962b1c7fccceef99436b2" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "84e423bfd3bf84ebb04acb95cf7600731e9f361f" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "84e423bfd3bf84ebb04acb95cf7600731e9f361f" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "84e423bfd3bf84ebb04acb95cf7600731e9f361f" }
 proptest = "1.4.0"
 quote = "1.0"
 rand = "0.8.5"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -492,10 +492,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "09bcfa6b9201f75891a5413928bb088cc150d319"
+source.commit = "4661c23b248da18862012cf55af21b17b79a468e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "32a0cc78b436679ed9966564e5a7c0214d67f56c4a5fbac0a5b9507d99752b15"
+source.sha256 = "14e607d04234a6749e981c8049437523dbc75494938541822e31ea61090800bf"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -504,10 +504,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "09bcfa6b9201f75891a5413928bb088cc150d319"
+source.commit = "4661c23b248da18862012cf55af21b17b79a468e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "99028aaac8c879e4855296ce0bde826ceb8f73504fadf0ded7674dcf45fb0446"
+source.sha256 = "9a2181b43d7581468d075e37b5286e478ff008de65dd73b7f49a6e72bc9a43f5"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -519,10 +519,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "9b2deee64874b315427962b1c7fccceef99436b2"
+source.commit = "84e423bfd3bf84ebb04acb95cf7600731e9f361f"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "b32be7167e0c10ebad874de011a752edcbf936cf55abdaddef7f40025beb9b6a"
+source.sha256 = "db72c83b4c0a09e0759ec52e48a5589e9d732c3f390fb4c084f820d173b4f058"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Crucible
Increase max backpressure again (#1243)
Bump backpressure delay for byte-based backpressure (#1240) `crutest` cleaning; adding rand-read/write tests (#1233) Propolis, just the above crucible.