### PR TITLE
Fix "project" (silo) IP pool view perms for non-admins

### DIFF
--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -101,10 +101,16 @@ impl super::Nexus {
     ) -> LookupResult<(db::model::IpPool, db::model::IpPoolResource)> {
         let (authz_pool, pool) = self
             .ip_pool_lookup(opctx, pool)?
-            // TODO: This is a smell. This works because it is the permission
-            // for allocating IPs from a pool, which any authenticated user has.
-            // But what we really want to say is that any authenticated user has
-            // actual Read permission on any IP pool linked to their silo.
+            // TODO-robustness: https://github.com/oxidecomputer/omicron/issues/3995
+            // Checking CreateChild works because it is the permission for
+            // allocating IPs from a pool, which any authenticated user has.
+            // But what we really want to say is that any authenticated user
+            // has actual Read permission on any IP pool linked to their silo.
+            // Instead we are backing into this with the next line: never fail
+            // this auth check as long as you're authed, then 404 if unlinked.
+            // This is not a correctness issue per se because the logic as-is is
+            // correct. The main problem is that it is fiddly to get right and
+            // has to be done manually each time.
             .fetch_for(authz::Action::CreateChild)
             .await?;
 

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -99,8 +99,14 @@ impl super::Nexus {
         opctx: &'a OpContext,
         pool: &'a NameOrId,
     ) -> LookupResult<(db::model::IpPool, db::model::IpPoolResource)> {
-        let (authz_pool, pool) =
-            self.ip_pool_lookup(opctx, pool)?.fetch().await?;
+        let (authz_pool, pool) = self
+            .ip_pool_lookup(opctx, pool)?
+            // TODO: This is a smell. This works because it is the permission
+            // for allocating IPs from a pool, which any authenticated user has.
+            // But what we really want to say is that any authenticated user has
+            // actual Read permission on any IP pool linked to their silo.
+            .fetch_for(authz::Action::CreateChild)
+            .await?;
 
         // 404 if no link is found in the current silo
         let link = self.db_datastore.ip_pool_fetch_link(opctx, pool.id()).await;


### PR DESCRIPTION
Closes #5883

Authz for IP pools is undercooked. Every user has `CreateChild` on them so they can allocate IPs, but they generally don't have `Read` on them unless they're a fleet viewer. Ideally, we'd be able to say "you have `Read` on an IP pool if it is linked to your silo", but I don't know how to express that relationship with polar (plus it requires a join to the silo-pool links table to tell).

Update: after [discussing](https://matrix.to/#/!YNYPOVxjAUeXksTcRj:oxide.computer/$XTbZiYkEFRKWHwe6XSVivBrqiWWl_z25u2_TcjwRohE?via=oxide.computer&via=unix.house&via=matrix.org) this with @davepacheco in chat, we agreed on a direction but also agreed it might be fairly complicated. Based on that, I think it would be most expedient to 

1. Merge this fix as-is (with a link to https://github.com/oxidecomputer/omicron/issues/3995, which I forgot I had made 10 months ago 😢)
2. Update #3995 with more details from the chat