### PR TITLE
Adding ip pool id to view

### DIFF
--- a/nexus/db-model/src/external_ip.rs
+++ b/nexus/db-model/src/external_ip.rs
@@ -590,6 +590,7 @@ impl From<FloatingIp> for views::FloatingIp {
 
         views::FloatingIp {
             ip: ip.ip.ip(),
+            ip_pool_id: ip.ip_pool_id,
             identity,
             project_id: ip.project_id,
             instance_id: ip.parent_id,

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -153,7 +153,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // automatically linked to current silo
-    create_default_ip_pool(&client).await;
+    let default_pool = create_default_ip_pool(&client).await;
 
     assert_ip_pool_utilization(client, "default", 0, 65536, 0, 0).await;
 
@@ -162,7 +162,8 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
             .unwrap(),
     );
     // not automatically linked to currently silo. see below
-    create_ip_pool(&client, "other-pool", Some(other_pool_range)).await;
+    let (other_pool, ..) =
+        create_ip_pool(&client, "other-pool", Some(other_pool_range)).await;
 
     assert_ip_pool_utilization(client, "other-pool", 0, 5, 0, 0).await;
 
@@ -182,6 +183,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, IpAddr::from(Ipv4Addr::new(10, 0, 0, 0)));
+    assert_eq!(fip.ip_pool_id, default_pool.identity.id);
 
     assert_ip_pool_utilization(client, "default", 1, 65536, 0, 0).await;
 
@@ -200,6 +202,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, ip_addr);
+    assert_eq!(fip.ip_pool_id, default_pool.identity.id);
 
     assert_ip_pool_utilization(client, "default", 2, 65536, 0, 0).await;
 
@@ -230,11 +233,11 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, IpAddr::from(Ipv4Addr::new(10, 1, 0, 1)));
-    // assert_eq!(fip.ip_pool_id, "how to get the expected pool id?");
+    assert_eq!(fip.ip_pool_id, other_pool.identity.id);
 
     assert_ip_pool_utilization(client, "other-pool", 1, 5, 0, 0).await;
 
-    // Create with chosen IP from fleet-scoped named pool.
+    // Create with chosen IP from non-default pool.
     let fip_name = FIP_NAMES[3];
     let ip_addr = "10.1.0.5".parse().unwrap();
     let fip = create_floating_ip(
@@ -249,12 +252,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, ip_addr);
-
-    let url = format!("/v1/system/ip-pools/{}/utilization", "default");
-    // let utilization: views::IpPoolUtilization = object_get(client, &url).await;
-    let ip_pool = views::IpPool::objects_get(client, &url).await;
-
-    // assert_eq!(fip.ip_pool_id, "how to get the expected pool id?");
+    assert_eq!(fip.ip_pool_id, other_pool.identity.id);
 
     assert_ip_pool_utilization(client, "other-pool", 2, 5, 0, 0).await;
 }

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -230,6 +230,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, IpAddr::from(Ipv4Addr::new(10, 1, 0, 1)));
+    // assert_eq!(fip.ip_pool_id, "how to get the expected pool id?");
 
     assert_ip_pool_utilization(client, "other-pool", 1, 5, 0, 0).await;
 
@@ -248,6 +249,12 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.project_id, project.identity.id);
     assert_eq!(fip.instance_id, None);
     assert_eq!(fip.ip, ip_addr);
+
+    let url = format!("/v1/system/ip-pools/{}/utilization", "default");
+    // let utilization: views::IpPoolUtilization = object_get(client, &url).await;
+    let ip_pool = views::IpPool::objects_get(client, &url).await;
+
+    // assert_eq!(fip.ip_pool_id, "how to get the expected pool id?");
 
     assert_ip_pool_utilization(client, "other-pool", 2, 5, 0, 0).await;
 }

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -450,6 +450,8 @@ pub struct FloatingIp {
     pub identity: IdentityMetadata,
     /// The IP address held by this resource.
     pub ip: IpAddr,
+    /// The ID of the IP pool this resource belongs to.
+    pub ip_pool_id: Uuid,
     /// The project this resource exists within.
     pub project_id: Uuid,
     /// The ID of the instance that this Floating IP is attached to,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12420,6 +12420,11 @@
                 "type": "string",
                 "format": "ip"
               },
+              "ip_pool_id": {
+                "description": "The ID of the IP pool this resource belongs to.",
+                "type": "string",
+                "format": "uuid"
+              },
               "kind": {
                 "type": "string",
                 "enum": [
@@ -12454,6 +12459,7 @@
               "description",
               "id",
               "ip",
+              "ip_pool_id",
               "kind",
               "name",
               "project_id",
@@ -12896,6 +12902,11 @@
             "type": "string",
             "format": "ip"
           },
+          "ip_pool_id": {
+            "description": "The ID of the IP pool this resource belongs to.",
+            "type": "string",
+            "format": "uuid"
+          },
           "name": {
             "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
@@ -12924,6 +12935,7 @@
           "description",
           "id",
           "ip",
+          "ip_pool_id",
           "name",
           "project_id",
           "time_created",


### PR DESCRIPTION
Fixes #5716

This PR adds the IP Pool's ID to the Floating IP view, so we can use it on the frontend. Adds a few test assertions as well to existing tests.