### PR TITLE
Expand Buildomat output rules to upload nested files

### DIFF
--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -6,7 +6,7 @@
 #: rust_toolchain = true
 #: output_rules = [
 #:	"%/work/*",
-#:	"%/var/tmp/omicron_tmp/*",
+#:	"%/var/tmp/omicron_tmp/**/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -6,7 +6,7 @@
 #: rust_toolchain = true
 #: output_rules = [
 #:	"%/work/*",
-#:	"%/var/tmp/omicron_tmp/*",
+#:	"%/var/tmp/omicron_tmp/**/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]


### PR DESCRIPTION
Buildomat uses `glob` rules to find files to upload. Our previous rules looked like `/tmp/*`, which matches any file directly inside `/tmp`. This modifies the rules to look like `/tmp/**/*`, which matches anything in `/tmp` or directory rooted there.