### PR TITLE
Reject add sled requests for sleds that already exist

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -37,6 +37,7 @@ progenitor::generate_api!(
         NetworkInterfaceKind = omicron_common::api::internal::shared::NetworkInterfaceKind,
         TypedUuidForCollectionKind = omicron_uuid_kinds::CollectionUuid,
         TypedUuidForDownstairsKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::DownstairsKind>,
+        TypedUuidForSledKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::SledKind>,
         TypedUuidForUpstairsKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsKind>,
         TypedUuidForUpstairsRepairKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsRepairKind>,
         TypedUuidForUpstairsSessionKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::UpstairsSessionKind>,

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1231,14 +1231,16 @@ async fn cmd_nexus_sled_add(
     args: &SledAddArgs,
     _destruction_token: DestructiveOperationToken,
 ) -> Result<(), anyhow::Error> {
-    client
+    let sled_id = client
         .sled_add(&UninitializedSledId {
             part: args.part.clone(),
             serial: args.serial.clone(),
         })
         .await
-        .context("adding sled")?;
-    eprintln!("added sled {} ({})", args.serial, args.part);
+        .context("adding sled")?
+        .into_inner()
+        .id;
+    eprintln!("added sled {} ({}): {sled_id}", args.serial, args.part);
     Ok(())
 }
 

--- a/nexus/db-model/src/sled_underlay_subnet_allocation.rs
+++ b/nexus/db-model/src/sled_underlay_subnet_allocation.rs
@@ -3,6 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::schema::sled_underlay_subnet_allocation;
+use crate::typed_uuid::DbTypedUuid;
+use omicron_uuid_kinds::SledKind;
 use uuid::Uuid;
 
 /// Underlay allocation for a sled added to an initialized rack
@@ -10,7 +12,7 @@ use uuid::Uuid;
 #[diesel(table_name = sled_underlay_subnet_allocation)]
 pub struct SledUnderlaySubnetAllocation {
     pub rack_id: Uuid,
-    pub sled_id: Uuid,
+    pub sled_id: DbTypedUuid<SledKind>,
     pub subnet_octet: i16,
     pub hw_baseboard_id: Uuid,
 }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -107,6 +107,7 @@ pub use inventory::DataStoreInventoryTest;
 use nexus_db_model::AllSchemaVersions;
 pub use probe::ProbeInfo;
 pub use rack::RackInit;
+pub use rack::SledUnderlayAllocationResult;
 pub use silo::Discoverability;
 pub use switch_port::SwitchPortSettingsCombinedResult;
 pub use virtual_provisioning_collection::StorageType;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -83,6 +83,7 @@ use omicron_common::api::external::{
     http_pagination::data_page_params_for, AggregateBgpMessageHistory,
 };
 use omicron_common::bail_unless;
+use omicron_uuid_kinds::SledUuid;
 use parse_display::Display;
 use propolis_client::support::tungstenite::protocol::frame::coding::CloseCode;
 use propolis_client::support::tungstenite::protocol::{
@@ -5210,6 +5211,12 @@ async fn sled_list_uninitialized(
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }
 
+/// The unique ID of a sled.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct SledId {
+    pub id: SledUuid,
+}
+
 /// Add sled to initialized rack
 //
 // TODO: In the future this should really be a PUT request, once we resolve
@@ -5218,19 +5225,19 @@ async fn sled_list_uninitialized(
 // we are only operating on single rack systems.
 #[endpoint {
     method = POST,
-    path = "/v1/system/hardware/sleds/",
+    path = "/v1/system/hardware/sleds",
     tags = ["system/hardware"]
 }]
 async fn sled_add(
     rqctx: RequestContext<Arc<ServerContext>>,
     sled: TypedBody<params::UninitializedSledId>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+) -> Result<HttpResponseCreated<SledId>, HttpError> {
     let apictx = rqctx.context();
     let nexus = &apictx.nexus;
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
-        nexus.sled_add(&opctx, sled.into_inner()).await?;
-        Ok(HttpResponseUpdatedNoContent())
+        let id = nexus.sled_add(&opctx, sled.into_inner()).await?;
+        Ok(HttpResponseCreated(SledId { id }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
 }

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -61,6 +61,9 @@ use omicron_uuid_kinds::ZpoolUuid;
 use oximeter_collector::Oximeter;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
+use sled_agent_client::types::EarlyNetworkConfig;
+use sled_agent_client::types::EarlyNetworkConfigBody;
+use sled_agent_client::types::RackNetworkConfigV1;
 use slog::{debug, error, o, Logger};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -911,6 +914,26 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             })
             .await
             .expect("Failed to configure sled agent with our zones");
