### PR TITLE
Plumb IP allow list all the way to the front door

### DIFF
--- a/wicket/src/cli/rack_setup/config_template.toml
+++ b/wicket/src/cli/rack_setup/config_template.toml
@@ -39,15 +39,21 @@ internal_services_ip_pool_ranges = []
 bootstrap_sleds = []
 
 # Allowlist of source IPs that can make requests to user-facing services.
-[allowed_source_ips]
-# Any external IPs to make requests. This is the default.
-allow = "any"
-
+#
+# Use the key:
+#
+# allow = "any"
+#
+# to indicate any external IPs are allowed to make requests. This is the default.
+#
 # Use the below two lines to only allow requests from the specified IP subnets.
 # Requests from any other source IPs are refused. Note that individual addresses
-# must include the netmask, e.g., `1.2.3.4/32`.
+# must include the netmask, e.g., "1.2.3.4/32".
+#
 # allow = "list"
 # ips = [ "1.2.3.4/5", "5.6.7.8/10" ]
+[allowed_source_ips]
+allow = "any"
 
 # TODO: docs on network config
 [rack_network_config]

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -122,7 +122,25 @@ fn populate_allowed_source_ips(
     doc: &mut DocumentMut,
     allowed_source_ips: Option<&AllowedSourceIps>,
 ) {
+    const ALLOWLIST_COMMENT: &str = r#"
+# Allowlist of source IPs that can make requests to user-facing services.
+#
+# Use the key:
+#
+# allow = "any"
+#
+# to indicate any external IPs are allowed to make requests. This is the default.
+#
+# Use the below two lines to only allow requests from the specified IP subnets.
+# Requests from any other source IPs are refused. Note that individual addresses
+# must include the netmask, e.g., "1.2.3.4/32".
+#
+# allow = "list"
+# ips = [ "1.2.3.4/5", "5.6.7.8/10" ]
+"#;
+
     let mut table = toml_edit::Table::new();
+    table.decor_mut().set_prefix(ALLOWLIST_COMMENT);
     match allowed_source_ips {
         None | Some(AllowedSourceIps::Any) => {
             table.insert(

--- a/wicket/tests/output/example_non_empty.toml
+++ b/wicket/tests/output/example_non_empty.toml
@@ -50,6 +50,20 @@ bootstrap_sleds = [
     5, # serial 4 5 6 (model model2 revision 5, ::1)
 ]
 
+# Allowlist of source IPs that can make requests to user-facing services.
+#
+# Use the key:
+#
+# allow = "any"
+#
+# to indicate any external IPs are allowed to make requests. This is the default.
+#
+# Use the below two lines to only allow requests from the specified IP subnets.
+# Requests from any other source IPs are refused. Note that individual addresses
+# must include the netmask, e.g., "1.2.3.4/32".
+#
+# allow = "list"
+# ips = [ "1.2.3.4/5", "5.6.7.8/10" ]
 [allowed_source_ips]
 allow = "any"
 

--- a/wicket/tests/output/example_non_empty.toml
+++ b/wicket/tests/output/example_non_empty.toml
@@ -67,12 +67,6 @@ bootstrap_sleds = [
 [allowed_source_ips]
 allow = "any"
 
-# Use the below two lines to only allow requests from the specified IP subnets.
-# Requests from any other source IPs are refused. Note that individual addresses
-# must include the netmask, e.g., `1.2.3.4/32`.
-# allow = "list"
-# ips = [ "1.2.3.4/5", "5.6.7.8/10" ]
-
 # TODO: docs on network config
 [rack_network_config]
 infra_ip_first = "172.30.0.1"

--- a/wicket/tests/output/example_non_empty.toml
+++ b/wicket/tests/output/example_non_empty.toml
@@ -50,9 +50,7 @@ bootstrap_sleds = [
     5, # serial 4 5 6 (model model2 revision 5, ::1)
 ]
 
-# Allowlist of source IPs that can make requests to user-facing services.
 [allowed_source_ips]
-# Any external IPs to make requests. This is the default.
 allow = "any"
 
 # Use the below two lines to only allow requests from the specified IP subnets.

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -527,6 +527,7 @@ impl CurrentRssConfig {
             value.internal_services_ip_pool_ranges;
         self.external_dns_ips = value.external_dns_ips;
         self.external_dns_zone_name = value.external_dns_zone_name;
+        self.allowed_source_ips = Some(value.allowed_source_ips);
 
         // Build a new auth key map, dropping all old keys from the map.
         let new_bgp_auth_key_ids =


### PR DESCRIPTION
- Fixes #5728
- Store the uploaded allowlist in the `wicketd` server context
- Spit the allowlist out in the TOML document we get back from the `wicket` CLI `setup get-config` subcommand