### PR TITLE
[reconfigurator] Remove external networking CRDB records for expunged zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,7 +4721,9 @@ name = "nexus-reconfigurator-execution"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-bb8-diesel",
  "chrono",
+ "diesel",
  "dns-service-client",
  "futures",
  "httptest",

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -139,12 +139,12 @@ impl ReconfiguratorSim {
         for (_, zone) in
             parent_blueprint.all_omicron_zones(BlueprintZoneFilter::All)
         {
-            if let Some(external_ip) = zone.zone_type.external_ip() {
+            if let Some((external_ip, nic)) =
+                zone.zone_type.external_networking()
+            {
                 builder
                     .add_omicron_zone_external_ip(zone.id, external_ip)
                     .context("adding omicron zone external IP")?;
-            }
-            if let Some(nic) = zone.zone_type.opte_vnic() {
                 let nic = OmicronZoneNic {
                     id: nic.id,
                     mac: nic.mac,

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -232,8 +232,10 @@ impl BpOmicronZone {
         sled_id: SledUuid,
         blueprint_zone: &BlueprintZoneConfig,
     ) -> Result<Self, anyhow::Error> {
-        let external_ip_id =
-            blueprint_zone.zone_type.external_ip().map(|ip| ip.id());
+        let external_ip_id = blueprint_zone
+            .zone_type
+            .external_networking()
+            .map(|(ip, _)| ip.id());
         let zone = OmicronZone::new(
             sled_id,
             blueprint_zone.id.into_untyped_uuid(),
@@ -381,7 +383,7 @@ impl BpOmicronZoneNic {
         blueprint_id: Uuid,
         zone: &BlueprintZoneConfig,
     ) -> Result<Option<BpOmicronZoneNic>, anyhow::Error> {
-        let Some(nic) = zone.zone_type.opte_vnic() else {
+        let Some((_, nic)) = zone.zone_type.external_networking() else {
             return Ok(None);
         };
         let nic = OmicronZoneNic::new(zone.id.into_untyped_uuid(), nic)?;

--- a/nexus/reconfigurator/execution/Cargo.toml
+++ b/nexus/reconfigurator/execution/Cargo.toml
@@ -33,6 +33,8 @@ pq-sys = "*"
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+async-bb8-diesel.workspace = true
+diesel.workspace = true
 httptest.workspace = true
 ipnet.workspace = true
 nexus-reconfigurator-planning.workspace = true

--- a/nexus/reconfigurator/execution/src/external_networking.rs
+++ b/nexus/reconfigurator/execution/src/external_networking.rs
@@ -2,20 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Manges allocation of resources required for blueprint realization
+//! Manages allocation and deallocation of external networking resources
+//! required for blueprint realization
 
 use anyhow::bail;
 use anyhow::Context;
 use nexus_db_model::IncompleteNetworkInterface;
-use nexus_db_model::VpcSubnet;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::fixed_data::vpc_subnet::DNS_VPC_SUBNET;
 use nexus_db_queries::db::fixed_data::vpc_subnet::NEXUS_VPC_SUBNET;
 use nexus_db_queries::db::fixed_data::vpc_subnet::NTP_VPC_SUBNET;
 use nexus_db_queries::db::DataStore;
-use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::BlueprintZoneConfig;
-use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::OmicronZoneExternalIp;
 use omicron_common::api::external::IdentityMetadataCreateParams;
 use omicron_common::api::internal::shared::NetworkInterface;
@@ -27,432 +25,358 @@ use slog::error;
 use slog::info;
 use slog::warn;
 
-pub(crate) async fn ensure_zone_resources_allocated(
+pub(crate) async fn ensure_zone_external_networking_allocated(
     opctx: &OpContext,
     datastore: &DataStore,
     all_omicron_zones: impl Iterator<Item = &BlueprintZoneConfig>,
 ) -> anyhow::Result<()> {
-    let allocator = ResourceAllocator { opctx, datastore };
-
     for z in all_omicron_zones {
-        match &z.zone_type {
-            BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
-                external_ip,
-                nic,
-                ..
-            }) => {
-                allocator
-                    .ensure_nexus_external_networking_allocated(
-                        z.id,
-                        OmicronZoneExternalIp::Floating(*external_ip),
-                        nic,
-                    )
-                    .await?;
-            }
-            BlueprintZoneType::ExternalDns(
-                blueprint_zone_type::ExternalDns { dns_address, nic, .. },
-            ) => {
-                allocator
-                    .ensure_external_dns_external_networking_allocated(
-                        z.id,
-                        OmicronZoneExternalIp::Floating(dns_address.into_ip()),
-                        nic,
-                    )
-                    .await?;
-            }
-            BlueprintZoneType::BoundaryNtp(
-                blueprint_zone_type::BoundaryNtp { external_ip, nic, .. },
-            ) => {
-                allocator
-                    .ensure_boundary_ntp_external_networking_allocated(
-                        z.id,
-                        OmicronZoneExternalIp::Snat(*external_ip),
-                        nic,
-                    )
-                    .await?;
-            }
-            BlueprintZoneType::InternalNtp(_)
-            | BlueprintZoneType::Clickhouse(_)
-            | BlueprintZoneType::ClickhouseKeeper(_)
-            | BlueprintZoneType::CockroachDb(_)
-            | BlueprintZoneType::Crucible(_)
-            | BlueprintZoneType::CruciblePantry(_)
-            | BlueprintZoneType::InternalDns(_)
-            | BlueprintZoneType::Oximeter(_) => (),
-        }
+        let Some((external_ip, nic)) = z.zone_type.external_networking() else {
+            continue;
+        };
+
+        let kind = z.zone_type.kind();
+        ensure_external_service_ip(opctx, datastore, kind, z.id, external_ip)
+            .await?;
+        ensure_service_nic(opctx, datastore, kind, z.id, nic).await?;
     }
 
     Ok(())
 }
 
-struct ResourceAllocator<'a> {
-    opctx: &'a OpContext,
-    datastore: &'a DataStore,
-}
+// Helper function to determine whether a given external IP address is
+// already allocated to a specific service zone.
+async fn is_external_ip_already_allocated(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    zone_kind: ZoneKind,
+    zone_id: OmicronZoneUuid,
+    external_ip: OmicronZoneExternalIp,
+) -> anyhow::Result<bool> {
+    // localhost is used by many components in the test suite.  We can't use
+    // the normal path because normally a given external IP must only be
+    // used once.  Just treat localhost in the test suite as though it's
+    // already allocated.  We do the same in is_nic_already_allocated().
+    if cfg!(test) && external_ip.ip().is_loopback() {
+        return Ok(true);
+    }
 
-impl<'a> ResourceAllocator<'a> {
-    // Helper function to determine whether a given external IP address is
-    // already allocated to a specific service zone.
-    async fn is_external_ip_already_allocated(
-        &self,
-        zone_kind: ZoneKind,
-        zone_id: OmicronZoneUuid,
-        external_ip: OmicronZoneExternalIp,
-    ) -> anyhow::Result<bool> {
-        // localhost is used by many components in the test suite.  We can't use
-        // the normal path because normally a given external IP must only be
-        // used once.  Just treat localhost in the test suite as though it's
-        // already allocated.  We do the same in is_nic_already_allocated().
-        if cfg!(test) && external_ip.ip().is_loopback() {
-            return Ok(true);
-        }
+    let allocated_ips = datastore
+        .external_ip_list_service(opctx, zone_id.into_untyped_uuid())
+        .await
+        .with_context(|| {
+            format!("failed to look up external IPs for {zone_kind} {zone_id}")
+        })?;
 
-        let allocated_ips = self
-            .datastore
-            .external_ip_list_service(self.opctx, zone_id.into_untyped_uuid())
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to look up external IPs for {zone_kind} {zone_id}"
-                )
-            })?;
-
-        // We expect to find either 0 or exactly 1 IP for any given zone. If 0,
-        // we know the IP isn't allocated; if 1, we'll check that it matches
-        // below.
-        let existing_ip = match allocated_ips.as_slice() {
-            [] => {
-                info!(
-                    self.opctx.log, "external IP allocation required for zone";
-                    "zone_kind" => %zone_kind,
-                    "zone_id" => %zone_id,
-                    "ip" => ?external_ip,
-                );
-
-                return Ok(false);
-            }
-            [ip] => ip,
-            _ => {
-                warn!(
-                    self.opctx.log, "zone has multiple IPs allocated";
-                    "zone_kind" => %zone_kind,
-                    "zone_id" => %zone_id,
-                    "want_ip" => ?external_ip,
-                    "allocated_ips" => ?allocated_ips,
-                );
-                bail!(
-                    "zone {zone_id} already has {} IPs allocated (expected 1)",
-                    allocated_ips.len()
-                );
-            }
-        };
-
-        // We expect this to always succeed; a failure here means we've stored
-        // an Omicron zone IP in the database that can't be converted back to an
-        // Omicron zone IP!
-        let existing_ip = match OmicronZoneExternalIp::try_from(existing_ip) {
-            Ok(existing_ip) => existing_ip,
-            Err(err) => {
-                error!(
-                    self.opctx.log, "invalid IP in database for zone";
-                    "zone_kind" => %zone_kind,
-                    "zone_id" => %zone_id,
-                    "ip" => ?existing_ip,
-                    &err,
-                );
-                bail!("zone {zone_id} has invalid IP database record: {err}");
-            }
-        };
-
-        if existing_ip == external_ip {
+    // We expect to find either 0 or exactly 1 IP for any given zone. If 0,
+    // we know the IP isn't allocated; if 1, we'll check that it matches
+    // below.
+    let existing_ip = match allocated_ips.as_slice() {
+        [] => {
             info!(
-                self.opctx.log, "found already-allocated external IP";
+                opctx.log, "external IP allocation required for zone";
                 "zone_kind" => %zone_kind,
                 "zone_id" => %zone_id,
                 "ip" => ?external_ip,
             );
-            Ok(true)
-        } else {
+
+            return Ok(false);
+        }
+        [ip] => ip,
+        _ => {
             warn!(
-                self.opctx.log, "zone has unexpected IP allocated";
+                opctx.log, "zone has multiple IPs allocated";
                 "zone_kind" => %zone_kind,
                 "zone_id" => %zone_id,
                 "want_ip" => ?external_ip,
-                "allocated_ip" => ?existing_ip,
+                "allocated_ips" => ?allocated_ips,
             );
             bail!(
-                "zone {zone_id} has a different IP allocated ({existing_ip:?})",
+                "zone {zone_id} already has {} IPs allocated (expected 1)",
+                allocated_ips.len()
             );
         }
-    }
+    };
 
-    // Helper function to determine whether a given NIC is already allocated to
-    // a specific service zone.
-    async fn is_nic_already_allocated(
-        &self,
-        zone_type: &'static str,
-        zone_id: OmicronZoneUuid,
-        nic: &NetworkInterface,
-    ) -> anyhow::Result<bool> {
-        // See the comment in is_external_ip_already_allocated().
-        if cfg!(test) && nic.ip.is_loopback() {
-            return Ok(true);
-        }
-
-        let allocated_nics = self
-            .datastore
-            .service_list_network_interfaces(
-                self.opctx,
-                zone_id.into_untyped_uuid(),
-            )
-            .await
-            .with_context(|| {
-                format!("failed to look up NICs for {zone_type} {zone_id}")
-            })?;
-
-        if !allocated_nics.is_empty() {
-            // All the service zones that want NICs only expect to have a single
-            // one. Bail out here if this zone already has one or more allocated
-            // NICs but not the one we think it needs.
-            //
-            // This doesn't check the allocated NIC's subnet against our NICs,
-            // because that would require an extra DB lookup. We'll assume if
-            // these main properties are correct, the subnet is too.
-            for allocated_nic in &allocated_nics {
-                if allocated_nic.ip.ip() == nic.ip
-                    && *allocated_nic.mac == nic.mac
-                    && *allocated_nic.slot == nic.slot
-                    && allocated_nic.primary == nic.primary
-                {
-                    info!(
-                        self.opctx.log, "found already-allocated NIC";
-                        "zone_type" => zone_type,
-                        "zone_id" => %zone_id,
-                        "nic" => ?allocated_nic,
-                    );
-                    return Ok(true);
-                }
-            }
-
-            warn!(
-                self.opctx.log, "zone has unexpected NICs allocated";
-                "zone_type" => zone_type,
+    // We expect this to always succeed; a failure here means we've stored
+    // an Omicron zone IP in the database that can't be converted back to an
+    // Omicron zone IP!
+    let existing_ip = match OmicronZoneExternalIp::try_from(existing_ip) {
+        Ok(existing_ip) => existing_ip,
+        Err(err) => {
+            error!(
+                opctx.log, "invalid IP in database for zone";
+                "zone_kind" => %zone_kind,
                 "zone_id" => %zone_id,
-                "want_nic" => ?nic,
-                "allocated_nics" => ?allocated_nics,
+                "ip" => ?existing_ip,
+                &err,
             );
-
-            bail!(
-                "zone {zone_id} already has {} non-matching NIC(s) allocated",
-                allocated_nics.len()
-            );
+            bail!("zone {zone_id} has invalid IP database record: {err}");
         }
+    };
 
+    if existing_ip == external_ip {
         info!(
-            self.opctx.log, "NIC allocation required for zone";
-            "zone_type" => zone_type,
-            "zone_id" => %zone_id,
-            "nid" => ?nic,
-        );
-
-        Ok(false)
-    }
-
-    async fn ensure_external_service_ip(
-        &self,
-        zone_kind: ZoneKind,
-        zone_id: OmicronZoneUuid,
-        external_ip: OmicronZoneExternalIp,
-    ) -> anyhow::Result<()> {
-        // Only attempt to allocate `external_ip` if it isn't already assigned
-        // to this zone.
-        //
-        // Checking for the existing of the external IP and then creating it
-        // if not found inserts a classic TOCTOU race: what if another Nexus
-        // is running concurrently, we both check and see that the IP is not
-        // allocated, then both attempt to create it? We believe this is
-        // okay: the loser of the race (i.e., the one whose create tries to
-        // commit second) will fail to allocate the IP, which will bubble
-        // out and prevent realization of the current blueprint. That's
-        // exactly what we want if two Nexuses try to realize the same
-        // blueprint at the same time.
-        if self
-            .is_external_ip_already_allocated(zone_kind, zone_id, external_ip)
-            .await?
-        {
-            return Ok(());
-        }
-        self.datastore
-            .external_ip_allocate_omicron_zone(
-                self.opctx,
-                zone_id,
-                zone_kind,
-                external_ip,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to allocate IP to {zone_kind} {zone_id}: \
-                     {external_ip:?}"
-                )
-            })?;
-
-        info!(
-            self.opctx.log, "successfully allocated external IP";
+            opctx.log, "found already-allocated external IP";
             "zone_kind" => %zone_kind,
             "zone_id" => %zone_id,
             "ip" => ?external_ip,
         );
+        Ok(true)
+    } else {
+        warn!(
+            opctx.log, "zone has unexpected IP allocated";
+            "zone_kind" => %zone_kind,
+            "zone_id" => %zone_id,
+            "want_ip" => ?external_ip,
+            "allocated_ip" => ?existing_ip,
+        );
+        bail!("zone {zone_id} has a different IP allocated ({existing_ip:?})",);
+    }
+}
 
-        Ok(())
+// Helper function to determine whether a given NIC is already allocated to
+// a specific service zone.
+async fn is_nic_already_allocated(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    zone_kind: ZoneKind,
+    zone_id: OmicronZoneUuid,
+    nic: &NetworkInterface,
+) -> anyhow::Result<bool> {
+    // See the comment in is_external_ip_already_allocated().
+    if cfg!(test) && nic.ip.is_loopback() {
+        return Ok(true);
     }
 
-    // All service zones with external connectivity get service vNICs.
-    async fn ensure_service_nic(
-        &self,
-        zone_type: &'static str,
-        service_id: OmicronZoneUuid,
-        nic: &NetworkInterface,
-        nic_subnet: &VpcSubnet,
-    ) -> anyhow::Result<()> {
-        // We don't pass `nic.kind` into the database below, but instead
-        // explicitly call `service_create_network_interface`. Ensure this is
-        // indeed a service NIC.
-        match &nic.kind {
-            NetworkInterfaceKind::Instance { .. } => {
-                bail!("invalid NIC kind (expected service, got instance)")
-            }
-            NetworkInterfaceKind::Service { .. } => (),
-            NetworkInterfaceKind::Probe { .. } => (),
-        }
-
-        // Only attempt to allocate `nic` if it isn't already assigned to this
-        // zone.
-        //
-        // This is subject to the same kind of TOCTOU race as described for IP
-        // allocation in `ensure_external_service_ip`, and we believe it's okay
-        // for the same reasons as described there.
-        if self.is_nic_already_allocated(zone_type, service_id, nic).await? {
-            return Ok(());
-        }
-        let nic_arg = IncompleteNetworkInterface::new_service(
-            nic.id,
-            service_id.into_untyped_uuid(),
-            nic_subnet.clone(),
-            IdentityMetadataCreateParams {
-                name: nic.name.clone(),
-                description: format!("{zone_type} service vNIC"),
-            },
-            nic.ip,
-            nic.mac,
-            nic.slot,
-        )
+    let allocated_nics = datastore
+        .service_list_network_interfaces(opctx, zone_id.into_untyped_uuid())
+        .await
         .with_context(|| {
-            format!(
-                "failed to convert NIC into IncompleteNetworkInterface: {nic:?}"
-            )
+            format!("failed to look up NICs for {zone_kind} {zone_id}")
         })?;
-        let created_nic = self
-            .datastore
-            .service_create_network_interface(self.opctx, nic_arg)
-            .await
-            .map_err(|err| err.into_external())
-            .with_context(|| {
-                format!(
-                    "failed to allocate NIC to {zone_type} {service_id}: \
-                     {nic:?}"
-                )
-            })?;
 
-        // We don't pass all the properties of `nic` into the create request
-        // above. Double-check that the properties the DB assigned match
-        // what we expect.
+    if !allocated_nics.is_empty() {
+        // All the service zones that want NICs only expect to have a single
+        // one. Bail out here if this zone already has one or more allocated
+        // NICs but not the one we think it needs.
         //
-        // We do not check `nic.vni`, because it's not stored in the
-        // database. (All services are given the constant vni
-        // `Vni::SERVICES_VNI`.)
-        if created_nic.primary != nic.primary || *created_nic.slot != nic.slot {
-            warn!(
-                self.opctx.log, "unexpected property on allocated NIC";
-                "db_primary" => created_nic.primary,
-                "expected_primary" => nic.primary,
-                "db_slot" => *created_nic.slot,
-                "expected_slot" => nic.slot,
-            );
-
-            // Now what? We've allocated a NIC in the database but it's
-            // incorrect. Should we try to delete it? That would be best
-            // effort (we could fail to delete, or we could crash between
-            // creation and deletion).
-            //
-            // We only expect services to have one NIC, so the only way it
-            // should be possible to get a different primary/slot value is
-            // if somehow this same service got a _different_ NIC allocated
-            // to it in the TOCTOU race window above. That should be
-            // impossible with the way we generate blueprints, so we'll just
-            // return a scary error here and expect to never see it.
-            bail!(
-                "database cleanup required: \
-                 unexpected NIC ({created_nic:?}) \
-                 allocated for {zone_type} {service_id}"
-            );
+        // This doesn't check the allocated NIC's subnet against our NICs,
+        // because that would require an extra DB lookup. We'll assume if
+        // these main properties are correct, the subnet is too.
+        for allocated_nic in &allocated_nics {
+            if allocated_nic.ip.ip() == nic.ip
+                && *allocated_nic.mac == nic.mac
+                && *allocated_nic.slot == nic.slot
+                && allocated_nic.primary == nic.primary
+            {
+                info!(
+                    opctx.log, "found already-allocated NIC";
+                    "zone_kind" => %zone_kind,
+                    "zone_id" => %zone_id,
+                    "nic" => ?allocated_nic,
+                );
+                return Ok(true);
+            }
         }
 
-        info!(
-            self.opctx.log, "successfully allocated service vNIC";
-            "zone_type" => zone_type,
-            "zone_id" => %service_id,
-            "nic" => ?nic,
+        warn!(
+            opctx.log, "zone has unexpected NICs allocated";
+            "zone_kind" => %zone_kind,
+            "zone_id" => %zone_id,
+            "want_nic" => ?nic,
+            "allocated_nics" => ?allocated_nics,
         );
 
-        Ok(())
+        bail!(
+            "zone {zone_id} already has {} non-matching NIC(s) allocated",
+            allocated_nics.len()
+        );
     }
 
-    async fn ensure_nexus_external_networking_allocated(
-        &self,
-        zone_id: OmicronZoneUuid,
-        external_ip: OmicronZoneExternalIp,
-        nic: &NetworkInterface,
-    ) -> anyhow::Result<()> {
-        self.ensure_external_service_ip(ZoneKind::Nexus, zone_id, external_ip)
-            .await?;
-        self.ensure_service_nic("nexus", zone_id, nic, &NEXUS_VPC_SUBNET)
-            .await?;
-        Ok(())
-    }
+    info!(
+        opctx.log, "NIC allocation required for zone";
+        "zone_kind" => %zone_kind,
+        "zone_id" => %zone_id,
+        "nid" => ?nic,
+    );
 
-    async fn ensure_external_dns_external_networking_allocated(
-        &self,
-        zone_id: OmicronZoneUuid,
-        external_ip: OmicronZoneExternalIp,
-        nic: &NetworkInterface,
-    ) -> anyhow::Result<()> {
-        self.ensure_external_service_ip(
-            ZoneKind::ExternalDns,
+    Ok(false)
+}
+
+async fn ensure_external_service_ip(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    zone_kind: ZoneKind,
+    zone_id: OmicronZoneUuid,
+    external_ip: OmicronZoneExternalIp,
+) -> anyhow::Result<()> {
+    // Only attempt to allocate `external_ip` if it isn't already assigned
+    // to this zone.
+    //
+    // Checking for the existing of the external IP and then creating it
+    // if not found inserts a classic TOCTOU race: what if another Nexus
+    // is running concurrently, we both check and see that the IP is not
+    // allocated, then both attempt to create it? We believe this is
+    // okay: the loser of the race (i.e., the one whose create tries to
+    // commit second) will fail to allocate the IP, which will bubble
+    // out and prevent realization of the current blueprint. That's
+    // exactly what we want if two Nexuses try to realize the same
+    // blueprint at the same time.
+    if is_external_ip_already_allocated(
+        opctx,
+        datastore,
+        zone_kind,
+        zone_id,
+        external_ip,
+    )
+    .await?
+    {
+        return Ok(());
+    }
+    datastore
+        .external_ip_allocate_omicron_zone(
+            opctx,
             zone_id,
+            zone_kind,
             external_ip,
         )
-        .await?;
-        self.ensure_service_nic("external_dns", zone_id, nic, &DNS_VPC_SUBNET)
-            .await?;
-        Ok(())
+        .await
+        .with_context(|| {
+            format!(
+                "failed to allocate IP to {zone_kind} {zone_id}: \
+                     {external_ip:?}"
+            )
+        })?;
+
+    info!(
+        opctx.log, "successfully allocated external IP";
+        "zone_kind" => %zone_kind,
+        "zone_id" => %zone_id,
+        "ip" => ?external_ip,
+    );
+
+    Ok(())
+}
+
+// All service zones with external connectivity get service vNICs.
+async fn ensure_service_nic(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    zone_kind: ZoneKind,
+    service_id: OmicronZoneUuid,
+    nic: &NetworkInterface,
+) -> anyhow::Result<()> {
+    // We don't pass `nic.kind` into the database below, but instead
+    // explicitly call `service_create_network_interface`. Ensure this is
+    // indeed a service NIC.
+    match &nic.kind {
+        NetworkInterfaceKind::Instance { .. } => {
+            bail!("invalid NIC kind (expected service, got instance)")
+        }
+        NetworkInterfaceKind::Probe { .. } => {
+            bail!("invalid NIC kind (expected service, got probe)")
+        }
+        NetworkInterfaceKind::Service { .. } => (),
     }
 
-    async fn ensure_boundary_ntp_external_networking_allocated(
-        &self,
-        zone_id: OmicronZoneUuid,
-        external_ip: OmicronZoneExternalIp,
-        nic: &NetworkInterface,
-    ) -> anyhow::Result<()> {
-        self.ensure_external_service_ip(
-            ZoneKind::BoundaryNtp,
-            zone_id,
-            external_ip,
-        )
-        .await?;
-        self.ensure_service_nic("ntp", zone_id, nic, &NTP_VPC_SUBNET).await?;
-        Ok(())
+    let nic_subnet = match zone_kind {
+        ZoneKind::BoundaryNtp => &*NTP_VPC_SUBNET,
+        ZoneKind::ExternalDns => &*DNS_VPC_SUBNET,
+        ZoneKind::Nexus => &*NEXUS_VPC_SUBNET,
+        ZoneKind::Clickhouse
+        | ZoneKind::ClickhouseKeeper
+        | ZoneKind::CockroachDb
+        | ZoneKind::Crucible
+        | ZoneKind::CruciblePantry
+        | ZoneKind::InternalDns
+        | ZoneKind::InternalNtp
+        | ZoneKind::Oximeter => {
+            bail!("no VPC subnet available for {zone_kind} zone")
+        }
+    };
+
+    // Only attempt to allocate `nic` if it isn't already assigned to this
+    // zone.
+    //
+    // This is subject to the same kind of TOCTOU race as described for IP
+    // allocation in `ensure_external_service_ip`, and we believe it's okay
+    // for the same reasons as described there.
+    if is_nic_already_allocated(opctx, datastore, zone_kind, service_id, nic)
+        .await?
+    {
+        return Ok(());
     }
+    let nic_arg = IncompleteNetworkInterface::new_service(
+        nic.id,
+        service_id.into_untyped_uuid(),
+        nic_subnet.clone(),
+        IdentityMetadataCreateParams {
+            name: nic.name.clone(),
+            description: format!("{zone_kind} service vNIC"),
+        },
+        nic.ip,
+        nic.mac,
+        nic.slot,
+    )
+    .with_context(|| {
+        format!(
+            "failed to convert NIC into IncompleteNetworkInterface: {nic:?}"
+        )
+    })?;
+    let created_nic = datastore
+        .service_create_network_interface(opctx, nic_arg)
+        .await
+        .map_err(|err| err.into_external())
+        .with_context(|| {
+            format!(
+                "failed to allocate NIC to {zone_kind} {service_id}: \
+                     {nic:?}"
+            )
+        })?;
+
+    // We don't pass all the properties of `nic` into the create request
+    // above. Double-check that the properties the DB assigned match
+    // what we expect.
+    //
+    // We do not check `nic.vni`, because it's not stored in the
+    // database. (All services are given the constant vni
+    // `Vni::SERVICES_VNI`.)
+    if created_nic.primary != nic.primary || *created_nic.slot != nic.slot {
+        warn!(
+            opctx.log, "unexpected property on allocated NIC";
+            "db_primary" => created_nic.primary,
+            "expected_primary" => nic.primary,
+            "db_slot" => *created_nic.slot,
+            "expected_slot" => nic.slot,
+        );
+
+        // Now what? We've allocated a NIC in the database but it's
+        // incorrect. Should we try to delete it? That would be best
+        // effort (we could fail to delete, or we could crash between
+        // creation and deletion).
+        //
+        // We only expect services to have one NIC, so the only way it
+        // should be possible to get a different primary/slot value is
+        // if somehow this same service got a _different_ NIC allocated
+        // to it in the TOCTOU race window above. That should be
+        // impossible with the way we generate blueprints, so we'll just
+        // return a scary error here and expect to never see it.
+        bail!(
+            "database cleanup required: \
+                 unexpected NIC ({created_nic:?}) \
+                 allocated for {zone_kind} {service_id}"
+        );
+    }
+
+    info!(
+        opctx.log, "successfully allocated service vNIC";
+        "zone_kind" => %zone_kind,
+        "zone_id" => %service_id,
+        "nic" => ?nic,
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -461,6 +385,8 @@ mod tests {
     use nexus_config::NUM_INITIAL_RESERVED_IP_ADDRESSES;
     use nexus_db_model::SqlU16;
     use nexus_test_utils_macros::nexus_test;
+    use nexus_types::deployment::blueprint_zone_type;
+    use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::OmicronZoneDataset;
@@ -652,10 +578,14 @@ mod tests {
 
         // Initialize resource allocation: this should succeed and create all
         // the relevant db records.
-        ensure_zone_resources_allocated(&opctx, datastore, zones.iter())
-            .await
-            .with_context(|| format!("{zones:#?}"))
-            .unwrap();
+        ensure_zone_external_networking_allocated(
+            &opctx,
+            datastore,
+            zones.iter(),
+        )
+        .await
+        .with_context(|| format!("{zones:#?}"))
+        .unwrap();
 
         // Check that the external IP records were created.
         let db_nexus_ips = datastore
@@ -750,10 +680,14 @@ mod tests {
 
         // We should be able to run the function again with the same inputs, and
         // it should succeed without inserting any new records.
-        ensure_zone_resources_allocated(&opctx, datastore, zones.iter())
-            .await
-            .with_context(|| format!("{zones:#?}"))
-            .unwrap();
+        ensure_zone_external_networking_allocated(
+            &opctx,
+            datastore,
+            zones.iter(),
+        )
+        .await
+        .with_context(|| format!("{zones:#?}"))
+        .unwrap();
         assert_eq!(
             db_nexus_ips,
             datastore
@@ -886,7 +820,7 @@ mod tests {
             };
 
             // and check that we get the error we expect.
-            let err = ensure_zone_resources_allocated(
+            let err = ensure_zone_external_networking_allocated(
                 &opctx,
                 datastore,
                 mutated_zones.iter(),
@@ -944,7 +878,7 @@ mod tests {
                 {
                     let expected_error = mutate_nic_fn(zone.id, nic);
 
-                    let err = ensure_zone_resources_allocated(
+                    let err = ensure_zone_external_networking_allocated(
                         &opctx,
                         datastore,
                         mutated_zones.iter(),
@@ -970,7 +904,7 @@ mod tests {
                 {
                     let expected_error = mutate_nic_fn(zone.id, nic);
 
-                    let err = ensure_zone_resources_allocated(
+                    let err = ensure_zone_external_networking_allocated(
                         &opctx,
                         datastore,
                         mutated_zones.iter(),
@@ -996,7 +930,7 @@ mod tests {
                 {
                     let expected_error = mutate_nic_fn(zone.id, nic);
 
-                    let err = ensure_zone_resources_allocated(
+                    let err = ensure_zone_external_networking_allocated(
                         &opctx,
                         datastore,
                         mutated_zones.iter(),

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -24,10 +24,10 @@ use std::net::SocketAddrV6;
 
 mod datasets;
 mod dns;
+mod external_networking;
 mod omicron_physical_disks;
 mod omicron_zones;
 mod overridables;
-mod resource_allocation;
 
 pub use dns::blueprint_external_dns_config;
 pub use dns::blueprint_internal_dns_config;
@@ -109,7 +109,7 @@ where
         "blueprint_id" => %blueprint.id
     );
 
-    resource_allocation::ensure_zone_resources_allocated(
+    external_networking::ensure_zone_external_networking_allocated(
         &opctx,
         datastore,
         blueprint

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -184,5 +184,17 @@ where
     .await
     .map_err(|e| vec![anyhow!("{}", InlineErrorChain::new(&e))])?;
 
+    external_networking::ensure_zone_external_networking_deallocated(
+        &opctx,
+        datastore,
+        blueprint
+            .all_omicron_zones_not_in(
+                BlueprintZoneFilter::ShouldBeExternallyReachable,
+            )
+            .map(|(_sled_id, zone)| zone),
+    )
+    .await
+    .map_err(|err| vec![err])?;
+
     Ok(())
 }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1515,7 +1515,9 @@ pub mod test {
             // Nexus with no remaining external IPs should fail.
             let mut used_ip_ranges = Vec::new();
             for (_, z) in parent.all_omicron_zones(BlueprintZoneFilter::All) {
-                if let Some(external_ip) = z.zone_type.external_ip() {
+                if let Some((external_ip, _)) =
+                    z.zone_type.external_networking()
+                {
                     used_ip_ranges.push(IpRange::from(external_ip.ip()));
                 }
             }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -291,7 +291,7 @@ impl<'a> BlueprintBuilder<'a> {
                 }
             }
 
-            if let Some(external_ip) = zone_type.external_ip() {
+            if let Some((external_ip, nic)) = zone_type.external_networking() {
                 // For the test suite, ignore localhost.  It gets reused many
                 // times and that's okay.  We don't expect to see localhost
                 // outside the test suite.
@@ -300,9 +300,7 @@ impl<'a> BlueprintBuilder<'a> {
                 {
                     bail!("duplicate external IP: {external_ip:?}");
                 }
-            }
 
-            if let Some(nic) = zone_type.opte_vnic() {
                 if !used_macs.insert(nic.mac) {
                     bail!("duplicate service vNIC MAC: {}", nic.mac);
                 }

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -99,12 +99,12 @@ impl ExampleSystem {
             };
             for zone in zones.zones.iter() {
                 let service_id = zone.id;
-                if let Some(external_ip) = zone.zone_type.external_ip() {
+                if let Some((external_ip, nic)) =
+                    zone.zone_type.external_networking()
+                {
                     input_builder
                         .add_omicron_zone_external_ip(service_id, external_ip)
                         .expect("failed to add Omicron zone external IP");
-                }
-                if let Some(nic) = zone.zone_type.opte_vnic() {
                     input_builder
                         .add_omicron_zone_nic(
                             service_id,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -163,6 +163,21 @@ impl Blueprint {
         })
     }
 
+    /// Iterate over the [`BlueprintZoneConfig`] instances in the blueprint
+    /// that do not match the provided filter, along with the associated sled
+    /// id.
+    pub fn all_omicron_zones_not_in(
+        &self,
+        filter: BlueprintZoneFilter,
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
+        self.blueprint_zones.iter().flat_map(move |(sled_id, z)| {
+            z.zones
+                .iter()
+                .filter(move |z| !z.disposition.matches(filter))
+                .map(|z| (SledUuid::from_untyped_uuid(*sled_id), z))
+        })
+    }
+
     // Temporary method that provides the list of Omicron zones using
     // `TypedUuid`.
     //

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -33,33 +33,21 @@ pub enum BlueprintZoneType {
 }
 
 impl BlueprintZoneType {
-    pub fn external_ip(&self) -> Option<OmicronZoneExternalIp> {
+    pub fn external_networking(
+        &self,
+    ) -> Option<(OmicronZoneExternalIp, &NetworkInterface)> {
         match self {
-            BlueprintZoneType::Nexus(nexus) => {
-                Some(OmicronZoneExternalIp::Floating(nexus.external_ip))
-            }
-            BlueprintZoneType::ExternalDns(dns) => {
-                Some(OmicronZoneExternalIp::Floating(dns.dns_address.into_ip()))
-            }
+            BlueprintZoneType::Nexus(nexus) => Some((
+                OmicronZoneExternalIp::Floating(nexus.external_ip),
+                &nexus.nic,
+            )),
+            BlueprintZoneType::ExternalDns(dns) => Some((
+                OmicronZoneExternalIp::Floating(dns.dns_address.into_ip()),
+                &dns.nic,
+            )),
             BlueprintZoneType::BoundaryNtp(ntp) => {
-                Some(OmicronZoneExternalIp::Snat(ntp.external_ip))
+                Some((OmicronZoneExternalIp::Snat(ntp.external_ip), &ntp.nic))
             }
-            BlueprintZoneType::Clickhouse(_)
-            | BlueprintZoneType::ClickhouseKeeper(_)
-            | BlueprintZoneType::CockroachDb(_)
-            | BlueprintZoneType::Crucible(_)
-            | BlueprintZoneType::CruciblePantry(_)
-            | BlueprintZoneType::InternalDns(_)
-            | BlueprintZoneType::InternalNtp(_)
-            | BlueprintZoneType::Oximeter(_) => None,
-        }
-    }
-
-    pub fn opte_vnic(&self) -> Option<&NetworkInterface> {
-        match self {
-            BlueprintZoneType::Nexus(nexus) => Some(&nexus.nic),
-            BlueprintZoneType::ExternalDns(dns) => Some(&dns.nic),
-            BlueprintZoneType::BoundaryNtp(ntp) => Some(&ntp.nic),
             BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
             | BlueprintZoneType::CockroachDb(_)


### PR DESCRIPTION
Testing this on a4x2; after RSS, we have 7 services with external networking:

```
root@oxz_switch:~# omdb db network list-eips
 IP                PORTS        KIND      STATE     OWNER_KIND  OWNER_ID                              OWNER_NAME   OWNER_DISPOSITION
 198.51.100.20/32  0/65535      floating  Attached  service     468417ce-2edd-4c54-9162-b06d6424fbc9  ExternalDns  in service
 198.51.100.21/32  0/65535      floating  Attached  service     20d58632-4d53-4e93-97d3-3f594e794d08  ExternalDns  in service
 198.51.100.22/32  0/65535      floating  Attached  service     bd8d80b2-d04a-4372-ad9e-17579f27e89f  Nexus        in service
 198.51.100.23/32  0/65535      floating  Attached  service     32121854-7847-4edb-be06-78c0accbbcf4  Nexus        in service
 198.51.100.24/32  0/65535      floating  Attached  service     de48fe95-3757-46ed-811d-1bce5a749a10  Nexus        in service
 198.51.100.25/32  0/16383      SNAT      Attached  service     e33ef135-cb35-4514-b6cd-058674b35226  Ntp          in service
 198.51.100.26/32  16384/32767  SNAT      Attached  service     cb4e511d-d06d-4fac-bc08-12fe181876b4  Ntp          in service

root@oxz_switch:~# omdb db network list-vnics
 IP             MAC                SLOT  PRIMARY  KIND     SUBNET         PARENT_ID                             PARENT_NAME
 172.30.1.5/32  A8:40:25:FF:C7:6E  0     true     service  172.30.1.0/24  468417ce-2edd-4c54-9162-b06d6424fbc9  external-dns-468417ce-2edd-4c54-9162-b06d6424fbc9
 172.30.1.6/32  A8:40:25:FF:E6:99  0     true     service  172.30.1.0/24  20d58632-4d53-4e93-97d3-3f594e794d08  external-dns-20d58632-4d53-4e93-97d3-3f594e794d08
 172.30.2.5/32  A8:40:25:FF:8B:B8  0     true     service  172.30.2.0/24  bd8d80b2-d04a-4372-ad9e-17579f27e89f  nexus-bd8d80b2-d04a-4372-ad9e-17579f27e89f
 172.30.2.6/32  A8:40:25:FF:D7:82  0     true     service  172.30.2.0/24  32121854-7847-4edb-be06-78c0accbbcf4  nexus-32121854-7847-4edb-be06-78c0accbbcf4
 172.30.2.7/32  A8:40:25:FF:AF:30  0     true     service  172.30.2.0/24  de48fe95-3757-46ed-811d-1bce5a749a10  nexus-de48fe95-3757-46ed-811d-1bce5a749a10
 172.30.3.5/32  A8:40:25:FF:84:53  0     true     service  172.30.3.0/24  e33ef135-cb35-4514-b6cd-058674b35226  ntp-e33ef135-cb35-4514-b6cd-058674b35226
```

After expunging `g1` (running Nexus and Boundary NTP) and adding `g2` (which gained a Nexus from Reconfigurator's goal of staying at 3), we see that one of the Nexuses has been replaced, and one of the boundary NTP records is gone:

```
root@oxz_switch:~# omdb db network list-eips
 IP                PORTS    KIND      STATE     OWNER_KIND  OWNER_ID                              OWNER_NAME   OWNER_DISPOSITION
 198.51.100.20/32  0/65535  floating  Attached  service     468417ce-2edd-4c54-9162-b06d6424fbc9  ExternalDns  in service
 198.51.100.21/32  0/65535  floating  Attached  service     20d58632-4d53-4e93-97d3-3f594e794d08  ExternalDns  in service
 198.51.100.23/32  0/65535  floating  Attached  service     32121854-7847-4edb-be06-78c0accbbcf4  Nexus        in service
 198.51.100.24/32  0/65535  floating  Attached  service     de48fe95-3757-46ed-811d-1bce5a749a10  Nexus        in service
 198.51.100.25/32  0/16383  SNAT      Attached  service     e33ef135-cb35-4514-b6cd-058674b35226  Ntp          in service
 198.51.100.27/32  0/65535  floating  Attached  service     44e26da6-8998-4204-b79c-a4e68b0beeab  Nexus        in service
root@oxz_switch:~# omdb db network list-vnics
 IP             MAC                SLOT  PRIMARY  KIND     SUBNET         PARENT_ID                             PARENT_NAME
 172.30.1.5/32  A8:40:25:FF:C7:6E  0     true     service  172.30.1.0/24  468417ce-2edd-4c54-9162-b06d6424fbc9  external-dns-468417ce-2edd-4c54-9162-b06d6424fbc9
 172.30.1.6/32  A8:40:25:FF:E6:99  0     true     service  172.30.1.0/24  20d58632-4d53-4e93-97d3-3f594e794d08  external-dns-20d58632-4d53-4e93-97d3-3f594e794d08
 172.30.2.6/32  A8:40:25:FF:D7:82  0     true     service  172.30.2.0/24  32121854-7847-4edb-be06-78c0accbbcf4  nexus-32121854-7847-4edb-be06-78c0accbbcf4
 172.30.2.7/32  A8:40:25:FF:AF:30  0     true     service  172.30.2.0/24  de48fe95-3757-46ed-811d-1bce5a749a10  nexus-de48fe95-3757-46ed-811d-1bce5a749a10
 172.30.2.8/32  A8:40:25:FF:80:00  0     true     service  172.30.2.0/24  44e26da6-8998-4204-b79c-a4e68b0beeab  nexus-44e26da6-8998-4204-b79c-a4e68b0beeab
 172.30.3.5/32  A8:40:25:FF:84:53  0     true     service  172.30.3.0/24  e33ef135-cb35-4514-b6cd-058674b35226  ntp-e33ef135-cb35-4514-b6cd-058674b35226
```

I'd like to test this on madrid before merging, but I think this is more or less complete.

The diff is surprisingly large - I renamed `resource_allocation.rs` to `external_networking.rs`, but I must have made enough whitespace changes that git doesn't realize this was a rename + changes, and is treating it as a full delete/add. If this is a big hassle I'm happy to back out the name change and do that in a subsequent PR.