### PR TITLE
Fix swapping of rack_id and nexus id params

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -378,8 +378,8 @@ impl Nexus {
             &background_ctx,
             Arc::clone(&db_datastore),
             &config.pkg.background_tasks,
+            rack_id,
             config.deployment.id,
-            config.deployment.rack_id,
             resolver.clone(),
             saga_request,
         );


### PR DESCRIPTION
This let's add sled work again. I had broken it with a fix to another bug in https://github.com/oxidecomputer/omicron/pull/5526.