### PR TITLE
Close parentheses on ddm retry log events

### DIFF
--- a/clients/ddm-admin-client/src/lib.rs
+++ b/clients/ddm-admin-client/src/lib.rs
@@ -96,7 +96,7 @@ impl Client {
             }, |err, duration| {
                 info!(
                     me.log,
-                    "Failed to notify ddmd of our address (will retry after {duration:?}";
+                    "Failed to notify ddmd of our address (will retry after {duration:?})";
                     "err" => %err,
                 );
             }).await.unwrap();
@@ -112,7 +112,7 @@ impl Client {
             }, |err, duration| {
                 info!(
                     me.log,
-                    "Failed to notify ddmd of tunnel endpoint (retry in {duration:?}";
+                    "Failed to notify ddmd of tunnel endpoint (retry in {duration:?})";
                     "err" => %err,
                 );
             }).await.unwrap();
@@ -176,7 +176,7 @@ impl Client {
             }, |err, duration| {
                 info!(
                     me.log,
-                    "Failed enable ddm stats (will retry after {duration:?}";
+                    "Failed enable ddm stats (will retry after {duration:?})";
                     "err" => %err,
                 );
             }).await.unwrap();


### PR DESCRIPTION
Currently we do not add a trailing `)` for `ddm` "will retry after" log messages.

Close the parens.

Before:

```
  Failed enable ddm stats (will retry after 208.130529ms
```

After:

```
  Failed enable ddm stats (will retry after 208.130529ms)
```