### PR TITLE
[xtask] Make virtual-hardware destroy idempotent

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -275,6 +275,8 @@ fn remove_softnpu_zone(npu_zone: &Utf8Path) -> Result<()> {
         if output.to_string().contains("No such zone configured") {
             println!("zone {npu_zone} already destroyed");
             return Ok(());
+        } else {
+            return Err(output);
         }
     }
     Ok(())

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -270,7 +270,12 @@ fn remove_softnpu_zone(npu_zone: &Utf8Path) -> Result<()> {
         "--ports",
         "sc0_1,tfportqsfp0_0",
     ]);
-    execute(cmd)?;
+    if let Err(output) = execute(cmd) {
+        // Don't throw an error if the zone was already removed
+        if output.to_string().contains("No such zone configured") {
+            return Ok(());
+        }
+    }
     Ok(())
 }
 

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -273,6 +273,7 @@ fn remove_softnpu_zone(npu_zone: &Utf8Path) -> Result<()> {
     if let Err(output) = execute(cmd) {
         // Don't throw an error if the zone was already removed
         if output.to_string().contains("No such zone configured") {
+            println!("zone {npu_zone} already destroyed");
             return Ok(());
         }
     }


### PR DESCRIPTION
Tested on atrium: re-running `cargo xtask virtual-hardware destroy` no longer throws errors

Fixes https://github.com/oxidecomputer/omicron/issues/5566