### PR TITLE
quiesce log rotation at the end of the deploy job

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -30,9 +30,15 @@ set -o xtrace
 #
 _exit_trap() {
 	local status=$?
+	set +o errexit
+
+	#
+	# Stop cron in all zones (to stop logadm log rotation)
+	#
+	svcadm -Z disable -s cron
+
 	[[ $status -eq 0 ]] && exit 0
 
-	set +o errexit
 	set -o xtrace
 	banner evidence
 	zoneadm list -civ

--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -35,7 +35,7 @@ _exit_trap() {
 	#
 	# Stop cron in all zones (to stop logadm log rotation)
 	#
-	svcadm -Z disable -s cron
+	pfexec svcadm -Z disable -s cron
 
 	[[ $status -eq 0 ]] && exit 0
 


### PR DESCRIPTION
@smklein reported [a job](https://buildomat.eng.oxide.computer/wg/0/details/01J07HSDXW6AATXK8XMWXRZ0QH/vgNrVjB0enc9YwXphv869uvx7MO6IpiCTmceCREdSDpDcbl6/01J07HSRTJN8WH86VMCW62HBMJ) where the vast majority of uploaded logs were zero bytes. The root crontab runs logadm in all zones at 0, 15, 30, and 45 past the hour:

https://github.com/oxidecomputer/omicron/blob/306b76743de056567f97582be4575f1cf1ccfa0f/smf/logadm/crontab.root#L1

Buildomat searched for files to upload at 01:59:34, and logadm rotated the log files at around 02:00:00. Oops!

This change adds `svcadm -Z disable -s cron` to the function that runs at exit in our job, regardless of whether the job succeeded or failed. This stops cron from running logadm, which stops log files from being rotated.

This _doesn't_ stop sled-agent from archiving the log files from out of the zones and into `/pool/ext/*/crypt/debug`; we may also want to stop sled-agent here? Unsure.