### PR TITLE
Filter available artifacts by signing hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10906,6 +10906,7 @@ dependencies = [
  "crossterm",
  "expectorate",
  "futures",
+ "hex",
  "humantime",
  "indexmap 2.2.6",
  "indicatif",

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -1089,6 +1089,7 @@ mod test {
             git_commit: String::from("git_commit1"),
             name: String::from("name1"),
             version: String::from("version1"),
+            sign: None,
         };
         assert!(!builder
             .found_caboose_already(&bogus_baseboard, CabooseWhich::SpSlot0));
@@ -1155,6 +1156,7 @@ mod test {
                     git_commit: String::from("git_commit2"),
                     name: String::from("name2"),
                     version: String::from("version2"),
+                    sign: None,
                 },
             )
             .unwrap_err();

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -489,6 +489,7 @@ pub fn caboose(unique: &str) -> SpComponentCaboose {
         git_commit: format!("git_commit_{}", unique),
         name: format!("name_{}", unique),
         version: format!("version_{}", unique),
+        sign: None,
     }
 }
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -2611,6 +2611,9 @@
           },
           "version": {
             "type": "string"
+          },
+	  "sign": {
+	    "type": "string"
           }
         },
         "required": [

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1658,7 +1658,16 @@
             "items": {
               "$ref": "#/components/schemas/ArtifactHashId"
             }
-          }
+          },
+	  "sign": {
+	    "nullable": true,
+	    "type": "array",
+            "items": {
+               "type": "integer",
+               "format": "uint8",
+               "minimum": 0
+	    }
+	  }
         },
         "required": [
           "artifact_id",
@@ -2908,7 +2917,10 @@
           },
           "version": {
             "type": "string"
-          }
+          },
+	  "sign": {
+            "type": "string"
+	  }
         },
         "required": [
           "board",

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1441,40 +1441,16 @@ impl SpHandler for Handler {
             (SpComponent::ROT, b"NAME", _, _) => ROT_NAME,
             (SpComponent::ROT, b"VERS", 0, _) => ROT_VERS0,
             (SpComponent::ROT, b"VERS", 1, _) => ROT_VERS1,
+            // gimlet staging/devel hash
+            (SpComponent::ROT, b"SIGN", _, _) => &"11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
             (SpComponent::STAGE0, b"GITC", 0, false) => STAGE0_GITC0,
             (SpComponent::STAGE0, b"GITC", 1, false) => STAGE0_GITC1,
             (SpComponent::STAGE0, b"BORD", _, false) => STAGE0_BORD,
             (SpComponent::STAGE0, b"NAME", _, false) => STAGE0_NAME,
             (SpComponent::STAGE0, b"VERS", 0, false) => STAGE0_VERS0,
             (SpComponent::STAGE0, b"VERS", 1, false) => STAGE0_VERS1,
-            _ => return Err(SpError::NoSuchCabooseKey(key)),
-        };
-
-        buf[..val.len()].copy_from_slice(val);
-        Ok(val.len())
-    }
-
-    #[cfg(any(feature = "no-caboose", feature = "old-state"))]
-    fn get_component_caboose_value(
-        &mut self,
-        component: SpComponent,
-        slot: u16,
-        key: [u8; 4],
-        buf: &mut [u8],
-    ) -> std::result::Result<usize, SpError> {
-        let val = match (component, &key, slot) {
-            (SpComponent::SP_ITSELF, b"GITC", 0) => SP_GITC0,
-            (SpComponent::SP_ITSELF, b"GITC", 1) => SP_GITC1,
-            (SpComponent::SP_ITSELF, b"BORD", _) => SP_BORD,
-            (SpComponent::SP_ITSELF, b"NAME", _) => SP_NAME,
-            (SpComponent::SP_ITSELF, b"VERS", 0) => SP_VERS0,
-            (SpComponent::SP_ITSELF, b"VERS", 1) => SP_VERS1,
-            (SpComponent::ROT, b"GITC", 0) => ROT_GITC0,
-            (SpComponent::ROT, b"GITC", 1) => ROT_GITC1,
-            (SpComponent::ROT, b"BORD", _) => ROT_BORD,
-            (SpComponent::ROT, b"NAME", _) => ROT_NAME,
-            (SpComponent::ROT, b"VERS", 0) => ROT_VERS0,
-            (SpComponent::ROT, b"VERS", 1) => ROT_VERS1,
+            // gimlet staging/devel hash
+            (SpComponent::STAGE0, b"SIGN", _, false) => &"11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
             _ => return Err(SpError::NoSuchCabooseKey(key)),
         };
 

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -1171,12 +1171,16 @@ impl SpHandler for Handler {
             (SpComponent::ROT, b"NAME", _, _) => ROT_NAME,
             (SpComponent::ROT, b"VERS", 0, _) => ROT_VERS0,
             (SpComponent::ROT, b"VERS", 1, _) => ROT_VERS1,
+            // sidecar staging/devel hash
+            (SpComponent::ROT, b"SIGN", _, _) => &"1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
             (SpComponent::STAGE0, b"GITC", 0, false) => STAGE0_GITC0,
             (SpComponent::STAGE0, b"GITC", 1, false) => STAGE0_GITC1,
             (SpComponent::STAGE0, b"BORD", _, false) => STAGE0_BORD,
             (SpComponent::STAGE0, b"NAME", _, false) => STAGE0_NAME,
             (SpComponent::STAGE0, b"VERS", 0, false) => STAGE0_VERS0,
             (SpComponent::STAGE0, b"VERS", 1, false) => STAGE0_VERS1,
+            // sidecar staging/devel hash
+            (SpComponent::STAGE0, b"SIGN", _, false) => &"1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
             _ => return Err(SpError::NoSuchCabooseKey(key)),
         };
 

--- a/wicket/Cargo.toml
+++ b/wicket/Cargo.toml
@@ -17,6 +17,7 @@ ciborium.workspace = true
 clap.workspace = true
 crossterm.workspace = true
 futures.workspace = true
+hex.workspace = true
 humantime.workspace = true
 indexmap.workspace = true
 indicatif.workspace = true

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -31,7 +31,7 @@ pub enum Event {
     /// TUF repo artifacts unpacked by wicketd, and event reports
     ArtifactsAndEventReports {
         system_version: Option<SemverVersion>,
-        artifacts: Vec<ArtifactId>,
+        artifacts: Vec<(ArtifactId, Option<Vec<u8>>)>,
         event_reports: EventReportMap,
     },
 

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -1130,6 +1130,7 @@ fn append_caboose(
         git_commit,
         // Currently `name` is always the same as `board`, so we'll skip it.
         name: _,
+        sign,
         version,
     } = caboose;
     let label_style = style::text_label();
@@ -1151,6 +1152,16 @@ fn append_caboose(
         ]
         .into(),
     );
+    if let Some(s) = sign {
+        spans.push(
+            vec![
+                prefix.clone(),
+                Span::styled("Sign Hash: ", label_style),
+                Span::styled(s.clone(), ok_style),
+            ]
+            .into(),
+        );
+    }
     let mut version_spans =
         vec![prefix.clone(), Span::styled("Version: ", label_style)];
     version_spans.push(Span::styled(version, ok_style));

--- a/wicket/src/wicketd.rs
+++ b/wicket/src/wicketd.rs
@@ -449,7 +449,9 @@ impl WicketdManager {
                         let artifacts = rsp
                             .artifacts
                             .into_iter()
-                            .map(|artifact| artifact.artifact_id)
+                            .map(|artifact| {
+                                (artifact.artifact_id, artifact.sign)
+                            })
                             .collect();
                         let system_version = rsp.system_version;
                         let event_reports: EventReportMap = rsp.event_reports;

--- a/wicketd/src/artifacts/store.rs
+++ b/wicketd/src/artifacts/store.rs
@@ -44,12 +44,14 @@ impl WicketdArtifactStore {
         let artifacts = self.artifacts_with_plan.lock().unwrap();
         let artifacts = artifacts.as_ref()?;
         let system_version = artifacts.plan().system_version.clone();
+
         let artifact_ids = artifacts
             .by_id()
             .iter()
             .map(|(k, v)| InstallableArtifacts {
                 artifact_id: k.clone(),
                 installable: v.clone(),
+                sign: artifacts.rot_by_sign().get(&k).cloned(),
             })
             .collect();
         Some((system_version, artifact_ids))

--- a/wicketd/src/http_entrypoints.rs
+++ b/wicketd/src/http_entrypoints.rs
@@ -637,6 +637,7 @@ async fn put_repository(
 pub struct InstallableArtifacts {
     pub artifact_id: ArtifactId,
     pub installable: Vec<ArtifactHashId>,
+    pub sign: Option<Vec<u8>>,
 }
 
 /// The response to a `get_artifacts` call: the system version, and the list of


### PR DESCRIPTION
The artifact repository now allows multiple versions of the same artifact type signed with different keys but this isn't quite sufficent. Wicket still needs to know which version to display for updates. Make the signing information available to wicket for display artifact versions. This also makes it clear if the repository does not contain an image signed with the expected keys.