### PR TITLE
[blueprints] Add external IP IDs to `BlueprintZoneType`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4796,6 +4796,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "slog",
+ "slog-error-chain",
 ]
 
 [[package]]

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -21,8 +21,6 @@ use nexus_reconfigurator_planning::system::{
     SledBuilder, SledHwInventory, SystemDescription,
 };
 use nexus_types::deployment::BlueprintZoneFilter;
-use nexus_types::deployment::OmicronZoneExternalFloatingIp;
-use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
@@ -34,13 +32,10 @@ use nexus_types::inventory::SledRole;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::Name;
 use omicron_uuid_kinds::CollectionUuid;
-use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::SledUuid;
 use reedline::{Reedline, Signal};
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::BufRead;
-use std::net::IpAddr;
 use swrite::{swriteln, SWrite};
 use tabled::Tabled;
 use uuid::Uuid;
@@ -60,14 +55,6 @@ struct ReconfiguratorSim {
 
     /// blueprints created by the user
     blueprints: IndexMap<Uuid, Blueprint>,
-
-    /// external IPs allocated to services
-    ///
-    /// In the real system, external IPs have IDs, but those IDs only live in
-    /// CRDB - they're not part of the zone config sent from Reconfigurator to
-    /// sled-agent. This mimics the minimal bit of the CRDB `external_ip` table
-    /// we need.
-    external_ips: RefCell<IndexMap<IpAddr, ExternalIpUuid>>,
 
     /// internal DNS configurations
     internal_dns: BTreeMap<Generation, DnsConfigParams>,
@@ -152,19 +139,7 @@ impl ReconfiguratorSim {
         for (_, zone) in
             parent_blueprint.all_omicron_zones(BlueprintZoneFilter::All)
         {
-            if let Some(ip) = zone.zone_type.external_ip() {
-                // TODO-cleanup This is potentially wrong; zone_type should tell
-                // us the IP kind and ID.
-                let external_ip = OmicronZoneExternalIp::Floating(
-                    OmicronZoneExternalFloatingIp {
-                        id: *self
-                            .external_ips
-                            .borrow_mut()
-                            .entry(ip)
-                            .or_insert_with(ExternalIpUuid::new_v4),
-                        ip,
-                    },
-                );
+            if let Some(external_ip) = zone.zone_type.external_ip() {
                 builder
                     .add_omicron_zone_external_ip(zone.id, external_ip)
                     .context("adding omicron zone external IP")?;
@@ -207,7 +182,6 @@ fn main() -> anyhow::Result<()> {
         system: SystemDescription::new(),
         collections: IndexMap::new(),
         blueprints: IndexMap::new(),
-        external_ips: RefCell::new(IndexMap::new()),
         internal_dns: BTreeMap::new(),
         external_dns: BTreeMap::new(),
         log,

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -21,8 +21,8 @@ use nexus_reconfigurator_planning::system::{
     SledBuilder, SledHwInventory, SystemDescription,
 };
 use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalIp;
-use nexus_types::deployment::OmicronZoneExternalIpKind;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
@@ -153,16 +153,18 @@ impl ReconfiguratorSim {
             parent_blueprint.all_omicron_zones(BlueprintZoneFilter::All)
         {
             if let Some(ip) = zone.zone_type.external_ip() {
-                let external_ip = OmicronZoneExternalIp {
-                    id: *self
-                        .external_ips
-                        .borrow_mut()
-                        .entry(ip)
-                        .or_insert_with(ExternalIpUuid::new_v4),
-                    // TODO-cleanup This is potentially wrong;
-                    // zone_type should tell us the IP kind.
-                    kind: OmicronZoneExternalIpKind::Floating(ip),
-                };
+                // TODO-cleanup This is potentially wrong; zone_type should tell
+                // us the IP kind and ID.
+                let external_ip = OmicronZoneExternalIp::Floating(
+                    OmicronZoneExternalFloatingIp {
+                        id: *self
+                            .external_ips
+                            .borrow_mut()
+                            .entry(ip)
+                            .or_insert_with(ExternalIpUuid::new_v4),
+                        ip,
+                    },
+                );
                 builder
                     .add_omicron_zone_external_ip(zone.id, external_ip)
                     .context("adding omicron zone external IP")?;

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -233,7 +233,7 @@ impl BpOmicronZone {
         blueprint_zone: &BlueprintZoneConfig,
     ) -> Result<Self, anyhow::Error> {
         let external_ip_id =
-            blueprint_zone.zone_type.external_ip().map(|ip| ip.id().into());
+            blueprint_zone.zone_type.external_ip().map(|ip| ip.id());
         let zone = OmicronZone::new(
             sled_id,
             blueprint_zone.id.into_untyped_uuid(),

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -15,7 +15,6 @@ use crate::typed_uuid::DbTypedUuid;
 use crate::{
     impl_enum_type, ipv6, Generation, MacAddr, Name, SqlU16, SqlU32, SqlU8,
 };
-use anyhow::Context;
 use chrono::{DateTime, Utc};
 use ipnetwork::IpNetwork;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
@@ -289,13 +288,11 @@ impl BpOmicronZone {
             snat_first_port: self.snat_first_port,
             snat_last_port: self.snat_last_port,
         };
-        let config =
-            zone.into_omicron_zone_config(nic_row.map(OmicronZoneNic::from))?;
-        BlueprintZoneConfig::from_omicron_zone_config(
-            config,
+        zone.into_blueprint_zone_config(
             self.disposition.into(),
+            None, // TODO FIXME db migration - add external IP ID
+            nic_row.map(OmicronZoneNic::from),
         )
-        .context("failed to convert OmicronZoneConfig")
     }
 }
 

--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -17,8 +17,9 @@ use db_macros::Resource;
 use diesel::Queryable;
 use diesel::Selectable;
 use ipnetwork::IpNetwork;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalIp;
-use nexus_types::deployment::OmicronZoneExternalIpKind;
+use nexus_types::deployment::OmicronZoneExternalSnatIp;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::views;
@@ -146,6 +147,10 @@ pub enum OmicronZoneExternalIpError {
     #[error("invalid SNAT configuration")]
     InvalidSnatConfig(#[from] SourceNatConfigError),
     #[error(
+        "Omicron zone has a range of IPs ({0}); only a single IP is supported"
+    )]
+    NotSingleIp(IpNetwork),
+    #[error(
         "database IP is ephemeral; currently unsupported for Omicron zones"
     )]
     EphemeralIp,
@@ -158,24 +163,31 @@ impl TryFrom<&'_ ExternalIp> for OmicronZoneExternalIp {
         if !row.is_service {
             return Err(OmicronZoneExternalIpError::IpIsForInstance);
         }
+        let size = match row.ip.size() {
+            ipnetwork::NetworkSize::V4(n) => u128::from(n),
+            ipnetwork::NetworkSize::V6(n) => n,
+        };
+        if size != 1 {
+            return Err(OmicronZoneExternalIpError::NotSingleIp(row.ip));
+        }
 
-        let kind = match row.kind {
-            IpKind::SNat => {
-                OmicronZoneExternalIpKind::Snat(SourceNatConfig::new(
+        match row.kind {
+            IpKind::SNat => Ok(Self::Snat(OmicronZoneExternalSnatIp {
+                id: ExternalIpUuid::from_untyped_uuid(row.id),
+                snat_cfg: SourceNatConfig::new(
                     row.ip.ip(),
                     row.first_port.0,
                     row.last_port.0,
-                )?)
-            }
+                )?,
+            })),
             IpKind::Floating => {
-                OmicronZoneExternalIpKind::Floating(row.ip.ip())
+                Ok(Self::Floating(OmicronZoneExternalFloatingIp {
+                    id: ExternalIpUuid::from_untyped_uuid(row.id),
+                    ip: row.ip.ip(),
+                }))
             }
-            IpKind::Ephemeral => {
-                return Err(OmicronZoneExternalIpError::EphemeralIp)
-            }
-        };
-
-        Ok(Self { id: ExternalIpUuid::from_untyped_uuid(row.id), kind })
+            IpKind::Ephemeral => Err(OmicronZoneExternalIpError::EphemeralIp),
+        }
     }
 }
 
@@ -355,10 +367,8 @@ impl IncompleteExternalIp {
         zone_id: OmicronZoneUuid,
         zone_kind: ZoneKind,
     ) -> Self {
-        let (kind, ip, port_range, name, description, state) = match external_ip
-            .kind
-        {
-            OmicronZoneExternalIpKind::Floating(ip) => {
+        let (kind, port_range, name, description, state) = match external_ip {
+            OmicronZoneExternalIp::Floating(_) => {
                 // We'll name this external IP the same as we'll name the NIC
                 // associated with this zone.
                 let name = ServiceNetworkInterface::name(zone_id, zone_kind);
@@ -371,19 +381,20 @@ impl IncompleteExternalIp {
 
                 (
                     IpKind::Floating,
-                    ip,
                     None,
                     Some(name),
                     Some(zone_kind.to_string()),
                     state,
                 )
             }
-            OmicronZoneExternalIpKind::Snat(snat_cfg) => {
+            OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
+                snat_cfg,
+                ..
+            }) => {
                 let (first_port, last_port) = snat_cfg.port_range_raw();
                 let kind = IpKind::SNat;
                 (
                     kind,
-                    snat_cfg.ip,
                     Some((first_port.into(), last_port.into())),
                     // Only floating IPs are allowed to have names and
                     // descriptions.
@@ -395,7 +406,7 @@ impl IncompleteExternalIp {
         };
 
         Self {
-            id: external_ip.id.into_untyped_uuid(),
+            id: external_ip.id().into_untyped_uuid(),
             name,
             description,
             time_created: Utc::now(),
@@ -405,7 +416,7 @@ impl IncompleteExternalIp {
             parent_id: Some(zone_id.into_untyped_uuid()),
             pool_id,
             project_id: None,
-            explicit_ip: Some(IpNetwork::from(ip)),
+            explicit_ip: Some(IpNetwork::from(external_ip.ip())),
             explicit_port_range: port_range,
             state,
         }

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -882,11 +882,14 @@ impl InvOmicronZone {
         sled_id: SledUuid,
         zone: &nexus_types::inventory::OmicronZoneConfig,
     ) -> Result<InvOmicronZone, anyhow::Error> {
+        // Inventory zones do not know the external IP ID.
+        let external_ip_id = None;
         let zone = OmicronZone::new(
             sled_id,
             zone.id,
             zone.underlay_address,
             &zone.zone_type,
+            external_ip_id,
         )?;
         Ok(Self {
             inv_collection_id: inv_collection_id.into(),
@@ -938,6 +941,9 @@ impl InvOmicronZone {
             snat_ip: self.snat_ip,
             snat_first_port: self.snat_first_port,
             snat_last_port: self.snat_last_port,
+            // Inventory zones don't know an external IP ID, and Omicron zone
+            // configs don't need it.
+            external_ip_id: None,
         };
         zone.into_omicron_zone_config(nic_row.map(OmicronZoneNic::from))
     }

--- a/nexus/db-model/src/omicron_zone_config.rs
+++ b/nexus/db-model/src/omicron_zone_config.rs
@@ -11,17 +11,22 @@
 //! collecting extra metadata like uptime). This module provides conversion
 //! helpers for the parts of those tables that are common between the two.
 
-use std::net::{Ipv6Addr, SocketAddrV6};
-
 use crate::inventory::ZoneType;
 use crate::{ipv6, MacAddr, Name, SqlU16, SqlU32, SqlU8};
 use anyhow::{anyhow, bail, ensure, Context};
 use ipnetwork::IpNetwork;
-use nexus_types::inventory::OmicronZoneType;
-use omicron_common::api::internal::shared::{
-    NetworkInterface, NetworkInterfaceKind,
+use nexus_types::deployment::BlueprintZoneDisposition;
+use nexus_types::deployment::BlueprintZoneType;
+use nexus_types::deployment::{
+    blueprint_zone_type, OmicronZoneExternalFloatingAddr,
+    OmicronZoneExternalFloatingIp, OmicronZoneExternalSnatIp,
 };
-use omicron_uuid_kinds::SledUuid;
+use nexus_types::inventory::{NetworkInterface, OmicronZoneType};
+use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use omicron_uuid_kinds::{
+    ExternalIpUuid, GenericUuid, OmicronZoneUuid, SledUuid,
+};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -215,17 +220,268 @@ impl OmicronZone {
         })
     }
 
+    pub(crate) fn into_blueprint_zone_config(
+        self,
+        disposition: BlueprintZoneDisposition,
+        external_ip_id: Option<ExternalIpUuid>,
+        nic_row: Option<OmicronZoneNic>,
+    ) -> anyhow::Result<nexus_types::deployment::BlueprintZoneConfig> {
+        let common = self.into_zone_config_common(nic_row)?;
+        let address = common.primary_service_address;
+        let zone_type = match common.zone_type {
+            ZoneType::BoundaryNtp => {
+                let snat_cfg = match (
+                    common.snat_ip,
+                    common.snat_first_port,
+                    common.snat_last_port,
+                ) {
+                    (Some(ip), Some(first_port), Some(last_port)) => {
+                        nexus_types::inventory::SourceNatConfig::new(
+                            ip.ip(),
+                            *first_port,
+                            *last_port,
+                        )
+                        .context("bad SNAT config for boundary NTP")?
+                    }
+                    _ => bail!(
+                        "expected non-NULL snat properties, \
+                         found at least one NULL"
+                    ),
+                };
+                BlueprintZoneType::BoundaryNtp(
+                    blueprint_zone_type::BoundaryNtp {
+                        address,
+                        dns_servers: common.ntp_dns_servers?,
+                        domain: common.ntp_domain,
+                        nic: common.nic?,
+                        ntp_servers: common.ntp_ntp_servers?,
+                        external_ip: OmicronZoneExternalSnatIp {
+                            id: external_ip_id
+                                .context("expected non-NULL external IP ID")?,
+                            snat_cfg,
+                        },
+                    },
+                )
+            }
+            ZoneType::Clickhouse => {
+                BlueprintZoneType::Clickhouse(blueprint_zone_type::Clickhouse {
+                    address,
+                    dataset: common.dataset?,
+                })
+            }
+            ZoneType::ClickhouseKeeper => BlueprintZoneType::ClickhouseKeeper(
+                blueprint_zone_type::ClickhouseKeeper {
+                    address,
+                    dataset: common.dataset?,
+                },
+            ),
+            ZoneType::CockroachDb => BlueprintZoneType::CockroachDb(
+                blueprint_zone_type::CockroachDb {
+                    address,
+                    dataset: common.dataset?,
+                },
+            ),
+            ZoneType::Crucible => {
+                BlueprintZoneType::Crucible(blueprint_zone_type::Crucible {
+                    address,
+                    dataset: common.dataset?,
+                })
+            }
+            ZoneType::CruciblePantry => BlueprintZoneType::CruciblePantry(
+                blueprint_zone_type::CruciblePantry { address },
+            ),
+            ZoneType::ExternalDns => BlueprintZoneType::ExternalDns(
+                blueprint_zone_type::ExternalDns {
+                    dataset: common.dataset?,
+                    dns_address: OmicronZoneExternalFloatingAddr {
+                        id: external_ip_id
+                            .context("expected non-NULL external IP ID")?,
+                        addr: common.dns_address?,
+                    },
+                    http_address: address,
+                    nic: common.nic?,
+                },
+            ),
+            ZoneType::InternalDns => BlueprintZoneType::InternalDns(
+                blueprint_zone_type::InternalDns {
+                    dataset: common.dataset?,
+                    dns_address: match common.dns_address? {
+                        SocketAddr::V4(addr) => {
+                            bail!("expected V6 address; got {addr}")
+                        }
+                        SocketAddr::V6(addr) => addr,
+                    },
+                    http_address: address,
+                    gz_address: *common.dns_gz_address.ok_or_else(|| {
+                        anyhow!("expected dns_gz_address, found none")
+                    })?,
+                    gz_address_index: *common.dns_gz_address_index.ok_or_else(
+                        || anyhow!("expected dns_gz_address_index, found none"),
+                    )?,
+                },
+            ),
+            ZoneType::InternalNtp => BlueprintZoneType::InternalNtp(
+                blueprint_zone_type::InternalNtp {
+                    address,
+                    dns_servers: common.ntp_dns_servers?,
+                    domain: common.ntp_domain,
+                    ntp_servers: common.ntp_ntp_servers?,
+                },
+            ),
+            ZoneType::Nexus => {
+                BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
+                    internal_address: address,
+                    nic: common.nic?,
+                    external_tls: common
+                        .nexus_external_tls
+                        .ok_or_else(|| anyhow!("expected 'external_tls'"))?,
+                    external_ip: OmicronZoneExternalFloatingIp {
+                        id: external_ip_id
+                            .context("expected non-NULL external IP ID")?,
+                        ip: common
+                            .second_service_ip
+                            .ok_or_else(|| {
+                                anyhow!("expected second service IP")
+                            })?
+                            .ip(),
+                    },
+                    external_dns_servers: common
+                        .nexus_external_dns_servers
+                        .ok_or_else(|| {
+                            anyhow!("expected 'external_dns_servers'")
+                        })?
+                        .into_iter()
+                        .map(|i| i.ip())
+                        .collect(),
+                })
+            }
+            ZoneType::Oximeter => {
+                BlueprintZoneType::Oximeter(blueprint_zone_type::Oximeter {
+                    address,
+                })
+            }
+        };
+        Ok(nexus_types::deployment::BlueprintZoneConfig {
+            disposition,
+            id: OmicronZoneUuid::from_untyped_uuid(common.id),
+            underlay_address: std::net::Ipv6Addr::from(common.underlay_address),
+            zone_type,
+        })
+    }
+
     pub(crate) fn into_omicron_zone_config(
         self,
         nic_row: Option<OmicronZoneNic>,
     ) -> anyhow::Result<nexus_types::inventory::OmicronZoneConfig> {
-        let address = SocketAddrV6::new(
+        let common = self.into_zone_config_common(nic_row)?;
+        let address = common.primary_service_address.to_string();
+
+        let zone_type = match common.zone_type {
+            ZoneType::BoundaryNtp => {
+                let snat_cfg = match (
+                    common.snat_ip,
+                    common.snat_first_port,
+                    common.snat_last_port,
+                ) {
+                    (Some(ip), Some(first_port), Some(last_port)) => {
+                        nexus_types::inventory::SourceNatConfig::new(
+                            ip.ip(),
+                            *first_port,
+                            *last_port,
+                        )
+                        .context("bad SNAT config for boundary NTP")?
+                    }
+                    _ => bail!(
+                        "expected non-NULL snat properties, \
+                        found at least one NULL"
+                    ),
+                };
+                OmicronZoneType::BoundaryNtp {
+                    address,
+                    dns_servers: common.ntp_dns_servers?,
+                    domain: common.ntp_domain,
+                    nic: common.nic?,
+                    ntp_servers: common.ntp_ntp_servers?,
+                    snat_cfg,
+                }
+            }
+            ZoneType::Clickhouse => OmicronZoneType::Clickhouse {
+                address,
+                dataset: common.dataset?,
+            },
+            ZoneType::ClickhouseKeeper => OmicronZoneType::ClickhouseKeeper {
+                address,
+                dataset: common.dataset?,
+            },
+            ZoneType::CockroachDb => OmicronZoneType::CockroachDb {
+                address,
+                dataset: common.dataset?,
+            },
+            ZoneType::Crucible => {
+                OmicronZoneType::Crucible { address, dataset: common.dataset? }
+            }
+            ZoneType::CruciblePantry => {
+                OmicronZoneType::CruciblePantry { address }
+            }
+            ZoneType::ExternalDns => OmicronZoneType::ExternalDns {
+                dataset: common.dataset?,
+                dns_address: common.dns_address?.to_string(),
+                http_address: address,
+                nic: common.nic?,
+            },
+            ZoneType::InternalDns => OmicronZoneType::InternalDns {
+                dataset: common.dataset?,
+                dns_address: common.dns_address?.to_string(),
+                http_address: address,
+                gz_address: *common.dns_gz_address.ok_or_else(|| {
+                    anyhow!("expected dns_gz_address, found none")
+                })?,
+                gz_address_index: *common.dns_gz_address_index.ok_or_else(
+                    || anyhow!("expected dns_gz_address_index, found none"),
+                )?,
+            },
+            ZoneType::InternalNtp => OmicronZoneType::InternalNtp {
+                address,
+                dns_servers: common.ntp_dns_servers?,
+                domain: common.ntp_domain,
+                ntp_servers: common.ntp_ntp_servers?,
+            },
+            ZoneType::Nexus => OmicronZoneType::Nexus {
+                internal_address: address,
+                nic: common.nic?,
+                external_tls: common
+                    .nexus_external_tls
+                    .ok_or_else(|| anyhow!("expected 'external_tls'"))?,
+                external_ip: common
+                    .second_service_ip
+                    .ok_or_else(|| anyhow!("expected second service IP"))?
+                    .ip(),
+                external_dns_servers: common
+                    .nexus_external_dns_servers
+                    .ok_or_else(|| anyhow!("expected 'external_dns_servers'"))?
+                    .into_iter()
+                    .map(|i| i.ip())
+                    .collect(),
+            },
+            ZoneType::Oximeter => OmicronZoneType::Oximeter { address },
+        };
+        Ok(nexus_types::inventory::OmicronZoneConfig {
+            id: common.id,
+            underlay_address: std::net::Ipv6Addr::from(common.underlay_address),
+            zone_type,
+        })
+    }
+
+    fn into_zone_config_common(
+        self,
+        nic_row: Option<OmicronZoneNic>,
+    ) -> anyhow::Result<ZoneConfigCommon> {
+        let primary_service_address = SocketAddrV6::new(
             std::net::Ipv6Addr::from(self.primary_service_ip),
             *self.primary_service_port,
             0,
             0,
-        )
-        .to_string();
+        );
 
         // Assemble a value that we can use to extract the NIC _if necessary_
         // and report an error if it was needed but not found.
@@ -277,8 +533,7 @@ impl OmicronZone {
         let dns_address =
             match (self.second_service_ip, self.second_service_port) {
                 (Some(dns_ip), Some(dns_port)) => {
-                    Ok(std::net::SocketAddr::new(dns_ip.ip(), *dns_port)
-                        .to_string())
+                    Ok(std::net::SocketAddr::new(dns_ip.ip(), *dns_port))
                 }
                 _ => Err(anyhow!(
                     "expected second service IP and port, \
@@ -296,98 +551,50 @@ impl OmicronZone {
         let ntp_ntp_servers =
             self.ntp_ntp_servers.ok_or_else(|| anyhow!("expected ntp_servers"));
 
-        let zone_type = match self.zone_type {
-            ZoneType::BoundaryNtp => {
-                let snat_cfg = match (
-                    self.snat_ip,
-                    self.snat_first_port,
-                    self.snat_last_port,
-                ) {
-                    (Some(ip), Some(first_port), Some(last_port)) => {
-                        nexus_types::inventory::SourceNatConfig::new(
-                            ip.ip(),
-                            *first_port,
-                            *last_port,
-                        )
-                        .context("bad SNAT config for boundary NTP")?
-                    }
-                    _ => bail!(
-                        "expected non-NULL snat properties, \
-                        found at least one NULL"
-                    ),
-                };
-                OmicronZoneType::BoundaryNtp {
-                    address,
-                    dns_servers: ntp_dns_servers?,
-                    domain: self.ntp_domain,
-                    nic: nic?,
-                    ntp_servers: ntp_ntp_servers?,
-                    snat_cfg,
-                }
-            }
-            ZoneType::Clickhouse => {
-                OmicronZoneType::Clickhouse { address, dataset: dataset? }
-            }
-            ZoneType::ClickhouseKeeper => {
-                OmicronZoneType::ClickhouseKeeper { address, dataset: dataset? }
-            }
-            ZoneType::CockroachDb => {
-                OmicronZoneType::CockroachDb { address, dataset: dataset? }
-            }
-            ZoneType::Crucible => {
-                OmicronZoneType::Crucible { address, dataset: dataset? }
-            }
-            ZoneType::CruciblePantry => {
-                OmicronZoneType::CruciblePantry { address }
-            }
-            ZoneType::ExternalDns => OmicronZoneType::ExternalDns {
-                dataset: dataset?,
-                dns_address: dns_address?,
-                http_address: address,
-                nic: nic?,
-            },
-            ZoneType::InternalDns => OmicronZoneType::InternalDns {
-                dataset: dataset?,
-                dns_address: dns_address?,
-                http_address: address,
-                gz_address: *self.dns_gz_address.ok_or_else(|| {
-                    anyhow!("expected dns_gz_address, found none")
-                })?,
-                gz_address_index: *self.dns_gz_address_index.ok_or_else(
-                    || anyhow!("expected dns_gz_address_index, found none"),
-                )?,
-            },
-            ZoneType::InternalNtp => OmicronZoneType::InternalNtp {
-                address,
-                dns_servers: ntp_dns_servers?,
-                domain: self.ntp_domain,
-                ntp_servers: ntp_ntp_servers?,
-            },
-            ZoneType::Nexus => OmicronZoneType::Nexus {
-                internal_address: address,
-                nic: nic?,
-                external_tls: self
-                    .nexus_external_tls
-                    .ok_or_else(|| anyhow!("expected 'external_tls'"))?,
-                external_ip: self
-                    .second_service_ip
-                    .ok_or_else(|| anyhow!("expected second service IP"))?
-                    .ip(),
-                external_dns_servers: self
-                    .nexus_external_dns_servers
-                    .ok_or_else(|| anyhow!("expected 'external_dns_servers'"))?
-                    .into_iter()
-                    .map(|i| i.ip())
-                    .collect(),
-            },
-            ZoneType::Oximeter => OmicronZoneType::Oximeter { address },
-        };
-        Ok(nexus_types::inventory::OmicronZoneConfig {
+        Ok(ZoneConfigCommon {
             id: self.id,
-            underlay_address: std::net::Ipv6Addr::from(self.underlay_address),
-            zone_type,
+            underlay_address: self.underlay_address,
+            zone_type: self.zone_type,
+            primary_service_address,
+            snat_ip: self.snat_ip,
+            snat_first_port: self.snat_first_port,
+            snat_last_port: self.snat_last_port,
+            ntp_domain: self.ntp_domain,
+            dns_gz_address: self.dns_gz_address,
+            dns_gz_address_index: self.dns_gz_address_index,
+            nexus_external_tls: self.nexus_external_tls,
+            nexus_external_dns_servers: self.nexus_external_dns_servers,
+            second_service_ip: self.second_service_ip,
+            nic,
+            dataset,
+            dns_address,
+            ntp_dns_servers,
+            ntp_ntp_servers,
         })
     }
+}
+
+struct ZoneConfigCommon {
+    id: Uuid,
+    underlay_address: ipv6::Ipv6Addr,
+    zone_type: ZoneType,
+    primary_service_address: SocketAddrV6,
+    snat_ip: Option<IpNetwork>,
+    snat_first_port: Option<SqlU16>,
+    snat_last_port: Option<SqlU16>,
+    ntp_domain: Option<String>,
+    dns_gz_address: Option<ipv6::Ipv6Addr>,
+    dns_gz_address_index: Option<SqlU32>,
+    nexus_external_tls: Option<bool>,
+    nexus_external_dns_servers: Option<Vec<IpNetwork>>,
+    second_service_ip: Option<IpNetwork>,
+    // These properties may or may not be needed, depending on the zone type. We
+    // store results here that can be unpacked once we determine our zone type.
+    nic: anyhow::Result<NetworkInterface>,
+    dataset: anyhow::Result<nexus_types::inventory::OmicronZoneDataset>,
+    dns_address: anyhow::Result<SocketAddr>,
+    ntp_dns_servers: anyhow::Result<Vec<IpAddr>>,
+    ntp_ntp_servers: anyhow::Result<Vec<String>>,
 }
 
 #[derive(Debug)]

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1517,6 +1517,7 @@ table! {
         snat_first_port -> Nullable<Int4>,
         snat_last_port -> Nullable<Int4>,
         disposition -> crate::DbBpZoneDispositionEnum,
+        external_ip_id -> Nullable<Uuid>,
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(53, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(54, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(54, "blueprint-add-external-ip-id"),
         KnownVersion::new(53, "drop-service-table"),
         KnownVersion::new(52, "blueprint-physical-disk"),
         KnownVersion::new(51, "blueprint-disposition-column"),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -48,8 +48,9 @@ use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalIp;
-use nexus_types::deployment::OmicronZoneExternalIpKind;
+use nexus_types::deployment::OmicronZoneExternalSnatIp;
 use nexus_types::external_api::params as external_params;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::shared::IdentityType;
@@ -479,10 +480,12 @@ impl DataStore {
             BlueprintZoneType::ExternalDns(
                 blueprint_zone_type::ExternalDns { nic, dns_address, .. },
             ) => {
-                let external_ip = OmicronZoneExternalIp {
-                    id: ExternalIpUuid::new_v4(),
-                    kind: OmicronZoneExternalIpKind::Floating(dns_address.ip()),
-                };
+                let external_ip = OmicronZoneExternalIp::Floating(
+                    OmicronZoneExternalFloatingIp {
+                        id: ExternalIpUuid::new_v4(),
+                        ip: dns_address.ip(),
+                    },
+                );
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -506,10 +509,12 @@ impl DataStore {
                 external_ip,
                 ..
             }) => {
-                let external_ip = OmicronZoneExternalIp {
-                    id: ExternalIpUuid::new_v4(),
-                    kind: OmicronZoneExternalIpKind::Floating(*external_ip),
-                };
+                let external_ip = OmicronZoneExternalIp::Floating(
+                    OmicronZoneExternalFloatingIp {
+                        id: ExternalIpUuid::new_v4(),
+                        ip: *external_ip,
+                    },
+                );
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -531,10 +536,11 @@ impl DataStore {
             BlueprintZoneType::BoundaryNtp(
                 blueprint_zone_type::BoundaryNtp { snat_cfg, nic, .. },
             ) => {
-                let external_ip = OmicronZoneExternalIp {
-                    id: ExternalIpUuid::new_v4(),
-                    kind: OmicronZoneExternalIpKind::Snat(*snat_cfg),
-                };
+                let external_ip =
+                    OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
+                        id: ExternalIpUuid::new_v4(),
+                        snat_cfg: *snat_cfg,
+                    });
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -48,9 +48,7 @@ use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
-use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalIp;
-use nexus_types::deployment::OmicronZoneExternalSnatIp;
 use nexus_types::external_api::params as external_params;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::shared::IdentityType;
@@ -65,7 +63,6 @@ use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::bail_unless;
-use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use slog_error_chain::InlineErrorChain;
 use std::sync::{Arc, OnceLock};
@@ -480,12 +477,8 @@ impl DataStore {
             BlueprintZoneType::ExternalDns(
                 blueprint_zone_type::ExternalDns { nic, dns_address, .. },
             ) => {
-                let external_ip = OmicronZoneExternalIp::Floating(
-                    OmicronZoneExternalFloatingIp {
-                        id: ExternalIpUuid::new_v4(),
-                        ip: dns_address.ip(),
-                    },
-                );
+                let external_ip =
+                    OmicronZoneExternalIp::Floating(dns_address.into_ip());
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -509,12 +502,7 @@ impl DataStore {
                 external_ip,
                 ..
             }) => {
-                let external_ip = OmicronZoneExternalIp::Floating(
-                    OmicronZoneExternalFloatingIp {
-                        id: ExternalIpUuid::new_v4(),
-                        ip: *external_ip,
-                    },
-                );
+                let external_ip = OmicronZoneExternalIp::Floating(*external_ip);
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -534,13 +522,9 @@ impl DataStore {
                 Some((external_ip, db_nic))
             }
             BlueprintZoneType::BoundaryNtp(
-                blueprint_zone_type::BoundaryNtp { snat_cfg, nic, .. },
+                blueprint_zone_type::BoundaryNtp { external_ip, nic, .. },
             ) => {
-                let external_ip =
-                    OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
-                        id: ExternalIpUuid::new_v4(),
-                        snat_cfg: *snat_cfg,
-                    });
+                let external_ip = OmicronZoneExternalIp::Snat(*external_ip);
                 let db_nic = IncompleteNetworkInterface::new_service(
                     nic.id,
                     zone_config.id.into_untyped_uuid(),
@@ -971,9 +955,14 @@ mod test {
         SledBuilder, SystemDescription,
     };
     use nexus_test_utils::db::test_setup_database;
-    use nexus_types::deployment::BlueprintZoneConfig;
-    use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZonesConfig;
+    use nexus_types::deployment::{
+        BlueprintZoneConfig, OmicronZoneExternalFloatingAddr,
+        OmicronZoneExternalFloatingIp,
+    };
+    use nexus_types::deployment::{
+        BlueprintZoneDisposition, OmicronZoneExternalSnatIp,
+    };
     use nexus_types::external_api::shared::SiloIdentityMode;
     use nexus_types::identity::Asset;
     use nexus_types::internal_api::params::DnsRecord;
@@ -988,8 +977,8 @@ mod test {
     };
     use omicron_common::api::internal::shared::SourceNatConfig;
     use omicron_test_utils::dev;
-    use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::TypedUuid;
+    use omicron_uuid_kinds::{ExternalIpUuid, OmicronZoneUuid};
     use omicron_uuid_kinds::{GenericUuid, ZpoolUuid};
     use sled_agent_client::types::OmicronZoneDataset;
     use std::collections::{BTreeMap, HashMap};
@@ -1315,10 +1304,10 @@ mod test {
                             blueprint_zone_type::ExternalDns {
                                 dataset: random_dataset(),
                                 http_address: "[::1]:80".parse().unwrap(),
-                                dns_address: SocketAddr::new(
-                                    external_dns_ip,
-                                    53,
-                                ),
+                                dns_address: OmicronZoneExternalFloatingAddr {
+                                    id: ExternalIpUuid::new_v4(),
+                                    addr: SocketAddr::new(external_dns_ip, 53),
+                                },
                                 nic: NetworkInterface {
                                     id: Uuid::new_v4(),
                                     kind: NetworkInterfaceKind::Service {
@@ -1364,10 +1353,13 @@ mod test {
                                     primary: true,
                                     slot: 0,
                                 },
-                                snat_cfg: SourceNatConfig::new(
-                                    ntp1_ip, 16384, 32767,
-                                )
-                                .unwrap(),
+                                external_ip: OmicronZoneExternalSnatIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    snat_cfg: SourceNatConfig::new(
+                                        ntp1_ip, 16384, 32767,
+                                    )
+                                    .unwrap(),
+                                },
                             },
                         ),
                     },
@@ -1386,7 +1378,10 @@ mod test {
                         zone_type: BlueprintZoneType::Nexus(
                             blueprint_zone_type::Nexus {
                                 internal_address: "[::1]:80".parse().unwrap(),
-                                external_ip: nexus_ip,
+                                external_ip: OmicronZoneExternalFloatingIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    ip: nexus_ip,
+                                },
                                 external_tls: false,
                                 external_dns_servers: vec![],
                                 nic: NetworkInterface {
@@ -1434,10 +1429,13 @@ mod test {
                                     primary: true,
                                     slot: 0,
                                 },
-                                snat_cfg: SourceNatConfig::new(
-                                    ntp2_ip, 0, 16383,
-                                )
-                                .unwrap(),
+                                external_ip: OmicronZoneExternalSnatIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    snat_cfg: SourceNatConfig::new(
+                                        ntp2_ip, 0, 16383,
+                                    )
+                                    .unwrap(),
+                                },
                             },
                         ),
                     },
@@ -1633,7 +1631,10 @@ mod test {
                         zone_type: BlueprintZoneType::Nexus(
                             blueprint_zone_type::Nexus {
                                 internal_address: "[::1]:80".parse().unwrap(),
-                                external_ip: nexus_ip_start.into(),
+                                external_ip: OmicronZoneExternalFloatingIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    ip: nexus_ip_start.into(),
+                                },
                                 external_tls: false,
                                 external_dns_servers: vec![],
                                 nic: NetworkInterface {
@@ -1662,7 +1663,10 @@ mod test {
                         zone_type: BlueprintZoneType::Nexus(
                             blueprint_zone_type::Nexus {
                                 internal_address: "[::1]:80".parse().unwrap(),
-                                external_ip: nexus_ip_end.into(),
+                                external_ip: OmicronZoneExternalFloatingIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    ip: nexus_ip_end.into(),
+                                },
                                 external_tls: false,
                                 external_dns_servers: vec![],
                                 nic: NetworkInterface {
@@ -1788,7 +1792,7 @@ mod test {
                 .1
                 .zone_type
             {
-                *external_ip
+                external_ip.ip
             } else {
                 panic!("Unexpected zone type")
             }
@@ -1807,7 +1811,7 @@ mod test {
                 .1
                 .zone_type
             {
-                *external_ip
+                external_ip.ip
             } else {
                 panic!("Unexpected service kind")
             }
@@ -1896,7 +1900,10 @@ mod test {
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:80".parse().unwrap(),
-                            external_ip: nexus_ip,
+                            external_ip: OmicronZoneExternalFloatingIp {
+                                id: ExternalIpUuid::new_v4(),
+                                ip: nexus_ip,
+                            },
                             external_tls: false,
                             external_dns_servers: vec![],
                             nic: NetworkInterface {
@@ -1999,7 +2006,10 @@ mod test {
                             blueprint_zone_type::ExternalDns {
                                 dataset: random_dataset(),
                                 http_address: "[::1]:80".parse().unwrap(),
-                                dns_address: SocketAddr::new(ip, 53),
+                                dns_address: OmicronZoneExternalFloatingAddr {
+                                    id: ExternalIpUuid::new_v4(),
+                                    addr: SocketAddr::new(ip, 53),
+                                },
                                 nic: NetworkInterface {
                                     id: Uuid::new_v4(),
                                     kind: NetworkInterfaceKind::Service {
@@ -2026,7 +2036,10 @@ mod test {
                         zone_type: BlueprintZoneType::Nexus(
                             blueprint_zone_type::Nexus {
                                 internal_address: "[::1]:80".parse().unwrap(),
-                                external_ip: ip,
+                                external_ip: OmicronZoneExternalFloatingIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    ip,
+                                },
                                 external_tls: false,
                                 external_dns_servers: vec![],
                                 nic: NetworkInterface {

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -888,8 +888,9 @@ mod tests {
     use nexus_db_model::IpPoolResource;
     use nexus_db_model::IpPoolResourceType;
     use nexus_test_utils::db::test_setup_database;
+    use nexus_types::deployment::OmicronZoneExternalFloatingIp;
     use nexus_types::deployment::OmicronZoneExternalIp;
-    use nexus_types::deployment::OmicronZoneExternalIpKind;
+    use nexus_types::deployment::OmicronZoneExternalSnatIp;
     use nexus_types::external_api::params::InstanceCreate;
     use nexus_types::external_api::shared::IpRange;
     use nexus_types::inventory::SourceNatConfig;
@@ -1345,21 +1346,26 @@ mod tests {
         context.initialize_ip_pool(SERVICE_IP_POOL_NAME, ip_range).await;
 
         let ip_10_0_0_2 =
-            OmicronZoneExternalIpKind::Floating("10.0.0.2".parse().unwrap());
+            OmicronZoneExternalIp::Floating(OmicronZoneExternalFloatingIp {
+                id: ExternalIpUuid::new_v4(),
+                ip: "10.0.0.2".parse().unwrap(),
+            });
         let ip_10_0_0_3 =
-            OmicronZoneExternalIpKind::Floating("10.0.0.3".parse().unwrap());
+            OmicronZoneExternalIp::Floating(OmicronZoneExternalFloatingIp {
+                id: ExternalIpUuid::new_v4(),
+                ip: "10.0.0.3".parse().unwrap(),
+            });
 
         // Allocate an IP address as we would for an external, rack-associated
         // service.
         let service_id = OmicronZoneUuid::new_v4();
-        let id = ExternalIpUuid::new_v4();
         let ip = context
             .db_datastore
             .external_ip_allocate_omicron_zone(
                 &context.opctx,
                 service_id,
                 ZoneKind::Nexus,
-                OmicronZoneExternalIp { id, kind: ip_10_0_0_3 },
+                ip_10_0_0_3,
             )
             .await
             .expect("Failed to allocate service IP address");
@@ -1376,7 +1382,7 @@ mod tests {
                 &context.opctx,
                 service_id,
                 ZoneKind::Nexus,
-                OmicronZoneExternalIp { id, kind: ip_10_0_0_3 },
+                ip_10_0_0_3,
             )
             .await
             .expect("Failed to allocate service IP address");
@@ -1392,10 +1398,10 @@ mod tests {
                 &context.opctx,
                 service_id,
                 ZoneKind::Nexus,
-                OmicronZoneExternalIp {
+                OmicronZoneExternalIp::Floating(OmicronZoneExternalFloatingIp {
                     id: ExternalIpUuid::new_v4(),
-                    kind: ip_10_0_0_3,
-                },
+                    ip: ip_10_0_0_3.ip(),
+                }),
             )
             .await
             .expect_err("Should have failed to re-allocate same IP address (different UUID)");
@@ -1412,10 +1418,10 @@ mod tests {
                 &context.opctx,
                 service_id,
                 ZoneKind::Nexus,
-                OmicronZoneExternalIp {
-                    id,
-                    kind: ip_10_0_0_2,
-                },
+                OmicronZoneExternalIp::Floating(OmicronZoneExternalFloatingIp {
+                    id: ip_10_0_0_3.id(),
+                    ip: ip_10_0_0_2.ip(),
+                }),
             )
             .await
             .expect_err("Should have failed to re-allocate different IP address (same UUID)");
@@ -1426,17 +1432,19 @@ mod tests {
 
         // Try allocating the same service IP once more, but do it with a
         // different port range.
-        let ip_10_0_0_3_snat_0 = OmicronZoneExternalIpKind::Snat(
-            SourceNatConfig::new("10.0.0.3".parse().unwrap(), 0, 16383)
-                .unwrap(),
-        );
+        let ip_10_0_0_3_snat_0 =
+            OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
+                id: ip_10_0_0_3.id(),
+                snat_cfg: SourceNatConfig::new(ip_10_0_0_3.ip(), 0, 16383)
+                    .unwrap(),
+            });
         let err = context
             .db_datastore
             .external_ip_allocate_omicron_zone(
                 &context.opctx,
                 service_id,
                 ZoneKind::BoundaryNtp,
-                OmicronZoneExternalIp { id, kind: ip_10_0_0_3_snat_0 },
+                ip_10_0_0_3_snat_0,
             )
             .await
             .expect_err("Should have failed to re-allocate different IP address (different port range)");
@@ -1446,22 +1454,24 @@ mod tests {
         );
 
         // This time start with an explicit SNat
-        let ip_10_0_0_1_snat_32768 = OmicronZoneExternalIpKind::Snat(
-            SourceNatConfig::new("10.0.0.1".parse().unwrap(), 32768, 49151)
+        let ip_10_0_0_1_snat_32768 =
+            OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
+                id: ExternalIpUuid::new_v4(),
+                snat_cfg: SourceNatConfig::new(
+                    "10.0.0.1".parse().unwrap(),
+                    32768,
+                    49151,
+                )
                 .unwrap(),
-        );
+            });
         let snat_service_id = OmicronZoneUuid::new_v4();
-        let snat_id = ExternalIpUuid::new_v4();
         let snat_ip = context
             .db_datastore
             .external_ip_allocate_omicron_zone(
                 &context.opctx,
                 snat_service_id,
                 ZoneKind::BoundaryNtp,
-                OmicronZoneExternalIp {
-                    id: snat_id,
-                    kind: ip_10_0_0_1_snat_32768,
-                },
+                ip_10_0_0_1_snat_32768,
             )
             .await
             .expect("Failed to allocate service IP address");
@@ -1482,10 +1492,7 @@ mod tests {
                 &context.opctx,
                 snat_service_id,
                 ZoneKind::BoundaryNtp,
-                OmicronZoneExternalIp {
-                    id: snat_id,
-                    kind: ip_10_0_0_1_snat_32768,
-                },
+                ip_10_0_0_1_snat_32768,
             )
             .await
             .expect("Failed to allocate service IP address");
@@ -1497,20 +1504,23 @@ mod tests {
 
         // Try allocating the same service IP once more, but do it with a
         // different port range.
-        let ip_10_0_0_1_snat_49152 = OmicronZoneExternalIpKind::Snat(
-            SourceNatConfig::new("10.0.0.1".parse().unwrap(), 49152, 65535)
+        let ip_10_0_0_1_snat_49152 =
+            OmicronZoneExternalIp::Snat(OmicronZoneExternalSnatIp {
+                id: ip_10_0_0_1_snat_32768.id(),
+                snat_cfg: SourceNatConfig::new(
+                    ip_10_0_0_1_snat_32768.ip(),
+                    49152,
+                    65535,
+                )
                 .unwrap(),
-        );
+            });
         let err = context
             .db_datastore
             .external_ip_allocate_omicron_zone(
                 &context.opctx,
                 snat_service_id,
                 ZoneKind::BoundaryNtp,
-                OmicronZoneExternalIp {
-                    id: snat_id,
-                    kind: ip_10_0_0_1_snat_49152,
-                },
+                ip_10_0_0_1_snat_49152,
             )
             .await
             .expect_err("Should have failed to re-allocate different IP address (different port range)");
@@ -1536,19 +1546,20 @@ mod tests {
         .unwrap();
         context.initialize_ip_pool(SERVICE_IP_POOL_NAME, ip_range).await;
 
-        let ip_10_0_0_5 = OmicronZoneExternalIpKind::Floating(IpAddr::V4(
-            Ipv4Addr::new(10, 0, 0, 5),
-        ));
+        let ip_10_0_0_5 =
+            OmicronZoneExternalIp::Floating(OmicronZoneExternalFloatingIp {
+                id: ExternalIpUuid::new_v4(),
+                ip: "10.0.0.5".parse().unwrap(),
+            });
 
         let service_id = OmicronZoneUuid::new_v4();
-        let id = ExternalIpUuid::new_v4();
         let err = context
             .db_datastore
             .external_ip_allocate_omicron_zone(
                 &context.opctx,
                 service_id,
                 ZoneKind::Nexus,
-                OmicronZoneExternalIp { id, kind: ip_10_0_0_5 },
+                ip_10_0_0_5,
             )
             .await
             .expect_err("Should have failed to allocate out-of-bounds IP");

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -445,7 +445,7 @@ pub fn blueprint_nexus_external_ips(blueprint: &Blueprint) -> Vec<IpAddr> {
             BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                 external_ip,
                 ..
-            }) => Some(external_ip),
+            }) => Some(external_ip.ip),
             _ => None,
         })
         .collect()
@@ -494,6 +494,7 @@ mod test {
     use omicron_common::api::external::Generation;
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_test_utils::dev::test_setup_log;
+    use omicron_uuid_kinds::ExternalIpUuid;
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use std::collections::BTreeMap;
@@ -565,10 +566,14 @@ mod test {
                         .zones
                         .zones
                         .into_iter()
-                        .map(|config| {
+                        .map(|config| -> BlueprintZoneConfig {
                             BlueprintZoneConfig::from_omicron_zone_config(
                                 config,
                                 BlueprintZoneDisposition::InService,
+                                // We don't get external IP IDs in inventory
+                                // collections. We'll just make one up for every
+                                // zone that needs one here. This is gross.
+                                Some(ExternalIpUuid::new_v4()),
                             )
                             .expect("failed to convert zone config")
                         })

--- a/nexus/reconfigurator/execution/src/resource_allocation.rs
+++ b/nexus/reconfigurator/execution/src/resource_allocation.rs
@@ -668,7 +668,10 @@ mod tests {
             db_nexus_ips[0].parent_id,
             Some(nexus_id.into_untyped_uuid())
         );
-        // TODO-john add assertion on IP ID
+        assert_eq!(
+            db_nexus_ips[0].id,
+            nexus_external_ip.id.into_untyped_uuid()
+        );
         assert_eq!(db_nexus_ips[0].ip, nexus_external_ip.ip.into());
         assert_eq!(db_nexus_ips[0].first_port, SqlU16(0));
         assert_eq!(db_nexus_ips[0].last_port, SqlU16(65535));
@@ -680,7 +683,7 @@ mod tests {
         assert_eq!(db_dns_ips.len(), 1);
         assert!(db_dns_ips[0].is_service);
         assert_eq!(db_dns_ips[0].parent_id, Some(dns_id.into_untyped_uuid()));
-        // TODO-john add assertion on IP ID
+        assert_eq!(db_dns_ips[0].id, dns_external_addr.id.into_untyped_uuid());
         assert_eq!(db_dns_ips[0].ip, dns_external_addr.addr.ip().into());
         assert_eq!(db_dns_ips[0].first_port, SqlU16(0));
         assert_eq!(db_dns_ips[0].last_port, SqlU16(65535));
@@ -692,7 +695,7 @@ mod tests {
         assert_eq!(db_ntp_ips.len(), 1);
         assert!(db_ntp_ips[0].is_service);
         assert_eq!(db_ntp_ips[0].parent_id, Some(ntp_id.into_untyped_uuid()));
-        // TODO-john add assertion on IP ID
+        assert_eq!(db_ntp_ips[0].id, ntp_external_ip.id.into_untyped_uuid());
         assert_eq!(db_ntp_ips[0].ip, ntp_external_ip.snat_cfg.ip.into());
         assert_eq!(
             db_ntp_ips[0].first_port.0..=db_ntp_ips[0].last_port.0,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -25,6 +25,7 @@ use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::BlueprintZonesConfig;
 use nexus_types::deployment::DiskFilter;
 use nexus_types::deployment::OmicronZoneDataset;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::SledResources;
@@ -43,6 +44,7 @@ use omicron_common::api::external::MacAddr;
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::shared::NetworkInterface;
 use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneKind;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -293,10 +295,10 @@ impl<'a> BlueprintBuilder<'a> {
                 // For the test suite, ignore localhost.  It gets reused many
                 // times and that's okay.  We don't expect to see localhost
                 // outside the test suite.
-                if !external_ip.is_loopback()
-                    && !used_external_ips.insert(external_ip)
+                if !external_ip.ip().is_loopback()
+                    && !used_external_ips.insert(external_ip.ip())
                 {
-                    bail!("duplicate external IP: {external_ip}");
+                    bail!("duplicate external IP: {external_ip:?}");
                 }
             }
 
@@ -740,13 +742,16 @@ impl<'a> BlueprintBuilder<'a> {
 
         for _ in 0..num_nexus_to_add {
             let nexus_id = self.rng.zone_rng.next();
-            let external_ip = self
-                .available_external_ips
-                .next()
-                .ok_or(Error::NoExternalServiceIpAvailable)?;
+            let external_ip = OmicronZoneExternalFloatingIp {
+                id: ExternalIpUuid::new_v4(),
+                ip: self
+                    .available_external_ips
+                    .next()
+                    .ok_or(Error::NoExternalServiceIpAvailable)?,
+            };
 
             let nic = {
-                let (ip, subnet) = match external_ip {
+                let (ip, subnet) = match external_ip.ip {
                     IpAddr::V4(_) => (
                         self.nexus_v4_ips
                             .next()
@@ -1512,8 +1517,8 @@ pub mod test {
             // Nexus with no remaining external IPs should fail.
             let mut used_ip_ranges = Vec::new();
             for (_, z) in parent.all_omicron_zones(BlueprintZoneFilter::All) {
-                if let Some(ip) = z.zone_type.external_ip() {
-                    used_ip_ranges.push(IpRange::from(ip));
+                if let Some(external_ip) = z.zone_type.external_ip() {
+                    used_ip_ranges.push(IpRange::from(external_ip.ip()));
                 }
             }
             assert!(!used_ip_ranges.is_empty());

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -9,8 +9,8 @@ use crate::system::SledBuilder;
 use crate::system::SystemDescription;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalIp;
-use nexus_types::deployment::OmicronZoneExternalIpKind;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
@@ -106,12 +106,14 @@ impl ExampleSystem {
                     input_builder
                         .add_omicron_zone_external_ip(
                             service_id,
-                            OmicronZoneExternalIp {
-                                id: ExternalIpUuid::new_v4(),
-                                // TODO-cleanup This is potentially wrong;
-                                // zone_type should tell us the IP kind.
-                                kind: OmicronZoneExternalIpKind::Floating(ip),
-                            },
+                            // TODO-cleanup This is potentially wrong;
+                            // zone_type should tell us the IP kind.
+                            OmicronZoneExternalIp::Floating(
+                                OmicronZoneExternalFloatingIp {
+                                    id: ExternalIpUuid::new_v4(),
+                                    ip,
+                                },
+                            ),
                         )
                         .expect("failed to add Omicron zone external IP");
                 }

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -9,13 +9,10 @@ use crate::system::SledBuilder;
 use crate::system::SystemDescription;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneFilter;
-use nexus_types::deployment::OmicronZoneExternalFloatingIp;
-use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
-use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledKind;
 use typed_rng::TypedUuidRng;
@@ -102,19 +99,9 @@ impl ExampleSystem {
             };
             for zone in zones.zones.iter() {
                 let service_id = zone.id;
-                if let Some(ip) = zone.zone_type.external_ip() {
+                if let Some(external_ip) = zone.zone_type.external_ip() {
                     input_builder
-                        .add_omicron_zone_external_ip(
-                            service_id,
-                            // TODO-cleanup This is potentially wrong;
-                            // zone_type should tell us the IP kind.
-                            OmicronZoneExternalIp::Floating(
-                                OmicronZoneExternalFloatingIp {
-                                    id: ExternalIpUuid::new_v4(),
-                                    ip,
-                                },
-                            ),
-                        )
+                        .add_omicron_zone_external_ip(service_id, external_ip)
                         .expect("failed to add Omicron zone external IP");
                 }
                 if let Some(nic) = zone.zone_type.opte_vnic() {

--- a/nexus/reconfigurator/preparation/Cargo.toml
+++ b/nexus/reconfigurator/preparation/Cargo.toml
@@ -12,5 +12,6 @@ nexus-types.workspace = true
 omicron-common.workspace = true
 omicron-uuid-kinds.workspace = true
 slog.workspace = true
+slog-error-chain.workspace = true
 
 omicron-workspace-hack.workspace = true

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -7,7 +7,6 @@
 use anyhow::Context;
 use futures::StreamExt;
 use nexus_db_model::DnsGroup;
-use nexus_db_model::IpKind;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::datastore::DataStoreDnsTest;
 use nexus_db_queries::db::datastore::DataStoreInventoryTest;
@@ -17,10 +16,9 @@ use nexus_db_queries::db::pagination::Paginator;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintMetadata;
-use nexus_types::deployment::OmicronZoneExternalIpKind;
+use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
-use nexus_types::deployment::PlanningInputBuildError;
 use nexus_types::deployment::PlanningInputBuilder;
 use nexus_types::deployment::Policy;
 use nexus_types::deployment::SledDetails;
@@ -30,7 +28,6 @@ use nexus_types::deployment::UnstableReconfiguratorState;
 use nexus_types::identity::Asset;
 use nexus_types::identity::Resource;
 use nexus_types::inventory::Collection;
-use nexus_types::inventory::SourceNatConfig;
 use omicron_common::address::IpRange;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::NEXUS_REDUNDANCY;
@@ -38,7 +35,6 @@ use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupType;
 use omicron_common::disk::DiskIdentity;
-use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -46,6 +42,7 @@ use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use slog::error;
 use slog::Logger;
+use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
@@ -136,32 +133,17 @@ impl PlanningInputFromDb<'_> {
 
             let zone_id = OmicronZoneUuid::from_untyped_uuid(zone_id);
 
-            let to_kind = |ip| match external_ip_row.kind {
-                IpKind::Floating => Ok(OmicronZoneExternalIpKind::Floating(ip)),
-                IpKind::SNat => {
-                    let snat = SourceNatConfig::new(
-                        ip,
-                        *external_ip_row.first_port,
-                        *external_ip_row.last_port,
-                    )
-                    .map_err(|err| {
-                        PlanningInputBuildError::BadSnatConfig { zone_id, err }
-                    })?;
-                    Ok(OmicronZoneExternalIpKind::Snat(snat))
-                }
-                IpKind::Ephemeral => Err(
-                    PlanningInputBuildError::EphemeralIpUnsupported(zone_id),
-                ),
-            };
+            let external_ip = OmicronZoneExternalIp::try_from(external_ip_row)
+                .map_err(|e| {
+                    Error::internal_error(&format!(
+                        "invalid database IP record for \
+                         Omicron zone {zone_id}: {}",
+                        InlineErrorChain::new(&e)
+                    ))
+                })?;
 
             builder
-                .add_omicron_zone_external_ip_network(
-                    zone_id,
-                    // TODO-cleanup use `TypedUuid` everywhere
-                    ExternalIpUuid::from_untyped_uuid(external_ip_row.id),
-                    external_ip_row.ip,
-                    to_kind,
-                )
+                .add_omicron_zone_external_ip(zone_id, external_ip)
                 .map_err(|e| {
                     Error::internal_error(&format!(
                         "unexpectedly failed to add external IP \

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -200,7 +200,7 @@ impl super::Nexus {
                 BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                     external_ip,
                     ..
-                }) => Some(match external_ip {
+                }) => Some(match external_ip.ip {
                     IpAddr::V4(addr) => DnsRecord::A(addr),
                     IpAddr::V6(addr) => DnsRecord::Aaaa(addr),
                 }),

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -275,11 +275,11 @@ impl nexus_test_interface::NexusServer for Server {
             .filter_map(|(_, zc)| match &zc.zone_type {
                 BlueprintZoneType::ExternalDns(
                     blueprint_zone_type::ExternalDns { dns_address, .. },
-                ) => Some(IpRange::from(dns_address.ip())),
+                ) => Some(IpRange::from(dns_address.addr.ip())),
                 BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                     external_ip,
                     ..
-                }) => Some(IpRange::from(*external_ip)),
+                }) => Some(IpRange::from(external_ip.ip)),
                 _ => None,
             })
             .collect();

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -31,6 +31,8 @@ use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::BlueprintZonesConfig;
+use nexus_types::deployment::OmicronZoneExternalFloatingAddr;
+use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::external_api::params::UserId;
 use nexus_types::internal_api::params::Certificate;
 use nexus_types::internal_api::params::DatasetCreateRequest;
@@ -52,6 +54,7 @@ use omicron_common::api::internal::shared::NetworkInterfaceKind;
 use omicron_common::api::internal::shared::SwitchLocation;
 use omicron_sled_agent::sim;
 use omicron_test_utils::dev;
+use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::ZpoolUuid;
@@ -657,7 +660,10 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                     .deployment
                     .external_dns_servers
                     .clone(),
-                external_ip: external_address,
+                external_ip: OmicronZoneExternalFloatingIp {
+                    id: ExternalIpUuid::new_v4(),
+                    ip: external_address,
+                },
                 external_tls: self.config.deployment.dropshot_external.tls,
                 internal_address: address,
                 nic: NetworkInterface {
@@ -976,7 +982,10 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             zone_type: BlueprintZoneType::ExternalDns(
                 blueprint_zone_type::ExternalDns {
                     dataset: OmicronZoneDataset { pool_name },
-                    dns_address: dns_address.into(),
+                    dns_address: OmicronZoneExternalFloatingAddr {
+                        id: ExternalIpUuid::new_v4(),
+                        addr: dns_address.into(),
+                    },
                     http_address: dropshot_address,
                     nic: NetworkInterface {
                         id: Uuid::new_v4(),

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -44,8 +44,9 @@ mod planning_input;
 mod zone_type;
 
 pub use planning_input::DiskFilter;
+pub use planning_input::OmicronZoneExternalFloatingIp;
 pub use planning_input::OmicronZoneExternalIp;
-pub use planning_input::OmicronZoneExternalIpKind;
+pub use planning_input::OmicronZoneExternalSnatIp;
 pub use planning_input::OmicronZoneNic;
 pub use planning_input::PlanningInput;
 pub use planning_input::PlanningInputBuildError;

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -23,11 +23,13 @@ use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::net::IpAddr;
+use std::net::SocketAddr;
 use strum::IntoEnumIterator;
 use uuid::Uuid;
 
@@ -179,10 +181,27 @@ impl OmicronZoneExternalIp {
 /// This is a slimmer `nexus_db_model::ExternalIp` that only stores the fields
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+)]
 pub struct OmicronZoneExternalFloatingIp {
     pub id: ExternalIpUuid,
     pub ip: IpAddr,
+}
+
+/// Floating external address with port allocated to an Omicron-managed zone.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+)]
+pub struct OmicronZoneExternalFloatingAddr {
+    pub id: ExternalIpUuid,
+    pub addr: SocketAddr,
+}
+
+impl OmicronZoneExternalFloatingAddr {
+    pub fn into_ip(self) -> OmicronZoneExternalFloatingIp {
+        OmicronZoneExternalFloatingIp { id: self.id, ip: self.addr.ip() }
+    }
 }
 
 /// SNAT (outbound) external IP allocated to an Omicron-managed zone.
@@ -190,7 +209,9 @@ pub struct OmicronZoneExternalFloatingIp {
 /// This is a slimmer `nexus_db_model::ExternalIp` that only stores the fields
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+)]
 pub struct OmicronZoneExternalSnatIp {
     pub id: ExternalIpUuid,
     pub snat_cfg: SourceNatConfig,

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -8,13 +8,13 @@
 //! internal API, but include additional information needed by Reconfigurator
 //! that is not needed by sled-agent.
 
+use super::OmicronZoneExternalIp;
 use omicron_common::api::internal::shared::NetworkInterface;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use sled_agent_client::types::OmicronZoneType;
 use sled_agent_client::ZoneKind;
-use std::net::IpAddr;
 
 #[derive(Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -33,11 +33,17 @@ pub enum BlueprintZoneType {
 }
 
 impl BlueprintZoneType {
-    pub fn external_ip(&self) -> Option<IpAddr> {
+    pub fn external_ip(&self) -> Option<OmicronZoneExternalIp> {
         match self {
-            BlueprintZoneType::Nexus(nexus) => Some(nexus.external_ip),
-            BlueprintZoneType::ExternalDns(dns) => Some(dns.dns_address.ip()),
-            BlueprintZoneType::BoundaryNtp(ntp) => Some(ntp.snat_cfg.ip),
+            BlueprintZoneType::Nexus(nexus) => {
+                Some(OmicronZoneExternalIp::Floating(nexus.external_ip))
+            }
+            BlueprintZoneType::ExternalDns(dns) => {
+                Some(OmicronZoneExternalIp::Floating(dns.dns_address.into_ip()))
+            }
+            BlueprintZoneType::BoundaryNtp(ntp) => {
+                Some(OmicronZoneExternalIp::Snat(ntp.external_ip))
+            }
             BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
             | BlueprintZoneType::CockroachDb(_)
@@ -126,7 +132,7 @@ impl From<BlueprintZoneType> for OmicronZoneType {
                 dns_servers: zone.dns_servers,
                 domain: zone.domain,
                 nic: zone.nic,
-                snat_cfg: zone.snat_cfg,
+                snat_cfg: zone.external_ip.snat_cfg,
             },
             BlueprintZoneType::Clickhouse(zone) => Self::Clickhouse {
                 address: zone.address.to_string(),
@@ -152,7 +158,7 @@ impl From<BlueprintZoneType> for OmicronZoneType {
             BlueprintZoneType::ExternalDns(zone) => Self::ExternalDns {
                 dataset: zone.dataset,
                 http_address: zone.http_address.to_string(),
-                dns_address: zone.dns_address.to_string(),
+                dns_address: zone.dns_address.addr.to_string(),
                 nic: zone.nic,
             },
             BlueprintZoneType::InternalDns(zone) => Self::InternalDns {
@@ -170,7 +176,7 @@ impl From<BlueprintZoneType> for OmicronZoneType {
             },
             BlueprintZoneType::Nexus(zone) => Self::Nexus {
                 internal_address: zone.internal_address.to_string(),
-                external_ip: zone.external_ip,
+                external_ip: zone.external_ip.ip,
                 nic: zone.nic,
                 external_tls: zone.external_tls,
                 external_dns_servers: zone.external_dns_servers,
@@ -202,15 +208,16 @@ impl BlueprintZoneType {
 }
 
 pub mod blueprint_zone_type {
+    use crate::deployment::planning_input::OmicronZoneExternalFloatingAddr;
+    use crate::deployment::OmicronZoneExternalFloatingIp;
+    use crate::deployment::OmicronZoneExternalSnatIp;
     use crate::inventory::OmicronZoneDataset;
     use omicron_common::api::internal::shared::NetworkInterface;
-    use omicron_common::api::internal::shared::SourceNatConfig;
     use schemars::JsonSchema;
     use serde::Deserialize;
     use serde::Serialize;
     use std::net::IpAddr;
     use std::net::Ipv6Addr;
-    use std::net::SocketAddr;
     use std::net::SocketAddrV6;
 
     #[derive(
@@ -223,8 +230,7 @@ pub mod blueprint_zone_type {
         pub domain: Option<String>,
         /// The service vNIC providing outbound connectivity using OPTE.
         pub nic: NetworkInterface,
-        /// The SNAT configuration for outbound connections.
-        pub snat_cfg: SourceNatConfig,
+        pub external_ip: OmicronZoneExternalSnatIp,
     }
 
     #[derive(
@@ -274,7 +280,7 @@ pub mod blueprint_zone_type {
         /// The address at which the external DNS server API is reachable.
         pub http_address: SocketAddrV6,
         /// The address at which the external DNS server is reachable.
-        pub dns_address: SocketAddr,
+        pub dns_address: OmicronZoneExternalFloatingAddr,
         /// The service vNIC providing external connectivity using OPTE.
         pub nic: NetworkInterface,
     }
@@ -316,7 +322,7 @@ pub mod blueprint_zone_type {
         /// The address at which the internal nexus server is reachable.
         pub internal_address: SocketAddrV6,
         /// The address at which the external nexus server is reachable.
-        pub external_ip: IpAddr,
+        pub external_ip: OmicronZoneExternalFloatingIp,
         /// The service vNIC providing external connectivity using OPTE.
         pub nic: NetworkInterface,
         /// Whether Nexus's external endpoint should use TLS

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2794,6 +2794,9 @@
                 "nullable": true,
                 "type": "string"
               },
+              "external_ip": {
+                "$ref": "#/components/schemas/OmicronZoneExternalSnatIp"
+              },
               "nic": {
                 "description": "The service vNIC providing outbound connectivity using OPTE.",
                 "allOf": [
@@ -2808,14 +2811,6 @@
                   "type": "string"
                 }
               },
-              "snat_cfg": {
-                "description": "The SNAT configuration for outbound connections.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/SourceNatConfig"
-                  }
-                ]
-              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -2826,9 +2821,9 @@
             "required": [
               "address",
               "dns_servers",
+              "external_ip",
               "nic",
               "ntp_servers",
-              "snat_cfg",
               "type"
             ]
           },
@@ -2946,7 +2941,11 @@
               },
               "dns_address": {
                 "description": "The address at which the external DNS server is reachable.",
-                "type": "string"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OmicronZoneExternalFloatingAddr"
+                  }
+                ]
               },
               "http_address": {
                 "description": "The address at which the external DNS server API is reachable.",
@@ -3064,8 +3063,11 @@
               },
               "external_ip": {
                 "description": "The address at which the external nexus server is reachable.",
-                "type": "string",
-                "format": "ip"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OmicronZoneExternalFloatingIp"
+                  }
+                ]
               },
               "external_tls": {
                 "description": "Whether Nexus's external endpoint should use TLS",
@@ -5891,6 +5893,55 @@
           "pool_name"
         ]
       },
+      "OmicronZoneExternalFloatingAddr": {
+        "description": "Floating external address with port allocated to an Omicron-managed zone.",
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/TypedUuidForExternalIpKind"
+          }
+        },
+        "required": [
+          "addr",
+          "id"
+        ]
+      },
+      "OmicronZoneExternalFloatingIp": {
+        "description": "Floating external IP allocated to an Omicron-managed zone.\n\nThis is a slimmer `nexus_db_model::ExternalIp` that only stores the fields necessary for blueprint planning, and requires that the zone have a single IP.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TypedUuidForExternalIpKind"
+          },
+          "ip": {
+            "type": "string",
+            "format": "ip"
+          }
+        },
+        "required": [
+          "id",
+          "ip"
+        ]
+      },
+      "OmicronZoneExternalSnatIp": {
+        "description": "SNAT (outbound) external IP allocated to an Omicron-managed zone.\n\nThis is a slimmer `nexus_db_model::ExternalIp` that only stores the fields necessary for blueprint planning, and requires that the zone have a single IP.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TypedUuidForExternalIpKind"
+          },
+          "snat_cfg": {
+            "$ref": "#/components/schemas/SourceNatConfig"
+          }
+        },
+        "required": [
+          "id",
+          "snat_cfg"
+        ]
+      },
       "OximeterInfo": {
         "description": "Message used to notify Nexus that this oximeter instance is up and running.",
         "type": "object",
@@ -7134,6 +7185,10 @@
         "type": "object"
       },
       "TypedUuidForDownstairsRegionKind": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "TypedUuidForExternalIpKind": {
         "type": "string",
         "format": "uuid"
       },

--- a/schema/crdb/blueprint-add-external-ip-id/up1.sql
+++ b/schema/crdb/blueprint-add-external-ip-id/up1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bp_omicron_zone ADD COLUMN IF NOT EXISTS external_ip_id UUID;

--- a/schema/crdb/blueprint-add-external-ip-id/up2.sql
+++ b/schema/crdb/blueprint-add-external-ip-id/up2.sql
@@ -1,3 +1,5 @@
+set local disallow_full_table_scans = off;
+
 -- Fill in the external IP IDs for all past blueprints.
 --
 -- This query makes some assumptions that are true at the time of its writing

--- a/schema/crdb/blueprint-add-external-ip-id/up2.sql
+++ b/schema/crdb/blueprint-add-external-ip-id/up2.sql
@@ -1,0 +1,20 @@
+-- Fill in the external IP IDs for all past blueprints.
+--
+-- This query makes some assumptions that are true at the time of its writing
+-- for systems where this migration will run, but may not be true in the future
+-- or for other systems:
+--
+-- 1. We've never deleted an Omicron zone external IP. (This will be untrue
+--    _soon_, as the driver for this migration is to do exactly that.)
+-- 2. Only the three zone types listed below have external IPs.
+-- 3. Every blueprint zone of one of those three types has exactly one external
+--    IP.
+-- 4. We do not have any blueprints that have not yet been realized. (If we did,
+--    those zones would not have corresponding external IPs. We'd leave the IPs
+--    as NULL, which would prevent them from being loaded from the db.)
+UPDATE bp_omicron_zone SET external_ip_id = (
+   SELECT external_ip.id FROM external_ip
+       WHERE external_ip.parent_id = bp_omicron_zone.id
+       AND   time_deleted IS NULL
+)
+WHERE zone_type IN ('nexus','external_dns','boundary_ntp');

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3332,6 +3332,15 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone (
     -- Zone disposition
     disposition omicron.public.bp_zone_disposition NOT NULL,
 
+    -- For some zones, either primary_service_ip or second_service_ip (but not
+    -- both!) is an external IP address. For such zones, this is the ID of that
+    -- external IP. In general this is a foreign key into
+    -- omicron.public.external_ip, though the row many not exist: if this
+    -- blueprint is old, it's possible the IP has been deleted, and if this
+    -- blueprint has not yet been realized, it's possible the IP hasn't been
+    -- created yet.
+    external_ip_id UUID,
+
     PRIMARY KEY (blueprint_id, id)
 );
 
@@ -3756,7 +3765,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    ( TRUE, NOW(), NOW(), '53.0.0', NULL)
+    ( TRUE, NOW(), NOW(), '54.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -103,8 +103,8 @@ use omicron_common::backoff::{
 };
 use omicron_common::ledger::{self, Ledger, Ledgerable};
 use omicron_ddm_admin_client::{Client as DdmAdminClient, DdmError};
-use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::{ExternalIpUuid, GenericUuid};
 use serde::{Deserialize, Serialize};
 use sled_agent_client::{
     types as SledAgentTypes, Client as SledAgentClient, Error as SledAgentError,
@@ -1341,6 +1341,16 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
         BlueprintZoneConfig::from_omicron_zone_config(
             z.clone().into(),
             disposition,
+            // This is pretty weird: IP IDs don't exist yet, so it's fine for us
+            // to make them up (Nexus will record them as a part of the
+            // handoff). We could pass `None` here for some zone types, but it's
+            // a little simpler to just always pass a new ID, which will only be
+            // used if the zone type has an external IP.
+            //
+            // This should all go away once RSS starts using blueprints more
+            // directly (instead of this conversion after the fact):
+            // https://github.com/oxidecomputer/omicron/issues/5272
+            Some(ExternalIpUuid::new_v4()),
         )
     };
 


### PR DESCRIPTION
This converts the `BlueprintZoneType`s for Nexus, External DNS, and Boundary NTP to hold `OmicronZoneExternalIp`s of various flavors, which contain the database ID for this IP in addition to the other information they already held (IP address, SNAT config, etc., as applicable). The motivating case here is to _delete_ external IPs (by ID) for expunged zones, which will come in a subsequent PR.

There is some other immediate payoff here. For example, `reconfigurator-cli` can now drop its goofy `external_ip` ID map; previously, it had to conjure up IDs for external IPs at various points, but now it can read them directly from the blueprint. We also get to remove a couple `TODO-cleanup`s where we were assuming a particular kind of IP (floating vs snat), where now we know exactly what the kind is.