### PR TITLE
re-use reqwest::Client in disk_manual_import

### DIFF
--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -488,10 +488,10 @@ impl super::Nexus {
             // that user's program can act accordingly. In a way, the user's
             // program is an externally driven saga instead.
 
-            let client = crucible_pantry_client::Client::new(&format!(
-                "http://{}",
-                endpoint
-            ));
+            let client = crucible_pantry_client::Client::new_with_client(
+                &format!("http://{}", endpoint),
+                self.reqwest_client.clone(),
+            );
             let request = crucible_pantry_client::types::BulkWriteRequest {
                 offset: param.offset,
                 base64_encoded_data: param.base64_encoded_data,

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -152,6 +152,13 @@ pub struct Nexus {
     /// The metric producer server from which oximeter collects metric data.
     producer_server: std::sync::Mutex<Option<ProducerServer>>,
 
+    /// Reusable `reqwest::Client`, to be cloned and used with the Progenitor-
+    /// generated `Client::new_with_client`.
+    ///
+    /// (This does not need to be in an `Arc` because `reqwest::Client` uses
+    /// `Arc` internally.)
+    reqwest_client: reqwest::Client,
+
     /// Client to the timeseries database.
     timeseries_client: LazyTimeseriesClient,
 
@@ -343,6 +350,12 @@ impl Nexus {
             }
         }
 
+        let reqwest_client = reqwest::ClientBuilder::new()
+            .connect_timeout(std::time::Duration::from_secs(15))
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| e.to_string())?;
+
         // Connect to clickhouse - but do so lazily.
         // Clickhouse may not be executing when Nexus starts.
         let timeseries_client = if let Some(address) =
@@ -411,6 +424,7 @@ impl Nexus {
             internal_server: std::sync::Mutex::new(None),
             producer_server: std::sync::Mutex::new(None),
             populate_status,
+            reqwest_client,
             timeseries_client,
             updates_config: config.pkg.updates.clone(),
             tunables: config.pkg.tunables.clone(),


### PR DESCRIPTION
Fixes #5717. @faithanalog will follow-up with performance numbers she's running now.

We should probably do this to other clients we generate on-the-fly in Nexus, too, but this is probably the worst offender to fix.