### PR TITLE
[nix flake] make dev shell moldy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -384,8 +384,13 @@
       devShells.x86_64-linux.default =
         pkgs.mkShell.override
           {
-            # use Clang as the C compiler for all C libraries
-            stdenv = pkgs.clangStdenv;
+            stdenv =
+              # use Mold as the linker rather than ld, for faster builds. Mold
+              # to require substantially less memory to link Nexus and its
+              # avoiding swapping on memory-constrained dev systems.
+              pkgs.stdenvAdapters.useMoldLinker
+                # use Clang as the C compiler for all C libraries.
+                pkgs.clangStdenv;
           }
           {
             inherit buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, rust-overlay, ... }:
+  outputs = { nixpkgs, rust-overlay, ... }:
     let
       overlays = [ (import rust-overlay) ];
       pkgs = import nixpkgs {

--- a/flake.nix
+++ b/flake.nix
@@ -381,16 +381,16 @@
           };
         };
 
-      devShells.x86_64-linux.default =
-        pkgs.mkShell.override
+      devShells.x86_64-linux.default = with pkgs;
+        mkShell.override
           {
             stdenv =
               # use Mold as the linker rather than ld, for faster builds. Mold
               # to require substantially less memory to link Nexus and its
               # avoiding swapping on memory-constrained dev systems.
-              pkgs.stdenvAdapters.useMoldLinker
+              stdenvAdapters.useMoldLinker
                 # use Clang as the C compiler for all C libraries.
-                pkgs.clangStdenv;
+                clangStdenv;
           }
           {
             inherit buildInputs;
@@ -403,10 +403,10 @@
             ];
 
             name = "omicron";
-            DEP_PQ_LIBDIRS = "${pkgs.postgresql.lib}/lib";
-            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-            OPENSSL_DIR = "${pkgs.openssl.dev}";
-            OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+            DEP_PQ_LIBDIRS = "${postgresql.lib}/lib";
+            LIBCLANG_PATH = "${libclang.lib}/lib";
+            OPENSSL_DIR = "${openssl.dev}";
+            OPENSSL_LIB_DIR = "${openssl.out}/lib";
 
             MG_OPENAPI_PATH = mgOpenAPI;
             DDM_OPENAPI_PATH = ddmOpenAPI;


### PR DESCRIPTION
This commit switches the dev shell provided by the Nix flake to use
`mold` as the linker, rather than `ld`. This results in substantially
faster build times (at least on my build machine, where building Nexus
with `ld` results in memory bottlenecks and swaps to disk a bunch).

To use `mold` in the Nix dev shell, we override the Nix `stdenv` to use
Mold as the system linker, as well as overriding `clang` as the C
compiler (which we did previously).

Additionally, I've made a couple very minor style tweaks to the Nix flake.

@sunshowers, I'd be interested to know whether the Nix dev shell is now
usable on your system, as I know we had problems previously due to your
system-wide non-Nix use of `mold`...
