### PR TITLE
Only apply external IP allowlist to Nexus

### DIFF
--- a/nexus/db-fixed-data/src/vpc_firewall_rule.rs
+++ b/nexus/db-fixed-data/src/vpc_firewall_rule.rs
@@ -33,10 +33,17 @@ pub static DNS_VPC_FW_RULE: Lazy<VpcFirewallRuleUpdate> =
         priority: VpcFirewallRulePriority(65534),
     });
 
+/// The name for the built-in VPC firewall rule for Nexus.
+pub const NEXUS_VPC_FW_RULE_NAME: &str = "nexus-inbound";
+
 /// Built-in VPC firewall rule for Nexus.
+///
+/// Note that we currently rely on this being exactly one rule to implement the
+/// Nexus allowlist. See `nexus/networking/src/firewall_rules.rs` for more
+/// details.
 pub static NEXUS_VPC_FW_RULE: Lazy<VpcFirewallRuleUpdate> =
     Lazy::new(|| VpcFirewallRuleUpdate {
-        name: "nexus-inbound".parse().unwrap(),
+        name: NEXUS_VPC_FW_RULE_NAME.parse().unwrap(),
         description:
             "allow inbound connections for console & api from anywhere"
                 .to_string(),

--- a/nexus/db-model/src/allow_list.rs
+++ b/nexus/db-model/src/allow_list.rs
@@ -44,7 +44,7 @@ impl AllowList {
         Self { id, time_created: now, time_modified: now, allowed_ips }
     }
 
-    /// Create an `AllowedSourceIps` type from the contained address.
+    /// Create an `AllowedSourceIps` type from the contained addresses.
     pub fn allowed_source_ips(
         &self,
     ) -> Result<external::AllowedSourceIps, Error> {


### PR DESCRIPTION
- Fixes #5892
- Modifies the application of the external services IP allowlist so that it's only relevant for Nexus API servers, rather than all external-facing services (DNS being the other example today). It is not always possible to know the peer addresses for DNS servers in the case of recursive DNS, and so the allowlist cannot directly apply to external DNS. This works by inserting the allowlist entries as a host-filter, which we were doing before, but only on the named VPC Firewall rule for the Nexus VPC Subnet.