### PR TITLE
[omdb] Show physical disks in blueprints and inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,6 +4888,7 @@ dependencies = [
  "base64 0.22.0",
  "chrono",
  "clap",
+ "derive_more",
  "dns-service-client",
  "futures",
  "gateway-client",

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -31,6 +31,9 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::debug!(log, "client response"; "result" => ?result);
     }),
+    patch = {
+        OmicronPhysicalDiskConfig = { derives = [Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord] }
+    },
     //TODO trade the manual transformations later in this file for the
     //     replace directives below?
     replace = {
@@ -56,7 +59,6 @@ progenitor::generate_api!(
 // We cannot easily configure progenitor to derive `Eq` on all the client-
 // generated types because some have floats and other types that can't impl
 // `Eq`.  We impl it explicitly for a few types on which we need it.
-impl Eq for types::OmicronPhysicalDiskConfig {}
 impl Eq for types::OmicronPhysicalDisksConfig {}
 impl Eq for types::OmicronZonesConfig {}
 impl Eq for types::OmicronZoneConfig {}

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -49,6 +49,7 @@ use nexus_db_model::ExternalIp;
 use nexus_db_model::HwBaseboardId;
 use nexus_db_model::Instance;
 use nexus_db_model::InvCollection;
+use nexus_db_model::InvPhysicalDisk;
 use nexus_db_model::IpAttachState;
 use nexus_db_model::IpKind;
 use nexus_db_model::NetworkInterface;
@@ -96,6 +97,7 @@ use omicron_common::api::external::InstanceState;
 use omicron_common::api::external::MacAddr;
 use omicron_uuid_kinds::CollectionUuid;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::SledUuid;
 use sled_agent_client::types::VolumeConstructionRequest;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -367,6 +369,8 @@ enum InventoryCommands {
     Cabooses,
     /// list and show details from particular collections
     Collections(CollectionsArgs),
+    /// show all physical disks every found
+    PhysicalDisks(PhysicalDisksArgs),
     /// list all root of trust pages ever found
     RotPages,
 }
@@ -392,6 +396,15 @@ struct CollectionsShowArgs {
     /// show long strings in their entirety
     #[clap(long)]
     show_long_strings: bool,
+}
+
+#[derive(Debug, Args, Clone, Copy)]
+struct PhysicalDisksArgs {
+    #[clap(long)]
+    collection_id: Option<CollectionUuid>,
+
+    #[clap(long, requires("collection_id"))]
+    sled_id: Option<SledUuid>,
 }
 
 #[derive(Debug, Args)]
@@ -2635,6 +2648,9 @@ async fn cmd_db_inventory(
             )
             .await
         }
+        InventoryCommands::PhysicalDisks(args) => {
+            cmd_db_inventory_physical_disks(&conn, limit, args).await
+        }
         InventoryCommands::RotPages => {
             cmd_db_inventory_rot_pages(&conn, limit).await
         }
@@ -2709,6 +2725,63 @@ async fn cmd_db_inventory_cabooses(
         version: caboose.version,
         git_commit: caboose.git_commit,
     });
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn cmd_db_inventory_physical_disks(
+    conn: &DataStoreConnection<'_>,
+    limit: NonZeroU32,
+    args: PhysicalDisksArgs,
+) -> Result<(), anyhow::Error> {
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct DiskRow {
+        inv_collection_id: Uuid,
+        sled_id: Uuid,
+        slot: i64,
+        vendor: String,
+        model: String,
+        serial: String,
+        variant: String,
+    }
+
+    use db::schema::inv_physical_disk::dsl;
+    let mut query = dsl::inv_physical_disk.into_boxed();
+    query = query.limit(i64::from(u32::from(limit)));
+
+    if let Some(collection_id) = args.collection_id {
+        query = query.filter(
+            dsl::inv_collection_id.eq(collection_id.into_untyped_uuid()),
+        );
+    }
+
+    if let Some(sled_id) = args.sled_id {
+        query = query.filter(dsl::sled_id.eq(sled_id.into_untyped_uuid()));
+    }
+
+    let disks = query
+        .select(InvPhysicalDisk::as_select())
+        .load_async(&**conn)
+        .await
+        .context("loading physical disks")?;
+
+    let rows = disks.into_iter().map(|disk| DiskRow {
+        inv_collection_id: disk.inv_collection_id.into_untyped_uuid(),
+        sled_id: disk.sled_id.into_untyped_uuid(),
+        slot: disk.slot,
+        vendor: disk.vendor,
+        model: disk.model.clone(),
+        serial: disk.model.clone(),
+        variant: format!("{:?}", disk.variant),
+    });
+
     let table = tabled::Table::new(rows)
         .with(tabled::settings::Style::empty())
         .with(tabled::settings::Padding::new(0, 1, 0, 0))

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -562,6 +562,10 @@ to:   blueprint ......<REDACTED_BLUEPRINT_ID>.......
      internal_dns      ..........<REDACTED_UUID>...........   in service    ::1                      
      nexus             ..........<REDACTED_UUID>...........   in service    ::ffff:127.0.0.1         
 
+   ----------------------------------
+     vendor   model   serial  status 
+   ----------------------------------
+
   METADATA:
     internal DNS version:  1 (unchanged)
     external DNS version:  2 (unchanged)

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -489,6 +489,10 @@ parent:    <none>
     internal_dns      ..........<REDACTED_UUID>...........   in service   ::1              
     nexus             ..........<REDACTED_UUID>...........   in service   ::ffff:127.0.0.1 
 
+  -------------------------
+    vendor   model  serial 
+  -------------------------
+
 METADATA:
   created by:            nexus-test-utils        
   created at:            <REDACTED     TIMESTAMP>
@@ -521,6 +525,10 @@ parent:    <none>
     external_dns      ..........<REDACTED_UUID>...........   in service   ::1              
     internal_dns      ..........<REDACTED_UUID>...........   in service   ::1              
     nexus             ..........<REDACTED_UUID>...........   in service   ::ffff:127.0.0.1 
+
+  -------------------------
+    vendor   model  serial 
+  -------------------------
 
 METADATA:
   created by:            nexus-test-utils        

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -77,6 +77,7 @@ impl ExampleSystem {
                     vec![],
                 )
                 .unwrap();
+            let _ = builder.sled_ensure_disks(sled_id, sled_resources).unwrap();
             for pool_name in sled_resources.zpools.keys() {
                 let _ = builder
                     .sled_ensure_zone_crucible(sled_id, *pool_name)

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -453,6 +453,8 @@ mod test {
         assert_eq!(diff.sleds_added().len(), 0);
         assert_eq!(diff.sleds_removed().len(), 0);
         assert_eq!(diff.sleds_modified().count(), 0);
+        assert_eq!(diff.physical_disks().added.len(), 0);
+        assert_eq!(diff.physical_disks().removed.len(), 0);
         verify_blueprint(&blueprint2);
 
         // Now add a new sled.

--- a/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
+++ b/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
@@ -49,6 +49,48 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
      internal_ntp   aac3ab51-9e2b-4605-9bf6-e3eb3681c2b5   in service    fd00:1122:3344:102::21         
      nexus          29278a22-1ba1-4117-bfdb-39fcb9ae7fd1   in service    fd00:1122:3344:102::22         
 
+        -------------------------------------------------------------------------------------------------
+             vendor           model           serial                                          status     
+        -------------------------------------------------------------------------------------------------
+                                                                                                         
+  REMOVED SLEDS:                                                                                         
+                                                                                                         
+-  sled 08c7046b-c9c4-4368-881f-19a72df22143: blueprint disks: old gen None, new gen Some(Generation(1)) 
+-            fake-vendor      fake-model      serial-04138a25-c575-42e1-8d23-d2d9754274ae     removed    
+-            fake-vendor      fake-model      serial-16bbc40a-f465-4da8-be9a-31662c267bc0     removed    
+-            fake-vendor      fake-model      serial-660b6fcf-4cff-40ed-9495-7a60f3d7d90f     removed    
+-            fake-vendor      fake-model      serial-818fdf58-55f2-42d0-b68c-52e480c4b6c3     removed    
+-            fake-vendor      fake-model      serial-971d2d04-83cf-4564-996a-9af440c9b350     removed    
+-            fake-vendor      fake-model      serial-9b583b97-9d7d-4416-ac69-b96ae421e962     removed    
+-            fake-vendor      fake-model      serial-9c3a13e9-a37a-4eba-b1be-ef2492aa9b93     removed    
+-            fake-vendor      fake-model      serial-b657bc35-336c-4cb0-9cec-7ffe18edd129     removed    
+-            fake-vendor      fake-model      serial-c311e953-3a56-48b3-8453-d07edeaad683     removed    
+-            fake-vendor      fake-model      serial-e5049408-6765-4924-af8c-7b32a0ee02ef     removed    
+                                                                                                         
+-  sled 84ac367e-9b03-4e9d-a846-df1a08deee6c: blueprint disks: old gen None, new gen Some(Generation(1)) 
+-            fake-vendor      fake-model      serial-12a5bea4-d3c8-496e-ad19-0877663106ca     removed    
+-            fake-vendor      fake-model      serial-ca8377ab-f65c-47a5-aae8-fb6c6783cb68     removed    
+-            fake-vendor      fake-model      serial-ca8858fc-26e1-4d6e-9f9c-a90716e82a4a     removed    
+-            fake-vendor      fake-model      serial-cef7e1bb-d82d-45ee-9822-9329cc0fc652     removed    
+-            fake-vendor      fake-model      serial-d1a87932-4dd7-43c4-b16b-d610d26f3fdd     removed    
+-            fake-vendor      fake-model      serial-d1ba577a-474b-4ccc-ba51-96680809345e     removed    
+-            fake-vendor      fake-model      serial-d538cdef-e723-4a4e-bd5e-39de33f46d27     removed    
+-            fake-vendor      fake-model      serial-d782a2e1-a587-4b5d-bce8-2d71e45b5761     removed    
+-            fake-vendor      fake-model      serial-e472e99d-3ae0-495a-b86c-bcadb01275bd     removed    
+-            fake-vendor      fake-model      serial-ee262dc3-2103-445f-bd5b-65058a014f72     removed    
+                                                                                                         
+-  sled be7f4375-2a6b-457f-b1a4-3074a715e5fe: blueprint disks: old gen None, new gen Some(Generation(1)) 
+-            fake-vendor      fake-model      serial-5255927b-eb2f-48f2-aaa6-02474c174994     removed    
+-            fake-vendor      fake-model      serial-6bf127c0-6695-4237-aea8-adb8aee679b5     removed    
+-            fake-vendor      fake-model      serial-769e436a-c0d0-4f6a-a119-d808fe65ef6c     removed    
+-            fake-vendor      fake-model      serial-846dd32a-a9e8-4274-8bcf-b6ed36aafb15     removed    
+-            fake-vendor      fake-model      serial-86f5af41-4fc8-4630-8d94-a235c615c5c5     removed    
+-            fake-vendor      fake-model      serial-b66e5714-c13a-4fef-8d2a-6936a94a3cf3     removed    
+-            fake-vendor      fake-model      serial-d769c5a2-c4eb-4555-8e9a-d883c5a029a0     removed    
+-            fake-vendor      fake-model      serial-dff09bd2-2160-43ce-8f0f-857be8768f84     removed    
+-            fake-vendor      fake-model      serial-e7814ff1-34e8-4d55-abc1-4bd6055c9d91     removed    
+-            fake-vendor      fake-model      serial-f3396a8f-33c3-4045-8549-540c508c437c     removed    
+
   METADATA:
 +   internal DNS version:  (not present in collection) -> 1
 +   external DNS version:  (not present in collection) -> 1

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -54,6 +54,62 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 +  sled b59ec570-2abb-4017-80ce-129d94e7a025: blueprint zones at generation 2                           
 +    internal_ntp   2d73d30e-ca47-46a8-9c12-917d4ab824b6   in service    fd00:1122:3344:104::21  added  
 
+         ---------------------------------------------------------------------------------------------------------------
+                 vendor              model              serial                                             status       
+         ---------------------------------------------------------------------------------------------------------------
+                                                                                                                        
+  UNCHANGED DISKS:                                                                                                      
+                                                                                                                        
+   sled 41f45d9f-766e-4ca6-a881-61ee45c80f57: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-138ab7c9-83cf-4983-bfb2-d1dab36e2675                     
+                 fake-vendor         fake-model         serial-31a4279e-1404-42df-9704-b56c7047a552                     
+                 fake-vendor         fake-model         serial-32d83abe-c39e-4900-bbf7-2f7b2923cd05                     
+                 fake-vendor         fake-model         serial-4e533a0f-cbf4-4a3e-8ef8-8fcf94433e05                     
+                 fake-vendor         fake-model         serial-53d2e2a1-3ea8-4035-b8ed-c5e434b5133f                     
+                 fake-vendor         fake-model         serial-6101afa7-496a-4ddf-a8c1-fa7085db7a01                     
+                 fake-vendor         fake-model         serial-67c82f8c-9736-4c72-a827-81e44292b235                     
+                 fake-vendor         fake-model         serial-72014fc8-d8df-450b-9dc7-154cfa4442b5                     
+                 fake-vendor         fake-model         serial-7dd8afb5-997c-4a5c-955c-f7c62d1eaffe                     
+                 fake-vendor         fake-model         serial-ff7563be-bf2c-40bc-a297-3f37465045ed                     
+                                                                                                                        
+   sled 43677374-8d2f-4deb-8a41-eeea506db8e0: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-1cf4508e-9197-4edf-92f1-5c7cf10554a3                     
+                 fake-vendor         fake-model         serial-2561782e-737b-4d7f-8218-f22aab16d9e0                     
+                 fake-vendor         fake-model         serial-318dd026-13c4-42a9-8c0d-19e066a023ab                     
+                 fake-vendor         fake-model         serial-3ff074a7-0654-45c9-974d-2cc8fcc84f53                     
+                 fake-vendor         fake-model         serial-4218accf-770e-4c8f-b25c-723ee759b6b8                     
+                 fake-vendor         fake-model         serial-879192fd-06a3-46d2-88c8-97218dde0c03                     
+                 fake-vendor         fake-model         serial-9306c572-a557-4e72-9758-b5c621c807e0                     
+                 fake-vendor         fake-model         serial-b6a8faea-bbf0-4b31-95c7-9733646c1e44                     
+                 fake-vendor         fake-model         serial-ca4a5ae9-4c43-4cb8-a733-b98e5edc24f5                     
+                 fake-vendor         fake-model         serial-d54d1fd9-cf93-4c6a-b230-71afdfcbd92a                     
+                                                                                                                        
+   sled 590e3034-d946-4166-b0e5-2d0034197a07: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-02847aec-0b4d-46aa-bf7c-056d8945285f                     
+                 fake-vendor         fake-model         serial-2bdae70c-4891-4e9d-908e-97edbf310809                     
+                 fake-vendor         fake-model         serial-4fca5082-b314-4b2d-acc6-1b78028aa7d8                     
+                 fake-vendor         fake-model         serial-62cb5e5a-51e7-4134-92d0-f0df3593992e                     
+                 fake-vendor         fake-model         serial-68ef4931-4f52-46cc-a024-c4558d52c1f7                     
+                 fake-vendor         fake-model         serial-91818b8b-823e-435b-b58e-72722c7599ac                     
+                 fake-vendor         fake-model         serial-bac212c0-7ad2-455c-8663-3870b3621d53                     
+                 fake-vendor         fake-model         serial-c387aa96-2f2c-441c-88f9-37e1153d2708                     
+                 fake-vendor         fake-model         serial-e3d7ce11-b4f4-4bdf-947e-a7c665ffe273                     
+                 fake-vendor         fake-model         serial-f9103362-2da7-4f78-bf10-0c008e3d78be                     
+                                                                                                                        
+  ADDED DISKS:                                                                                                          
+                                                                                                                        
++  sled b59ec570-2abb-4017-80ce-129d94e7a025: blueprint disks: old gen None, new gen Some(Generation(1))                
++                fake-vendor         fake-model         serial-03eddaa7-cbbc-4be6-b515-554f69b82eb6        added        
++                fake-vendor         fake-model         serial-11f8582b-17cb-459e-a6e6-ea727e475bef        added        
++                fake-vendor         fake-model         serial-1e315dd7-89b0-4880-9ba7-52701423a7fc        added        
++                fake-vendor         fake-model         serial-34d18fe7-5662-4857-a3c9-b364de551154        added        
++                fake-vendor         fake-model         serial-703e3a5c-7603-44ad-b4b9-ac0093ac491f        added        
++                fake-vendor         fake-model         serial-98fe4c8b-5f71-4d09-a00c-bccabf136fce        added        
++                fake-vendor         fake-model         serial-bee0943d-96ed-41b2-8e2d-772ee4aa7674        added        
++                fake-vendor         fake-model         serial-c3745558-b8a5-4778-8d34-1ba15bb063cc        added        
++                fake-vendor         fake-model         serial-c58e4588-7a35-4f97-8615-921102cb70d1        added        
++                fake-vendor         fake-model         serial-c73747cc-d14d-4779-8fc5-50b5d8bde837        added        
+
   METADATA:
     internal DNS version:  1 (unchanged)
     external DNS version:  1 (unchanged)

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -64,6 +64,60 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 +    crucible       f6125d45-b9cc-4721-ba60-ed4dbb177e41   in service    fd00:1122:3344:104::26  added  
 +    crucible       f86e19d2-9145-41cf-be89-6aaa34a73873   in service    fd00:1122:3344:104::24  added  
 
+         ---------------------------------------------------------------------------------------------------------------
+                 vendor              model              serial                                             status       
+         ---------------------------------------------------------------------------------------------------------------
+                                                                                                                        
+  UNCHANGED DISKS:                                                                                                      
+                                                                                                                        
+   sled 41f45d9f-766e-4ca6-a881-61ee45c80f57: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-138ab7c9-83cf-4983-bfb2-d1dab36e2675                     
+                 fake-vendor         fake-model         serial-31a4279e-1404-42df-9704-b56c7047a552                     
+                 fake-vendor         fake-model         serial-32d83abe-c39e-4900-bbf7-2f7b2923cd05                     
+                 fake-vendor         fake-model         serial-4e533a0f-cbf4-4a3e-8ef8-8fcf94433e05                     
+                 fake-vendor         fake-model         serial-53d2e2a1-3ea8-4035-b8ed-c5e434b5133f                     
+                 fake-vendor         fake-model         serial-6101afa7-496a-4ddf-a8c1-fa7085db7a01                     
+                 fake-vendor         fake-model         serial-67c82f8c-9736-4c72-a827-81e44292b235                     
+                 fake-vendor         fake-model         serial-72014fc8-d8df-450b-9dc7-154cfa4442b5                     
+                 fake-vendor         fake-model         serial-7dd8afb5-997c-4a5c-955c-f7c62d1eaffe                     
+                 fake-vendor         fake-model         serial-ff7563be-bf2c-40bc-a297-3f37465045ed                     
+                                                                                                                        
+   sled 43677374-8d2f-4deb-8a41-eeea506db8e0: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-1cf4508e-9197-4edf-92f1-5c7cf10554a3                     
+                 fake-vendor         fake-model         serial-2561782e-737b-4d7f-8218-f22aab16d9e0                     
+                 fake-vendor         fake-model         serial-318dd026-13c4-42a9-8c0d-19e066a023ab                     
+                 fake-vendor         fake-model         serial-3ff074a7-0654-45c9-974d-2cc8fcc84f53                     
+                 fake-vendor         fake-model         serial-4218accf-770e-4c8f-b25c-723ee759b6b8                     
+                 fake-vendor         fake-model         serial-879192fd-06a3-46d2-88c8-97218dde0c03                     
+                 fake-vendor         fake-model         serial-9306c572-a557-4e72-9758-b5c621c807e0                     
+                 fake-vendor         fake-model         serial-b6a8faea-bbf0-4b31-95c7-9733646c1e44                     
+                 fake-vendor         fake-model         serial-ca4a5ae9-4c43-4cb8-a733-b98e5edc24f5                     
+                 fake-vendor         fake-model         serial-d54d1fd9-cf93-4c6a-b230-71afdfcbd92a                     
+                                                                                                                        
+   sled 590e3034-d946-4166-b0e5-2d0034197a07: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-02847aec-0b4d-46aa-bf7c-056d8945285f                     
+                 fake-vendor         fake-model         serial-2bdae70c-4891-4e9d-908e-97edbf310809                     
+                 fake-vendor         fake-model         serial-4fca5082-b314-4b2d-acc6-1b78028aa7d8                     
+                 fake-vendor         fake-model         serial-62cb5e5a-51e7-4134-92d0-f0df3593992e                     
+                 fake-vendor         fake-model         serial-68ef4931-4f52-46cc-a024-c4558d52c1f7                     
+                 fake-vendor         fake-model         serial-91818b8b-823e-435b-b58e-72722c7599ac                     
+                 fake-vendor         fake-model         serial-bac212c0-7ad2-455c-8663-3870b3621d53                     
+                 fake-vendor         fake-model         serial-c387aa96-2f2c-441c-88f9-37e1153d2708                     
+                 fake-vendor         fake-model         serial-e3d7ce11-b4f4-4bdf-947e-a7c665ffe273                     
+                 fake-vendor         fake-model         serial-f9103362-2da7-4f78-bf10-0c008e3d78be                     
+                                                                                                                        
+   sled b59ec570-2abb-4017-80ce-129d94e7a025: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(1)) 
+                 fake-vendor         fake-model         serial-03eddaa7-cbbc-4be6-b515-554f69b82eb6                     
+                 fake-vendor         fake-model         serial-11f8582b-17cb-459e-a6e6-ea727e475bef                     
+                 fake-vendor         fake-model         serial-1e315dd7-89b0-4880-9ba7-52701423a7fc                     
+                 fake-vendor         fake-model         serial-34d18fe7-5662-4857-a3c9-b364de551154                     
+                 fake-vendor         fake-model         serial-703e3a5c-7603-44ad-b4b9-ac0093ac491f                     
+                 fake-vendor         fake-model         serial-98fe4c8b-5f71-4d09-a00c-bccabf136fce                     
+                 fake-vendor         fake-model         serial-bee0943d-96ed-41b2-8e2d-772ee4aa7674                     
+                 fake-vendor         fake-model         serial-c3745558-b8a5-4778-8d34-1ba15bb063cc                     
+                 fake-vendor         fake-model         serial-c58e4588-7a35-4f97-8615-921102cb70d1                     
+                 fake-vendor         fake-model         serial-c73747cc-d14d-4779-8fc5-50b5d8bde837                     
+
   METADATA:
     internal DNS version:  1 (unchanged)
     external DNS version:  1 (unchanged)

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -133,6 +133,48 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 +    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d  added    
 +    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f  added    
 
+         ---------------------------------------------------------------------------------------------------------------
+                 vendor              model              serial                                             status       
+         ---------------------------------------------------------------------------------------------------------------
+                                                                                                                        
+  ADDED SLEDS:                                                                                                          
+                                                                                                                        
++  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(2)) 
++                fake-vendor         fake-model         serial-22ee4a63-a9e5-48dc-a0f6-0b0ad2fb5b87        added        
++                fake-vendor         fake-model         serial-26cc3424-86fe-40dd-9431-87228263706b        added        
++                fake-vendor         fake-model         serial-6158799f-5048-454a-a981-3c6a20b34974        added        
++                fake-vendor         fake-model         serial-a1805901-0efe-437f-9857-23f3bee1fa6f        added        
++                fake-vendor         fake-model         serial-adaacf44-905e-47fb-ba94-ee767c638739        added        
++                fake-vendor         fake-model         serial-c5779a50-965e-4d6a-aa76-15283ba07b87        added        
++                fake-vendor         fake-model         serial-c8e2eacf-7a60-4657-8c68-9f2ce634f1b7        added        
++                fake-vendor         fake-model         serial-cad20cd3-aca0-4fcd-a181-c652e4594b49        added        
++                fake-vendor         fake-model         serial-d45fe0d4-f330-42b4-814c-0a65f18a0111        added        
++                fake-vendor         fake-model         serial-de6c7224-c11e-46bd-9820-7668e56d0fdd        added        
+                                                                                                                        
++  sled 75bc286f-2b4b-482c-9431-59272af529da: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(2)) 
++                fake-vendor         fake-model         serial-459f3c2b-f2bd-4c96-8577-d9bd0019cff6        added        
++                fake-vendor         fake-model         serial-5ca56e5a-e251-4011-bf99-b1f6cb3e414c        added        
++                fake-vendor         fake-model         serial-5eff78e9-d839-4c83-8b9b-9421e39d3fa2        added        
++                fake-vendor         fake-model         serial-64ce1e4a-838d-4fb7-a395-89dea4c7c67b        added        
++                fake-vendor         fake-model         serial-7e6bb6b7-5d4e-4bdd-905b-4a02e2e7e16b        added        
++                fake-vendor         fake-model         serial-85ad4f3a-1e26-4ac7-975e-da451223f717        added        
++                fake-vendor         fake-model         serial-97e37bf0-165e-492f-a415-fb61c18f4a32        added        
++                fake-vendor         fake-model         serial-ab12e1c9-facc-44a8-a780-2b61fdf83c89        added        
++                fake-vendor         fake-model         serial-b322518a-2142-40a4-9196-8736d8c613f5        added        
++                fake-vendor         fake-model         serial-cbad9e28-fa08-4b83-9ab0-1edf87610f0c        added        
+                                                                                                                        
++  sled affab35f-600a-4109-8ea0-34a067a4e0bc: blueprint disks: old gen Some(Generation(1)), new gen Some(Generation(2)) 
++                fake-vendor         fake-model         serial-10d25032-35c1-4e63-8ff8-a8720d8ebc3f        added        
++                fake-vendor         fake-model         serial-1c1dfe2e-b8b9-4952-8d26-a12334e9b5d1        added        
++                fake-vendor         fake-model         serial-2bdebe90-df1a-45f5-ab0c-b7124df5d409        added        
++                fake-vendor         fake-model         serial-2d86d960-92a6-4b30-b9fe-4d1ab69d6008        added        
++                fake-vendor         fake-model         serial-6f019519-eaac-4d77-a97f-ec44c635c42f        added        
++                fake-vendor         fake-model         serial-78b5b8aa-96ea-4c20-ac9e-06b91682a70d        added        
++                fake-vendor         fake-model         serial-846e4243-2ce0-43d2-9120-df4be98c6052        added        
++                fake-vendor         fake-model         serial-afcd1eb9-9646-4f44-9207-053fa0cff655        added        
++                fake-vendor         fake-model         serial-bf959d9f-f872-41f4-b608-41a717e96355        added        
++                fake-vendor         fake-model         serial-ea41d6ec-ddae-4776-8786-5c76971ab15a        added        
+
   METADATA:
     internal DNS version:  1 (unchanged)
     external DNS version:  1 (unchanged)

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -94,6 +94,48 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -    internal_ntp   67d913e0-0005-4599-9b28-0abbf6cc2916   expunged      fd00:1122:3344:103::21  removed  
 -    nexus          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   expunged      fd00:1122:3344:103::22  removed  
 
