### PR TITLE
[nexus] SNAT IP comes from same pool as ephemeral IP

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -67,12 +67,13 @@ impl DataStore {
         opctx: &OpContext,
         ip_id: Uuid,
         instance_id: Uuid,
-        pool_id: Uuid,
+        pool: Option<authz::IpPool>,
     ) -> CreateResult<ExternalIp> {
+        let authz_pool = self.resolve_pool_for_allocation(&opctx, pool).await?;
         let data = IncompleteExternalIp::for_instance_source_nat(
             ip_id,
             instance_id,
-            pool_id,
+            authz_pool.id(),
         );
         self.allocate_external_ip(opctx, data).await
     }

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -1038,15 +1038,6 @@ mod tests {
             instance_id
         }
 
-        async fn default_pool_id(&self) -> Uuid {
-            let (.., pool) = self
-                .db_datastore
-                .ip_pools_fetch_default(&self.opctx)
-                .await
-                .expect("Failed to lookup default ip pool");
-            pool.identity.id
-        }
-
         async fn success(mut self) {
             self.db.cleanup().await.unwrap();
             self.logctx.cleanup_successful();
@@ -1075,7 +1066,7 @@ mod tests {
                     &context.opctx,
                     id,
                     instance_id,
-                    context.default_pool_id().await,
+                    None,
                 )
                 .await
                 .expect("Failed to allocate instance external IP address");
@@ -1092,7 +1083,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                context.default_pool_id().await,
+                None,
             )
             .await
             .expect_err(
@@ -1148,7 +1139,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                context.default_pool_id().await,
+                None,
             )
             .await;
         assert!(
@@ -1225,7 +1216,7 @@ mod tests {
                     &context.opctx,
                     Uuid::new_v4(),
                     instance_id,
-                    context.default_pool_id().await,
+                    None,
                 )
                 .await
                 .expect("Failed to allocate instance external IP address");
@@ -1253,7 +1244,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                context.default_pool_id().await,
+                None,
             )
             .await
             .expect("Failed to allocate instance external IP address");
@@ -1280,7 +1271,7 @@ mod tests {
                 &context.opctx,
                 Uuid::new_v4(),
                 instance_id,
-                context.default_pool_id().await,
+                None,
             )
             .await
             .expect("Failed to allocate instance external IP address");
@@ -1589,12 +1580,7 @@ mod tests {
         let id = Uuid::new_v4();
         let ip = context
             .db_datastore
-            .allocate_instance_snat_ip(
-                &context.opctx,
-                id,
-                instance_id,
-                context.default_pool_id().await,
-            )
+            .allocate_instance_snat_ip(&context.opctx, id, instance_id, None)
             .await
             .expect("Failed to allocate instance SNAT IP address");
         assert_eq!(ip.kind, IpKind::SNat);
@@ -1606,12 +1592,7 @@ mod tests {
         // value.
         let new_ip = context
             .db_datastore
-            .allocate_instance_snat_ip(
-                &context.opctx,
-                id,
-                instance_id,
-                context.default_pool_id().await,
-            )
+            .allocate_instance_snat_ip(&context.opctx, id, instance_id, None)
             .await
             .expect("Failed to allocate instance SNAT IP address");
 


### PR DESCRIPTION
Closes #5043

Like I said [here](https://github.com/oxidecomputer/omicron/issues/5043#issuecomment-2087903321), this is arguably a little strange when you think about it: why should the IP pool for the ephemeral IP also govern where the SNAT IP comes from? I'll definitely wait for confirmation from a networking knower that this is actually the desired behavior.