### PR TITLE
[nexus] fix up some uses of blueprints that were using the Debug impl

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -974,7 +974,7 @@ async fn cmd_nexus_blueprints_show(
         .blueprint_view(&args.blueprint_id)
         .await
         .with_context(|| format!("fetching blueprint {}", args.blueprint_id))?;
-    println!("{:?}", blueprint);
+    println!("{}", blueprint.display());
     Ok(())
 }
 

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -3,8 +3,8 @@ termination: Exited(0)
 ---------------------------------------------
 stdout:
 SERIAL       IP          ROLE     ID                                   
-sim-039be560 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
-sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
+sim-039be560 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
+sim-b6d65341 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -293,8 +293,8 @@ termination: Exited(0)
 ---------------------------------------------
 stdout:
 SERIAL       IP          ROLE     ID                                   
-sim-039be560 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
-sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
+sim-039be560 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
+sim-b6d65341 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
 ---------------------------------------------
 stderr:
 note: database URL not specified.  Will search DNS.
@@ -307,8 +307,8 @@ termination: Exited(0)
 ---------------------------------------------
 stdout:
 SERIAL       IP          ROLE     ID                                   
-sim-039be560 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
-sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
+sim-039be560 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
+sim-b6d65341 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
 ---------------------------------------------
 stderr:
 note: database URL not specified.  Will search DNS.

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -58,7 +58,7 @@ stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (<redacted database version>)
 =============================================
