### PR TITLE
only unset xtrace if env.sh set it first

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -4,11 +4,16 @@
 #
 # See also: ./.envrc
 
+OLD_SHELL_OPTS=$-
 set -o xtrace
-OMICRON_WS="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
+OMICRON_WS=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 export PATH="$OMICRON_WS/out/cockroachdb/bin:$PATH"
 export PATH="$OMICRON_WS/out/clickhouse:$PATH"
 export PATH="$OMICRON_WS/out/dendrite-stub/bin:$PATH"
 export PATH="$OMICRON_WS/out/mgd/root/opt/oxide/mgd/bin:$PATH"
-unset OMICRON_WS
-set +o xtrace
+# if xtrace was set previously, do not unset it
+case $OLD_SHELL_OPTS in
+    *x*) ;;
+    *) set +o xtrace ;;
+esac
+unset OLD_SHELL_OPTS OMICRON_WS

--- a/env.sh
+++ b/env.sh
@@ -6,14 +6,20 @@
 
 OLD_SHELL_OPTS=$-
 set -o xtrace
+
 OMICRON_WS=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 export PATH="$OMICRON_WS/out/cockroachdb/bin:$PATH"
 export PATH="$OMICRON_WS/out/clickhouse:$PATH"
 export PATH="$OMICRON_WS/out/dendrite-stub/bin:$PATH"
 export PATH="$OMICRON_WS/out/mgd/root/opt/oxide/mgd/bin:$PATH"
+
 # if xtrace was set previously, do not unset it
 case $OLD_SHELL_OPTS in
-    *x*) ;;
-    *) set +o xtrace ;;
+    *x*)
+        unset OLD_SHELL_OPTS OMICRON_WS
+        ;;
+    *)
+        unset OLD_SHELL_OPTS OMICRON_WS
+        set +o xtrace
+        ;;
 esac
-unset OLD_SHELL_OPTS OMICRON_WS


### PR DESCRIPTION
I noticed that the Buildomat logs for some of our tests didn't have execution tracing, despite `set -o xtrace` at the top of their scripts! Turns out env.sh was the cause.

Despite this script being Bash-specific (`$BASH_SOURCE`) I went with a POSIXy implementation here.

(Also fixed quoting, in case your checkout is within a directory path containing spaces.)