### PR TITLE
Update the uuid kinds to emit a JSON Schema that includes the x-rust-type extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5741,6 +5741,7 @@ dependencies = [
  "newtype-uuid",
  "paste",
  "schemars",
+ "serde_json",
 ]
 
 [[package]]

--- a/uuid-kinds/Cargo.toml
+++ b/uuid-kinds/Cargo.toml
@@ -14,11 +14,12 @@ workspace = true
 [dependencies]
 newtype-uuid.workspace = true
 schemars = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 paste.workspace = true
 
 [features]
 default = ["std"]
 serde = ["newtype-uuid/serde"]
-schemars08 = ["newtype-uuid/schemars08", "schemars"]
+schemars08 = ["newtype-uuid/schemars08", "dep:schemars", "dep:serde_json"]
 std = ["newtype-uuid/std"]
 uuid-v4 = ["newtype-uuid/v4"]


### PR DESCRIPTION
Unfortunately this doesn't yet have a visible change, but I thought it would be useful to break things up into smaller pieces. This will have visible changes after https://github.com/oxidecomputer/newtype-uuid/pull/47 and become useful after https://github.com/oxidecomputer/typify/pull/584.