### PR TITLE
add pumpkind to switch and global zones

### DIFF
--- a/.github/buildomat/jobs/package.sh
+++ b/.github/buildomat/jobs/package.sh
@@ -29,6 +29,9 @@ set -o xtrace
 cargo --version
 rustc --version
 
+WORK=/work
+pfexec mkdir -p $WORK && pfexec chown $USER $WORK
+
 #
 # Generate the version for control plane artifacts here. We use `0.git` as the
 # prerelease field because it comes before `alpha`.
@@ -66,19 +69,11 @@ files=(
 	target/release/xtask
 )
 
-pfexec mkdir -p /work && pfexec chown $USER /work
-ptime -m tar cvzf /work/package.tar.gz "${files[@]}"
+ptime -m tar cvzf $WORK/package.tar.gz "${files[@]}"
 
 tarball_src_dir="$(pwd)/out/versioned"
 stamp_packages() {
 	for package in "$@"; do
-		# TODO: remove once https://github.com/oxidecomputer/omicron-package/pull/54 lands
-		if [[ $package == mg-ddm-gz ]]; then
-			echo "0.0.0" > VERSION
-			tar rvf "out/$package.tar" VERSION
-			rm VERSION
-		fi
-
 		cargo run --locked --release --bin omicron-package -- stamp "$package" "$VERSION"
 	done
 }
@@ -92,10 +87,10 @@ ptime -m cargo run --locked --release --bin omicron-package -- \
   -t host target create -i standard -m gimlet -s asic -r multi-sled
 ptime -m cargo run --locked --release --bin omicron-package -- \
   -t host package
-stamp_packages omicron-sled-agent mg-ddm-gz propolis-server overlay oxlog
+stamp_packages omicron-sled-agent mg-ddm-gz propolis-server overlay oxlog pumpkind-gz
 
-# Create global zone package @ /work/global-zone-packages.tar.gz
-ptime -m ./tools/build-global-zone-packages.sh "$tarball_src_dir" /work
+# Create global zone package @ $WORK/global-zone-packages.tar.gz
+ptime -m ./tools/build-global-zone-packages.sh "$tarball_src_dir" $WORK
 
 # Non-Global Zones
 
@@ -107,7 +102,7 @@ ptime -m ./tools/build-global-zone-packages.sh "$tarball_src_dir" /work
 #
 # Note that when building for a real gimlet, `propolis-server` and `switch-*`
 # should be included in the OS ramdisk.
-mkdir -p /work/zones
+mkdir -p $WORK/zones
 zones=(
   out/clickhouse.tar.gz
   out/clickhouse_keeper.tar.gz
@@ -127,7 +122,7 @@ zones=(
   out/overlay.tar.gz
   out/probe.tar.gz
 )
-cp "${zones[@]}" /work/zones/
+cp "${zones[@]}" $WORK/zones/
 
 #
 # Global Zone files for Trampoline image
@@ -140,5 +135,5 @@ ptime -m cargo run --locked --release --bin omicron-package -- \
   -t recovery package
 stamp_packages installinator mg-ddm-gz
 
-# Create trampoline global zone package @ /work/trampoline-global-zone-packages.tar.gz
-ptime -m ./tools/build-trampoline-global-zone-packages.sh "$tarball_src_dir" /work
+# Create trampoline global zone package @ $WORK/trampoline-global-zone-packages.tar.gz
+ptime -m ./tools/build-trampoline-global-zone-packages.sh "$tarball_src_dir" $WORK

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -582,6 +582,26 @@ source.sha256 = "15a9068fdd4521a77f7d32c80d1e6d3a6a4ad15accab77641ed8f14175ae0db
 output.type = "zone"
 output.intermediate_only = true
 
+[package.pumpkind]
+service_name = "pumpkind"
+source.type = "prebuilt"
+source.repo = "pumpkind"
+source.commit = "b648f61cb1cc23ec3c850349a5db49c980580ead"
+source.sha256 = "d20d877ca42eb6207a870802e7cec8a9c7143348c22ed9271646b3d6bfcc2b85"
+output.type = "zone"
+output.intermediate_only = true
+only_for_targets.image = "standard"
+only_for_targets.switch = "asic"
+
+[package.pumpkind-gz]
+service_name = "pumpkind-gz"
+source.type = "prebuilt"
+source.repo = "pumpkind"
+source.commit = "b648f61cb1cc23ec3c850349a5db49c980580ead"
+source.sha256 = "83b29f0694c1750296d3c52698ca284980efd779bd1ef635b014931e5083d630"
+output.type = "tarball"
+only_for_targets.image = "standard"
+
 [package.dendrite-stub]
 service_name = "dendrite"
 only_for_targets.switch = "stub"
@@ -678,6 +698,7 @@ source.packages = [
   "omicron-gateway-asic.tar.gz",
   "dendrite-asic.tar.gz",
   "lldp.tar.gz",
+  "pumpkind.tar.gz",
   "wicketd.tar.gz",
   "wicket.tar.gz",
   "mg-ddm.tar.gz",

--- a/sled-agent/src/bootstrap/mod.rs
+++ b/sled-agent/src/bootstrap/mod.rs
@@ -12,6 +12,7 @@ mod http_entrypoints;
 mod maghemite;
 pub(crate) mod params;
 mod pre_server;
+mod pumpkind;
 mod rack_ops;
 pub(crate) mod rss_handle;
 pub mod secret_retriever;

--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::result_large_err)]
 
 use super::maghemite;
