### PR TITLE
[wicketd] Pass RSS a /56 rack subnet instead of a raw IP address (/128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10984,6 +10984,7 @@ dependencies = [
  "omicron-passwords",
  "omicron-test-utils",
  "omicron-workspace-hack",
+ "once_cell",
  "openapi-lint",
  "openapiv3",
  "rand 0.8.5",

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -29,6 +29,7 @@ illumos-utils.workspace = true
 ipnetwork.workspace = true
 internal-dns.workspace = true
 itertools.workspace = true
+once_cell.workspace = true
 reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true


### PR DESCRIPTION
I think this should fix #5665. I checked a4x2 and it has a `/56`, so I think #5665 is specific to RSS when it's been run via wicket. I'll try this on madrid once a TUF repo is built.

I opened #5669 for the fact that our types allow this mistake; e.g., I think both https://github.com/oxidecomputer/omicron/blob/9c90e4b54694e8b4bec1884306d2626dcd062246/common/src/api/internal/shared.rs#L162 and https://github.com/oxidecomputer/omicron/blob/9c90e4b54694e8b4bec1884306d2626dcd062246/nexus/db-model/src/rack.rs#L19 are incorrect in that they allow any network size, and both should probably be `Ipv6Net<RACK_PREFIX>` instead. Fixing that is not trivial because at least the former is serialized in the bootstore.