### PR TITLE
Revert sidecar bump to v1.0.18

### DIFF
--- a/tools/permslip_staging
+++ b/tools/permslip_staging
@@ -1,4 +1,4 @@
 03df89d44ad8b653abbeb7fbb83821869f008733e9da946457e72a13cb11d6cc manifest-gimlet-v1.0.19.toml
 b973cc9feb20f7bba447e7f5291c4070387fa9992deab81301f67f0a3844cd0c manifest-oxide-rot-1-v1.0.11.toml
 aae829e02d79ec0fe19019c783b6426c6fcc1fe4427aea70b65afc2884f53db8 manifest-psc-v1.0.17.toml
-5fc2aca37c2165c57cef4321fbaa4fe03ff38dcd992b6d6a076f54c167e0ad9f manifest-sidecar-v1.0.18.toml
+16992e82dff635eda1e065e0f6e325c795b6e90c879c7442ae062c063940a60a manifest-sidecar-v1.0.17.toml


### PR DESCRIPTION
At @Aaron-Hartwig's request.

This partially reverts commit 509bf0727e8bb98d88ed7346ce6469d70bd3c848 (#5781).