+use super::pumpkind;
 use super::server::StartError;
 use crate::config::Config;
 use crate::config::SidecarRevision;
@@ -75,6 +76,7 @@ impl BootstrapAgentStartup {
         let (config, log, ddm_admin_localhost_client, startup_networking) =
             tokio::task::spawn_blocking(move || {
                 enable_mg_ddm(&config, &log)?;
+                pumpkind::enable_pumpkind_service(&log)?;
                 ensure_zfs_key_directory_exists(&log)?;
 
                 let startup_networking = BootstrapNetworking::setup(&config)?;

--- a/sled-agent/src/bootstrap/pumpkind.rs
+++ b/sled-agent/src/bootstrap/pumpkind.rs
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Starting the pumpkind service.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error configuring service: {0}")]
+    Config(#[from] smf::ConfigError),
+
+    #[error("Error administering service: {0}")]
+    Adm(#[from] smf::AdmError),
+}
+
+#[cfg(feature = "switch-asic")]
+pub(super) fn enable_pumpkind_service(log: &slog::Logger) -> Result<(), Error> {
+    const SERVICE_FMRI: &str = "svc:/oxide/pumpkind";
+    const MANIFEST_PATH: &str =
+        "/opt/oxide/pumpkind/lib/svc/manifest/system/pumpkind.xml";
+
+    info!(log, "Importing pumpkind service"; "path" => MANIFEST_PATH);
+    smf::Config::import().run(MANIFEST_PATH)?;
+
+    info!(log, "Enabling pumpkind service");
+    smf::Adm::new()
+        .enable()
+        .temporary()
+        .run(smf::AdmSelection::ByPattern(&[SERVICE_FMRI]))?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "switch-asic"))]
+pub(super) fn enable_pumpkind_service(
+    _log: &slog::Logger,
+) -> Result<(), Error> {
+    Ok(())
+}

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use crate::bootstrap::http_entrypoints::api as http_api;
 use crate::bootstrap::http_entrypoints::BootstrapServerContext;
 use crate::bootstrap::maghemite;
 use crate::bootstrap::pre_server::BootstrapAgentStartup;
+use crate::bootstrap::pumpkind;
 use crate::bootstrap::rack_ops::RssAccess;
 use crate::bootstrap::secret_retriever::LrtqOrHardcodedSecretRetriever;
 use crate::bootstrap::sprockets_server::SprocketsServer;
@@ -73,6 +74,9 @@ pub enum StartError {
 
     #[error("Failed to enable mg-ddm")]
     EnableMgDdm(#[from] maghemite::Error),
+
+    #[error("Failed to enable pumpkind")]
+    EnablePumpkind(#[from] pumpkind::Error),
 
     #[error("Failed to create zfs key directory {dir:?}")]
     CreateZfsKeyDirectory {

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -481,6 +481,7 @@ enum SwitchService {
     Wicketd { baseboard: Baseboard },
     Dendrite { asic: DendriteAsic },
     Lldpd { baseboard: Baseboard },
+    Pumpkind { asic: DendriteAsic },
     Tfport { pkt_source: String, asic: DendriteAsic },
     Uplink,
     MgDdm { mode: String },
@@ -495,6 +496,7 @@ impl crate::smf_helper::Service for SwitchService {
             SwitchService::Wicketd { .. } => "wicketd",
             SwitchService::Dendrite { .. } => "dendrite",
             SwitchService::Lldpd { .. } => "lldpd",
+            SwitchService::Pumpkind { .. } => "pumpkind",
             SwitchService::Tfport { .. } => "tfport",
             SwitchService::Uplink { .. } => "uplink",
             SwitchService::MgDdm { .. } => "mg-ddm",
@@ -2760,6 +2762,18 @@ impl ServiceManager {
                             }
                             smfh.refresh()?;
                         }
+                        SwitchService::Pumpkind { asic } => {
+                            // The pumpkin daemon is only needed when running on
+                            // with real sidecar.
+                            if asic == &DendriteAsic::TofinoAsic {
+                                info!(
+                                    self.inner.log,
+                                    "Setting up pumpkind service"
+                                );
+                                smfh.setprop("config/mode", "switch")?;
+                                smfh.refresh()?;
+                            }
+                        }
                         SwitchService::Uplink => {
                             // Nothing to do here - this service is special and
                             // configured in
@@ -3616,6 +3630,7 @@ impl ServiceManager {
                     SwitchService::Dendrite { asic: DendriteAsic::TofinoAsic },
                     SwitchService::Lldpd { baseboard: baseboard.clone() },
                     SwitchService::ManagementGatewayService,
+                    SwitchService::Pumpkind { asic: DendriteAsic::TofinoAsic },
                     SwitchService::Tfport {
                         pkt_source: "tfpkt0".to_string(),
                         asic: DendriteAsic::TofinoAsic,
@@ -4007,6 +4022,11 @@ impl ServiceManager {
                             // Since tfport and dpd communicate using localhost,
                             // the tfport service shouldn't need to be
                             // restarted.
+                        }
+                        SwitchService::Pumpkind { .. } => {
+                            // Unless we want to plumb through the "only log
+                            // errors, don't react" option, there are no user
+                            // serviceable parts for this daemon.
                         }
                         SwitchService::Uplink { .. } => {
                             // Only configured in

--- a/tools/build-global-zone-packages.sh
+++ b/tools/build-global-zone-packages.sh
@@ -13,6 +13,7 @@ out_dir="$(readlink -f "${2:-"$tarball_src_dir"}")"
 deps=(
     "$tarball_src_dir/omicron-sled-agent.tar"
     "$tarball_src_dir/mg-ddm-gz.tar"
+    "$tarball_src_dir/pumpkind-gz.tar"
     "$tarball_src_dir/propolis-server.tar.gz"
     "$tarball_src_dir/overlay.tar.gz"
     "$tarball_src_dir/oxlog.tar"
@@ -48,6 +49,12 @@ pkg_dir="$tmp_gz/root/opt/oxide/mg-ddm"
 mkdir -p "$pkg_dir"
 cd "$pkg_dir"
 tar -xvfz "$tarball_src_dir/mg-ddm-gz.tar"
+cd -
+# Extract the pumpkind tarball for re-packaging into the layered GZ archive.
+pkg_dir="$tmp_gz/root/opt/oxide/pumpkind"
+mkdir -p "$pkg_dir"
+cd "$pkg_dir"
+tar -xvfz "$tarball_src_dir/pumpkind-gz.tar"
 cd -
 # Extract the oxlog tarball for re-packaging into the layered GZ archive.
 pkg_dir="$tmp_gz/root/opt/oxide/oxlog"

--- a/tools/update_crucible.sh
+++ b/tools/update_crucible.sh
@@ -8,6 +8,7 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
+    echo "  -b COMMIT   Ask to update Crucible to HEAD on the named branch."
     echo "  -c COMMIT   Ask to update Crucible to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
@@ -32,8 +33,11 @@ REPO="oxidecomputer/crucible"
 function main {
     TARGET_COMMIT=""
     DRY_RUN=""
-    while getopts "c:n" o; do
+    while getopts "b:c:n" o; do
       case "${o}" in
+        b)
+          TARGET_BRANCH="$OPTARG"
+          ;;
         c)
           TARGET_COMMIT="$OPTARG"
           ;;
@@ -46,7 +50,9 @@ function main {
       esac
     done
 
-    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    if [[ -z "$TARGET_COMMIT" ]]; then
+	    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_BRANCH")
+    fi
     install_toml2json
     do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
     do_update_crates "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${CRATES[@]}"

--- a/tools/update_dendrite.sh
+++ b/tools/update_dendrite.sh
@@ -8,7 +8,8 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
-    echo "  -c COMMIT   Ask to update Dendrite to a specific commit."
+    echo "  -b COMMIT   Ask to update dendrite to HEAD on the named branch."
+    echo "  -c COMMIT   Ask to update dendrite to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
     exit 1
@@ -67,8 +68,11 @@ function update_dendrite_stub_shas {
 function main {
     TARGET_COMMIT=""
     DRY_RUN=""
-    while getopts "c:n" o; do
+    while getopts "b:c:n" o; do
       case "${o}" in
+        b)
+          TARGET_BRANCH="$OPTARG"
+          ;;
         c)
           TARGET_COMMIT="$OPTARG"
           ;;
@@ -81,7 +85,9 @@ function main {
       esac
     done
 
-    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    if [[ -z "$TARGET_COMMIT" ]]; then
+	    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_BRANCH")
+    fi
     install_toml2json
     do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
     update_openapi "$TARGET_COMMIT" "$DRY_RUN"

--- a/tools/update_helpers.sh
+++ b/tools/update_helpers.sh
@@ -31,12 +31,13 @@ function get_sha {
 
 function get_latest_commit_from_gh {
     REPO="$1"
-    TARGET_COMMIT="$2"
-    if [[ -z "$TARGET_COMMIT" ]]; then
-        curl -fsS "https://buildomat.eng.oxide.computer/public/branch/$REPO/main"
+    if [[ -z "$2" ]]; then
+	    TARGET_BRANCH=main
     else
-        echo "$TARGET_COMMIT"
+	    TARGET_BRANCH="$2"
     fi
+
+    curl -fsS "https://buildomat.eng.oxide.computer/public/branch/$REPO/$TARGET_BRANCH"
 }
 
 function install_toml2json {

--- a/tools/update_lldp.sh
+++ b/tools/update_lldp.sh
@@ -8,7 +8,8 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
-    echo "  -c COMMIT   Ask to update Lldp to a specific commit."
+    echo "  -b COMMIT   Ask to update lldp to HEAD on the named branch."
+    echo "  -c COMMIT   Ask to update lldp to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
     exit 1
@@ -29,8 +30,11 @@ REPO="oxidecomputer/lldp"
 function main {
     TARGET_COMMIT=""
     DRY_RUN=""
-    while getopts "c:n" o; do
+    while getopts "b:c:n" o; do
       case "${o}" in
+        b)
+          TARGET_BRANCH="$OPTARG"
+          ;;
         c)
           TARGET_COMMIT="$OPTARG"
           ;;

--- a/tools/update_maghemite.sh
+++ b/tools/update_maghemite.sh
@@ -8,6 +8,7 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
+    echo "  -b COMMIT   Ask to update Maghemite to HEAD on the named branch."
     echo "  -c COMMIT   Ask to update Maghemite to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
@@ -25,8 +26,11 @@ REPO="oxidecomputer/maghemite"
 function main {
     TARGET_COMMIT=""
     DRY_RUN=""
-    while getopts "c:n" o; do
+    while getopts "b:c:n" o; do
       case "${o}" in
+        b)
+          TARGET_BRANCH="$OPTARG"
+          ;;
         c)
           TARGET_COMMIT="$OPTARG"
           ;;
@@ -39,7 +43,9 @@ function main {
       esac
     done
 
-    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    if [[ -z "$TARGET_COMMIT" ]]; then
+	    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_BRANCH")
+    fi
     install_toml2json
     do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
 }

--- a/tools/update_pumpkind.sh
+++ b/tools/update_pumpkind.sh
@@ -8,23 +8,19 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
-    echo "  -b COMMIT   Ask to update Propolis to HEAD on the named branch."
-    echo "  -c COMMIT   Ask to update Propolis to a specific commit."
+    echo "  -b COMMIT   Ask to update pumpkind to HEAD on the named branch."
+    echo "  -c COMMIT   Ask to update pumpkind to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
     exit 1
 }
 
 PACKAGES=(
-  "propolis-server"
+  "pumpkind"
+  "pumpkind-gz"
 )
 
-CRATES=(
-  "propolis-client"
-  "propolis-server"
-)
-
-REPO="oxidecomputer/propolis"
+REPO="oxidecomputer/pumpkind"
 
 . "$SOURCE_DIR/update_helpers.sh"
 
@@ -53,7 +49,6 @@ function main {
     fi
     install_toml2json
     do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
-    do_update_crates "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${CRATES[@]}"
 }
 
 main "$@"

--- a/tools/update_transceiver_control.sh
+++ b/tools/update_transceiver_control.sh
@@ -8,7 +8,8 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 function usage {
     echo "usage: $0 [-c COMMIT] [-n]"
     echo
-    echo "  -c COMMIT   Ask to update Dendrite to a specific commit."
+    echo "  -b COMMIT   Ask to update transceiver_control to HEAD on the named branch."
+    echo "  -c COMMIT   Ask to update transceiver_control to a specific commit."
     echo "              If this is unset, Github is queried."
     echo "  -n          Dry-run"
     exit 1
@@ -53,7 +54,9 @@ function main {
       esac
     done
 
-    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    if [[ -z "$TARGET_COMMIT" ]]; then
+	    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_BRANCH")
+    fi
     update_transceiver_control "$TARGET_COMMIT" "$DRY_RUN"
 }
 


### PR DESCRIPTION
This adds the `pumpkind` daemon and service to the switch zone and the global zone, and connects the wires to start it in both places.

In addition, this adds a `-b <branch>` option to each of the `tools/update_<service>` scripts, making it easier to test something other than `main`.  The `-c <commit>` option is still present, but I suspect the `-b` will end up being more commonly used.

I've added Ry as the reviewer, as I _think_ he's the only other person who has added the same service to both the global and in switch zones before.