### PR TITLE
BUGFIX: use sled filter to apply v2p mappings

### DIFF
--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -290,6 +290,7 @@ Options:
             for discretionary services)
           - query-during-inventory: Sleds whose sled agents should be queried for inventory
           - reservation-create:     Sleds on which reservations can be created
+          - v2p-mapping:            Sleds which should be sent OPTE V2P mappings
           - vpc-firewall:           Sleds which should be sent VPC firewall rules
 
       --log-level <LOG_LEVEL>

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -286,17 +286,6 @@ table! {
 }
 
 table! {
-    v2p_mapping_view (nic_id) {
-        nic_id -> Uuid,
-        sled_id -> Uuid,
-        sled_ip -> Inet,
-        vni -> Int4,
-        mac -> Int8,
-        ip -> Inet,
-    }
-}
-
-table! {
     bgp_announce_set (id) {
         id -> Uuid,
         name -> Text,
@@ -1842,6 +1831,7 @@ allow_tables_to_appear_in_same_query!(
     user_builtin,
     role_builtin,
     role_assignment,
+    probe,
 );
 
 allow_tables_to_appear_in_same_query!(dns_zone, dns_version, dns_name);
@@ -1870,3 +1860,5 @@ joinable!(instance_ssh_key -> ssh_key (ssh_key_id));
 joinable!(instance_ssh_key -> instance (instance_id));
 
 allow_tables_to_appear_in_same_query!(sled, sled_instance);
+
+joinable!(network_interface -> probe (parent_id));

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(76, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(77, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(77, "remove-view-for-v2p-mappings"),
         KnownVersion::new(76, "lookup-region-snapshot-by-snapshot-id"),
         KnownVersion::new(75, "add-cockroach-zone-id-to-node-id"),
         KnownVersion::new(74, "add-migration-table"),

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -44,7 +44,7 @@ pub struct SledSystemHardware {
 #[diesel(table_name = sled)]
 pub struct Sled {
     #[diesel(embed)]
-    identity: SledIdentity,
+    pub identity: SledIdentity,
     time_deleted: Option<DateTime<Utc>>,
     pub rcgen: Generation,
 

--- a/nexus/db-model/src/v2p_mapping.rs
+++ b/nexus/db-model/src/v2p_mapping.rs
@@ -1,15 +1,17 @@
-use crate::schema::v2p_mapping_view;
-use crate::{MacAddr, Vni};
+use crate::{Ipv6Addr, MacAddr, Vni};
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Queryable, Selectable, Clone, Debug, Serialize, Deserialize)]
-#[diesel(table_name = v2p_mapping_view)]
+/// This is not backed by an actual database view,
+/// but it is still essentially a "view" in the sense
+/// that it is a read-only data model derived from
+/// multiple db tables
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct V2PMappingView {
     pub nic_id: Uuid,
     pub sled_id: Uuid,
-    pub sled_ip: IpNetwork,
+    pub sled_ip: Ipv6Addr,
     pub vni: Vni,
     pub mac: MacAddr,
     pub ip: IpNetwork,

--- a/nexus/db-queries/src/db/datastore/v2p_mapping.rs
+++ b/nexus/db-queries/src/db/datastore/v2p_mapping.rs
@@ -76,13 +76,15 @@ impl DataStore {
                 .await
                 .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?
                 .into_iter()
-                .map(|i: (NetworkInterface, Sled, Vpc)| V2PMappingView {
-                    nic_id: i.0.identity.id,
-                    sled_id: i.1.identity.id,
-                    sled_ip: i.1.ip,
-                    vni: i.2.vni,
-                    mac: i.0.mac,
-                    ip: i.0.ip,
+                .map(|(nic, sled, vpc): (NetworkInterface, Sled, Vpc)| {
+                    V2PMappingView {
+                        nic_id: nic.identity.id,
+                        sled_id: sled.identity.id,
+                        sled_ip: sled.ip,
+                        vni: vpc.vni,
+                        mac: nic.mac,
+                        ip: nic.ip,
+                    }
                 })
                 .collect();
 
@@ -124,13 +126,15 @@ impl DataStore {
                 .await
                 .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?
                 .into_iter()
-                .map(|i: (NetworkInterface, Sled, Vpc)| V2PMappingView {
-                    nic_id: i.0.identity.id,
-                    sled_id: i.1.identity.id,
-                    sled_ip: i.1.ip,
-                    vni: i.2.vni,
-                    mac: i.0.mac,
-                    ip: i.0.ip,
+                .map(|(nic, sled, vpc): (NetworkInterface, Sled, Vpc)| {
+                    V2PMappingView {
+                        nic_id: nic.identity.id,
+                        sled_id: sled.identity.id,
+                        sled_ip: sled.ip,
+                        vni: vpc.vni,
+                        mac: nic.mac,
+                        ip: nic.ip,
+                    }
                 })
                 .collect();
 

--- a/nexus/src/app/background/v2p_mappings.rs
+++ b/nexus/src/app/background/v2p_mappings.rs
@@ -74,28 +74,13 @@ impl BackgroundTask for V2PManager {
             // create a set of updates from the v2p mappings
             let desired_v2p: HashSet<_> = v2p_mappings
                 .into_iter()
-                .filter_map(|mapping| {
-                    let physical_host_ip = match mapping.sled_ip.ip() {
-                        std::net::IpAddr::V4(v) => {
-                            // sled ip should never be ipv4
-                            error!(
-                                &log,
-                                "sled ip should be ipv6 but is ipv4: {v}"
-                            );
-                            return None;
-                        }
-                        std::net::IpAddr::V6(v) => v,
-                    };
-
-                    let vni = mapping.vni.0;
-
-                    let mapping = VirtualNetworkInterfaceHost {
+                .map(|mapping| {
+                    VirtualNetworkInterfaceHost {
                         virtual_ip: mapping.ip.ip(),
                         virtual_mac: *mapping.mac,
-                        physical_host_ip,
-                        vni,
-                    };
-                    Some(mapping)
+                        physical_host_ip: *mapping.sled_ip,
+                        vni: mapping.vni.0,
+                    }
                 })
                 .collect();
 

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -482,6 +482,9 @@ pub enum SledFilter {
     /// Sleds on which reservations can be created.
     ReservationCreate,
 
+    /// Sleds which should be sent OPTE V2P mappings.
+    V2PMapping,
+
     /// Sleds which should be sent VPC firewall rules.
     VpcFirewall,
 }
@@ -536,6 +539,7 @@ impl SledPolicy {
                 SledFilter::InService => true,
                 SledFilter::QueryDuringInventory => true,
                 SledFilter::ReservationCreate => true,
+                SledFilter::V2PMapping => true,
                 SledFilter::VpcFirewall => true,
             },
             SledPolicy::InService {
@@ -547,6 +551,7 @@ impl SledPolicy {
                 SledFilter::InService => true,
                 SledFilter::QueryDuringInventory => true,
                 SledFilter::ReservationCreate => false,
+                SledFilter::V2PMapping => true,
                 SledFilter::VpcFirewall => true,
             },
             SledPolicy::Expunged => match filter {
@@ -556,6 +561,7 @@ impl SledPolicy {
                 SledFilter::InService => false,
                 SledFilter::QueryDuringInventory => false,
                 SledFilter::ReservationCreate => false,
+                SledFilter::V2PMapping => false,
                 SledFilter::VpcFirewall => false,
             },
         }
@@ -587,6 +593,7 @@ impl SledState {
                 SledFilter::InService => true,
                 SledFilter::QueryDuringInventory => true,
                 SledFilter::ReservationCreate => true,
+                SledFilter::V2PMapping => true,
                 SledFilter::VpcFirewall => true,
             },
             SledState::Decommissioned => match filter {
@@ -596,6 +603,7 @@ impl SledState {
                 SledFilter::InService => false,
                 SledFilter::QueryDuringInventory => false,
                 SledFilter::ReservationCreate => false,
+                SledFilter::V2PMapping => false,
                 SledFilter::VpcFirewall => false,
             },
         }

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3891,53 +3891,6 @@ ON omicron.public.switch_port (port_settings_id, port_name) STORING (switch_loca
 
 CREATE INDEX IF NOT EXISTS switch_port_name ON omicron.public.switch_port (port_name);
 
-COMMIT;
-BEGIN;
-
--- view for v2p mapping rpw
-CREATE VIEW IF NOT EXISTS omicron.public.v2p_mapping_view
-AS
-WITH VmV2pMappings AS (
-  SELECT
-    n.id as nic_id,
-    s.id as sled_id,
-    s.ip as sled_ip,
-    v.vni,
-    n.mac,
-    n.ip
-  FROM omicron.public.network_interface n
-  JOIN omicron.public.vpc_subnet vs ON vs.id = n.subnet_id
-  JOIN omicron.public.vpc v ON v.id = n.vpc_id
-  JOIN omicron.public.vmm vmm ON n.parent_id = vmm.instance_id
-  JOIN omicron.public.sled s ON vmm.sled_id = s.id
-  WHERE n.time_deleted IS NULL
-  AND n.kind = 'instance'
-  AND (vmm.state = 'running' OR vmm.state = 'starting')
-  AND s.sled_policy = 'in_service'
-  AND s.sled_state = 'active'
-),
-ProbeV2pMapping AS (
-  SELECT
-    n.id as nic_id,
-    s.id as sled_id,
-    s.ip as sled_ip,
-    v.vni,
-    n.mac,
-    n.ip
-  FROM omicron.public.network_interface n
-  JOIN omicron.public.vpc_subnet vs ON vs.id = n.subnet_id
-  JOIN omicron.public.vpc v ON v.id = n.vpc_id
-  JOIN omicron.public.probe p ON n.parent_id = p.id
-  JOIN omicron.public.sled s ON p.sled = s.id
-  WHERE n.time_deleted IS NULL
-  AND n.kind = 'probe'
-  AND s.sled_policy = 'in_service'
-  AND s.sled_state = 'active'
-)
-SELECT nic_id, sled_id, sled_ip, vni, mac, ip FROM VmV2pMappings
-UNION
-SELECT nic_id, sled_id, sled_ip, vni, mac, ip FROM ProbeV2pMapping;
-
 CREATE INDEX IF NOT EXISTS network_interface_by_parent
 ON omicron.public.network_interface (parent_id)
 STORING (name, kind, vpc_id, subnet_id, mac, ip, slot);
@@ -4145,7 +4098,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '76.0.0', NULL)
+    (TRUE, NOW(), NOW(), '77.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/remove-view-for-v2p-mappings/up01.sql
+++ b/schema/crdb/remove-view-for-v2p-mappings/up01.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS omicron.public.v2p_mapping_view;


### PR DESCRIPTION
It has been reported that marking a sled as "non_provisionable" causes it to lose the instance v2p mappings. This is a regression. It was determined that the scoping of the mappings is too strict, relying on the sled_policy to be set to "in service" via the db view.

The preferred option is to rely on the sled policy machinery to do the filtering for us, so the view has been removed and the querying logic updated accordingly.

Also, based on a comment in a previous related PR, we are now selecting target sleds for instances using the active_propolis_id to avoid potential conflicts during live migrations.

## Related
---
#5872 