### PR TITLE
move clippy args to `[workspace.lints.clippy]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,11 @@ redundant_field_names = "warn"
 # idiomatically declaring a static array of atomics uses `const Atomic`). We
 # warn on this to catch the former, and expect any uses of the latter to allow
 # this locally.
+#
+# Note: any const value with a type containing a `bytes::Bytes` hits this lint,
+# and you should `#![allow]` it for now. This is most likely to be seen with
+# `http::header::{HeaderName, HeaderValue}`. This is a Clippy bug which will be
+# fixed in the Rust 1.80 toolchain (rust-lang/rust-clippy#12691).
 declare_interior_mutable_const = "warn"
 # Also warn on casts, preferring explicit conversions instead.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,43 @@ default-members = [
 ]
 resolver = "2"
 
+#
+# Tree-wide lint configuration.
+# https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
+#
+# For a list of Clippy lints, see
+# https://rust-lang.github.io/rust-clippy/master.
+#
+[workspace.lints.clippy]
+# Clippy's style nits are useful, but not worth keeping in CI.
+style = { level = "allow", priority = -1 }
+# But continue to warn on anything in the "disallowed_" namespace.
+disallowed_macros = "warn"
+disallowed_methods = "warn"
+disallowed_names = "warn"
+disallowed_script_idents = "warn"
+disallowed_types = "warn"
+# Warn on some more style lints that are relatively stable and make sense.
+iter_cloned_collect = "warn"
+iter_next_slice = "warn"
+iter_nth = "warn"
+iter_nth_zero = "warn"
+iter_skip_next = "warn"
+len_zero = "warn"
+redundant_field_names = "warn"
+# `declare_interior_mutable_const` is classified as a style lint, but it can
+# identify real bugs (e.g., declarying a `const Atomic` and using it like
+# a `static Atomic`). However, it is also subject to false positives (e.g.,
+# idiomatically declaring a static array of atomics uses `const Atomic`). We
+# warn on this to catch the former, and expect any uses of the latter to allow
+# this locally.
+declare_interior_mutable_const = "warn"
+# Also warn on casts, preferring explicit conversions instead.
+#
+# We'd like to warn on lossy casts in the future, but lossless casts are the
+# easiest ones to convert over.
+cast_lossless = "warn"
+
 [workspace.dependencies]
 anyhow = "1.0"
 anstyle = "1.0.6"

--- a/api_identity/Cargo.toml
+++ b/api_identity/Cargo.toml
@@ -10,6 +10,9 @@ license = "MPL-2.0"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true

--- a/bootstore/Cargo.toml
+++ b/bootstore/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 [build-dependencies]
 omicron-rpaths.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes.workspace = true
 camino.workspace = true

--- a/caboose-util/Cargo.toml
+++ b/caboose-util/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 hubtools.workspace = true

--- a/certificates/Cargo.toml
+++ b/certificates/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 display-error-chain.workspace = true
 foreign-types.workspace = true

--- a/clients/bootstrap-agent-client/Cargo.toml
+++ b/clients/bootstrap-agent-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 omicron-common.workspace = true
 progenitor.workspace = true

--- a/clients/ddm-admin-client/Cargo.toml
+++ b/clients/ddm-admin-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 either.workspace = true
 progenitor-client.workspace = true

--- a/clients/dns-service-client/Cargo.toml
+++ b/clients/dns-service-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/clients/dpd-client/Cargo.toml
+++ b/clients/dpd-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures.workspace = true
 progenitor-client.workspace = true

--- a/clients/gateway-client/Cargo.toml
+++ b/clients/gateway-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 base64.workspace = true
 chrono.workspace = true

--- a/clients/installinator-artifact-client/Cargo.toml
+++ b/clients/installinator-artifact-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 installinator-common.workspace = true
 progenitor.workspace = true

--- a/clients/nexus-client/Cargo.toml
+++ b/clients/nexus-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 futures.workspace = true

--- a/clients/oxide-client/Cargo.toml
+++ b/clients/oxide-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true

--- a/clients/oximeter-client/Cargo.toml
+++ b/clients/oximeter-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 futures.workspace = true

