### PR TITLE
Add sled-identifiers to instance vCPU stats

### DIFF
--- a/oximeter/oximeter/schema/virtual-machine.toml
+++ b/oximeter/oximeter/schema/virtual-machine.toml
@@ -5,7 +5,7 @@ name = "virtual_machine"
 description = "A guest virtual machine instance"
 authz_scope = "project"
 versions = [
-    { version = 1, fields = [ "instance_id", "project_id", "silo_id" ] },
+    { version = 1, fields = [ "instance_id", "project_id", "silo_id", "sled_id", "sled_model", "sled_revision", "sled_serial" ] },
 ]
 
 [[metrics]]
@@ -55,6 +55,22 @@ description = "ID of the virtual machine instance's project"
 [fields.silo_id]
 type = "uuid"
 description = "ID of the virtual machine instance's silo"
+
+[fields.sled_id]
+type = "uuid"
+description = "ID of the sled hosting the instance"
+
+[fields.sled_model]
+type = "string"
+description = "Model number of the sled hosting the instance"
+
+[fields.sled_revision]
+type = "u32"
+description = "Revision number of the sled hosting the instance"
+
+[fields.sled_serial]
+type = "string"
+description = "Serial number of the sled hosting the instance"
 
 [fields.state]
 type = "string"


### PR DESCRIPTION
This adds the sled UUID and baseboard info into the existing vCPU stats. This is an incompatible change, and will require dropping old data from the previous versions of the timeseries. That's unused today, and it's not yet clear how we'll actually manage the timeseries data across a schema change, so I'd like to include this now.