### PR TITLE
better abstract Nexus saga execution subsystem

### DIFF
--- a/nexus/db-queries/src/db/sec_store.rs
+++ b/nexus/db-queries/src/db/sec_store.rs
@@ -87,7 +87,7 @@ impl steno::SecStore for CockroachDbSecStore {
                 // At a higher level, callers should plan for the fact that
                 // record_event could potentially loop forever. See
                 // https://github.com/oxidecomputer/omicron/issues/5406 and the
-                // note in `nexus/src/app/saga.rs`'s `execute_saga` for more
+                // note in `nexus/src/app/saga.rs`'s `saga_execute` for more
                 // details.
                 self.datastore
                     .saga_create_event(&our_event)

--- a/nexus/db-queries/src/db/sec_store.rs
+++ b/nexus/db-queries/src/db/sec_store.rs
@@ -70,8 +70,6 @@ impl steno::SecStore for CockroachDbSecStore {
             // This is an internal service query to CockroachDB.
             backoff::retry_policy_internal_service(),
             || {
-                // An interesting question is how to handle errors.
-                //
                 // In general, there are some kinds of database errors that are
                 // temporary/server errors (e.g. network failures), and some
                 // that are permanent/client errors (e.g. conflict during
@@ -85,10 +83,9 @@ impl steno::SecStore for CockroachDbSecStore {
                 // errors that likely require operator intervention.)
                 //
                 // At a higher level, callers should plan for the fact that
-                // record_event could potentially loop forever. See
-                // https://github.com/oxidecomputer/omicron/issues/5406 and the
-                // note in `nexus/src/app/saga.rs`'s `saga_execute` for more
-                // details.
+                // record_event (and, so, saga execution) could potentially loop
+                // indefinitely while the datastore (or other dependent
+                // services) are down.
                 self.datastore
                     .saga_create_event(&our_event)
                     .map_err(backoff::BackoffError::transient)

--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -203,7 +203,8 @@ impl super::Nexus {
             create_params: params.clone(),
         };
         let saga_outputs = self
-            .execute_saga::<sagas::disk_create::SagaDiskCreate>(saga_params)
+            .sagas
+            .saga_execute::<sagas::disk_create::SagaDiskCreate>(saga_params)
             .await?;
         let disk_created = saga_outputs
             .lookup_node_output::<db::model::Disk>("created_disk")
@@ -342,7 +343,8 @@ impl super::Nexus {
             disk_id: authz_disk.id(),
             volume_id: db_disk.volume_id,
         };
-        self.execute_saga::<sagas::disk_delete::SagaDiskDelete>(saga_params)
+        self.sagas
+            .saga_execute::<sagas::disk_delete::SagaDiskDelete>(saga_params)
             .await?;
         Ok(())
     }
@@ -585,10 +587,9 @@ impl super::Nexus {
             snapshot_name: finalize_params.snapshot_name.clone(),
         };
 
-        self.execute_saga::<sagas::finalize_disk::SagaFinalizeDisk>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::finalize_disk::SagaFinalizeDisk>(saga_params)
+            .await?;
 
         Ok(())
     }

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -270,7 +270,8 @@ impl super::Nexus {
             image_param,
         };
 
-        self.execute_saga::<sagas::image_delete::SagaImageDelete>(saga_params)
+        self.sagas
+            .saga_execute::<sagas::image_delete::SagaImageDelete>(saga_params)
             .await?;
 
         Ok(())

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -379,7 +379,8 @@ impl super::Nexus {
         };
 
         let saga_outputs = self
-            .execute_saga::<sagas::instance_create::SagaInstanceCreate>(
+            .sagas
+            .saga_execute::<sagas::instance_create::SagaInstanceCreate>(
                 saga_params,
             )
             .await?;
@@ -462,10 +463,11 @@ impl super::Nexus {
             instance,
             boundary_switches,
         };
-        self.execute_saga::<sagas::instance_delete::SagaInstanceDelete>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::instance_delete::SagaInstanceDelete>(
+                saga_params,
+            )
+            .await?;
         Ok(())
     }
 
@@ -510,10 +512,11 @@ impl super::Nexus {
             src_vmm: vmm.clone(),
             migrate_params: params,
         };
-        self.execute_saga::<sagas::instance_migrate::SagaInstanceMigrate>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::instance_migrate::SagaInstanceMigrate>(
+                saga_params,
+            )
+            .await?;
 
         // TODO correctness TODO robustness TODO design
         // Should we lookup the instance again here?
@@ -757,10 +760,11 @@ impl super::Nexus {
             db_instance: instance.clone(),
         };
 
-        self.execute_saga::<sagas::instance_start::SagaInstanceStart>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::instance_start::SagaInstanceStart>(
+                saga_params,
+            )
+            .await?;
 
         self.db_datastore.instance_fetch_with_vmm(opctx, &authz_instance).await
     }
@@ -1938,7 +1942,8 @@ impl super::Nexus {
         };
 
         let saga_outputs = self
-            .execute_saga::<sagas::instance_ip_attach::SagaInstanceIpAttach>(
+            .sagas
+            .saga_execute::<sagas::instance_ip_attach::SagaInstanceIpAttach>(
                 saga_params,
             )
             .await?;
@@ -1967,7 +1972,8 @@ impl super::Nexus {
         };
 
         let saga_outputs = self
-            .execute_saga::<sagas::instance_ip_detach::SagaInstanceIpDetach>(
+            .sagas
+            .saga_execute::<sagas::instance_ip_detach::SagaInstanceIpDetach>(
                 saga_params,
             )
             .await?;

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -130,8 +130,7 @@ pub struct Nexus {
     db_datastore: Arc<db::DataStore>,
 
     /// handle to global authz information
-    // XXX-dap
-    pub(super) authz: Arc<authz::Authz>,
+    authz: Arc<authz::Authz>,
 
     /// saga execution coordinator
     sagas: SagaExecutor,
@@ -560,6 +559,10 @@ impl Nexus {
     /// Return the tunable configuration parameters, e.g. for use in tests.
     pub fn tunables(&self) -> &Tunables {
         &self.tunables
+    }
+
+    pub fn authz(&self) -> &Arc<authz::Authz> {
+        &self.authz
     }
 
     pub(crate) async fn wait_for_populate(&self) -> Result<(), anyhow::Error> {

--- a/nexus/src/app/project.rs
+++ b/nexus/src/app/project.rs
@@ -59,7 +59,8 @@ impl super::Nexus {
             authz_silo,
         };
         let saga_outputs = self
-            .execute_saga::<sagas::project_create::SagaProjectCreate>(
+            .sagas
+            .saga_execute::<sagas::project_create::SagaProjectCreate>(
                 saga_params,
             )
             .await?;

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -360,9 +360,9 @@ impl super::Nexus {
 
         // TODO
         // configure rack networking / boundary services here
-        // Currently calling some of the apis directly, but should we be using sagas
-        // going forward via self.run_saga()? Note that self.create_runnable_saga and
-        // self.execute_saga are currently not available within this scope.
+        // Currently calling some of the apis directly, but should we be using
+        // sagas going forward via self.sagas.saga_execute()? Note that
+        // this may not be available within this scope.
         info!(log, "Recording Rack Network Configuration");
         let address_lot_name = Name::from_str(INFRA_LOT).map_err(|e| {
             Error::internal_error(&format!(

--- a/nexus/src/app/saga.rs
+++ b/nexus/src/app/saga.rs
@@ -87,7 +87,7 @@ pub(crate) fn create_saga_dag<N: NexusSaga>(
     Ok(SagaDag::new(dag, params))
 }
 
-/// External handle to a self-contained subsystem for kicking off sagas
+/// Handle to a self-contained subsystem for kicking off sagas
 ///
 /// See the module-level documentation for details.
 pub(crate) struct SagaExecutor {
@@ -113,9 +113,15 @@ impl SagaExecutor {
     // one call site, it does fail cleanly if someone tries to use
     // `SagaExecutor` before this has been set, and the result is much cleaner
     // for all the other users of `SagaExecutor`.
+    //
+    // # Panics
+    //
+    // This function should be called exactly once in the lifetime of any
+    // `SagaExecutor` object.  If it gets called more than once, concurrently or
+    // not, it panics.
     pub(crate) fn set_nexus(&self, nexus: Arc<Nexus>) {
         self.nexus.set(nexus).unwrap_or_else(|_| {
-            panic!("concurrent initialization of SagaExecutor")
+            panic!("multiple initialization of SagaExecutor")
         })
     }
 
@@ -293,7 +299,7 @@ impl RunnableSaga {
     }
 }
 
-/// Describes a saga that's been started running
+/// Describes a saga that's started running
 pub(crate) struct RunningSaga {
     id: SagaId,
     saga_completion_future: BoxFuture<'static, SagaResult>,

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -883,15 +883,11 @@ pub(crate) mod test {
         let project_id =
             create_project(&client, PROJECT_NAME).await.identity.id;
 
-        // Build the saga DAG with the provided test parameters
+        // Build the saga DAG with the provided test parameters and run it.
         let opctx = test_opctx(cptestctx);
         let params = new_test_params(&opctx, project_id);
-        let dag = create_saga_dag::<SagaDiskCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        let output = nexus.run_saga(runnable_saga).await.unwrap();
-
+        let output =
+            nexus.sagas.saga_execute::<SagaDiskCreate>(params).await.unwrap();
         let disk = output
             .lookup_node_output::<nexus_db_queries::db::model::Disk>(
                 "created_disk",

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -236,7 +236,7 @@ pub(crate) mod test {
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
         let disk = create_disk(&cptestctx).await;
 
-        // Build the saga DAG with the provided test parameters
+        // Build the saga DAG with the provided test parameters and run it.
         let opctx = test_opctx(&cptestctx);
         let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
@@ -244,11 +244,7 @@ pub(crate) mod test {
             disk_id: disk.id(),
             volume_id: disk.volume_id,
         };
-        let dag = create_saga_dag::<SagaDiskDelete>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        nexus.run_saga(runnable_saga).await.unwrap();
+        nexus.sagas.saga_execute::<SagaDiskDelete>(params).await.unwrap();
     }
 
     #[nexus_test(server = crate::Server)]

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1140,15 +1140,12 @@ pub mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_org_project_and_disk(&client).await;
 
-        // Build the saga DAG with the provided test parameters
+        // Build the saga DAG with the provided test parameters and run it
         let opctx = test_helpers::test_opctx(&cptestctx);
         let params = new_test_params(&opctx, project_id);
-        let dag = create_saga_dag::<SagaInstanceCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
         nexus
-            .run_saga(runnable_saga)
+            .sagas
+            .saga_execute::<SagaInstanceCreate>(params)
             .await
             .expect("Saga should have succeeded");
     }

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -268,22 +268,17 @@ mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         create_org_project_and_disk(&client).await;
 
-        // Build the saga DAG with the provided test parameters
-        let dag = create_saga_dag::<SagaInstanceDelete>(
-            new_test_params(
-                &cptestctx,
-                create_instance(&cptestctx, new_instance_create_params())
-                    .await
-                    .id(),
-            )
-            .await,
+        // Build the saga DAG with the provided test parameters and run it.
+        let params = new_test_params(
+            &cptestctx,
+            create_instance(&cptestctx, new_instance_create_params())
+                .await
+                .id(),
         )
-        .unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
+        .await;
         nexus
-            .run_saga(runnable_saga)
+            .sagas
+            .saga_execute::<SagaInstanceDelete>(params)
             .await
             .expect("Saga should have succeeded");
     }

--- a/nexus/src/app/sagas/instance_ip_attach.rs
+++ b/nexus/src/app/sagas/instance_ip_attach.rs
@@ -427,10 +427,11 @@ pub(crate) mod test {
 
         for use_float in [false, true] {
             let params = new_test_params(&opctx, datastore, use_float).await;
-
-            let dag = create_saga_dag::<SagaInstanceIpAttach>(params).unwrap();
-            let saga = nexus.create_runnable_saga(dag).await.unwrap();
-            nexus.run_saga(saga).await.expect("Attach saga should succeed");
+            nexus
+                .sagas
+                .saga_execute::<SagaInstanceIpAttach>(params)
+                .await
+                .expect("Attach saga should succeed");
         }
 
         // Sled agent has a record of the new external IPs.

--- a/nexus/src/app/sagas/instance_ip_detach.rs
+++ b/nexus/src/app/sagas/instance_ip_detach.rs
@@ -402,10 +402,11 @@ pub(crate) mod test {
 
         for use_float in [false, true] {
             let params = new_test_params(&opctx, datastore, use_float).await;
-
-            let dag = create_saga_dag::<SagaInstanceIpDetach>(params).unwrap();
-            let saga = nexus.create_runnable_saga(dag).await.unwrap();
-            nexus.run_saga(saga).await.expect("Detach saga should succeed");
+            nexus
+                .sagas
+                .saga_execute::<SagaInstanceIpDetach>(params)
+                .await
+                .expect("Detach saga should succeed");
         }
 
         // Sled agent has removed its records of the external IPs.

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -574,7 +574,7 @@ async fn sim_instance_migrate(
 
 #[cfg(test)]
 mod tests {
-    use crate::app::{saga::create_saga_dag, sagas::test_helpers};
+    use crate::app::sagas::test_helpers;
     use camino::Utf8Path;
     use dropshot::test_util::ClientTestContext;
     use nexus_test_interface::NexusServer;
@@ -707,9 +707,11 @@ mod tests {
             },
         };
 
-        let dag = create_saga_dag::<SagaInstanceMigrate>(params).unwrap();
-        let saga = nexus.create_runnable_saga(dag).await.unwrap();
-        nexus.run_saga(saga).await.expect("Migration saga should succeed");
+        nexus
+            .sagas
+            .saga_execute::<SagaInstanceMigrate>(params)
+            .await
+            .expect("Migration saga should succeed");
 
         // Merely running the migration saga (without simulating any completion
         // steps in the simulated agents) should not change where the instance

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -922,11 +922,9 @@ mod test {
 
         let runnable_saga = nexus.sagas.saga_prepare(dag).await.unwrap();
         let saga_result = runnable_saga
-            .start()
+            .run_to_completion()
             .await
             .expect("saga execution should have started")
-            .wait_until_stopped()
-            .await
             .into_raw_result();
         let saga_error = saga_result
             .kind

--- a/nexus/src/app/sagas/project_create.rs
+++ b/nexus/src/app/sagas/project_create.rs
@@ -154,7 +154,7 @@ async fn spc_create_vpc_params(
 #[cfg(test)]
 mod test {
     use crate::{
-        app::saga::create_saga_dag, app::sagas::project_create::Params,
+        app::sagas::project_create::Params,
         app::sagas::project_create::SagaProjectCreate, external_api::params,
     };
     use async_bb8_diesel::{AsyncRunQueryDsl, AsyncSimpleConnection};
@@ -263,15 +263,11 @@ mod test {
         // Before running the test, confirm we have no records of any projects.
         verify_clean_slate(nexus.datastore()).await;
 
-        // Build the saga DAG with the provided test parameters
+        // Build the saga DAG with the provided test parameters and run it.
         let opctx = test_opctx(&cptestctx);
         let authz_silo = opctx.authn.silo_required().unwrap();
         let params = new_test_params(&opctx, authz_silo);
-        let dag = create_saga_dag::<SagaProjectCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        nexus.run_saga(runnable_saga).await.unwrap();
+        nexus.sagas.saga_execute::<SagaProjectCreate>(params).await.unwrap();
     }
 
     #[nexus_test(server = crate::Server)]

--- a/nexus/src/app/sagas/region_replacement_finish.rs
+++ b/nexus/src/app/sagas/region_replacement_finish.rs
@@ -206,7 +206,6 @@ async fn srrf_update_request_record(
 #[cfg(test)]
 pub(crate) mod test {
     use crate::{
-        app::saga::create_saga_dag,
         app::sagas::region_replacement_finish::Params,
         app::sagas::region_replacement_finish::SagaRegionReplacementFinish,
     };
@@ -315,17 +314,16 @@ pub(crate) mod test {
             .unwrap();
 
         // Run the region replacement finish saga
-        let dag = create_saga_dag::<SagaRegionReplacementFinish>(Params {
+        let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             region_volume_id: old_region_volume_id,
             request: request.clone(),
-        })
-        .unwrap();
-
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        let _output = nexus.run_saga(runnable_saga).await.unwrap();
+        };
+        let _output = nexus
+            .sagas
+            .saga_execute::<SagaRegionReplacementFinish>(params)
+            .await
+            .unwrap();
 
         // Validate the state transition
         let result = datastore

--- a/nexus/src/app/sagas/region_replacement_start.rs
+++ b/nexus/src/app/sagas/region_replacement_start.rs
@@ -864,19 +864,18 @@ pub(crate) mod test {
             .unwrap();
 
         // Run the region replacement start saga
-        let dag = create_saga_dag::<SagaRegionReplacementStart>(Params {
+        let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             request: request.clone(),
             allocation_strategy: RegionAllocationStrategy::Random {
                 seed: None,
             },
-        })
-        .unwrap();
-
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        let output = nexus.run_saga(runnable_saga).await.unwrap();
+        };
+        let output = nexus
+            .sagas
+            .saga_execute::<SagaRegionReplacementStart>(params)
+            .await
+            .unwrap();
 
         // Validate the state transition
         let result = datastore

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -2254,11 +2254,9 @@ mod test {
 
         // Actually run the saga
         let output = runnable_saga
-            .start()
+            .run_to_completion()
             .await
             .unwrap()
-            .wait_until_stopped()
-            .await
             .into_omicron_result();
 
         // Expect to see 409
@@ -2377,11 +2375,9 @@ mod test {
 
         // Actually run the saga. This should fail.
         let output = runnable_saga
-            .start()
+            .run_to_completion()
             .await
             .unwrap()
-            .wait_until_stopped()
-            .await
             .into_omicron_result();
 
         assert!(output.is_err());

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1908,11 +1908,12 @@ mod test {
             None, // not attached to an instance
             true, // use the pantry
         );
-        let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
         // Actually run the saga
-        let output = nexus.run_saga(runnable_saga).await.unwrap();
+        let output = nexus
+            .sagas
+            .saga_execute::<SagaSnapshotCreate>(params)
+            .await
+            .unwrap();
 
         let snapshot = output
             .lookup_node_output::<nexus_db_queries::db::model::Snapshot>(
@@ -2237,7 +2238,7 @@ mod test {
         );
 
         let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
+        let runnable_saga = nexus.sagas.saga_prepare(dag).await.unwrap();
 
         // Before running the saga, attach the disk to an instance!
         let _instance_and_vmm = setup_test_instance(
@@ -2252,7 +2253,13 @@ mod test {
         .await;
 
         // Actually run the saga
-        let output = nexus.run_saga(runnable_saga).await;
+        let output = runnable_saga
+            .start()
+            .await
+            .unwrap()
+            .wait_until_stopped()
+            .await
+            .into_omicron_result();
 
         // Expect to see 409
         match output {
@@ -2295,9 +2302,8 @@ mod test {
             true, // use the pantry
         );
 
-        let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-        let output = nexus.run_saga(runnable_saga).await;
+        let output =
+            nexus.sagas.saga_execute::<SagaSnapshotCreate>(params).await;
 
         // Expect 200
         assert!(output.is_ok());
@@ -2349,7 +2355,7 @@ mod test {
         );
 
         let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
+        let runnable_saga = nexus.sagas.saga_prepare(dag).await.unwrap();
 
         // Before running the saga, detach the disk!
         let (.., authz_disk, db_disk) =
@@ -2370,7 +2376,13 @@ mod test {
             .expect("failed to detach disk"));
 
         // Actually run the saga. This should fail.
-        let output = nexus.run_saga(runnable_saga).await;
+        let output = runnable_saga
+            .start()
+            .await
+            .unwrap()
+            .wait_until_stopped()
+            .await
+            .into_omicron_result();
 
         assert!(output.is_err());
 
@@ -2397,9 +2409,8 @@ mod test {
             false, // use the pantry
         );
 
-        let dag = create_saga_dag::<SagaSnapshotCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-        let output = nexus.run_saga(runnable_saga).await;
+        let output =
+            nexus.sagas.saga_execute::<SagaSnapshotCreate>(params).await;
 
         // Expect 200
         assert!(output.is_ok());

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -278,11 +278,9 @@ pub(crate) async fn actions_succeed_idempotently(
     }
 
     runnable_saga
-        .start()
+        .run_to_completion()
         .await
         .expect("Saga should have started")
-        .wait_until_stopped()
-        .await
         .into_omicron_result()
         .expect("Saga should have succeeded");
 }
@@ -362,11 +360,9 @@ pub(crate) async fn action_failure_can_unwind<'a, S, B, A>(
             .unwrap();
 
         let saga_result = runnable_saga
-            .start()
+            .run_to_completion()
             .await
             .expect("saga should have started successfully")
-            .wait_until_stopped()
-            .await
             .into_raw_result();
 
         let saga_error =
@@ -480,11 +476,9 @@ pub(crate) async fn action_failure_can_unwind_idempotently<'a, S, B, A>(
             .unwrap();
 
         let saga_error = runnable_saga
-            .start()
+            .run_to_completion()
             .await
             .expect("saga should have started successfully")
-            .wait_until_stopped()
-            .await
             .into_raw_result()
             .kind
             .expect_err("saga execution should have failed");

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -261,7 +261,7 @@ pub(crate) async fn actions_succeed_idempotently(
     nexus: &Arc<Nexus>,
     dag: SagaDag,
 ) {
-    let runnable_saga = nexus.create_runnable_saga(dag.clone()).await.unwrap();
+    let runnable_saga = nexus.sagas.saga_prepare(dag.clone()).await.unwrap();
     for node in dag.get_nodes() {
         nexus
             .sec()
@@ -277,7 +277,14 @@ pub(crate) async fn actions_succeed_idempotently(
             .unwrap();
     }
 
-    nexus.run_saga(runnable_saga).await.expect("Saga should have succeeded");
+    runnable_saga
+        .start()
+        .await
+        .expect("Saga should have started")
+        .wait_until_stopped()
+        .await
+        .into_omicron_result()
+        .expect("Saga should have succeeded");
 }
 
 /// Tests that a saga `S` functions properly when any of its nodes fails and
@@ -346,7 +353,7 @@ pub(crate) async fn action_failure_can_unwind<'a, S, B, A>(
         );
 
         let runnable_saga =
-            nexus.create_runnable_saga(dag.clone()).await.unwrap();
+            nexus.sagas.saga_prepare(dag.clone()).await.unwrap();
 
         nexus
             .sec()
@@ -354,12 +361,16 @@ pub(crate) async fn action_failure_can_unwind<'a, S, B, A>(
             .await
             .unwrap();
 
-        let saga_error = nexus
-            .run_saga_raw_result(runnable_saga)
+        let saga_result = runnable_saga
+            .start()
             .await
             .expect("saga should have started successfully")
-            .kind
-            .expect_err("saga execution should have failed");
+            .wait_until_stopped()
+            .await
+            .into_raw_result();
+
+        let saga_error =
+            saga_result.kind.expect_err("saga execution should have failed");
 
         assert_eq!(saga_error.error_node_name, *node.name());
 
@@ -447,7 +458,7 @@ pub(crate) async fn action_failure_can_unwind_idempotently<'a, S, B, A>(
         );
 
         let runnable_saga =
-            nexus.create_runnable_saga(dag.clone()).await.unwrap();
+            nexus.sagas.saga_prepare(dag.clone()).await.unwrap();
 
         nexus
             .sec()
@@ -468,10 +479,13 @@ pub(crate) async fn action_failure_can_unwind_idempotently<'a, S, B, A>(
             .await
             .unwrap();
 
-        let saga_error = nexus
-            .run_saga_raw_result(runnable_saga)
+        let saga_error = runnable_saga
+            .start()
             .await
             .expect("saga should have started successfully")
+            .wait_until_stopped()
+            .await
+            .into_raw_result()
             .kind
             .expect_err("saga execution should have failed");
 

--- a/nexus/src/app/sagas/test_saga.rs
+++ b/nexus/src/app/sagas/test_saga.rs
@@ -88,11 +88,9 @@ async fn test_saga_stuck(cptestctx: &ControlPlaneTestContext) {
     nexus.sec().saga_inject_error(saga_id, n2).await.unwrap();
     nexus.sec().saga_inject_error_undo(saga_id, n1).await.unwrap();
     let result = runnable_saga
-        .start()
+        .run_to_completion()
         .await
         .expect("expected saga to start")
-        .wait_until_stopped()
-        .await
         .into_omicron_result()
         .expect_err("expected saga to finish stuck");
 

--- a/nexus/src/app/sagas/vpc_create.rs
+++ b/nexus/src/app/sagas/vpc_create.rs
@@ -485,8 +485,8 @@ async fn svc_notify_sleds(
 #[cfg(test)]
 pub(crate) mod test {
     use crate::{
-        app::saga::create_saga_dag, app::sagas::vpc_create::Params,
-        app::sagas::vpc_create::SagaVpcCreate, external_api::params,
+        app::sagas::vpc_create::Params, app::sagas::vpc_create::SagaVpcCreate,
+        external_api::params,
     };
     use async_bb8_diesel::AsyncRunQueryDsl;
     use diesel::{
@@ -782,11 +782,7 @@ pub(crate) mod test {
         )
         .await;
         let params = new_test_params(&opctx, authz_project);
-        let dag = create_saga_dag::<SagaVpcCreate>(params).unwrap();
-        let runnable_saga = nexus.create_runnable_saga(dag).await.unwrap();
-
-        // Actually run the saga
-        nexus.run_saga(runnable_saga).await.unwrap();
+        nexus.sagas.saga_execute::<SagaVpcCreate>(params).await.unwrap();
     }
 
     #[nexus_test(server = crate::Server)]

--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -125,7 +125,8 @@ impl super::Nexus {
         };
 
         let saga_outputs = self
-            .execute_saga::<sagas::snapshot_create::SagaSnapshotCreate>(
+            .sagas
+            .saga_execute::<sagas::snapshot_create::SagaSnapshotCreate>(
                 saga_params,
             )
             .await?;
@@ -165,10 +166,11 @@ impl super::Nexus {
             snapshot: db_snapshot,
         };
 
-        self.execute_saga::<sagas::snapshot_delete::SagaSnapshotDelete>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::snapshot_delete::SagaSnapshotDelete>(
+                saga_params,
+            )
+            .await?;
 
         Ok(())
     }

--- a/nexus/src/app/volume.rs
+++ b/nexus/src/app/volume.rs
@@ -34,10 +34,11 @@ impl super::Nexus {
             volume_id,
         };
 
-        self.execute_saga::<sagas::volume_remove_rop::SagaVolumeRemoveROP>(
-            saga_params,
-        )
-        .await?;
+        self.sagas
+            .saga_execute::<sagas::volume_remove_rop::SagaVolumeRemoveROP>(
+                saga_params,
+            )
+            .await?;
 
         Ok(())
     }

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -81,7 +81,8 @@ impl super::Nexus {
         };
 
         let saga_outputs = self
-            .execute_saga::<sagas::vpc_create::SagaVpcCreate>(saga_params)
+            .sagas
+            .saga_execute::<sagas::vpc_create::SagaVpcCreate>(saga_params)
             .await?;
 
         let (_, db_vpc) = saga_outputs

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 pub(crate) struct SagaContext {
     nexus: Arc<Nexus>,
     log: Logger,
-    authz: Arc<authz::Authz>,
 }
 
 impl fmt::Debug for SagaContext {
@@ -26,12 +25,8 @@ impl fmt::Debug for SagaContext {
 }
 
 impl SagaContext {
-    pub(crate) fn new(
-        nexus: Arc<Nexus>,
-        log: Logger,
-        authz: Arc<authz::Authz>,
-    ) -> SagaContext {
-        SagaContext { authz, nexus, log }
+    pub(crate) fn new(nexus: Arc<Nexus>, log: Logger) -> SagaContext {
+        SagaContext { nexus, log }
     }
 
     pub(crate) fn log(&self) -> &Logger {
@@ -39,7 +34,7 @@ impl SagaContext {
     }
 
     pub(crate) fn authz(&self) -> &Arc<authz::Authz> {
-        &self.authz
+        &self.nexus.authz
     }
 
     pub(crate) fn nexus(&self) -> &Arc<Nexus> {

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -34,7 +34,7 @@ impl SagaContext {
     }
 
     pub(crate) fn authz(&self) -> &Arc<authz::Authz> {
-        &self.nexus.authz
+        &self.nexus.authz()
     }
 
     pub(crate) fn nexus(&self) -> &Arc<Nexus> {


### PR DESCRIPTION
There's a sort of mini-subsystem in Nexus for managing sagas, consisting of:

* `Nexus::execute_saga()`: runs a saga from soup to nuts (starting with params, ending with the result)
* `Nexus::create_runnable_saga()` + `Nexus::run_saga()`: similar to the above, but breaks it up so that you can inject errors and the like before running the saga
* `Nexus::run_saga_raw_result()`, which is like `Nexus::run_saga()` but avoids interpreting the Steno Error as an Omicron Error (used only for tests)

Today, these are just methods on `Nexus` and feel (to me) a little _ad hoc_.

This PR creates a bit more abstraction:

* There is now a `SagaExecutor` stored into the `Nexus.sagas` field.
* Some of the same pieces still exist, but are renamed in a way I hope would be clearer in terms of how you use them:
    * `SagaExecutor::saga_prepare()` is what used to be `create_runnable_saga()`.  This still returns a `RunnableSaga`.
    * `RunnableSaga::start()` starts the saga running.  (Having this available fixes #5406.)  This returns a `RunningSaga`.
    * `RunningSaga::wait_until_stopped()` waits for the saga to finish.  This returns a `StoppedSaga`.
    * `StoppedSaga` can be turned into either a "raw" result or an "Omicron" result.
    * `SagaExecutor::saga_execute()` still runs the saga soup to nuts and gives you back an Omicron result.  This just chains the above functions together.
* There's no longer a `run_saga()` vs. `run_saga_raw_result()`.  Instead, you run the saga the same way every time, but you can turn it into either kind of result at the end.

Motivation:

* Based on recent discussions (like #5856), I've been looking for opportunities to factor out whole subsystems from the mass of Nexus.  I think this at least organizes this small area in a more coherent way.  In principle I think most of `saga.rs` could actually go into a subpackage of Nexus, which might be nice for incremental compile times.  I have not tried to do that here.
* In trying to do #5964, I found I wanted to be able to hand background tasks a thing they could use to run sagas that was narrower than the whole `Arc<Nexus>`.  I plan to revisit #5964 after this PR and plug a reference to `SagaExecutor` into the background tasks instead.
* This fixes #5406.