### PR TITLE
"external xtasks" pattern; wire up `cargo xtask releng`

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -65,4 +65,4 @@ esac
 pfexec zfs create -p "rpool/images/$USER/host"
 pfexec zfs create -p "rpool/images/$USER/recovery"
 
-cargo run --release --bin omicron-releng -- --output-dir /work
+cargo xtask releng --output-dir /work

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -104,7 +104,7 @@ static WORKSPACE_DIR: Lazy<Utf8PathBuf> = Lazy::new(|| {
 /// Note that `--host-dataset` and `--recovery-dataset` must be set to different
 /// values to build the two OS images in parallel. This is strongly recommended.
 #[derive(Parser)]
-#[command(name = "cargo xtask releng")]
+#[command(name = "cargo xtask releng", bin_name = "cargo xtask releng")]
 struct Args {
     /// ZFS dataset to use for `helios-build` when building the host image
     #[clap(long, default_value_t = Self::default_dataset("host"))]

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -96,7 +96,6 @@ static WORKSPACE_DIR: Lazy<Utf8PathBuf> = Lazy::new(|| {
     dir
 });
 
-#[derive(Parser)]
 /// Run the Oxide release engineering process and produce a TUF repo that can be
 /// used to update a rack.
 ///
@@ -104,6 +103,8 @@ static WORKSPACE_DIR: Lazy<Utf8PathBuf> = Lazy::new(|| {
 ///
 /// Note that `--host-dataset` and `--recovery-dataset` must be set to different
 /// values to build the two OS images in parallel. This is strongly recommended.
+#[derive(Parser)]
+#[command(name = "cargo xtask releng")]
 struct Args {
     /// ZFS dataset to use for `helios-build` when building the host image
     #[clap(long, default_value_t = Self::default_dataset("host"))]

--- a/dev-tools/xtask/src/external.rs
+++ b/dev-tools/xtask/src/external.rs
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! External xtasks. (extasks?)
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+/// Argument parser for external xtasks.
+///
+/// In general we want all developer tasks to be discoverable simply by running
+/// `cargo xtask`, but some development tools end up with a particularly
+/// large dependency tree. It's not ideal to have to pay the cost of building
+/// our release engineering tooling if all the user wants to do is check for
+/// workspace dependency issues.
+///
+/// `External` provides a pattern for creating xtasks that live in other crates.
+/// An external xtask is defined on `crate::Cmds` as a tuple variant containing
+/// `External`, which captures all arguments and options (even `--help`) as
+/// a `Vec<OsString>`. The main function then calls `External::exec` with the
+/// appropriate bin target name and any additional Cargo arguments.
+#[derive(Parser)]
+#[clap(
+    disable_help_flag(true),
+    disable_help_subcommand(true),
+    disable_version_flag(true)
+)]
+pub struct External {
+    #[clap(trailing_var_arg(true), allow_hyphen_values(true))]
+    args: Vec<OsString>,
+
+    #[clap(skip)]
+    command: Option<Command>,
+}
+
+impl External {
+    pub fn cargo_args(
+        mut self,
+        args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    ) -> External {
+        self.command.get_or_insert_with(default_command).args(args);
+        self
+    }
+
+    pub fn exec(self, bin_target: impl AsRef<OsStr>) -> Result<()> {
+        let error = self
+            .command
+            .unwrap_or_else(default_command)
+            .arg("--bin")
+            .arg(bin_target)
+            .arg("--")
+            .args(self.args)
+            .exec();
+        Err(error).context("failed to exec `cargo run`")
+    }
+}
+
+fn default_command() -> Command {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut command = Command::new(cargo);
+    command.arg("run");
+    command
+}

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -21,7 +21,11 @@ mod verify_libraries;
 mod virtual_hardware;
 
 #[derive(Parser)]
-#[command(name = "cargo xtask", about = "Workspace-related developer tools")]
+#[command(
+    name = "cargo xtask",
+    bin_name = "cargo xtask",
+    about = "Workspace-related developer tools"
+)]
 struct Args {
     #[command(subcommand)]
     cmd: Cmds,

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -12,6 +12,7 @@ use clap::{Parser, Subcommand};
 
 mod check_workspace_deps;
 mod clippy;
+#[cfg_attr(not(target_os = "illumos"), allow(dead_code))]
 mod external;
 
 #[cfg(target_os = "illumos")]


### PR DESCRIPTION
I finally found the set of Clap options to do what I wanted!

```
$ cargo xtask releng --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.58s
     Running `target/debug/xtask releng --help`
    Finished release [optimized] target(s) in 1.02s
     Running `target/release/omicron-releng --help`
Run the Oxide release engineering process and produce a TUF repo that can be used to update a rack.

For more information, see `docs/releng.adoc` in the Omicron repository.

Note that `--host-dataset` and `--recovery-dataset` must be set to different values to build the two OS images in parallel. This is strongly recommended.

Usage: omicron-releng [OPTIONS]

Options:
      --host-dataset <HOST_DATASET>
          ZFS dataset to use for `helios-build` when building the host image

[... and so on]
```