+        client
+            .write_network_bootstore_config(&EarlyNetworkConfig {
+                body: EarlyNetworkConfigBody {
+                    ntp_servers: Vec::new(),
+                    rack_network_config: Some(RackNetworkConfigV1 {
+                        bfd: Vec::new(),
+                        bgp: Vec::new(),
+                        infra_ip_first: "192.0.2.10".parse().unwrap(),
+                        infra_ip_last: "192.0.2.100".parse().unwrap(),
+                        ports: Vec::new(),
+                        rack_subnet: "fd00:1122:3344:0100::/56"
+                            .parse()
+                            .unwrap(),
+                    }),
+                },
+                generation: 1,
+                schema_version: 1,
+            })
+            .await
+            .expect("Failed to write early networking config to bootstore");
     }
 
     // Set up the Crucible Pantry on an existing Sled Agent.

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1223,8 +1223,15 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "resource updated"
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledId"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -4352,6 +4359,18 @@
           "usable_physical_ram"
         ]
       },
+      "SledId": {
+        "description": "The unique ID of a sled.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TypedUuidForSledKind"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "SledInstanceState": {
         "description": "A wrapper type containing a sled's total knowledge of the state of a specific VMM and the instance it incarnates.",
         "type": "object",
@@ -4584,6 +4603,10 @@
         "format": "uuid"
       },
       "TypedUuidForOmicronZoneKind": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "TypedUuidForSledKind": {
         "type": "string",
         "format": "uuid"
       },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -4326,8 +4326,15 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "resource updated"
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledId"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -16203,6 +16210,18 @@
           "usable_physical_ram"
         ]
       },
+      "SledId": {
+        "description": "The unique ID of a sled.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TypedUuidForSledKind"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "SledInstance": {
         "description": "An operator's view of an instance running on a given sled",
         "type": "object",
@@ -17555,6 +17574,10 @@
         "required": [
           "items"
         ]
+      },
+      "TypedUuidForSledKind": {
+        "type": "string",
+        "format": "uuid"
       },
       "UninitializedSled": {
         "description": "A sled that has not been added to an initialized rack yet",

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -4,9 +4,8 @@
 
 //! HTTP entrypoint functions for the sled agent's exposed API
 
-use crate::bootstrap::early_networking::{
-    EarlyNetworkConfig, EarlyNetworkConfigBody,
-};
+use crate::bootstrap::early_networking::EarlyNetworkConfig;
+use crate::bootstrap::params::AddSledRequest;
 use crate::params::{
     DiskEnsureBody, InstanceEnsureBody, InstanceExternalIpBody,
     InstancePutMigrationIdsBody, InstancePutStateBody,
@@ -23,16 +22,13 @@ use dropshot::RequestContext;
 use dropshot::TypedBody;
 use illumos_utils::opte::params::DeleteVirtualNetworkInterfaceHost;
 use illumos_utils::opte::params::SetVirtualNetworkInterfaceHost;
-use ipnetwork::Ipv6Network;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::SledInstanceState;
 use omicron_common::api::internal::nexus::UpdateArtifactId;
-use omicron_common::api::internal::shared::RackNetworkConfig;
 use omicron_common::api::internal::shared::SwitchPorts;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_storage::resources::DisksManagementResult;
-use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -65,6 +61,7 @@ pub fn api() -> SledApiDescription {
         api.register(omicron_physical_disks_put)?;
         api.register(omicron_zones_get)?;
         api.register(omicron_zones_put)?;
+        api.register(sled_add)?;
 
         Ok(())
     }
@@ -396,24 +393,9 @@ async fn uplink_ensure(
     path = "/network-bootstore-config",
 }]
 async fn read_network_bootstore_config(
-    _rqctx: RequestContext<Arc<SledAgent>>,
+    rqctx: RequestContext<Arc<SledAgent>>,
 ) -> Result<HttpResponseOk<EarlyNetworkConfig>, HttpError> {
-    let config = EarlyNetworkConfig {
-        generation: 0,
-        schema_version: 1,
-        body: EarlyNetworkConfigBody {
-            ntp_servers: Vec::new(),
-            rack_network_config: Some(RackNetworkConfig {
-                rack_subnet: Ipv6Network::new(Ipv6Addr::UNSPECIFIED, 56)
-                    .unwrap(),
-                infra_ip_first: Ipv4Addr::UNSPECIFIED,
-                infra_ip_last: Ipv4Addr::UNSPECIFIED,
-                ports: Vec::new(),
-                bgp: Vec::new(),
-                bfd: Vec::new(),
-            }),
-        },
-    };
+    let config = rqctx.context().bootstore_network_config.lock().await.clone();
     Ok(HttpResponseOk(config))
 }
 
@@ -422,9 +404,11 @@ async fn read_network_bootstore_config(
     path = "/network-bootstore-config",
 }]
 async fn write_network_bootstore_config(
-    _rqctx: RequestContext<Arc<SledAgent>>,
-    _body: TypedBody<EarlyNetworkConfig>,
+    rqctx: RequestContext<Arc<SledAgent>>,
+    body: TypedBody<EarlyNetworkConfig>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let mut config = rqctx.context().bootstore_network_config.lock().await;
+    *config = body.into_inner();
     Ok(HttpResponseUpdatedNoContent())
 }
 
@@ -491,5 +475,16 @@ async fn omicron_zones_put(
     let sa = rqctx.context();
     let body_args = body.into_inner();
     sa.omicron_zones_ensure(body_args).await;
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+#[endpoint {
+    method = PUT,
+    path = "/sleds"
+}]
+async fn sled_add(
+    _rqctx: RequestContext<Arc<SledAgent>>,
+    _body: TypedBody<AddSledRequest>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     Ok(HttpResponseUpdatedNoContent())
 }

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -10,6 +10,9 @@ use super::disk::SimDisk;
 use super::instance::SimInstance;
 use super::storage::CrucibleData;
 use super::storage::Storage;
