### PR TITLE
[dns-server] tempdir -> camino-tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
+ "camino-tempfile",
  "chrono",
  "clap 4.5.1",
  "dns-service-client",
@@ -1969,7 +1970,6 @@ dependencies = [
  "slog-envlogger",
  "slog-term",
  "subprocess",
- "tempdir",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2555,12 +2555,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -7238,19 +7232,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -7292,21 +7273,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7403,15 +7369,6 @@ dependencies = [
  "ring 0.17.8",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7589,15 +7546,6 @@ name = "relative-path"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -9485,16 +9433,6 @@ dependencies = [
  "guppy-workspace-hack",
  "target-lexicon",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -413,7 +413,6 @@ libsw = { version = "3.3.1", features = ["tokio"] }
 syn = { version = "2.0" }
 tabled = "0.15.0"
 tar = "0.4"
-tempdir = "0.3"
 tempfile = "3.10"
 term = "0.7"
 termios = "0.3"

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -33,11 +33,11 @@ uuid.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+camino-tempfile.workspace = true
 expectorate.workspace = true
 omicron-test-utils.workspace = true
 openapiv3.workspace = true
 openapi-lint.workspace = true
 serde_json.workspace = true
 subprocess.workspace = true
-tempdir.workspace = true
 trust-dns-resolver.workspace = true

--- a/dns-server/src/storage.rs
+++ b/dns-server/src/storage.rs
@@ -783,6 +783,7 @@ mod test {
     use crate::storage::QueryError;
     use anyhow::Context;
     use camino::Utf8PathBuf;
+    use camino_tempfile::Utf8TempDir;
     use omicron_test_utils::dev::test_setup_log;
     use std::collections::BTreeSet;
     use std::collections::HashMap;
@@ -796,7 +797,7 @@ mod test {
     /// our tests and helps make sure they get cleaned up properly.
     struct TestContext {
         logctx: dropshot::test_util::LogContext,
-        tmpdir: tempdir::TempDir,
+        tmpdir: Utf8TempDir,
         store: Store,
         db: Arc<sled::Db>,
     }
@@ -804,12 +805,9 @@ mod test {
     impl TestContext {
         fn new(test_name: &str) -> TestContext {
             let logctx = test_setup_log(test_name);
-            let tmpdir = tempdir::TempDir::new("dns-server-storage-test")
+            let tmpdir = Utf8TempDir::with_prefix("dns-server-storage-test")
                 .expect("failed to create tmp directory for test");
-            let storage_path =
-                Utf8PathBuf::from_path_buf(tmpdir.path().to_path_buf()).expect(
-                    "failed to create Utf8PathBuf for test temporary directory",
-                );
+            let storage_path = tmpdir.path().to_path_buf();
 
             let db = Arc::new(
                 sled::open(&storage_path).context("creating db").unwrap(),

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{Context, Result};
+use camino_tempfile::Utf8TempDir;
 use dns_service_client::{
     types::{DnsConfigParams, DnsConfigZone, DnsRecord, Srv},
     Client,
@@ -332,7 +333,7 @@ struct TestContext {
     resolver: TokioAsyncResolver,
     dns_server: dns_server::dns_server::ServerHandle,
     dropshot_server: dropshot::HttpServer<dns_server::http_server::Context>,
-    tmp: tempdir::TempDir,
+    tmp: Utf8TempDir,
     logctx: LogContext,
 }
 
@@ -401,7 +402,7 @@ fn test_config(
     test_name: &str,
 ) -> Result<
     (
-        tempdir::TempDir,
+        Utf8TempDir,
         dns_server::storage::Config,
         dropshot::ConfigDropshot,
         LogContext,
@@ -409,10 +410,9 @@ fn test_config(
     anyhow::Error,
 > {
     let logctx = test_setup_log(test_name);
-    let tmp_dir = tempdir::TempDir::new("dns-server-test")?;
+    let tmp_dir = Utf8TempDir::with_prefix("dns-server-test")?;
     let mut storage_path = tmp_dir.path().to_path_buf();
     storage_path.push("test");
-    let storage_path = storage_path.to_str().unwrap().into();
     let config_storage =
         dns_server::storage::Config { storage_path, keep_old_generations: 3 };
     let config_dropshot = dropshot::ConfigDropshot {

--- a/dns-server/tests/commands_test.rs
+++ b/dns-server/tests/commands_test.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use camino::Utf8PathBuf;
+use camino_tempfile::Utf8TempDir;
 use dns_server::storage::Store;
 use omicron_test_utils::dev::test_cmds::assert_exit_code;
 use omicron_test_utils::dev::test_cmds::path_to_executable;
@@ -17,10 +17,9 @@ const CMD_DNSADM: &str = env!("CARGO_BIN_EXE_dnsadm");
 async fn test_dnsadm() {
     // Start a DNS server with some sample data.
     let logctx = test_setup_log("test_dnsadm");
-    let tmpdir = tempdir::TempDir::new("test_dnsadm")
+    let tmpdir = Utf8TempDir::with_prefix("test_dnsadm")
         .expect("failed to create tmp directory for test");
-    let storage_path = Utf8PathBuf::from_path_buf(tmpdir.path().to_path_buf())
-        .expect("failed to create Utf8PathBuf for test temporary directory");
+    let storage_path = tmpdir.path().to_path_buf();
 
     let store = Store::new(
         logctx.log.clone(),


### PR DESCRIPTION
tempdir is unmaintained -- tempfile replaces it, and we can use the camino
wrapper around it because we're in the camino world anyway.
