### PR TITLE
[nexus] Remove `v2p_notification_tx`

### DIFF
--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -291,11 +291,11 @@ impl Activator {
 impl ActivatorInner {
     async fn activated(&self) {
         debug_assert!(
-            self.0.wired_up.load(Ordering::SeqCst),
+            self.wired_up.load(Ordering::SeqCst),
             "nothing should await activation from an activator that hasn't \
              been wired up"
         );
-        self.0.notify.notified().await
+        self.notify.notified().await
     }
 }
 

--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -151,11 +151,6 @@ impl Driver {
         // This just provides the handles we need to read status and wake up the
         // tokio task.
         let task = Task {
-            description,
-            period,
-            status: status_rx,
-            tokio_task,
-            activator: activator.clone(),
             description: taskdef.description.to_string(),
             period: taskdef.period,
             status: status_rx,

--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -236,7 +236,7 @@ pub struct Activator(Arc<ActivatorInner>);
 
 /// Shared state for an `Activator`.
 struct ActivatorInner {
-    pub(super) notify: Arc<Notify>,
+    pub(super) notify: Notify,
     pub(super) wired_up: AtomicBool,
 }
 
@@ -244,7 +244,7 @@ impl Activator {
     /// Create an activator that is not yet wired up to any background task
     pub fn new() -> Activator {
         Self(Arc::new(ActivatorInner {
-            notify: Arc::new(Notify::new()),
+            notify: Notify::new(),
             wired_up: AtomicBool::new(false),
         }))
     }

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -254,7 +254,6 @@ impl BackgroundTasksInitializer {
         nexus_id: Uuid,
         resolver: internal_dns::resolver::Resolver,
         saga_request: Sender<SagaRequest>,
-        v2p_watcher: (watch::Sender<()>, watch::Receiver<()>),
         producer_registry: ProducerRegistry,
     ) -> Driver {
         let mut driver = self.driver;
@@ -539,7 +538,7 @@ impl BackgroundTasksInitializer {
             config.v2p_mapping_propagation.period_secs,
             Box::new(V2PManager::new(datastore.clone())),
             opctx.child(BTreeMap::new()),
-            vec![Box::new(v2p_watcher.1)],
+            vec![],
             task_v2p_manager,
         );
 
@@ -590,7 +589,7 @@ impl BackgroundTasksInitializer {
                 resolver.clone(),
                 producer_registry,
                 instance_watcher::WatcherIdentity { nexus_id, rack_id },
-                v2p_watcher.0,
+                task_v2p_manager.clone(),
             );
             driver.register(
                 "instance_watcher".to_string(),

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1552,7 +1552,7 @@ impl super::Nexus {
             &self.log,
             instance_id,
             new_runtime_state,
-            self.v2p_notification_tx.clone(),
+            &self.background_tasks.task_v2p_manager,
         )
         .await?;
         self.vpc_needed_notify_sleds();
@@ -2005,7 +2005,7 @@ pub(crate) async fn notify_instance_updated(
     log: &slog::Logger,
     instance_id: &InstanceUuid,
     new_runtime_state: &nexus::SledInstanceState,
-    v2p_notification_tx: tokio::sync::watch::Sender<()>,
+    v2p_manager: &crate::app::background::Activator,
 ) -> Result<Option<InstanceUpdateResult>, Error> {
     let propolis_id = new_runtime_state.propolis_id;
 
@@ -2045,7 +2045,7 @@ pub(crate) async fn notify_instance_updated(
         &authz_instance,
         db_instance.runtime(),
         &new_runtime_state.instance_state,
-        v2p_notification_tx.clone(),
+        v2p_manager,
     )
     .await?;
 

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -206,9 +206,6 @@ pub struct Nexus {
 
     /// Default Crucible region allocation strategy
     default_region_allocation_strategy: RegionAllocationStrategy,
-
-    /// Channel for notifying background task of change to opte v2p state
-    v2p_notification_tx: tokio::sync::watch::Sender<()>,
 }
 
 impl Nexus {
@@ -405,8 +402,6 @@ impl Nexus {
             Arc::clone(&db_datastore) as Arc<dyn nexus_auth::storage::Storage>,
         );
 
-        let v2p_watcher_channel = tokio::sync::watch::channel(());
-
         let (saga_request, mut saga_request_recv) = SagaRequest::channel();
 
         let (background_tasks_initializer, background_tasks) =
@@ -465,7 +460,6 @@ impl Nexus {
                 .pkg
                 .default_region_allocation_strategy
                 .clone(),
-            v2p_notification_tx: v2p_watcher_channel.0.clone(),
         };
 
         // TODO-cleanup all the extra Arcs here seems wrong
@@ -524,7 +518,6 @@ impl Nexus {
                 task_config.deployment.id,
                 resolver,
                 saga_request,
-                v2p_watcher_channel.clone(),
                 task_registry,
             );
 


### PR DESCRIPTION
Currently, a `tokio::sync::watch` channel is explicitly passed around to
allow both Nexus and other background tasks to notify the `v2p_manager`
background task. This must be passed explicitly through most of Nexus,
which is a bit awkward.

The new `background::Activator` API introduced in PR #5962 makes it a
bit easier to nicely activate background tasks. Now, we have an
`Activator` type which represents the `tokio::sync::Notify` used to wake
the background task, and this can be passed into the various functions
which must activate it. Because `Activator`s are constructed _before_
background tasks are started, the `Activator` can be passed to the
background tasks that must activate the `v2p_manager` task (in this
case, the `instance_watcher` task).

This branch removes the `tokio::sync::watch` channel used to activate
the `v2p_manager`, and replaces it with a use of the `Activator` API.
Because the `Activator` type is not currently `Clone`, I refactored it
slightly so that both the wired-up flag _and_ the `Notify` live within
an `Arc`, allowing a clone of the `Activator` for the `v2p_manager` task
to be passed into the `instance_watcher` task when it's constructed. I
don't think this really introduces any new opportunities for accidental
`Activator` misuse, as the assertion that an activator is not wired up
twice still stands.