### PR TITLE
Clean up IP pool resolution from `NameOrId`

### DIFF
--- a/nexus/db-queries/src/db/datastore/probe.rs
+++ b/nexus/db-queries/src/db/datastore/probe.rs
@@ -15,7 +15,6 @@ use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use nexus_db_model::IncompleteNetworkInterface;
 use nexus_db_model::Probe;
 use nexus_db_model::VpcSubnet;
-use nexus_types::external_api::params;
 use nexus_types::identity::Resource;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::api::external::CreateResult;
@@ -278,20 +277,19 @@ impl super::DataStore {
         &self,
         opctx: &OpContext,
         authz_project: &authz::Project,
-        new_probe: &params::ProbeCreate,
+        probe: &Probe,
+        ip_pool: Option<authz::IpPool>,
     ) -> CreateResult<Probe> {
         //TODO in transaction
         use db::schema::probe::dsl;
         let pool = self.pool_connection_authorized(opctx).await?;
-
-        let probe = Probe::from_create(new_probe, authz_project.id());
 
         let _eip = self
             .allocate_probe_ephemeral_ip(
                 opctx,
                 Uuid::new_v4(),
                 probe.id(),
-                new_probe.ip_pool.clone().map(Into::into),
+                ip_pool,
             )
             .await?;
 

--- a/nexus/src/app/external_ip.rs
+++ b/nexus/src/app/external_ip.rs
@@ -111,13 +111,10 @@ impl super::Nexus {
 
         let params::FloatingIpCreate { identity, pool, ip } = params;
 
+        // resolve NameOrId into authz::IpPool
         let pool = match pool {
             Some(pool) => Some(
                 self.ip_pool_lookup(opctx, &pool)?
-                    // every authenticated user has CreateChild on IP pools
-                    // because they need to be able to allocate IPs from them.
-                    // The check that the pool is linked to the current silo
-                    // happens inside allocate_floating_ip
                     .lookup_for(authz::Action::CreateChild)
                     .await?
                     .0,


### PR DESCRIPTION
Followup to #5660, specifically https://github.com/oxidecomputer/omicron/pull/5660#discussion_r1583752697. I didn't do it quite as suggested, basically because I think datastore functions being aware of `NameOrId` is a bad thing as that is, to me, an API concept that we should have resolved to something real by the time we get to the datastore functions. This is still a little odd and a little redundant, but it is cleaner and more consistent.

In each case (floating IP create, probe create, instance ephemeral IP allocated) we are doing the following:

1. In the Nexus layer, turn `Option<NameOrId>` into `Option<authz::IpPool>` (this is a DB query of course)
2. In the datastore, call the new `resolve_pool_for_allocation`, which
  a. If a pool is specified, makes sure it's linked to the current silo, otherwise 404
  b. If a pool is not specified, get the default pool for the current silo
  c. Either way, make sure we have `CreateChild` on the pool (we always do if we're authenticated at all, but that could change in the future)
3. At this point we definitely have an `authz::IpPool` and can get on with whatever allocation