-EXECUTING COMMAND: omdb ["db", "reconfigurator-save", "<REDACTED>"]
+EXECUTING COMMAND: omdb ["db", "reconfigurator-save", "TMP_PATH_REDACTED_TMP_PATH_REDACTED_TMP"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
@@ -67,7 +67,7 @@ stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (<redacted database version>)
 assembling reconfigurator state ... done
-wrote <REDACTED>
+wrote TMP_PATH_REDACTED_TMP_PATH_REDACTED_TMP
 =============================================
 EXECUTING COMMAND: omdb ["db", "services", "list-instances"]
 termination: Exited(0)
@@ -459,6 +459,49 @@ task: "switch_port_config_manager"
   last completed activation: iter 2, triggered by an explicit signal
     started at <REDACTED     TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "switch_port_config_manager" (don't know how to interpret details: Object {})
+
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "blueprints", "list"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+T ENA ID                                   PARENT TIME_CREATED             
+* no  BLUEPRINT_ID_REDACTED_BLUEPRINT_ID_R <none> <REDACTED     TIMESTAMP> 
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "blueprints", "show", "BLUEPRINT_ID_REDACTED_BLUEPRINT_ID_R"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+blueprint  BLUEPRINT_ID_REDACTED_BLUEPRINT_ID_R
+parent:    <none>
+
+  -----------------------------------------------------------------------------------------
+    zone type         zone ID                                disposition  underlay IP      
+  -----------------------------------------------------------------------------------------
+                                                                                           
+  sled REDACTED_UUID_REDACTED_UUID_REDACTED: zones at generation 2                         
+   (no zones)                                                                              
+                                                                                           
+  sled REDACTED_UUID_REDACTED_UUID_REDACTED: zones at generation 2                         
+    clickhouse        REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
+    cockroach_db      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
+    crucible_pantry   REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
+    external_dns      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
+    internal_dns      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
+    nexus             REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::ffff:127.0.0.1 
+
+METADATA:
+  created by:            nexus-test-utils        
+  created at:            <REDACTED     TIMESTAMP>
+  comment:               initial test blueprint  
+  internal DNS version:  1                       
+  external DNS version:  2                       
 
 ---------------------------------------------
 stderr:

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -26,7 +26,7 @@ termination: Exited(0)
 stdout:
 DNS zone:                   oxide-dev.test (External)
 requested version:          2 (created at <REDACTED_TIMESTAMP>)
-version created by Nexus:   REDACTED_UUID_REDACTED_UUID_REDACTED
+version created by Nexus:   ..........<REDACTED_UUID>...........
 version created because:    create silo: "test-suite-silo"
 changes:                    names added: 1, names removed: 0
 
@@ -74,12 +74,12 @@ termination: Exited(0)
 ---------------------------------------------
 stdout:
 SERVICE        INSTANCE_ID                          ADDR                     SLED_SERIAL  
-CruciblePantry REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              sim-b6d65341 
-ExternalDns    REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              sim-b6d65341 
-InternalDns    REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              sim-b6d65341 
-Nexus          REDACTED_UUID_REDACTED_UUID_REDACTED [::ffff:127.0.0.1]:REDACTED_PORT sim-b6d65341 
-Mgd            REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              sim-039be560 
-Mgd            REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              sim-b6d65341 
+CruciblePantry ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              sim-b6d65341 
+ExternalDns    ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              sim-b6d65341 
+InternalDns    ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              sim-b6d65341 
+Nexus          ..........<REDACTED_UUID>........... [::ffff:127.0.0.1]:REDACTED_PORT sim-b6d65341 
+Mgd            ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              sim-039be560 
+Mgd            ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              sim-b6d65341 
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -89,19 +89,19 @@ EXECUTING COMMAND: omdb ["db", "services", "list-by-sled"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
-sled: sim-039be560 (id REDACTED_UUID_REDACTED_UUID_REDACTED)
+sled: sim-039be560 (id ..........<REDACTED_UUID>...........)
 
   SERVICE INSTANCE_ID                          ADDR        
-  Mgd     REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT 
+  Mgd     ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT 
 
-sled: sim-b6d65341 (id REDACTED_UUID_REDACTED_UUID_REDACTED)
+sled: sim-b6d65341 (id ..........<REDACTED_UUID>...........)
 
   SERVICE        INSTANCE_ID                          ADDR                     
-  CruciblePantry REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              
-  ExternalDns    REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              
-  InternalDns    REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              
-  Nexus          REDACTED_UUID_REDACTED_UUID_REDACTED [::ffff:127.0.0.1]:REDACTED_PORT 
-  Mgd            REDACTED_UUID_REDACTED_UUID_REDACTED [::1]:REDACTED_PORT              
+  CruciblePantry ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              
+  ExternalDns    ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              
+  InternalDns    ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              
+  Nexus          ..........<REDACTED_UUID>........... [::ffff:127.0.0.1]:REDACTED_PORT 
+  Mgd            ..........<REDACTED_UUID>........... [::1]:REDACTED_PORT              
 
 ---------------------------------------------
 stderr:
@@ -113,8 +113,8 @@ termination: Exited(0)
 ---------------------------------------------
 stdout:
 SERIAL       IP          ROLE     ID                                   
-sim-039be560 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
-sim-b6d65341 [::1]:REDACTED_PORT scrimlet REDACTED_UUID_REDACTED_UUID_REDACTED 
+sim-039be560 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
+sim-b6d65341 [::1]:REDACTED_PORT scrimlet ..........<REDACTED_UUID>........... 
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -405,12 +405,12 @@ task: "external_endpoints"
     external API endpoints: 2 ('*' below marks default)
 
           SILO_ID                              DNS_NAME                           
-          REDACTED_UUID_REDACTED_UUID_REDACTED default-silo.sys.oxide-dev.test    
-        * REDACTED_UUID_REDACTED_UUID_REDACTED test-suite-silo.sys.oxide-dev.test 
+          ..........<REDACTED_UUID>........... default-silo.sys.oxide-dev.test    
+        * ..........<REDACTED_UUID>........... test-suite-silo.sys.oxide-dev.test 
 
     warnings: 2
-        warning: silo REDACTED_UUID_REDACTED_UUID_REDACTED with DNS name "default-silo.sys.oxide-dev.test" has no usable certificates
-        warning: silo REDACTED_UUID_REDACTED_UUID_REDACTED with DNS name "test-suite-silo.sys.oxide-dev.test" has no usable certificates
+        warning: silo ..........<REDACTED_UUID>........... with DNS name "default-silo.sys.oxide-dev.test" has no usable certificates
+        warning: silo ..........<REDACTED_UUID>........... with DNS name "test-suite-silo.sys.oxide-dev.test" has no usable certificates
 
     TLS certificates: 0
 
@@ -419,7 +419,7 @@ task: "inventory_collection"
   currently executing: no
   last completed activation: iter 3, triggered by an explicit signal
     started at <REDACTED     TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last collection id:      REDACTED_UUID_REDACTED_UUID_REDACTED
+    last collection id:      ..........<REDACTED_UUID>...........
     last collection started: <REDACTED_TIMESTAMP>
     last collection done:    <REDACTED_TIMESTAMP>
 
@@ -485,16 +485,16 @@ parent:    <none>
     zone type         zone ID                                disposition  underlay IP      
   -----------------------------------------------------------------------------------------
                                                                                            
-  sled REDACTED_UUID_REDACTED_UUID_REDACTED: zones at generation 2                         
+  sled ..........<REDACTED_UUID>...........: zones at generation 2                         
    (no zones)                                                                              
                                                                                            
-  sled REDACTED_UUID_REDACTED_UUID_REDACTED: zones at generation 2                         
-    clickhouse        REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
-    cockroach_db      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
-    crucible_pantry   REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
-    external_dns      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
-    internal_dns      REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::1              
-    nexus             REDACTED_UUID_REDACTED_UUID_REDACTED   in service   ::ffff:127.0.0.1 
+  sled ..........<REDACTED_UUID>...........: zones at generation 2                         
+    clickhouse        ..........<REDACTED_UUID>...........   in service   ::1              
+    cockroach_db      ..........<REDACTED_UUID>...........   in service   ::1              
+    crucible_pantry   ..........<REDACTED_UUID>...........   in service   ::1              
+    external_dns      ..........<REDACTED_UUID>...........   in service   ::1              
+    internal_dns      ..........<REDACTED_UUID>...........   in service   ::1              
+    nexus             ..........<REDACTED_UUID>...........   in service   ::ffff:127.0.0.1 
 
 METADATA:
   created by:            nexus-test-utils        

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -117,7 +117,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
             },
             &cmd_path,
             args,
-            &ExtraRedactions::new()
+            ExtraRedactions::new()
                 .variable_length("tmp_path", tmppath.as_str())
                 .fixed_length("blueprint_id", &initial_blueprint_id),
         )

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -11,8 +11,9 @@ use expectorate::assert_contents;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::deployment::UnstableReconfiguratorState;
 use omicron_test_utils::dev::test_cmds::path_to_executable;
-use omicron_test_utils::dev::test_cmds::redact_variable;
+use omicron_test_utils::dev::test_cmds::redact_extra;
 use omicron_test_utils::dev::test_cmds::run_command;
+use omicron_test_utils::dev::test_cmds::ExtraRedactions;
 use slog_error_chain::InlineErrorChain;
 use std::fmt::Write;
 use std::path::Path;
@@ -56,7 +57,7 @@ async fn test_omdb_usage_errors() {
     ];
 
     for args in invocations {
-        do_run(&mut output, |exec| exec, &cmd_path, args, &[]).await;
+        do_run(&mut output, |exec| exec, &cmd_path, args).await;
     }
 
     assert_contents("tests/usage_errors.out", &output);
@@ -77,7 +78,10 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
     let tmpdir = camino_tempfile::tempdir()
         .expect("failed to create temporary directory");
     let tmppath = tmpdir.path().join("reconfigurator-save.out");
+    let initial_blueprint_id = cptestctx.initial_blueprint_id.to_string();
+
     let mut output = String::new();
+
     let invocations: &[&[&str]] = &[
         &["db", "disks", "list"],
         &["db", "dns", "show"],
@@ -91,6 +95,8 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         &["mgs", "inventory"],
         &["nexus", "background-tasks", "doc"],
         &["nexus", "background-tasks", "show"],
+        &["nexus", "blueprints", "list"],
+        &["nexus", "blueprints", "show", &initial_blueprint_id],
         // We can't easily test the sled agent output because that's only
         // provided by a real sled agent, which is not available in the
         // ControlPlaneTestContext.
@@ -101,7 +107,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         let p = postgres_url.to_string();
         let u = nexus_internal_url.clone();
         let g = mgs_url.clone();
-        do_run(
+        do_run_extra(
             &mut output,
             move |exec| {
                 exec.env("OMDB_DB_URL", &p)
@@ -110,7 +116,9 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
             },
             &cmd_path,
             args,
-            &[tmppath.as_str()],
+            &ExtraRedactions::new()
+                .add("tmp_path", tmppath.as_str())
+                .add("blueprint_id", &initial_blueprint_id),
         )
         .await;
     }
@@ -163,7 +171,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     // Database URL
     // Case 1: specified on the command line
     let args = &["db", "--db-url", &postgres_url, "sleds"];
-    do_run(&mut output, |exec| exec, &cmd_path, args, &[]).await;
+    do_run(&mut output, |exec| exec, &cmd_path, args).await;
 
     // Case 2: specified in multiple places (command-line argument wins)
     let args = &["db", "--db-url", "junk", "sleds"];
@@ -173,7 +181,6 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         move |exec| exec.env("OMDB_DB_URL", &p),
         &cmd_path,
         args,
-        &[],
     )
     .await;
 
@@ -186,7 +193,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         "background-tasks",
         "doc",
     ];
