### PR TITLE
[nexus] really deflake test_instance_watcher_metrics

### DIFF
--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -318,6 +318,28 @@ pub async fn timeseries_query(
 async fn test_instance_watcher_metrics(
     cptestctx: &ControlPlaneTestContext<omicron_nexus::Server>,
 ) {
+    macro_rules! assert_gte {
+        ($a:expr, $b:expr) => {{
+            let a = $a;
+            let b = $b;
+            assert!(
+                $a >= $b,
+                concat!(
+                    "assertion failed: ",
+                    stringify!($a),
+                    " >= ",
+                    stringify!($b),
+                    ", ",
+                    stringify!($a),
+                    " = {:?}, ",
+                    stringify!($b),
+                    " = {:?}",
+                ),
+                a,
+                b
+            );
+        }};
+    }
     use oximeter::types::FieldValue;
     const INSTANCE_ID_FIELD: &str = "instance_id";
     const STATE_FIELD: &str = "state";
@@ -462,7 +484,7 @@ async fn test_instance_watcher_metrics(
         .find(|t| t.name() == "virtual_machine:check")
         .expect("missing virtual_machine:check");
     let ts = dbg!(count_state(&checks, instance1_uuid, STATE_STARTING));
-    assert_eq!(ts, 1);
+    assert_gte!(ts, 1);
 
     // okay, make another instance
     eprintln!("--- creating instance 2 ---");
@@ -479,8 +501,8 @@ async fn test_instance_watcher_metrics(
         .expect("missing virtual_machine:check");
     let ts1 = dbg!(count_state(&checks, instance1_uuid, STATE_STARTING));
     let ts2 = dbg!(count_state(&checks, instance2_uuid, STATE_STARTING));
-    assert_eq!(ts1, 2);
-    assert_eq!(ts2, 1);
+    assert_gte!(ts1, 2);
+    assert_gte!(ts2, 1);
 
     // poke instance 1 to get it into the running state
     eprintln!("--- starting instance 1 ---");
@@ -498,9 +520,9 @@ async fn test_instance_watcher_metrics(
         dbg!(count_state(&checks, instance1_uuid, STATE_STARTING));
     let ts1_running = dbg!(count_state(&checks, instance1_uuid, STATE_RUNNING));
     let ts2 = dbg!(count_state(&checks, instance2_uuid, STATE_STARTING));
-    assert_eq!(ts1_starting, 2);
-    assert_eq!(ts1_running, 1);
-    assert_eq!(ts2, 2);
+    assert_gte!(ts1_starting, 2);
+    assert_gte!(ts1_running, 1);
+    assert_gte!(ts2, 2);
 
     // poke instance 2 to get it into the Running state.
     eprintln!("--- starting instance 2 ---");
@@ -528,11 +550,11 @@ async fn test_instance_watcher_metrics(
     let ts2_starting =
         dbg!(count_state(&checks, instance2_uuid, STATE_STARTING));
     let ts2_running = dbg!(count_state(&checks, instance2_uuid, STATE_RUNNING));
-    assert_eq!(ts1_starting, 2);
-    assert_eq!(ts1_running, 1);
-    assert_eq!(ts1_stopping, 1);
-    assert_eq!(ts2_starting, 2);
-    assert_eq!(ts2_running, 1);
+    assert_gte!(ts1_starting, 2);
+    assert_gte!(ts1_running, 1);
+    assert_gte!(ts1_stopping, 1);
+    assert_gte!(ts2_starting, 2);
+    assert_gte!(ts2_running, 1);
 
     // simulate instance 1 completing its stop, which will remove it from the
     // set of active instances in CRDB. now, it won't be checked again.
@@ -556,11 +578,11 @@ async fn test_instance_watcher_metrics(
     let ts2_starting =
         dbg!(count_state(&checks, instance2_uuid, STATE_STARTING));
     let ts2_running = dbg!(count_state(&checks, instance2_uuid, STATE_RUNNING));
-    assert_eq!(ts1_starting, 2);
-    assert_eq!(ts1_running, 1);
-    assert_eq!(ts1_stopping, 1);
-    assert_eq!(ts2_starting, 2);
-    assert_eq!(ts2_running, 2);
+    assert_gte!(ts1_starting, 2);
+    assert_gte!(ts1_running, 1);
+    assert_gte!(ts1_stopping, 1);
+    assert_gte!(ts2_starting, 2);
+    assert_gte!(ts2_running, 2);
 }
 
 /// Wait until a producer is registered with Oximeter.


### PR DESCRIPTION
The test `integration_tests::metrics::test_instance_watcher_metrics`
remains flaky even after adding an explicit call to
`Oximeter::force_collect` to ensure that metrics have been collected. I
believe this is due to the fact that, if the test runs long enough, the
`instance_watcher` background may be activated by its timer, causing
metrics to be collected another time, in addition to the test's explicit
activations. This can cause flaky failures when we then assert that
there is exactly a certain number of timeseries counted.

This branch changes the test to make assertions based on inequality,
instead. Now, we assert that the timeseries has *at least* the expected
count, so if the `instance_watcher` task has collected instance metrics
an additional time, we can tolerate that. We're still able to assert
that at least the expected counts are present. This is based on the
approach suggested by @bnaecker in [this comment][1].

I've re-run the test five times on my machine, and it appears to always
pass. Hopefully, this should actually fix #5752, but we probably
shouldn't close the issue until this has made it through a few CI
runs...

[1] https://github.com/oxidecomputer/omicron/pull/5768#discussion_r1602328362