### PR TITLE
remove cargo registry patch for samael

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11541,8 +11541,3 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[patch.unused]]
-name = "samael"
-version = "0.0.14"
-source = "git+https://github.com/oxidecomputer/samael?branch=oxide/omicron#9e609a8f6fa0dd84e3bb8f579f46bd780c8be62b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -660,11 +660,6 @@ branch = "oxide/omicron"
 [patch.crates-io.omicron-workspace-hack]
 path = "workspace-hack"
 
-# Pulls in https://github.com/njaremko/samael/pull/41
-[patch.crates-io.samael]
-git = "https://github.com/oxidecomputer/samael"
-branch = "oxide/omicron"
-
 # Several crates such as crucible and propolis have have a Git dependency on
 # this repo. Omicron itself depends on these crates, which can lead to two
 # copies of these crates in the dependency graph. (As a Git dependency, and as


### PR DESCRIPTION
Fixes the following warning introduced by #5408:

```
warning: Patch `samael v0.0.14 (https://github.com/oxidecomputer/samael?branch=oxide/omicron#9e609a8f)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
```

#5408 bumped samael to v0.0.15, which brought in the upstream fix for #4920, which is why we had the patch in the first place.