### PR TITLE
Manually supply disks for non-gimlet systems

### DIFF
--- a/installinator/src/hardware.rs
+++ b/installinator/src/hardware.rs
@@ -25,8 +25,8 @@ impl Hardware {
             .context("failed to detect whether host is a gimlet")?;
         ensure!(is_gimlet, "hardware scan only supported on gimlets");
 
-        let hardware =
-            HardwareManager::new(log, SledMode::Auto).map_err(|err| {
+        let hardware = HardwareManager::new(log, SledMode::Auto, vec![])
+            .map_err(|err| {
                 anyhow!("failed to create HardwareManager: {err}")
             })?;
 

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -15,6 +15,7 @@ use illumos_utils::dladm::CHELSIO_LINK_PREFIX;
 use omicron_common::vlan::VlanID;
 use serde::Deserialize;
 use sled_hardware::is_gimlet;
+use sled_hardware::UnparsedDisk;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -66,6 +67,10 @@ pub struct Config {
     pub vlan: Option<VlanID>,
     /// Optional list of virtual devices to be used as "discovered disks".
     pub vdevs: Option<Vec<Utf8PathBuf>>,
+    /// Optional list of real devices to be used as "discovered disks" (for use
+    /// with non-gimlets).
+    #[serde(default)]
+    pub supplied_unparsed_disks: Option<Vec<UnparsedDisk>>,
     /// Optionally skip waiting for time synchronization
     pub skip_timesync: Option<bool>,
 

--- a/sled-agent/src/config.rs
+++ b/sled-agent/src/config.rs
@@ -67,10 +67,10 @@ pub struct Config {
     pub vlan: Option<VlanID>,
     /// Optional list of virtual devices to be used as "discovered disks".
     pub vdevs: Option<Vec<Utf8PathBuf>>,
-    /// Optional list of real devices to be used as "discovered disks" (for use
-    /// with non-gimlets).
+    /// Optional list of real devices to be injected as observed disks during
+    /// device polling.
     #[serde(default)]
-    pub supplied_unparsed_disks: Option<Vec<UnparsedDisk>>,
+    pub nongimlet_observed_disks: Option<Vec<UnparsedDisk>>,
     /// Optionally skip waiting for time synchronization
     pub skip_timesync: Option<bool>,
 

--- a/sled-agent/src/hardware_monitor.rs
+++ b/sled-agent/src/hardware_monitor.rs
@@ -258,10 +258,13 @@ impl HardwareMonitor {
         } else {
             None
         };
+
         info!(
             self.log, "Checking current full hardware snapshot";
             "underlay_network_info" => ?underlay_network,
+            "disks" => ?self.hardware_manager.disks(),
         );
+
         if self.hardware_manager.is_scrimlet_driver_loaded() {
             self.activate_switch().await;
         } else {

--- a/sled-agent/src/long_running_tasks.rs
+++ b/sled-agent/src/long_running_tasks.rs
@@ -73,11 +73,11 @@ pub async fn spawn_all_longrunning_tasks(
 
     spawn_storage_monitor(log, storage_manager.clone());
 
-    let supplied_unparsed_disks =
-        config.supplied_unparsed_disks.clone().unwrap_or(vec![]);
+    let nongimlet_observed_disks =
+        config.nongimlet_observed_disks.clone().unwrap_or(vec![]);
 
     let hardware_manager =
-        spawn_hardware_manager(log, sled_mode, supplied_unparsed_disks).await;
+        spawn_hardware_manager(log, sled_mode, nongimlet_observed_disks).await;
 
     // Start monitoring for hardware changes
     let (sled_agent_started_tx, service_manager_ready_tx) =
@@ -149,7 +149,7 @@ fn spawn_storage_monitor(log: &Logger, storage_handle: StorageHandle) {
 async fn spawn_hardware_manager(
     log: &Logger,
     sled_mode: SledMode,
-    supplied_unparsed_disks: Vec<UnparsedDisk>,
+    nongimlet_observed_disks: Vec<UnparsedDisk>,
 ) -> HardwareManager {
     // The `HardwareManager` does not use the the "task/handle" pattern
     // and spawns its worker task inside `HardwareManager::new`. Instead of returning
@@ -159,10 +159,10 @@ async fn spawn_hardware_manager(
     //
     // There are pros and cons to both methods, but the reason to mention it here is that
     // the handle in this case is the `HardwareManager` itself.
-    info!(log, "Starting HardwareManager"; "sled_mode" => ?sled_mode, "supplied_unparsed_disks" => ?supplied_unparsed_disks);
+    info!(log, "Starting HardwareManager"; "sled_mode" => ?sled_mode, "nongimlet_observed_disks" => ?nongimlet_observed_disks);
     let log = log.clone();
     tokio::task::spawn_blocking(move || {
-        HardwareManager::new(&log, sled_mode, supplied_unparsed_disks).unwrap()
+        HardwareManager::new(&log, sled_mode, nongimlet_observed_disks).unwrap()
     })
     .await
     .unwrap()

--- a/sled-agent/src/long_running_tasks.rs
+++ b/sled-agent/src/long_running_tasks.rs
@@ -26,7 +26,6 @@ use bootstore::schemes::v0 as bootstore;
 use key_manager::{KeyManager, StorageKeyRequester};
 use sled_hardware::{HardwareManager, SledMode, UnparsedDisk};
 use sled_storage::config::MountConfig;
-use sled_storage::disk::RawDisk;
 use sled_storage::disk::RawSyntheticDisk;
 use sled_storage::manager::{StorageHandle, StorageManager};
 use slog::{info, Logger};
@@ -86,9 +85,6 @@ pub async fn spawn_all_longrunning_tasks(
 
     // Add some synthetic disks if necessary.
     upsert_synthetic_disks_if_needed(&log, &storage_manager, &config).await;
-
-    // Add user supplied unparsed disks if necessary.
-    upsert_unparsed_disks_if_needed(&log, &storage_manager, &config).await;
 
     // Wait for the boot disk so that we can work with any ledgers,
     // such as those needed by the bootstore and sled-agent
@@ -242,30 +238,6 @@ async fn upsert_synthetic_disks_if_needed(
                 .expect("Failed to parse synthetic disk")
                 .into();
             storage_manager.detected_raw_disk(disk).await.await.unwrap();
-        }
-    }
-}
-
-async fn upsert_unparsed_disks_if_needed(
-    log: &Logger,
-    storage_manager: &StorageHandle,
-    config: &Config,
-) {
-    if let Some(supplied_unparsed_disks) = &config.supplied_unparsed_disks {
-        for supplied_unparsed_disk in supplied_unparsed_disks {
-            info!(
-                log,
-                "Upserting supplied unparsed disk to Storage Manager";
-                "supplied_unparsed_disk" => format!("{supplied_unparsed_disk:?}"),
-            );
-
-            storage_manager
-                .detected_raw_disk(RawDisk::Real(
-                    supplied_unparsed_disk.clone(),
-                ))
-                .await
-                .await
-                .unwrap();
         }
     }
 }

--- a/sled-agent/src/long_running_tasks.rs
+++ b/sled-agent/src/long_running_tasks.rs
@@ -74,11 +74,8 @@ pub async fn spawn_all_longrunning_tasks(
 
     spawn_storage_monitor(log, storage_manager.clone());
 
-    let supplied_unparsed_disks = config
-        .supplied_unparsed_disks
-        .as_ref()
-        .map(|x| x.clone())
-        .unwrap_or(vec![]);
+    let supplied_unparsed_disks =
+        config.supplied_unparsed_disks.clone().unwrap_or(vec![]);
 
     let hardware_manager =
         spawn_hardware_manager(log, sled_mode, supplied_unparsed_disks).await;

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -66,7 +66,9 @@ pub enum Partition {
     ZfsPool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Deserialize, Serialize,
+)]
 pub struct DiskPaths {
     // Full path to the disk under "/devices".
     // Should NOT end with a ":partition_letter".
@@ -137,7 +139,9 @@ impl DiskPaths {
 /// This exists as a distinct entity from `Disk` in `sled-storage` because it
 /// may be desirable to monitor for hardware in one context, and conform disks
 /// to partition layouts in a different context.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Deserialize, Serialize,
+)]
 pub struct UnparsedDisk {
     paths: DiskPaths,
     slot: i64,

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -509,6 +509,7 @@ fn poll_blkdev_node(
 fn poll_device_tree(
     log: &Logger,
     inner: &Arc<Mutex<HardwareView>>,
+    supplied_unparsed_disks: &[UnparsedDisk],
     tx: &broadcast::Sender<HardwareUpdate>,
 ) -> Result<(), Error> {
     // Construct a view of hardware by walking the device tree.
@@ -517,28 +518,36 @@ fn poll_device_tree(
 
         Err(e) => {
             if let Error::NotAGimlet(root_node) = &e {
+                let mut inner = inner.lock().unwrap();
+
                 if root_node.as_str() == "i86pc" {
                     // If on i86pc, generate some baseboard information before
                     // returning this error. Each sled agent has to be uniquely
                     // identified for multiple non-gimlets to work.
-                    {
-                        let mut inner = inner.lock().unwrap();
+                    if inner.baseboard.is_none() {
+                        let pc_baseboard = Baseboard::new_pc(
+                            gethostname().into_string().unwrap_or_else(|_| {
+                                Uuid::new_v4().simple().to_string()
+                            }),
+                            root_node.clone(),
+                        );
 
-                        if inner.baseboard.is_none() {
-                            let pc_baseboard = Baseboard::new_pc(
-                                gethostname().into_string().unwrap_or_else(
-                                    |_| Uuid::new_v4().simple().to_string(),
-                                ),
-                                root_node.clone(),
-                            );
+                        info!(
+                            log,
+                            "Generated i86pc baseboard {:?}", pc_baseboard
+                        );
 
-                            info!(
-                                log,
-                                "Generated i86pc baseboard {:?}", pc_baseboard
-                            );
+                        inner.baseboard = Some(pc_baseboard);
+                    }
+                }
 
-                            inner.baseboard = Some(pc_baseboard);
-                        }
+                // For platforms that don't support the HardwareSnapshot
+                // functionality, sled-agent can be supplied a fixed list of
+                // UnparsedDisks. Add those to the HardwareSnapshot here if they
+                // are missing (which they will be for non-gimlets).
+                for unparsed_disk in supplied_unparsed_disks {
+                    if !inner.disks.contains(unparsed_disk) {
+                        inner.disks.insert(unparsed_disk.clone());
                     }
                 }
             }
@@ -572,10 +581,11 @@ fn poll_device_tree(
 async fn hardware_tracking_task(
     log: Logger,
     inner: Arc<Mutex<HardwareView>>,
+    supplied_unparsed_disks: Vec<UnparsedDisk>,
     tx: broadcast::Sender<HardwareUpdate>,
 ) {
     loop {
-        match poll_device_tree(&log, &inner, &tx) {
+        match poll_device_tree(&log, &inner, &supplied_unparsed_disks, &tx) {
             // We've already warned about `NotAGimlet` by this point,
             // so let's not spam the logs.
             Ok(_) | Err(Error::NotAGimlet(_)) => (),
@@ -604,7 +614,11 @@ impl HardwareManager {
     ///
     /// Arguments:
     /// - `sled_mode`: The sled's mode of operation (auto detect or force gimlet/scrimlet).
-    pub fn new(log: &Logger, sled_mode: SledMode) -> Result<Self, String> {
+    pub fn new(
+        log: &Logger,
+        sled_mode: SledMode,
+        supplied_unparsed_disks: Vec<UnparsedDisk>,
+    ) -> Result<Self, String> {
         let log = log.new(o!("component" => "HardwareManager"));
         info!(log, "Creating HardwareManager");
 
@@ -650,7 +664,7 @@ impl HardwareManager {
         // This mitigates issues where the Sled Agent could try to propagate
         // an "empty" view of hardware to other consumers before the first
         // query.
-        match poll_device_tree(&log, &inner, &tx) {
+        match poll_device_tree(&log, &inner, &supplied_unparsed_disks, &tx) {
             Ok(_) => (),
             // Allow non-gimlet devices to proceed with a "null" view of
             // hardware, otherwise they won't be able to start.
@@ -666,7 +680,8 @@ impl HardwareManager {
         let inner2 = inner.clone();
         let tx2 = tx.clone();
         tokio::task::spawn(async move {
-            hardware_tracking_task(log2, inner2, tx2).await
+            hardware_tracking_task(log2, inner2, supplied_unparsed_disks, tx2)
+                .await
         });
 
         Ok(Self { log, inner, tx })

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -33,7 +33,7 @@ impl HardwareManager {
     pub fn new(
         _log: &Logger,
         _sled_mode: SledMode,
-        _supplied_unparsed_disks: Vec<UnparsedDisk>,
+        _nongimlet_observed_disks: Vec<UnparsedDisk>,
     ) -> Result<Self, String> {
         unimplemented!("Accessing hardware unsupported on non-illumos");
     }

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -30,7 +30,11 @@ pub enum NvmeFormattingError {
 pub struct HardwareManager {}
 
 impl HardwareManager {
-    pub fn new(_log: &Logger, _sled_mode: SledMode) -> Result<Self, String> {
+    pub fn new(
+        _log: &Logger,
+        _sled_mode: SledMode,
+        _supplied_unparsed_disks: Vec<UnparsedDisk>,
+    ) -> Result<Self, String> {
         unimplemented!("Accessing hardware unsupported on non-illumos");
     }
 

--- a/sled-storage/src/resources.rs
+++ b/sled-storage/src/resources.rs
@@ -531,8 +531,10 @@ impl StorageResources {
     pub(crate) fn remove_disk(&mut self, id: &DiskIdentity) {
         info!(self.log, "Removing disk"; "identity" => ?id);
         let Some(entry) = self.disks.values.get(id) else {
+            info!(self.log, "Disk not found by id, exiting"; "identity" => ?id);
             return;
         };
+
         let synthetic = match entry {
             ManagedDisk::ExplicitlyManaged(disk)
             | ManagedDisk::ImplicitlyManaged(disk) => disk.is_synthetic(),
@@ -548,6 +550,7 @@ impl StorageResources {
                 // In production, we disallow removal of synthetic disks as they
                 // are only added once.
                 if synthetic {
+                    info!(self.log, "Not removing synthetic disk"; "identity" => ?id);
                     return;
                 }
             }


### PR DESCRIPTION
A sled-agent running on a non-gimlet will bail out of `HardwareSnapshot::new`, not returning any disks for use. Previously a hard coded `zpools` field in the sled's config.toml could supply pools to use, but that was recently removed.

Add an option into the sled's config.toml to fill in "discovered" disks for the sled agent to use:

```toml
[[supplied_unparsed_disks]]
slot = 0
variant = "U2"
is_boot_disk = false

[supplied_unparsed_disks.paths]
devfs_path = "/devices/pci@0,0/pci1022,1483@1,1/pci15b7,5011@0/blkdev@w001B448B456F8DB8,0"

[supplied_unparsed_disks.identity]
vendor = "Synthetic"
serial = "214664801348"
model = "WDS100T1XHE-00AFY0"
```

These should be indistinguishable from what would be returned in the `HardwareSnapshot`, and should exercise the same related code that a regular gimlet would execute (with respect to partitioning, creating zpools, etc).