### PR TITLE
Fix type mismatch between table and view

### DIFF
--- a/nexus/db-model/src/bgp.rs
+++ b/nexus/db-model/src/bgp.rs
@@ -5,7 +5,7 @@
 use crate::schema::{
     bgp_announce_set, bgp_announcement, bgp_config, bgp_peer_view,
 };
-use crate::SqlU32;
+use crate::{SqlU16, SqlU32};
 use db_macros::Resource;
 use ipnetwork::IpNetwork;
 use nexus_types::external_api::params;
@@ -141,5 +141,5 @@ pub struct BgpPeerView {
     pub multi_exit_discriminator: Option<SqlU32>,
     pub local_pref: Option<SqlU32>,
     pub enforce_first_as: bool,
-    pub vlan_id: Option<SqlU32>,
+    pub vlan_id: Option<SqlU16>,
 }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -281,7 +281,7 @@ table! {
         multi_exit_discriminator -> Nullable<Int8>,
         local_pref -> Nullable<Int8>,
         enforce_first_as -> Bool,
-        vlan_id -> Nullable<Int8>,
+        vlan_id -> Nullable<Int4>,
     }
 }
 

--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -965,7 +965,7 @@ impl BackgroundTask for SwitchPortSettingsManager {
                                     communities: Vec::new(),
                                     allowed_export: ImportExportPolicy::NoFiltering,
                                     allowed_import: ImportExportPolicy::NoFiltering,
-                                    vlan_id: c.vlan_id.map(|x| x.0 as u16),
+                                    vlan_id: c.vlan_id.map(|x| x.0),
                                 }
                         }).collect(),
                         port: port.port_name.clone(),


### PR DESCRIPTION
vlan_id column in switchport settings child table is type `Int4`, but `bgp_peer_view`'s diesel schema is `Int8`, causing an error when deserializing data from the view (allocated buffer is larger than the received bytes).

Test Results (a4x2 POP topo)
---
```
20:31:15.191Z INFO 173b096a-1fd5-41d6-819b-6d9c939e9eb4 (ServerContext): applying bgp config
    background_task = switch_port_config_manager
    config = ApplyRequest { asn: 65547, checker: None, originate: [Prefix4 { length: 24, value: 198.51.100.0 }, Prefix4 { length: 24, value: 203.0.113.0 }], peers: {"
qsfp0": [BgpPeerConfig { allow_export: NoFiltering, allow_import: NoFiltering, communities: [], connect_retry: 3, delay_open: 3, enforce_first_as: false, hold_time: 6
, host: "169.254.10.1:179", idle_hold_time: 3, keepalive: 2, local_pref: None, md5_auth_key: None, min_ttl: None, multi_exit_discriminator: None, name: "169.254.10.1"
, passive: false, remote_asn: None, resolution: 100, vlan_id: None }, BgpPeerConfig { allow_export: NoFiltering, allow_import: NoFiltering, communities: [], connect_r
etry: 0, delay_open: 0, enforce_first_as: false, hold_time: 6, host: "169.254.30.1:179", idle_hold_time: 0, keepalive: 2, local_pref: None, md5_auth_key: None, min_tt
l: None, multi_exit_discriminator: None, name: "169.254.30.1", passive: false, remote_asn: None, resolution: 100, vlan_id: Some(300) }]}, shaper: None }
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:820
    rack_id = e077dad7-287d-4ac7-a263-63ad6a9ad9d5
    switch_location = Switch0
20:31:15.191Z INFO 173b096a-1fd5-41d6-819b-6d9c939e9eb4 (ServerContext): applying bgp config
    background_task = switch_port_config_manager
    config = ApplyRequest { asn: 65547, checker: None, originate: [Prefix4 { length: 24, value: 198.51.100.0 }, Prefix4 { length: 24, value: 203.0.113.0 }], peers: {"
qsfp0": [BgpPeerConfig { allow_export: NoFiltering, allow_import: NoFiltering, communities: [], connect_retry: 3, delay_open: 3, enforce_first_as: false, hold_time: 6
, host: "169.254.20.1:179", idle_hold_time: 3, keepalive: 2, local_pref: None, md5_auth_key: None, min_ttl: None, multi_exit_discriminator: None, name: "169.254.20.1"
, passive: false, remote_asn: None, resolution: 100, vlan_id: None }, BgpPeerConfig { allow_export: NoFiltering, allow_import: NoFiltering, communities: [], connect_r
etry: 0, delay_open: 0, enforce_first_as: false, hold_time: 6, host: "169.254.40.1:179", idle_hold_time: 0, keepalive: 2, local_pref: None, md5_auth_key: None, min_tt
l: None, multi_exit_discriminator: None, name: "169.254.40.1", passive: false, remote_asn: None, resolution: 100, vlan_id: Some(400) }]}, shaper: None }
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:820
    rack_id = e077dad7-287d-4ac7-a263-63ad6a9ad9d5
    switch_location = Switch1
```

Related
---
Resolves #6023 