### PR TITLE
Add more checks to timeseries schema

### DIFF
--- a/oximeter/impl/src/schema/codegen.rs
+++ b/oximeter/impl/src/schema/codegen.rs
@@ -78,7 +78,9 @@ fn emit_target(schema: &TimeseriesSchema) -> TokenStream {
 fn fields_are_copyable<'a>(
     mut fields: impl Iterator<Item = &'a FieldSchema>,
 ) -> bool {
-    !fields.any(|field| field.field_type == FieldType::String)
+    // Do a positive match, to ensure new variants don't actually derive copy
+    // inappropriately. Better we clone, in that case.
+    fields.all(FieldSchema::is_copyable)
 }
 
 fn compute_extra_derives(

--- a/oximeter/impl/src/schema/codegen.rs
+++ b/oximeter/impl/src/schema/codegen.rs
@@ -74,6 +74,41 @@ fn emit_target(schema: &TimeseriesSchema) -> TokenStream {
     emit_one(FieldSource::Target, schema)
 }
 
+/// Return true if all the fields in the schema are `Copy`.
+fn fields_are_copyable<'a>(
+    mut fields: impl Iterator<Item = &'a FieldSchema>,
+) -> bool {
+    !fields.any(|field| field.field_type == FieldType::String)
+}
+
+fn compute_extra_derives(
+    source: FieldSource,
+    schema: &TimeseriesSchema,
+) -> TokenStream {
+    match source {
+        FieldSource::Target => {
+            if fields_are_copyable(schema.target_fields()) {
+                quote! { #[derive(Copy, Eq, Hash, Ord, PartialOrd)] }
+            } else {
+                quote! { #[derive(Eq, Hash, Ord, PartialOrd)] }
+            }
+        }
+        FieldSource::Metric => {
+            if schema.datum_type.is_histogram() {
+                // No other traits can be derived, since the Histogram<T> won't
+                // satisfy them.
+                quote! {}
+            } else {
+                if fields_are_copyable(schema.metric_fields()) {
+                    quote! { #[derive(Copy, Eq, Hash, Ord, PartialOrd)] }
+                } else {
+                    quote! { #[derive(Eq, Hash, Ord, PartialOrd)] }
+                }
+            }
+        }
+    }
+}
+
 fn emit_one(source: FieldSource, schema: &TimeseriesSchema) -> TokenStream {
     let name = match source {
         FieldSource::Target => schema.target_name(),
@@ -98,6 +133,7 @@ fn emit_one(source: FieldSource, schema: &TimeseriesSchema) -> TokenStream {
             }
         })
         .collect();
+    let extra_derives = compute_extra_derives(source, schema);
     let (oximeter_trait, maybe_datum, type_docstring) = match source {
         FieldSource::Target => (
             quote! {::oximeter::Target },
@@ -116,6 +152,7 @@ fn emit_one(source: FieldSource, schema: &TimeseriesSchema) -> TokenStream {
     quote! {
         #[doc = #type_docstring]
         #[derive(Clone, Debug, PartialEq, #oximeter_trait)]
+        #extra_derives
         pub struct #struct_name {
             #( #field_defs, )*
             #maybe_datum
@@ -431,6 +468,7 @@ mod tests {
         let expected = quote! {
             #[doc = "a target"]
             #[derive(Clone, Debug, PartialEq, ::oximeter::Target)]
+            #[derive(Eq, Hash, Ord, PartialOrd)]
             pub struct Foo {
                 #[doc = "target field"]
                 pub f0: ::std::borrow::Cow<'static, str>,
@@ -438,6 +476,7 @@ mod tests {
 
             #[doc = "a metric"]
             #[derive(Clone, Debug, PartialEq, ::oximeter::Metric)]
+            #[derive(Copy, Eq, Hash, Ord, PartialOrd)]
             pub struct Bar {
                 #[doc = "metric field"]
                 pub f1: ::uuid::Uuid,
@@ -474,6 +513,7 @@ mod tests {
         let expected = quote! {
             #[doc = "a target"]
             #[derive(Clone, Debug, PartialEq, ::oximeter::Target)]
+            #[derive(Eq, Hash, Ord, PartialOrd)]
             pub struct Foo {
                 #[doc = "target field"]
                 pub f0: ::std::borrow::Cow<'static, str>,
@@ -481,6 +521,7 @@ mod tests {
 
             #[doc = "a metric"]
             #[derive(Clone, Debug, PartialEq, ::oximeter::Metric)]
+            #[derive(Copy, Eq, Hash, Ord, PartialOrd)]
             pub struct Bar {
                 pub datum: ::oximeter::types::Cumulative<u64>,
             }

--- a/oximeter/impl/src/schema/mod.rs
+++ b/oximeter/impl/src/schema/mod.rs
@@ -54,6 +54,13 @@ pub struct FieldSchema {
     pub description: String,
 }
 
+impl FieldSchema {
+    /// Return `true` if this field is copyable.
+    pub const fn is_copyable(&self) -> bool {
+        self.field_type.is_copyable()
+    }
+}
+
 /// The source from which a field is derived, the target or metric.
 #[derive(
     Clone,

--- a/oximeter/impl/src/schema/mod.rs
+++ b/oximeter/impl/src/schema/mod.rs
@@ -297,6 +297,24 @@ impl TimeseriesSchema {
         self.field_schema.iter().find(|field| field.name == name.as_ref())
     }
 
+    /// Return an iterator over the target fields.
+    pub fn target_fields(&self) -> impl Iterator<Item = &FieldSchema> {
+        self.field_iter(FieldSource::Target)
+    }
+
+    /// Return an iterator over the metric fields.
+    pub fn metric_fields(&self) -> impl Iterator<Item = &FieldSchema> {
+        self.field_iter(FieldSource::Metric)
+    }
+
+    /// Return an iterator over fields from the given source.
+    fn field_iter(
+        &self,
+        source: FieldSource,
+    ) -> impl Iterator<Item = &FieldSchema> {
+        self.field_schema.iter().filter(move |field| field.source == source)
+    }
+
     /// Return the target and metric component names for this timeseries
     pub fn component_names(&self) -> (&str, &str) {
         self.timeseries_name

--- a/oximeter/impl/src/types.rs
+++ b/oximeter/impl/src/types.rs
@@ -63,6 +63,29 @@ pub enum FieldType {
     Bool,
 }
 
+impl FieldType {
+    /// Return `true` if a field of this type is copyable.
+    ///
+    /// NOTE: This doesn't mean `self` is copyable, instead refering to a field
+    /// with this type.
+    pub const fn is_copyable(&self) -> bool {
+        match self {
+            FieldType::String => false,
+            FieldType::I8
+            | FieldType::U8
+            | FieldType::I16
+            | FieldType::U16
+            | FieldType::I32
+            | FieldType::U32
+            | FieldType::I64
+            | FieldType::U64
+            | FieldType::IpAddr
+            | FieldType::Uuid
+            | FieldType::Bool => true,
+        }
+    }
+}
+
 impl std::fmt::Display for FieldType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)

--- a/oximeter/impl/src/types.rs
+++ b/oximeter/impl/src/types.rs
@@ -693,7 +693,19 @@ impl From<MetricsError> for omicron_common::api::external::Error {
 }
 
 /// A cumulative or counter data type.
-#[derive(Debug, Clone, Copy, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Deserialize,
+    Clone,
+    Copy,
+    Eq,
+    Hash,
+    JsonSchema,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+)]
 #[schemars(rename = "Cumulative{T}")]
 pub struct Cumulative<T> {
     start_time: DateTime<Utc>,


### PR DESCRIPTION
- Add checks for the length of all field names, timeseries names, and descriptions. All must be non-empty, and below some const limit. Add tests for these as well.
- Add extra derives to generated target / metric types. Where possible, derive Copy, Eq, PartialOrd, Ord, and Hash, based on the types in the definitions (e.g., strings mean the type cannot be copy).