### PR TITLE
Support env variables in virtual-hardware xtask

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -19,7 +19,7 @@ enum Commands {
         /// The physical link over which Chelsio links are simulated
         ///
         /// Will be inferred by `dladm show-phys` if unsupplied.
-        #[clap(long)]
+        #[clap(long, env)]
         physical_link: Option<String>,
 
         /// Sets `promisc-filtered` off for the sc0_1 vnic.
@@ -33,6 +33,10 @@ enum Commands {
         /// Will be inferred via `netstat` if unsupplied.
         #[clap(long)]
         gateway_ip: Option<String>,
+
+        /// The configured mode for softnpu
+        #[clap(long, env, default_value = "zone")]
+        softnpu_mode: String,
 
         /// The MAC address of your gateway IP
         ///
@@ -153,6 +157,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
         Commands::Create {
             physical_link,
             promiscuous_filter_off,
+            softnpu_mode,
             gateway_ip,
             gateway_mac,
             pxa,
@@ -168,7 +173,9 @@ pub fn run_cmd(args: Args) -> Result<()> {
             if matches!(args.scope, Scope::All | Scope::Disks) {
                 ensure_vdevs(&sled_agent_config, &args.vdev_dir)?;
             }
-            if matches!(args.scope, Scope::All | Scope::Network) {
+            if matches!(args.scope, Scope::All | Scope::Network)
+                && softnpu_mode == "zone"
+            {
                 ensure_simulated_links(&physical_link, promiscuous_filter_off)?;
                 ensure_softnpu_zone(&npu_zone)?;
                 initialize_softnpu_zone(gateway_ip, gateway_mac, pxa, pxa_mac)?;


### PR DESCRIPTION
Some of these environment variables were not carried over when transitioning from the `create-virtual-hardware.sh` bash script to the xtask. This prevented the a4x2 testbed softnpu setup from being correctly setup, which resulted in bootstrap addresses not being routable. This commit fixes that.

Once this is merged, then the corresponding [fix](https://github.com/oxidecomputer/testbed/pull/43) in testbed should work.