+         ---------------------------------------------------------------------------------------------------------------
+                 vendor              model              serial                                             status       
+         ---------------------------------------------------------------------------------------------------------------
+                                                                                                                        
+  UNCHANGED SLEDS:                                                                                                      
+                                                                                                                        
+   sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9: blueprint disks: old gen Some(Generation(2)), new gen Some(Generation(2)) 
+                 fake-vendor         fake-model         serial-22ee4a63-a9e5-48dc-a0f6-0b0ad2fb5b87                     
+                 fake-vendor         fake-model         serial-26cc3424-86fe-40dd-9431-87228263706b                     
+                 fake-vendor         fake-model         serial-6158799f-5048-454a-a981-3c6a20b34974                     
+                 fake-vendor         fake-model         serial-a1805901-0efe-437f-9857-23f3bee1fa6f                     
+                 fake-vendor         fake-model         serial-adaacf44-905e-47fb-ba94-ee767c638739                     
+                 fake-vendor         fake-model         serial-c5779a50-965e-4d6a-aa76-15283ba07b87                     
+                 fake-vendor         fake-model         serial-c8e2eacf-7a60-4657-8c68-9f2ce634f1b7                     
+                 fake-vendor         fake-model         serial-cad20cd3-aca0-4fcd-a181-c652e4594b49                     
+                 fake-vendor         fake-model         serial-d45fe0d4-f330-42b4-814c-0a65f18a0111                     
+                 fake-vendor         fake-model         serial-de6c7224-c11e-46bd-9820-7668e56d0fdd                     
+                                                                                                                        
+   sled 75bc286f-2b4b-482c-9431-59272af529da: blueprint disks: old gen Some(Generation(2)), new gen Some(Generation(2)) 
+                 fake-vendor         fake-model         serial-459f3c2b-f2bd-4c96-8577-d9bd0019cff6                     
+                 fake-vendor         fake-model         serial-5ca56e5a-e251-4011-bf99-b1f6cb3e414c                     
+                 fake-vendor         fake-model         serial-5eff78e9-d839-4c83-8b9b-9421e39d3fa2                     
+                 fake-vendor         fake-model         serial-64ce1e4a-838d-4fb7-a395-89dea4c7c67b                     
+                 fake-vendor         fake-model         serial-7e6bb6b7-5d4e-4bdd-905b-4a02e2e7e16b                     
+                 fake-vendor         fake-model         serial-85ad4f3a-1e26-4ac7-975e-da451223f717                     
+                 fake-vendor         fake-model         serial-97e37bf0-165e-492f-a415-fb61c18f4a32                     
+                 fake-vendor         fake-model         serial-ab12e1c9-facc-44a8-a780-2b61fdf83c89                     
+                 fake-vendor         fake-model         serial-b322518a-2142-40a4-9196-8736d8c613f5                     
+                 fake-vendor         fake-model         serial-cbad9e28-fa08-4b83-9ab0-1edf87610f0c                     
+                                                                                                                        
+   sled affab35f-600a-4109-8ea0-34a067a4e0bc: blueprint disks: old gen Some(Generation(2)), new gen Some(Generation(2)) 
+                 fake-vendor         fake-model         serial-10d25032-35c1-4e63-8ff8-a8720d8ebc3f                     
+                 fake-vendor         fake-model         serial-1c1dfe2e-b8b9-4952-8d26-a12334e9b5d1                     
+                 fake-vendor         fake-model         serial-2bdebe90-df1a-45f5-ab0c-b7124df5d409                     
+                 fake-vendor         fake-model         serial-2d86d960-92a6-4b30-b9fe-4d1ab69d6008                     
+                 fake-vendor         fake-model         serial-6f019519-eaac-4d77-a97f-ec44c635c42f                     
+                 fake-vendor         fake-model         serial-78b5b8aa-96ea-4c20-ac9e-06b91682a70d                     
+                 fake-vendor         fake-model         serial-846e4243-2ce0-43d2-9120-df4be98c6052                     
+                 fake-vendor         fake-model         serial-afcd1eb9-9646-4f44-9207-053fa0cff655                     
+                 fake-vendor         fake-model         serial-bf959d9f-f872-41f4-b608-41a717e96355                     
+                 fake-vendor         fake-model         serial-ea41d6ec-ddae-4776-8786-5c76971ab15a                     
+
   METADATA:
     internal DNS version:  1 (unchanged)
 *   external DNS version:  1 -> 2       

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -86,40 +86,40 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
      ------------------------------------------------------------------------
                                                                              
   sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9: blueprint disks at generation 2 
