### PR TITLE
Make network interface deletion query idempotent

### DIFF
--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -11,15 +11,16 @@ use crate::db::pool::DbConnection;
 use crate::db::queries::next_item::DefaultShiftGenerator;
 use crate::db::queries::next_item::NextItem;
 use crate::db::schema::network_interface::dsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::DateTime;
 use chrono::Utc;
 use diesel::pg::Pg;
 use diesel::prelude::Column;
-use diesel::query_builder::AstPass;
 use diesel::query_builder::QueryFragment;
 use diesel::query_builder::QueryId;
+use diesel::query_builder::{AstPass, Query};
 use diesel::result::Error as DieselError;
-use diesel::sql_types;
+use diesel::sql_types::{self, Nullable};
 use diesel::Insertable;
 use diesel::QueryResult;
 use diesel::RunQueryDsl;
@@ -31,6 +32,7 @@ use nexus_db_model::{NetworkInterfaceKindEnum, SqlU8};
 use omicron_common::api::external;
 use omicron_common::api::external::MacAddr;
 use once_cell::sync::Lazy;
+use slog_error_chain::SlogInlineError;
 use std::net::IpAddr;
 use uuid::Uuid;
 
@@ -1502,18 +1504,39 @@ fn push_instance_state_verification_subquery<'a>(
 ///                     parent_id = <parent_id> AND
 ///                     kind = <kind> AND
 ///                     time_deleted IS NULL
-///             ) = 1,
+///             ) <= 1,
 ///             '<interface_id>',
 ///             'secondaries'
 ///         ) AS UUID)
+///     ),
+///     found_interface AS (
+///         SELECT
+///             id
+///         FROM
+///             network_interface
+///         WHERE
+///             id = <interface_id>
+///     ),
+///     updated AS (
+///         UPDATE
+///             network_interface
+///         SET
+///             time_deleted = NOW()
+///         WHERE
+///             id = <interface_id> AND
+///             time_deleted IS NULL
+///         RETURNING
+///             id
 ///     )
-/// UPDATE
-///     network_interface
-/// SET
-///     time_deleted = NOW()
-/// WHERE
-///     id = <interface_id> AND
-///     time_deleted IS NULL
+/// SELECT
+///     found_interface.id,
+///     updated.id
+/// FROM
+///     found_interface
+/// LEFT JOIN
+///     updated
+/// ON
+///     found_interface.id = updated.id
 /// ```
 ///
 /// Notes
@@ -1543,6 +1566,37 @@ impl DeleteQuery {
             kind,
             parent_id,
             parent_id_str: parent_id.to_string(),
+        }
+    }
+
+    /// Issue the delete and parses the result.
+    ///
+    /// The three outcomes are:
+    /// - Ok(Row exists and was deleted)
+    /// - Ok(Row exists, but was not deleted)
+    /// - Error (row doesn't exist, or other diesel error)
+    pub async fn execute_and_check(
+        self,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+    ) -> Result<bool, DieselError> {
+        let (found_id, deleted_id) =
+            self.get_result_async::<(Option<Uuid>, Option<Uuid>)>(conn).await?;
+        match (found_id, deleted_id) {
+            (Some(found), Some(deleted)) => {
+                assert_eq!(
+                    found, deleted,
+                    "internal query error: mismatched interface IDs"
+                );
+                Ok(true)
+            }
+            (Some(_), None) => Ok(false),
+            (None, Some(deleted)) => {
+                panic!(
+                    "internal query error: \
+                     deleted nonexisted interface {deleted}"
+                )
+            }
+            (None, None) => Err(DieselError::NotFound),
         }
     }
 }
@@ -1592,13 +1646,21 @@ impl QueryFragment<Pg> for DeleteQuery {
         )?;
         out.push_sql(" AND ");
         out.push_identifier(dsl::time_deleted::NAME)?;
-        out.push_sql(" IS NULL) = 1, ");
+        out.push_sql(" IS NULL) <= 1, ");
         out.push_bind_param::<sql_types::Text, String>(&self.parent_id_str)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Text, &str>(
             &DeleteError::HAS_SECONDARIES_SENTINEL,
         )?;
