### PR TITLE
Update crucible and propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,16 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12#27e2789d381c0fcc237fbe30cec2ec66bd750c12"
+dependencies = [
+ "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12)",
+ "libc",
+ "strum",
+]
+
+[[package]]
+name = "bhyve_api"
+version = "0.0.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
 dependencies = [
  "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af)",
@@ -471,11 +481,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bhyve_api"
+name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7#dd788a311a382b09ce1d3e35f7777b378e09fdf7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12#27e2789d381c0fcc237fbe30cec2ec66bd750c12"
 dependencies = [
- "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7)",
  "libc",
  "strum",
 ]
@@ -484,15 +493,6 @@ dependencies = [
 name = "bhyve_api_sys"
 version = "0.0.0"
 source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
-dependencies = [
- "libc",
- "strum",
-]
-
-[[package]]
-name = "bhyve_api_sys"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7#dd788a311a382b09ce1d3e35f7777b378e09fdf7"
 dependencies = [
  "libc",
  "strum",
@@ -1391,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1ef72f3c935e7dc936bf43310c04668fb60d7a20#1ef72f3c935e7dc936bf43310c04668fb60d7a20"
+source = "git+https://github.com/oxidecomputer/crucible?rev=62cc2cfe64ca09c6876be7633355026fa65c8545#62cc2cfe64ca09c6876be7633355026fa65c8545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1ef72f3c935e7dc936bf43310c04668fb60d7a20#1ef72f3c935e7dc936bf43310c04668fb60d7a20"
+source = "git+https://github.com/oxidecomputer/crucible?rev=62cc2cfe64ca09c6876be7633355026fa65c8545#62cc2cfe64ca09c6876be7633355026fa65c8545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1ef72f3c935e7dc936bf43310c04668fb60d7a20#1ef72f3c935e7dc936bf43310c04668fb60d7a20"
+source = "git+https://github.com/oxidecomputer/crucible?rev=62cc2cfe64ca09c6876be7633355026fa65c8545#62cc2cfe64ca09c6876be7633355026fa65c8545"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -3486,7 +3486,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7)",
+ "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12)",
  "byteorder",
  "camino",
  "camino-tempfile",
@@ -5429,7 +5429,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12)",
  "rand 0.8.5",
  "rcgen",
  "ref-cast",
@@ -5644,7 +5644,7 @@ dependencies = [
  "oximeter-instruments",
  "oximeter-producer",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12)",
  "propolis-mock-server",
  "rand 0.8.5",
  "rcgen",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
+source = "git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12#27e2789d381c0fcc237fbe30cec2ec66bd750c12"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -7092,7 +7092,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7#dd788a311a382b09ce1d3e35f7777b378e09fdf7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7#dd788a311a382b09ce1d3e35f7777b378e09fdf7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12#27e2789d381c0fcc237fbe30cec2ec66bd750c12"
 dependencies = [
  "anyhow",
  "atty",
@@ -7123,7 +7123,7 @@ dependencies = [
  "futures",
  "hyper 0.14.28",
  "progenitor",
- "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7)",
+ "propolis_types 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12)",
  "rand 0.8.5",
  "reqwest",
  "schemars",
@@ -7155,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
+source = "git+https://github.com/oxidecomputer/propolis?rev=27e2789d381c0fcc237fbe30cec2ec66bd750c12#27e2789d381c0fcc237fbe30cec2ec66bd750c12"
 dependencies = [
  "schemars",
  "serde",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=dd788a311a382b09ce1d3e35f7777b378e09fdf7#dd788a311a382b09ce1d3e35f7777b378e09fdf7"
+source = "git+https://github.com/oxidecomputer/propolis?rev=6dceb9ef69c217cb78a2018bbedafbc19f6ec1af#6dceb9ef69c217cb78a2018bbedafbc19f6ec1af"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,9 +197,9 @@ cookie = "0.18"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "1ef72f3c935e7dc936bf43310c04668fb60d7a20" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "1ef72f3c935e7dc936bf43310c04668fb60d7a20" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "1ef72f3c935e7dc936bf43310c04668fb60d7a20" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "62cc2cfe64ca09c6876be7633355026fa65c8545" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "62cc2cfe64ca09c6876be7633355026fa65c8545" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "62cc2cfe64ca09c6876be7633355026fa65c8545" }
 csv = "1.3.0"
 curve25519-dalek = "4"
 datatest-stable = "0.2.9"
@@ -338,9 +338,9 @@ prettyplease = { version = "0.2.19", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "dd788a311a382b09ce1d3e35f7777b378e09fdf7" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "dd788a311a382b09ce1d3e35f7777b378e09fdf7" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "dd788a311a382b09ce1d3e35f7777b378e09fdf7" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "27e2789d381c0fcc237fbe30cec2ec66bd750c12" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "27e2789d381c0fcc237fbe30cec2ec66bd750c12" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "27e2789d381c0fcc237fbe30cec2ec66bd750c12" }
 proptest = "1.4.0"
 quote = "1.0"
 rand = "0.8.5"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -517,10 +517,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "dd788a311a382b09ce1d3e35f7777b378e09fdf7"
+source.commit = "27e2789d381c0fcc237fbe30cec2ec66bd750c12"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "4aaff4a683d44f7c4d52a102a6c0592ff6135e5255f3a3317b1a38b962abd745"
+source.sha256 = "b6dd0188bd062a749fee2f2e39bcdb8e86bbbb3dd86fec463c140419736b0f86"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -490,10 +490,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "1ef72f3c935e7dc936bf43310c04668fb60d7a20"
+source.commit = "62cc2cfe64ca09c6876be7633355026fa65c8545"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "f4b9189d82729f851bab25ee7991134db2732f82657a15e88889500ed8a6e6c2"
+source.sha256 = "5b9e3ce16c8b3558e2ce20567165268088bd1b40a518636daf658eee28dd5843"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -502,10 +502,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "1ef72f3c935e7dc936bf43310c04668fb60d7a20"
+source.commit = "62cc2cfe64ca09c6876be7633355026fa65c8545"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "e7bf9cf165c3191c899c1f019df4edb6a34c0fe83d61cce861ae0aefc649882d"
+source.sha256 = "4aaff4a683d44f7c4d52a102a6c0592ff6135e5255f3a3317b1a38b962abd745"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -520,7 +520,7 @@ source.repo = "propolis"
 source.commit = "dd788a311a382b09ce1d3e35f7777b378e09fdf7"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "f9ebee502fdaa115563ac84e855805c0bf5582437820445dd1734423216dfc5b"
+source.sha256 = "4aaff4a683d44f7c4d52a102a6c0592ff6135e5255f3a3317b1a38b962abd745"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/sled-agent/src/sim/http_entrypoints_pantry.rs
+++ b/sled-agent/src/sim/http_entrypoints_pantry.rs
@@ -261,7 +261,7 @@ async fn scrub(
     Ok(HttpResponseOk(ScrubResponse { job_id }))
 }
 
-/// Flush and close a volume, removing it from the Pantry
+/// Deactivate a volume, removing it from the Pantry
 #[endpoint {
     method = DELETE,
     path = "/crucible/pantry/0/volume/{id}",


### PR DESCRIPTION
Propolis:
Update oximeter dependency to pull in automatic producer registration (#689)
Propagate ReplaceResult up; return disk status (#687)
Enable clippy warnings for lossless casts
Update rustls deps for CVE-2024-32650
migration: refrain from offering all pages when possible (#682)

Crucible:
DTrace probes for IO on/off the network (#1284)
Update oximeter dep to pull in automatic producer registration (#1279) Remove `ReadResponse` in favor of `RawReadResponse` (#1212) Fix typo in DTrace upstairs_info (#1276)
replace needing no work should not be an error (#1275) Add some DTrace scripts to the package. (#1274)
More Pantry updates for Region replacement (#1269) Send the correct task count for reconciliations (#1271)
Raw extent cleanup (#1268)