### PR TITLE
[ci] undo workaround for amd-host-image-builder breakage

### DIFF
--- a/.github/buildomat/jobs/host-image.sh
+++ b/.github/buildomat/jobs/host-image.sh
@@ -49,7 +49,6 @@ source "$TOP/tools/include/force-git-over-https.sh"
 HELIOSDIR=/work/helios
 git clone https://github.com/oxidecomputer/helios.git "$HELIOSDIR"
 cd "$HELIOSDIR"
-git checkout pin-amd-host-image-builder
 # Record the branch and commit in the output
 git status --branch --porcelain=2
 # Setting BUILD_OS to no makes setup skip repositories we don't need for


### PR DESCRIPTION
Remove workaround for https://github.com/oxidecomputer/amd-host-image-builder/issues/181 added in https://github.com/oxidecomputer/omicron/pull/5649.