--- a/clients/sled-agent-client/Cargo.toml
+++ b/clients/sled-agent-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/clients/wicketd-client/Cargo.toml
+++ b/clients/wicketd-client/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 installinator-common.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 # NOTE:
 #
 # This crate is depended on by several other workspaces! Be careful of adding

--- a/dev-tools/crdb-seed/Cargo.toml
+++ b/dev-tools/crdb-seed/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MPL-2.0"
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 dropshot.workspace = true

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/dev-tools/omicron-dev/Cargo.toml
+++ b/dev-tools/omicron-dev/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/dev-tools/oxlog/Cargo.toml
+++ b/dev-tools/oxlog/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/dev-tools/reconfigurator-cli/Cargo.toml
+++ b/dev-tools/reconfigurator-cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/dev-tools/xtask/Cargo.toml
+++ b/dev-tools/xtask/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/dev-tools/xtask/src/clippy.rs
+++ b/dev-tools/xtask/src/clippy.rs
@@ -34,54 +34,7 @@ pub fn run_cmd(args: ClippyArgs) -> Result<()> {
         //
         // We disallow warnings by default.
         .arg("--deny")
-        .arg("warnings")
-        // Clippy's style nits are useful, but not worth keeping in CI.  This
-        // override belongs in src/lib.rs, and it is there, but that doesn't
-        // reliably work due to rust-lang/rust-clippy#6610.
-        .arg("--allow")
-        .arg("clippy::style")
-        // But continue to warn on anything in the "disallowed_" namespace.
-        // (These will be turned into errors by `--deny warnings` above.)
-        .arg("--warn")
-        .arg("clippy::disallowed_macros")
-        .arg("--warn")
-        .arg("clippy::disallowed_methods")
-        .arg("--warn")
-        .arg("clippy::disallowed_names")
-        .arg("--warn")
-        .arg("clippy::disallowed_script_idents")
-        .arg("--warn")
-        .arg("clippy::disallowed_types")
-        // Warn on some more style lints that are relatively stable and make
-        // sense.
-        .arg("--warn")
-        .arg("clippy::iter_cloned_collect")
-        .arg("--warn")
-        .arg("clippy::iter_next_slice")
-        .arg("--warn")
-        .arg("clippy::iter_nth")
-        .arg("--warn")
-        .arg("clippy::iter_nth_zero")
-        .arg("--warn")
-        .arg("clippy::iter_skip_next")
-        .arg("--warn")
-        .arg("clippy::len_zero")
-        .arg("--warn")
-        .arg("clippy::redundant_field_names")
-        // `declare_interior_mutable_const` is classified as a style lint, but
-        // it can identify real bugs (e.g., declarying a `const Atomic` and
-        // using it like a `static Atomic`). However, it is also subject to
-        // false positives (e.g., idiomatically declaring a static array of
-        // atomics uses `const Atomic`). We warn on this to catch the former,
-        // and expect any uses of the latter to allow this locally.
-        .arg("--warn")
-        .arg("clippy::declare_interior_mutable_const")
-        // Also warn on casts, preferring explicit conversions instead.
-        //
-        // We'd like to warn on lossy casts in the future, but lossless casts
-        // are the easiest ones to convert over.
-        .arg("--warn")
-        .arg("clippy::cast_lossless");
+        .arg("warnings");
 
     eprintln!(
         "running: {:?} {}",

--- a/dns-server/Cargo.toml
+++ b/dns-server/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/end-to-end-tests/Cargo.toml
+++ b/end-to-end-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true

--- a/gateway-cli/Cargo.toml
+++ b/gateway-cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/gateway-test-utils/Cargo.toml
+++ b/gateway-test-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 dropshot.workspace = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/installinator-artifactd/Cargo.toml
+++ b/installinator-artifactd/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/installinator-common/Cargo.toml
+++ b/installinator-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/installinator/Cargo.toml
+++ b/installinator/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/internal-dns-cli/Cargo.toml
+++ b/internal-dns-cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/internal-dns/Cargo.toml
+++ b/internal-dns/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/ipcc/Cargo.toml
+++ b/ipcc/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 ciborium.workspace = true
 libc.workspace = true

--- a/key-manager/Cargo.toml
+++ b/key-manager/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 hkdf.workspace = true

--- a/nexus-config/Cargo.toml
+++ b/nexus-config/Cargo.toml
@@ -3,6 +3,9 @@ name = "nexus-config"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/nexus/authz-macros/Cargo.toml
+++ b/nexus/authz-macros/Cargo.toml
@@ -7,6 +7,9 @@ license = "MPL-2.0"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heck.workspace = true
 nexus-macros-common.workspace = true

--- a/nexus/db-macros/Cargo.toml
+++ b/nexus/db-macros/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 heck.workspace = true
 nexus-macros-common.workspace = true

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/nexus/db-queries/Cargo.toml
+++ b/nexus/db-queries/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/nexus/defaults/Cargo.toml
+++ b/nexus/defaults/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 ipnetwork.workspace = true
 once_cell.workspace = true

--- a/nexus/inventory/Cargo.toml
+++ b/nexus/inventory/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true

--- a/nexus/macros-common/Cargo.toml
+++ b/nexus/macros-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }

--- a/nexus/metrics-producer-gc/Cargo.toml
+++ b/nexus/metrics-producer-gc/Cargo.toml
@@ -3,6 +3,9 @@ name = "nexus-metrics-producer-gc"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/nexus/networking/Cargo.toml
+++ b/nexus/networking/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures.workspace = true
 ipnetwork.workspace = true

--- a/nexus/reconfigurator/execution/Cargo.toml
+++ b/nexus/reconfigurator/execution/Cargo.toml
@@ -3,6 +3,9 @@ name = "nexus-reconfigurator-execution"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 omicron-rpaths.workspace = true
 

--- a/nexus/reconfigurator/planning/Cargo.toml
+++ b/nexus/reconfigurator/planning/Cargo.toml
@@ -3,6 +3,9 @@ name = "nexus-reconfigurator-planning"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/nexus/reconfigurator/preparation/Cargo.toml
+++ b/nexus/reconfigurator/preparation/Cargo.toml
@@ -3,6 +3,9 @@ name = "nexus-reconfigurator-preparation"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true

--- a/nexus/src/app/background/common.rs
+++ b/nexus/src/app/background/common.rs
@@ -376,7 +376,7 @@ impl TaskExec {
                     self.activate(ActivationReason::Signaled).await;
                 }
 
-                _ = dependencies.next(), if dependencies.len() > 0 => {
+                _ = dependencies.next(), if !dependencies.is_empty() => {
                     self.activate(ActivationReason::Dependency).await;
                 }
             }

--- a/nexus/src/app/instance_network.rs
+++ b/nexus/src/app/instance_network.rs
@@ -1147,7 +1147,7 @@ pub(crate) async fn probe_delete_dpd_config(
         };
     }
 
