### PR TITLE
[ci] bump nextest version to 0.9.70

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.64", recommended = "0.9.67" }
+nextest-version = { required = "0.9.64", recommended = "0.9.70" }
 
 experimental = ["setup-scripts"]
 

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -9,7 +9,7 @@ target_os=$1
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.67'
+NEXTEST_VERSION='0.9.70'
 
 cargo --version
 rustc --version


### PR DESCRIPTION
Nextest 0.9.70 has a bunch of improvements compared to 0.9.67, and also ships
symbols so that `pstack` works.
