### PR TITLE
[nexus] fix semantic merge conflict on main

### DIFF
--- a/nexus/src/app/instance_network.rs
+++ b/nexus/src/app/instance_network.rs
@@ -18,6 +18,7 @@ use nexus_db_queries::db;
 use nexus_db_queries::db::identity::Asset;
 use nexus_db_queries::db::lookup::LookupPath;
 use nexus_db_queries::db::DataStore;
+use nexus_types::deployment::SledFilter;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::Ipv4Net;
@@ -843,7 +844,10 @@ pub(crate) async fn create_instance_v2p_mappings(
             limit: std::num::NonZeroU32::new(10).unwrap(),
         };
 
-        let sleds_page = datastore.sled_list(&opctx_alloc, &pagparams).await?;
+        let sleds_page = datastore
+            // XXX: InService might not be exactly correct
+            .sled_list(&opctx_alloc, &pagparams, SledFilter::InService)
+            .await?;
         let mut join_handles =
             Vec::with_capacity(sleds_page.len() * instance_nics.len());
 
@@ -947,7 +951,10 @@ pub(crate) async fn delete_instance_v2p_mappings(
             limit: std::num::NonZeroU32::new(10).unwrap(),
         };
 
-        let sleds_page = datastore.sled_list(&opctx_alloc, &pagparams).await?;
+        let sleds_page = datastore
+            // XXX: InService might not be exactly correct
+            .sled_list(&opctx_alloc, &pagparams, SledFilter::InService)
+            .await?;
         let mut join_handles =
             Vec::with_capacity(sleds_page.len() * instance_nics.len());
 


### PR DESCRIPTION
Conflict between #5596 and #5622.

* #5596 changed `DataStore::sled_list` to take a `SledFilter` argument -- and `Nexus::sled_list` always uses `InService`.
* #5622 made the functions call `DataStore::sled_list` instead of `Nexus::sled_list`

Not entirely sure that `InService` is correct, but it seems fine to just have all non-expunged sleds here for now.