-       fake-vendor   fake-model  serial-38e60bb0-7d75-4956-9c16-d886a5357ca0 
-       fake-vendor   fake-model  serial-b17cf7c5-6511-4004-93f0-01fdeab116b5 
-       fake-vendor   fake-model  serial-0b12e8ce-8e6a-45b7-8268-554345caf696 
-       fake-vendor   fake-model  serial-5b05178a-142f-4c07-a29c-2d0ab8acbfdf 
-       fake-vendor   fake-model  serial-412fc498-cf8e-4b21-8cda-973fa7c2a2d7 
-       fake-vendor   fake-model  serial-6e6c4621-2ee5-4305-ac8c-26fc6c664292 
-       fake-vendor   fake-model  serial-a25fae3d-34c0-46af-8e24-7f099e820558 
-       fake-vendor   fake-model  serial-5d2011e2-8110-4bf4-ba9c-f0b311d2beac 
-       fake-vendor   fake-model  serial-bd03633c-fd27-434a-aab5-ff806a211803 
-       fake-vendor   fake-model  serial-602e6cec-8cfc-4216-826d-748e8c53fe1c 
+       fake-vendor   fake-model  serial-c5779a50-965e-4d6a-aa76-15283ba07b87 
+       fake-vendor   fake-model  serial-adaacf44-905e-47fb-ba94-ee767c638739 
+       fake-vendor   fake-model  serial-a1805901-0efe-437f-9857-23f3bee1fa6f 
+       fake-vendor   fake-model  serial-26cc3424-86fe-40dd-9431-87228263706b 
+       fake-vendor   fake-model  serial-de6c7224-c11e-46bd-9820-7668e56d0fdd 
+       fake-vendor   fake-model  serial-d45fe0d4-f330-42b4-814c-0a65f18a0111 
+       fake-vendor   fake-model  serial-22ee4a63-a9e5-48dc-a0f6-0b0ad2fb5b87 
+       fake-vendor   fake-model  serial-cad20cd3-aca0-4fcd-a181-c652e4594b49 
+       fake-vendor   fake-model  serial-6158799f-5048-454a-a981-3c6a20b34974 
+       fake-vendor   fake-model  serial-c8e2eacf-7a60-4657-8c68-9f2ce634f1b7 
                                                                              
   sled 75bc286f-2b4b-482c-9431-59272af529da: blueprint disks at generation 2 
