### PR TITLE
Fix race between sled-agent and zone-setup service

### DIFF
--- a/illumos-utils/src/addrobj.rs
+++ b/illumos-utils/src/addrobj.rs
@@ -5,7 +5,17 @@
 //! API for operating on addrobj objects.
 
 /// The name provided to all link-local IPv6 addresses.
-pub const IPV6_LINK_LOCAL_NAME: &str = "ll";
+pub const IPV6_LINK_LOCAL_ADDROBJ_NAME: &str = "ll";
+
+/// The name provided to all static IPv6 underlay addresses.
+pub const IPV6_STATIC_ADDROBJ_NAME: &str = "omicron6";
+
+/// The name provided to all static IPv4 addresses, usually for public OPTE
+/// interfaces.
+pub const IPV4_STATIC_ADDROBJ_NAME: &str = "omicron6";
+
+/// The name provided to DHCP-configured addresses, of either family.
+pub const DHCP_ADDROBJ_NAME: &str = "omicron";
 
 /// Describes an "addrobj", which is the combination of an interface
 /// with an associated name.
@@ -59,7 +69,7 @@ impl AddrObject {
     /// Create a new addrobj on the same interface with the IPv6 link-local
     /// name.
     pub fn link_local_on_same_interface(&self) -> Result<Self, ParseError> {
-        self.on_same_interface(IPV6_LINK_LOCAL_NAME)
+        self.on_same_interface(IPV6_LINK_LOCAL_ADDROBJ_NAME)
     }
 
     pub fn new(interface: &str, name: &str) -> Result<Self, ParseError> {
@@ -76,7 +86,7 @@ impl AddrObject {
 
     /// A link-local IPv6 addrobj over the provided interface.
     pub fn link_local(interface: &str) -> Result<Self, ParseError> {
-        Self::new(interface, IPV6_LINK_LOCAL_NAME)
+        Self::new(interface, IPV6_LINK_LOCAL_ADDROBJ_NAME)
     }
 
     pub fn interface(&self) -> &str {

--- a/illumos-utils/src/addrobj.rs
+++ b/illumos-utils/src/addrobj.rs
@@ -12,7 +12,7 @@ pub const IPV6_STATIC_ADDROBJ_NAME: &str = "omicron6";
 
 /// The name provided to all static IPv4 addresses, usually for public OPTE
 /// interfaces.
-pub const IPV4_STATIC_ADDROBJ_NAME: &str = "omicron6";
+pub const IPV4_STATIC_ADDROBJ_NAME: &str = "omicron4";
 
 /// The name provided to DHCP-configured addresses, of either family.
 pub const DHCP_ADDROBJ_NAME: &str = "omicron";

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -4,7 +4,10 @@
 
 //! Utilities to manage running zones.
 
-use crate::addrobj::AddrObject;
+use crate::addrobj::{
+    AddrObject, DHCP_ADDROBJ_NAME, IPV4_STATIC_ADDROBJ_NAME,
+    IPV6_STATIC_ADDROBJ_NAME,
+};
 use crate::dladm::Etherstub;
 use crate::link::{Link, VnicAllocator};
 use crate::opte::{Port, PortTicket};
@@ -360,7 +363,11 @@ impl RunningZone {
     }
 
     pub fn control_interface(&self) -> AddrObject {
-        AddrObject::new(self.inner.get_control_vnic_name(), "omicron6").unwrap()
+        AddrObject::new(
+            self.inner.get_control_vnic_name(),
+            IPV6_STATIC_ADDROBJ_NAME,
+        )
+        .unwrap()
     }
 
     /// Runs a command within the Zone, return the output.
@@ -547,10 +554,10 @@ impl RunningZone {
         addrtype: AddressRequest,
     ) -> Result<IpNetwork, EnsureAddressError> {
         let name = match addrtype {
-            AddressRequest::Dhcp => "omicron",
+            AddressRequest::Dhcp => DHCP_ADDROBJ_NAME,
             AddressRequest::Static(net) => match net.ip() {
-                std::net::IpAddr::V4(_) => "omicron4",
-                std::net::IpAddr::V6(_) => "omicron6",
+                std::net::IpAddr::V4(_) => IPV4_STATIC_ADDROBJ_NAME,
+                std::net::IpAddr::V6(_) => IPV6_STATIC_ADDROBJ_NAME,
             },
         };
         self.ensure_address_with_name(addrtype, name).await

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -43,7 +43,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use dpd_client::{types as DpdTypes, Client as DpdClient, Error as DpdError};
 use dropshot::HandlerTaskMode;
 use illumos_utils::addrobj::AddrObject;
-use illumos_utils::addrobj::IPV6_LINK_LOCAL_NAME;
+use illumos_utils::addrobj::IPV6_LINK_LOCAL_ADDROBJ_NAME;
 use illumos_utils::dladm::{
     Dladm, Etherstub, EtherstubVnic, GetSimnetError, PhysicalLink,
 };
@@ -2879,7 +2879,7 @@ impl ServiceManager {
                                             // cabled together.
                                             AddrObject::new(
                                                 &format!("tfportrear{}_0", i),
-                                                IPV6_LINK_LOCAL_NAME,
+                                                IPV6_LINK_LOCAL_ADDROBJ_NAME,
                                             )
                                             .unwrap()
                                         })
@@ -2891,7 +2891,7 @@ impl ServiceManager {
                                         .map(|i| {
                                             AddrObject::new(
                                                 &i.to_string(),
-                                                IPV6_LINK_LOCAL_NAME,
+                                                IPV6_LINK_LOCAL_ADDROBJ_NAME,
                                             )
                                             .unwrap()
                                         })
@@ -3648,7 +3648,7 @@ impl ServiceManager {
                 }
             }
             Err(e) => {
-                info!(self.inner.log, "chronyc command failed: {}", e);
+                error!(self.inner.log, "chronyc command failed: {}", e);
                 Err(Error::NtpZoneNotReady)
             }
         }

--- a/smf/zone-network-setup/manifest.xml
+++ b/smf/zone-network-setup/manifest.xml
@@ -7,7 +7,7 @@
   <create_default_instance enabled='true' />
 
   <!-- Run after the zone's networking stack is up. -->
-  <dependency name='physical' grouping='require_all' restart_on='none'
+  <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />
   </dependency>
@@ -16,7 +16,7 @@
           have been set by the sled-agent, which happens after the
           `manifest-import` service is running.
   -->
-  <dependency name='zone-network-setup-manifest-import' type='service' grouping='require_all' restart_on='none'>
+  <dependency name='manifest-import' type='service' grouping='require_all' restart_on='none'>
     <service_fmri value='svc:/system/manifest-import:default' />
   </dependency>
 

--- a/smf/zone-network-setup/manifest.xml
+++ b/smf/zone-network-setup/manifest.xml
@@ -6,21 +6,26 @@
 <service name='oxide/zone-network-setup' type='service' version='1'>
   <create_default_instance enabled='true' />
 
-  <!-- Run after the operating system's svc:/network/physical service is done. -->
+  <!-- Run after the zone's networking stack is up. -->
   <dependency name='physical' grouping='require_all' restart_on='none'
     type='service'>
-  <service_fmri value='svc:/network/physical:default' />
+  <service_fmri value='svc:/milestone/network:default' />
   </dependency>
 
-  <dependency name='multi_user' grouping='require_all' restart_on='none'
-    type='service'>
-  <service_fmri value='svc:/milestone/multi-user:default' />
+  <!-- The zone-setup binary is not ready to run until its initial properties
+          have been set by the sled-agent, which happens after the
+          `manifest-import` service is running.
+  -->
+  <dependency name='zone-network-setup-manifest-import' type='service' grouping='require_all' restart_on='none'>
+    <service_fmri value='svc:/system/manifest-import:default' />
   </dependency>
 
   <exec_method type='method' name='start'
     exec='/opt/oxide/zone-setup-cli/bin/zone-setup common-networking -d %{config/datalink} -s %{config/static_addr} -g %{config/gateway}'
     timeout_seconds='0' />
-  
+
+  <exec_method type='method' name='stop' exec=':true' timeout_seconds='0' />
+
   <property_group name='startd' type='framework'>
     <propval name='duration' type='astring' value='transient' />
   </property_group>


### PR DESCRIPTION
- Fixes #6149
- Most zones run the `zone-network-setup` once, at startup, with their underlay addresses already provided by the sled-agent. That's not true for the switch zone, which starts with only a localhost address, and then is provided an underlay address by the sled-agent only after the bootstrapping process has proceededed further. However, the zone-setup-service previously deleted its IP interfaces prior to setting the underlay address on it, apparently as a workaround for https://github.com/oxidecomputer/stlouis/issues/435. That's fine for other zones, but that races with the sled-agent setting that underlay address later in the switch zone. It's possible for the zone-setup-service to delete the interface _after_ those addresses are set, which obviously prevents the rest of the control plane from deploying correctly. This fixes the issue by simply removing that call to `ipadm delete-if` in the zone-setup-service. The mentioned issue has been resolved, and the workaround is no longer needed.
- Move the `zone-network-setup` service depend on the network milestone, instead of multi-user. This just moves it earlier a bit in the dependency graph, though should not be strictly necessary. We might want to move the sled-agent's notion of "zone readiness" to depend on `multi-user` instead of `single-user` in the future, so this could help with that.
- Extract out a few constants, some whitespace cleanup