-        out.push_sql(") AS UUID)) UPDATE ");
+        out.push_sql(") AS UUID)), found_interface AS (SELECT ");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(" FROM ");
+        NETWORK_INTERFACE_FROM_CLAUSE.walk_ast(out.reborrow())?;
+        out.push_sql(" WHERE ");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(" = ");
+        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.interface_id)?;
+        out.push_sql("), updated AS (UPDATE ");
         NETWORK_INTERFACE_FROM_CLAUSE.walk_ast(out.reborrow())?;
         out.push_sql(" SET ");
         out.push_identifier(dsl::time_deleted::NAME)?;
@@ -1608,25 +1670,43 @@ impl QueryFragment<Pg> for DeleteQuery {
         out.push_bind_param::<sql_types::Uuid, Uuid>(&self.interface_id)?;
         out.push_sql(" AND ");
         out.push_identifier(dsl::time_deleted::NAME)?;
-        out.push_sql(" IS NULL");
+        out.push_sql(" IS NULL RETURNING ");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(") SELECT found_interface.");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(", updated.");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(" FROM found_interface LEFT JOIN updated");
+        out.push_sql(" ON found_interface.");
+        out.push_identifier(dsl::id::NAME)?;
+        out.push_sql(" = updated.");
+        out.push_identifier(dsl::id::NAME)?;
         Ok(())
     }
