### PR TITLE
honor `XTASK_BIN` in `tools/install_*_prerequisites.sh`

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -85,6 +85,15 @@ function retry
   exit $retry_rc
 }
 
+function xtask
+{
+  if [ -z ${XTASK_BIN+x} ]; then
+    cargo xtask "$@"
+  else
+    "$XTASK_BIN" "$@"
+  fi
+}
+
 # Packages to be installed on all OSes:
 #
 # - libpq, the PostgreSQL client lib.
@@ -191,7 +200,7 @@ retry install_packages
 # - Packaging: When constructing packages on Helios, these utilities
 # are packaged into zones which may be launched by the sled agent.
 
-retry cargo xtask download \
+retry xtask download \
     cockroach \
     clickhouse \
     console \

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -84,6 +84,15 @@ function retry
   exit $retry_rc
 }
 
+function xtask
+{
+  if [ -z ${XTASK_BIN+x} ]; then
+    cargo xtask "$@"
+  else
+    "$XTASK_BIN" "$@"
+  fi
+}
+
 # Packages to be installed Helios:
 #
 # - libpq, the PostgreSQL client lib.
@@ -154,7 +163,7 @@ if [[ "${HOST_OS}" == "SunOS" ]]; then
     # Grab the SoftNPU machinery (ASIC simulator, scadm, P4 program, etc.)
     #
     # "cargo xtask virtual-hardware create" will use those to setup the softnpu zone
-    retry cargo xtask download softnpu
+    retry xtask download softnpu
 fi
 
 echo "All runner prerequisites installed successfully"


### PR DESCRIPTION
Merging #5482 introduced breakage I didn't account for: being able to run `install_runner_prerequisites.sh` without having Cargo available, which is used by the a4x2 testbed. This change introduces the `XTASK_BIN` environment variable which will be used instead of `cargo xtask` if set.

The companion PR in a4x2 is https://github.com/oxidecomputer/testbed/pull/49/files.

Tested that all these work:
- `./tools/install_builder_prerequisites.sh -y`
- `XTASK_BIN=target/debug/xtask ./tools/install_builder_prerequisites.sh -y` (after building xtask)
- `XTASK_BIN=target/debug/nonexistent-file ./tools/install_builder_prerequisites.sh -y` (correctly fails with ENOENT)