### PR TITLE
fix: mac path handling and run script

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,10 +3,15 @@
 
 PATH_add out/cockroachdb/bin
 PATH_add out/clickhouse
-PATH_add out/dendrite-stub/bin
+PATH_add out/dendrite-stub/root/opt/oxide/dendrite/bin
 PATH_add out/mgd/root/opt/oxide/mgd/bin
 
 if [ "$OMICRON_USE_FLAKE" = 1 ] && nix flake show &> /dev/null
 then
     use flake;
+fi
+
+if [ "$(uname -s)" = "Darwin" ] && [ -d /opt/homebrew/opt/libxml2 ]
+then
+    export PKG_CONFIG_PATH=/opt/homebrew/opt/libxml2/lib/pkgconfig
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 .falcon/*
 .img/*
 connectivity-report.json
+*.toml-e

--- a/env.sh
+++ b/env.sh
@@ -8,7 +8,13 @@ set -o xtrace
 OMICRON_WS="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
 export PATH="$OMICRON_WS/out/cockroachdb/bin:$PATH"
 export PATH="$OMICRON_WS/out/clickhouse:$PATH"
-export PATH="$OMICRON_WS/out/dendrite-stub/bin:$PATH"
+export PATH="$OMICRON_WS/out/dendrite-stub/root/opt/oxide/dendrite/bin:$PATH"
 export PATH="$OMICRON_WS/out/mgd/root/opt/oxide/mgd/bin:$PATH"
 unset OMICRON_WS
+
+if [ "$(uname -s)" = "Darwin" ] && [ -d /opt/homebrew/opt/libxml2 ]
+then
+    export PKG_CONFIG_PATH=/opt/homebrew/opt/libxml2/lib/pkgconfig
+fi
+
 set +o xtrace

--- a/tools/ci_download_maghemite_mgd
+++ b/tools/ci_download_maghemite_mgd
@@ -166,7 +166,7 @@ function linux_binaries
 function osx_binaries
 {
 	echo "OSX binaries not officially supported"
-	./tools/omicron-install-dendrite-mac.sh
+	./tools/install_dendrite_and_maghemite_mac.sh
 }
 
 function unsupported_os

--- a/tools/ci_download_maghemite_mgd
+++ b/tools/ci_download_maghemite_mgd
@@ -29,7 +29,7 @@ PACKAGE_BASE_URL="$ARTIFACT_URL/$REPO/image/$COMMIT"
 
 function main
 {
-    rm -rf $DOWNLOAD_DIR/root
+	rm -rf $DOWNLOAD_DIR/root
 
 	#
 	# Process command-line arguments. We generally don't expect any, but
@@ -88,6 +88,9 @@ function configure_os
 		  	;;
 		solaris*)
 			SET_BINARIES=""
+			;;
+		darwin*)
+			SET_BINARIES="osx_binaries"
 			;;
 		*)
 			echo "WARNING: binaries for $1 are not published by maghemite"
@@ -160,11 +163,17 @@ function linux_binaries
 	cp "$DOWNLOAD_DIR/mgd" "$BIN_DIR"
 }
 
+function osx_binaries
+{
+	echo "OSX binaries not officially supported"
+	./tools/omicron-install-dendrite-mac.sh
+}
+
 function unsupported_os
 {
 	mkdir -p "$BIN_DIR"
-	echo "echo 'unsupported os' && exit 1" >> "$BIN_DIR/dpd"
-	chmod +x "$BIN_DIR/dpd"
+	echo "echo 'unsupported os' && exit 1" >> "$BIN_DIR/mgd"
+	chmod +x "$BIN_DIR/mgd"
 }
 
 main "$@"

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -106,7 +106,7 @@ HOST_OS=$(uname -s)
 function install_packages {
   if [[ "${HOST_OS}" == "Linux" ]]; then
     # If Nix is in use, we don't need to install any packagess here,
-    # as they're provided by the Nix flake. 
+    # as they're provided by the Nix flake.
     if nix flake show &> /dev/null; then
       return
     fi
@@ -170,6 +170,8 @@ function install_packages {
       'postgresql'
       'pkg-config'
       'libxmlsec1'
+      'yq'
+      'gh'
     )
     confirm "Install (or update) [${packages[*]}]?" && brew install "${packages[@]}"
   else

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -171,7 +171,6 @@ function install_packages {
       'pkg-config'
       'libxmlsec1'
       'yq'
-      'gh'
     )
     confirm "Install (or update) [${packages[*]}]?" && brew install "${packages[@]}"
   else

--- a/tools/install_dendrite_and_maghemite_mac.sh
+++ b/tools/install_dendrite_and_maghemite_mac.sh
@@ -1,14 +1,9 @@
 #! /usr/bin/env bash
 
 # Updated from https://gist.github.com/david-crespo/d8aa7ea1afb877ff585e6ad90fc5bc2c.
-# Installs: yq, gh.
+# Relies on the `brew install` of `yq` from the install_builder_prerequisites.sh script.
 
 set -euo pipefail
-
-# Auth first via GH client.
-if ! gh auth status 2>/dev/null ; then
-  exit 1
-fi
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SOURCE_DIR}/.."

--- a/tools/install_dendrite_and_maghemite_mac.sh
+++ b/tools/install_dendrite_and_maghemite_mac.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # Updated from https://gist.github.com/david-crespo/d8aa7ea1afb877ff585e6ad90fc5bc2c.
-# Installs: yq, gh
+# Installs: yq, gh.
 
 set -euo pipefail
 

--- a/tools/install_dendrite_and_maghemite_mac.sh
+++ b/tools/install_dendrite_and_maghemite_mac.sh
@@ -20,6 +20,8 @@ MGD_REPO="../maghemite"
 if [ ! -d "$DENDRITE_REPO" ]; then
     mkdir -p "$DENDRITE_REPO"
     git clone git@github.com:oxidecomputer/dendrite.git $DENDRITE_REPO
+else
+    echo "dendrite repo already exists"
 fi
 
 cd "$DENDRITE_REPO"
@@ -32,6 +34,8 @@ cp target/release/swadm "$DENDRITE_BIN_DIR/swadm"
 if [ ! -d "$MGD_REPO" ]; then
     mkdir -p "$MGD_REPO"
     git clone  git@github.com:oxidecomputer/maghemite.git "$MGD_REPO"
+else
+    echo "maghemite repo already exists"
 fi
 
 cd "$MGD_REPO"

--- a/tools/omicron-install-dendrite-mac.sh
+++ b/tools/omicron-install-dendrite-mac.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env bash
+
+# Updated from https://gist.github.com/david-crespo/d8aa7ea1afb877ff585e6ad90fc5bc2c.
+# Installs: yq, gh
+
+set -euo pipefail
+
+# Auth first via GH client.
+if ! gh auth status 2>/dev/null ; then
+  exit 1
+fi
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SOURCE_DIR}/.."
+
+DENDRITE_BIN_DIR="$(pwd)/out/dendrite-stub/root/opt/oxide/dendrite/bin"
+MGD_BIN_DIR="$(pwd)/out/mgd/root/opt/oxide/mgd/bin"
+
+DENDRITE_COMMIT="$(yq '.package.dendrite-stub.source.commit' package-manifest.toml)"
+MGD_COMMIT="$(yq '.package.mgd.source.commit' package-manifest.toml)"
+
+DENDRITE_REPO="../dendrite"
+MGD_REPO="../maghemite"
+
+if [ ! -d "$DENDRITE_REPO" ]; then
+    mkdir -p "$DENDRITE_REPO"
+    git clone git@github.com:oxidecomputer/dendrite.git $DENDRITE_REPO
+fi
+
+cd "$DENDRITE_REPO"
+git fetch --all && git checkout "$DENDRITE_COMMIT"
+cargo build -p dpd --release --features=tofino_stub
+cargo build -p swadm --release
+cp target/release/dpd "$DENDRITE_BIN_DIR/dpd"
+cp target/release/swadm "$DENDRITE_BIN_DIR/swadm"
+
+if [ ! -d "$MGD_REPO" ]; then
+    mkdir -p "$MGD_REPO"
+    git clone  git@github.com:oxidecomputer/maghemite.git "$MGD_REPO"
+fi
+
+cd "$MGD_REPO"
+git fetch --all && git checkout "$MGD_COMMIT"
+cargo build --bin mgd --no-default-features
+cp target/debug/mgd "$MGD_BIN_DIR/mgd"
+
+echo "now add the bin dirs to your path"
+echo ""
+echo "  export PATH=\"$DENDRITE_BIN_DIR:\$PATH\""
+echo "  export PATH=\"$MGD_BIN_DIR:\$PATH\""


### PR DESCRIPTION
This short-term fixes some minor bits with running omicron in simulation mode on OSX.

## Includes

- set known dpd path (symlink is still in play) to match mgd
- add darwin case to ci_download_maghemite_mgd script, which stops it from rewriting dpd (which caused path issues with OSX)
- in the darwin case, have ci_download_maghemite_mgd (called from install_builder_prerequisites.sh) execute a modified version of https://gist.github.com/david-crespo/d8aa7ea1afb877ff585e6ad90fc5bc2c for darwin
- including new brew installs for the OSX-specific script
- have env.sh/.envrc set PKG_CONFIG_PATH on OSX to handle samael errors with the xmlsec1 feature

## History

When running `cargo run --bin=omicron-dev -- run-all`, I ran into this error:

```
log file: /var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.0.log
note: configured to log to "/var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.0.log"
DB URL: postgresql://root@[::1]:58923/omicron?sslmode=disable
DB address: [::1]:58923
log file: /var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.2.log
note: configured to log to "/var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.2.log"
log file: /var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.3.log
note: configured to log to "/var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/omicron-dev-omicron-dev.40810.3.log"
thread 'main' panicked at /Users/zeeshanlakhani/oxide/omicron/nexus/test-utils/src/lib.rs:510:72:
called `Result::unwrap()` on an `Err` value: failed to discover dendrite port from files in /var/folders/xd/7vkl5j810pj33j25vw5cmfjr0000gn/T/.tmpN3KcKU

Caused by:
    0: time out while discovering dendrite port number
    1: deadline has elapsed
```

After incorporating this [script](https://gist.github.com/david-crespo/d8aa7ea1afb877ff585e6ad90fc5bc2c) and debugging with @david-crespo, I observed issues with how the dpd path and how ci_download_maghemite_mgd was handling the unsupported case. 

The samael issue/fix with pkg_config_path and libxml2 seems like a known thing on OSX. 

### Related PRs/Issues

- https://github.com/oxidecomputer/omicron/issues/4333
- https://github.com/oxidecomputer/omicron/issues/3938