### PR TITLE
fix: remove flaky, unbounded test and move it to a benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6421,6 +6421,7 @@ dependencies = [
  "approx",
  "bytes",
  "chrono",
+ "criterion",
  "float-ord",
  "heck 0.5.0",
  "num",

--- a/oximeter/impl/Cargo.toml
+++ b/oximeter/impl/Cargo.toml
@@ -32,8 +32,14 @@ uuid.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
+# For benchmark
+criterion.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 rand_distr.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 trybuild.workspace = true
+
+[[bench]]
+name = "quantile"
+harness = false

--- a/oximeter/impl/benches/quantile.rs
+++ b/oximeter/impl/benches/quantile.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Benchmarks for the implementation of the P² algorithm with
+//! quantile estimation.
+
+// Copyright 2024 Oxide Computer Company
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use oximeter_impl::Quantile;
+use rand_distr::{Distribution, Normal};
+
+/// Emulates baseline code in a Python implementation of the P²
+/// algorithm:
+/// <https://github.com/rfrenoy/psquare/blob/master/tests/test_psquare.py#L47>.
+fn normal_distribution_quantile(size: i32, p: f64) -> f64 {
+    let mu = 500.;
+    let sigma = 100.;
+    let mut q = Quantile::new(p).unwrap();
+    let normal = Normal::new(mu, sigma).unwrap();
+    for _ in 0..size {
+        q.append(normal.sample(&mut rand::thread_rng())).unwrap();
+    }
+    q.estimate().unwrap()
+}
+
+fn baseline_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Quantile");
+    let size = 1000;
+    for p in [0.5, 0.9, 0.95, 0.99].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Estimate on Normal Distribution", p),
+            p,
+            |b, p| b.iter(|| normal_distribution_quantile(size, *p)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, baseline_benchmark);
+criterion_main!(benches);

--- a/oximeter/impl/src/quantile.rs
+++ b/oximeter/impl/src/quantile.rs
@@ -426,7 +426,6 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use rand::{Rng, SeedableRng};
-    use rand_distr::{Distribution, Normal};
 
     fn test_quantile_impl(
         p: f64,
@@ -567,38 +566,5 @@ mod tests {
         assert_eq!(q.find_cell(7.), Some(4));
         assert_eq!(q.find_cell(4.), Some(3));
         assert_eq!(q.find_cell(3.5), Some(2));
-    }
-
-    /// Emulates baseline test in a basic Python implementation of the P²
-    /// algorithm:
-    /// <https://github.com/rfrenoy/psquare/blob/master/tests/test_psquare.py#L47>.
-    #[test]
-    fn test_against_baseline_normal_distribution() {
-        let mu = 500.;
-        let sigma = 100.;
-        let size = 1000;
-        let p = 0.9;
-
-        let normal = Normal::new(mu, sigma);
-        let mut observations = (0..size)
-            .map(|_| normal.unwrap().sample(&mut rand::thread_rng()))
-            .collect::<Vec<f64>>();
-        float_ord::sort(&mut observations);
-        let idx = ((f64::from(size) - 1.) * p) as usize;
-
-        let base_p_est = observations[idx];
-
-        let mut q = Quantile::new(p).unwrap();
-        for o in observations.iter() {
-            q.append(*o).unwrap();
-        }
-        let p_est = q.estimate().unwrap();
-
-        println!("Base: {}, Est: {}", base_p_est, p_est);
-        assert!(
-            (base_p_est - p_est).abs() < 10.0,
-            "Difference {} is not less than 10",
-            (base_p_est - p_est).abs()
-        );
     }
 }


### PR DESCRIPTION
Closes https://github.com/oxidecomputer/omicron/issues/6100 (which was a bit unnecessary and more for testing)