### PR TITLE
[meta] TypedUuid<SledKind> -> SledUuid, OmicronZoneKind -> OmicronZoneUuid

### DIFF
--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -32,8 +32,9 @@ use nexus_types::inventory::OmicronZonesConfig;
 use nexus_types::inventory::SledRole;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::Name;
-use omicron_uuid_kinds::SledKind;
-use omicron_uuid_kinds::{GenericUuid, OmicronZoneKind, TypedUuid};
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SledUuid;
 use reedline::{Reedline, Signal};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -150,8 +151,7 @@ impl ReconfiguratorSim {
         for (_, zone) in
             parent_blueprint.all_omicron_zones(BlueprintZoneFilter::All)
         {
-            let zone_id =
-                TypedUuid::<OmicronZoneKind>::from_untyped_uuid(zone.id);
+            let zone_id = OmicronZoneUuid::from_untyped_uuid(zone.id);
             if let Ok(Some(ip)) = zone.zone_type.external_ip() {
                 let external_ip = ExternalIp {
                     id: *self
@@ -406,13 +406,13 @@ enum Commands {
 #[derive(Debug, Args)]
 struct SledAddArgs {
     /// id of the new sled
-    sled_id: Option<TypedUuid<SledKind>>,
+    sled_id: Option<SledUuid>,
 }
 
 #[derive(Debug, Args)]
 struct SledArgs {
     /// id of the sled
-    sled_id: TypedUuid<SledKind>,
+    sled_id: SledUuid,
 }
 
 #[derive(Debug, Args)]
@@ -454,7 +454,7 @@ enum BlueprintEditCommands {
     /// add a Nexus instance to a particular sled
     AddNexus {
         /// sled on which to deploy the new instance
-        sled_id: TypedUuid<SledKind>,
+        sled_id: SledUuid,
     },
 }
 
@@ -576,7 +576,7 @@ fn cmd_sled_list(
     #[derive(Tabled)]
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
     struct Sled {
-        id: TypedUuid<SledKind>,
+        id: SledUuid,
         nzpools: usize,
         subnet: String,
     }

--- a/dev-tools/reconfigurator-cli/tests/test_basic.rs
+++ b/dev-tools/reconfigurator-cli/tests/test_basic.rs
@@ -20,8 +20,7 @@ use omicron_test_utils::dev::test_cmds::path_to_executable;
 use omicron_test_utils::dev::test_cmds::redact_variable;
 use omicron_test_utils::dev::test_cmds::run_command;
 use omicron_test_utils::dev::test_cmds::EXIT_SUCCESS;
-use omicron_uuid_kinds::SledKind;
-use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::SledUuid;
 use slog::debug;
 use std::io::BufReader;
 use std::io::BufWriter;
@@ -119,7 +118,7 @@ async fn test_blueprint_edit(cptestctx: &ControlPlaneTestContext) {
     .expect("failed to assemble reconfigurator state");
 
     // Smoke check the initial state.
-    let sled_id: TypedUuid<SledKind> = SLED_AGENT_UUID.parse().unwrap();
+    let sled_id: SledUuid = SLED_AGENT_UUID.parse().unwrap();
     assert!(state1.planning_input.sled_resources(&sled_id).is_some());
     assert!(!state1.planning_input.service_ip_pool_ranges().is_empty());
     assert!(!state1.silo_names.is_empty());

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -1092,7 +1092,7 @@ mod tests {
     use omicron_common::api::external::Generation;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::GenericUuid;
-    use omicron_uuid_kinds::TypedUuid;
+    use omicron_uuid_kinds::SledUuid;
     use omicron_uuid_kinds::ZpoolUuid;
     use pretty_assertions::assert_eq;
     use rand::thread_rng;
@@ -1202,7 +1202,7 @@ mod tests {
             );
             for (sled_id, agent) in &collection.sled_agents {
                 // TODO-cleanup use `TypedUuid` everywhere
-                let sled_id = TypedUuid::from_untyped_uuid(*sled_id);
+                let sled_id = SledUuid::from_untyped_uuid(*sled_id);
                 builder
                     .add_sled(
                         sled_id,
@@ -1370,7 +1370,7 @@ mod tests {
         );
 
         // Add a new sled.
-        let new_sled_id = TypedUuid::new_v4();
+        let new_sled_id = SledUuid::new_v4();
 
         // While we're at it, use a different DNS version to test that that
         // works.

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -530,7 +530,7 @@ mod test {
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_test_utils::dev::test_setup_log;
     use omicron_uuid_kinds::GenericUuid;
-    use omicron_uuid_kinds::TypedUuid;
+    use omicron_uuid_kinds::SledUuid;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
     use std::collections::HashMap;
@@ -627,7 +627,7 @@ mod test {
             Generation::new(),
             policy_sleds.keys().map(|sled_id| {
                 // TODO-cleanup use `TypedUuid` everywhere
-                TypedUuid::from_untyped_uuid(*sled_id)
+                SledUuid::from_untyped_uuid(*sled_id)
             }),
             "test-suite",
         )

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -16,9 +16,8 @@ use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::OmicronZoneKind;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledKind;
-use omicron_uuid_kinds::TypedUuid;
 use sled_agent_client::types::OmicronZonesConfig;
 use typed_rng::TypedUuidRng;
 use uuid::Uuid;
@@ -128,8 +127,7 @@ impl ExampleSystem {
                 continue;
             };
             for zone in zones.zones.iter().map(|z| &z.config) {
-                let service_id =
-                    TypedUuid::<OmicronZoneKind>::from_untyped_uuid(zone.id);
+                let service_id = OmicronZoneUuid::from_untyped_uuid(zone.id);
                 if let Ok(Some(ip)) = zone.zone_type.external_ip() {
                     input_builder
                         .add_omicron_zone_external_ip(

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -15,8 +15,7 @@ use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::SledKind;
-use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::SledUuid;
 use slog::{info, warn, Logger};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -191,7 +190,7 @@ impl<'a> Planner<'a> {
 
     fn ensure_correct_number_of_nexus_zones(
         &mut self,
-        sleds_waiting_for_ntp_zone: &BTreeSet<TypedUuid<SledKind>>,
+        sleds_waiting_for_ntp_zone: &BTreeSet<SledUuid>,
     ) -> Result<(), Error> {
         // Count the number of Nexus zones on all in-service sleds. This will
         // include sleds that are in service but not eligible for new services,
@@ -222,7 +221,7 @@ impl<'a> Planner<'a> {
         // by their current Nexus zone count. Skip sleds with a policy/state
         // that should be eligible for Nexus but that don't yet have an NTP
         // zone.
-        let mut sleds_by_num_nexus: BTreeMap<usize, Vec<TypedUuid<SledKind>>> =
+        let mut sleds_by_num_nexus: BTreeMap<usize, Vec<SledUuid>> =
             BTreeMap::new();
         for sled_id in self
             .input
@@ -244,8 +243,7 @@ impl<'a> Planner<'a> {
         }
 
         // Build a map of sled -> new nexus zone count.
-        let mut sleds_to_change: BTreeMap<TypedUuid<SledKind>, usize> =
-            BTreeMap::new();
+        let mut sleds_to_change: BTreeMap<SledUuid, usize> = BTreeMap::new();
 
         'outer: for _ in 0..nexus_to_add {
             // `sleds_by_num_nexus` is sorted by key already, and we want to

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -32,7 +32,7 @@ use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::SledKind;
+use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::TypedUuid;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
@@ -65,7 +65,7 @@ impl<T> SubnetIterator for T where
 #[derive(Debug)]
 pub struct SystemDescription {
     collector: Option<String>,
-    sleds: IndexMap<TypedUuid<SledKind>, Sled>,
+    sleds: IndexMap<SledUuid, Sled>,
     sled_subnets: Box<dyn SubnetIterator>,
     available_non_scrimlet_slots: BTreeSet<u16>,
     available_scrimlet_slots: BTreeSet<u16>,
@@ -232,7 +232,7 @@ impl SystemDescription {
     /// database of an existing system
     pub fn sled_full(
         &mut self,
-        sled_id: TypedUuid<SledKind>,
+        sled_id: SledUuid,
         sled_policy: SledPolicy,
         sled_resources: SledResources,
         inventory_sp: Option<SledHwInventory<'_>>,
@@ -330,7 +330,7 @@ pub enum SledHardware {
 
 #[derive(Clone, Debug)]
 pub struct SledBuilder {
-    id: Option<TypedUuid<SledKind>>,
+    id: Option<SledUuid>,
     unique: Option<String>,
     hardware: SledHardware,
     hardware_slot: Option<u16>,
@@ -354,7 +354,7 @@ impl SledBuilder {
     /// Set the id of the sled
     ///
     /// Default: randomly generated
-    pub fn id(mut self, id: TypedUuid<SledKind>) -> Self {
+    pub fn id(mut self, id: SledUuid) -> Self {
         self.id = Some(id);
         self
     }
@@ -417,7 +417,7 @@ pub struct SledHwInventory<'a> {
 /// Collection.
 #[derive(Clone, Debug)]
 struct Sled {
-    sled_id: TypedUuid<SledKind>,
+    sled_id: SledUuid,
     sled_subnet: Ipv6Subnet<SLED_PREFIX>,
     inventory_sp: Option<(u16, SpState)>,
     inventory_sled_agent: sled_agent_client::types::Inventory,
@@ -428,7 +428,7 @@ struct Sled {
 impl Sled {
     /// Create a `Sled` using faked-up information based on a `SledBuilder`
     fn new_simulated(
-        sled_id: TypedUuid<SledKind>,
+        sled_id: SledUuid,
         sled_subnet: Ipv6Subnet<SLED_PREFIX>,
         sled_role: SledRole,
         unique: Option<String>,
@@ -518,7 +518,7 @@ impl Sled {
     /// Create a `Sled` based on real information from another `Policy` and
     /// inventory `Collection`
     fn new_full(
-        sled_id: TypedUuid<SledKind>,
+        sled_id: SledUuid,
         sled_policy: SledPolicy,
         sled_resources: SledResources,
         inventory_sp: Option<SledHwInventory<'_>>,

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -33,7 +33,8 @@ use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupType;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use slog::error;
 use slog::Logger;
@@ -107,7 +108,7 @@ impl PlanningInputFromDb<'_> {
                 resources: SledResources { subnet, zpools },
             };
             // TODO-cleanup use `TypedUuid` everywhere
-            let sled_id = TypedUuid::from_untyped_uuid(sled_id);
+            let sled_id = SledUuid::from_untyped_uuid(sled_id);
             builder.add_sled(sled_id, sled_details).map_err(|e| {
                 Error::internal_error(&format!(
                     "unexpectedly failed to add sled to planning input: {e}"
@@ -127,7 +128,7 @@ impl PlanningInputFromDb<'_> {
                 );
                 continue;
             };
-            let zone_id = TypedUuid::from_untyped_uuid(zone_id);
+            let zone_id = OmicronZoneUuid::from_untyped_uuid(zone_id);
             builder
                 .add_omicron_zone_external_ip(
                     zone_id,

--- a/uuid-kinds/README.adoc
+++ b/uuid-kinds/README.adoc
@@ -38,6 +38,20 @@ Then, start changing your UUID types over. It's generally easiest to change the 
 
 - If your UUID is widely used, you may need to break your change up across several commits. It's easiest to carve out a section of your code to make changes in, and use the `GenericUuid` conversions into and out of this code. For an example, see the ongoing conversion for sled UUIDs in https://github.com/oxidecomputer/omicron/pull/5404[#5404] and https://github.com/oxidecomputer/omicron/pull/5488[#5488].
 
+[IMPORTANT] 
+.Using type aliases
+==== 
+For `TypedUuid<T>`, prefer to use the type aliases. For example, `SledUuid` rather than `TypedUuid<SledKind>`.
+
+Some older code is still being ported over to type aliases; see https://github.com/oxidecomputer/omicron/pull/5511[#5511] for an example.
+
+Other types that use the same kinds, like `nexus_db_model::DbTypedUuid<T>` and
+`typed_rng::TypedUuidRng<T>`, don't have aliases defined for them. That's
+because their frequency of use falls below the threshold at which the benefits
+of type aliases outweigh the costs.
+
+====
+
 Some special cases:
 
 . If part of your change is at an OpenAPI schema boundary, then you generally also want to have clients use the same UUID types. The best way to do that currently is to use a `replace` directive, as in https://github.com/oxidecomputer/omicron/pull/5135[#5135]. There is ongoing design work to make this work automatically, in https://github.com/oxidecomputer/typify/issues/503[typify#503] and elsewhere.


### PR DESCRIPTION
Followup from #5501 -- use `SledUuid` everywhere. I wanted to try it out to see
how it feels, and I think I like it a lot.

Depends on #5501.

(Accidentally landed https://github.com/oxidecomputer/omicron/pull/5511 on the wrong branch -- this is identical and was already reviewed there.)