-    if let Some(e) = errors.into_iter().nth(0) {
+    if let Some(e) = errors.into_iter().next() {
         return Err(e);
     }
 

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -8,6 +8,19 @@
 //! external API, but in order to avoid CORS issues for now, we are serving
 //! these routes directly from the external API.
 
+// `HeaderName` and `HeaderValue` contain `bytes::Bytes`, which trips
+// the `declare_interior_mutable_const` lint. But in a `const fn`
+// context, the `AtomicPtr` that is used in `Bytes` only ever points
+// to a `&'static str`, so does not have interior mutability in that
+// context.
+//
+// A Clippy bug means that even if you ignore interior mutability of
+// `Bytes` (the default behavior), it will still not ignore it for types
+// where the only interior mutability is through `Bytes`. This is fixed
+// in rust-lang/rust-clippy#12691, which should land in the Rust 1.80
+// toolchain; we can remove this attribute then.
+#![allow(clippy::declare_interior_mutable_const)]
+
 use crate::ServerContext;
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -9,8 +9,6 @@
 #![allow(rustdoc::private_intra_doc_links)]
 // TODO(#40): Remove this exception once resolved.
 #![allow(clippy::unnecessary_wraps)]
-// Clippy's style lints are useful, but not worth running automatically.
-#![allow(clippy::style)]
 
 pub mod app; // Public for documentation examples
 mod cidata;

--- a/nexus/test-interface/Cargo.toml
+++ b/nexus/test-interface/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 nexus-config.workspace = true

--- a/nexus/test-utils-macros/Cargo.toml
+++ b/nexus/test-utils-macros/Cargo.toml
@@ -7,6 +7,9 @@ license = "MPL-2.0"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 quote.workspace = true
 syn = { workspace = true, features = [ "fold", "parsing" ] }

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "The oximeter metric collection server"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Tools for interacting with the Oxide control plane telemetry database"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-recursion = "1.1.0"

--- a/oximeter/instruments/Cargo.toml
+++ b/oximeter/instruments/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 cfg-if = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }

--- a/oximeter/oximeter-macro-impl/Cargo.toml
+++ b/oximeter/oximeter-macro-impl/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true

--- a/oximeter/oximeter/Cargo.toml
+++ b/oximeter/oximeter/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true, features = [ "serde" ] }
 chrono.workspace = true

--- a/oximeter/producer/Cargo.toml
+++ b/oximeter/producer/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Crate for producing metric data to be collected by the Oxide control plane"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 dropshot.workspace = true

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/passwords/Cargo.toml
+++ b/passwords/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 argon2 = { version = "0.5.3", features = ["alloc", "password-hash", "rand", "std"] }
 rand.workspace = true

--- a/rpaths/Cargo.toml
+++ b/rpaths/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 omicron-workspace-hack.workspace = true

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -7,8 +7,6 @@
 // We only use rustdoc for internal documentation, including private items, so
 // it's expected that we'll have links to private items in the docs.
 #![allow(rustdoc::private_intra_doc_links)]
-// Clippy's style lints are useful, but not worth running automatically.
-#![allow(clippy::style)]
 
 // Module for executing the simulated sled agent.
 pub mod sim;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -610,7 +610,7 @@ impl From<OmicronZoneType> for sled_agent_client::types::OmicronZoneType {
                 domain,
                 ntp_servers,
                 snat_cfg,
-                nic: nic,
+                nic,
             },
             OmicronZoneType::Clickhouse { address, dataset } => {
                 Other::Clickhouse {
@@ -646,7 +646,7 @@ impl From<OmicronZoneType> for sled_agent_client::types::OmicronZoneType {
                 dataset: dataset.into(),
                 http_address: http_address.to_string(),
                 dns_address: dns_address.to_string(),
-                nic: nic,
+                nic,
             },
             OmicronZoneType::InternalDns {
                 dataset,
@@ -683,7 +683,7 @@ impl From<OmicronZoneType> for sled_agent_client::types::OmicronZoneType {
                 external_ip,
                 external_tls,
                 internal_address: internal_address.to_string(),
-                nic: nic,
+                nic,
             },
             OmicronZoneType::Oximeter { address } => {
                 Other::Oximeter { address: address.to_string() }

--- a/sled-agent/src/rack_setup/config.rs
+++ b/sled-agent/src/rack_setup/config.rs
@@ -233,7 +233,7 @@ mod test {
         let read_cfg = SetupServiceConfig::from_file(&cfg_path)
             .expect("failed to read generated config with certificate");
         assert_eq!(read_cfg.external_certificates.len(), 1);
-        let cert = read_cfg.external_certificates.iter().next().unwrap();
+        let cert = read_cfg.external_certificates.first().unwrap();
         let _ = rcgen::KeyPair::from_pem(&cert.key)
             .expect("generated PEM did not parse as KeyPair");
     }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -531,7 +531,7 @@ impl ServiceInner {
                             }
                         })
                         .collect();
-                    if dns_addrs.len() > 0 {
+                    if !dns_addrs.is_empty() {
                         Some(dns_addrs)
                     } else {
                         None

--- a/sled-agent/src/swap_device.rs
+++ b/sled-agent/src/swap_device.rs
@@ -62,7 +62,7 @@ pub(crate) fn ensure_swap_device(
     assert!(size_gb > 0);
 
     let devs = swapctl::list_swap_devices()?;
-    if devs.len() > 0 {
+    if !devs.is_empty() {
         if devs.len() > 1 {
             // This should really never happen unless we've made a mistake, but it's
             // probably fine to have more than one swap device. Thus, don't panic
@@ -450,7 +450,7 @@ mod swapctl {
             let path = String::from_utf8_lossy(p.to_bytes()).to_string();
 
             devices.push(SwapDevice {
-                path: path,
+                path,
                 start: e.ste_start as u64,
                 length: e.ste_length as u64,
                 total_pages: e.ste_pages as u64,
@@ -473,8 +473,8 @@ mod swapctl {
             SwapDeviceError::AddDevice {
                 msg: format!("could not convert path to CString: {}", e,),
                 path: path_cp.clone(),
-                start: start,
-                length: length,
+                start,
+                length,
             }
         })?;
 
@@ -490,8 +490,8 @@ mod swapctl {
                 SwapDeviceError::AddDevice {
                     msg: e.to_string(),
                     path: path_cp,
-                    start: start,
-                    length: length,
+                    start,
+                    length,
                 }
             })?
         };

--- a/sled-hardware/Cargo.toml
+++ b/sled-hardware/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/sled-hardware/types/Cargo.toml
+++ b/sled-hardware/types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 illumos-utils.workspace = true
 omicron-common.workspace = true

--- a/sled-storage/Cargo.toml
+++ b/sled-storage/Cargo.toml
@@ -3,6 +3,9 @@ name = "sled-storage"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 atomicwrites.workspace = true

--- a/tufaceous-lib/Cargo.toml
+++ b/tufaceous-lib/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MPL-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true

--- a/tufaceous/Cargo.toml
+++ b/tufaceous/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MPL-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 camino.workspace = true

--- a/typed-rng/Cargo.toml
+++ b/typed-rng/Cargo.toml
@@ -3,6 +3,9 @@ name = "typed-rng"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 newtype-uuid.workspace = true
 omicron-workspace-hack.workspace = true

--- a/update-common/Cargo.toml
+++ b/update-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true

--- a/update-engine/Cargo.toml
+++ b/update-engine/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 cancel-safe-futures.workspace = true

--- a/uuid-kinds/Cargo.toml
+++ b/uuid-kinds/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 # The dependencies and features are written so as to make it easy for no-std
 # code to import omicron-uuid-kinds. All the features below are turned on
 # within omicron.

--- a/wicket-common/Cargo.toml
+++ b/wicket-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 omicron-common.workspace = true

--- a/wicket-dbg/Cargo.toml
+++ b/wicket-dbg/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true

--- a/wicket/Cargo.toml
+++ b/wicket/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 license = "MPL-2.0"
 default-run = "wicket"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 buf-list.workspace = true

--- a/wicketd/Cargo.toml
+++ b/wicketd/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -9,6 +9,9 @@ description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false
 
+[lints]
+workspace = true
+
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments
 # are managed by hakari.
 

--- a/zone-setup/Cargo.toml
+++ b/zone-setup/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true


### PR DESCRIPTION
This moves our Clippy configuration out of xtask and into Cargo's relatively-new lint configuration functionality. https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#lint-configuration-through-cargo

This seeks to solve a similar root issue as #5714, which is "please, rust-analyzer, do not tell me about clippy lints we don't care about in CI".

Unfortunately this requires littering `[lints] workspace = true` in every Cargo.toml, at least until [implicit workspace inheritance](https://github.com/rust-lang/cargo/issues/12208) is figured out, which is most of the noise of this PR. We may want a CI check to ensure that this is set in all packages.

As part of this I removed the `#![allow(clippy::style)]` attributes from nexus and sled-agent, which revealed that this was overriding any style lints we re-enabled in the xtask code.

One issue is that workspace crates can't override these lints yet (https://github.com/rust-lang/cargo/issues/13157), but they can continue to override them with `#![allow(clippy::whatever)]` attributes.