### PR TITLE
add tool for experimenting with argon2 hash parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,7 +5642,9 @@ dependencies = [
 name = "omicron-passwords"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "argon2",
+ "clap",
  "criterion",
  "omicron-workspace-hack",
  "rand 0.8.5",

--- a/dev-tools/xtask/src/external.rs
+++ b/dev-tools/xtask/src/external.rs
@@ -52,14 +52,17 @@ impl External {
         self
     }
 
-    pub fn exec(mut self, bin_target: impl AsRef<OsStr>) -> Result<()> {
-        let error = self
-            .command
-            .arg("--bin")
-            .arg(bin_target)
-            .arg("--")
-            .args(self.args)
-            .exec();
+    pub fn exec_example(self, example_target: impl AsRef<OsStr>) -> Result<()> {
+        self.exec_common("--example", example_target.as_ref())
+    }
+
+    pub fn exec_bin(self, bin_target: impl AsRef<OsStr>) -> Result<()> {
+        self.exec_common("--bin", bin_target.as_ref())
+    }
+
+    fn exec_common(mut self, kind: &'static str, target: &OsStr) -> Result<()> {
+        let error =
+            self.command.arg(kind).arg(target).arg("--").args(self.args).exec();
         Err(error).context("failed to exec `cargo run`")
     }
 }

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Cmds {
+    /// Run Argon2 hash with specific parameters (quick performance check)
+    Argon2(external::External),
+
     /// Check that dependencies are not duplicated in any packages in the
     /// workspace
     CheckWorkspaceDeps,
@@ -69,12 +72,15 @@ enum Cmds {
 async fn main() -> Result<()> {
     let args = Args::parse();
     match args.cmd {
+        Cmds::Argon2(external) => {
+            external.cargo_args(["--release"]).exec_example("argon2")
+        }
         Cmds::Clippy(args) => clippy::run_cmd(args),
         Cmds::CheckWorkspaceDeps => check_workspace_deps::run_cmd(),
         Cmds::Download(args) => download::run_cmd(args).await,
         #[cfg(target_os = "illumos")]
         Cmds::Releng(external) => {
-            external.cargo_args(["--release"]).exec("omicron-releng")
+            external.cargo_args(["--release"]).exec_bin("omicron-releng")
         }
         #[cfg(target_os = "illumos")]
         Cmds::VerifyLibraries(args) => verify_libraries::run_cmd(args),

--- a/passwords/Cargo.toml
+++ b/passwords/Cargo.toml
@@ -17,8 +17,13 @@ serde_with.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+# For tests
 argon2alt = { package = "rust-argon2", version = "2.1.0" }
+# For benchmark
 criterion.workspace = true
+# For the "argon2" example
+anyhow.workspace = true
+clap.workspace = true
 
 [[bench]]
 name = "argon2"

--- a/passwords/examples/argon2.rs
+++ b/passwords/examples/argon2.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Command-line tool for playing with Argon2 parameters
+
+use anyhow::Context;
+use argon2::Algorithm;
+use argon2::Argon2;
+use argon2::Params;
+use argon2::Version;
+use clap::Parser;
+use omicron_passwords::Hasher;
+use omicron_passwords::Password;
+use omicron_passwords::ARGON2_COST_M_KIB;
+use omicron_passwords::ARGON2_COST_P;
+use omicron_passwords::ARGON2_COST_T;
+
+/// Quickly check performance of Argon2 hashing with given parameter values
+///
+/// For a bit more stats, modify the associated benchmark to use your values and
+/// run that.  This tool is aimed at more quickly iterating on which values are
+/// worth benchmarking.
+#[derive(Parser)]
+struct Cli {
+    /// iterations
+    #[arg(long, default_value_t = 5)]
+    count: u128,
+    /// input (password) to hash
+    #[arg(long, default_value_t = String::from("hunter2"))]
+    input: String,
+    /// argon2 parameter 'm': memory size in 1 KiB blocks
+    #[arg(long, default_value_t = ARGON2_COST_M_KIB)]
+    m_cost: u32,
+    /// argon2 parameter 'p': degree of parallelism
+    #[arg(long, default_value_t = ARGON2_COST_P)]
+    p_cost: u32,
+    /// argon2 parameter 't': number of iterations
+    #[arg(long, default_value_t = ARGON2_COST_T)]
+    t_cost: u32,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    const ALGORITHM: Algorithm = Algorithm::Argon2id;
+    let version = Version::default();
+    const OUTPUT_SIZE_OVERRIDE: Option<usize> = None;
+    let params =
+        Params::new(cli.m_cost, cli.t_cost, cli.p_cost, OUTPUT_SIZE_OVERRIDE)
+            .context("unsupported Argon2 parameters")?;
+    let argon = Argon2::new(ALGORITHM, version, params);
+    let mut hasher = Hasher::new(argon.clone(), rand::thread_rng());
+    let password = Password::new(&cli.input).unwrap();
+    let password_hash = hasher.create_password(&password).unwrap();
+
+    println!("algorithm:  {} version {:?}", ALGORITHM, version);
+    println!("  'm' cost: {} KiB", cli.m_cost);
+    println!("  'p' cost: {} (degree of parallelism)", cli.p_cost);
+    println!("  't' cost: {} (number of iterations)", cli.t_cost);
+    println!(
+        "output size override: {}",
+        OUTPUT_SIZE_OVERRIDE
+            .map(|s| s.to_string())
+            .as_deref()
+            .unwrap_or("none")
+    );
+    println!("trials: {}", cli.count);
+
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "WARN: running a debug binary \
+            (performance numbers are not meaningful)"
+        );
+    }
+
+    let start = std::time::Instant::now();
+    for i in 0..cli.count {
+        eprint!("iter {} ... ", i + 1);
+        let iter_start = std::time::Instant::now();
+        hasher.verify_password(&password, &password_hash).unwrap();
+        let iter_elapsed = iter_start.elapsed();
+        eprintln!("{} ms", iter_elapsed.as_millis());
+    }
+
+    let total_elapsed = start.elapsed();
+    println!(
+        "completed {} iteration{} in {} ms (average: {} ms per iteration)",
+        cli.count,
+        if cli.count == 1 { "" } else { "s" },
+        total_elapsed.as_millis(),
+        total_elapsed.as_millis() / cli.count,
+    );
+
+    Ok(())
+}

--- a/passwords/src/lib.rs
+++ b/passwords/src/lib.rs
@@ -33,9 +33,9 @@ use thiserror::Error;
 // values (provided by the `argon2` crate) for the version, salt length, and
 // output length.
 const ARGON2_ALGORITHM: argon2::Algorithm = argon2::Algorithm::Argon2id;
-const ARGON2_COST_M_KIB: u32 = 96 * 1024;
-const ARGON2_COST_T: u32 = 13;
-const ARGON2_COST_P: u32 = 1;
+pub const ARGON2_COST_M_KIB: u32 = 96 * 1024;
+pub const ARGON2_COST_T: u32 = 13;
+pub const ARGON2_COST_P: u32 = 1;
 
 // Maximum password length, intended to prevent denial of service attacks.  See
 // CVE-2013-1443, CVE-2014-9016, and CVE-2014-9034 for examples.


### PR DESCRIPTION
I had this sitting around from last time we were tweaking the argon2 hash parameters.  I figured it was worth having something in the repo for this.  It's quite simple but without this you have to recompile every time you want to try a different set of parameters.