### PR TITLE
Fix underflow in wicket in a cross-screen interaction

### DIFF
--- a/wicket/src/state/rack.rs
+++ b/wicket/src/state/rack.rs
@@ -102,13 +102,8 @@ impl RackState {
     pub fn left_or_right(&mut self) {
         match self.selected {
             ComponentId::Sled(i) => {
-                if self.left_column {
-                    self.left_column = false;
-                    self.selected = ComponentId::Sled(i + 1);
-                } else {
-                    self.left_column = true;
-                    self.selected = ComponentId::Sled(i - 1);
-                }
+                self.selected = ComponentId::Sled(i ^ 1);
+                self.set_column();
             }
             _ => (),
         }


### PR DESCRIPTION
Closes #5877 (see https://github.com/oxidecomputer/omicron/issues/5877#issuecomment-2163349194 for the reproduction steps)