### PR TITLE
fix `clippy::redundant_closure_call` warning

### DIFF
--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -667,7 +667,7 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
     ) -> impl IntoIterator<Item = KvListWithHeading> {
         macro_rules! diff_row {
             ($member:ident, $label:expr) => {
-                diff_row!($member, $label, |value| value)
+                diff_row!($member, $label, std::convert::identity)
             };
 
             ($member:ident, $label:expr, $display:expr) => {


### PR DESCRIPTION
The `diff_row!` macro in `blueprint_diff.rs` has recently started
generating [`clippy::redundant_closure_call`][1] warnings, as
invocations without a `display` function pass in a closure that performs
an identity operation (e.g. just returns the value). Rather than
allowing the warning, which would also have been fine, I've changed this
arm of the macro to pass the named function `std::convert::identity`
instead, which is equivalent but eliminates the closure.

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call