+use crate::bootstrap::early_networking::{
+    EarlyNetworkConfig, EarlyNetworkConfigBody,
+};
 use crate::nexus::NexusClient;
 use crate::params::{
     DiskStateRequested, InstanceExternalIpBody, InstanceHardware,
@@ -26,6 +29,7 @@ use futures::lock::Mutex;
 use illumos_utils::opte::params::{
     DeleteVirtualNetworkInterfaceHost, SetVirtualNetworkInterfaceHost,
 };
+use ipnetwork::Ipv6Network;
 use omicron_common::api::external::{
     ByteCount, DiskState, Error, Generation, ResourceType,
 };
@@ -35,6 +39,7 @@ use omicron_common::api::internal::nexus::{
 use omicron_common::api::internal::nexus::{
     InstanceRuntimeState, VmmRuntimeState,
 };
+use omicron_common::api::internal::shared::RackNetworkConfig;
 use omicron_common::disk::DiskIdentity;
 use omicron_uuid_kinds::ZpoolUuid;
 use propolis_client::{
@@ -44,7 +49,7 @@ use propolis_mock_server::Context as PropolisContext;
 use sled_storage::resources::DisksManagementResult;
 use slog::Logger;
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -77,6 +82,7 @@ pub struct SledAgent {
     config: Config,
     fake_zones: Mutex<OmicronZonesConfig>,
     instance_ensure_state_error: Mutex<Option<Error>>,
+    pub bootstore_network_config: Mutex<EarlyNetworkConfig>,
     pub log: Logger,
 }
 
@@ -144,6 +150,23 @@ impl SledAgent {
         let disk_log = log.new(o!("kind" => "disks"));
         let storage_log = log.new(o!("kind" => "storage"));
 
+        let bootstore_network_config = Mutex::new(EarlyNetworkConfig {
+            generation: 0,
+            schema_version: 1,
+            body: EarlyNetworkConfigBody {
+                ntp_servers: Vec::new(),
+                rack_network_config: Some(RackNetworkConfig {
+                    rack_subnet: Ipv6Network::new(Ipv6Addr::UNSPECIFIED, 56)
+                        .unwrap(),
+                    infra_ip_first: Ipv4Addr::UNSPECIFIED,
+                    infra_ip_last: Ipv4Addr::UNSPECIFIED,
+                    ports: Vec::new(),
+                    bgp: Vec::new(),
+                    bfd: Vec::new(),
+                }),
+            },
+        });
+
         Arc::new(SledAgent {
             id,
             ip: config.dropshot.bind_address.ip(),
@@ -176,6 +199,7 @@ impl SledAgent {
             }),
             instance_ensure_state_error: Mutex::new(None),
             log,
+            bootstore_network_config,
         })
     }
 


### PR DESCRIPTION
I ran into this as a part of #5625, where adding a previously-expunged sled appeared to succeed, but didn't actually add anything new.

Today if we try to add a sled that is already _running_, we get a 500, because Nexus fails when it tries to tell the sled-agent to start. But with this PR, we fail earlier: adding a sled that already has a subnet allocation fails before we even try to talk to the sled-agent, because it means someone has already added this sled:

```
root@oxz_switch:~# omdb -w nexus sleds add g2 i86pc
added sled g2 (i86pc): 90413e40-8139-43b4-9081-365dab6e5579
root@oxz_switch:~# omdb -w nexus sleds add g2 i86pc
Error: adding sled

Caused by:
    Error Response: status: 400 Bad Request; headers: {"content-type": "application/json", "x-request-id": "9eb95a9f-3fe0-4f75-8846-13490b95500e", "content-length": "188", "date": "Tue, 30 Apr 2024 20:54:49 GMT"}; value: Error { error_code: Some("ObjectAlreadyExists"), message: "already exists: sled \"g2 / i86pc (90413e40-8139-43b4-9081-365dab6e5579)\"", request_id: "9eb95a9f-3fe0-4f75-8846-13490b95500e" }
```

This does change the external API slightly (204 -> 201 created, and we now return the ID), but I think (?) that's probably fine since we have no real consumers of that yet.