### PR TITLE
ci: publish the tufaceous manifest

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -23,6 +23,11 @@
 #:
 #: [[publish]]
 #: series = "rot-all"
+#: name = "manifest.toml"
+#: from_output = "/work/manifest.toml"
+#:
+#: [[publish]]
+#: series = "rot-all"
 #: name = "repo.zip"
 #: from_output = "/work/repo-rot-all.zip"
 #:


### PR DESCRIPTION
While working on updating the script we use for downloading TUF repos over in meta, I was hitting unexpected 403 errors. This is because the script wants to also download the manifest.toml, and it can only get the URL for that artefact by hitting GitHub's check runs endpoint to get the URL from [the job status posted there by Buildomat](https://github.com/oxidecomputer/omicron/runs/23406222391), and GitHub [rate limits anonymous API requests significantly](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-unauthenticated-users).

The fewer things we ask of GitHub the better, I think.