### PR TITLE
[nexus] use the SledFilter type in the database as well

### DIFF
--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -370,7 +370,7 @@ mod diesel_util {
     /// table.
     ///
     /// This needs to live here, rather than in `nexus-db-queries`, because it
-    /// names the [`DbSledPolicy`] type which is private to this crate.
+    /// names the `DbSledPolicy` type which is private to this crate.
     pub trait ApplySledFilterExt {
         type Output;
 

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -347,3 +347,67 @@ impl SledReservationConstraintBuilder {
         self.constraints
     }
 }
+
+mod diesel_util {
+    use crate::{
+        schema::sled::{sled_policy, sled_state},
+        sled_policy::DbSledPolicy,
+        to_db_sled_policy,
+    };
+    use diesel::{
+        helper_types::{And, EqAny},
+        prelude::*,
+        query_dsl::methods::FilterDsl,
+    };
+    use nexus_types::{
+        deployment::SledFilter,
+        external_api::views::{SledPolicy, SledState},
+    };
+
+    /// An extension trait to apply a [`SledFilter`] to a Diesel expression.
+    ///
+    /// This is applicable to any Diesel expression which includes the `sled`
+    /// table.
+    ///
+    /// This needs to live here, rather than in `nexus-db-queries`, because it
+    /// names the [`DbSledPolicy`] type which is private to this crate.
+    pub trait ApplySledFilterExt {
+        type Output;
+
+        /// Applies a [`SledFilter`] to a Diesel expression.
+        fn sled_filter(self, filter: SledFilter) -> Self::Output;
+    }
+
+    impl<E> ApplySledFilterExt for E
+    where
+        E: FilterDsl<SledFilterQuery>,
+    {
+        type Output = E::Output;
+
+        fn sled_filter(self, filter: SledFilter) -> Self::Output {
+            use crate::schema::sled::dsl as sled_dsl;
+
+            // These are only boxed for ease of reference above.
+            let all_matching_policies: BoxedIterator<DbSledPolicy> = Box::new(
+                SledPolicy::all_matching(filter).map(to_db_sled_policy),
+            );
+            let all_matching_states: BoxedIterator<crate::SledState> =
+                Box::new(SledState::all_matching(filter).map(Into::into));
+
+            FilterDsl::filter(
+                self,
+                sled_dsl::sled_policy
+                    .eq_any(all_matching_policies)
+                    .and(sled_dsl::sled_state.eq_any(all_matching_states)),
+            )
+        }
+    }
+
+    type BoxedIterator<T> = Box<dyn Iterator<Item = T>>;
+    type SledFilterQuery = And<
+        EqAny<sled_policy, BoxedIterator<DbSledPolicy>>,
+        EqAny<sled_state, BoxedIterator<crate::SledState>>,
+    >;
+}
+
+pub use diesel_util::ApplySledFilterExt;

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -482,8 +482,8 @@ impl DataStore {
     /// # Errors
     ///
     /// This method returns an error if the sled policy is not a state that is
-    /// valid to decommission from (i.e. if, the cur,
-    /// [`SledPolicy::is_decommissionable`] returns `false`).
+    /// valid to decommission from (i.e. if [`SledPolicy::is_decommissionable`]
+    /// returns `false`).
     pub async fn sled_set_state_to_decommissioned(
         &self,
         opctx: &OpContext,

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -24,6 +24,8 @@ use crate::transaction_retry::OptionalError;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
 use diesel::prelude::*;
+use nexus_db_model::ApplySledFilterExt;
+use nexus_types::deployment::SledFilter;
 use nexus_types::external_api::views::SledPolicy;
 use nexus_types::external_api::views::SledProvisionPolicy;
 use nexus_types::identity::Asset;
@@ -198,26 +200,22 @@ impl DataStore {
 
                     // Generate a query describing all of the sleds that have space
                     // for this reservation.
-                    let mut sled_targets =
-                        sled_dsl::sled
-                            .left_join(
-                                resource_dsl::sled_resource
-                                    .on(resource_dsl::sled_id.eq(sled_dsl::id)),
-                            )
-                            .group_by(sled_dsl::id)
-                            .having(
-                                sled_has_space_for_threads
-                                    .and(sled_has_space_for_rss)
-                                    .and(sled_has_space_in_reservoir),
-                            )
-                            .filter(sled_dsl::time_deleted.is_null())
-                            // Ensure that the sled is in-service and active.
-                            .filter(sled_dsl::sled_policy.eq(
-                                to_db_sled_policy(SledPolicy::provisionable()),
-                            ))
-                            .filter(sled_dsl::sled_state.eq(SledState::Active))
-                            .select(sled_dsl::id)
-                            .into_boxed();
+                    let mut sled_targets = sled_dsl::sled
+                        .left_join(
+                            resource_dsl::sled_resource
+                                .on(resource_dsl::sled_id.eq(sled_dsl::id)),
+                        )
+                        .group_by(sled_dsl::id)
+                        .having(
+                            sled_has_space_for_threads
+                                .and(sled_has_space_for_rss)
+                                .and(sled_has_space_in_reservoir),
+                        )
+                        .filter(sled_dsl::time_deleted.is_null())
+                        // Ensure that reservations can be created on the sled.
+                        .sled_filter(SledFilter::ReservationCreate)
+                        .select(sled_dsl::id)
+                        .into_boxed();
 
                     // Further constrain the sled IDs according to any caller-
                     // supplied constraints.
@@ -484,7 +482,7 @@ impl DataStore {
     /// # Errors
     ///
     /// This method returns an error if the sled policy is not a state that is
-    /// valid to decommission from (i.e. if, for the current sled policy,
+    /// valid to decommission from (i.e. if, the cur,
     /// [`SledPolicy::is_decommissionable`] returns `false`).
     pub async fn sled_set_state_to_decommissioned(
         &self,
@@ -1147,7 +1145,9 @@ mod test {
             (
                 // In-service and active sleds can be marked as expunged.
                 Before::new(
-                    predicate::in_iter(SledPolicy::all_in_service()),
+                    predicate::in_iter(SledPolicy::all_matching(
+                        SledFilter::InService,
+                    )),
                     predicate::eq(SledState::Active),
                 ),
                 SledTransition::Policy(SledPolicy::Expunged),
@@ -1156,7 +1156,9 @@ mod test {
                 // The provision policy of in-service sleds can be changed, or
                 // kept the same (1 of 2).
                 Before::new(
-                    predicate::in_iter(SledPolicy::all_in_service()),
+                    predicate::in_iter(SledPolicy::all_matching(
+                        SledFilter::InService,
+                    )),
                     predicate::eq(SledState::Active),
                 ),
                 SledTransition::Policy(SledPolicy::InService {
@@ -1166,7 +1168,9 @@ mod test {
             (
                 // (2 of 2)
                 Before::new(
-                    predicate::in_iter(SledPolicy::all_in_service()),
+                    predicate::in_iter(SledPolicy::all_matching(
+                        SledFilter::InService,
+                    )),
                     predicate::eq(SledState::Active),
                 ),
                 SledTransition::Policy(SledPolicy::InService {

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -6,6 +6,7 @@
 //! blueprints.
 
 use crate::external_api::views::SledPolicy;
+use crate::external_api::views::SledProvisionPolicy;
 use crate::external_api::views::SledState;
 use crate::inventory::ZpoolName;
 use ipnetwork::IpNetwork;
@@ -22,6 +23,7 @@ use serde::Serialize;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use strum::IntoEnumIterator;
 use uuid::Uuid;
 
 /// Describes the resources available on each sled for the planner
@@ -85,6 +87,119 @@ pub enum SledFilter {
     /// Sleds that are in service (even if they might not be eligible for
     /// discretionary services).
     InService,
+
+    /// Sleds on which reservations can be created.
+    ReservationCreate,
+}
+
+impl SledFilter {
+    /// Returns true if self matches the provided policy and state.
+    pub fn matches_policy_and_state(
+        self,
+        policy: SledPolicy,
+        state: SledState,
+    ) -> bool {
+        policy.matches(self) && state.matches(self)
+    }
+}
+
+impl SledPolicy {
+    /// Returns true if self matches the filter.
+    ///
+    /// Any users of this must also compare against the [`SledState`], if
+    /// relevant: a sled filter is fully matched when it matches both the
+    /// policy and the state. See [`SledFilter::matches_policy_and_state`].
+    pub fn matches(self, filter: SledFilter) -> bool {
+        // Some notes:
+        //
+        // # Match style
+        //
+        // This code could be written in three ways:
+        //
+        // 1. match self { match filter { ... } }
+        // 2. match filter { match self { ... } }
+        // 3. match (self, filter) { ... }
+        //
+        // We choose 1 here because we expect many filters and just a few
+        // policies, and 1 is the easiest form to represent that.
+        //
+        // # Illegal states
+        //
+        // Some of the code that checks against both policies and filters is
+        // effectively checking for illegal states. We shouldn't be able to
+        // have a policy+state combo where the policy says the sled is in
+        // service but the state is decommissioned, for example, but the two
+        // separate types let us represent that. Code that ANDs
+        // policy.matches(filter) and state.matches(filter) naturally guards
+        // against those states.
+        match self {
+            SledPolicy::InService {
+                provision_policy: SledProvisionPolicy::Provisionable,
+            } => match filter {
+                SledFilter::All => true,
+                SledFilter::EligibleForDiscretionaryServices => true,
+                SledFilter::InService => true,
+                SledFilter::ReservationCreate => true,
+            },
+            SledPolicy::InService {
+                provision_policy: SledProvisionPolicy::NonProvisionable,
+            } => match filter {
+                SledFilter::All => true,
+                SledFilter::EligibleForDiscretionaryServices => false,
+                SledFilter::InService => true,
+                SledFilter::ReservationCreate => false,
+            },
+            SledPolicy::Expunged => match filter {
+                SledFilter::All => true,
+                SledFilter::EligibleForDiscretionaryServices => false,
+                SledFilter::InService => false,
+                SledFilter::ReservationCreate => false,
+            },
+        }
+    }
+
+    /// Returns all policies matching the given filter.
+    ///
+    /// This is meant for database access, and is generally paired with
+    /// [`SledState::all_matching`]. See `ApplySledFilterExt` in
+    /// nexus-db-model.
+    pub fn all_matching(filter: SledFilter) -> impl Iterator<Item = Self> {
+        Self::iter().filter(move |policy| policy.matches(filter))
+    }
+}
+
+impl SledState {
+    /// Returns true if self matches the filter.
+    ///
+    /// Any users of this must also compare against the [`SledPolicy`], if
+    /// relevant: a sled filter is fully matched when both the policy and the
+    /// state match. See [`SledFilter::matches_policy_and_state`].
+    pub fn matches(self, filter: SledFilter) -> bool {
+        // See `SledFilter::matches` above for some notes.
+        match self {
+            SledState::Active => match filter {
+                SledFilter::All => true,
+                SledFilter::EligibleForDiscretionaryServices => true,
+                SledFilter::InService => true,
+                SledFilter::ReservationCreate => true,
+            },
+            SledState::Decommissioned => match filter {
+                SledFilter::All => true,
+                SledFilter::EligibleForDiscretionaryServices => false,
+                SledFilter::InService => false,
+                SledFilter::ReservationCreate => false,
+            },
+        }
+    }
+
+    /// Returns all policies matching the given filter.
+    ///
+    /// This is meant for database access, and is generally paired with
+    /// [`SledPolicy::all_matching`]. See `ApplySledFilterExt` in
+    /// nexus-db-model.
+    pub fn all_matching(filter: SledFilter) -> impl Iterator<Item = Self> {
+        Self::iter().filter(move |state| state.matches(filter))
+    }
 }
 
 /// Fleet-wide deployment policy
@@ -176,32 +291,10 @@ impl PlanningInput {
         &self,
         filter: SledFilter,
     ) -> impl Iterator<Item = (TypedUuid<SledKind>, &SledDetails)> + '_ {
-        self.sleds.iter().filter_map(move |(&sled_id, details)| match filter {
-            SledFilter::All => Some((sled_id, details)),
-            SledFilter::EligibleForDiscretionaryServices => {
-                if details.policy.is_provisionable()
-                    && details.state.is_eligible_for_discretionary_services()
-                {
-                    Some((sled_id, details))
-                } else {
-                    None
-                }
-            }
-            SledFilter::InService => {
-                if details.policy.is_in_service() {
-                    // Check for illegal states; we shouldn't be able to have a
-                    // policy+state combo where the policy says the sled is in
-                    // service but the state is decommissioned, for example, but
-                    // the two separate types let us represent that, so we'll
-                    // guard against it here.
-                    match details.state {
-                        SledState::Active => Some((sled_id, details)),
-                        SledState::Decommissioned => None,
-                    }
-                } else {
-                    None
-                }
-            }
+        self.sleds.iter().filter_map(move |(&sled_id, details)| {
+            filter
+                .matches_policy_and_state(details.policy, details.state)
+                .then_some((sled_id, details))
         })
     }
 


### PR DESCRIPTION
Now that we have the `SledFilter` type, we should be able to use it for
database queries as well.

I spent some time trying to figure out the most ergonomic way to use the
`sled_filter` method, and this is the one I settled on.

This also serves as an example for how we're going to do this for blueprint
zone filters.