### PR TITLE
fix #5698 vs. #5751 semantic merge conflict

### DIFF
--- a/nexus/reconfigurator/execution/src/sled_state.rs
+++ b/nexus/reconfigurator/execution/src/sled_state.rs
@@ -90,7 +90,7 @@ mod tests {
     async fn test_decommission_is_idempotent(
         cptestctx: &ControlPlaneTestContext,
     ) {
-        let nexus = &cptestctx.server.apictx().nexus;
+        let nexus = &cptestctx.server.server_context().nexus;
         let datastore = nexus.datastore();
         let opctx = OpContext::for_tests(
             cptestctx.logctx.log.clone(),


### PR DESCRIPTION
Semantic merge conflict between:
- #5698
- #5751