### PR TITLE
Increase default session timeout to 8 hours idle, 24 hours absolute

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -5,7 +5,7 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "out/console-assets"
-session_idle_timeout_minutes = 480      # 6 hours
+session_idle_timeout_minutes = 480 # 8 hours
 session_absolute_timeout_minutes = 1440 # 24 hours
 
 # List of authentication schemes to support.

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -5,8 +5,8 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "tests/static"
-session_idle_timeout_minutes = 60
-session_absolute_timeout_minutes = 480
+session_idle_timeout_minutes = 480 # 8 hours
+session_absolute_timeout_minutes = 1440 # 24 hours
 
 # List of authentication schemes to support.
 [authn]

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -892,7 +892,7 @@ async fn log_in_and_extract_token(
     let (session_token, rest) = session_cookie.split_once("; ").unwrap();
 
     assert!(session_token.starts_with("session="));
-    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=28800");
+    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=86400");
 
     session_token.to_string()
 }

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -447,7 +447,7 @@ async fn expect_login_success(
         .split_once("; ")
         .expect("session cookie: bad cookie header value (missing semicolon)");
     assert!(token_cookie.starts_with("session="));
-    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=28800");
+    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=86400");
     let (_, session_token) = token_cookie
         .split_once('=')
         .expect("session cookie: bad cookie header value (missing 'session=')");

--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -5,8 +5,8 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "/var/nexus/static"
-session_idle_timeout_minutes = 60
-session_absolute_timeout_minutes = 480
+session_idle_timeout_minutes = 480 # 8 hours
+session_absolute_timeout_minutes = 1440 # 24 hours
 
 [authn]
 schemes_external = ["session_cookie", "access_token"]

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -5,8 +5,8 @@
 [console]
 # Directory for static assets. Absolute path or relative to CWD.
 static_dir = "/var/nexus/static"
-session_idle_timeout_minutes = 60
-session_absolute_timeout_minutes = 480
+session_idle_timeout_minutes = 480 # 8 hours
+session_absolute_timeout_minutes = 1440 # 24 hours
 
 [authn]
 schemes_external = ["session_cookie", "access_token"]


### PR DESCRIPTION
We want to make the values configurable (#5477), but in the meantime we can improve the user experience substantially by increasing the hard-coded values so people get logged out less often. I picked 8 hours/24 hours so that someone could log in in the morning and stay logged in all day.

It's worth noting that there are no deleterious effects if the IdP's own session timeout is less than ours as long as the customer is willing to accept the longer console session. It just means that whenever the user gets logged out of the console and wants to log back in, they may have to also complete the login step in their IdP.