### PR TITLE
ensure omicron-common can be built outside of omicron

### DIFF
--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#:
+#: name = "omicron-common (helios)"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "1.77.2"
+#: output_rules = []
+#: skip_clone = true
+
+# Verify that omicron-common builds successfully when used as a dependency
+# in an external project. It must not leak anything that requires an external
+# dependency (apart from OpenSSL/pkg-config).
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+cargo new --lib test-project
+cd test-project
+cargo add omicron-common \
+    --git https://github.com/oxidecomputer/omicron.git \
+    --rev "$GITHUB_SHA"
+cargo check
+cargo build --release


### PR DESCRIPTION
Closes #5748.

The combination of `cargo check` / `cargo build --release` mostly exists to check for any weird differences between dev and release mode.

I had an earlier draft which did both Ubuntu and Helios but I'm not sure if that's valuable, and it makes the implementation worse (if you want to share code you can't use `skip_clone = true` and need to jump around somewhere else to create the test project).