### PR TITLE
Reconfigurator: Don't talk to expunged sleds from executor

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -81,6 +81,7 @@ use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
+use nexus_types::deployment::SledFilter;
 use nexus_types::identity::Resource;
 use nexus_types::internal_api::params::DnsRecord;
 use nexus_types::internal_api::params::Srv;
@@ -1438,7 +1439,7 @@ async fn cmd_db_sleds(
 ) -> Result<(), anyhow::Error> {
     let limit = fetch_opts.fetch_limit;
     let sleds = datastore
-        .sled_list(&opctx, &first_page(limit))
+        .sled_list(&opctx, &first_page(limit), SledFilter::All)
         .await
         .context("listing sleds")?;
     check_limit(&sleds, limit, || String::from("listing sleds"));

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(53, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(54, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(54, "add-lookup-sled-by-policy-and-state-index"),
         KnownVersion::new(53, "drop-service-table"),
         KnownVersion::new(52, "blueprint-physical-disk"),
         KnownVersion::new(51, "blueprint-disposition-column"),

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -1455,6 +1455,7 @@ mod test {
             .sled_list_all_batched(&opctx, SledFilter::All)
             .await
             .expect("failed to list all sleds");
+
         // We don't need to sort these ids because the sleds are enumerated in
         // id order.
         let found_ids: Vec<_> = sleds.into_iter().map(|s| s.id()).collect();

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -477,6 +477,7 @@ mod test {
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZonesConfig;
+    use nexus_types::deployment::SledFilter;
     use nexus_types::external_api::params;
     use nexus_types::external_api::shared;
     use nexus_types::identity::Resource;
@@ -1182,7 +1183,10 @@ mod test {
         // Now, go through the motions of provisioning a new Nexus zone.
         // We do this directly with BlueprintBuilder to avoid the planner
         // deciding to make other unrelated changes.
-        let sled_rows = datastore.sled_list_all_batched(&opctx).await.unwrap();
+        let sled_rows = datastore
+            .sled_list_all_batched(&opctx, SledFilter::All)
+            .await
+            .unwrap();
         let zpool_rows =
             datastore.zpool_list_all_external_batched(&opctx).await.unwrap();
         let ip_pool_range_rows = {

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -11,6 +11,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::SledFilter;
 use nexus_types::identity::Asset;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
@@ -120,7 +121,7 @@ where
     .map_err(|err| vec![err])?;
 
     let sleds_by_id: BTreeMap<SledUuid, _> = datastore
-        .sled_list_all_batched(&opctx)
+        .sled_list_all_batched(&opctx, SledFilter::InService)
         .await
         .context("listing all sleds")
         .map_err(|e| vec![e])?

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -10,7 +10,6 @@ use anyhow::Context;
 use futures::stream;
 use futures::StreamExt;
 use nexus_db_queries::context::OpContext;
-use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZonesConfig;
 use omicron_uuid_kinds::GenericUuid;

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -34,9 +34,7 @@ pub(crate) async fn deploy_zones(
             {
                 Some(sled) => sled,
                 None => {
-                    if config.zones.iter().all(|c| {
-                        c.disposition == BlueprintZoneDisposition::Expunged
-                    }) {
+                    if config.are_all_zones_expunged() {
                         info!(
                             opctx.log,
                             "Skipping zone deployment to expunged sled";

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -357,8 +357,9 @@ impl<'a> BlueprintBuilder<'a> {
         // are no longer in service and need expungement work.
         let blueprint_zones =
             self.zones.into_zones_map(self.input.all_sled_ids(SledFilter::All));
-        let blueprint_disks =
-            self.disks.into_disks_map(self.input.all_sled_ids(SledFilter::All));
+        let blueprint_disks = self
+            .disks
+            .into_disks_map(self.input.all_sled_ids(SledFilter::InService));
         Blueprint {
             id: self.rng.blueprint_rng.next(),
             blueprint_zones,

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -25,6 +25,7 @@ use nexus_types::deployment::PlanningInputBuilder;
 use nexus_types::deployment::Policy;
 use nexus_types::deployment::SledDetails;
 use nexus_types::deployment::SledDisk;
+use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::SledResources;
 use nexus_types::deployment::UnstableReconfiguratorState;
 use nexus_types::identity::Asset;
@@ -199,7 +200,7 @@ pub async fn reconfigurator_state_load(
 ) -> Result<UnstableReconfiguratorState, anyhow::Error> {
     opctx.check_complex_operations_allowed()?;
     let sled_rows = datastore
-        .sled_list_all_batched(opctx)
+        .sled_list_all_batched(opctx, SledFilter::All)
         .await
         .context("listing sleds")?;
     let zpool_rows = datastore

--- a/nexus/src/app/background/inventory_collection.rs
+++ b/nexus/src/app/background/inventory_collection.rs
@@ -14,6 +14,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::pagination::Paginator;
 use nexus_db_queries::db::DataStore;
 use nexus_inventory::InventoryError;
+use nexus_types::deployment::SledFilter;
 use nexus_types::identity::Asset;
 use nexus_types::inventory::Collection;
 use omicron_uuid_kinds::CollectionUuid;
@@ -180,7 +181,11 @@ impl<'a> nexus_inventory::SledAgentEnumerator for DbSledAgentEnumerator<'a> {
             while let Some(p) = paginator.next() {
                 let records_batch = self
                     .datastore
-                    .sled_list(&self.opctx, &p.current_pagparams())
+                    .sled_list(
+                        &self.opctx,
+                        &p.current_pagparams(),
+                        SledFilter::All,
+                    )
                     .await
                     .context("listing sleds")?;
                 paginator = p.found_batch(

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -14,6 +14,7 @@ use nexus_types::deployment::BlueprintMetadata;
 use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::BlueprintTargetSet;
 use nexus_types::deployment::PlanningInput;
+use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
 use omicron_common::address::NEXUS_REDUNDANCY;
 use omicron_common::api::external::CreateResult;
@@ -129,7 +130,8 @@ impl super::Nexus {
         let creator = self.id.to_string();
         let datastore = self.datastore();
 
-        let sled_rows = datastore.sled_list_all_batched(opctx).await?;
+        let sled_rows =
+            datastore.sled_list_all_batched(opctx, SledFilter::All).await?;
         let zpool_rows =
             datastore.zpool_list_all_external_batched(opctx).await?;
         let ip_pool_range_rows = {

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -740,7 +740,7 @@ impl super::Nexus {
         debug!(self.log, "Listing sleds");
         let sleds = self
             .db_datastore
-            .sled_list(opctx, &pagparams, SledFilter::All)
+            .sled_list(opctx, &pagparams, SledFilter::InService)
             .await?;
 
         let mut uninitialized_sleds: Vec<UninitializedSled> = collection

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -23,6 +23,7 @@ use nexus_reconfigurator_execution::silo_dns_name;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
+use nexus_types::deployment::SledFilter;
 use nexus_types::external_api::params::Address;
 use nexus_types::external_api::params::AddressConfig;
 use nexus_types::external_api::params::AddressLotBlockCreate;
@@ -737,7 +738,10 @@ impl super::Nexus {
         };
 
         debug!(self.log, "Listing sleds");
-        let sleds = self.db_datastore.sled_list(opctx, &pagparams).await?;
+        let sleds = self
+            .db_datastore
+            .sled_list(opctx, &pagparams, SledFilter::All)
+            .await?;
 
         let mut uninitialized_sleds: Vec<UninitializedSled> = collection
             .sps

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -116,7 +116,9 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Sled> {
-        self.db_datastore.sled_list(&opctx, pagparams, SledFilter::All).await
+        self.db_datastore
+            .sled_list(&opctx, pagparams, SledFilter::InService)
+            .await
     }
 
     pub async fn sled_client(

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -13,6 +13,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::lookup;
 use nexus_db_queries::db::model::DatasetKind;
+use nexus_types::deployment::SledFilter;
 use nexus_types::external_api::views::SledPolicy;
 use nexus_types::external_api::views::SledProvisionPolicy;
 use omicron_common::api::external::DataPageParams;
@@ -115,7 +116,7 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Sled> {
-        self.db_datastore.sled_list(&opctx, pagparams).await
+        self.db_datastore.sled_list(&opctx, pagparams, SledFilter::All).await
     }
 
     pub async fn sled_client(

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -338,6 +338,14 @@ impl BlueprintZonesConfig {
                 .collect(),
         }
     }
+
+    /// Returns true if all zones in the blueprint have a disposition of
+    // `Expunged`, false otherwise.
+    pub fn are_all_zones_expunged(&self) -> bool {
+        self.zones
+            .iter()
+            .all(|c| c.disposition == BlueprintZoneDisposition::Expunged)
+    }
 }
 
 trait ZoneSortKey {

--- a/schema/crdb/add-lookup-sled-by-policy-and-state-index/up.sql
+++ b/schema/crdb/add-lookup-sled-by-policy-and-state-index/up.sql
@@ -1,0 +1,5 @@
+/* Add an index which lets us look up sleds based on policy and state */
+CREATE INDEX IF NOT EXISTS lookup_sled_by_policy_and_state ON omicron.public.sled (
+    sled_policy,
+    sled_state
+);

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -163,6 +163,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS lookup_sled_by_rack ON omicron.public.sled (
     id
 ) WHERE time_deleted IS NULL;
 
+/* Add an index which lets us look up sleds based on policy and state */
+CREATE INDEX IF NOT EXISTS lookup_sled_by_policy_and_state ON omicron.public.sled (
+    sled_policy,
+    sled_state
+);
+
 CREATE TYPE IF NOT EXISTS omicron.public.sled_resource_kind AS ENUM (
     -- omicron.public.instance
     'instance'
@@ -3756,7 +3762,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '53.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '54.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
We confirmed on a4x2 that Nexus gets deployed on the new sled with this change.

Fixes #5594