+}
+
+impl Query for DeleteQuery {
+    type SqlType = (Nullable<sql_types::Uuid>, Nullable<sql_types::Uuid>);
 }
 
 impl RunQueryDsl<DbConnection> for DeleteQuery {}
 
 /// Errors related to deleting a network interface
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error, SlogInlineError)]
 pub enum DeleteError {
     /// Attempting to delete the primary interface, while there still exist
     /// secondary interfaces.
+    #[error("cannot delete primary interface while secondaries exist")]
     SecondariesExist(Uuid),
     /// Instance must be stopped or failed prior to deleting interfaces from it
+    #[error("cannot delete interface in current instance state")]
     InstanceBadState(Uuid),
     /// The instance does not exist at all, or is in the destroyed state.
+    #[error("instance not found ({0})")]
     InstanceNotFound(Uuid),
     /// Any other error
-    External(external::Error),
+    #[error("cannot delete interface")]
+    External(#[source] external::Error),
 }
 
 impl DeleteError {
@@ -1777,6 +1857,7 @@ mod tests {
     use omicron_common::api::external::MacAddr;
     use omicron_test_utils::dev;
     use omicron_test_utils::dev::db::CockroachInstance;
+    use slog_error_chain::InlineErrorChain;
     use std::collections::HashSet;
     use std::convert::TryInto;
     use std::net::IpAddr;
@@ -2040,6 +2121,78 @@ mod tests {
             )
             .await
         }
+    }
+
+    #[tokio::test]
+    async fn test_delete_service_is_idempotent() {
+        let context =
+            TestContext::new("test_insert_running_instance_fails", 2).await;
+        let service_id = Uuid::new_v4();
+        let ip = context.net1.subnets[0]
+            .ipv4_block
+            .iter()
+            .nth(NUM_INITIAL_RESERVED_IP_ADDRESSES)
+            .unwrap();
+        let interface = IncompleteNetworkInterface::new_service(
+            Uuid::new_v4(),
+            service_id,
+            context.net1.subnets[0].clone(),
+            IdentityMetadataCreateParams {
+                name: "service-nic".parse().unwrap(),
+                description: String::from("service nic"),
+            },
+            ip.into(),
+            MacAddr::random_system(),
+            0,
+        )
+        .unwrap();
+        let inserted_interface = context
+            .db_datastore
+            .service_create_network_interface_raw(&context.opctx, interface)
+            .await
+            .expect("Failed to insert interface");
+
+        // We should be able to delete twice, and be told that the first delete
+        // modified the row and the second did not.
+        let first_deleted = context
+            .db_datastore
+            .service_delete_network_interface(
+                &context.opctx,
+                service_id,
+                inserted_interface.id(),
+            )
+            .await
+            .expect("failed first delete");
+        assert!(first_deleted, "first delete removed interface");
+
+        let second_deleted = context
+            .db_datastore
+            .service_delete_network_interface(
+                &context.opctx,
+                service_id,
+                inserted_interface.id(),
+            )
+            .await
+            .expect("failed second delete");
+        assert!(!second_deleted, "second delete did nothing");
+
+        // Attempting to delete a nonexistent interface should fail.
+        let err = context
+            .db_datastore
+            .service_delete_network_interface(
+                &context.opctx,
+                service_id,
+                Uuid::new_v4(),
+            )
+            .await
+            .expect_err(
+                "unexpectedly succeeded deleting nonexistent interface",
+            );
+        let err = InlineErrorChain::new(&err).to_string();
+        assert!(
+            err.contains("Record not found"),
+            "expected `Record not found`; got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -2126,7 +2126,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_service_is_idempotent() {
         let context =
-            TestContext::new("test_insert_running_instance_fails", 2).await;
+            TestContext::new("test_delete_service_is_idempotent", 2).await;
         let service_id = Uuid::new_v4();
         let ip = context.net1.subnets[0]
             .ipv4_block
@@ -2193,6 +2193,7 @@ mod tests {
             err.contains("Record not found"),
             "expected `Record not found`; got {err:?}"
         );
+        context.success().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
I ran into this working on the Reconfigurator executor trying to clean up external IPs and network interfaces. Deleting external IPs is already idempotent, but deleting NICs is not, and trying to delete the same NIC twice fails with an incorrect error (specifically, that the interface cannot be deleted because secondary interfaces still exist, which doesn't make sense because the interface is _already_ deleted and there never were any secondary interfaces).

The same query is used to delete instance network interfaces, so I'd appreciate a careful look here that I didn't break something. I think this change does fix a very minor bug for instance NICs, though, where clients could see the same nonsensical error about secondary interfaces. Specifically, today on main, if you delete an interface twice from the CLI serially, the second attempt 404s as expected:

```console
% ./oxide instance nic delete --interface 561bf0bd-acd3-4be9-87fc-5ad3f5df1d51
null
% ./oxide instance nic delete --interface 561bf0bd-acd3-4be9-87fc-5ad3f5df1d51
error
Error Response: status: 404 Not Found; headers: {"content-type": "application/json", "x-request-id": "4eab6025-0678-4302-81aa-6ca04958b091", "content-length": "195", "date": "Wed, 24 Apr 2024 14:46:01 GMT"}; value: Error { error_code: Some("ObjectNotFound"), message: "not found: instance-network-interface with id \"561bf0bd-acd3-4be9-87fc-5ad3f5df1d51\"", request_id: "4eab6025-0678-4302-81aa-6ca04958b091" }
```

But the 404 is coming from [the authz lookup](https://github.com/oxidecomputer/omicron/blob/aec34001a1a9df2c503a7c8cee51530d9c43af2e/nexus/src/app/network_interface.rs#L168-L169), not the database query, so if we issue multiple requests simultaneously, they can TOCTOU past the authz lookup, at which point one succeeds and the other fails with the nonsense 400:

```console
% ./oxide instance nic delete --interface dbea0c30-9389-4aaf-bbcc-582de02e6736 &
% ./oxide instance nic delete --interface dbea0c30-9389-4aaf-bbcc-582de02e6736 &
null
error
Error Response: status: 400 Bad Request; headers: {"content-type": "application/json", "x-request-id": "1e3d8c7e-db60-4ee4-8c2c-5c46f0dae691", "content-length": "195", "date": "Wed, 24 Apr 2024 14:48:40 GMT"}; value: Error { error_code: Some("InvalidRequest"), message: "The primary interface may not be deleted while secondary interfaces are still attached", request_id: "1e3d8c7e-db60-4ee4-8c2c-5c46f0dae691" }
```

This PR changes the query to return a `Result<bool, ...>` indicating whether or not the delete was performed (using an almost identical CTE as our [update_and_check gadget](https://github.com/oxidecomputer/omicron/blob/aec34001a1a9df2c503a7c8cee51530d9c43af2e/nexus/db-queries/src/db/update_and_check.rs#L200-L216), which I don't think is directly usable here because we already have a CTE of our own, not a diesel update statement). In the public API, I'm mapping `Ok(false)` to a 404, which should fix the above 400.

There's one other caller of this function I didn't touch: the instance create saga has an undo action [that uses this query to delete a NIC](https://github.com/oxidecomputer/omicron/blob/aec34001a1a9df2c503a7c8cee51530d9c43af2e/nexus/src/app/sagas/instance_create.rs#L437-L445). I don't think this is idempotent today - is it supposed to be? It will be as of this PR, but if that's wrong and it needs to do something special for `Ok(false)`, I'm happy to make changes there.
