### PR TITLE
ci: fix omicron-common job for PRs from forks

### DIFF
--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -5,7 +5,6 @@
 #: target = "helios-2.0"
 #: rust_toolchain = "1.77.2"
 #: output_rules = []
-#: skip_clone = true
 
 # Verify that omicron-common builds successfully when used as a dependency
 # in an external project. It must not leak anything that requires an external
@@ -18,10 +17,9 @@ set -o xtrace
 cargo --version
 rustc --version
 
+cd /tmp
 cargo new --lib test-project
 cd test-project
-cargo add omicron-common \
-    --git https://github.com/oxidecomputer/omicron.git \
-    --rev "$GITHUB_SHA"
+cargo add omicron-common --path /work/oxidecomputer/omicron/common
 cargo check
 cargo build --release


### PR DESCRIPTION
@jmpesp reported an issue where a PR submitted from a branch on his fork resulted in the omicron-common job failing.

`cargo add --git` uses Cargo's machinery to clone and checkout a particular version of a Git repository. If the URL is detected to be from GitHub, Cargo executes some "fast path" code which asks the GitHub API what the current HEAD of a particular reference is to return early if the repository doesn't require an update. _However_, it also [subtly changes the behavior of the fetch](https://github.com/rust-lang/cargo/blob/84dc5dc11a9007a08f27170454da6097265e510e/src/cargo/sources/git/utils.rs#L929-L937): if a particular revision is provided, and the GitHub fast-path code succeeds, Cargo knows [to explicitly fetch `refs/commit/{commit}`](https://github.com/rust-lang/cargo/blob/84dc5dc11a9007a08f27170454da6097265e510e/src/cargo/sources/git/utils.rs#L969).

However if this request fails (e.g. you are rate limited), Cargo does _not_ tell the Git implementation (either git2-rs or the Git CLI) to fetch `refs/commit/{commit}`. This causes this job to fail somewhat reliably for PRs from forks, because the commit is not any of the heads that would have otherwise been cloned.

This is pretty clearly a bug in Cargo, although how it might be resolved is a mystery. I'll find an issue if it exists or file one if it doesn't. In the meantime, we will instead let Buildomat fetch the repository at the commit we want to test in a much more reliable way, and use `cargo add --path` from an external project to verify what we want to verify.