### PR TITLE
Support deleting timeseries by name during schema upgrades

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1001,6 +1001,9 @@ impl Client {
             })
             .await?;
 
+        // This size is arbitrary, and just something to avoid enormous requests
+        // to ClickHouse. It's unlikely that we'll hit this in practice anyway,
+        // given that we have far fewer than 1000 timeseries today.
         const DELETE_BATCH_SIZE: usize = 1000;
         let maybe_on_cluster = if replicated {
             format!("ON CLUSTER {}", crate::CLUSTER_NAME)
@@ -1056,7 +1059,7 @@ impl Client {
                 .map(|line| line.trim().parse().map_err(Error::from))
                 .collect(),
             Err(e) if e.kind() == ErrorKind::NotFound => Ok(vec![]),
-            Err(err) => Err(Error::ReadTimeseriesToDelete { err }),
+            Err(err) => Err(Error::ReadTimeseriesToDeleteFile { err }),
         }
     }
 

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -138,6 +138,12 @@ pub enum Error {
     #[error("Schema update versions must be sequential without gaps")]
     NonSequentialSchemaVersions,
 
+    #[error("Could not read timeseries_to_delete file")]
+    ReadTimeseriesToDelete {
+        #[source]
+        err: io::Error,
+    },
+
     #[cfg(any(feature = "sql", test))]
     #[error("SQL error")]
     Sql(#[from] sql::Error),
@@ -295,6 +301,20 @@ const DATABASE_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.9f";
 
 // The name of the database storing all metric information.
 const DATABASE_NAME: &str = "oximeter";
+
+// The name of the oximeter cluster, in the case of a replicated database.
+//
+// This must match what is used in the replicated SQL files when created the
+// database itself, and the XML files describing the cluster.
+const CLUSTER_NAME: &str = "oximeter_cluster";
+
+// The name of the table storing database version information.
+const VERSION_TABLE_NAME: &str = "version";
+
+// During schema upgrades, it is possible to list timeseries that should be
+// deleted, rather than deleting the entire database. These must be listed one
+// per line, in the file inside the schema version directory with this name.
+const TIMESERIES_TO_DELETE_FILE: &str = "timeseries-to-delete.txt";
 
 // The output format used for the result of select queries
 //

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -139,7 +139,7 @@ pub enum Error {
     NonSequentialSchemaVersions,
 
     #[error("Could not read timeseries_to_delete file")]
-    ReadTimeseriesToDelete {
+    ReadTimeseriesToDeleteFile {
         #[source]
         err: io::Error,
     },


### PR DESCRIPTION
This adds support for listing timeseries by name in a schema upgrade directory, and deleting all records (schema and data) from those timeseries during an offline ClickHouse database upgrade. The main goal here is a relatively simple but effective mechanism to clean up abandoned timeseries, while we figure out how to implement breaking changes more robustly.

We alreay have examples of these abandonded timeseries in some existing installations. The existing effort to move timeseries to TOML also presents an opportunity to make one-time breaking changes for individual timeseries. Both of these can be supported with this mechanism.

Fixes #5266