### PR TITLE
Adding OxQL table operations for limiting data

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -871,7 +871,14 @@ impl Client {
         let response = self
             .client
             .post(&self.url)
-            .query(&[("output_format_json_quote_64bit_integers", "0")])
+            .query(&[
+                ("output_format_json_quote_64bit_integers", "0"),
+                // TODO-performance: This is needed to get the correct counts of
+                // rows/bytes accessed during a query, but implies larger memory
+                // consumption on the server and higher latency for the request.
+                // We may want to sacrifice accuracy of those counts.
+                ("wait_end_of_query", "1"),
+            ])
             .body(sql)
             .send()
             .await

--- a/oximeter/db/src/oxql/ast/grammar.rs
+++ b/oximeter/db/src/oxql/ast/grammar.rs
@@ -26,6 +26,8 @@ peg::parser! {
         use crate::oxql::ast::table_ops::BasicTableOp;
         use crate::oxql::ast::table_ops::TableOp;
         use crate::oxql::ast::table_ops::group_by::Reducer;
+        use crate::oxql::ast::table_ops::limit::Limit;
+        use crate::oxql::ast::table_ops::limit::LimitKind;
         use crate::oxql::ast::literal::duration_consts;
         use oximeter::TimeseriesName;
         use std::time::Duration;
@@ -531,12 +533,29 @@ peg::parser! {
             Align { method, period }
         }
 
+        /// Parse a limit kind
+        pub rule limit_kind() -> LimitKind
+            = "first" { LimitKind::First }
+            / "last" { LimitKind::Last }
+
+        /// Parse a limit table operation
+        pub rule limit() -> Limit
+            = kind:limit_kind() _ count:integer_literal_impl()
+        {?
+            if count <= 0 || count > usize::MAX as i128 {
+                return Err("limit count must be a nonzero usize")
+            };
+            let count = std::num::NonZeroUsize::new(count.try_into().unwrap()).unwrap();
+            Ok(Limit { kind, count })
+        }
+
         pub(super) rule basic_table_op() -> TableOp
             = g:"get" _ t:timeseries_name() { TableOp::Basic(BasicTableOp::Get(t)) }
             / f:filter() { TableOp::Basic(BasicTableOp::Filter(f)) }
             / g:group_by() { TableOp::Basic(BasicTableOp::GroupBy(g)) }
             / join() { TableOp::Basic(BasicTableOp::Join(Join)) }
             / a:align() { TableOp::Basic(BasicTableOp::Align(a)) }
+            / l:limit() { TableOp::Basic(BasicTableOp::Limit(l)) }
 
         pub(super) rule grouped_table_op() -> TableOp
             = "{" _? ops:(query() ++ grouped_table_op_delim()) _? "}"
@@ -649,6 +668,8 @@ mod tests {
     use crate::oxql::ast::table_ops::filter::FilterExpr;
     use crate::oxql::ast::table_ops::filter::SimpleFilter;
     use crate::oxql::ast::table_ops::group_by::Reducer;
+    use crate::oxql::ast::table_ops::limit::Limit;
+    use crate::oxql::ast::table_ops::limit::LimitKind;
     use chrono::NaiveDate;
     use chrono::NaiveDateTime;
     use chrono::NaiveTime;
@@ -1304,5 +1325,26 @@ mod tests {
             query_parser::filter_expr("(a == 0) || !(a == 0 && a == 0)")
                 .unwrap();
         assert_eq!(negated, expected, "Failed to handle multiple negations");
+    }
+
+    #[test]
+    fn test_limiting_table_ops() {
+        assert_eq!(
+            query_parser::limit("first 100").unwrap(),
+            Limit { kind: LimitKind::First, count: 100.try_into().unwrap() },
+        );
+        assert_eq!(
+            query_parser::limit("last 100").unwrap(),
+            Limit { kind: LimitKind::Last, count: 100.try_into().unwrap() },
+        );
+
+        assert!(query_parser::limit(&format!(
+            "first {}",
+            usize::MAX as i128 + 1
+        ))
+        .is_err());
+        assert!(query_parser::limit("first 0").is_err());
+        assert!(query_parser::limit("first -1").is_err());
+        assert!(query_parser::limit("first \"foo\"").is_err());
     }
 }

--- a/oximeter/db/src/oxql/ast/table_ops/limit.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/limit.rs
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! An AST node apply limiting timeseries operations.
+
+// Copyright 2024 Oxide Computer Company
+
+use crate::oxql::point::Points;
+use crate::oxql::point::ValueArray;
+use crate::oxql::point::Values;
+use crate::oxql::Error;
+use crate::oxql::Table;
+use crate::oxql::Timeseries;
+use std::num::NonZeroUsize;
+
+/// The kind of limiting operation
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LimitKind {
+    /// Limit the timeseries to the first points.
+    First,
+    /// Limit the timeseries to the last points.
+    Last,
+}
+
+/// A table operation limiting a timeseries to a number of points.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Limit {
+    /// The kind of limit
+    pub kind: LimitKind,
+    /// The number of points the timeseries is limited to.
+    pub count: NonZeroUsize,
+}
+impl Limit {
+    /// Apply the limit operation to the input tables.
+    pub(crate) fn apply(&self, tables: &[Table]) -> Result<Vec<Table>, Error> {
+        if tables.is_empty() {
+            return Ok(vec![]);
+        }
+
+        tables
+            .iter()
+            .map(|table| {
+                let timeseries = table.iter().map(|timeseries| {
+                    let input_points = &timeseries.points;
+
+                    // Compute the slice indices for this timeseries.
+                    let (start, end) = match self.kind {
+                        LimitKind::First => {
+                            // The count in the limit operation should not be
+                            // larger than the number of data points.
+                            let end = input_points.len().min(self.count.get());
+                            (0, end)
+                        }
+                        LimitKind::Last => {
+                            // When taking the last k points, we need to
+                            // subtract the count from the end of the array,
+                            // taking care that we don't panic if the count is
+                            // larger than the number of data points.
+                            let start = input_points
+                                .len()
+                                .saturating_sub(self.count.get());
+                            let end = input_points.len();
+                            (start, end)
+                        }
+                    };
+
+                    // Slice the various data arrays.
+                    let start_times = input_points
+                        .start_times
+                        .as_ref()
+                        .map(|s| s[start..end].to_vec());
+                    let timestamps =
+                        input_points.timestamps[start..end].to_vec();
+                    let values = input_points
+                        .values
+                        .iter()
+                        .map(|vals| {
+                            let values = match &vals.values {
+                                ValueArray::Integer(inner) => {
+                                    ValueArray::Integer(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                                ValueArray::Double(inner) => {
+                                    ValueArray::Double(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                                ValueArray::Boolean(inner) => {
+                                    ValueArray::Boolean(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                                ValueArray::String(inner) => {
+                                    ValueArray::String(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                                ValueArray::IntegerDistribution(inner) => {
+                                    ValueArray::IntegerDistribution(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                                ValueArray::DoubleDistribution(inner) => {
+                                    ValueArray::DoubleDistribution(
+                                        inner[start..end].to_vec(),
+                                    )
+                                }
+                            };
+                            Values { values, metric_type: vals.metric_type }
+                        })
+                        .collect();
+                    let points = Points { start_times, timestamps, values };
+                    Timeseries {
+                        fields: timeseries.fields.clone(),
+                        points,
+                        alignment: timeseries.alignment,
+                    }
+                });
+                Table::from_timeseries(table.name(), timeseries)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oxql::point::{DataType, MetricType};
+    use chrono::Utc;
+    use oximeter::FieldValue;
+    use std::{collections::BTreeMap, time::Duration};
+
+    fn test_tables() -> Vec<Table> {
+        let mut fields = BTreeMap::new();
+        fields.insert("foo".to_string(), FieldValue::from("bar"));
+        fields.insert("bar".to_string(), FieldValue::from(1u8));
+
+        let now = Utc::now();
+        let timestamps = vec![
+            now - Duration::from_secs(4),
+            now - Duration::from_secs(3),
+            now - Duration::from_secs(2),
+        ];
+
+        let mut timeseries = Timeseries::new(
+            fields.clone().into_iter(),
+            DataType::Integer,
+            MetricType::Gauge,
+        )
+        .unwrap();
+        timeseries.points.timestamps = timestamps.clone();
+        timeseries.points.values[0].values.as_integer_mut().unwrap().extend([
+            Some(1),
+            Some(2),
+            Some(3),
+        ]);
+        let table1 =
+            Table::from_timeseries("first", std::iter::once(timeseries))
+                .unwrap();
+
+        let mut timeseries = Timeseries::new(
+            fields.clone().into_iter(),
+            DataType::Integer,
+            MetricType::Gauge,
+        )
+        .unwrap();
+        timeseries.points.timestamps = timestamps.clone();
+        timeseries.points.values[0].values.as_integer_mut().unwrap().extend([
+            Some(4),
+            Some(5),
+            Some(6),
+        ]);
+        let table2 =
+            Table::from_timeseries("second", std::iter::once(timeseries))
+                .unwrap();
+
+        vec![table1, table2]
+    }
+
+    #[test]
+    fn test_first_k() {
+        test_limit_impl(LimitKind::First);
+    }
+
+    #[test]
+    fn test_last_k() {
+        test_limit_impl(LimitKind::Last);
+    }
+
+    fn test_limit_impl(kind: LimitKind) {
+        let (start, end) = match kind {
+            LimitKind::First => (0, 2),
+            LimitKind::Last => (1, 3),
+        };
+
+        // Create test data and apply limit operation.
+        let tables = test_tables();
+        let limit = Limit { kind, count: 2.try_into().unwrap() };
+        let limited = limit.apply(&tables).expect("This should be infallible");
+        assert_eq!(
+            tables.len(),
+            limited.len(),
+            "Limiting should not change the number of tables"
+        );
+
+        // Should apply to all tables the same way.
+        for (table, limited_table) in tables.iter().zip(limited.iter()) {
+            assert_eq!(
+                table.name(),
+                limited_table.name(),
+                "Limited table whould have the same name"
+            );
+
+            // Compare all timeseries.
+            for (timeseries, limited_timeseries) in
+                table.iter().zip(limited_table.iter())
+            {
+                // The fields and basic shape should not change.
+                assert_eq!(
+                    timeseries.fields, limited_timeseries.fields,
+                    "Limited table should have the same fields"
+                );
+                assert_eq!(
+                    timeseries.alignment, limited_timeseries.alignment,
+                    "Limited timeseries should have the same alignment"
+                );
+                assert_eq!(
+                    timeseries.points.dimensionality(),
+                    limited_timeseries.points.dimensionality(),
+                    "Limited timeseries should have the same number of dimensions"
+                );
+
+                // Compare data points themselves.
+                //
+                // These depend on the limit operation.
+                let points = &timeseries.points;
+                let limited_points = &limited_timeseries.points;
+                assert_eq!(points.start_times, limited_points.start_times);
+                assert_eq!(
+                    points.timestamps[start..end],
+                    limited_points.timestamps
+                );
+                assert_eq!(
+                    limited_points.values[0].values.as_integer().unwrap(),
+                    &points.values[0].values.as_integer().unwrap()[start..end],
+                    "Points should be limited to [{start}..{end}]",
+                );
+            }
+        }
+
+        // Check that limiting the table to more points than exist returns the
+        // whole table.
+        let limit = Limit { kind, count: 100.try_into().unwrap() };
+        let limited = limit.apply(&tables).expect("This should be infallible");
+        assert_eq!(
+            limited,
+            tables,
+            "Limiting tables to more than their length should return the same thing"
+        );
+    }
+}

--- a/oximeter/db/src/oxql/ast/table_ops/mod.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/mod.rs
@@ -11,11 +11,13 @@ pub mod filter;
 pub mod get;
 pub mod group_by;
 pub mod join;
+pub mod limit;
 
 use self::align::Align;
 use self::filter::Filter;
 use self::group_by::GroupBy;
 use self::join::Join;
+use self::limit::Limit;
 use crate::oxql::ast::Query;
 use crate::oxql::Error;
 use crate::oxql::Table;
@@ -31,6 +33,7 @@ pub enum BasicTableOp {
     GroupBy(GroupBy),
     Join(Join),
     Align(Align),
+    Limit(Limit),
 }
 
 impl BasicTableOp {
@@ -45,6 +48,7 @@ impl BasicTableOp {
             BasicTableOp::GroupBy(g) => g.apply(tables),
             BasicTableOp::Join(j) => j.apply(tables),
             BasicTableOp::Align(a) => a.apply(tables, query_end),
+            BasicTableOp::Limit(l) => l.apply(tables),
         }
     }
 }

--- a/oximeter/db/src/oxql/table.rs
+++ b/oximeter/db/src/oxql/table.rs
@@ -26,7 +26,7 @@ use std::hash::Hasher;
 ///
 /// This includes the typed key-value pairs that uniquely identify it, and the
 /// set of timestamps and data values from it.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 pub struct Timeseries {
     pub fields: BTreeMap<String, FieldValue>,
     pub points: Points,
@@ -140,7 +140,7 @@ impl Timeseries {
 /// A table is the result of an OxQL query. It contains a name, usually the name
 /// of the timeseries schema from which the data is derived, and any number of
 /// timeseries, which contain the actual data.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 pub struct Table {
     // The name of the table.
     //


### PR DESCRIPTION
- Resolves #5436
- Adds a `Limit` table op, for taking either the first or last `k` points from any number of timeseries.
- Add OxQL grammar rules for parsing `first k` and `last k` into the table op types.
- Add methods for coalescing the limit operations in a query, similar to coalescing predicates. This lets us push filters through limits (and vice versa), to implement predicate pushdown.
- Include limits when fetching data from ClickHouse. This uses the `LIMIT BY` clause, which makes this extremely simple to implement in the database itself. That also reveals an unfortunate interaction between our table sort ordering and the `start_time` for cumulative metrics, specifically those which are created before NTP is synced. That can lead to incorrect results when using the `LIMIT BY` clause, since that takes the first few results. That means data with an early timestamp, and early (and random) start time, can come before the desired data with a later timestamp (but also later start time). In this one case, with a `last k` table op, we pay the cost of a CTE and an additional re-sorting of the data based on timestamp.