### PR TITLE
[deps] update slog_term to 2.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8890,11 +8890,11 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+checksum = "b6e022d0b998abfe5c3782c1f03551a596269450ccd677ea51c56f8b214610e8"
 dependencies = [
- "atty",
+ "is-terminal",
  "slog",
  "term",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,7 +391,7 @@ slog-bunyan = "2.5"
 slog-dtrace = "0.3"
 slog-envlogger = "2.2"
 slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain", branch = "main", features = ["derive"] }
-slog-term = "2.9"
+slog-term = "2.9.1"
 smf = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 sp-sim = { path = "sp-sim" }


### PR DESCRIPTION
2.9.0 depends on atty which is deprecated.

(Going to land this myself, as if renovate made this PR.)