### PR TITLE
provide default for enforce_first_as

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(58, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(59, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(59, "enforce-first-as-default"),
         KnownVersion::new(58, "insert-default-allowlist"),
         KnownVersion::new(57, "add-allowed-source-ips"),
         KnownVersion::new(56, "bgp-oxpop-features"),

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2637,7 +2637,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.switch_port_settings_bgp_peer_config (
     md5_auth_key TEXT,
     multi_exit_discriminator INT8,
     local_pref INT8,
-    enforce_first_as BOOLEAN,
+    enforce_first_as BOOLEAN NOT NULL DEFAULT false,
     allow_import_list_active BOOLEAN NOT NULL DEFAULT false,
     allow_export_list_active BOOLEAN NOT NULL DEFAULT false,
     vlan_id INT4,
@@ -3842,7 +3842,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '58.0.0', NULL)
+    (TRUE, NOW(), NOW(), '59.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/enforce-first-as-default/up01.sql
+++ b/schema/crdb/enforce-first-as-default/up01.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.switch_port_settings_bgp_peer_config ALTER COLUMN enforce_first_as SET DEFAULT false;

--- a/schema/crdb/enforce-first-as-default/up02.sql
+++ b/schema/crdb/enforce-first-as-default/up02.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.switch_port_settings_bgp_peer_config ALTER COLUMN enforce_first_as SET NOT NULL;


### PR DESCRIPTION
Makes this consistent with diesel code. I think this will fix the upgrade issue we hit on rack 2.

```
06:40:41.919Z ERRO 65a11c18-7f59-41ac-b9e7-680627f996e7 (ServerContext): failed to generate changeset for switchport settings
    background_task = switch_port_config_manager
    error = {"error":"failed to get switch port settings: Internal Error: Unknown diesel error creating SwitchPortSettings called \\"d0dca0fb-4911-4bd7-b199-d12ce663707e\\": Unexpected null for non-null column"}
    file = nexus/src/app/background/sync_switch_configuration.rs:355
    rack_id = de608e01-b8e4-4d93-b972-a7dbed36dd22
```

The `enforce_first_as` value was not optional in the diesel code, but was in the DB, causing the above error.

It was verified this was the case in the DB.

```
root@[fd00:1122:3344:108::3]:32221/omicron> select enforce_first_as, allow_import_list_active, allow_export_list_active from switch_port_settings_bgp_peer_config ;
  enforce_first_as | allow_import_list_active | allow_export_list_active
-------------------+--------------------------+---------------------------
        NULL       |          false           |          false
        NULL       |          false           |          false
(2 rows)
```

The symptom this was causing was flapping communication. I set these NULL values to false and the flapping went away. The setup in switch0 was also incomplete, there was a missing link and no BGP session. Once this value was set to false instead of NULL in the databse, the link came to life, along with the BGP session.