### PR TITLE
[nexus] Put a `SagaContext` in a once cell

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -669,6 +669,12 @@ impl Nexus {
             Arc::clone(&background_tasks),
         );
 
+        // Initialize a global `SagaContext`. This provides access to
+        // background tasks.
+        saga_interface::SAGA_CONTEXT
+            .set(saga_context.clone())
+            .expect("SAGA_CONTEXT already initialized");
+
         let nexus = Nexus {
             id: config.deployment.id,
             rack_id,

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -16,6 +16,11 @@ use nexus_db_queries::{authz, db};
 use slog::Logger;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::OnceLock;
+
+/// Callers that want to execute a saga can clone a context from here,  and
+/// modify the logger if desired.
+pub static SAGA_CONTEXT: OnceLock<SagaContext> = OnceLock::new();
 
 /// A type accessible to all saga methods
 #[derive(Clone)]


### PR DESCRIPTION
This allows the ability to run sagas from background tasks. The `SagaContext` already has a copy of an `Arc<BackgroundTasks>` which means that individual background tasks must have been created/ initialized before the `SagaContext`. We get around this build time circular dependency by putting the `SagaContext` inside a static `OnceCell` where the background tasks can access it at runtime.

Builds upon #5856