### PR TITLE
[nexus] Improve metrics endpoint summaries for docs

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5539,7 +5539,9 @@ struct SystemMetricsPathParam {
     metric_name: SystemMetricName,
 }
 
-/// Access metrics data
+/// View metrics
+///
+/// View CPU, memory, or storage utilization metrics at the fleet or silo level.
 #[endpoint {
      method = GET,
      path = "/v1/system/metrics/{metric_name}",
@@ -5581,7 +5583,9 @@ async fn system_metric(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Access metrics data
+/// View metrics
+///
+/// View CPU, memory, or storage utilization metrics at the silo or project level.
 #[endpoint {
      method = GET,
      path = "/v1/metrics/{metric_name}",
@@ -5628,7 +5632,7 @@ async fn silo_metric(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// List available timeseries schema.
+/// List timeseries schemas
 #[endpoint {
     method = GET,
     path = "/v1/timeseries/schema",
@@ -5654,7 +5658,11 @@ async fn timeseries_schema_list(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
-/// Run a timeseries query, written OxQL.
+// TODO: can we link to an OxQL reference? Do we have one? Can we even do links?
+
+/// Run timeseries query
+///
+/// Queries are written in OxQL.
 #[endpoint {
     method = POST,
     path = "/v1/timeseries/query",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -3089,7 +3089,8 @@
         "tags": [
           "metrics"
         ],
-        "summary": "Access metrics data",
+        "summary": "View metrics",
+        "description": "View CPU, memory, or storage utilization metrics at the silo or project level.",
         "operationId": "silo_metric",
         "parameters": [
           {
@@ -5954,7 +5955,8 @@
         "tags": [
           "system/metrics"
         ],
-        "summary": "Access metrics data",
+        "summary": "View metrics",
+        "description": "View CPU, memory, or storage utilization metrics at the fleet or silo level.",
         "operationId": "system_metric",
         "parameters": [
           {
@@ -7934,7 +7936,8 @@
         "tags": [
           "metrics"
         ],
-        "summary": "Run a timeseries query, written OxQL.",
+        "summary": "Run timeseries query",
+        "description": "Queries are written in OxQL.",
         "operationId": "timeseries_query",
         "requestBody": {
           "content": {
@@ -7975,7 +7978,7 @@
         "tags": [
           "metrics"
         ],
-        "summary": "List available timeseries schema.",
+        "summary": "List timeseries schemas",
         "operationId": "timeseries_schema_list",
         "parameters": [
           {


### PR DESCRIPTION
This is an immediate improvement so I'm not going to hold it on figuring out what to link to as an OxQL reference.

### Before

<img src="https://github.com/oxidecomputer/omicron/assets/3612203/9a43f659-bcf5-48c6-b1c3-dc20ae3f7346" width="277"/>

### After

<img src="https://github.com/oxidecomputer/omicron/assets/3612203/9714adf2-66df-4afa-889c-754a57fa340f" width="273" />

