### PR TITLE
[nexus] move dataset IDs to TypedUuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "nexus-config",
  "nexus-types",
  "omicron-common",
+ "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "slog",
  "uuid 1.8.0",

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -37,6 +37,7 @@ progenitor::generate_api!(
         NetworkInterfaceKind = omicron_common::api::internal::shared::NetworkInterfaceKind,
         TypedUuidForCollectionKind = omicron_uuid_kinds::CollectionUuid,
         TypedUuidForDownstairsKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::DownstairsKind>,
+        TypedUuidForOmicronZoneKind = omicron_uuid_kinds::OmicronZoneUuid,
         TypedUuidForUpstairsKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsKind>,
         TypedUuidForUpstairsRepairKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsRepairKind>,
         TypedUuidForUpstairsSessionKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsSessionKind>,

--- a/nexus/db-model/src/dataset.rs
+++ b/nexus/db-model/src/dataset.rs
@@ -8,6 +8,7 @@ use crate::ipv6;
 use crate::schema::{dataset, region};
 use chrono::{DateTime, Utc};
 use db_macros::Asset;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv6Addr, SocketAddrV6};
 use uuid::Uuid;
@@ -28,6 +29,7 @@ use uuid::Uuid;
     PartialEq,
 )]
 #[diesel(table_name = dataset)]
