### PR TITLE
bump softnpu/sidecar-lite machinery

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -113,8 +113,8 @@ const ZPOOL: &'static str = "/usr/sbin/zpool";
 const ZONEADM: &'static str = "/usr/sbin/zoneadm";
 
 const SIDECAR_LITE_COMMIT: &'static str =
-    "e3ea4b495ba0a71801ded0776ae4bbd31df57e26";
-const SOFTNPU_COMMIT: &'static str = "dbab082dfa89da5db5ca2325c257089d2f130092";
+    "960f11afe859e0316088e04578aedb700fba6159";
+const SOFTNPU_COMMIT: &'static str = "3203c51cf4473d30991b522062ac0df2e045c2f2";
 const PXA_MAC_DEFAULT: &'static str = "a8:e1:de:01:70:1d";
 
 const PXA_WARNING: &'static str = r#"  You have not set up the proxy-ARP environment variables

--- a/tools/ci_download_softnpu_machinery
+++ b/tools/ci_download_softnpu_machinery
@@ -15,7 +15,7 @@ OUT_DIR="out/npuzone"
 
 # Pinned commit for softnpu ASIC simulator
 SOFTNPU_REPO="softnpu"
-SOFTNPU_COMMIT="dbab082dfa89da5db5ca2325c257089d2f130092"
+SOFTNPU_COMMIT="3203c51cf4473d30991b522062ac0df2e045c2f2"
 
 # This is the softnpu ASIC simulator
 echo "fetching npuzone"


### PR DESCRIPTION
Due to recent explosions, sidecar-lite and softnpu have been pinned to Rust 1.77.0. This commit picks up that pinning.