### PR TITLE
Add tests for ClickHouse schema upgrades

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -4381,8 +4381,8 @@ mod tests {
         // the direct path.
         let extra_keys: Vec<_> = tables_through_upgrades
             .keys()
+            .filter(|k| !tables.contains_key(k.as_str()))
             .cloned()
-            .filter(|k| !tables.contains_key(k))
             .collect();
         assert!(
             extra_keys.is_empty(),
@@ -4400,7 +4400,7 @@ mod tests {
         client: &Client,
     ) -> BTreeMap<String, serde_json::Map<String, serde_json::Value>> {
         let out = client
-            .execute_with_body(format!(
+            .execute_with_body(
                 "SELECT \
                 name,
                 engine_full,
@@ -4409,8 +4409,8 @@ mod tests {
                 primary_key
             FROM system.tables \
             WHERE database = 'oximeter'\
-            FORMAT JSONEachRow;"
-            ))
+            FORMAT JSONEachRow;",
+            )
             .await
             .unwrap()
             .1;


### PR DESCRIPTION
- Adds a check that verifies the SQL contained in each upgrade. This does the basic sanity checks like: one statement per file, no data modifications, but doesn't actually apply the upgrades.
- Adds another test that ensures that the set of tables we arrive at either by upgrading or directly initializing the latest database version are the same.