### PR TITLE
[reconfigurator] Only provision to zpools with in-service physical disks

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -223,6 +223,25 @@ impl types::OmicronZoneType {
             | types::OmicronZoneType::Oximeter { .. } => None,
         }
     }
+
+    /// Returns the zpool being used by this zone, if any.
+    pub fn zpool(&self) -> Option<&types::ZpoolName> {
+        match self {
+            types::OmicronZoneType::Clickhouse { dataset, .. }
+            | types::OmicronZoneType::ClickhouseKeeper { dataset, .. }
+            | types::OmicronZoneType::CockroachDb { dataset, .. }
+            | types::OmicronZoneType::Crucible { dataset, .. }
+            | types::OmicronZoneType::ExternalDns { dataset, .. }
+            | types::OmicronZoneType::InternalDns { dataset, .. } => {
+                Some(&dataset.pool_name)
+            }
+            types::OmicronZoneType::BoundaryNtp { .. }
+            | types::OmicronZoneType::InternalNtp { .. }
+            | types::OmicronZoneType::Nexus { .. }
+            | types::OmicronZoneType::Oximeter { .. }
+            | types::OmicronZoneType::CruciblePantry { .. } => None,
+        }
+    }
 }
 
 impl omicron_common::api::external::ClientError for types::Error {

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
@@ -23,16 +23,16 @@ REDACTED_UUID_REDACTED_UUID_REDACTED 10      fd00:1122:3344:101::/64
 sled REDACTED_UUID_REDACTED_UUID_REDACTED
 subnet fd00:1122:3344:101::/64
 zpools (10):
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
+    (ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED"), PhysicalDiskInfo { id: REDACTED_UUID_REDACTED_UUID_REDACTED, variant: U2, policy: InService, state: Active })
 
 
 > sled-add REDACTED_UUID_REDACTED_UUID_REDACTED

--- a/nexus/db-model/src/physical_disk.rs
+++ b/nexus/db-model/src/physical_disk.rs
@@ -79,6 +79,17 @@ impl From<PhysicalDisk> for views::PhysicalDisk {
     }
 }
 
+impl From<&PhysicalDisk> for nexus_types::deployment::PhysicalDiskInfo {
+    fn from(disk: &PhysicalDisk) -> Self {
+        Self {
+            id: disk.id(),
+            variant: disk.variant.into(),
+            policy: disk.disk_policy.into(),
+            state: disk.disk_state.into(),
+        }
+    }
+}
+
 impl DatastoreCollectionConfig<super::Zpool> for PhysicalDisk {
     type CollectionId = Uuid;
     type GenerationNumberColumn = physical_disk::dsl::rcgen;

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -1193,8 +1193,10 @@ mod test {
         // We do this directly with BlueprintBuilder to avoid the planner
         // deciding to make other unrelated changes.
         let sled_rows = datastore.sled_list_all_batched(&opctx).await.unwrap();
-        let zpool_rows =
-            datastore.zpool_list_all_external_batched(&opctx).await.unwrap();
+        let zpool_rows = datastore
+            .zpool_list_all_external_batched_in_service(&opctx)
+            .await
+            .unwrap();
         let ip_pool_range_rows = {
             let (authz_service_ip_pool, _) =
                 datastore.ip_pools_service_lookup(&opctx).await.unwrap();

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -108,7 +108,7 @@ impl ExampleSystem {
                     vec![],
                 )
                 .unwrap();
-            for pool_name in &sled_resources.zpools {
+            for pool_name in sled_resources.provisionable_zpools() {
                 let _ = builder
                     .sled_ensure_zone_crucible(*sled_id, pool_name.clone())
                     .unwrap();

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -182,7 +182,7 @@ impl<'a> Planner<'a> {
                 continue;
             }
 
-            // Every provisionable zpool on the sled should have a Crucible zone on it,
+            // Every provisionable zpool on the sled should have a Crucible zone on it.
             let mut ncrucibles_added = 0;
             for zpool_name in sled_info.provisionable_zpools() {
                 if self

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -103,7 +103,7 @@ pub async fn reconfigurator_state_load(
         .await
         .context("listing sleds")?;
     let zpool_rows = datastore
-        .zpool_list_all_external_batched(opctx)
+        .zpool_list_all_external_batched_in_service(opctx)
         .await
         .context("listing zpools")?;
     let ip_pool_range_rows = {

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -140,7 +140,7 @@ impl super::Nexus {
 
         let sled_rows = datastore.sled_list_all_batched(opctx).await?;
         let zpool_rows =
-            datastore.zpool_list_all_external_batched(opctx).await?;
+            datastore.zpool_list_all_external_batched_in_service(opctx).await?;
         let ip_pool_range_rows = {
             let (authz_service_ip_pool, _) =
                 datastore.ip_pools_service_lookup(opctx).await?;

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -140,7 +140,7 @@ impl super::Nexus {
 
         let sled_rows = datastore.sled_list_all_batched(opctx).await?;
         let zpool_rows =
-            datastore.zpool_list_all_external_batched_in_service(opctx).await?;
+            datastore.zpool_list_all_external_batched(opctx).await?;
         let ip_pool_range_rows = {
             let (authz_service_ip_pool, _) =
                 datastore.ip_pools_service_lookup(opctx).await?;

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -24,7 +24,7 @@ use std::net::IpAddr;
 use strum::{EnumIter, IntoEnumIterator};
 use uuid::Uuid;
 
-use super::params::PhysicalDiskKind;
+pub use super::params::PhysicalDiskKind;
 
 // SILOS
 


### PR DESCRIPTION
- Expand reconfigurator's `Policy`, `SystemDescription` to be aware of "what disks back zpools".
- Updates callsites iterating over "all zpools" to consider whether or not they only want provisionable zpools, using active + in-service disks.
- Adds a method `sled_ensure_zones_not_using_expunged_disks`, which can be used to remove zones using expunged disks.
  - This implementation leaves some TODOs, however, as it depends on https://github.com/oxidecomputer/omicron/pull/5211 , and partially depends on https://github.com/oxidecomputer/omicron/pull/5050

Partial fix of https://github.com/oxidecomputer/omicron/issues/5372