### PR TITLE
[sled-agent-client] automatically derive Eq/Hash for a few structs

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -12,9 +12,6 @@ use std::fmt;
 use std::hash::Hash;
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use types::{
-    BfdPeerConfig, BgpConfig, BgpPeerConfig, PortConfigV1, RouteConfig,
-};
 use uuid::Uuid;
 
 progenitor::generate_api!(
@@ -31,6 +28,13 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::debug!(log, "client response"; "result" => ?result);
     }),
+    patch = {
+        BfdPeerConfig = { derives = [PartialEq, Eq, Hash, Serialize, Deserialize] },
+        BgpConfig = { derives = [PartialEq, Eq, Hash, Serialize, Deserialize] },
+        BgpPeerConfig = { derives = [PartialEq, Eq, Hash, Serialize, Deserialize] },
+        PortConfigV1 = { derives = [PartialEq, Eq, Hash, Serialize, Deserialize] },
+        RouteConfig = { derives = [PartialEq, Eq, Hash, Serialize, Deserialize] },
+    },
     //TODO trade the manual transformations later in this file for the
     //     replace directives below?
     replace = {
@@ -662,62 +666,5 @@ impl TestInterfaces for Client {
             .send()
             .await
             .expect("disk_finish_transition() failed unexpectedly");
-    }
-}
-
-impl Eq for BgpConfig {}
-
-impl Hash for BgpConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.asn.hash(state);
-        self.originate.hash(state);
-    }
-}
-
-impl Hash for BgpPeerConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.addr.hash(state);
-        self.asn.hash(state);
-        self.port.hash(state);
-        self.hold_time.hash(state);
-        self.connect_retry.hash(state);
-        self.delay_open.hash(state);
-        self.idle_hold_time.hash(state);
-        self.keepalive.hash(state);
-    }
-}
-
-impl Hash for RouteConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.destination.hash(state);
-        self.nexthop.hash(state);
-    }
-}
-
-impl Eq for PortConfigV1 {}
-
-impl Hash for PortConfigV1 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.addresses.hash(state);
-        self.autoneg.hash(state);
-        self.bgp_peers.hash(state);
-        self.port.hash(state);
-        self.routes.hash(state);
-        self.switch.hash(state);
-        self.uplink_port_fec.hash(state);
-        self.uplink_port_speed.hash(state);
-    }
-}
-
-impl Eq for BfdPeerConfig {}
-
-impl Hash for BfdPeerConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.local.hash(state);
-        self.remote.hash(state);
-        self.detection_threshold.hash(state);
-        self.required_rx.hash(state);
-        self.mode.hash(state);
-        self.switch.hash(state);
     }
 }

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -362,7 +362,7 @@ pub enum ExternalPortDiscovery {
 
 /// Switchport Speed options
 #[derive(
-    Copy, Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema, Hash,
+    Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, JsonSchema, Hash,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum PortSpeed {
@@ -388,7 +388,7 @@ pub enum PortSpeed {
 
 /// Switchport FEC options
 #[derive(
-    Copy, Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema, Hash,
+    Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, JsonSchema, Hash,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum PortFec {


### PR DESCRIPTION
These impls are currently correct, but https://github.com/oxidecomputer/omicron/pull/5649 was going to add new fields to these structs. That would make these impls incorrect in a somewhat terrifying fashion. Having `PartialEq` and `Hash` disagree for a type is a recipe for
difficult-to-debug bugs and security vulnerabilities. See https://users.rust-lang.org/t/what-hapens-if-hash-and-partialeq-dont-match-when-using-hashmap/98052/19 for some discussion.

In this case we can simply tell progenitor to derive these traits. But in the future, one way to handle this at compile time is to write:

```rust
let BgpConfig {
    asn,
    originate,
} = self;
asn.hash(hasher);
originate.hash(hasher);
```

If a new field is added, then this will fail loudly.
