### PR TITLE
remove the newtype uuid from the public API

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -83,7 +83,7 @@ use omicron_common::api::external::{
     http_pagination::data_page_params_for, AggregateBgpMessageHistory,
 };
 use omicron_common::bail_unless;
-use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::GenericUuid;
 use parse_display::Display;
 use propolis_client::support::tungstenite::protocol::frame::coding::CloseCode;
 use propolis_client::support::tungstenite::protocol::{
@@ -5214,7 +5214,7 @@ async fn sled_list_uninitialized(
 /// The unique ID of a sled.
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct SledId {
-    pub id: SledUuid,
+    pub id: Uuid,
 }
 
 /// Add sled to initialized rack
@@ -5236,7 +5236,10 @@ async fn sled_add(
     let nexus = &apictx.nexus;
     let handler = async {
         let opctx = crate::context::op_context_for_external_api(&rqctx).await?;
-        let id = nexus.sled_add(&opctx, sled.into_inner()).await?;
+        let id = nexus
+            .sled_add(&opctx, sled.into_inner())
+            .await?
+            .into_untyped_uuid();
         Ok(HttpResponseCreated(SledId { id }))
     };
     apictx.external_latencies.instrument_dropshot_handler(&rqctx, handler).await
@@ -5521,13 +5524,13 @@ async fn sled_physical_disk_list(
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SystemMetricParams {
-    /// A silo ID. If unspecified, get aggregrate metrics across all silos.
+    /// A silo ID. If unspecified, get aggregate metrics across all silos.
     pub silo_id: Option<Uuid>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SiloMetricParams {
-    /// A project ID. If unspecified, get aggregrate metrics across all projects
+    /// A project ID. If unspecified, get aggregate metrics across all projects
     /// in current silo.
     pub project_id: Option<Uuid>,
 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -5,7 +5,6 @@
 //! Handler functions (entrypoints) for HTTP APIs internal to the control plane
 
 use super::params::{OximeterInfo, RackInitializationRequest};
-use crate::external_api::http_entrypoints::SledId;
 use crate::ServerContext;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
@@ -52,11 +51,13 @@ use omicron_common::api::internal::nexus::RepairStartInfo;
 use omicron_common::api::internal::nexus::SledInstanceState;
 use omicron_common::update::ArtifactId;
 use omicron_uuid_kinds::DownstairsKind;
+use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::TypedUuid;
 use omicron_uuid_kinds::UpstairsKind;
 use omicron_uuid_kinds::UpstairsRepairKind;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -400,14 +401,7 @@ async fn cpapi_producers_post(
         .await
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    serde::Deserialize,
-    schemars::JsonSchema,
-    serde::Serialize,
-)]
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct CollectorIdPathParams {
     /// The ID of the oximeter collector.
     pub collector_id: Uuid,
@@ -1028,6 +1022,11 @@ async fn sled_list_uninitialized(
         Ok(HttpResponseOk(ResultsPage { items: sleds, next_page: None }))
     };
     apictx.internal_latencies.instrument_dropshot_handler(&rqctx, handler).await
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct SledId {
+    pub id: SledUuid,
 }
 
 /// Add sled to initialized rack

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -4360,7 +4360,6 @@
         ]
       },
       "SledId": {
-        "description": "The unique ID of a sled.",
         "type": "object",
         "properties": {
           "id": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -16215,7 +16215,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/TypedUuidForSledKind"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
@@ -17574,10 +17575,6 @@
         "required": [
           "items"
         ]
-      },
-      "TypedUuidForSledKind": {
-        "type": "string",
-        "format": "uuid"
       },
       "UninitializedSled": {
         "description": "A sled that has not been added to an initialized rack yet",


### PR DESCRIPTION
I don't **think** we want to include newtype UUIDs in the public API. There's only one and it was added (I think by accident) recently.