### PR TITLE
add `oxlog services` to print filterable service names

### DIFF
--- a/dev-tools/oxlog/src/bin/oxlog.rs
+++ b/dev-tools/oxlog/src/bin/oxlog.rs
@@ -22,7 +22,7 @@ enum Commands {
 
     /// List logs for a given service
     Logs {
-        // The name of the zone
+        /// The name of the zone
         zone: String,
 
         /// The name of the service to list logs for
@@ -36,10 +36,13 @@ enum Commands {
         filter: FilterArgs,
     },
 
-    /// List the names of all services on the system, from the perspective of
-    /// oxlog. Use these names with `oxlog logs` to filter output to logs from a
+    /// List the names of all services in a zone, from the perspective of oxlog.
+    /// Use these names with `oxlog logs` to filter output to logs from a
     /// specific service.
-    Services,
+    Services {
+        /// The name of the zone
+        zone: String,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -130,7 +133,7 @@ fn main() -> Result<(), anyhow::Error> {
             }
             Ok(())
         }
-        Commands::Services => {
+        Commands::Services { zone } => {
             let zones = Zones::load()?;
 
             // We want all logs that exist, anywhere, so we can find their
@@ -142,13 +145,10 @@ fn main() -> Result<(), anyhow::Error> {
                 show_empty: true,
             };
 
-            // Collect a unique set of services, based on the logs in all zones
-            let services: BTreeSet<String> = zones
-                .zones
-                .keys()
-                .flat_map(|zone| zones.zone_logs(&zone, filter).into_iter())
-                .map(|(name, _)| name)
-                .collect();
+            // Collect a unique set of services, based on the logs in the
+            // specified zone
+            let services: BTreeSet<String> =
+                zones.zone_logs(&zone, filter).into_keys().collect();
 
             for svc in services {
                 println!("{}", svc);


### PR DESCRIPTION
`oxlog logs` can filter to logs from a specific service. This is convenient, but I wasn't sure what the name of the service was that I wanted to find.

I read the oxlog logic and came up with this command:

```
$ ./oxlog zones | xargs -n1 ./oxlog logs --current --archived | awk -F/ '{ print $NF }' | awk -F: '{ svc=$1; gsub(/^[^-]+-/, "", svc); print svc }' | sort -u
chrony-setup
cockroachdb
crucible-agent
crucible-downstairs
crucible-pantry
dendrite
illumos-propolis-server    <- note the error in my prefix-stripping, oops! should be propolis-server
internal_dns
lldpd
mg-ddm
mgd
mgs
nexus
ntp
opte-interface-setup
pumpkind
sled-agent
switch_zone_setup
tfport
uplink
wicketd
zone-network-setup
```

But that's a bit cumbersome I think, so this PR adds `oxlog services`, which generates the same list based on oxlog's own understanding of the service names:

```
$ ./oxlog services
chrony-setup
cockroachdb
crucible-agent
crucible-downstairs
crucible-pantry
dendrite
internal_dns
lldpd
mg-ddm
mgd
mgs
nexus
ntp
opte-interface-setup
propolis-server
pumpkind
sled-agent
switch_zone_setup
tfport
uplink
wicketd
zone-network-setup
```