### PR TITLE
Fix dataset unmount during virtual hardware destroy

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -663,10 +663,10 @@ fn zfs_list_internal(canmount: &str, mounted: &str) -> Result<Vec<String>> {
             if !dataset.starts_with("oxi_") {
                 return None;
             }
-            if canmount != cols.next()? {
+            if mounted != cols.next()? {
                 return None;
             }
-            if mounted != cols.next()? {
+            if canmount != cols.next()? {
                 return None;
             }
             return Some(dataset.to_string());

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -210,7 +210,7 @@ fn demount_backingfs() -> Result<()> {
     const BACKED_SERVICES: &str = "svc:/system/fmd:default";
     println!("Disabling {BACKED_SERVICES}");
     svcadm_temporary_toggle(BACKED_SERVICES, false)?;
-    for dataset in zfs_list_internal("yes", "noauto")? {
+    for dataset in zfs_list_internal("noauto", "yes")? {
         println!("unmounting: {dataset}");
         zfs_umount(&dataset)?;
     }
@@ -663,10 +663,10 @@ fn zfs_list_internal(canmount: &str, mounted: &str) -> Result<Vec<String>> {
             if !dataset.starts_with("oxi_") {
                 return None;
             }
-            if mounted != cols.next()? {
+            if canmount != cols.next()? {
                 return None;
             }
-            if canmount != cols.next()? {
+            if mounted != cols.next()? {
                 return None;
             }
             return Some(dataset.to_string());


### PR DESCRIPTION
Fixes a bug where running `cargo xtask virtual-hardware destroy` after installing and uninstalling omicron would result in the following error:

```console
$ cargo xtask virtual-hardware destroy
    Finished dev [unoptimized + debuginfo] target(s) in 0.81s
     Running `target/debug/xtask virtual-hardware destroy`
destroying virtual hardware
Disabling svc:/system/fmd:default
Re-enabling svc:/system/fmd:default
unloading xde driver
ensuring softnpu zone destroyed
destroying: oxi_3dfef4dd-139b-4456-b322-deb39e1e86a5
destroyed: oxi_3dfef4dd-139b-4456-b322-deb39e1e86a5
destroying: oxi_9fca391c-2991-4964-90dc-8e5f321c1176
Error: "/usr/bin/pfexec" failed: exit status: 1 (stderr: cannot unmount '/var/fm/fmd': Device busy
)
```

When looking into this further I noticed the code was checking the second column to see if it could not be mounted by asserting if its value was not equal to "yes" and checking the third column to see if it was not mounted by asserting if its value did not equal "noauto":

```rust
// Lines 213-216
for dataset in zfs_list_internal("yes", "noauto")? {
    println!("unmounting: {dataset}");
    zfs_umount(&dataset)?;
}

// Lines 652-675
fn zfs_list_internal(canmount: &str, mounted: &str) -> Result<Vec<String>> {
    let mut cmd = Command::new(ZFS);
    cmd.args(["list", "-rHpo", "name,canmount,mounted"]);
    let output = execute(cmd)?;

    Ok(String::from_utf8(output.stdout)
        .context("Invalid zfs list output")?
        .lines()
        .filter_map(|line| {
            let mut cols = line.trim().split_whitespace();
            let dataset = cols.next()?;
            if !dataset.starts_with("oxi_") {
                return None;
            }
            if canmount != cols.next()? {
                return None;
            }
            if mounted != cols.next()? {
                return None;
            }
            return Some(dataset.to_string());
        })
        .collect())
}
```

The values when calling `zfs_list_internal()` on line 213 should be inverted to reflect the ordering of the `$ zfs list -rHpo name,canmount,mounted` command called in lines 653 and 654:

```rust
    let mut cmd = Command::new(ZFS);
    cmd.args(["list", "-rHpo", "name,canmount,mounted"]);
```

### Fix tested on a Helios machine

```console
$ cargo xtask virtual-hardware create --gateway-ip "$GATEWAY_IP" --pxa-start "$PXA_START" --pxa-end "$PXA_END" --physical-link "$PHYSICAL_LINK" --gateway-mac "$GATEWAY_MAC"
    Finished dev [unoptimized + debuginfo] target(s) in 0.42s
     Running `target/debug/xtask virtual-hardware create --gateway-ip 192.168.1.199 --pxa-start 192.168.1.20 --pxa-end 192.168.1.40 --physical-link fake_external_stub0 --gateway-mac '02:08:20:95:4a:29'`
creating virtual hardware
creating /var/tmp/m2_0.vdev
creating /var/tmp/m2_1.vdev
creating /var/tmp/u2_0.vdev
creating /var/tmp/u2_1.vdev
creating /var/tmp/u2_2.vdev
creating /var/tmp/u2_3.vdev
creating /var/tmp/u2_4.vdev
creating /var/tmp/u2_5.vdev
creating /var/tmp/u2_6.vdev
creating /var/tmp/u2_7.vdev
creating /var/tmp/u2_8.vdev
Simnet net0/sc0_0 exists
Simnet net1/sc1_0 exists
Vnic sc0_1 exists
Using 192.168.1.199 as gateway ip
using 02:08:20:95:4A:29 as gateway mac
configuring SoftNPU ARP entry
configuring SoftNPU proxy ARP
SoftNPU state:
  local v6:
  local v4:
  router v6:
  router v4_idx:
  router v4_routes:
  resolver v4:
  192.168.1.199 -> 02:08:20:95:4a:29
  resolver v6:
  nat v4:
  nat_v6:
  port_mac:
  proxy arp:
  192.168.1.20/192.168.1.40: a8:e1:de:01:70:1d
created virtual hardware
$ pfexec ./target/release/omicron-package -t centzon install
Logging to: /home/coatlicue/src/omicron/out/LOG
$ zoneadm list
global
sidecar_softnpu
oxz_switch
oxz_internal_dns_2ce8fd4d-8a4c-402f-8627-ecebe856cbe5
oxz_internal_dns_cc8e7214-a66d-4ef6-81e7-54745dc0792e
oxz_internal_dns_95c58b1a-7e0c-4f44-9600-8a296f718f2c
oxz_ntp_20fdc77d-d04f-4ed2-9d3e-e5018e1262ad
oxz_cockroachdb_6d5f28d1-0f2c-4a81-a2ec-aa643fbafc1a
oxz_cockroachdb_d2f8c0e0-9552-4ce1-89a9-b131e4c4a9e4
oxz_cockroachdb_a019f6c5-a006-42d1-96e6-eeef99705123
oxz_cockroachdb_b9b2b59b-4524-4e82-aa12-1872371ffbbd
oxz_cockroachdb_edbff36d-6731-47bc-98f1-a6beebf6a57a
oxz_crucible_b645cdec-6978-48d8-b573-6f4278df485b
oxz_crucible_acebdb38-d38e-4071-b833-3558b8c5c23f
oxz_crucible_fb969ea3-e8e3-4360-83b8-b3e8e4ed1e85
oxz_crucible_e70aeeed-dd41-4f1b-964d-65776d7eba77
oxz_crucible_77380b8b-7ec9-42dd-bd9e-6f3ddaa3bdfc
oxz_oximeter_da21473b-c931-4a56-b18f-267d19abc547
oxz_crucible_1faca31c-6284-4cca-a0a6-9e4662d9be4f
oxz_crucible_b27a2bfa-b593-4ce6-9b39-0fd74685f5a2
oxz_crucible_pantry_8f15bcb2-1e68-4cd4-973a-b720209eff32
oxz_crucible_c03e85ae-6d0c-4b18-a36e-6bbacbf4b634
oxz_nexus_2daf75d3-cd94-4734-8f7a-074bc84a6732
oxz_nexus_5a3543b7-df7b-4cbe-a493-55e7d9cf74ee
oxz_crucible_pantry_c3b8a111-3bbe-49ba-920d-88e6e83a18fb
oxz_crucible_pantry_457c44a3-37d2-4125-a695-806331a5d074
oxz_crucible_7de1e905-dd8c-4785-aa9e-3d796e0c7a0e
oxz_external_dns_971460cb-2280-4456-ad5c-33eada634b48
oxz_external_dns_ff27df0a-dece-4cbc-8604-e099f90d9022
oxz_clickhouse_b6d8b8b6-90e8-4abc-ace9-3e792d709130
oxz_nexus_868d1b38-c4b0-49a0-8f18-4e56b07576e5
$ pfexec ./target/release/omicron-package -t centzon uninstall
Logging to: /home/coatlicue/src/omicron/out/LOG
About to delete the following datasets: [
    "oxi_16193889-6446-469f-bd2b-35b1206dc1d7/cluster",
    "oxi_16193889-6446-469f-bd2b-35b1206dc1d7/config",
    "oxi_16193889-6446-469f-bd2b-35b1206dc1d7/debug",
    "oxi_16193889-6446-469f-bd2b-35b1206dc1d7/install",
    "oxi_7c6f7791-992e-4d87-b26f-4f76602820c8/cluster",
    "oxi_7c6f7791-992e-4d87-b26f-4f76602820c8/config",
    "oxi_7c6f7791-992e-4d87-b26f-4f76602820c8/debug",
    "oxi_7c6f7791-992e-4d87-b26f-4f76602820c8/install",
    "oxp_1637b74e-5bd3-45c1-8a85-71eb9b8c7158/crucible",
    "oxp_1637b74e-5bd3-45c1-8a85-71eb9b8c7158/crypt",
    "oxp_44abd0b7-0592-4406-8e3a-a70ce55f9500/crucible",
    "oxp_44abd0b7-0592-4406-8e3a-a70ce55f9500/crypt",
    "oxp_6879b1df-cfdd-4f99-b58c-32e04066c242/crucible",
    "oxp_6879b1df-cfdd-4f99-b58c-32e04066c242/crypt",
    "oxp_9deecf63-7fe1-46b3-9cfb-9bc2689345be/crucible",
    "oxp_9deecf63-7fe1-46b3-9cfb-9bc2689345be/crypt",
    "oxp_b6c2eae1-9a71-4d3d-953b-41e3f6bfb0c2/crucible",
    "oxp_b6c2eae1-9a71-4d3d-953b-41e3f6bfb0c2/crypt",
    "oxp_b9910049-d8fb-41f1-9ec7-b07723fce648/crucible",
    "oxp_b9910049-d8fb-41f1-9ec7-b07723fce648/crypt",
    "oxp_deacd5ab-ff26-4728-bcf7-bdb4ab7cf937/crucible",
    "oxp_deacd5ab-ff26-4728-bcf7-bdb4ab7cf937/crypt",
    "oxp_df79a8ac-d4f9-47f9-98a0-e7ec958c305b/crucible",
    "oxp_df79a8ac-d4f9-47f9-98a0-e7ec958c305b/crypt",
    "oxp_ee7b3860-8fd7-44ac-a7f8-0ee2e9b9432b/crucible",
    "oxp_ee7b3860-8fd7-44ac-a7f8-0ee2e9b9432b/crypt",
    "rpool/zone/oxz_switch",
]
[yY to confirm] >> y
$ cargo xtask virtual-hardware destroy
    Finished dev [unoptimized + debuginfo] target(s) in 0.82s
     Running `target/debug/xtask virtual-hardware destroy`
destroying virtual hardware
Disabling svc:/system/fmd:default
unmounting: oxi_7c6f7791-992e-4d87-b26f-4f76602820c8/backing/fmd
Re-enabling svc:/system/fmd:default
unloading xde driver
ensuring softnpu zone destroyed
destroying: oxi_16193889-6446-469f-bd2b-35b1206dc1d7
destroyed: oxi_16193889-6446-469f-bd2b-35b1206dc1d7
destroying: oxi_7c6f7791-992e-4d87-b26f-4f76602820c8
destroyed: oxi_7c6f7791-992e-4d87-b26f-4f76602820c8
destroying: oxp_1637b74e-5bd3-45c1-8a85-71eb9b8c7158
destroyed: oxp_1637b74e-5bd3-45c1-8a85-71eb9b8c7158
destroying: oxp_44abd0b7-0592-4406-8e3a-a70ce55f9500
destroyed: oxp_44abd0b7-0592-4406-8e3a-a70ce55f9500
destroying: oxp_6879b1df-cfdd-4f99-b58c-32e04066c242
destroyed: oxp_6879b1df-cfdd-4f99-b58c-32e04066c242
destroying: oxp_9deecf63-7fe1-46b3-9cfb-9bc2689345be
destroyed: oxp_9deecf63-7fe1-46b3-9cfb-9bc2689345be
destroying: oxp_b6c2eae1-9a71-4d3d-953b-41e3f6bfb0c2
destroyed: oxp_b6c2eae1-9a71-4d3d-953b-41e3f6bfb0c2
destroying: oxp_b9910049-d8fb-41f1-9ec7-b07723fce648
destroyed: oxp_b9910049-d8fb-41f1-9ec7-b07723fce648
destroying: oxp_deacd5ab-ff26-4728-bcf7-bdb4ab7cf937
destroyed: oxp_deacd5ab-ff26-4728-bcf7-bdb4ab7cf937
destroying: oxp_df79a8ac-d4f9-47f9-98a0-e7ec958c305b
destroyed: oxp_df79a8ac-d4f9-47f9-98a0-e7ec958c305b
destroying: oxp_ee7b3860-8fd7-44ac-a7f8-0ee2e9b9432b
destroyed: oxp_ee7b3860-8fd7-44ac-a7f8-0ee2e9b9432b
deleted /var/tmp/m2_0.vdev
deleted /var/tmp/m2_1.vdev
deleted /var/tmp/u2_0.vdev
deleted /var/tmp/u2_1.vdev
deleted /var/tmp/u2_2.vdev
deleted /var/tmp/u2_3.vdev
deleted /var/tmp/u2_4.vdev
deleted /var/tmp/u2_5.vdev
deleted /var/tmp/u2_6.vdev
deleted /var/tmp/u2_7.vdev
deleted /var/tmp/u2_8.vdev
destroyed virtual hardware

```

Closes https://github.com/oxidecomputer/omicron/issues/5559