### PR TITLE
[nexus] add background task for cleaning up abandoned VMMs

### DIFF
--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -25,6 +25,11 @@ EXECUTING COMMAND: omdb ["nexus", "--nexus-internal-url", "http://127.0.0.1:REDA
 termination: Exited(0)
 ---------------------------------------------
 stdout:
+task: "abandoned_vmm_reaper"
+    deletes sled reservations for VMMs that have been abandoned by their
+    instances
+
+
 task: "bfd_manager"
     Manages bidirectional fowarding detection (BFD) configuration on rack
     switches
@@ -136,6 +141,11 @@ EXECUTING COMMAND: omdb ["nexus", "background-tasks", "doc"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
+task: "abandoned_vmm_reaper"
+    deletes sled reservations for VMMs that have been abandoned by their
+    instances
+
+
 task: "bfd_manager"
     Manages bidirectional fowarding detection (BFD) configuration on rack
     switches
@@ -234,6 +244,11 @@ EXECUTING COMMAND: omdb ["--dns-server", "[::1]:REDACTED_PORT", "nexus", "backgr
 termination: Exited(0)
 ---------------------------------------------
 stdout:
+task: "abandoned_vmm_reaper"
+    deletes sled reservations for VMMs that have been abandoned by their
+    instances
+
+
 task: "bfd_manager"
     Manages bidirectional fowarding detection (BFD) configuration on rack
     switches

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -202,6 +202,11 @@ EXECUTING COMMAND: omdb ["nexus", "background-tasks", "doc"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
+task: "abandoned_vmm_reaper"
+    deletes sled reservations for VMMs that have been abandoned by their
+    instances
+
+
 task: "bfd_manager"
     Manages bidirectional fowarding detection (BFD) configuration on rack
     switches
@@ -375,6 +380,16 @@ task: "blueprint_executor"
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED     TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: no blueprint
+
+task: "abandoned_vmm_reaper"
+  configured period: every 1m
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
+    started at <REDACTED     TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+    total abandoned VMMs found: 0
+      VMM records deleted: 0
+      VMM records already deleted by another Nexus: 0
+    sled resource reservations deleted: 0
 
 task: "bfd_manager"
   configured period: every 30s

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -379,6 +379,8 @@ pub struct BackgroundTaskConfig {
     pub instance_watcher: InstanceWatcherConfig,
     /// configuration for service VPC firewall propagation task
     pub service_firewall_propagation: ServiceFirewallPropagationConfig,
+    /// configuration for abandoned VMM reaper task
+    pub abandoned_vmm_reaper: AbandonedVmmReaperConfig,
 }
 
 #[serde_as]
@@ -534,6 +536,14 @@ pub struct InstanceWatcherConfig {
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ServiceFirewallPropagationConfig {
+    /// period (in seconds) for periodic activations of this background task
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub period_secs: Duration,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AbandonedVmmReaperConfig {
     /// period (in seconds) for periodic activations of this background task
     #[serde_as(as = "DurationSeconds<u64>")]
     pub period_secs: Duration,
@@ -777,6 +787,7 @@ mod test {
             region_replacement.period_secs = 30
             instance_watcher.period_secs = 30
             service_firewall_propagation.period_secs = 300
+            abandoned_vmm_reaper.period_secs = 60
             [default_region_allocation_strategy]
             type = "random"
             seed = 0
@@ -911,7 +922,10 @@ mod test {
                         service_firewall_propagation:
                             ServiceFirewallPropagationConfig {
                                 period_secs: Duration::from_secs(300),
-                            }
+                            },
+                        abandoned_vmm_reaper: AbandonedVmmReaperConfig {
+                            period_secs: Duration::from_secs(60),
+                        }
                     },
                     default_region_allocation_strategy:
                         crate::nexus_config::RegionAllocationStrategy::Random {
@@ -980,6 +994,7 @@ mod test {
             region_replacement.period_secs = 30
             instance_watcher.period_secs = 30
             service_firewall_propagation.period_secs = 300
+            abandoned_vmm_reaper.period_secs = 60
             [default_region_allocation_strategy]
             type = "random"
             "##,

--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -198,18 +198,17 @@ impl DataStore {
                     .on(instance_dsl::id.eq(dsl::instance_id)),
             )
             .filter(
-                instance_dsl::active_propolis_id.ne(dsl::id.nullable()).and(
-                    instance_dsl::target_propolis_id.ne(dsl::id.nullable()),
-                ),
+                dsl::id
+                    .nullable()
+                    .ne(instance_dsl::active_propolis_id)
+                    .or(instance_dsl::active_propolis_id.is_null()),
             )
-            // .filter(diesel::dsl::not(diesel::dsl::exists(
-            //     instance_dsl::instance.filter(
-            //         instance_dsl::active_propolis_id
-            //             .eq(dsl::id.nullable())
-            //             .or(instance_dsl::target_propolis_id
-            //                 .eq(dsl::id.nullable())),
-            //     ),
-            // )))
+            .filter(
+                dsl::id
+                    .nullable()
+                    .ne(instance_dsl::target_propolis_id)
+                    .or(instance_dsl::target_propolis_id.is_null()),
+            )
             .select(Vmm::as_select())
             .load_async(&*self.pool_connection_authorized(opctx).await?)
             .await

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -116,6 +116,7 @@ region_replacement.period_secs = 30
 # How frequently to query the status of active instances.
 instance_watcher.period_secs = 30
 service_firewall_propagation.period_secs = 300
+abandoned_vmm_reaper.period_secs = 60
 
 [default_region_allocation_strategy]
 # allocate region on 3 random distinct zpools, on 3 random distinct sleds.

--- a/nexus/src/app/background/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/abandoned_vmm_reaper.rs
@@ -33,7 +33,7 @@ pub struct AbandonedVmmReaper {
 #[derive(Debug, Default)]
 struct ActivationResults {
     found: usize,
-    sled_resources_deleted: usize,
+    sled_reservations_deleted: usize,
     vmms_deleted: usize,
     vmms_already_deleted: usize,
     error_count: usize,
@@ -101,7 +101,7 @@ impl AbandonedVmmReaper {
                         "Deleted abandoned VMM's sled reservation";
                         "vmm" => %vmm_id,
                     );
-                    results.sled_resources_deleted += 1;
+                    results.sled_reservations_deleted += 1;
                 }
                 Err(e) => {
                     slog::warn!(
@@ -165,7 +165,7 @@ impl BackgroundTask for AbandonedVmmReaper {
                 Ok(_) => {
                     slog::info!(opctx.log, "Abandoned VMMs reaped";
                         "found" => results.found,
-                        "sled_resources_deleted" => results.sled_resources_deleted,
+                        "sled_reservations_deleted" => results.sled_reservations_deleted,
                         "vmms_deleted" => results.vmms_deleted,
                         "vmms_already_deleted" => results.vmms_already_deleted,
                     );
@@ -175,7 +175,7 @@ impl BackgroundTask for AbandonedVmmReaper {
                     slog::error!(opctx.log, "Abandoned VMM reaper activation failed";
                         "error" => %err,
                         "found" => results.found,
-                        "sled_resources_deleted" => results.sled_resources_deleted,
+                        "sled_reservations_deleted" => results.sled_reservations_deleted,
                         "vmms_deleted" => results.vmms_deleted,
                         "vmms_already_deleted" => results.vmms_already_deleted,
                     );
@@ -186,7 +186,7 @@ impl BackgroundTask for AbandonedVmmReaper {
                 "found": results.found,
                 "vmms_deleted": results.vmms_deleted,
                 "vmms_already_deleted": results.vmms_already_deleted,
-                "sled_resources_deleted": results.sled_resources_deleted,
+                "sled_reservations_deleted": results.sled_reservations_deleted,
                 "error_count": results.error_count,
                 "error": error,
             })
@@ -342,7 +342,7 @@ mod tests {
         dbg!(&results);
 
         assert_eq!(results.vmms_deleted, 1);
-        assert_eq!(results.sled_resources_deleted, 1);
+        assert_eq!(results.sled_reservations_deleted, 1);
         assert_eq!(results.vmms_already_deleted, 0);
         assert_eq!(results.error_count, 0);
         fixture.assert_reaped(datastore).await;
@@ -389,7 +389,7 @@ mod tests {
 
         assert_eq!(results.found, 1);
         assert_eq!(results.vmms_deleted, 0);
-        assert_eq!(results.sled_resources_deleted, 1);
+        assert_eq!(results.sled_reservations_deleted, 1);
         assert_eq!(results.vmms_already_deleted, 1);
         assert_eq!(results.error_count, 0);
 
@@ -441,7 +441,7 @@ mod tests {
 
         assert_eq!(results.found, 1);
         assert_eq!(results.vmms_deleted, 1);
-        assert_eq!(results.sled_resources_deleted, 1);
+        assert_eq!(results.sled_reservations_deleted, 1);
         assert_eq!(results.vmms_already_deleted, 0);
         assert_eq!(results.error_count, 0);
 

--- a/nexus/src/app/background/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/abandoned_vmm_reaper.rs
@@ -30,7 +30,7 @@ pub struct AbandonedVmmReaper {
     datastore: Arc<DataStore>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct ActivationResults {
     found: usize,
     sled_resources_deleted: usize,
@@ -248,7 +248,8 @@ mod tests {
         let mut results = ActivationResults::default();
         dbg!(task.reap(&mut results, &opctx,).await)
             .expect("activation completes successfully");
-        assert_eq!(results.found, 1);
+        dbg!(&results);
+
         assert_eq!(results.vmms_deleted, 1);
         assert_eq!(results.sled_resources_deleted, 1);
         assert_eq!(results.vmms_already_deleted, 0);

--- a/nexus/src/app/background/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/abandoned_vmm_reaper.rs
@@ -1,0 +1,258 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Ensures abandoned VMMs are fully destroyed.
+//!
+//! A VMM is considered "abandoned" if (and only if):
+//!
+//! - It is in the `Destroyed` state.
+//! - It has previously been asigned to an instance.
+//! - It is not currently running the instance, and it is also not the
+//!   migration target of that instance (i.e. it is no longer pointed to by
+//!   the instance record's `active_propolis_id` and `target_propolis_id`
+//!   fields).
+//! - It has not been deleted yet.
+
+use super::common::BackgroundTask;
+use anyhow::Context;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::pagination::Paginator;
+use nexus_db_queries::db::DataStore;
+use omicron_common::api::external::Error;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+/// Background task that searches for abandoned VMM recordss and deletes them.
+pub struct AbandonedVmmReaper {
+    datastore: Arc<DataStore>,
+}
+
+#[derive(Default)]
+struct ActivationResults {
+    found: usize,
+    sled_resources_deleted: usize,
+    sled_resources_already_deleted: usize,
+    vmms_deleted: usize,
+    vmms_already_deleted: usize,
+    error_count: usize,
+}
+
+const MAX_BATCH: NonZeroU32 = unsafe {
+    // Safety: last time I checked, 100 was greater than zero.
+    NonZeroU32::new_unchecked(100)
+};
+
+impl AbandonedVmmReaper {
+    pub fn new(datastore: Arc<DataStore>) -> Self {
+        Self { datastore }
+    }
+
+    async fn reap(
+        &mut self,
+        results: &mut ActivationResults,
+        opctx: &OpContext,
+    ) -> Result<(), anyhow::Error> {
+        slog::info!(opctx.log, "Abandoned VMM reaper running");
+
+        let mut paginator = Paginator::new(MAX_BATCH);
+        let mut last_err = Ok(());
+        while let Some(p) = paginator.next() {
+            let vmms = self
+                .datastore
+                .vmm_list_abandoned(opctx, &p.current_pagparams())
+                .await
+                .context("failed to list abandoned VMMs")?;
+            paginator = p.found_batch(&vmms, &|vmm| vmm.id);
+            results.found += vmms.len();
+            slog::debug!(opctx.log, "Found abandoned VMMs"; "count" => vmms.len());
+
+            for vmm in vmms {
+                let vmm_id = vmm.id;
+                slog::trace!(opctx.log, "Deleting abandoned VMM"; "vmm" => %vmm_id);
+                // Attempt to remove the abandoned VMM from the virtual
+                // provisioning collection.
+                match self
+                    .datastore
+                    .sled_reservation_delete(opctx, vmm_id)
+                    .await
+                {
+                    Ok(_) => results.sled_resources_deleted += 1,
+                    Err(Error::ObjectNotFound { .. }) => {
+                        results.sled_resources_already_deleted += 1;
+                    }
+                    Err(e) => {
+                        slog::warn!(opctx.log, "Failed to delete sled reservation for abandoned VMM";
+                            "vmm" => %vmm_id,
+                            "error" => %e,
+                        );
+                        results.error_count += 1;
+                        last_err = Err(e).with_context(|| {
+                            format!("failed to delete sled reservation for {vmm_id}")
+                        });
+                    }
+                }
+
+                // Now, attempt to mark the VMM record as deleted.
+                match self.datastore.vmm_mark_deleted(opctx, &vmm_id).await {
+                    Ok(_) => results.vmms_deleted += 1,
+                    Err(Error::ObjectNotFound { .. }) => {
+                        results.vmms_already_deleted += 1;
+                    }
+                    Err(e) => {
+                        slog::warn!(opctx.log, "Failed to mark abandoned VMM as deleted";
+                            "vmm" => %vmm_id,
+                            "error" => %e,
+                        );
+                        results.error_count += 1;
+                        last_err = Err(e).with_context(|| {
+                            format!("failed to mark {vmm_id} as deleted")
+                        });
+                    }
+                }
+            }
+        }
+
+        last_err
+    }
+}
+
+impl BackgroundTask for AbandonedVmmReaper {
+    fn activate<'a>(
+        &'a mut self,
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
+        async move {
+            let mut results = ActivationResults::default();
+            let error = match self.reap(&mut results, opctx).await {
+                Ok(_) => {
+                    slog::info!(opctx.log, "Abandoned VMMs reaped";
+                        "found" => results.found,
+                        "sled_resources_deleted" => results.sled_resources_deleted,
+                        "sled_resources_already_deleted" => results.sled_resources_already_deleted,
+                        "vmms_deleted" => results.vmms_deleted,
+                    );
+                    None
+                }
+                Err(err) => {
+                    slog::error!(opctx.log, "Abandoned VMM reaper activation failed";
+                        "error" => %err,
+                        "found" => results.found,
+                        "sled_resources_deleted" => results.sled_resources_deleted,
+                        "sled_resources_already_deleted" => results.sled_resources_already_deleted,
+                        "vmms_deleted" => results.vmms_deleted,
+                    );
+                    Some(err.to_string())
+                }
+            };
+            serde_json::json!({
+                "found": results.found,
+                "vmms_deleted": results.vmms_deleted,
+                "vmms_already_deleted": results.vmms_already_deleted,
+                "sled_resources_deleted": results.sled_resources_deleted,
+                "sled_resources_already_deleted": results.sled_resources_already_deleted,
+                "error_count": results.error_count,
+                "error": error,
+            })
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use chrono::Utc;
+    use nexus_db_model::ByteCount;
+    use nexus_db_model::Generation;
+    use nexus_db_model::InstanceState;
+    use nexus_db_model::Resources;
+    use nexus_db_model::SledResourceKind;
+    use nexus_db_model::Vmm;
+    use nexus_db_model::VmmRuntimeState;
+    use nexus_db_queries::context::OpContext;
+    use nexus_test_utils::resource_helpers;
+    use nexus_test_utils_macros::nexus_test;
+    use omicron_common::api::external::InstanceState as ApiInstanceState;
+    use uuid::Uuid;
+
+    type ControlPlaneTestContext =
+        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+    const PROJECT_NAME: &str = "carcosa";
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_abandoned_vmms_are_reaped(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = OpContext::for_tests(
+            cptestctx.logctx.log.clone(),
+            datastore.clone(),
+        );
+        let client = &cptestctx.external_client;
+        resource_helpers::create_default_ip_pool(&client).await;
+
+        let _project =
+            dbg!(resource_helpers::create_project(client, PROJECT_NAME).await);
+        let instance = dbg!(
+            resource_helpers::create_instance(client, PROJECT_NAME, "cassilda")
+                .await
+        );
+
+        let destroyed_vmm_id = Uuid::new_v4();
+        datastore
+            .vmm_insert(
+                &opctx,
+                dbg!(Vmm {
+                    id: destroyed_vmm_id,
+                    time_created: Utc::now(),
+                    time_deleted: None,
+                    instance_id: instance.identity.id,
+                    sled_id: Uuid::new_v4(),
+                    propolis_ip: "::1".parse().unwrap(),
+                    propolis_port: 12345.into(),
+                    runtime: VmmRuntimeState {
+                        state: InstanceState::new(ApiInstanceState::Destroyed),
+                        time_state_updated: Utc::now(),
+                        gen: Generation::new(),
+                    }
+                }),
+            )
+            .await
+            .expect("it should work");
+        let resources = Resources::new(
+            1,
+            // Just require the bare non-zero amount of RAM.
+            ByteCount::try_from(1024).unwrap(),
+            ByteCount::try_from(1024).unwrap(),
+        );
+        let constraints = nexus_db_model::SledReservationConstraints::none();
+        let resource = dbg!(datastore
+            .sled_reservation_create(
+                &opctx,
+                destroyed_vmm_id,
+                SledResourceKind::Instance,
+                resources.clone(),
+                constraints,
+            )
+            .await
+            .expect("should work"));
+
+        let mut task = AbandonedVmmReaper::new(datastore.clone());
+
+        let mut results = ActivationResults::default();
+        dbg!(task.reap(&mut results, &opctx,).await)
+            .expect("activation completes successfully");
+        assert_eq!(results.found, 1);
+        assert_eq!(results.vmms_deleted, 1);
+        assert_eq!(results.sled_resources_deleted, 1);
+        assert_eq!(results.vmms_already_deleted, 0);
+        assert_eq!(results.sled_resources_already_deleted, 0);
+        assert_eq!(results.error_count, 0);
+    }
+}

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -4,6 +4,7 @@
 
 //! Background task initialization
 
+use super::abandoned_vmm_reaper;
 use super::bfd;
 use super::blueprint_execution;
 use super::blueprint_load;
@@ -100,6 +101,10 @@ pub struct BackgroundTasks {
     /// task handle for propagation of VPC firewall rules for Omicron services
     /// with external network connectivity,
     pub task_service_firewall_propagation: common::TaskHandle,
+
+    /// task handle for deletion of database records for VMMs abandoned by their
+    /// instances.
+    pub task_abandoned_vmm_reaper: common::TaskHandle,
 }
 
 impl BackgroundTasks {
@@ -377,11 +382,25 @@ impl BackgroundTasks {
             ),
             config.service_firewall_propagation.period_secs,
             Box::new(service_firewall_rules::ServiceRulePropagator::new(
-                datastore,
+                datastore.clone(),
             )),
             opctx.child(BTreeMap::new()),
             vec![],
         );
+
+        // Background task: abandoned VMM reaping
+        let task_abandoned_vmm_reaper = driver.register(
+        String::from("abandoned_vmm_reaper"),
+        String::from(
+            "deletes sled reservations for VMMs that have been abandoned by their instances",
+        ),
+        config.abandoned_vmm_reaper.period_secs,
+        Box::new(abandoned_vmm_reaper::AbandonedVmmReaper::new(
+            datastore,
+        )),
+        opctx.child(BTreeMap::new()),
+        vec![],
+    );
 
         BackgroundTasks {
             driver,
@@ -404,6 +423,7 @@ impl BackgroundTasks {
             task_region_replacement,
             task_instance_watcher,
             task_service_firewall_propagation,
+            task_abandoned_vmm_reaper,
         }
     }
 

--- a/nexus/src/app/background/mod.rs
+++ b/nexus/src/app/background/mod.rs
@@ -4,6 +4,7 @@
 
 //! Background tasks
 
+mod abandoned_vmm_reaper;
 mod bfd;
 mod blueprint_execution;
 mod blueprint_load;

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -111,6 +111,7 @@ switch_port_settings_manager.period_secs = 30
 region_replacement.period_secs = 30
 instance_watcher.period_secs = 30
 service_firewall_propagation.period_secs = 300
+abandoned_vmm_reaper.period_secs = 60
 
 [default_region_allocation_strategy]
 # we only have one sled in the test environment, so we need to use the

--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -57,6 +57,7 @@ switch_port_settings_manager.period_secs = 30
 region_replacement.period_secs = 30
 service_firewall_propagation.period_secs = 300
 instance_watcher.period_secs = 30
+abandoned_vmm_reaper.period_secs = 60
 
 [default_region_allocation_strategy]
 # by default, allocate across 3 distinct sleds

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -57,6 +57,7 @@ switch_port_settings_manager.period_secs = 30
 region_replacement.period_secs = 30
 service_firewall_propagation.period_secs = 300
 instance_watcher.period_secs = 30
+abandoned_vmm_reaper.period_secs = 60
 
 [default_region_allocation_strategy]
 # by default, allocate without requirement for distinct sleds.


### PR DESCRIPTION
**Note**: This change is part of the ongoing work on instance lifecycle
management that I'm working on in PR #5749. It's not actually necessary
on its own, it's just a component of the upcoming instance updater saga.
However, I thought it would be easier to review if I factored out this
change into a separate PR that can be reviewed and merged on its own.

The instance update saga (see PR #5749) will only clean up after VMMs
whose IDs appear in an `instance` record. When a live migration finishes
(successfully or not), we want to allow a new migration to begin as soon
as possible, which means we have to unlink the “unused” side of the
migration --- the source if migration succeeded, or the target if it
failed --- from the instance, even though that VMM may not be fully
destroyed yet. Once this happens, the instance update saga will no
longer be able to clean up these VMMs, so we’ll need a separate task
that cleans up these "abandoned" VMMs in the background.

This branch introduces an `abandoned_vmm_reaper` background task that's
responsible for doing this. It queries the database to list VMMs which
are:

- in the `Destroyed` state
- not deleted yet (i.e. `time_deleted` IS NOT NULL)
- not pointed to by their corresponding instances (neither the
  `active_propolis_id` nor the `target_propolis_id` equals the VMM's ID)
  
For any VMMs returned by this query, the `abandoned_vmm_reaper` task
will:
- remove the `sled_resource` reservation for that VMM
- sets the `time_deleted` on the VMM record if it was not already set.

This cleanup process will be executed periodically in the background.
Eventually, the background task will also be explicitly triggered by the
instance update saga when it knows it has abandoned a VMM.

As an aside, I noticed that the current implementation of
`DataStore::vmm_mark_deleted` will always unconditionally set the
`time_deleted` field on a VMM record, even if it's already set. This is
"probably fine" for overall correctness: the VMM remains deleted, so the
operation is still idempotent-ish. But, it's not *great*, as it means
that any queries for VMMs deleted before a certain timestamp may not be
strictly correct, and we're updating the database more frequently than
we really need to. So, I've gone ahead and changed it to only set
`time_deleted` if the record's `time_deleted` is null, using
`check_if_exists` so that the method still returns `Ok` if the record
was already deleted --- the caller can inspect the returned `bool` to
determine whether or not they were the actual deleter, but the query
still doesn't fail.