-       fake-vendor   fake-model  serial-2aba8887-8073-409e-82e5-292e77dbfa5a 
-       fake-vendor   fake-model  serial-27d7c7e7-cf17-48ed-9c56-230548c4b6f5 
-       fake-vendor   fake-model  serial-3887e3a2-dc88-42e8-86cf-f0bbcba8ca37 
-       fake-vendor   fake-model  serial-8125abd4-1a93-4c13-881c-176d3eaceee0 
-       fake-vendor   fake-model  serial-ccbbd6c0-2562-4f73-b0f6-c58024ff16bb 
-       fake-vendor   fake-model  serial-103b1764-1c71-481d-a358-46209f6093f9 
-       fake-vendor   fake-model  serial-a6285b5e-a470-4448-8e10-cac35aba8c1c 
-       fake-vendor   fake-model  serial-7b39369b-e92d-48b5-9915-d63ceff694c4 
-       fake-vendor   fake-model  serial-b06ee27d-673f-40cd-8d09-ece05d1bb1f3 
-       fake-vendor   fake-model  serial-fd4d43f3-ddd8-4a56-a93b-d78b47a05ff8 
+       fake-vendor   fake-model  serial-7e6bb6b7-5d4e-4bdd-905b-4a02e2e7e16b 
+       fake-vendor   fake-model  serial-85ad4f3a-1e26-4ac7-975e-da451223f717 
+       fake-vendor   fake-model  serial-64ce1e4a-838d-4fb7-a395-89dea4c7c67b 
+       fake-vendor   fake-model  serial-459f3c2b-f2bd-4c96-8577-d9bd0019cff6 
+       fake-vendor   fake-model  serial-ab12e1c9-facc-44a8-a780-2b61fdf83c89 
+       fake-vendor   fake-model  serial-97e37bf0-165e-492f-a415-fb61c18f4a32 
+       fake-vendor   fake-model  serial-cbad9e28-fa08-4b83-9ab0-1edf87610f0c 
+       fake-vendor   fake-model  serial-b322518a-2142-40a4-9196-8736d8c613f5 
+       fake-vendor   fake-model  serial-5ca56e5a-e251-4011-bf99-b1f6cb3e414c 
+       fake-vendor   fake-model  serial-5eff78e9-d839-4c83-8b9b-9421e39d3fa2 
                                                                              
   sled affab35f-600a-4109-8ea0-34a067a4e0bc: blueprint disks at generation 2 