+#[asset(uuid_kind = OmicronZoneKind)]
 pub struct Dataset {
     #[diesel(embed)]
     identity: DatasetIdentity,
@@ -45,7 +47,7 @@ pub struct Dataset {
 
 impl Dataset {
     pub fn new(
-        id: Uuid,
+        id: OmicronZoneUuid,
         pool_id: Uuid,
         addr: SocketAddrV6,
         kind: DatasetKind,

--- a/nexus/db-model/src/region_snapshot.rs
+++ b/nexus/db-model/src/region_snapshot.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::schema::region_snapshot;
+use crate::{schema::region_snapshot, typed_uuid::DbTypedUuid};
+use omicron_uuid_kinds::OmicronZoneKind;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -23,7 +24,7 @@ use uuid::Uuid;
 #[diesel(table_name = region_snapshot)]
 pub struct RegionSnapshot {
     // unique identifier of this region snapshot
-    pub dataset_id: Uuid,
+    pub dataset_id: DbTypedUuid<OmicronZoneKind>,
     pub region_id: Uuid,
     pub snapshot_id: Uuid,
 

--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -18,10 +18,12 @@ use crate::transaction_retry::OptionalError;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::prelude::*;
 use nexus_config::RegionAllocationStrategy;
+use nexus_db_model::to_db_typed_uuid;
 use nexus_types::external_api::params;
 use omicron_common::api::external;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use slog::Logger;
 use uuid::Uuid;
 
@@ -294,13 +296,13 @@ impl DataStore {
     /// Return the total occupied size for a dataset
     pub async fn regions_total_occupied_size(
         &self,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
     ) -> Result<u64, Error> {
         use db::schema::region::dsl as region_dsl;
 
         let total_occupied_size: Option<diesel::pg::data_types::PgNumeric> =
             region_dsl::region
-                .filter(region_dsl::dataset_id.eq(dataset_id))
+                .filter(region_dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
                 .select(diesel::dsl::sum(
                     region_dsl::block_size
                         * region_dsl::blocks_per_extent

--- a/nexus/db-queries/src/db/datastore/region_snapshot.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot.rs
@@ -12,9 +12,11 @@ use crate::db::model::RegionSnapshot;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::prelude::*;
 use diesel::OptionalExtension;
+use nexus_db_model::to_db_typed_uuid;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::LookupResult;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use uuid::Uuid;
 
 impl DataStore {
@@ -35,14 +37,14 @@ impl DataStore {
 
     pub async fn region_snapshot_get(
         &self,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         region_id: Uuid,
         snapshot_id: Uuid,
     ) -> LookupResult<Option<RegionSnapshot>> {
         use db::schema::region_snapshot::dsl;
 
         dsl::region_snapshot
-            .filter(dsl::dataset_id.eq(dataset_id))
+            .filter(dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
             .filter(dsl::region_id.eq(region_id))
             .filter(dsl::snapshot_id.eq(snapshot_id))
             .select(RegionSnapshot::as_select())
@@ -56,14 +58,14 @@ impl DataStore {
 
     pub async fn region_snapshot_remove(
         &self,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         region_id: Uuid,
         snapshot_id: Uuid,
     ) -> DeleteResult {
         use db::schema::region_snapshot::dsl;
 
         diesel::delete(dsl::region_snapshot)
-            .filter(dsl::dataset_id.eq(dataset_id))
+            .filter(dsl::dataset_id.eq(to_db_typed_uuid(dataset_id)))
             .filter(dsl::region_id.eq(region_id))
             .filter(dsl::snapshot_id.eq(snapshot_id))
             .execute_async(&*self.pool_connection_unauthorized().await?)

--- a/nexus/reconfigurator/execution/src/datasets.rs
+++ b/nexus/reconfigurator/execution/src/datasets.rs
@@ -14,6 +14,7 @@ use nexus_types::deployment::OmicronZoneConfig;
 use nexus_types::deployment::OmicronZoneType;
 use nexus_types::identity::Asset;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use slog::info;
 use slog::warn;
 use slog_error_chain::InlineErrorChain;
@@ -57,7 +58,8 @@ pub(crate) async fn ensure_crucible_dataset_records_exist(
             continue;
         };
 
-        let id = zone.id;
+        // TODO-cleanup use TypedUuid everywhere
+        let id = OmicronZoneUuid::from_untyped_uuid(zone.id);
 
         // If already present in the datastore, move on.
         if crucible_datasets.remove(&id) {

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1311,7 +1311,7 @@ async fn ssc_start_running_snapshot(
         osagactx
             .datastore()
             .region_snapshot_create(db::model::RegionSnapshot {
-                dataset_id: dataset.id(),
+                dataset_id: dataset.id().into(),
                 region_id: region.id(),
                 snapshot_id,
                 snapshot_addr,

--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -307,7 +307,7 @@ async fn svd_delete_crucible_snapshot_records(
         osagactx
             .datastore()
             .region_snapshot_remove(
-                region_snapshot.dataset_id,
+                region_snapshot.dataset_id.into(),
                 region_snapshot.region_id,
                 region_snapshot.snapshot_id,
             )

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -19,6 +19,7 @@ use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use sled_agent_client::Client as SledAgentClient;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
@@ -255,7 +256,7 @@ impl super::Nexus {
     /// Upserts a dataset into the database, updating it if it already exists.
     pub(crate) async fn upsert_dataset(
         &self,
-        id: Uuid,
+        id: OmicronZoneUuid,
         zpool_id: Uuid,
         address: SocketAddrV6,
         kind: DatasetKind,

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -39,6 +39,7 @@ use omicron_common::api::internal::shared::{
     ExternalPortDiscovery, RackNetworkConfig, SwitchLocation,
 };
 use omicron_common::FileKv;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use slog::Logger;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV6};
@@ -351,7 +352,7 @@ impl nexus_test_interface::NexusServer for Server {
         &self,
         physical_disk: PhysicalDiskPutRequest,
         zpool: ZpoolPutRequest,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         address: SocketAddrV6,
     ) {
         let opctx = self.apictx.nexus.opctx_for_internal_api();

--- a/nexus/test-interface/Cargo.toml
+++ b/nexus/test-interface/Cargo.toml
@@ -9,6 +9,7 @@ async-trait.workspace = true
 nexus-config.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true
+omicron-uuid-kinds.workspace = true
 slog.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true

--- a/nexus/test-interface/src/lib.rs
+++ b/nexus/test-interface/src/lib.rs
@@ -39,6 +39,7 @@ use nexus_types::internal_api::params::{
 };
 use nexus_types::inventory::Collection;
 use omicron_common::api::external::Error;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use slog::Logger;
 use std::net::{SocketAddr, SocketAddrV6};
 use uuid::Uuid;
@@ -99,7 +100,7 @@ pub trait NexusServer: Send + Sync + 'static {
         &self,
         physical_disk: PhysicalDiskPutRequest,
         zpool: ZpoolPutRequest,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         address: SocketAddrV6,
     );
 

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -254,7 +254,7 @@ impl RackInitRequestBuilder {
     fn add_dataset(
         &mut self,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         address: SocketAddrV6,
         kind: DatasetKind,
         service_name: internal_dns::ServiceName,
@@ -266,11 +266,7 @@ impl RackInitRequestBuilder {
         });
         let zone = self
             .internal_dns_config
-            .host_zone(
-                // TODO-cleanup use TypedUuid everywhere
-                OmicronZoneUuid::from_untyped_uuid(dataset_id),
-                *address.ip(),
-            )
+            .host_zone(dataset_id, *address.ip())
             .expect("Failed to set up DNS for {kind}");
         self.internal_dns_config
             .service_backend_zone(service_name, &zone, address.port())
@@ -430,7 +426,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             .expect("Failed to parse port");
 
         let zpool_id = ZpoolUuid::new_v4();
-        let dataset_id = Uuid::new_v4();
+        let dataset_id = OmicronZoneUuid::new_v4();
         eprintln!("DB address: {}", address);
         self.rack_init_builder.add_dataset(
             zpool_id,
@@ -444,7 +440,8 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             .parse()
             .unwrap();
         self.omicron_zones.push(OmicronZoneConfig {
-            id: dataset_id,
+            // TODO-cleanup use TypedUuid everywhere
+            id: dataset_id.into_untyped_uuid(),
             underlay_address: *address.ip(),
             zone_type: OmicronZoneType::CockroachDb {
                 address: address.to_string(),
@@ -467,7 +464,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         let port = clickhouse.port();
 
         let zpool_id = ZpoolUuid::new_v4();
-        let dataset_id = Uuid::new_v4();
+        let dataset_id = OmicronZoneUuid::new_v4();
         let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
         self.rack_init_builder.add_dataset(
             zpool_id,
@@ -493,7 +490,8 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             .parse()
             .unwrap();
         self.omicron_zones.push(OmicronZoneConfig {
-            id: dataset_id,
+            // TODO-cleanup use TUuidypedUuid everywhere
+            id: dataset_id.into_untyped_uuid(),
             underlay_address: *address.ip(),
             zone_type: OmicronZoneType::Clickhouse {
                 address: address.to_string(),

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -41,6 +41,7 @@ use omicron_sled_agent::sim::SledAgent;
 use omicron_test_utils::dev::poll::wait_for_condition;
 use omicron_test_utils::dev::poll::CondCheckError;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use slog::debug;
 use std::net::IpAddr;
@@ -694,7 +695,7 @@ pub async fn projects_list(
 }
 
 pub struct TestDataset {
-    pub id: Uuid,
+    pub id: OmicronZoneUuid,
 }
 
 pub struct TestZpool {
@@ -744,7 +745,7 @@ impl DiskTest {
             cptestctx,
             Uuid::new_v4(),
             ZpoolUuid::new_v4(),
-            Uuid::new_v4(),
+            OmicronZoneUuid::new_v4(),
             Self::DEFAULT_ZPOOL_SIZE_GIB,
         )
         .await
@@ -755,7 +756,7 @@ impl DiskTest {
         cptestctx: &ControlPlaneTestContext<N>,
         physical_disk_id: Uuid,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
         gibibytes: u32,
     ) {
         // To get a dataset, we actually need to create a new simulated physical

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -33,6 +33,7 @@ use omicron_common::api::external::Instance;
 use omicron_common::api::external::InstanceCpuCount;
 use omicron_common::api::external::Name;
 use omicron_nexus::app::MIN_DISK_SIZE_BYTES;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use uuid::Uuid;
 
 type ControlPlaneTestContext =
@@ -1198,7 +1199,7 @@ async fn test_region_snapshot_create_idempotent(
     let datastore = nexus.datastore();
 
     let region_snapshot = db::model::RegionSnapshot {
-        dataset_id: Uuid::new_v4(),
+        dataset_id: OmicronZoneUuid::new_v4().into(),
         region_id: Uuid::new_v4(),
         snapshot_id: Uuid::new_v4(),
 

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -20,6 +20,7 @@ use nexus_test_utils::http_testing::RequestBuilder;
 use nexus_test_utils::http_testing::TestResponse;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils_macros::nexus_test;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use once_cell::sync::Lazy;
 
@@ -61,7 +62,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
             cptestctx,
             nexus_test_utils::PHYSICAL_DISK_UUID.parse().unwrap(),
             ZpoolUuid::new_v4(),
-            uuid::Uuid::new_v4(),
+            OmicronZoneUuid::new_v4(),
             DiskTest::DEFAULT_ZPOOL_SIZE_GIB,
         )
         .await;

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -2215,7 +2215,7 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
             &region_snapshots[i];
         datastore
             .region_snapshot_create(nexus_db_model::RegionSnapshot {
-                dataset_id: *dataset_id,
+                dataset_id: (*dataset_id).into(),
                 region_id: *region_id,
                 snapshot_id: *snapshot_id,
                 snapshot_addr: snapshot_addr.clone(),
@@ -2328,7 +2328,7 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
             &region_snapshots[i];
         datastore
             .region_snapshot_create(nexus_db_model::RegionSnapshot {
-                dataset_id: *dataset_id,
+                dataset_id: (*dataset_id).into(),
                 region_id: *region_id,
                 snapshot_id: *snapshot_id,
                 snapshot_addr: snapshot_addr.clone(),

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -16,6 +16,7 @@ use omicron_common::api::external::Name;
 use omicron_common::api::internal::shared::ExternalPortDiscovery;
 use omicron_common::api::internal::shared::RackNetworkConfig;
 use omicron_common::api::internal::shared::SourceNatConfig;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -210,7 +211,7 @@ pub struct ServicePutRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DatasetCreateRequest {
     pub zpool_id: Uuid,
-    pub dataset_id: Uuid,
+    pub dataset_id: OmicronZoneUuid,
     pub request: DatasetPutRequest,
 }
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -3007,8 +3007,7 @@
         "type": "object",
         "properties": {
           "dataset_id": {
-            "type": "string",
-            "format": "uuid"
+            "$ref": "#/components/schemas/TypedUuidForOmicronZoneKind"
           },
           "request": {
             "$ref": "#/components/schemas/DatasetPutRequest"
@@ -7530,6 +7529,10 @@
         "format": "uuid"
       },
       "TypedUuidForDownstairsRegionKind": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "TypedUuidForOmicronZoneKind": {
         "type": "string",
         "format": "uuid"
       },

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -103,8 +103,8 @@ use omicron_common::backoff::{
 };
 use omicron_common::ledger::{self, Ledger, Ledgerable};
 use omicron_ddm_admin_client::{Client as DdmAdminClient, DdmError};
-use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::{GenericUuid, OmicronZoneUuid};
 use serde::{Deserialize, Serialize};
 use sled_agent_client::{
     types as SledAgentTypes, Client as SledAgentClient, Error as SledAgentError,
@@ -729,7 +729,8 @@ impl ServiceInner {
                 {
                     datasets.push(NexusTypes::DatasetCreateRequest {
                         zpool_id: dataset_name.pool().id().into_untyped_uuid(),
-                        dataset_id: zone.id,
+                        // TODO-cleanup use TypedUuid everywhere
+                        dataset_id: OmicronZoneUuid::from_untyped_uuid(zone.id),
                         request: NexusTypes::DatasetPutRequest {
                             address: dataset_address.to_string(),
                             kind: dataset_name.dataset().clone().convert(),

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -34,6 +34,7 @@ use omicron_common::backoff::{
 use omicron_common::disk::DiskIdentity;
 use omicron_common::FileKv;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use slog::{info, Drain, Logger};
 use std::collections::BTreeMap;
@@ -185,13 +186,13 @@ impl Server {
             sled_agent
                 .create_zpool(zpool_id, physical_disk_id, zpool.size)
                 .await;
-            let dataset_id = Uuid::new_v4();
+            let dataset_id = OmicronZoneUuid::new_v4();
             let address =
                 sled_agent.create_crucible_dataset(zpool_id, dataset_id).await;
 
             datasets.push(NexusTypes::DatasetCreateRequest {
                 zpool_id: zpool_id.into_untyped_uuid(),
-                dataset_id,
+                dataset_id: dataset_id,
                 request: NexusTypes::DatasetPutRequest {
                     address: address.to_string(),
                     kind: NexusTypes::DatasetKind::Crucible,
@@ -486,7 +487,7 @@ pub async fn run_standalone_server(
         {
             datasets.push(NexusTypes::DatasetCreateRequest {
                 zpool_id: zpool.id,
-                dataset_id,
+                dataset_id: dataset_id,
                 request: NexusTypes::DatasetPutRequest {
                     address: address.to_string(),
                     kind: NexusTypes::DatasetKind::Crucible,

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -36,7 +36,7 @@ use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, VmmRuntimeState,
 };
 use omicron_common::disk::DiskIdentity;
-use omicron_uuid_kinds::ZpoolUuid;
+use omicron_uuid_kinds::{OmicronZoneUuid, ZpoolUuid};
 use propolis_client::{
     types::VolumeConstructionRequest, Client as PropolisClient,
 };
@@ -549,7 +549,7 @@ impl SledAgent {
     pub async fn get_datasets(
         &self,
         zpool_id: ZpoolUuid,
-    ) -> Vec<(Uuid, SocketAddr)> {
+    ) -> Vec<(OmicronZoneUuid, SocketAddr)> {
         self.storage.lock().await.get_all_datasets(zpool_id)
     }
 
@@ -571,7 +571,7 @@ impl SledAgent {
     pub async fn create_crucible_dataset(
         &self,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
     ) -> SocketAddr {
         self.storage.lock().await.insert_dataset(zpool_id, dataset_id).await
     }
@@ -580,7 +580,7 @@ impl SledAgent {
     pub async fn get_crucible_dataset(
         &self,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
     ) -> Arc<CrucibleData> {
         self.storage.lock().await.get_dataset(zpool_id, dataset_id).await
     }

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -485,7 +485,7 @@ pub(crate) struct Zpool {
     id: ZpoolUuid,
     physical_disk_id: Uuid,
     total_size: u64,
-    datasets: HashMap<Uuid, CrucibleServer>,
+    datasets: HashMap<OmicronZoneUuid, CrucibleServer>,
 }
 
 impl Zpool {
@@ -496,7 +496,7 @@ impl Zpool {
     fn insert_dataset(
         &mut self,
         log: &Logger,
-        id: Uuid,
+        id: OmicronZoneUuid,
         crucible_ip: IpAddr,
         crucible_port: u16,
     ) -> &CrucibleServer {
@@ -644,7 +644,7 @@ impl Storage {
     pub async fn insert_dataset(
         &mut self,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
     ) -> SocketAddr {
         // Update our local data
         let dataset = self
@@ -704,7 +704,7 @@ impl Storage {
     pub fn get_all_datasets(
         &self,
         zpool_id: ZpoolUuid,
-    ) -> Vec<(Uuid, SocketAddr)> {
+    ) -> Vec<(OmicronZoneUuid, SocketAddr)> {
         let zpool = self.zpools.get(&zpool_id).expect("Zpool does not exist");
 
         zpool
@@ -717,7 +717,7 @@ impl Storage {
     pub async fn get_dataset(
         &self,
         zpool_id: ZpoolUuid,
-        dataset_id: Uuid,
+        dataset_id: OmicronZoneUuid,
     ) -> Arc<CrucibleData> {
         self.zpools
             .get(&zpool_id)


### PR DESCRIPTION
Datasets are zones, so they're `OmicronZoneUuid` instances. Was quite
straightforward in the end.

There is some messiness around Diesel, and honestly I'm half-tempted to just
fork and publish our own version of Diesel, with support for typed UUIDs +
other things we've run into.
