### PR TITLE
[nexus] Make 'dataset' columns for IP address optional

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2795,7 +2795,12 @@ async fn cmd_db_validate_region_snapshots(
         use crucible_agent_client::types::State;
         use crucible_agent_client::Client as CrucibleAgentClient;
 
-        let url = format!("http://{}", dataset.address());
+        let Some(dataset_addr) = dataset.address() else {
+            eprintln!("Dataset {} missing an IP address", dataset.id());
+            continue;
+        };
+
+        let url = format!("http://{}", dataset_addr);
         let client = CrucibleAgentClient::new(&url);
 
         let actual_region_snapshots = client
@@ -2856,7 +2861,7 @@ async fn cmd_db_validate_region_snapshots(
                                     dataset_id: region_snapshot.dataset_id,
                                     region_id: region_snapshot.region_id,
                                     snapshot_id: region_snapshot.snapshot_id,
-                                    dataset_addr: dataset.address(),
+                                    dataset_addr,
                                     error: String::from(
                                         "region snapshot was deleted, please remove its record",
                                     ),
@@ -2871,7 +2876,7 @@ async fn cmd_db_validate_region_snapshots(
                                     dataset_id: region_snapshot.dataset_id,
                                     region_id: region_snapshot.region_id,
                                     snapshot_id: region_snapshot.snapshot_id,
-                                    dataset_addr: dataset.address(),
+                                    dataset_addr,
                                     error: String::from(
                                         "NEXUS BUG: region snapshot was deleted, but the higher level snapshot was not!",
                                     ),
@@ -2900,7 +2905,7 @@ async fn cmd_db_validate_region_snapshots(
                                 dataset_id: region_snapshot.dataset_id,
                                 region_id: region_snapshot.region_id,
                                 snapshot_id: region_snapshot.snapshot_id,
-                                dataset_addr: dataset.address(),
+                                dataset_addr,
                                 error: format!(
                                     "AGENT BUG: region snapshot was deleted but has a running snapshot in state {:?}!",
                                     running_snapshot.state,
@@ -2950,7 +2955,12 @@ async fn cmd_db_validate_region_snapshots(
         use crucible_agent_client::types::State;
         use crucible_agent_client::Client as CrucibleAgentClient;
 
-        let url = format!("http://{}", dataset.address());
+        let Some(dataset_addr) = dataset.address() else {
+            eprintln!("Dataset {} missing an IP address", dataset.id());
+            continue;
+        };
+
+        let url = format!("http://{}", dataset_addr);
         let client = CrucibleAgentClient::new(&url);
 
         let actual_region_snapshots = client
@@ -2968,7 +2978,7 @@ async fn cmd_db_validate_region_snapshots(
                     dataset_id: dataset.id(),
                     region_id: region.id(),
                     snapshot_id,
-                    dataset_addr: dataset.address(),
+                    dataset_addr,
                     error: String::from(
                         "Nexus does not know about this snapshot!",
                     ),
@@ -2993,7 +3003,7 @@ async fn cmd_db_validate_region_snapshots(
                             dataset_id: dataset.id(),
                             region_id: region.id(),
                             snapshot_id,
-                            dataset_addr: dataset.address(),
+                            dataset_addr,
                             error: String::from(
                                 "Nexus does not know about this running snapshot!"
                             ),

--- a/nexus/db-model/src/dataset.rs
+++ b/nexus/db-model/src/dataset.rs
@@ -36,8 +36,8 @@ pub struct Dataset {
 
     pub pool_id: Uuid,
 
-    ip: ipv6::Ipv6Addr,
-    port: SqlU16,
+    ip: Option<ipv6::Ipv6Addr>,
+    port: Option<SqlU16>,
 
     pub kind: DatasetKind,
     pub size_used: Option<i64>,
@@ -47,7 +47,7 @@ impl Dataset {
     pub fn new(
         id: Uuid,
         pool_id: Uuid,
-        addr: SocketAddrV6,
+        addr: Option<SocketAddrV6>,
         kind: DatasetKind,
     ) -> Self {
         let size_used = match kind {
@@ -59,19 +59,19 @@ impl Dataset {
             time_deleted: None,
             rcgen: Generation::new(),
             pool_id,
-            ip: addr.ip().into(),
-            port: addr.port().into(),
+            ip: addr.map(|addr| addr.ip().into()),
+            port: addr.map(|addr| addr.port().into()),
             kind,
             size_used,
         }
     }
 
-    pub fn address(&self) -> SocketAddrV6 {
-        self.address_with_port(self.port.into())
+    pub fn address(&self) -> Option<SocketAddrV6> {
+        self.address_with_port(self.port?.into())
     }
 
-    pub fn address_with_port(&self, port: u16) -> SocketAddrV6 {
-        SocketAddrV6::new(Ipv6Addr::from(self.ip), port, 0, 0)
+    pub fn address_with_port(&self, port: u16) -> Option<SocketAddrV6> {
+        Some(SocketAddrV6::new(Ipv6Addr::from(self.ip?), port, 0, 0))
     }
 }
 

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1022,8 +1022,8 @@ table! {
 
         pool_id -> Uuid,
 
-        ip -> Inet,
-        port -> Int4,
+        ip -> Nullable<Inet>,
+        port -> Nullable<Int4>,
 
         kind -> crate::DatasetKindEnum,
         size_used -> Nullable<Int8>,

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(82, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(83, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(83, "dataset-address-optional"),
         KnownVersion::new(82, "region-port"),
         KnownVersion::new(81, "add-nullable-filesystem-pool"),
         KnownVersion::new(80, "add-instance-id-to-migrations"),

--- a/nexus/db-queries/src/db/datastore/dataset.rs
+++ b/nexus/db-queries/src/db/datastore/dataset.rs
@@ -290,7 +290,7 @@ mod test {
             .dataset_insert_if_not_exists(Dataset::new(
                 Uuid::new_v4(),
                 zpool_id,
-                "[::1]:0".parse().unwrap(),
+                Some("[::1]:0".parse().unwrap()),
                 DatasetKind::Crucible,
             ))
             .await
@@ -323,7 +323,7 @@ mod test {
             .dataset_insert_if_not_exists(Dataset::new(
                 dataset1.id(),
                 zpool_id,
-                "[::1]:12345".parse().unwrap(),
+                Some("[::1]:12345".parse().unwrap()),
                 DatasetKind::Cockroach,
             ))
             .await
@@ -339,7 +339,7 @@ mod test {
             .dataset_upsert(Dataset::new(
                 Uuid::new_v4(),
                 zpool_id,
-                "[::1]:0".parse().unwrap(),
+                Some("[::1]:0".parse().unwrap()),
                 DatasetKind::Cockroach,
             ))
             .await
@@ -371,7 +371,7 @@ mod test {
             .dataset_insert_if_not_exists(Dataset::new(
                 dataset1.id(),
                 zpool_id,
-                "[::1]:12345".parse().unwrap(),
+                Some("[::1]:12345".parse().unwrap()),
                 DatasetKind::Cockroach,
             ))
             .await

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -893,7 +893,8 @@ mod test {
                 .collect()
                 .await;
 
-            let bogus_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
+            let bogus_addr =
+                Some(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0));
 
             let datasets = stream::iter(zpools)
                 .map(|zpool| {
@@ -1267,7 +1268,8 @@ mod test {
             .collect()
             .await;
 
-        let bogus_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
+        let bogus_addr =
+            Some(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0));
 
         // 1 dataset per zpool
         stream::iter(zpool_ids.clone())
@@ -1366,7 +1368,8 @@ mod test {
                 .collect()
                 .await;
 
-        let bogus_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
+        let bogus_addr =
+            Some(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0));
 
         // 1 dataset per zpool
         stream::iter(zpool_ids)
@@ -1445,7 +1448,8 @@ mod test {
                 physical_disk_id,
             )
             .await;
-            let bogus_addr = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
+            let bogus_addr =
+                Some(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0));
             let dataset = Dataset::new(
                 Uuid::new_v4(),
                 zpool_id,

--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -496,7 +496,13 @@ impl DataStore {
 
         let dataset = self.dataset_get(region.dataset_id()).await?;
 
-        Ok(Some(SocketAddrV6::new(*dataset.address().ip(), port, 0, 0)))
+        let Some(address) = dataset.address() else {
+            return Err(Error::internal_error(
+                "Dataset for Crucible region does know IP address",
+            ));
+        };
+
+        Ok(Some(SocketAddrV6::new(*address.ip(), port, 0, 0)))
     }
 
     pub async fn regions_missing_ports(

--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -1164,12 +1164,14 @@ impl DataStore {
 
         let mut targets: Vec<SocketAddrV6> = vec![];
 
-        find_matching_rw_regions_in_volume(
-            &vcr,
-            dataset.address().ip(),
-            &mut targets,
-        )
-        .map_err(|e| Error::internal_error(&e.to_string()))?;
+        let Some(address) = dataset.address() else {
+            return Err(Error::internal_error(
+                "Crucible Dataset missing IP address",
+            ));
+        };
+
+        find_matching_rw_regions_in_volume(&vcr, address.ip(), &mut targets)
+            .map_err(|e| Error::internal_error(&e.to_string()))?;
 
         Ok(targets)
     }

--- a/nexus/reconfigurator/execution/src/datasets.rs
+++ b/nexus/reconfigurator/execution/src/datasets.rs
@@ -71,7 +71,7 @@ pub(crate) async fn ensure_crucible_dataset_records_exist(
         let dataset = Dataset::new(
             id.into_untyped_uuid(),
             pool_id.into_untyped_uuid(),
-            *address,
+            Some(*address),
             DatasetKind::Crucible,
         );
         let maybe_inserted = datastore

--- a/nexus/src/app/background/tasks/lookup_region_port.rs
+++ b/nexus/src/app/background/tasks/lookup_region_port.rs
@@ -91,26 +91,33 @@ impl BackgroundTask for LookupRegionPort {
                     }
                 };
 
-                let returned_region = match get_region_from_agent(
-                    &dataset.address(),
-                    region.id(),
-                )
-                .await
-                {
-                    Ok(returned_region) => returned_region,
-
-                    Err(e) => {
-                        let s = format!(
-                            "could not get region {} from agent: {e}",
-                            region.id(),
-                        );
-
-                        error!(log, "{s}");
-                        status.errors.push(s);
-
-                        continue;
-                    }
+                let Some(dataset_addr) = dataset.address() else {
+                    let s = format!(
+                        "Missing dataset address for dataset: {dataset_id}"
+                    );
+                    error!(log, "{s}");
+                    status.errors.push(s);
+                    continue;
                 };
+
+                let returned_region =
+                    match get_region_from_agent(&dataset_addr, region.id())
+                        .await
+                    {
+                        Ok(returned_region) => returned_region,
+
+                        Err(e) => {
+                            let s = format!(
+                                "could not get region {} from agent: {e}",
+                                region.id(),
+                            );
+
+                            error!(log, "{s}");
+                            status.errors.push(s);
+
+                            continue;
+                        }
+                    };
 
                 match self
                     .datastore

--- a/nexus/src/app/crucible.rs
+++ b/nexus/src/app/crucible.rs
@@ -69,11 +69,17 @@ impl super::Nexus {
     fn crucible_agent_client_for_dataset(
         &self,
         dataset: &db::model::Dataset,
-    ) -> CrucibleAgentClient {
-        CrucibleAgentClient::new_with_client(
-            &format!("http://{}", dataset.address()),
+    ) -> Result<CrucibleAgentClient, Error> {
+        let Some(addr) = dataset.address() else {
+            return Err(Error::internal_error(
+                "Missing crucible dataset address",
+            ));
+        };
+
+        Ok(CrucibleAgentClient::new_with_client(
+            &format!("http://{}", addr),
             self.reqwest_client.clone(),
-        )
+        ))
     }
 
     /// Return if the Crucible agent is expected to be there and answer Nexus:
@@ -147,7 +153,7 @@ impl super::Nexus {
         dataset: &db::model::Dataset,
         region: &db::model::Region,
     ) -> Result<Region, Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let Ok(extent_count) = u32::try_from(region.extent_count()) else {
@@ -261,7 +267,7 @@ impl super::Nexus {
         dataset: &db::model::Dataset,
         region_id: Uuid,
     ) -> Result<Option<Region>, Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let result = ProgenitorOperationRetry::new(
@@ -303,7 +309,7 @@ impl super::Nexus {
         dataset: &db::model::Dataset,
         region_id: Uuid,
     ) -> Result<GetSnapshotResponse, Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let result = ProgenitorOperationRetry::new(
@@ -343,7 +349,7 @@ impl super::Nexus {
         dataset: &db::model::Dataset,
         region_id: Uuid,
     ) -> Result<(), Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let result = ProgenitorOperationRetry::new(
@@ -386,7 +392,7 @@ impl super::Nexus {
         region_id: Uuid,
         snapshot_id: Uuid,
     ) -> Result<(), Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let result = ProgenitorOperationRetry::new(
@@ -435,7 +441,7 @@ impl super::Nexus {
         region_id: Uuid,
         snapshot_id: Uuid,
     ) -> Result<(), Error> {
-        let client = self.crucible_agent_client_for_dataset(dataset);
+        let client = self.crucible_agent_client_for_dataset(dataset)?;
         let dataset_id = dataset.id();
 
         let result = ProgenitorOperationRetry::new(

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -145,7 +145,7 @@ impl super::Nexus {
                 db::model::Dataset::new(
                     dataset.dataset_id,
                     dataset.zpool_id,
-                    dataset.request.address,
+                    Some(dataset.request.address),
                     dataset.request.kind.into(),
                 )
             })

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -498,9 +498,17 @@ async fn sdc_regions_ensure(
                     .map(|(dataset, region)| {
                         dataset
                             .address_with_port(region.port_number)
-                            .to_string()
+                            .ok_or_else(|| {
+                                ActionError::action_failed(
+                                    Error::internal_error(&format!(
+                                        "missing IP address for dataset {}",
+                                        dataset.id(),
+                                    )),
+                                )
+                            })
+                            .map(|addr| addr.to_string())
                     })
-                    .collect(),
+                    .collect::<Result<Vec<_>, ActionError>>()?,
 
                 lossy: false,
                 flush_timeout: None,

--- a/nexus/src/app/sagas/region_replacement_start.rs
+++ b/nexus/src/app/sagas/region_replacement_start.rs
@@ -534,12 +534,13 @@ async fn srrs_replace_region_in_volume(
         "ensured_dataset_and_region",
     )?;
 
-    let new_region_address = SocketAddrV6::new(
-        *new_dataset.address().ip(),
-        ensured_region.port_number,
-        0,
-        0,
-    );
+    let Some(new_address) = new_dataset.address() else {
+        return Err(ActionError::action_failed(Error::internal_error(
+            "Dataset missing IP address",
+        )));
+    };
+    let new_region_address =
+        SocketAddrV6::new(*new_address.ip(), ensured_region.port_number, 0, 0);
 
     // If this node is rerun, the forward action will have overwritten
     // db_region's volume id, so get the cached copy.
@@ -611,12 +612,11 @@ async fn srrs_replace_region_in_volume_undo(
         "ensured_dataset_and_region",
     )?;
 
-    let new_region_address = SocketAddrV6::new(
-        *new_dataset.address().ip(),
-        ensured_region.port_number,
-        0,
-        0,
-    );
+    let Some(new_address) = new_dataset.address() else {
+        anyhow::bail!("Dataset missing IP address");
+    };
+    let new_region_address =
+        SocketAddrV6::new(*new_address.ip(), ensured_region.port_number, 0, 0);
 
     // The forward action will have overwritten db_region's volume id, so get
     // the cached copy.
@@ -894,25 +894,25 @@ pub(crate) mod test {
             Dataset::new(
                 Uuid::new_v4(),
                 Uuid::new_v4(),
-                "[fd00:1122:3344:101::1]:12345".parse().unwrap(),
+                Some("[fd00:1122:3344:101::1]:12345".parse().unwrap()),
                 DatasetKind::Crucible,
             ),
             Dataset::new(
                 Uuid::new_v4(),
                 Uuid::new_v4(),
-                "[fd00:1122:3344:102::1]:12345".parse().unwrap(),
+                Some("[fd00:1122:3344:102::1]:12345".parse().unwrap()),
                 DatasetKind::Crucible,
             ),
             Dataset::new(
                 Uuid::new_v4(),
                 Uuid::new_v4(),
-                "[fd00:1122:3344:103::1]:12345".parse().unwrap(),
+                Some("[fd00:1122:3344:103::1]:12345".parse().unwrap()),
                 DatasetKind::Crucible,
             ),
             Dataset::new(
                 Uuid::new_v4(),
                 Uuid::new_v4(),
-                "[fd00:1122:3344:104::1]:12345".parse().unwrap(),
+                Some("[fd00:1122:3344:104::1]:12345".parse().unwrap()),
                 DatasetKind::Crucible,
             ),
         ];

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -281,7 +281,8 @@ impl super::Nexus {
             "dataset_id" => id.to_string(),
             "address" => address.to_string()
         );
-        let dataset = db::model::Dataset::new(id, zpool_id, address, kind);
+        let dataset =
+            db::model::Dataset::new(id, zpool_id, Some(address), kind);
         self.db_datastore.dataset_upsert(dataset).await?;
         Ok(())
     }

--- a/schema/crdb/dataset-address-optional/up01.sql
+++ b/schema/crdb/dataset-address-optional/up01.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.dataset ALTER COLUMN ip DROP NOT NULL;

--- a/schema/crdb/dataset-address-optional/up02.sql
+++ b/schema/crdb/dataset-address-optional/up02.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.dataset ALTER COLUMN port DROP NOT NULL;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -525,8 +525,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.dataset (
     pool_id UUID NOT NULL,
 
     /* Contact information for the dataset */
-    ip INET NOT NULL,
-    port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
+    ip INET,
+    port INT4 CHECK (port BETWEEN 0 AND 65535),
 
     kind omicron.public.dataset_kind NOT NULL,
 
@@ -4143,7 +4143,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '82.0.0', NULL)
+    (TRUE, NOW(), NOW(), '83.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
This is part of an effort to make datasets usable without an explicit service managing them (e.g., in the context of Support Bundles).