-       fake-vendor   fake-model  serial-e0e73417-ba21-4bbe-91e4-ca91fbd4af8b 
-       fake-vendor   fake-model  serial-10154987-17f0-44b5-ba90-1a811328db89 
-       fake-vendor   fake-model  serial-3424b998-3849-4204-8bad-19865c4ce2d6 
-       fake-vendor   fake-model  serial-1dedd1ee-13a9-46a4-bb9e-91ffa338f6ec 
-       fake-vendor   fake-model  serial-2694c7c7-a699-47a6-aa39-d9a50a228a33 
-       fake-vendor   fake-model  serial-96000bf7-de00-446a-babc-3eb6c38c0475 
-       fake-vendor   fake-model  serial-0c6ebcf3-e8d2-4881-a7aa-174ac4b84842 
-       fake-vendor   fake-model  serial-6df869cf-b29a-418e-82f5-681057ddb281 
-       fake-vendor   fake-model  serial-4976ed5b-f03a-4031-bd05-b02114c84d31 
-       fake-vendor   fake-model  serial-200a6c59-d9b6-404c-865a-6d27c679dd73 
+       fake-vendor   fake-model  serial-2d86d960-92a6-4b30-b9fe-4d1ab69d6008 
+       fake-vendor   fake-model  serial-2bdebe90-df1a-45f5-ab0c-b7124df5d409 
+       fake-vendor   fake-model  serial-1c1dfe2e-b8b9-4952-8d26-a12334e9b5d1 
+       fake-vendor   fake-model  serial-10d25032-35c1-4e63-8ff8-a8720d8ebc3f 
+       fake-vendor   fake-model  serial-846e4243-2ce0-43d2-9120-df4be98c6052 
+       fake-vendor   fake-model  serial-bf959d9f-f872-41f4-b608-41a717e96355 
+       fake-vendor   fake-model  serial-78b5b8aa-96ea-4c20-ac9e-06b91682a70d 
+       fake-vendor   fake-model  serial-afcd1eb9-9646-4f44-9207-053fa0cff655 
+       fake-vendor   fake-model  serial-6f019519-eaac-4d77-a97f-ec44c635c42f 
+       fake-vendor   fake-model  serial-ea41d6ec-ddae-4776-8786-5c76971ab15a 
 
 METADATA:
   created by:            test_blueprint2                                                                                                                                                                                                                                                                                                                                                  

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -81,6 +81,46 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service   fd00:1122:3344:101::2d 
     nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service   fd00:1122:3344:101::2f 
 
