### PR TITLE
400 instead of 500 on duplicate firewall rule names

### DIFF
--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -14,7 +14,6 @@ use nexus_types::identity::Resource;
 use omicron_common::api::external;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::json;
 use std::collections::HashSet;
 use std::io::Write;
 use uuid::Uuid;
@@ -279,14 +278,16 @@ fn ensure_no_duplicates(
         }
     }
 
-    if !dupes.is_empty() {
-        return Err(external::Error::invalid_value(
-            "rules",
-            format!("Rule names must be unique. Duplicates: {}", json!(dupes)),
-        ));
+    if dupes.is_empty() {
+        return Ok(());
     }
 
-    Ok(())
+    let dupes_str =
+        dupes.iter().map(|d| format!("\"{d}\"")).collect::<Vec<_>>().join(", ");
+    return Err(external::Error::invalid_value(
+        "rules",
+        format!("Rule names must be unique. Duplicates: [{}]", dupes_str),
+    ));
 }
 
 impl Into<external::VpcFirewallRule> for VpcFirewallRule {

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -179,7 +179,8 @@ impl super::Nexus {
         let rules = db::model::VpcFirewallRule::vec_from_params(
             authz_vpc.id(),
             params.clone(),
-        );
+        )?;
+
         let rules = self
             .db_datastore
             .vpc_update_firewall_rules(opctx, &authz_vpc, rules)
@@ -199,7 +200,7 @@ impl super::Nexus {
         let mut rules = db::model::VpcFirewallRule::vec_from_params(
             vpc_id,
             defaults::DEFAULT_FIREWALL_RULES.clone(),
-        );
+        )?;
         for rule in rules.iter_mut() {
             for target in rule.targets.iter_mut() {
                 match target.0 {


### PR DESCRIPTION
Closes #5725

This does the check in a helper function in the model file, which feels appropriate. I wasn't sure about raising external API validation errors from the model file, but we do that in a bunch of places:

```console
$ rg 'external::Error' nexus/db-model
nexus/db-model/src/allow_list.rs
17:use omicron_common::api::external::Error;

nexus/db-model/src/role_assignment.rs
9:use omicron_common::api::external::Error;

nexus/db-model/src/ipv6.rs
17:use omicron_common::api::external::Error;

nexus/db-model/src/saga_types.rs
21:use omicron_common::api::external::Error;

nexus/db-model/src/vpc_subnet.rs
76:    ) -> Result<(), external::Error> {
81:        .map_err(|e| external::Error::invalid_request(e.to_string()))

... there were a bunch more
```