### PR TITLE
Fix clippy::needless_update lint

### DIFF
--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1359,7 +1359,6 @@ mod tests {
                     propolis_id: Some(active_vmm.id),
                     dst_propolis_id: Some(target_vmm.id),
                     migration_id: Some(migration.id),
-                    ..snapshot.instance.runtime_state.clone()
                 },
             )
             .await


### PR DESCRIPTION
This lint was introduced while merging #5980. Because the `updater_id` and `updater_gen` fields are no longer part of `InstanceRuntimeState`, the struct update syntax now doesn't provide any fields and Clippy asks us to remove it.