### PR TITLE
Add `omdb expunge-testing fudge-serial <SLED_ID>`

### DIFF
--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -106,6 +106,7 @@ Commands:
   network              Print information about the network
   snapshots            Print information about snapshots
   validate             Validate the contents of the database
+  expunge-testing      Temporary utilities for sled expunge testing
   help                 Print this message or the help of the given subcommand(s)
 
 Options:
@@ -135,6 +136,7 @@ Commands:
   network              Print information about the network
   snapshots            Print information about snapshots
   validate             Validate the contents of the database
+  expunge-testing      Temporary utilities for sled expunge testing
   help                 Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
This subcommand should unblock looped sled add/expunge testing on madrid. After expunging, run this command to overwrite the serial numbers of the now-expunged sled, allowing it to be added again with its actual serial number.

This is obviously gross and should be removed once we solve #5625, which requires transitioning sleds to the decommissioned state.

There are some very primitive checks in place. Trying to fudge the serials for a sled that isn't expunged fails:

```
root@oxz_switch:~# ./omdb -w db expunge-testing fudge-serial 7bd6b802-e2d6-48bb-a53c-a7ee31f6e216
Error: serial number fudging only supported for expunged sleds; sled 7bd6b802-e2d6-48bb-a53c-a7ee31f6e216 has policy InService { provision_policy: Provisionable }
```

And trying to fudge the serials of the same sled twice fails:

```
root@oxz_switch:~# ./omdb -w db expunge-testing fudge-serial ac4a39a0-3dc5-4fc8-a7ad-5217af1b8f3d
Error: sled serial number (omdb-fudged-g2-0-1714162798) already appears fudged
```