### PR TITLE
[oximeter] use `Cow<'static, str>` for `FieldValue::String`

### DIFF
--- a/nexus/db-queries/src/transaction_retry.rs
+++ b/nexus/db-queries/src/transaction_retry.rs
@@ -353,7 +353,9 @@ mod test {
             assert_eq!(
                 target_fields["name"].value,
                 FieldValue::String(
-                    "test_transaction_retry_produces_samples".to_string()
+                    "test_transaction_retry_produces_samples"
+                        .to_string()
+                        .into()
                 )
             );
 

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -296,6 +296,7 @@ mod tests {
     use super::*;
     use crate::model::DbFieldList;
     use crate::model::DbTimeseriesSchema;
+    use std::borrow::Cow;
     use uuid::Uuid;
 
     // Validates that the timeseries_key stability for a sample is stable.
@@ -332,7 +333,7 @@ mod tests {
         use strum::EnumCount;
 
         let values = [
-            ("string", FieldValue::String(String::default())),
+            ("string", FieldValue::String(Cow::Owned(String::default()))),
             ("i8", FieldValue::I8(-0x0A)),
             ("u8", FieldValue::U8(0x0A)),
             ("i16", FieldValue::I16(-0x0ABC)),

--- a/oximeter/db/src/model.rs
+++ b/oximeter/db/src/model.rs
@@ -391,7 +391,7 @@ declare_field_row! {I32FieldRow, i32, "i32"}
 declare_field_row! {U32FieldRow, u32, "u32"}
 declare_field_row! {I64FieldRow, i64, "i64"}
 declare_field_row! {U64FieldRow, u64, "u64"}
-declare_field_row! {StringFieldRow, String, "string"}
+declare_field_row! {StringFieldRow, std::borrow::Cow<'static, str>, "string"}
 declare_field_row! {IpAddrFieldRow, Ipv6Addr, "ipaddr"}
 declare_field_row! {UuidFieldRow, Uuid, "uuid"}
 
@@ -1716,6 +1716,7 @@ pub(crate) fn parse_field_select_row(
                         .as_str()
                         .expect("Expected a UUID string for a Uuid field from the database")
                         .to_string()
+                        .into()
                     )
             }
         };


### PR DESCRIPTION
Fixes #5664.

Currently, Oximeter `FieldValue::String` fields are always represented
by a `String` value. This is somewhat unfortunate, as it requires
allocating a new `String` for every string field value that's emitted to
Oximeter, even when the string value is fixed at compile-time --- for
example, when an enum is used to generate a metric label with `&'static
str` values, they must be alloced into new `String`s to record the
metric.

This commit changes `FieldValue::String` from holding a `String` to
holding a `Cow<'static, str>`, so that static string constants need not
be heap-allocated.

Additionally, I've changed Oximeter's `self_stats` module to use
`Cow<'static, str>` to represent the field value generated by the
`FailureReason` enum. This way, a heap-allocated string is only
necessary for dynamically formatted variants (the `FailureReason::Other`
variant, which owns an HTTP `StatusCode`). For the
`FailureReason::Unreachable` and `FailureReason::Deserialization`
variants, we can just emit a `&'static str` without allocating.
Hopefully, this reduces resident memory for the collector process
somewhat when encountering a lot of failures.