### PR TITLE
RSS: Reuse SNAT IPs until port range is exhausted

### DIFF
--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -1133,6 +1133,8 @@ impl ServicePortBuilder {
         self.next_snat_port += NUM_SOURCE_NAT_PORTS;
         if self.next_snat_port.0 == 0 {
             self.next_snat_ip = None;
+        } else {
+            self.next_snat_ip = Some(snat_ip);
         }
 
         let snat_cfg =


### PR DESCRIPTION
Prior to this PR, RSS would step both the IP and the port range when assigning SNAT IPs to boundary NTP zones. E.g., on a4x2:

```json
            "snat_cfg": {
              "ip": "198.51.100.25",
              "first_port": 0,
              "last_port": 16383
            }
            "snat_cfg": {
              "ip": "198.51.100.26",
              "first_port": 16384,
              "last_port": 32767
            }
```

After the change, we reuse the IP and only step the ports:

```json
            "snat_cfg": {
              "ip": "198.51.100.25",
              "first_port": 0,
              "last_port": 16383
            }
            "snat_cfg": {
              "ip": "198.51.100.25",
              "first_port": 16384,
              "last_port": 32767
            }
```

I confirmed both boundary NTP zones still have external connectivity, as expected.

I believe the code here already intended to do this, but accidentally never assigned `self.next_snat_ip`, so always allocated a new IP.