### PR TITLE
Enable the SFTP subsystem in the switch zone ssh server

### DIFF
--- a/wicket/zone-etc/ssh/sshd_config
+++ b/wicket/zone-etc/ssh/sshd_config
@@ -22,6 +22,11 @@ AllowAgentForwarding no
 AllowTcpForwarding no
 PrintMotd no
 
+# Enable the SFTP sub-system. This allows clients such as scp(1) to use
+# SFTP rather than the legacy scp/rcp protocol, which is deprecated. SFTP has
+# been the default protocol for OpenSSH's scp(1) since April 2022.
+Subsystem sftp internal-sftp
+
 #
 # Allow the user to pass through a limited set of environment variables for
 # locale and shell preferences:
@@ -30,7 +35,8 @@ AcceptEnv LANG LC_* OXIDE_PREF_*
 
 AllowUsers wicket support
 
-# Allow "wicket" to log in without a password, and constrain it to the captive shell
+# Allow "wicket" to log in without a password, and constrain it to the captive
+# shell
 Match User wicket
         PermitEmptyPasswords yes
         PasswordAuthentication yes


### PR DESCRIPTION
We have historically accessed the rack's switch zone from systems running a version of OpenSSH from Helios 1.0, which uses the legacy scp/rcp protocol for `scp(1)` operations. More recent versions of OpenSSH default to using SFTP  and only fall back to the legacy protocol when the `scp -O` flag is used. SFTP is considered generally better and we should enable the subsystem for this SSH server instance.