### PR TITLE
Apply dest/target validation to VPC routes on PUT

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -259,7 +259,7 @@ pub struct SubnetSelector {
 pub struct RouterSelector {
     /// Name or ID of the project, only required if `vpc` is provided as a `Name`
     pub project: Option<NameOrId>,
-    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    /// Name or ID of the VPC, only required if `router` is provided as a `Name`
     pub vpc: Option<NameOrId>,
     /// Name or ID of the router
     pub router: NameOrId,
@@ -269,7 +269,7 @@ pub struct RouterSelector {
 pub struct OptionalRouterSelector {
     /// Name or ID of the project, only required if `vpc` is provided as a `Name`
     pub project: Option<NameOrId>,
-    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    /// Name or ID of the VPC, only required if `router` is provided as a `Name`
     pub vpc: Option<NameOrId>,
     /// Name or ID of the router
     pub router: Option<NameOrId>,
@@ -279,7 +279,7 @@ pub struct OptionalRouterSelector {
 pub struct RouteSelector {
     /// Name or ID of the project, only required if `vpc` is provided as a `Name`
     pub project: Option<NameOrId>,
-    /// Name or ID of the VPC, only required if `subnet` is provided as a `Name`
+    /// Name or ID of the VPC, only required if `router` is provided as a `Name`
     pub vpc: Option<NameOrId>,
     /// Name or ID of the router, only required if `route` is provided as a `Name`
     pub router: Option<NameOrId>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8401,7 +8401,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
+            "description": "Name or ID of the VPC, only required if `router` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -8458,7 +8458,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
+            "description": "Name or ID of the VPC, only required if `router` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -8531,7 +8531,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
+            "description": "Name or ID of the VPC, only required if `router` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -8591,7 +8591,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
+            "description": "Name or ID of the VPC, only required if `router` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }
@@ -8661,7 +8661,7 @@
           {
             "in": "query",
             "name": "vpc",
-            "description": "Name or ID of the VPC, only required if `subnet` is provided as a `Name`",
+            "description": "Name or ID of the VPC, only required if `router` is provided as a `Name`",
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
             }


### PR DESCRIPTION
VPC custom route creation applies various validations on the contents of a route. These include preventing mixed v4/v6 addresses (helpful) and disallowing system-only targets such as subnets/vpcs (mandatory). This PR ensures that these checks occur on modification of Default or Custom routes by users.

Fixes #6003. Also fixes some typos identified by @elaine-oxide.