-    do_run(&mut output, |exec| exec, &cmd_path.clone(), args, &[]).await;
+    do_run(&mut output, |exec| exec, &cmd_path.clone(), args).await;
 
     // Case 2: specified in multiple places (command-line argument wins)
     let args =
@@ -197,7 +204,6 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         move |exec| exec.env("OMDB_NEXUS_URL", &n),
         &cmd_path,
         args,
-        &[],
     )
     .await;
 
@@ -210,7 +216,6 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         move |exec| exec.env("OMDB_DNS_SERVER", dns_sockaddr.to_string()),
         &cmd_path,
         args,
-        &[],
     )
     .await;
 
@@ -221,7 +226,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         "background-tasks",
         "doc",
     ];
-    do_run(&mut output, move |exec| exec, &cmd_path, args, &[]).await;
+    do_run(&mut output, move |exec| exec, &cmd_path, args).await;
 
     let args = &["db", "sleds"];
     do_run(
@@ -229,12 +234,11 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         move |exec| exec.env("OMDB_DNS_SERVER", dns_sockaddr.to_string()),
         &cmd_path,
         args,
-        &[],
     )
     .await;
 
     let args = &["--dns-server", &dns_sockaddr.to_string(), "db", "sleds"];
-    do_run(&mut output, move |exec| exec, &cmd_path, args, &[]).await;
+    do_run(&mut output, move |exec| exec, &cmd_path, args).await;
 
     assert_contents("tests/env.out", &output);
 }
