### PR TITLE
[nexus] Avoid racing with sled expungement when inserting new physical disks

### DIFF
--- a/nexus/db-queries/src/db/error.rs
+++ b/nexus/db-queries/src/db/error.rs
@@ -76,9 +76,9 @@ impl<T: std::fmt::Debug> TransactionError<T> {
     ///
     /// The following pattern is used frequently in retryable transactions:
     ///
-    /// - Create an OptionalError
+    /// - Create an `OptionalError<TransactionError<T>>`
     /// - Execute a series of database operations, which return the
-    /// TransactionError<T> type
+    /// `TransactionError<T>` type
     /// - If the underlying operations return a retryable error from diesel,
     /// propagate that out.
     /// - Otherwise, set the OptionalError to a value of T, and rollback the transaction.

--- a/nexus/db-queries/src/db/error.rs
+++ b/nexus/db-queries/src/db/error.rs
@@ -4,6 +4,7 @@
 
 //! Error handling and conversions.
 
+use crate::transaction_retry::OptionalError;
 use diesel::result::DatabaseErrorInformation;
 use diesel::result::DatabaseErrorKind as DieselErrorKind;
 use diesel::result::Error as DieselError;
@@ -66,6 +67,30 @@ impl<T> TransactionError<T> {
                 Retryable(err)
             }
             _ => NotRetryable(self),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> TransactionError<T> {
+    /// Converts a TransactionError into a diesel error.
+    ///
+    /// The following pattern is used frequently in retryable transactions:
+    ///
+    /// - Create an OptionalError
+    /// - Execute a series of database operations, which return the
+    /// TransactionError<T> type
+    /// - If the underlying operations return a retryable error from diesel,
+    /// propagate that out.
+    /// - Otherwise, set the OptionalError to a value of T, and rollback the transaction.
+    ///
+    /// This function assists with that conversion.
+    pub fn into_diesel(
+        self,
+        err: &OptionalError<TransactionError<T>>,
+    ) -> DieselError {
+        match self.retryable() {
+            MaybeRetryable::NotRetryable(txn_error) => err.bail(txn_error),
+            MaybeRetryable::Retryable(diesel_error) => diesel_error,
         }
     }
 }

--- a/nexus/src/app/background/physical_disk_adoption.rs
+++ b/nexus/src/app/background/physical_disk_adoption.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Background task for autmatically adopting physical disks.
+//! Background task for automatically adopting physical disks.
 //!
 //! Removable disks may be arbitrarily attached and detached from
 //! Oxide racks. When this happens, if they had not previously


### PR DESCRIPTION
# Summary

- Prevents control-plane physical disks from being creates on sleds that are expunged
- Additionally cleans up retryable transaction errors from Diesel in `physical_disk_and_zpool_insert`.

# Background

As of https://github.com/oxidecomputer/omicron/pull/5506 , Nexus is responsible for adding new "control plane physical disks" to the system. It performs this action currently via a background task (see: https://github.com/oxidecomputer/omicron/blob/main/nexus/src/app/background/physical_disk_adoption.rs), though this may become a more explicit operation in the future, requiring explicit operator intervention. Either way, this implementation calls `physical_disk_and_zpool_insert` to create the control-plane object.

As we have been discussing solutions to https://github.com/oxidecomputer/omicron/issues/5594 , we have discussed "verifying that for expunged sleds, all zones are expunged, and all physical disks are expunged". This is a property we'd like to uphold. Prior to this PR, it was technically possible to insert a physical disk at the moment sled expungement was also occurring. In this situation, we could have an expunged sled, with a non-expunged physical disk, which would be an invalid state.

# Implementation

This PR adds a check to the `physical_disk_and_zpool_insert` transaction that the sled-under-modification is not currently expunged. Additionally, it adds a test for this behavior. 

There are some semi-related changes to Diesel error propagation in this PR -- this needed cleanup anyway, but the gist of it is that we ensure this transaction can correctly push retryable diesel errors all the way up to the transaction handler that knows how to parse them.