### PR TITLE
Use TypedUuid for Zpools in Sled Agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "macaddr",
  "mockall",
  "omicron-common",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "opte-ioctl",
  "oxide-vpc",
@@ -4857,6 +4858,7 @@ dependencies = [
  "omicron-passwords",
  "omicron-sled-agent",
  "omicron-test-utils",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oximeter",
  "oximeter-collector",
@@ -5630,6 +5632,7 @@ dependencies = [
  "omicron-common",
  "omicron-ddm-admin-client",
  "omicron-test-utils",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "once_cell",
  "openapi-lint",
@@ -5720,6 +5723,7 @@ name = "omicron-uuid-kinds"
 version = "0.1.0"
 dependencies = [
  "newtype-uuid",
+ "paste",
  "schemars",
 ]
 
@@ -8642,6 +8646,7 @@ dependencies = [
  "chrono",
  "ipnetwork",
  "omicron-common",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "progenitor",
  "regress",
@@ -8669,6 +8674,7 @@ dependencies = [
  "macaddr",
  "omicron-common",
  "omicron-test-utils",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "rand 0.8.5",
  "schemars",
@@ -8712,6 +8718,7 @@ dependencies = [
  "key-manager",
  "omicron-common",
  "omicron-test-utils",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "rand 0.8.5",
  "schemars",

--- a/clients/sled-agent-client/Cargo.toml
+++ b/clients/sled-agent-client/Cargo.toml
@@ -18,3 +18,4 @@ serde.workspace = true
 slog.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
+omicron-uuid-kinds.workspace = true

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -47,6 +47,7 @@ progenitor::generate_api!(
         SourceNatConfig = omicron_common::api::internal::shared::SourceNatConfig,
         Vni = omicron_common::api::external::Vni,
         NetworkInterface = omicron_common::api::internal::shared::NetworkInterface,
+        TypedUuidForZpoolKind = omicron_uuid_kinds::ZpoolUuid,
     }
 );
 

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -19,6 +19,7 @@ ipnetwork.workspace = true
 libc.workspace = true
 macaddr.workspace = true
 omicron-common.workspace = true
+omicron-uuid-kinds.workspace = true
 oxide-vpc.workspace = true
 oxlog.workspace = true
 schemars.workspace = true

--- a/illumos-utils/src/zpool.rs
+++ b/illumos-utils/src/zpool.rs
@@ -6,11 +6,11 @@
 
 use crate::{execute, ExecutionError, PFEXEC};
 use camino::{Utf8Path, Utf8PathBuf};
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
-use uuid::Uuid;
 
 pub const ZPOOL_EXTERNAL_PREFIX: &str = "oxp_";
 pub const ZPOOL_INTERNAL_PREFIX: &str = "oxi_";
@@ -319,7 +319,7 @@ pub enum ZpoolKind {
 /// when reading the structure, and validate that the UUID can be utilized.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ZpoolName {
-    id: Uuid,
+    id: ZpoolUuid,
     kind: ZpoolKind,
 }
 
@@ -357,15 +357,15 @@ impl JsonSchema for ZpoolName {
 }
 
 impl ZpoolName {
-    pub fn new_internal(id: Uuid) -> Self {
+    pub fn new_internal(id: ZpoolUuid) -> Self {
         Self { id, kind: ZpoolKind::Internal }
     }
 
-    pub fn new_external(id: Uuid) -> Self {
+    pub fn new_external(id: ZpoolUuid) -> Self {
         Self { id, kind: ZpoolKind::External }
     }
 
-    pub fn id(&self) -> Uuid {
+    pub fn id(&self) -> ZpoolUuid {
         self.id
     }
 
@@ -418,10 +418,10 @@ impl FromStr for ZpoolName {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(s) = s.strip_prefix(ZPOOL_EXTERNAL_PREFIX) {
-            let id = Uuid::from_str(s).map_err(|e| e.to_string())?;
+            let id = ZpoolUuid::from_str(s).map_err(|e| e.to_string())?;
             Ok(ZpoolName::new_external(id))
         } else if let Some(s) = s.strip_prefix(ZPOOL_INTERNAL_PREFIX) {
-            let id = Uuid::from_str(s).map_err(|e| e.to_string())?;
+            let id = ZpoolUuid::from_str(s).map_err(|e| e.to_string())?;
             Ok(ZpoolName::new_internal(id))
         } else {
             Err(format!(
@@ -525,7 +525,7 @@ mod test {
 
     #[test]
     fn test_parse_external_zpool_name() {
-        let uuid: Uuid =
+        let uuid: ZpoolUuid =
             "d462a7f7-b628-40fe-80ff-4e4189e2d62b".parse().unwrap();
         let good_name = format!("{}{}", ZPOOL_EXTERNAL_PREFIX, uuid);
 
@@ -536,7 +536,7 @@ mod test {
 
     #[test]
     fn test_parse_internal_zpool_name() {
-        let uuid: Uuid =
+        let uuid: ZpoolUuid =
             "d462a7f7-b628-40fe-80ff-4e4189e2d62b".parse().unwrap();
         let good_name = format!("{}{}", ZPOOL_INTERNAL_PREFIX, uuid);
 

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -31,6 +31,8 @@ use nexus_types::inventory::{
     BaseboardId, Caboose, Collection, PowerState, RotPage, RotSlot,
 };
 use omicron_common::api::internal::shared::NetworkInterface;
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::ZpoolUuid;
 use uuid::Uuid;
 
 // See [`nexus_types::inventory::PowerState`].
@@ -720,7 +722,7 @@ impl InvZpool {
         Self {
             inv_collection_id,
             time_collected: zpool.time_collected,
-            id: zpool.id,
+            id: zpool.id.into_untyped_uuid(),
             sled_id,
             total_size: zpool.total_size.into(),
         }
@@ -731,7 +733,7 @@ impl From<InvZpool> for nexus_types::inventory::Zpool {
     fn from(pool: InvZpool) -> Self {
         Self {
             time_collected: pool.time_collected,
-            id: pool.id,
+            id: ZpoolUuid::from_untyped_uuid(pool.id),
             total_size: *pool.total_size,
         }
     }

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -1093,6 +1093,7 @@ mod tests {
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::TypedUuid;
+    use omicron_uuid_kinds::ZpoolUuid;
     use pretty_assertions::assert_eq;
     use rand::thread_rng;
     use rand::Rng;
@@ -1144,7 +1145,8 @@ mod tests {
         use illumos_utils::zpool::ZpoolName;
         let zpools = (0..4)
             .map(|_| {
-                let name = ZpoolName::new_external(Uuid::new_v4()).to_string();
+                let name =
+                    ZpoolName::new_external(ZpoolUuid::new_v4()).to_string();
                 name.parse().unwrap()
             })
             .collect();

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -34,6 +34,7 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupType;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::ZpoolUuid;
 use slog::error;
 use slog::Logger;
 use std::collections::BTreeMap;
@@ -77,8 +78,9 @@ impl PlanningInputFromDb<'_> {
                 // It's unfortunate that Nexus knows how Sled Agent
                 // constructs zpool names, but there's not currently an
                 // alternative.
+                let id = ZpoolUuid::from_untyped_uuid(z.id());
                 let zpool_name_generated =
-                    illumos_utils::zpool::ZpoolName::new_external(z.id())
+                    illumos_utils::zpool::ZpoolName::new_external(id)
                         .to_string();
                 let zpool_name = ZpoolName::from_str(&zpool_name_generated)
                     .map_err(|e| {

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -30,6 +30,7 @@ omicron-common.workspace = true
 omicron-passwords.workspace = true
 omicron-sled-agent.workspace = true
 omicron-test-utils.workspace = true
+omicron-uuid-kinds.workspace = true
 oximeter.workspace = true
 oximeter-collector.workspace = true
 oximeter-producer.workspace = true

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -55,6 +55,8 @@ use omicron_common::api::internal::shared::NetworkInterfaceKind;
 use omicron_common::api::internal::shared::SwitchLocation;
 use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::ZpoolUuid;
 use oximeter_collector::Oximeter;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
@@ -246,14 +248,14 @@ impl RackInitRequestBuilder {
     // - The internal DNS configuration for this service
     fn add_dataset(
         &mut self,
-        zpool_id: Uuid,
+        zpool_id: ZpoolUuid,
         dataset_id: Uuid,
         address: SocketAddrV6,
         kind: DatasetKind,
         service_name: internal_dns::ServiceName,
     ) {
         self.datasets.push(DatasetCreateRequest {
-            zpool_id,
+            zpool_id: zpool_id.into_untyped_uuid(),
             dataset_id,
             request: DatasetPutRequest { address, kind },
         });
@@ -418,7 +420,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             .parse::<std::net::SocketAddrV6>()
             .expect("Failed to parse port");
 
-        let zpool_id = Uuid::new_v4();
+        let zpool_id = ZpoolUuid::new_v4();
         let dataset_id = Uuid::new_v4();
         eprintln!("DB address: {}", address);
         self.rack_init_builder.add_dataset(
@@ -455,7 +457,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         .unwrap();
         let port = clickhouse.port();
 
-        let zpool_id = Uuid::new_v4();
+        let zpool_id = ZpoolUuid::new_v4();
         let dataset_id = Uuid::new_v4();
         let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
         self.rack_init_builder.add_dataset(
@@ -1041,7 +1043,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             sled_id,
         );
 
-        let zpool_id = Uuid::new_v4();
+        let zpool_id = ZpoolUuid::new_v4();
         let pool_name = illumos_utils::zpool::ZpoolName::new_external(zpool_id)
             .to_string()
             .parse()
@@ -1088,7 +1090,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             sled_id,
         );
 
-        let zpool_id = Uuid::new_v4();
+        let zpool_id = ZpoolUuid::new_v4();
         let pool_name = illumos_utils::zpool::ZpoolName::new_external(zpool_id)
             .to_string()
             .parse()

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -40,6 +40,8 @@ use omicron_common::disk::DiskIdentity;
 use omicron_sled_agent::sim::SledAgent;
 use omicron_test_utils::dev::poll::wait_for_condition;
 use omicron_test_utils::dev::poll::CondCheckError;
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::ZpoolUuid;
 use slog::debug;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -696,7 +698,7 @@ pub struct TestDataset {
 }
 
 pub struct TestZpool {
-    pub id: Uuid,
+    pub id: ZpoolUuid,
     pub size: ByteCount,
     pub datasets: Vec<TestDataset>,
 }
@@ -741,7 +743,7 @@ impl DiskTest {
         self.add_zpool_with_dataset_ext(
             cptestctx,
             Uuid::new_v4(),
-            Uuid::new_v4(),
+            ZpoolUuid::new_v4(),
             Uuid::new_v4(),
             Self::DEFAULT_ZPOOL_SIZE_GIB,
         )
@@ -752,7 +754,7 @@ impl DiskTest {
         &mut self,
         cptestctx: &ControlPlaneTestContext<N>,
         physical_disk_id: Uuid,
-        zpool_id: Uuid,
+        zpool_id: ZpoolUuid,
         dataset_id: Uuid,
         gibibytes: u32,
     ) {
@@ -783,7 +785,7 @@ impl DiskTest {
 
         let zpool_request =
             nexus_types::internal_api::params::ZpoolPutRequest {
-                id: zpool.id,
+                id: zpool.id.into_untyped_uuid(),
                 physical_disk_id,
                 sled_id: self.sled_agent.id,
             };
@@ -865,7 +867,7 @@ impl DiskTest {
                             .flat_map(|sled_agent| {
                                 sled_agent.zpools.iter().map(|z| z.id)
                             })
-                            .collect::<std::collections::HashSet<Uuid>>();
+                            .collect::<std::collections::HashSet<ZpoolUuid>>();
 
                         if all_zpools.contains(&zpool.id) {
                             Ok(())

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -20,6 +20,7 @@ use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::http_testing::TestResponse;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
+use omicron_uuid_kinds::ZpoolUuid;
 use once_cell::sync::Lazy;
 
 type ControlPlaneTestContext =
@@ -59,7 +60,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
         .add_zpool_with_dataset_ext(
             cptestctx,
             nexus_test_utils::PHYSICAL_DISK_UUID.parse().unwrap(),
-            uuid::Uuid::new_v4(),
+            ZpoolUuid::new_v4(),
             uuid::Uuid::new_v4(),
             DiskTest::DEFAULT_ZPOOL_SIZE_GIB,
         )

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -21,6 +21,7 @@ use omicron_common::api::external::ByteCount;
 pub use omicron_common::api::internal::shared::NetworkInterface;
 pub use omicron_common::api::internal::shared::NetworkInterfaceKind;
 pub use omicron_common::api::internal::shared::SourceNatConfig;
+use omicron_uuid_kinds::ZpoolUuid;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 pub use sled_agent_client::types::OmicronZoneConfig;
@@ -371,7 +372,7 @@ impl From<sled_agent_client::types::InventoryDisk> for PhysicalDisk {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Zpool {
     pub time_collected: DateTime<Utc>,
-    pub id: Uuid,
+    pub id: ZpoolUuid,
     pub total_size: ByteCount,
 }
 

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3654,12 +3654,10 @@
                 "type": "object",
                 "properties": {
                   "expected": {
-                    "type": "string",
-                    "format": "uuid"
+                    "$ref": "#/components/schemas/TypedUuidForZpoolKind"
                   },
                   "observed": {
-                    "type": "string",
-                    "format": "uuid"
+                    "$ref": "#/components/schemas/TypedUuidForZpoolKind"
                   }
                 },
                 "required": [
@@ -5533,8 +5531,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "format": "uuid"
+            "$ref": "#/components/schemas/TypedUuidForZpoolKind"
           },
           "total_size": {
             "$ref": "#/components/schemas/ByteCount"
@@ -6003,8 +6000,7 @@
             "$ref": "#/components/schemas/DiskIdentity"
           },
           "pool_id": {
-            "type": "string",
-            "format": "uuid"
+            "$ref": "#/components/schemas/TypedUuidForZpoolKind"
           }
         },
         "required": [
@@ -7055,6 +7051,10 @@
           "sync"
         ]
       },
+      "TypedUuidForZpoolKind": {
+        "type": "string",
+        "format": "uuid"
+      },
       "UpdateArtifactId": {
         "description": "An identifier for a single update artifact.",
         "type": "object",
@@ -7470,8 +7470,7 @@
             "$ref": "#/components/schemas/DiskType"
           },
           "id": {
-            "type": "string",
-            "format": "uuid"
+            "$ref": "#/components/schemas/TypedUuidForZpoolKind"
           }
         },
         "required": [

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -48,6 +48,7 @@ nexus-config.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true
 omicron-ddm-admin-client.workspace = true
+omicron-uuid-kinds.workspace = true
 once_cell.workspace = true
 oximeter.workspace = true
 oximeter-instruments.workspace = true

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -19,6 +19,7 @@ use omicron_common::api::internal::nexus::{
 use omicron_common::api::internal::shared::{
     NetworkInterface, SourceNatConfig,
 };
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 pub use sled_hardware::DendriteAsic;
@@ -251,7 +252,7 @@ impl From<sled_hardware::DiskVariant> for DiskType {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct Zpool {
-    pub id: Uuid,
+    pub id: ZpoolUuid,
     pub disk_type: DiskType,
 }
 
@@ -896,7 +897,7 @@ pub struct InventoryDisk {
 /// Identifies information about zpools managed by the control plane
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct InventoryZpool {
-    pub id: Uuid,
+    pub id: ZpoolUuid,
     pub total_size: ByteCount,
 }
 

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -29,6 +29,7 @@ use omicron_common::backoff::{
     retry_notify_ext, retry_policy_internal_service_aggressive, BackoffError,
 };
 use omicron_common::ledger::{self, Ledger, Ledgerable};
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_agent_client::{
@@ -353,7 +354,7 @@ impl Plan {
                 .map(|disk| OmicronPhysicalDiskConfig {
                     identity: disk.identity.clone(),
                     id: Uuid::new_v4(),
-                    pool_id: Uuid::new_v4(),
+                    pool_id: ZpoolUuid::new_v4(),
                 })
                 .collect();
             sled_info.request.disks = OmicronPhysicalDisksConfig {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -103,6 +103,7 @@ use omicron_common::backoff::{
 };
 use omicron_common::ledger::{self, Ledger, Ledgerable};
 use omicron_ddm_admin_client::{Client as DdmAdminClient, DdmError};
+use omicron_uuid_kinds::GenericUuid;
 use serde::{Deserialize, Serialize};
 use sled_agent_client::{
     types as SledAgentTypes, Client as SledAgentClient, Error as SledAgentError,
@@ -726,7 +727,7 @@ impl ServiceInner {
                     zone.dataset_name_and_address()
                 {
                     datasets.push(NexusTypes::DatasetCreateRequest {
-                        zpool_id: dataset_name.pool().id(),
+                        zpool_id: dataset_name.pool().id().into_untyped_uuid(),
                         dataset_id: zone.id,
                         request: NexusTypes::DatasetPutRequest {
                             address: dataset_address.to_string(),
@@ -840,7 +841,7 @@ impl ServiceInner {
                 let sled_id = id_map.get(addr).expect("Missing sled");
                 config.disks.disks.iter().map(|config| {
                     NexusTypes::ZpoolPutRequest {
-                        id: config.pool_id,
+                        id: config.pool_id.into_untyped_uuid(),
                         physical_disk_id: config.id,
                         sled_id: *sled_id,
                     }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -36,6 +36,7 @@ use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, VmmRuntimeState,
 };
 use omicron_common::disk::DiskIdentity;
+use omicron_uuid_kinds::ZpoolUuid;
 use propolis_client::{
     types::VolumeConstructionRequest, Client as PropolisClient,
 };
@@ -547,7 +548,7 @@ impl SledAgent {
 
     pub async fn get_datasets(
         &self,
-        zpool_id: Uuid,
+        zpool_id: ZpoolUuid,
     ) -> Vec<(Uuid, SocketAddr)> {
         self.storage.lock().await.get_all_datasets(zpool_id)
     }
@@ -555,7 +556,7 @@ impl SledAgent {
     /// Adds a Zpool to the simulated sled agent.
     pub async fn create_zpool(
         &self,
-        id: Uuid,
+        id: ZpoolUuid,
         physical_disk_id: Uuid,
         size: u64,
     ) {
@@ -569,7 +570,7 @@ impl SledAgent {
     /// Adds a Crucible Dataset within a zpool.
     pub async fn create_crucible_dataset(
         &self,
-        zpool_id: Uuid,
+        zpool_id: ZpoolUuid,
         dataset_id: Uuid,
     ) -> SocketAddr {
         self.storage.lock().await.insert_dataset(zpool_id, dataset_id).await
@@ -578,7 +579,7 @@ impl SledAgent {
     /// Returns a crucible dataset within a particular zpool.
     pub async fn get_crucible_dataset(
         &self,
-        zpool_id: Uuid,
+        zpool_id: ZpoolUuid,
         dataset_id: Uuid,
     ) -> Arc<CrucibleData> {
         self.storage.lock().await.get_dataset(zpool_id, dataset_id).await

--- a/sled-hardware/Cargo.toml
+++ b/sled-hardware/Cargo.toml
@@ -15,6 +15,7 @@ illumos-utils.workspace = true
 libc.workspace = true
 macaddr.workspace = true
 omicron-common.workspace = true
+omicron-uuid-kinds.workspace = true
 rand.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -8,11 +8,11 @@ use illumos_utils::zpool::Zpool;
 use illumos_utils::zpool::ZpoolKind;
 use illumos_utils::zpool::ZpoolName;
 use omicron_common::disk::DiskIdentity;
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Logger;
 use slog::{info, warn};
-use uuid::Uuid;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "illumos")] {
@@ -35,7 +35,7 @@ pub enum PooledDiskError {
     #[error("Zpool UUID required to format this disk")]
     MissingZpoolUuid,
     #[error("Observed Zpool with unexpected UUID (saw: {observed}, expected: {expected})")]
-    UnexpectedUuid { expected: Uuid, observed: Uuid },
+    UnexpectedUuid { expected: ZpoolUuid, observed: ZpoolUuid },
     #[error("Unexpected disk variant")]
     UnexpectedVariant,
     #[error("Zpool does not exist")]
@@ -216,7 +216,7 @@ impl PooledDisk {
     pub fn new(
         log: &Logger,
         unparsed_disk: UnparsedDisk,
-        zpool_id: Option<Uuid>,
+        zpool_id: Option<ZpoolUuid>,
     ) -> Result<Self, PooledDiskError> {
         let paths = &unparsed_disk.paths;
         let variant = unparsed_disk.variant;
@@ -269,7 +269,7 @@ pub fn ensure_zpool_exists(
     log: &Logger,
     variant: DiskVariant,
     zpool_path: &Utf8Path,
-    zpool_id: Option<Uuid>,
+    zpool_id: Option<ZpoolUuid>,
 ) -> Result<ZpoolName, PooledDiskError> {
     let zpool_name = match Fstyp::get_zpool(&zpool_path) {
         Ok(zpool_name) => {
@@ -308,7 +308,7 @@ pub fn ensure_zpool_exists(
                     id
                 }
                 None => {
-                    let id = Uuid::new_v4();
+                    let id = ZpoolUuid::new_v4();
                     info!(log, "Formatting zpool with generated ID"; "id" => ?id);
                     id
                 }

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -12,9 +12,9 @@ use crate::{DiskPaths, DiskVariant, Partition, PooledDiskError};
 use camino::Utf8Path;
 use illumos_utils::zpool::ZpoolName;
 use omicron_common::disk::DiskIdentity;
+use omicron_uuid_kinds::ZpoolUuid;
 use slog::info;
 use slog::Logger;
-use uuid::Uuid;
 
 #[cfg(test)]
 use illumos_utils::zpool::MockZpool as Zpool;
@@ -148,7 +148,7 @@ pub fn ensure_partition_layout(
     paths: &DiskPaths,
     variant: DiskVariant,
     identity: &DiskIdentity,
-    zpool_id: Option<Uuid>,
+    zpool_id: Option<ZpoolUuid>,
 ) -> Result<Vec<Partition>, PooledDiskError> {
     internal_ensure_partition_layout::<libefi_illumos::Gpt>(
         log, paths, variant, identity, zpool_id,
@@ -162,7 +162,7 @@ fn internal_ensure_partition_layout<GPT: gpt::LibEfiGpt>(
     paths: &DiskPaths,
     variant: DiskVariant,
     identity: &DiskIdentity,
-    zpool_id: Option<Uuid>,
+    zpool_id: Option<ZpoolUuid>,
 ) -> Result<Vec<Partition>, PooledDiskError> {
     // Open the "Whole Disk" as a raw device to be parsed by the
     // libefi-illumos library. This lets us peek at the GPT before
@@ -431,7 +431,7 @@ mod test {
             },
             DiskVariant::U2,
             &mock_disk_identity(),
-            Some(Uuid::new_v4()),
+            Some(ZpoolUuid::new_v4()),
         )
         .expect("Should have succeeded partitioning disk");
 

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -7,6 +7,7 @@ use crate::disk::{
 };
 use crate::SledMode;
 use omicron_common::disk::DiskIdentity;
+use omicron_uuid_kinds::ZpoolUuid;
 use sled_hardware_types::Baseboard;
 use slog::Logger;
 use std::collections::HashSet;
@@ -68,7 +69,7 @@ pub fn ensure_partition_layout(
     _paths: &DiskPaths,
     _variant: DiskVariant,
     _identity: &DiskIdentity,
-    _zpool_id: Option<uuid::Uuid>,
+    _zpool_id: Option<ZpoolUuid>,
 ) -> Result<Vec<Partition>, PooledDiskError> {
     unimplemented!("Accessing hardware unsupported on non-illumos");
 }

--- a/sled-storage/Cargo.toml
+++ b/sled-storage/Cargo.toml
@@ -16,6 +16,7 @@ futures.workspace = true
 illumos-utils.workspace = true
 key-manager.workspace = true
 omicron-common.workspace = true
+omicron-uuid-kinds.workspace = true
 rand.workspace = true
 schemars = { workspace = true, features = [ "chrono", "uuid1" ] }
 serde.workspace = true

--- a/sled-storage/src/dataset.rs
+++ b/sled-storage/src/dataset.rs
@@ -794,11 +794,11 @@ async fn finalize_encryption_migration(
 #[cfg(test)]
 mod test {
     use super::*;
-    use uuid::Uuid;
+    use omicron_uuid_kinds::ZpoolUuid;
 
     #[test]
     fn serialize_dataset_name() {
-        let pool = ZpoolName::new_internal(Uuid::new_v4());
+        let pool = ZpoolName::new_internal(ZpoolUuid::new_v4());
         let kind = DatasetKind::Crucible;
         let name = DatasetName::new(pool, kind);
         serde_json::to_string(&name).unwrap();

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -12,6 +12,7 @@ use key_manager::StorageKeyRequester;
 use omicron_common::api::external::Generation;
 use omicron_common::disk::DiskIdentity;
 use omicron_common::ledger::Ledgerable;
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_hardware::{
@@ -29,7 +30,7 @@ use crate::dataset;
 pub struct OmicronPhysicalDiskConfig {
     pub identity: DiskIdentity,
     pub id: Uuid,
-    pub pool_id: Uuid,
+    pub pool_id: ZpoolUuid,
 }
 
 #[derive(
@@ -100,7 +101,7 @@ impl SyntheticDisk {
         log: &Logger,
         mount_config: &MountConfig,
         raw: RawSyntheticDisk,
-        zpool_id: Option<Uuid>,
+        zpool_id: Option<ZpoolUuid>,
     ) -> Self {
         let path = if raw.path.is_absolute() {
             raw.path.clone()
@@ -284,7 +285,7 @@ impl Disk {
         log: &Logger,
         mount_config: &MountConfig,
         raw_disk: RawDisk,
-        pool_id: Option<Uuid>,
+        pool_id: Option<ZpoolUuid>,
         key_requester: Option<&StorageKeyRequester>,
     ) -> Result<Self, DiskError> {
         let disk: Disk = match raw_disk {

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -870,6 +870,7 @@ mod tests {
     use omicron_common::api::external::Generation;
     use omicron_common::ledger;
     use omicron_test_utils::dev::test_setup_log;
+    use omicron_uuid_kinds::ZpoolUuid;
     use std::sync::atomic::Ordering;
     use uuid::Uuid;
 
@@ -1305,7 +1306,7 @@ mod tests {
         // First, we format the U.2s to have a zpool. This should work, even
         // without looping in the StorageManager.
         let first_u2 = &raw_disks[0];
-        let first_pool_id = Uuid::new_v4();
+        let first_pool_id = ZpoolUuid::new_v4();
         let _disk = crate::disk::Disk::new(
             &logctx.log,
             &harness.mount_config(),
@@ -1317,7 +1318,7 @@ mod tests {
         .expect("Failed to format U.2");
 
         let second_u2 = &raw_disks[1];
-        let second_pool_id = Uuid::new_v4();
+        let second_pool_id = ZpoolUuid::new_v4();
         let _disk = crate::disk::Disk::new(
             &logctx.log,
             &harness.mount_config(),

--- a/sled-storage/src/manager_test_harness.rs
+++ b/sled-storage/src/manager_test_harness.rs
@@ -9,6 +9,7 @@ use crate::disk::{OmicronPhysicalDisksConfig, RawDisk};
 use crate::manager::{StorageHandle, StorageManager};
 use camino::Utf8PathBuf;
 use key_manager::StorageKeyRequester;
+use omicron_uuid_kinds::ZpoolUuid;
 use slog::{info, Logger};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -322,7 +323,7 @@ impl StorageManagerTestHarness {
                 crate::disk::OmicronPhysicalDiskConfig {
                     identity: identity.clone(),
                     id: Uuid::new_v4(),
-                    pool_id: Uuid::new_v4(),
+                    pool_id: ZpoolUuid::new_v4(),
                 }
             })
             .collect();

--- a/sled-storage/src/resources.rs
+++ b/sled-storage/src/resources.rs
@@ -13,6 +13,7 @@ use cfg_if::cfg_if;
 use illumos_utils::zpool::ZpoolName;
 use key_manager::StorageKeyRequester;
 use omicron_common::disk::DiskIdentity;
+use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_hardware::DiskVariant;
@@ -20,7 +21,6 @@ use slog::{info, o, warn, Logger};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::watch;
-use uuid::Uuid;
 
 // The directory within the debug dataset in which bundles are created.
 const BUNDLE_DIRECTORY: &str = "bundle";
@@ -35,7 +35,7 @@ pub enum DiskManagementError {
     NotFound,
 
     #[error("Expected zpool UUID of {expected}, but saw {observed}")]
-    ZpoolUuidMismatch { expected: Uuid, observed: Uuid },
+    ZpoolUuidMismatch { expected: ZpoolUuid, observed: ZpoolUuid },
 
     #[error("Failed to access keys necessary to unlock storage. This error may be transient.")]
     KeyManager(String),

--- a/uuid-kinds/Cargo.toml
+++ b/uuid-kinds/Cargo.toml
@@ -11,6 +11,7 @@ license = "MPL-2.0"
 [dependencies]
 newtype-uuid.workspace = true
 schemars = { workspace = true, optional = true }
+paste.workspace = true
 
 [features]
 default = ["std"]

--- a/uuid-kinds/src/lib.rs
+++ b/uuid-kinds/src/lib.rs
@@ -20,16 +20,20 @@ use schemars::JsonSchema;
 macro_rules! impl_typed_uuid_kind {
     ($($kind:ident => $tag:literal),* $(,)?) => {
         $(
-            #[cfg_attr(feature = "schemars08", derive(JsonSchema))]
-            pub enum $kind {}
+            paste::paste! {
+                #[cfg_attr(feature = "schemars08", derive(JsonSchema))]
+                pub enum [< $kind Kind>] {}
 
-            impl TypedUuidKind for $kind {
-                #[inline]
-                fn tag() -> TypedUuidTag {
-                    // `const` ensures that tags are validated at compile-time.
-                    const TAG: TypedUuidTag = TypedUuidTag::new($tag);
-                    TAG
+                impl TypedUuidKind for [< $kind Kind >] {
+                    #[inline]
+                    fn tag() -> TypedUuidTag {
+                        // `const` ensures that tags are validated at compile-time.
+                        const TAG: TypedUuidTag = TypedUuidTag::new($tag);
+                        TAG
+                    }
                 }
+
+                pub type [< $kind Uuid>] = TypedUuid::<[< $kind Kind >]>;
             }
         )*
     };
@@ -45,13 +49,14 @@ macro_rules! impl_typed_uuid_kind {
 // Please keep this list in alphabetical order.
 
 impl_typed_uuid_kind! {
-    DownstairsKind => "downstairs",
-    DownstairsRegionKind => "downstairs_region",
-    LoopbackAddressKind => "loopback_address",
-    OmicronZoneKind => "service",
-    SledKind => "sled",
-    TufRepoKind => "tuf_repo",
-    UpstairsKind => "upstairs",
-    UpstairsRepairKind => "upstairs_repair",
-    UpstairsSessionKind => "upstairs_session",
+    Downstairs => "downstairs",
+    DownstairsRegion => "downstairs_region",
+    LoopbackAddress => "loopback_address",
+    OmicronZone => "service",
+    Sled => "sled",
+    TufRepo => "tuf_repo",
+    Upstairs => "upstairs",
+    UpstairsRepair => "upstairs_repair",
+    UpstairsSession => "upstairs_session",
+    Zpool => "zpool",
 }


### PR DESCRIPTION
Starts the conversion of using "typed UUIDs" within Sled Agent. This is a thin vertical slice, but if we're happy with how this looks, I can keep propagating types to other UUIDs in this area.

- I tried to convert effectively all usage within the sled agent and family of crates
- I intentionally did not apply any conversions to the DB schema within Nexus -- so the changes propagating up there are incidental to using Sled Agent APIs