### PR TITLE
Use SledUuid keys in Blueprint::blueprint_zones

### DIFF
--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -977,9 +977,9 @@ mod test {
     };
     use omicron_common::api::internal::shared::SourceNatConfig;
     use omicron_test_utils::dev;
-    use omicron_uuid_kinds::TypedUuid;
     use omicron_uuid_kinds::{ExternalIpUuid, OmicronZoneUuid};
     use omicron_uuid_kinds::{GenericUuid, ZpoolUuid};
+    use omicron_uuid_kinds::{SledUuid, TypedUuid};
     use sled_agent_client::types::OmicronZoneDataset;
     use std::collections::{BTreeMap, HashMap};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
@@ -1292,7 +1292,7 @@ mod test {
 
         let mut blueprint_zones = BTreeMap::new();
         blueprint_zones.insert(
-            sled1.id(),
+            SledUuid::from_untyped_uuid(sled1.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![
@@ -1367,7 +1367,7 @@ mod test {
             },
         );
         blueprint_zones.insert(
-            sled2.id(),
+            SledUuid::from_untyped_uuid(sled2.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![
@@ -1443,7 +1443,7 @@ mod test {
             },
         );
         blueprint_zones.insert(
-            sled3.id(),
+            SledUuid::from_untyped_uuid(sled3.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![BlueprintZoneConfig {
@@ -1620,7 +1620,7 @@ mod test {
 
         let mut blueprint_zones = BTreeMap::new();
         blueprint_zones.insert(
-            sled.id(),
+            SledUuid::from_untyped_uuid(sled.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![
@@ -1890,7 +1890,7 @@ mod test {
         let mut macs = MacAddr::iter_system();
         let mut blueprint_zones = BTreeMap::new();
         blueprint_zones.insert(
-            sled.id(),
+            SledUuid::from_untyped_uuid(sled.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![BlueprintZoneConfig {
@@ -1994,7 +1994,7 @@ mod test {
 
         let mut blueprint_zones = BTreeMap::new();
         blueprint_zones.insert(
-            sled.id(),
+            SledUuid::from_untyped_uuid(sled.id()),
             BlueprintZonesConfig {
                 generation: Generation::new().next(),
                 zones: vec![

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -1567,7 +1567,8 @@ mod tests {
 
         fn blueprint_zone_configs(
             &self,
-        ) -> impl Iterator<Item = (Uuid, BlueprintZoneConfig)> + '_ {
+        ) -> impl Iterator<Item = (SledUuid, BlueprintZoneConfig)> + '_
+        {
             self.nexuses.iter().zip(self.db_nics()).map(|(nexus, nic)| {
                 let config = BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
@@ -1597,7 +1598,7 @@ mod tests {
                         },
                     ),
                 };
-                (nexus.sled_id.into_untyped_uuid(), config)
+                (nexus.sled_id, config)
             })
         }
     }

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -496,7 +496,6 @@ mod test {
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_test_utils::dev::test_setup_log;
     use omicron_uuid_kinds::ExternalIpUuid;
-    use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
@@ -560,7 +559,7 @@ mod test {
         let mut blueprint_zones = BTreeMap::new();
         for (sled_id, zones_config) in collection.omicron_zones {
             blueprint_zones.insert(
-                sled_id.into_untyped_uuid(),
+                sled_id,
                 BlueprintZonesConfig {
                     generation: zones_config.zones.generation,
                     zones: zones_config
@@ -628,9 +627,8 @@ mod test {
             .zip(possible_sled_subnets)
             .enumerate()
             .map(|(i, (sled_id, subnet))| {
-                let sled_id = SledUuid::from_untyped_uuid(*sled_id);
                 let sled_info = Sled {
-                    id: sled_id,
+                    id: *sled_id,
                     sled_agent_address: get_sled_address(Ipv6Subnet::new(
                         subnet.network(),
                     )),
@@ -638,7 +636,7 @@ mod test {
                     // Scrimlets.
                     is_scrimlet: i < 2,
                 };
-                (sled_id, sled_info)
+                (*sled_id, sled_info)
             })
             .collect();
 

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -17,20 +17,17 @@ use omicron_uuid_kinds::SledUuid;
 use slog::info;
 use slog::warn;
 use std::collections::BTreeMap;
-use uuid::Uuid;
 
 /// Idempotently ensure that the specified Omicron zones are deployed to the
 /// corresponding sleds
 pub(crate) async fn deploy_zones(
     opctx: &OpContext,
     sleds_by_id: &BTreeMap<SledUuid, Sled>,
-    zones: &BTreeMap<Uuid, BlueprintZonesConfig>,
+    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
 ) -> Result<(), Vec<anyhow::Error>> {
     let errors: Vec<_> = stream::iter(zones)
         .filter_map(|(sled_id, config)| async move {
-            let db_sled = match sleds_by_id
-                .get(&SledUuid::from_untyped_uuid(*sled_id))
-            {
+            let db_sled = match sleds_by_id.get(sled_id) {
                 Some(sled) => sled,
                 None => {
                     if config.are_all_zones_expunged() {
@@ -41,7 +38,7 @@ pub(crate) async fn deploy_zones(
                         );
                         return None;
                     }
-                    let err = anyhow!("sled not found in db list: {}", sled_id);
+                    let err = anyhow!("sled not found in db list: {sled_id}");
                     warn!(opctx.log, "{err:#}");
                     return Some(err);
                 }
@@ -106,7 +103,6 @@ mod test {
     };
     use nexus_types::inventory::OmicronZoneDataset;
     use omicron_common::api::external::Generation;
-    use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use omicron_uuid_kinds::SledUuid;
     use std::collections::BTreeMap;
@@ -128,10 +124,7 @@ mod test {
             },
             Blueprint {
                 id,
-                blueprint_zones: blueprint_zones
-                    .into_iter()
-                    .map(|(typed_id, z)| (typed_id.into_untyped_uuid(), z))
-                    .collect(),
+                blueprint_zones,
                 blueprint_disks: BTreeMap::new(),
                 parent_blueprint_id: None,
                 internal_dns_version: Generation::new(),

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -58,7 +58,6 @@ use slog::error;
 use slog::info;
 use slog::o;
 use slog::Logger;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
@@ -70,7 +69,6 @@ use std::net::SocketAddrV6;
 use thiserror::Error;
 use typed_rng::TypedUuidRng;
 use typed_rng::UuidRng;
-use uuid::Uuid;
 
 use super::zones::is_already_expunged;
 use super::zones::BuilderZoneState;
@@ -198,7 +196,7 @@ impl<'a> BlueprintBuilder<'a> {
                     generation: Generation::new(),
                     zones: Vec::new(),
                 };
-                (sled_id.into_untyped_uuid(), config)
+                (sled_id, config)
             })
             .collect::<BTreeMap<_, _>>();
         let num_sleds = blueprint_zones.len();
@@ -961,17 +959,14 @@ impl BlueprintBuilderRng {
 /// struct makes it easy for callers iterate over the right set of zones.
 pub(super) struct BlueprintZonesBuilder<'a> {
     changed_zones: BTreeMap<SledUuid, BuilderZonesConfig>,
-    // Temporarily make a clone of the parent blueprint's zones so we can use
-    // typed UUIDs everywhere. Once we're done migrating, this `Cow` can be
-    // removed.
-    parent_zones: Cow<'a, BTreeMap<SledUuid, BlueprintZonesConfig>>,
+    parent_zones: &'a BTreeMap<SledUuid, BlueprintZonesConfig>,
 }
 
 impl<'a> BlueprintZonesBuilder<'a> {
     pub fn new(parent_blueprint: &'a Blueprint) -> BlueprintZonesBuilder {
         BlueprintZonesBuilder {
             changed_zones: BTreeMap::new(),
-            parent_zones: Cow::Owned(parent_blueprint.typed_blueprint_zones()),
+            parent_zones: &parent_blueprint.blueprint_zones,
         }
     }
 
@@ -1018,25 +1013,26 @@ impl<'a> BlueprintZonesBuilder<'a> {
     pub fn into_zones_map(
         mut self,
         sled_ids: impl Iterator<Item = SledUuid>,
-    ) -> BTreeMap<Uuid, BlueprintZonesConfig> {
+    ) -> BTreeMap<SledUuid, BlueprintZonesConfig> {
         sled_ids
             .map(|sled_id| {
                 // Start with self.changed_zones, which contains entries for any
                 // sled whose zones config is changing in this blueprint.
                 if let Some(zones) = self.changed_zones.remove(&sled_id) {
-                    (sled_id.into_untyped_uuid(), zones.build())
+                    (sled_id, zones.build())
                 }
-                // Next, check self.parent_zones, to represent an unchanged sled.
+                // Next, check self.parent_zones, to represent an unchanged
+                // sled.
                 else if let Some(parent_zones) =
                     self.parent_zones.get(&sled_id)
                 {
-                    (sled_id.into_untyped_uuid(), parent_zones.clone())
+                    (sled_id, parent_zones.clone())
                 } else {
-                    // If the sled is not in self.parent_zones, then it must be a
-                    // new sled and we haven't added any zones to it yet.  Use the
-                    // standard initial config.
+                    // If the sled is not in self.parent_zones, then it must be
+                    // a new sled and we haven't added any zones to it yet.  Use
+                    // the standard initial config.
                     (
-                        sled_id.into_untyped_uuid(),
+                        sled_id,
                         BlueprintZonesConfig {
                             generation: Generation::new(),
                             zones: vec![],
@@ -1465,7 +1461,7 @@ pub mod test {
                     // Also remove this zone from the blueprint.
                     parent
                         .blueprint_zones
-                        .get_mut(sled_id.as_untyped_uuid())
+                        .get_mut(sled_id)
                         .expect("missing sled")
                         .zones
                         .retain(|z| !z.zone_type.is_nexus());

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -13,7 +13,6 @@ use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
-use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledKind;
 use typed_rng::TypedUuidRng;
 
@@ -91,10 +90,7 @@ impl ExampleSystem {
         builder.set_rng_seed((test_name, "ExampleSystem collection"));
 
         for sled_id in blueprint.sleds() {
-            // TODO-cleanup use `TypedUuid` everywhere
-            let Some(zones) =
-                blueprint.blueprint_zones.get(sled_id.as_untyped_uuid())
-            else {
+            let Some(zones) = blueprint.blueprint_zones.get(&sled_id) else {
                 continue;
             };
             for zone in zones.zones.iter() {

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -417,7 +417,6 @@ mod test {
     use omicron_common::api::external::Generation;
     use omicron_common::disk::DiskIdentity;
     use omicron_test_utils::dev::test_setup_log;
-    use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::PhysicalDiskUuid;
     use omicron_uuid_kinds::ZpoolUuid;
     use std::collections::HashMap;
@@ -533,7 +532,7 @@ mod test {
                     sled_id: new_sled_id,
                     zones: blueprint4
                         .blueprint_zones
-                        .get(new_sled_id.as_untyped_uuid())
+                        .get(&new_sled_id)
                         .expect("blueprint should contain zones for new sled")
                         .to_omicron_zones_config(
                             BlueprintZoneFilter::ShouldBeRunning
@@ -628,9 +627,7 @@ mod test {
 
             assert_eq!(collection.sled_agents.len(), 1);
             assert_eq!(collection.omicron_zones.len(), 1);
-            blueprint
-                .blueprint_zones
-                .retain(|k, _v| keep_sled_id.as_untyped_uuid() == k);
+            blueprint.blueprint_zones.retain(|k, _v| keep_sled_id == *k);
 
             (keep_sled_id, blueprint, collection, builder.build())
         };
@@ -641,7 +638,7 @@ mod test {
         assert_eq!(
             blueprint1
                 .blueprint_zones
-                .get(sled_id.as_untyped_uuid())
+                .get(&sled_id)
                 .expect("missing kept sled")
                 .zones
                 .iter()
@@ -1015,8 +1012,7 @@ mod test {
         // Leave the non-provisionable sled's generation alone.
         let zones = &mut blueprint2a
             .blueprint_zones
-            // TODO-cleanup use `TypedUuid` everywhere
-            .get_mut(nonprovisionable_sled_id.as_untyped_uuid())
+            .get_mut(&nonprovisionable_sled_id)
             .unwrap()
             .zones;
 
@@ -1057,18 +1053,12 @@ mod test {
             }
         });
 
-        let expunged_zones = blueprint2a
-            .blueprint_zones
-            // TODO-cleanup use `TypedUuid` everywhere
-            .get_mut(expunged_sled_id.as_untyped_uuid())
-            .unwrap();
+        let expunged_zones =
+            blueprint2a.blueprint_zones.get_mut(&expunged_sled_id).unwrap();
         expunged_zones.zones.clear();
         expunged_zones.generation = expunged_zones.generation.next();
 
-        blueprint2a
-            .blueprint_zones
-            // TODO-cleanup use `TypedUuid` everywhere
-            .remove(decommissioned_sled_id.as_untyped_uuid());
+        blueprint2a.blueprint_zones.remove(&decommissioned_sled_id);
 
         blueprint2a.external_dns_version =
             blueprint2a.external_dns_version.next();

--- a/nexus/src/app/background/blueprint_execution.rs
+++ b/nexus/src/app/background/blueprint_execution.rs
@@ -127,9 +127,9 @@ mod test {
     };
     use nexus_types::inventory::OmicronZoneDataset;
     use omicron_common::api::external::Generation;
+    use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
-    use omicron_uuid_kinds::SledKind;
-    use omicron_uuid_kinds::TypedUuid;
+    use omicron_uuid_kinds::SledUuid;
     use serde::Deserialize;
     use serde_json::json;
     use std::collections::BTreeMap;
@@ -142,11 +142,8 @@ mod test {
         nexus_test_utils::ControlPlaneTestContext<crate::Server>;
 
     fn create_blueprint(
-        blueprint_zones: BTreeMap<Uuid, BlueprintZonesConfig>,
-        blueprint_disks: BTreeMap<
-            TypedUuid<SledKind>,
-            BlueprintPhysicalDisksConfig,
-        >,
+        blueprint_zones: BTreeMap<SledUuid, BlueprintZonesConfig>,
+        blueprint_disks: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
         dns_version: Generation,
     ) -> (BlueprintTarget, Blueprint) {
         let id = Uuid::new_v4();
@@ -186,8 +183,8 @@ mod test {
         // sleds to CRDB.
         let mut s1 = httptest::Server::run();
         let mut s2 = httptest::Server::run();
-        let sled_id1 = Uuid::new_v4();
-        let sled_id2 = Uuid::new_v4();
+        let sled_id1 = SledUuid::new_v4();
+        let sled_id2 = SledUuid::new_v4();
         let rack_id = Uuid::new_v4();
         for (i, (sled_id, server)) in
             [(sled_id1, &s1), (sled_id2, &s2)].iter().enumerate()
@@ -196,7 +193,7 @@ mod test {
                 panic!("Expected Ipv6 address. Got {}", server.addr());
             };
             let update = SledUpdate::new(
-                *sled_id,
+                sled_id.into_untyped_uuid(),
                 addr,
                 SledBaseboard {
                     serial_number: i.to_string(),

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -57,6 +57,7 @@ use omicron_test_utils::dev;
 use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use oximeter_collector::Oximeter;
 use oximeter_producer::LogConfig;
@@ -758,7 +759,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             ] {
                 if let Some(sa) = maybe_sled_agent {
                     blueprint_zones.insert(
-                        sa.sled_agent.id,
+                        SledUuid::from_untyped_uuid(sa.sled_agent.id),
                         BlueprintZonesConfig {
                             generation: Generation::new().next(),
                             zones: zones.clone(),

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -110,7 +110,7 @@ pub struct Blueprint {
     ///
     /// A sled is considered part of the control plane cluster iff it has an
     /// entry in this map.
-    pub blueprint_zones: BTreeMap<Uuid, BlueprintZonesConfig>,
+    pub blueprint_zones: BTreeMap<SledUuid, BlueprintZonesConfig>,
 
     /// A map of sled id -> disks in use on each sled.
     pub blueprint_disks: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
@@ -155,11 +155,12 @@ impl Blueprint {
     pub fn all_omicron_zones(
         &self,
         filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = (Uuid, &BlueprintZoneConfig)> {
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
         self.blueprint_zones.iter().flat_map(move |(sled_id, z)| {
-            z.zones.iter().filter_map(move |z| {
-                z.disposition.matches(filter).then_some((*sled_id, z))
-            })
+            z.zones
+                .iter()
+                .filter(move |z| z.disposition.matches(filter))
+                .map(|z| (*sled_id, z))
         })
     }
 
@@ -174,26 +175,13 @@ impl Blueprint {
             z.zones
                 .iter()
                 .filter(move |z| !z.disposition.matches(filter))
-                .map(|z| (SledUuid::from_untyped_uuid(*sled_id), z))
+                .map(|z| (*sled_id, z))
         })
-    }
-
-    // Temporary method that provides the list of Omicron zones using
-    // `TypedUuid`.
-    //
-    // In the future, `all_omicron_zones` will return `SledUuid`,
-    // and this method will go away.
-    pub fn all_omicron_zones_typed(
-        &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-        self.all_omicron_zones(filter)
-            .map(|(sled_id, z)| (SledUuid::from_untyped_uuid(sled_id), z))
     }
 
     /// Iterate over the ids of all sleds in the blueprint
     pub fn sleds(&self) -> impl Iterator<Item = SledUuid> + '_ {
-        self.blueprint_zones.keys().copied().map(SledUuid::from_untyped_uuid)
+        self.blueprint_zones.keys().copied()
     }
 
     /// Summarize the difference between sleds and zones between two
@@ -209,12 +197,12 @@ impl Blueprint {
         BlueprintDiff::new(
             DiffBeforeMetadata::Blueprint(Box::new(before.metadata())),
             before
-                .typed_blueprint_zones()
-                .into_iter()
-                .map(|(sled_id, zones)| (sled_id, zones.into()))
+                .blueprint_zones
+                .iter()
+                .map(|(sled_id, zones)| (*sled_id, zones.clone().into()))
                 .collect(),
             self.metadata(),
-            self.typed_blueprint_zones(),
+            self.blueprint_zones.clone(),
         )
     }
 
@@ -243,7 +231,7 @@ impl Blueprint {
             DiffBeforeMetadata::Collection { id: before.id },
             before_zones,
             self.metadata(),
-            self.typed_blueprint_zones(),
+            self.blueprint_zones.clone(),
         )
     }
 
@@ -251,21 +239,6 @@ impl Blueprint {
     /// blueprint.
     pub fn display(&self) -> BlueprintDisplay<'_> {
         BlueprintDisplay { blueprint: self }
-    }
-
-    /// Temporary method that returns `self.blueprint_zones`, except the keys
-    /// are `SledUuid`.
-    ///
-    /// TODO-cleanup use `TypedUuid` everywhere
-    pub fn typed_blueprint_zones(
-        &self,
-    ) -> BTreeMap<SledUuid, BlueprintZonesConfig> {
-        self.blueprint_zones
-            .iter()
-            .map(|(sled_id, zones)| {
-                (SledUuid::from_untyped_uuid(*sled_id), zones.clone())
-            })
-            .collect()
     }
 }
 

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -34,6 +34,7 @@ use omicron_common::backoff::{
 use omicron_common::disk::DiskIdentity;
 use omicron_common::FileKv;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use slog::{info, Drain, Logger};
 use std::collections::BTreeMap;
@@ -502,7 +503,10 @@ pub async fn run_standalone_server(
 
     let disks = server.sled_agent.omicron_physical_disks_list().await?;
     let mut sled_configs = BTreeMap::new();
-    sled_configs.insert(config.id, SledConfig { disks, zones });
+    sled_configs.insert(
+        SledUuid::from_untyped_uuid(config.id),
+        SledConfig { disks, zones },
+    );
 
     let rack_init_request = NexusTypes::RackInitializationRequest {
         blueprint: build_initial_blueprint_from_sled_configs(


### PR DESCRIPTION
Should all be mechanical changes, and lets us drop a couple of workarounds (`all_omicron_zones_types()` and the `Cow`).