### PR TITLE
[deps] update oxidecomputer/tofino

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,15 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,21 +1018,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
@@ -1314,7 +1290,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.1",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1957,7 +1933,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "dns-service-client",
  "dropshot",
  "expectorate",
@@ -2264,7 +2240,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.0",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "colored",
  "dhcproto",
  "http 0.2.12",
@@ -2677,7 +2653,7 @@ name = "gateway-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.1",
+ "clap",
  "futures",
  "gateway-client",
  "gateway-messages",
@@ -3599,7 +3575,7 @@ dependencies = [
  "bytes",
  "camino",
  "cancel-safe-futures",
- "clap 4.5.1",
+ "clap",
  "display-error-chain",
  "futures",
  "hex",
@@ -3660,7 +3636,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "expectorate",
  "hyper 0.14.28",
@@ -3741,7 +3717,7 @@ name = "internal-dns-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "internal-dns",
  "omicron-common",
@@ -3982,7 +3958,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "camino",
- "clap 4.5.1",
+ "clap",
  "colored",
  "futures",
  "libc",
@@ -4092,7 +4068,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
 dependencies = [
- "clap 4.5.1",
+ "clap",
  "termcolor",
  "threadpool",
 ]
@@ -4148,7 +4124,7 @@ version = "0.2.4"
 source = "git+https://github.com/oxidecomputer/lpc55_support#96f064eaae5e95930efaab6c29fd1b2e22225dac"
 dependencies = [
  "bitfield",
- "clap 4.5.1",
+ "clap",
  "packed_struct",
  "serde",
 ]
@@ -5264,7 +5240,7 @@ dependencies = [
  "anyhow",
  "camino",
  "camino-tempfile",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "expectorate",
  "futures",
@@ -5298,7 +5274,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.0",
  "camino",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "expectorate",
  "futures",
@@ -5349,7 +5325,7 @@ dependencies = [
  "camino-tempfile",
  "cancel-safe-futures",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "criterion",
  "crucible-agent-client",
  "crucible-pantry-client",
@@ -5466,7 +5442,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "crossterm",
  "crucible-agent-client",
  "csv",
@@ -5507,7 +5483,7 @@ dependencies = [
  "strum",
  "subprocess",
  "tabled",
- "textwrap 0.16.1",
+ "textwrap",
  "tokio",
  "unicode-width",
  "uuid 1.8.0",
@@ -5519,7 +5495,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
- "clap 4.5.1",
+ "clap",
  "expectorate",
  "futures",
  "hex",
@@ -5586,7 +5562,7 @@ dependencies = [
  "cancel-safe-futures",
  "cfg-if",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "crucible-agent-client",
  "derive_more",
  "display-error-chain",
@@ -5732,7 +5708,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cipher",
- "clap 4.5.1",
+ "clap",
  "clap_builder",
  "console",
  "const-oid",
@@ -6112,7 +6088,7 @@ dependencies = [
  "anyhow",
  "camino",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "expectorate",
  "futures",
@@ -6156,7 +6132,7 @@ dependencies = [
  "bytes",
  "camino",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "crossterm",
  "dropshot",
  "expectorate",
@@ -6229,7 +6205,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "nexus-client",
  "omicron-common",
@@ -6251,7 +6227,7 @@ dependencies = [
  "anyhow",
  "camino",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "omicron-workspace-hack",
  "sigpipe",
  "uuid 1.8.0",
@@ -7099,7 +7075,7 @@ dependencies = [
  "anyhow",
  "atty",
  "base64 0.21.7",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "futures",
  "hyper 0.14.28",
@@ -7388,7 +7364,7 @@ dependencies = [
  "assert_matches",
  "camino",
  "camino-tempfile",
- "clap 4.5.1",
+ "clap",
  "dns-service-client",
  "dropshot",
  "expectorate",
@@ -8964,7 +8940,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "futures",
  "gateway-messages",
@@ -9144,12 +9120,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -9204,30 +9174,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
-]
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9515,15 +9461,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
@@ -9704,13 +9641,11 @@ dependencies = [
 [[package]]
 name = "tofino"
 version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/tofino?branch=main#8283f8021068f055484b653f0cc6b4d5c0979dc1"
+source = "git+http://github.com/oxidecomputer/tofino?branch=main#1b66b89c3727d2191082df057b068ec52560e334"
 dependencies = [
  "anyhow",
  "cc",
- "chrono",
  "illumos-devinfo",
- "structopt",
 ]
 
 [[package]]
@@ -10146,7 +10081,7 @@ dependencies = [
  "assert_cmd",
  "camino",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "console",
  "datatest-stable",
  "fs-err",
@@ -10422,7 +10357,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "chrono",
- "clap 4.5.1",
+ "clap",
  "debug-ignore",
  "display-error-chain",
  "dropshot",
@@ -10453,7 +10388,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "cancel-safe-futures",
- "clap 4.5.1",
+ "clap",
  "debug-ignore",
  "derive-where",
  "either",
@@ -10648,12 +10583,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -10897,7 +10826,7 @@ dependencies = [
  "buf-list",
  "camino",
  "ciborium",
- "clap 4.5.1",
+ "clap",
  "crossterm",
  "futures",
  "humantime",
@@ -10922,7 +10851,7 @@ dependencies = [
  "slog-term",
  "supports-color",
  "tempfile",
- "textwrap 0.16.1",
+ "textwrap",
  "tokio",
  "tokio-util",
  "toml 0.8.12",
@@ -10958,7 +10887,7 @@ dependencies = [
  "bytes",
  "camino",
  "ciborium",
- "clap 4.5.1",
+ "clap",
  "crossterm",
  "omicron-workspace-hack",
  "reedline",
@@ -10983,7 +10912,7 @@ dependencies = [
  "bytes",
  "camino",
  "camino-tempfile",
- "clap 4.5.1",
+ "clap",
  "debug-ignore",
  "display-error-chain",
  "dpd-client",
@@ -11309,7 +11238,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "cargo_toml",
- "clap 4.5.1",
+ "clap",
  "fs-err",
  "macaddr",
  "serde",
@@ -11457,7 +11386,7 @@ name = "zone-network-setup"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.1",
+ "clap",
  "dropshot",
  "illumos-utils",
  "omicron-common",


### PR DESCRIPTION
Pull in the newer, lighter-weight crate which avoids a clap dependency.