+     ------------------------------------------------------------------------
+       vendor        model       serial                                      
+     ------------------------------------------------------------------------
+                                                                             
+  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9: blueprint disks at generation 2 
+       fake-vendor   fake-model  serial-38e60bb0-7d75-4956-9c16-d886a5357ca0 
+       fake-vendor   fake-model  serial-b17cf7c5-6511-4004-93f0-01fdeab116b5 
+       fake-vendor   fake-model  serial-0b12e8ce-8e6a-45b7-8268-554345caf696 
+       fake-vendor   fake-model  serial-5b05178a-142f-4c07-a29c-2d0ab8acbfdf 
+       fake-vendor   fake-model  serial-412fc498-cf8e-4b21-8cda-973fa7c2a2d7 
+       fake-vendor   fake-model  serial-6e6c4621-2ee5-4305-ac8c-26fc6c664292 
+       fake-vendor   fake-model  serial-a25fae3d-34c0-46af-8e24-7f099e820558 
+       fake-vendor   fake-model  serial-5d2011e2-8110-4bf4-ba9c-f0b311d2beac 
+       fake-vendor   fake-model  serial-bd03633c-fd27-434a-aab5-ff806a211803 
+       fake-vendor   fake-model  serial-602e6cec-8cfc-4216-826d-748e8c53fe1c 
+                                                                             
+  sled 75bc286f-2b4b-482c-9431-59272af529da: blueprint disks at generation 2 
+       fake-vendor   fake-model  serial-2aba8887-8073-409e-82e5-292e77dbfa5a 
+       fake-vendor   fake-model  serial-27d7c7e7-cf17-48ed-9c56-230548c4b6f5 
+       fake-vendor   fake-model  serial-3887e3a2-dc88-42e8-86cf-f0bbcba8ca37 
+       fake-vendor   fake-model  serial-8125abd4-1a93-4c13-881c-176d3eaceee0 
+       fake-vendor   fake-model  serial-ccbbd6c0-2562-4f73-b0f6-c58024ff16bb 
+       fake-vendor   fake-model  serial-103b1764-1c71-481d-a358-46209f6093f9 
+       fake-vendor   fake-model  serial-a6285b5e-a470-4448-8e10-cac35aba8c1c 
+       fake-vendor   fake-model  serial-7b39369b-e92d-48b5-9915-d63ceff694c4 
+       fake-vendor   fake-model  serial-b06ee27d-673f-40cd-8d09-ece05d1bb1f3 
+       fake-vendor   fake-model  serial-fd4d43f3-ddd8-4a56-a93b-d78b47a05ff8 
+                                                                             
+  sled affab35f-600a-4109-8ea0-34a067a4e0bc: blueprint disks at generation 2 
+       fake-vendor   fake-model  serial-e0e73417-ba21-4bbe-91e4-ca91fbd4af8b 
+       fake-vendor   fake-model  serial-10154987-17f0-44b5-ba90-1a811328db89 
+       fake-vendor   fake-model  serial-3424b998-3849-4204-8bad-19865c4ce2d6 
+       fake-vendor   fake-model  serial-1dedd1ee-13a9-46a4-bb9e-91ffa338f6ec 
+       fake-vendor   fake-model  serial-2694c7c7-a699-47a6-aa39-d9a50a228a33 
+       fake-vendor   fake-model  serial-96000bf7-de00-446a-babc-3eb6c38c0475 
+       fake-vendor   fake-model  serial-0c6ebcf3-e8d2-4881-a7aa-174ac4b84842 
+       fake-vendor   fake-model  serial-6df869cf-b29a-418e-82f5-681057ddb281 
+       fake-vendor   fake-model  serial-4976ed5b-f03a-4031-bd05-b02114c84d31 
+       fake-vendor   fake-model  serial-200a6c59-d9b6-404c-865a-6d27c679dd73 
+
 METADATA:
   created by:            test_blueprint2                                                                                                                                                                                                                                                                                                                                                  
   created at:            1970-01-01T00:00:00.000Z                                                                                                                                                                                                                                                                                                                                         

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 base64.workspace = true
+derive_more.workspace = true
 futures.workspace = true
 humantime.workspace = true
 ipnetwork.workspace = true

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -25,7 +25,16 @@ use crate::config::MountConfig;
 use crate::dataset;
 
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
 )]
 pub struct OmicronPhysicalDiskConfig {
     pub identity: DiskIdentity,


### PR DESCRIPTION
Fixes #5624

I added a requirement when filtering on sled-id, that we also filter on collection-id, because filtering on sled-id does a full table scan and requires a new index. I can make that change if we feel it's important.

I specifically did not add blueprint diff support for physical disks yet. I'd like to discuss changing the mechanisms we use to generate blueprint output in general, and think it can be structured such that adding more data is trivial.

Example output is below. For some reason, the blueprint table rendering doesn't look quite right. I don't think I did anything wrong, but it's hard to tell. This is part of why I'd like to make output rendering automatic based on a unified data structure computed from input and passed to the renderer. This would not require a whole bunch of manual spacing and alignment as defined in constants.

```
root@oxz_switch:~# /opt/oxide/omdb/bin/omdb nexus blueprints show current
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:101::6]:12221
blueprint  8427f7bc-1216-4505-975b-edc633ba9913
parent:    <none>

  ----------------------------------------------------------------------------------------------
    zone type         zone ID                                disposition  underlay IP
  ----------------------------------------------------------------------------------------------

  sled 29c884fd-8abd-4e01-9ddd-1a74b35835dd: blueprint zones at generation 5
    boundary_ntp      641b2498-b006-4b2a-9d5a-1e2ee4fdc54d   in service   fd00:1122:3344:101::d
    cockroach_db      3f964671-7970-4390-9ed9-60d7267b1b75   in service   fd00:1122:3344:101::3
    cockroach_db      aa482257-82d7-4f22-8b32-655a4b32a260   in service   fd00:1122:3344:101::4
    crucible          23c9bb89-51de-4ec4-8ba0-1c90cdb7ca93   in service   fd00:1122:3344:101::c
    crucible          3910e950-0360-48d8-8220-9a5a2746bd89   in service   fd00:1122:3344:101::9
    crucible          42df7db6-82d5-4b9e-acdb-c2e91746d5e1   in service   fd00:1122:3344:101::a
    crucible          76da4127-3375-46af-996d-96be72e5e9f8   in service   fd00:1122:3344:101::8
    crucible          fa0c0343-2832-48f7-b980-845baa27893e   in service   fd00:1122:3344:101::b
    crucible_pantry   0bf91fa9-296c-4eab-890a-d50571a4202d   in service   fd00:1122:3344:101::7
    external_dns      efb31e4e-4116-45a0-9bbd-4410493f8dd3   in service   fd00:1122:3344:101::5
    internal_dns      f9360481-ce66-416a-8c33-dfa2510a0376   in service   fd00:1122:3344:1::1
    nexus             8d40088f-1760-4ebc-9c69-edc44efb8401   in service   fd00:1122:3344:101::6

  sled 673033c9-88ee-45e8-8c1a-bd0220c28595: blueprint zones at generation 5
    boundary_ntp      aeec5e62-c065-47f2-aba7-f0caad3ef65a   in service   fd00:1122:3344:102::d
    cockroach_db      37cb5ffb-af57-431d-aabb-64362ed364f6   in service   fd00:1122:3344:102::4
    cockroach_db      9822ba9f-7993-4732-b78c-ddaee3b4489e   in service   fd00:1122:3344:102::3
    crucible          584195be-2801-4bd0-ac0f-48403b1a0441   in service   fd00:1122:3344:102::b
    crucible          6ba8b19c-6ade-40aa-a574-d23f475294e0   in service   fd00:1122:3344:102::8
    crucible          aa427122-8a59-40aa-816c-e25b69b34c7b   in service   fd00:1122:3344:102::c
    crucible          c0edeeb4-2284-41d4-b639-b147e2fff085   in service   fd00:1122:3344:102::9
    crucible          fd9384da-9a72-4f09-b375-988620aa5ef9   in service   fd00:1122:3344:102::a
    crucible_pantry   7bdc1884-edea-4683-a00a-b7b48c7c8a8f   in service   fd00:1122:3344:102::7
    internal_dns      d12e0dd4-0482-45c2-8614-70f06668f50c   in service   fd00:1122:3344:2::1
    nexus             f788fd46-3439-4537-9491-02def3179dfb   in service   fd00:1122:3344:102::5
    oximeter          3b2c06fb-09c6-466d-af76-f5df012bc606   in service   fd00:1122:3344:102::6

  sled f33f8098-f78f-40a7-ad15-7545c7d67c6f: blueprint zones at generation 5
    clickhouse        a6c66950-6b56-4b3f-9ed0-83c502411a27   in service   fd00:1122:3344:103::6
    cockroach_db      34d1d439-c2eb-41af-ac3e-c2199686060a   in service   fd00:1122:3344:103::3
    crucible          47631184-a98b-46cf-a4e9-32c16b6c5292   in service   fd00:1122:3344:103::8
    crucible          4b8b2cc9-393e-45ea-85bb-19e2c356357c   in service   fd00:1122:3344:103::a
    crucible          6d62a1b5-5123-4b74-865f-af376dddaed6   in service   fd00:1122:3344:103::b
    crucible          7513605c-63fb-4c62-8edd-6bc86a04172f   in service   fd00:1122:3344:103::c
    crucible          93ff9d16-3678-425b-a7bb-b87be14cab89   in service   fd00:1122:3344:103::9
    crucible_pantry   96da4762-bd36-4481-b0a0-5602fbf40636   in service   fd00:1122:3344:103::7
    external_dns      1986b11b-f956-435e-b245-5d9860e5a310   in service   fd00:1122:3344:103::4
    internal_dns      1dc8ec37-71f8-41d8-8516-1f6414c17cf0   in service   fd00:1122:3344:3::1
    internal_ntp      f5e917ae-61b2-4943-8679-e1a4e729f23c   in service   fd00:1122:3344:103::d
    nexus             06990808-1d50-483b-8883-dd018566ab0b   in service   fd00:1122:3344:103::5

      -----------------------------------------------------------------------
          vendor               model                 serial
      -----------------------------------------------------------------------

  sled 29c884fd-8abd-4e01-9ddd-1a74b35835dd: blueprint disks at generation 1
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g0_4
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g0_1
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g0_0
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g0_2
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g0_3

  sled 673033c9-88ee-45e8-8c1a-bd0220c28595: blueprint disks at generation 1
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g1_0
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g1_2
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g1_3
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g1_4
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g1_1

  sled f33f8098-f78f-40a7-ad15-7545c7d67c6f: blueprint disks at generation 1
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g3_1
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g3_3
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g3_4
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g3_2
          synthetic-vendor     synthetic-model-U2    synthetic-serial-g3_0

METADATA:
  created by:            RSS
  created at:            2024-04-28T20:36:03.980Z
  comment:               initial blueprint from rack setup
  internal DNS version:  1
  external DNS version:  2

root@oxz_switch:~# omdb db inventory physical-disks                                                                                                                                                                                                                                                                              [40/1886]
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:103::3]:32221,[fd00:1122:3344:102::4]:32221,[fd00:1122:3344:101::3]:32221,[fd00:1122:3344:102::3]:32221,[fd00:1122:3344:101::4]:32221/omicron?sslmode=disable
note: database schema version matches expected (55.0.0)
INV_COLLECTION_ID                    SLED_ID                              SLOT VENDOR           MODEL              SERIAL             VARIANT
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba 673033c9-88ee-45e8-8c1a-bd0220c28595 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
05e9f7ca-2918-4f32-b80d-da00ef166cba f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 673033c9-88ee-45e8-8c1a-bd0220c28595 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
0ebd0ca5-fe60-4cd8-875c-73b2f9e1df60 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 673033c9-88ee-45e8-8c1a-bd0220c28595 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
2849b637-259b-480b-80ac-b4cee420c286 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2

root@oxz_switch:~# omdb db inventory physical-disks --collection-id d55a7642-d15b-4687-8e7d-7a1a9dec3952
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:103::3]:32221,[fd00:1122:3344:102::4]:32221,[fd00:1122:3344:101::3]:32221,[fd00:1122:3344:102::3]:32221,[fd00:1122:3344:101::4]:32221/omicron?sslmode=disable
note: database schema version matches expected (55.0.0)
INV_COLLECTION_ID                    SLED_ID                              SLOT VENDOR           MODEL              SERIAL             VARIANT
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 29c884fd-8abd-4e01-9ddd-1a74b35835dd 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 673033c9-88ee-45e8-8c1a-bd0220c28595 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2

root@oxz_switch:~# omdb db inventory physical-disks --collection-id d55a7642-d15b-4687-8e7d-7a1a9dec3952 --sled-id f33f8098-f78f-40a7-ad15-7545c7d67c6f
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:103::3]:32221,[fd00:1122:3344:102::4]:32221,[fd00:1122:3344:101::3]:32221,[fd00:1122:3344:102::3]:32221,[fd00:1122:3344:101::4]:32221/omicron?sslmode=disable
note: database schema version matches expected (55.0.0)
INV_COLLECTION_ID                    SLED_ID                              SLOT VENDOR           MODEL              SERIAL             VARIANT
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1024 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1025 synthetic-vendor synthetic-model-M2 synthetic-model-M2 M2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1026 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1027 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1028 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1029 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2
d55a7642-d15b-4687-8e7d-7a1a9dec3952 f33f8098-f78f-40a7-ad15-7545c7d67c6f 1030 synthetic-vendor synthetic-model-U2 synthetic-model-U2 U2