@@ -244,7 +248,19 @@ async fn do_run<F>(
     modexec: F,
     cmd_path: &Path,
     args: &[&str],
-    extra_redactions: &[&str],
+) where
+    F: FnOnce(Exec) -> Exec + Send + 'static,
+{
+    do_run_extra(output, modexec, cmd_path, args, &ExtraRedactions::new())
+        .await;
+}
+
+async fn do_run_extra<F>(
+    output: &mut String,
+    modexec: F,
+    cmd_path: &Path,
+    args: &[&str],
+    extra_redactions: &ExtraRedactions<'_>,
 ) where
     F: FnOnce(Exec) -> Exec + Send + 'static,
 {
@@ -254,7 +270,7 @@ async fn do_run<F>(
         "EXECUTING COMMAND: {} {:?}\n",
         cmd_path.file_name().expect("missing command").to_string_lossy(),
         args.iter()
-            .map(|r| redact_variable(r, extra_redactions))
+            .map(|r| redact_extra(r, extra_redactions))
             .collect::<Vec<_>>(),
     )
     .unwrap();
@@ -287,9 +303,9 @@ async fn do_run<F>(
     write!(output, "termination: {:?}\n", exit_status).unwrap();
     write!(output, "---------------------------------------------\n").unwrap();
     write!(output, "stdout:\n").unwrap();
-    output.push_str(&redact_variable(&stdout_text, extra_redactions));
+    output.push_str(&redact_extra(&stdout_text, extra_redactions));
     write!(output, "---------------------------------------------\n").unwrap();
     write!(output, "stderr:\n").unwrap();
-    output.push_str(&redact_variable(&stderr_text, extra_redactions));
+    output.push_str(&redact_extra(&stderr_text, extra_redactions));
     write!(output, "=============================================\n").unwrap();
 }

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
@@ -9,50 +9,50 @@ ID
 
 > 
 
-> sled-show REDACTED_UUID_REDACTED_UUID_REDACTED
-error: no sled with id REDACTED_UUID_REDACTED_UUID_REDACTED
+> sled-show ..........<REDACTED_UUID>...........
+error: no sled with id ..........<REDACTED_UUID>...........
 
-> sled-add REDACTED_UUID_REDACTED_UUID_REDACTED
+> sled-add ..........<REDACTED_UUID>...........
 added sled
 
 > sled-list
 ID                                   NZPOOLS SUBNET                  
-REDACTED_UUID_REDACTED_UUID_REDACTED 10      fd00:1122:3344:101::/64 
+..........<REDACTED_UUID>........... 10      fd00:1122:3344:101::/64 
 
-> sled-show REDACTED_UUID_REDACTED_UUID_REDACTED
-sled REDACTED_UUID_REDACTED_UUID_REDACTED
+> sled-show ..........<REDACTED_UUID>...........
+sled ..........<REDACTED_UUID>...........
 subnet fd00:1122:3344:101::/64
 zpools (10):
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
-    ZpoolName("oxp_REDACTED_UUID_REDACTED_UUID_REDACTED")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
+    ZpoolName("oxp_..........<REDACTED_UUID>...........")
 
 
-> sled-add REDACTED_UUID_REDACTED_UUID_REDACTED
+> sled-add ..........<REDACTED_UUID>...........
 added sled
 
-> sled-add REDACTED_UUID_REDACTED_UUID_REDACTED
+> sled-add ..........<REDACTED_UUID>...........
 added sled
 
 > sled-list
 ID                                   NZPOOLS SUBNET                  
-REDACTED_UUID_REDACTED_UUID_REDACTED 10      fd00:1122:3344:103::/64 
-REDACTED_UUID_REDACTED_UUID_REDACTED 10      fd00:1122:3344:102::/64 
-REDACTED_UUID_REDACTED_UUID_REDACTED 10      fd00:1122:3344:101::/64 
+..........<REDACTED_UUID>........... 10      fd00:1122:3344:103::/64 
+..........<REDACTED_UUID>........... 10      fd00:1122:3344:102::/64 
+..........<REDACTED_UUID>........... 10      fd00:1122:3344:101::/64 
 
 > 
 
 > inventory-generate
-generated inventory collection REDACTED_UUID_REDACTED_UUID_REDACTED from configured sleds
+generated inventory collection ..........<REDACTED_UUID>........... from configured sleds
 
 > inventory-list
 ID                                   NERRORS TIME_DONE                
-REDACTED_UUID_REDACTED_UUID_REDACTED 0       <REDACTED     TIMESTAMP> 
+..........<REDACTED_UUID>........... 0       <REDACTED     TIMESTAMP> 
 

--- a/dev-tools/reconfigurator-cli/tests/test_basic.rs
+++ b/dev-tools/reconfigurator-cli/tests/test_basic.rs
@@ -41,7 +41,7 @@ fn test_basic() {
     let exec = Exec::cmd(path_to_cli()).arg("tests/input/cmds.txt");
     let (exit_status, stdout_text, stderr_text) = run_command(exec);
     assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
-    let stdout_text = redact_variable(&stdout_text, &[]);
+    let stdout_text = redact_variable(&stdout_text);
     assert_contents("tests/output/cmd-stdout", &stdout_text);
     assert_contents("tests/output/cmd-stderr", &stderr_text);
 }

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -1150,7 +1150,7 @@ mod test {
             .await
             .expect("failed to read current target blueprint")
             .expect("no target blueprint set");
-        eprintln!("blueprint: {:?}", blueprint);
+        eprintln!("blueprint: {}", blueprint.display());
 
         // Now, execute the initial blueprint.
         let overrides = Overridables::for_test(cptestctx);
@@ -1244,7 +1244,7 @@ mod test {
             .unwrap();
         assert_eq!(rv, EnsureMultiple::Added(1));
         let blueprint2 = builder.build();
-        eprintln!("blueprint2: {:?}", blueprint2);
+        eprintln!("blueprint2: {}", blueprint2.display());
         // Figure out the id of the new zone.
         let zones_before = blueprint
             .all_omicron_zones()

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -114,6 +114,7 @@ pub struct ControlPlaneTestContext<N> {
     pub external_dns_zone_name: String,
     pub external_dns: dns_server::TransientServer,
     pub internal_dns: dns_server::TransientServer,
+    pub initial_blueprint_id: Uuid,
     pub silo_name: Name,
     pub user_name: UserId,
 }
@@ -299,6 +300,7 @@ pub struct ControlPlaneTestContextBuilder<'a, N: NexusServer> {
     pub external_dns: Option<dns_server::TransientServer>,
     pub internal_dns: Option<dns_server::TransientServer>,
     dns_config: Option<DnsConfigParams>,
+    initial_blueprint_id: Option<Uuid>,
     omicron_zones: Vec<OmicronZoneConfig>,
     omicron_zones2: Vec<OmicronZoneConfig>,
 
@@ -343,6 +345,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             external_dns: None,
             internal_dns: None,
             dns_config: None,
+            initial_blueprint_id: None,
             omicron_zones: Vec::new(),
             omicron_zones2: Vec::new(),
             silo_name: None,
@@ -836,6 +839,8 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             }
         };
 
+        self.initial_blueprint_id = Some(blueprint.id);
+
         // Handoff all known service information to Nexus
         let server = N::start(
             self.nexus_internal
@@ -1124,6 +1129,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             external_dns_zone_name: self.external_dns_zone_name.unwrap(),
             external_dns: self.external_dns.unwrap(),
             internal_dns: self.internal_dns.unwrap(),
+            initial_blueprint_id: self.initial_blueprint_id.unwrap(),
             silo_name: self.silo_name.unwrap(),
             user_name: self.user_name.unwrap(),
         }

--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -288,7 +288,7 @@ mod tests {
             path3: /variable-length/path";
         let actual = redact_extra(
             input,
-            &ExtraRedactions::new()
+            ExtraRedactions::new()
                 .fixed_length("tp", "/var/tmp/tmp.456ms123s")
                 .fixed_length("short_redact", "/short")
                 .variable_length("variable", "/variable-length/path"),


### PR DESCRIPTION
Before we added the `display()` method, the way to get nicely formatted
blueprints was to use the Debug impl. While working on #5211, I noticed that
these callers were still using the old way to do things. Fix this up.

I tested this by making the `Debug` impl for `Blueprint` panic, then saw which
tests failed.

I also realized that we didn't have tests for omdb's blueprints. I believe at
the time it wasn't possible to write a test for this because we didn't have an
initial blueprint -- but now we do, so include a test.

(I also wanted to ensure that the actual blueprint ID was what we expected, so
I expanded the scope of `redact_variable` a bit. Introduce `ExtraRedactions`
so we can handle both fixed- and variable-length redactions, and use the same
logic for UUIDs.)
