### PR TITLE
[nix flake] Updates and maintainance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706634984,
-        "narHash": "sha256-xn7lGPE8gRGBe3Lt8ESoN/uUHm7IrbiV7siupwjHX1o=",
+        "lastModified": 1712888034,
+        "narHash": "sha256-SmBeT3oxdwOzheSfxZmk+3xmv98Z3zlzjlnl9nBdOIE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "883b84c426107a8ec020e7124f263d7c35a5bb9f",
+        "rev": "96fbdc73dec8eaa5a9d4a9b307b75c9a856e5dec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -224,6 +224,7 @@
             buildInputs = [
               glibc
               gcc-unwrapped
+              openssl.dev
             ];
 
             installPhase =
@@ -259,7 +260,7 @@
           # can't give Nix those hashes and must instead determine it ourselves.
           # this means that we will have to update this SHA if the clickhouse
           # version changes.
-          sha256 = "1lgxwh67apgl386ilpg0iy5xkyz12q4lgnz08zswjbxv88ra0qxj";
+          sha256 = "0wx8w9sdms5hsc9f835ivsissf15wjzdb9cvxr65xdi384i9pkzx";
           src = builtins.fetchurl
             {
               inherit sha256;
@@ -428,10 +429,3 @@
           };
     };
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
This commit updates the Nix flake so that it builds with the current dependencies on `mgd` and Clickhouse. The Clickhouse version we download has changed, so the SHA256 hash in the Nix flake must be updated (this can't be depended on automatically from the fs, currently, because we store its hash as MD5 in the `clickhouse_version` file, rather than SHA256). `mgd` now depends on OpenSSL, so I've changed the build inputs for its derivation to include OpenSSL headers for `autoPatchelfHook`.

I think I might be the only user of the Nix flake, so I don't know if it really makes sense to ask anyone else to review this. Rest assured that it does, in fact, fix it. :)