### PR TITLE
[clippy] warn on lossless casts

### DIFF
--- a/clients/dpd-client/src/lib.rs
+++ b/clients/dpd-client/src/lib.rs
@@ -479,7 +479,7 @@ impl From<u64> for Ipv4Cidr {
 impl From<Ipv4Cidr> for u64 {
     fn from(x: Ipv4Cidr) -> Self {
         let prefix: u32 = x.prefix.into();
-        ((prefix as u64) << 32) | (x.prefix_len as u64)
+        (u64::from(prefix) << 32) | u64::from(x.prefix_len)
     }
 }
 
@@ -762,12 +762,12 @@ impl fmt::Debug for MacAddr {
 
 impl From<MacAddr> for u64 {
     fn from(mac: MacAddr) -> u64 {
-        ((mac.a[0] as u64) << 40)
-            | ((mac.a[1] as u64) << 32)
-            | ((mac.a[2] as u64) << 24)
-            | ((mac.a[3] as u64) << 16)
-            | ((mac.a[4] as u64) << 8)
-            | (mac.a[5] as u64)
+        (u64::from(mac.a[0]) << 40)
+            | (u64::from(mac.a[1]) << 32)
+            | (u64::from(mac.a[2]) << 24)
+            | (u64::from(mac.a[3]) << 16)
+            | (u64::from(mac.a[4]) << 8)
+            | u64::from(mac.a[5])
     }
 }
 

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -256,7 +256,9 @@ impl From<std::time::Duration> for types::Duration {
 
 impl From<types::Duration> for std::time::Duration {
     fn from(s: types::Duration) -> Self {
-        std::time::Duration::from_nanos(s.secs * 1000000000 + u64::from(s.nanos))
+        std::time::Duration::from_nanos(
+            s.secs * 1000000000 + u64::from(s.nanos),
+        )
     }
 }
 

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -256,7 +256,7 @@ impl From<std::time::Duration> for types::Duration {
 
 impl From<types::Duration> for std::time::Duration {
     fn from(s: types::Duration) -> Self {
-        std::time::Duration::from_nanos(s.secs * 1000000000 + s.nanos as u64)
+        std::time::Duration::from_nanos(s.secs * 1000000000 + u64::from(s.nanos))
     }
 }
 

--- a/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/dashboard.rs
@@ -357,7 +357,7 @@ impl Graph {
 
             for (_ndx, s) in &mut self.series.iter_mut().enumerate() {
                 if let Some(datum) = s.raw[offs] {
-                    let point = (i as f64, datum as f64);
+                    let point = (i as f64, f64::from(datum));
 
                     if self.interpolate != 0 {
                         if let Some(last) = s.data.last() {
@@ -374,7 +374,7 @@ impl Graph {
                         }
                     }
 
-                    s.data.push((i as f64, datum as f64));
+                    s.data.push((i as f64, f64::from(datum)));
                 }
             }
         }

--- a/dev-tools/xtask/src/clippy.rs
+++ b/dev-tools/xtask/src/clippy.rs
@@ -67,7 +67,13 @@ pub fn run_cmd(args: ClippyArgs) -> Result<()> {
         .arg("--warn")
         .arg("clippy::len_zero")
         .arg("--warn")
-        .arg("clippy::redundant_field_names");
+        .arg("clippy::redundant_field_names")
+        // Also warn on casts, preferring explicit conversions instead.
+        //
+        // We'd like to warn on lossy casts in the future, but lossless casts
+        // are the easiest ones to convert over.
+        .arg("--warn")
+        .arg("clippy::cast_lossless");
 
     eprintln!(
         "running: {:?} {}",

--- a/nexus/db-model/src/bytecount.rs
+++ b/nexus/db-model/src/bytecount.rs
@@ -93,7 +93,7 @@ impl TryFrom<diesel::pg::data_types::PgNumeric> for ByteCount {
                 let mut multiplier = 1;
 
                 for digit in digits.iter().rev() {
-                    result += *digit as i64 * multiplier;
+                    result += i64::from(*digit) * multiplier;
                     multiplier *= 10000;
                 }
 

--- a/nexus/db-model/src/saga_types.rs
+++ b/nexus/db-model/src/saga_types.rs
@@ -123,7 +123,7 @@ impl ToSql<sql_types::BigInt, Pg> for SagaNodeId {
         out: &mut serialize::Output<'a, '_, Pg>,
     ) -> serialize::Result {
         // Diesel newtype -> steno type -> u32 -> i64 -> SQL
-        let id = u32::from(self.0) as i64;
+        let id = i64::from(u32::from(self.0));
         <i64 as ToSql<sql_types::BigInt, Pg>>::to_sql(&id, &mut out.reborrow())
     }
 }

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -590,7 +590,7 @@ impl DataStore {
                          attach will be safe to retry once start/stop completes"
                     )),
                     state if SAFE_TO_ATTACH_INSTANCE_STATES.contains(&state) => {
-                        if attached_count >= MAX_EXTERNAL_IPS_PLUS_SNAT as i64 {
+                        if attached_count >= i64::from(MAX_EXTERNAL_IPS_PLUS_SNAT) {
                             Error::invalid_request(&format!(
                                 "an instance may not have more than \
                                 {MAX_EXTERNAL_IPS_PER_INSTANCE} external IP addresses",

--- a/nexus/db-queries/src/db/datastore/ipv4_nat_entry.rs
+++ b/nexus/db-queries/src/db/datastore/ipv4_nat_entry.rs
@@ -303,7 +303,7 @@ impl DataStore {
                     .gt(version)
                     .or(dsl::version_removed.gt(version)),
             )
-            .limit(limit as i64)
+            .limit(i64::from(limit))
             .select(Ipv4NatEntry::as_select())
             .load_async(&*self.pool_connection_authorized(opctx).await?)
             .await
@@ -322,7 +322,7 @@ impl DataStore {
 
         let nat_changes = dsl::ipv4_nat_changes
             .filter(dsl::version.gt(version))
-            .limit(limit as i64)
+            .limit(i64::from(limit))
             .order_by(dsl::version)
             .select(Ipv4NatChange::as_select())
             .load_async(&*self.pool_connection_authorized(opctx).await?)

--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -112,7 +112,7 @@ impl DataStore {
         size: external::ByteCount,
     ) -> (u64, u64) {
         let blocks_per_extent =
-            Self::EXTENT_SIZE / block_size.to_bytes() as u64;
+            Self::EXTENT_SIZE / u64::from(block_size.to_bytes());
 
         let size = size.to_bytes();
 
@@ -175,7 +175,7 @@ impl DataStore {
 
         let query = crate::db::queries::region_allocation::allocation_query(
             volume_id,
-            block_size.to_bytes() as u64,
+            u64::from(block_size.to_bytes()),
             blocks_per_extent,
             extent_count,
             allocation_strategy,
@@ -378,7 +378,7 @@ mod test {
         // Note that i64::MAX bytes is an invalid disk size as it's not
         // divisible by 4096. Create the maximum sized disk here.
         let max_disk_size = i64::MAX
-            - (i64::MAX % (BlockSize::AdvancedFormat.to_bytes() as i64));
+            - (i64::MAX % i64::from(BlockSize::AdvancedFormat.to_bytes()));
         let (blocks_per_extent, extent_count) =
             DataStore::get_crucible_allocation(
                 &BlockSize::AdvancedFormat,
@@ -387,16 +387,16 @@ mod test {
 
         // We should still be rounding up to the nearest extent size.
         assert_eq!(
-            extent_count as u128 * DataStore::EXTENT_SIZE as u128,
+            u128::from(extent_count) * u128::from(DataStore::EXTENT_SIZE),
             i64::MAX as u128 + 1,
         );
 
         // Assert that the regions allocated will fit this disk
         assert!(
             max_disk_size as u128
-                <= extent_count as u128
-                    * blocks_per_extent as u128
-                    * DataStore::EXTENT_SIZE as u128
+                <= u128::from(extent_count)
+                    * u128::from(blocks_per_extent)
+                    * u128::from(DataStore::EXTENT_SIZE)
         );
     }
 }

--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -155,7 +155,7 @@ impl DataStore {
             .filter(dsl::id.eq(*vmm_id))
             .set((
                 dsl::propolis_ip.eq(new_ip),
-                dsl::propolis_port.eq(new_port as i32),
+                dsl::propolis_port.eq(i32::from(new_port)),
             ))
             .returning(Vmm::as_returning())
             .get_result_async(&*self.pool_connection_authorized(opctx).await?)

--- a/nexus/db-queries/src/db/queries/region_allocation.rs
+++ b/nexus/db-queries/src/db/queries/region_allocation.rs
@@ -90,7 +90,7 @@ pub fn allocation_query(
                         .unwrap()
                         .as_nanos()
                 },
-                |seed| seed as u128,
+                |seed| u128::from(seed),
             ),
             distinct_sleds,
         )

--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -151,7 +151,7 @@ impl super::Nexus {
 
         // Reject disks where the size isn't at least
         // MIN_DISK_SIZE_BYTES
-        if params.size.to_bytes() < MIN_DISK_SIZE_BYTES as u64 {
+        if params.size.to_bytes() < u64::from(MIN_DISK_SIZE_BYTES) {
             return Err(Error::invalid_value(
                 "size",
                 format!(
@@ -163,7 +163,7 @@ impl super::Nexus {
 
         // Reject disks where the MIN_DISK_SIZE_BYTES doesn't evenly
         // divide the size
-        if (params.size.to_bytes() % MIN_DISK_SIZE_BYTES as u64) != 0 {
+        if (params.size.to_bytes() % u64::from(MIN_DISK_SIZE_BYTES)) != 0 {
             return Err(Error::invalid_value(
                 "size",
                 format!(

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -150,7 +150,7 @@ impl super::Nexus {
                 // allow users to boot that. This should go away when that blob
                 // does.
                 let db_block_size = db::model::BlockSize::Traditional;
-                let block_size: u64 = db_block_size.to_bytes() as u64;
+                let block_size: u64 = u64::from(db_block_size.to_bytes());
 
                 let image_id = Uuid::new_v4();
 

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -294,7 +294,7 @@ impl super::Nexus {
 
         // Reject instances where the memory is not at least
         // MIN_MEMORY_BYTES_PER_INSTANCE
-        if params.memory.to_bytes() < MIN_MEMORY_BYTES_PER_INSTANCE as u64 {
+        if params.memory.to_bytes() < u64::from(MIN_MEMORY_BYTES_PER_INSTANCE) {
             return Err(Error::invalid_value(
                 "size",
                 format!(
@@ -306,7 +306,7 @@ impl super::Nexus {
 
         // Reject instances where the memory is not divisible by
         // MIN_MEMORY_BYTES_PER_INSTANCE
-        if (params.memory.to_bytes() % MIN_MEMORY_BYTES_PER_INSTANCE as u64)
+        if (params.memory.to_bytes() % u64::from(MIN_MEMORY_BYTES_PER_INSTANCE))
             != 0
         {
             return Err(Error::invalid_value(

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -153,7 +153,7 @@ async fn sim_reserve_sled_resources(
     let resource = super::instance_common::reserve_vmm_resources(
         osagactx.nexus(),
         propolis_id,
-        params.instance.ncpus.0 .0 as u32,
+        u32::from(params.instance.ncpus.0 .0),
         params.instance.memory,
         constraints,
     )

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -132,7 +132,7 @@ async fn sis_alloc_server(
     let resource = super::instance_common::reserve_vmm_resources(
         osagactx.nexus(),
         propolis_id,
-        hardware_threads.0 as u32,
+        u32::from(hardware_threads.0),
         reservoir_ram,
         db::model::SledReservationConstraints::none(),
     )

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -801,7 +801,7 @@ async fn test_disk_reject_total_size_not_divisible_by_block_size(
     // divisible by block size.
     assert!(
         disk_size.to_bytes()
-            < DiskTest::DEFAULT_ZPOOL_SIZE_GIB as u64 * 1024 * 1024 * 1024
+            < u64::from(DiskTest::DEFAULT_ZPOOL_SIZE_GIB) * 1024 * 1024 * 1024
     );
 
     let disks_url = get_disks_url();

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -857,7 +857,7 @@ async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
     let disks_url = get_disks_url();
 
     // Create a disk at just over half the capacity of what DiskTest allocates
-    let gibibytes: u64 = DiskTest::DEFAULT_ZPOOL_SIZE_GIB as u64 / 2 + 1;
+    let gibibytes: u64 = u64::from(DiskTest::DEFAULT_ZPOOL_SIZE_GIB) / 2 + 1;
     let disk_size =
         ByteCount::try_from(gibibytes * 1024 * 1024 * 1024).unwrap();
     let base_disk_name: Name = "base-disk".parse().unwrap();

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1289,7 +1289,7 @@ impl Into<ByteCount> for BlockSize {
 
 impl From<BlockSize> for u64 {
     fn from(bs: BlockSize) -> u64 {
-        bs.0 as u64
+        u64::from(bs.0)
     }
 }
 

--- a/oximeter/db/src/model.rs
+++ b/oximeter/db/src/model.rs
@@ -64,7 +64,7 @@ impl From<u64> for DbBool {
 
 impl From<bool> for DbBool {
     fn from(b: bool) -> Self {
-        DbBool { inner: b as _ }
+        DbBool { inner: u8::from(b) }
     }
 }
 

--- a/oximeter/db/src/oxql/ast/grammar.rs
+++ b/oximeter/db/src/oxql/ast/grammar.rs
@@ -708,7 +708,7 @@ mod tests {
         }
 
         assert!(query_parser::duration_literal_impl("-1m").is_err());
-        let too_big: i64 = u32::MAX as i64 + 1;
+        let too_big: i64 = i64::from(u32::MAX) + 1;
         assert!(query_parser::duration_literal_impl(&format!("{too_big}s"))
             .is_err());
     }

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -882,7 +882,7 @@ impl Pantry {
                         ..
                     } => (
                         block_size,
-                        block_size * blocks_per_extent * (extent_count as u64),
+                        block_size * blocks_per_extent * u64::from(extent_count),
                     ),
 
                     _ => {

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -882,7 +882,9 @@ impl Pantry {
                         ..
                     } => (
                         block_size,
-                        block_size * blocks_per_extent * u64::from(extent_count),
+                        block_size
+                            * blocks_per_extent
+                            * u64::from(extent_count),
                     ),
 
                     _ => {

--- a/sled-agent/src/vmm_reservoir.rs
+++ b/sled-agent/src/vmm_reservoir.rs
@@ -240,7 +240,8 @@ impl VmmReservoirManager {
                         percent
                     )));
                 };
-                (hardware_physical_ram_bytes as f64 * (f64::from(percent) / 100.0))
+                (hardware_physical_ram_bytes as f64
+                    * (f64::from(percent) / 100.0))
                     .floor() as u64
             }
         };

--- a/sled-agent/src/vmm_reservoir.rs
+++ b/sled-agent/src/vmm_reservoir.rs
@@ -240,7 +240,7 @@ impl VmmReservoirManager {
                         percent
                     )));
                 };
-                (hardware_physical_ram_bytes as f64 * (percent as f64 / 100.0))
+                (hardware_physical_ram_bytes as f64 * (f64::from(percent) / 100.0))
                     .floor() as u64
             }
         };

--- a/sled-hardware/types/src/underlay.rs
+++ b/sled-hardware/types/src/underlay.rs
@@ -45,9 +45,9 @@ fn mac_to_bootstrap_ip(mac: MacAddr, interface_id: u64) -> Ipv6Addr {
 
     Ipv6Addr::new(
         BOOTSTRAP_PREFIX,
-        ((mac_bytes[0] as u16) << 8) | mac_bytes[1] as u16,
-        ((mac_bytes[2] as u16) << 8) | mac_bytes[3] as u16,
-        ((mac_bytes[4] as u16) << 8) | mac_bytes[5] as u16,
+        (u16::from(mac_bytes[0]) << 8) | u16::from(mac_bytes[1]),
+        (u16::from(mac_bytes[2]) << 8) | u16::from(mac_bytes[3]),
+        (u16::from(mac_bytes[4]) << 8) | u16::from(mac_bytes[5]),
         (interface_id >> 48 & 0xffff).try_into().unwrap(),
         (interface_id >> 32 & 0xffff).try_into().unwrap(),
         (interface_id >> 16 & 0xffff).try_into().unwrap(),

--- a/sp-sim/src/update.rs
+++ b/sp-sim/src/update.rs
@@ -89,7 +89,7 @@ impl SimSpUpdate {
                 if chunk.id != *id || chunk.component != *component {
                     return Err(SpError::InvalidUpdateId { sp_update_id: *id });
                 };
-                if data.position() != chunk.offset as u64 {
+                if data.position() != u64::from(chunk.offset) {
                     return Err(SpError::UpdateInProgress(
                         self.state.to_message(),
                     ));

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -326,9 +326,9 @@ fn populate_network_table(
                     let mut bgp = Table::new();
                     bgp.insert(
                         "asn",
-                        Item::Value(Value::Integer(Formatted::new(
-                            i64::from(cfg.asn),
-                        ))),
+                        Item::Value(Value::Integer(Formatted::new(i64::from(
+                            cfg.asn,
+                        )))),
                     );
 
                     let mut originate = Array::new();

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -273,7 +273,7 @@ fn populate_network_table(
                         );
                         peer.insert(
                             "asn",
-                            Value::Integer(Formatted::new(p.asn as i64)),
+                            Value::Integer(Formatted::new(i64::from(p.asn))),
                         );
                         peer.insert(
                             "port",
@@ -327,7 +327,7 @@ fn populate_network_table(
                     bgp.insert(
                         "asn",
                         Item::Value(Value::Integer(Formatted::new(
-                            cfg.asn as i64,
+                            i64::from(cfg.asn),
                         ))),
                     );
 

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -2015,7 +2015,7 @@ impl ComponentUpdateListState {
                     {
                         if let Some(total) = counter.total {
                             let percentage =
-                                (counter.current as u128 * 100) / total as u128;
+                                (u128::from(counter.current) * 100) / u128::from(total);
                             item_spans.push(Span::styled(
                                 format!("[{:>2}%] ", percentage),
                                 style::selected(),

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -2014,8 +2014,9 @@ impl ComponentUpdateListState {
                         progress_event.kind.progress_counter()
                     {
                         if let Some(total) = counter.total {
-                            let percentage =
-                                (u128::from(counter.current) * 100) / u128::from(total);
+                            let percentage = (u128::from(counter.current)
+                                * 100)
+                                / u128::from(total);
                             item_spans.push(Span::styled(
                                 format!("[{:>2}%] ", percentage),
                                 style::selected(),

--- a/wicket/src/ui/widgets/popup.rs
+++ b/wicket/src/ui/widgets/popup.rs
@@ -195,7 +195,7 @@ impl PopupScrollability for Scrollable {
 ///
 /// This is currently 80% of screen width.
 pub fn popup_max_width(full_screen_width: u16) -> u16 {
-    (full_screen_width as u32 * 4 / 5) as u16
+    (u32::from(full_screen_width) * 4 / 5) as u16
 }
 
 /// Returns the maximum width that this popup can have, not including outer
@@ -210,7 +210,7 @@ pub fn popup_max_content_width(full_screen_width: u16) -> u16 {
 ///
 /// This is currently 80% of screen height.
 pub fn popup_max_height(full_screen_height: u16) -> u16 {
-    (full_screen_height as u32 * 4 / 5) as u16
+    (u32::from(full_screen_height) * 4 / 5) as u16
 }
 
 /// Returns the wrap options that should be used in most cases for popups.

--- a/wicket/src/ui/widgets/rack.rs
+++ b/wicket/src/ui/widgets/rack.rs
@@ -318,7 +318,9 @@ fn resize(rect: Rect) -> ComponentRects {
     for i in [17, 18] {
         let shelf_rect = Rect {
             x: rack_rect.x,
-            y: rack_rect.y + sled_height * 8 + other_height * (u16::from(i) - 16),
+            y: rack_rect.y
+                + sled_height * 8
+                + other_height * (u16::from(i) - 16),
             width: sled_width * 2,
             height: other_height,
         };

--- a/wicket/src/ui/widgets/rack.rs
+++ b/wicket/src/ui/widgets/rack.rs
@@ -318,7 +318,7 @@ fn resize(rect: Rect) -> ComponentRects {
     for i in [17, 18] {
         let shelf_rect = Rect {
             x: rack_rect.x,
-            y: rack_rect.y + sled_height * 8 + other_height * (i as u16 - 16),
+            y: rack_rect.y + sled_height * 8 + other_height * (u16::from(i) - 16),
             width: sled_width * 2,
             height: other_height,
         };
@@ -379,9 +379,9 @@ fn size_sled(
         rack.x + sled_width
     };
     let y = if index < 16 {
-        rack.y + sled_height * (index as u16 / 2)
+        rack.y + sled_height * (u16::from(index) / 2)
     } else {
-        rack.y + sled_height * (index as u16 / 2) + other_height * 4
+        rack.y + sled_height * (u16::from(index) / 2) + other_height * 4
     };
     let height = if (index == 30 || index == 31) && sled_height == 2 {
         // We saved space for a bottom border

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -26,13 +26,13 @@ impl From<ComponentId> for SpIdentifier {
     fn from(id: ComponentId) -> Self {
         match id {
             ComponentId::Sled(i) => {
-                SpIdentifier { type_: SpType::Sled, slot: i as u32 }
+                SpIdentifier { type_: SpType::Sled, slot: u32::from(i) }
             }
             ComponentId::Psc(i) => {
-                SpIdentifier { type_: SpType::Power, slot: i as u32 }
+                SpIdentifier { type_: SpType::Power, slot: u32::from(i) }
             }
             ComponentId::Switch(i) => {
-                SpIdentifier { type_: SpType::Switch, slot: i as u32 }
+                SpIdentifier { type_: SpType::Switch, slot: u32::from(i) }
             }
         }
     }

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -2159,8 +2159,8 @@ impl UpdateContext {
                         if let Some(progress) = progress {
                             cx.send_progress(
                                 StepProgress::with_current_and_total(
-                                    progress.current as u64,
-                                    progress.total as u64,
+                                    u64::from(progress.current),
+                                    u64::from(progress.total),
                                     // The actual units here depend on the
                                     // component being updated and are a bit
                                     // hard to explain succinctly:
@@ -2194,8 +2194,8 @@ impl UpdateContext {
                         ComponentUpdateStage::InProgress => {
                             cx.send_progress(
                                 StepProgress::with_current_and_total(
-                                    bytes_received as u64,
-                                    total_bytes as u64,
+                                    u64::from(bytes_received),
+                                    u64::from(total_bytes),
                                     ProgressUnits::BYTES,
                                     Default::default(),
                                 ),


### PR DESCRIPTION
Originally brought up in #5540.

It might seem strange to only warn on lossless casts for now, but:

- if the somewhat-illegible "from" type changes, they can suddenly become
  lossy, and
- these are the casts that are easiest to convert over

In the future, it would be nice to also warn on lossy casts.
