### PR TITLE
Add a omdb db volume command, with VCR support

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -310,6 +310,8 @@ enum DbCommands {
     Snapshots(SnapshotArgs),
     /// Validate the contents of the database
     Validate(ValidateArgs),
+    /// Print information about volumes
+    Volumes(VolumeArgs),
 }
 
 #[derive(Debug, Args)]
@@ -579,6 +581,26 @@ enum ValidateCommands {
     ValidateRegionSnapshots,
 }
 
+#[derive(Debug, Args)]
+struct VolumeArgs {
+    #[command(subcommand)]
+    command: VolumeCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum VolumeCommands {
+    /// Get info for a specific volume
+    Info(VolumeInfoArgs),
+    /// Summarize current volumes
+    List,
+}
+
+#[derive(Debug, Args)]
+struct VolumeInfoArgs {
+    /// The UUID of the volume
+    uuid: Uuid,
+}
+
 impl DbArgs {
     /// Run a `omdb db` subcommand.
     pub(crate) async fn run_cmd(
@@ -720,6 +742,12 @@ impl DbArgs {
             DbCommands::Validate(ValidateArgs {
                 command: ValidateCommands::ValidateRegionSnapshots,
             }) => cmd_db_validate_region_snapshots(&datastore).await,
+            DbCommands::Volumes(VolumeArgs {
+                command: VolumeCommands::Info(uuid),
+            }) => cmd_db_volume_info(&datastore, uuid).await,
+            DbCommands::Volumes(VolumeArgs {
+                command: VolumeCommands::List,
+            }) => cmd_db_volume_list(&datastore, &self.fetch_opts).await,
         }
     }
 }
@@ -1165,6 +1193,38 @@ async fn cmd_db_disk_info(
 
     println!("{}", table);
 
+    get_and_display_vcr(disk.volume_id, datastore).await?;
+    Ok(())
+}
+
+// Given a UUID, search the database for a volume with that ID
+// If found, attempt to parse the .data field into a VolumeConstructionRequest
+// and display it if successful.
+async fn get_and_display_vcr(
+    volume_id: Uuid,
+    datastore: &DataStore,
+) -> Result<(), anyhow::Error> {
+    // Get the VCR from the volume and display selected parts.
+    use db::schema::volume::dsl as volume_dsl;
+    let volumes = volume_dsl::volume
+        .filter(volume_dsl::id.eq(volume_id))
+        .limit(1)
+        .select(Volume::as_select())
+        .load_async(&*datastore.pool_connection_for_tests().await?)
+        .await
+        .context("loading requested volume")?;
+
+    for v in volumes {
+        match serde_json::from_str(&v.data()) {
+            Ok(vcr) => {
+                println!("\nVCR from volume ID {volume_id}");
+                print_vcr(vcr, 0);
+            }
+            Err(e) => {
+                println!("Volume had invalid VCR in data field: {e}");
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1569,8 +1629,10 @@ async fn cmd_db_snapshot_info(
         .context("loading requested snapshot")?;
 
     let mut dest_volume_ids = Vec::new();
+    let mut source_volume_ids = Vec::new();
     let rows = snapshots.into_iter().map(|snapshot| {
         dest_volume_ids.push(snapshot.destination_volume_id);
+        source_volume_ids.push(snapshot.volume_id);
         SnapshotRow::from(snapshot)
     });
     if rows.len() == 0 {
@@ -1584,6 +1646,10 @@ async fn cmd_db_snapshot_info(
 
     println!("{}", table);
 
+    println!("SOURCE VOLUME VCR:");
+    for vol in source_volume_ids {
+        get_and_display_vcr(vol, datastore).await?;
+    }
     for vol_id in dest_volume_ids {
         // Get the dataset backing this volume.
         let regions = datastore.get_allocated_regions(vol_id).await?;
@@ -1618,10 +1684,223 @@ async fn cmd_db_snapshot_info(
             .with(tabled::settings::Padding::new(0, 1, 0, 0))
             .to_string();
 
+        println!("DESTINATION REGION INFO:");
         println!("{}", table);
+        println!("DESTINATION VOLUME VCR:");
+        get_and_display_vcr(vol_id, datastore).await?;
     }
 
     Ok(())
+}
+
+// Volumes
+/// Run `omdb db volume list`.
+async fn cmd_db_volume_list(
+    datastore: &DataStore,
+    fetch_opts: &DbFetchOptions,
+) -> Result<(), anyhow::Error> {
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct VolumeRow {
+        id: String,
+        created: String,
+        modified: String,
+        deleted: String,
+    }
+
+    let ctx = || "listing volumes".to_string();
+
+    use db::schema::volume::dsl;
+    let mut query = dsl::volume.into_boxed();
+    if !fetch_opts.include_deleted {
+        query = query.filter(dsl::time_deleted.is_null());
+    }
+
+    let volumes = query
+        .limit(i64::from(u32::from(fetch_opts.fetch_limit)))
+        .select(Volume::as_select())
+        .load_async(&*datastore.pool_connection_for_tests().await?)
+        .await
+        .context("loading volumes")?;
+
+    check_limit(&volumes, fetch_opts.fetch_limit, ctx);
+
+    let rows = volumes.into_iter().map(|volume| VolumeRow {
+        id: volume.id().to_string(),
+        created: volume.time_created().to_string(),
+        modified: volume.time_modified().to_string(),
+        deleted: match volume.time_deleted {
+            Some(time) => time.to_string(),
+            None => "NULL".to_string(),
+        },
+    });
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}
+
+/// Run `omdb db volume info <UUID>`.
+async fn cmd_db_volume_info(
+    datastore: &DataStore,
+    args: &VolumeInfoArgs,
+) -> Result<(), anyhow::Error> {
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct VolumeRow {
+        id: String,
+        created: String,
+        modified: String,
+        deleted: String,
+    }
+
+    use db::schema::volume::dsl as volume_dsl;
+
+    let volumes = volume_dsl::volume
+        .filter(volume_dsl::id.eq(args.uuid))
+        .limit(1)
+        .select(Volume::as_select())
+        .load_async(&*datastore.pool_connection_for_tests().await?)
+        .await
+        .context("loading requested volume")?;
+
+    let mut vcrs = Vec::new();
+    let rows = volumes.into_iter().map(|volume| {
+        match serde_json::from_str(&volume.data()) {
+            Ok(vcr) => {
+                vcrs.push(vcr);
+            }
+            Err(e) => {
+                println!("Volume had invalid VCR in data field: {e}");
+            }
+        }
+
+        VolumeRow {
+            id: volume.id().to_string(),
+            created: volume.time_created().to_string(),
+            modified: volume.time_modified().to_string(),
+            deleted: match volume.time_deleted {
+                Some(time) => time.to_string(),
+                None => "NULL".to_string(),
+            },
+        }
+    });
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    for vcr in vcrs {
+        print_vcr(vcr, 0);
+    }
+    Ok(())
+}
+
+// Print the fields that I want to see of a VolumeConstructionRequests
+// This will call itself on all sub_volumes and read_only_parents it finds.
+// We use the pad variable to indicate how much indent we want to display
+// information at.  Each time we recurse into another VCR layer, we increase
+// the amount of indention.
+fn print_vcr(vcr: VolumeConstructionRequest, pad: usize) {
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct VCRVolume {
+        id: String,
+        bs: String,
+        sub_volumes: usize,
+        read_only_parent: bool,
+    }
+
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct VCRRegion {
+        id: String,
+        bs: String,
+        bpe: u64,
+        ec: u32,
+        gen: u64,
+        read_only: bool,
+    }
+
+    let indent = " ".repeat(pad);
+    match vcr {
+        VolumeConstructionRequest::Volume {
+            id,
+            block_size,
+            sub_volumes,
+            read_only_parent,
+        } => {
+            let row = VCRVolume {
+                id: id.to_string(),
+                bs: block_size.to_string(),
+                sub_volumes: sub_volumes.len(),
+                read_only_parent: read_only_parent.is_some(),
+            };
+            let table = tabled::Table::new(&[row])
+                .with(tabled::settings::Style::empty())
+                .with(tabled::settings::Padding::new(0, 1, 0, 0))
+                .to_string();
+
+            // Shift the entire table over our indent amount.
+            let indented_table: String = table
+                .lines()
+                .map(|line| format!("{}{}", indent, line))
+                .collect::<Vec<String>>()
+                .join("\n");
+            println!("{}\n", indented_table);
+
+            for (index, sv) in sub_volumes.iter().enumerate() {
+                println!("{indent}SUB VOLUME {index}");
+                print_vcr(sv.clone(), pad + 4);
+                println!("");
+            }
+
+            if let Some(rop) = read_only_parent {
+                println!("{indent}READ ONLY PARENT:");
+                print_vcr(*rop, pad + 4);
+            }
+        }
+        VolumeConstructionRequest::Region {
+            block_size,
+            blocks_per_extent,
+            extent_count,
+            gen,
+            opts,
+        } => {
+            let row = VCRRegion {
+                id: opts.id.to_string(),
+                bs: block_size.to_string(),
+                bpe: blocks_per_extent,
+                ec: extent_count,
+                gen,
+                read_only: opts.read_only,
+            };
+            let table = tabled::Table::new(&[row])
+                .with(tabled::settings::Style::empty())
+                .with(tabled::settings::Padding::new(0, 1, 0, 0))
+                .to_string();
+
+            // Shift the entire table over our indent amount.
+            let indented_table: String = table
+                .lines()
+                .map(|line| format!("{}{}", indent, line))
+                .collect::<Vec<String>>()
+                .join("\n");
+            println!("{}", indented_table);
+            for target in opts.target {
+                println!("{indent}{target}");
+            }
+        }
+        _ => {
+            println!("{indent}Unsupported volume type");
+        }
+    }
 }
 
 /// List all regions still missing ports

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -118,6 +118,7 @@ Commands:
   network              Print information about the network
   snapshots            Print information about snapshots
   validate             Validate the contents of the database
+  volumes              Print information about volumes
   help                 Print this message or the help of the given subcommand(s)
 
 Options:
@@ -160,6 +161,7 @@ Commands:
   network              Print information about the network
   snapshots            Print information about snapshots
   validate             Validate the contents of the database
+  volumes              Print information about volumes
   help                 Print this message or the help of the given subcommand(s)
 
 Options:

--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -48,7 +48,8 @@ impl super::Nexus {
                 snapshot: NameOrId::Id(_),
                 ..
             } => Err(Error::invalid_request(
-              "when providing snpashot as an ID, prject should not be specified"
+              "when providing snapshot as an ID, project should not \
+              be specified"
             )),
             _ => Err(Error::invalid_request(
               "snapshot should either be an ID or project should be specified"


### PR DESCRIPTION
Added a subcommand to dump the volume field in the database. The volume's data field holds a string that should be a VolumeConstructionRequest.  This also adds the ability to dump out a subset of the fields in that VCR.

Updated the `db disks info` and `db snapshots info` subcommands to print out the VCR as well.

Some sample output (with 2>/dev/null):

volumes list:
```
EVT22200005 # /alan/bin/omdbnew db volumes list
ID                                   CREATED                        MODIFIED                       DELETED 
0dd62f39-84da-4f8c-a7d5-268d26c81ec7 2024-07-25 00:54:47.400177 UTC 2024-07-25 00:54:47.400177 UTC NULL    
28e00ef9-743f-4977-b8e6-41b800110c55 2024-07-25 18:47:58.986959 UTC 2024-07-25 18:47:58.986959 UTC NULL    
392bd468-84cb-4d70-8060-cdb45eb6559d 2024-07-25 18:47:57.884814 UTC 2024-07-25 18:47:57.884814 UTC NULL    
3cb9fbe9-050f-4323-ae63-2fd362e184b7 2024-07-03 00:44:46.782906 UTC 2024-07-03 00:44:46.782906 UTC NULL    
67d4760d-0c70-4279-a970-7c761eb373a5 2024-07-25 21:13:13.404610 UTC 2024-07-25 21:13:13.404610 UTC NULL    
97b037db-14b7-418c-8adc-44d976af1b11 2024-07-25 21:13:14.529006 UTC 2024-07-25 21:13:14.529006 UTC NULL    
a59871df-d436-4053-baa2-9c660896e015 2024-07-23 23:22:49.464908 UTC 2024-07-23 23:22:49.464908 UTC NULL    
c6a3f00e-e237-42d2-ba28-2526f804f2e1 2024-07-03 00:45:06.875223 UTC 2024-07-03 00:45:06.875223 UTC NULL    
dfa2b2e7-582f-4689-ae5d-89a2381ae905 2024-07-03 00:44:45.807288 UTC 2024-07-03 00:44:45.807288 UTC NULL    
e0818cab-13be-4234-bc73-ea5fb445237a 2024-07-23 23:23:51.072133 UTC 2024-07-23 23:23:51.072133 UTC NULL    
eee8317b-32da-4688-86c6-4ce0b94765ab 2024-07-02 21:17:27.047523 UTC 2024-07-02 21:17:27.047523 UTC NULL    
```

volumes info
```
EVT22200005 # /alan/bin/omdbnew db volumes info a59871df-d436-4053-baa2-9c660896e015

ID                                   CREATED                        MODIFIED                       DELETED 
a59871df-d436-4053-baa2-9c660896e015 2024-07-23 23:22:49.464908 UTC 2024-07-23 23:22:49.464908 UTC NULL    
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
3168311b-dffc-443a-8a2f-efacf58ab1ea 512 1           false            

SUB VOLUME 0
    ID                                   BS  BPE    EC GEN READ_ONLY 
    0f3fd047-e148-444d-8365-b02e9c3112d1 512 131072 48 6   true      
    [fd00:1122:3344:101::13]:19002
    [fd00:1122:3344:101::14]:19001
    [fd00:1122:3344:101::15]:19001
```

disk info, now with VCR
```
EVT22200005 # /alan/bin/omdbnew db disks info 9ac8e1e5-7dc5-45ae-bf4a-e933b1cecac3 2> /dev/null
HOST_SERIAL       DISK_NAME    INSTANCE_NAME PROPOLIS_ZONE        VOLUME_ID                            DISK_STATE 
<not on any sled> dontbootboot dontboot      <no active Propolis> 0dd62f39-84da-4f8c-a7d5-268d26c81ec7 attached   
HOST_SERIAL REGION                               ZONE                                              PHYSICAL_DISK                        
unknown     d56bbc68-3356-4b88-872d-5fdccf3991ed oxz_crucible_40b98238-8831-41ad-b4b5-d38075caaa73 71b02dd2-31e3-4d07-b9ba-a92953b4f335 
unknown     3f14cdf5-cafe-4b66-9270-bf8e90d34047 oxz_crucible_a4b06536-5ca0-432e-930d-cac4f17056ef 31f767a5-920b-4141-9bac-a2fd1bc20c9d 
unknown     888ec433-2cf8-4e58-8673-e753fa315002 oxz_crucible_f37ad639-4180-4cb0-90b4-a702740a5ea5 5022679e-afa9-47a1-9f5a-7760648bf2d2 

VCR from volume ID 0dd62f39-84da-4f8c-a7d5-268d26c81ec7
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
9ac8e1e5-7dc5-45ae-bf4a-e933b1cecac3 512 1           true             

SUB VOLUME 0
    ID                                   BS  BPE    EC GEN READ_ONLY 
    9ac8e1e5-7dc5-45ae-bf4a-e933b1cecac3 512 131072 80 15  false     
    [fd00:1122:3344:101::18]:19004
    [fd00:1122:3344:101::12]:19002
    [fd00:1122:3344:101::14]:19005

READ ONLY PARENT:
    ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
    0feb2474-16cb-46f2-84ac-538af8e32854 512 1           false            

    SUB VOLUME 0
        ID                                   BS  BPE    EC GEN READ_ONLY 
        b6be3dcf-144e-4337-a3f5-2afdc4c09a34 512 131072 48 5   true      
        [fd00:1122:3344:101::13]:19002
        [fd00:1122:3344:101::14]:19001
        [fd00:1122:3344:101::15]:19001
```

snapshot info, now with VCR:
This snapshot is of a disk that has a ROP where we have not scrubbed it yet, so you
can see all the layers at work here.
```
EVT22200005 # /alan/bin/omdbnew db snapshots info 702ad255-bd6b-4f1a-8b82-b99d09cf25f2 2> /dev/null
SNAP_NAME ID                                   STATE SIZE  SOURCE_DISK_ID                       SOURCE_VOLUME_ID                     DESTINATION_VOLUME_ID                
newsnap   702ad255-bd6b-4f1a-8b82-b99d09cf25f2 ready 5 GiB 9ac8e1e5-7dc5-45ae-bf4a-e933b1cecac3 b146573d-903f-49ce-95a4-04370f4217b0 e24b0c85-05d4-4f32-9667-19c67bc66621 
SOURCE VOLUME VCR:

VCR from volume ID b146573d-903f-49ce-95a4-04370f4217b0
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
5cebfd29-2e84-4540-b0ca-cb17d2886ebe 512 1           true             

SUB VOLUME 0
    ID                                   BS  BPE    EC GEN READ_ONLY 
    e1f3d8c4-c513-416d-a007-25cc0652044b 512 131072 80 16  true      
    [fd00:1122:3344:101::18]:19006
    [fd00:1122:3344:101::12]:19001
    [fd00:1122:3344:101::14]:19003

READ ONLY PARENT:
    ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
    5179150e-02ad-4340-bbd2-eb47b73af63d 512 1           false            

    SUB VOLUME 0
        ID                                   BS  BPE    EC GEN READ_ONLY 
        1400dae0-eb93-44ee-b2bb-514786e33eba 512 131072 48 5   true      
        [fd00:1122:3344:101::13]:19002
        [fd00:1122:3344:101::14]:19001
        [fd00:1122:3344:101::15]:19001

DESTINATION REGION INFO:
HOST_SERIAL REGION                               ZONE                                              PHYSICAL_DISK                        
unknown     93b75c86-9e44-4a04-91b9-3785b605f030 oxz_crucible_2dca65c8-f432-4236-9659-26507f7f8b23 b43d86d3-cf5e-4b6d-a42d-39e453d546ec 
unknown     52cddb74-6108-4e01-91b7-a1c4103628ad oxz_crucible_40b98238-8831-41ad-b4b5-d38075caaa73 71b02dd2-31e3-4d07-b9ba-a92953b4f335 
unknown     404afa68-e2e1-4721-a9bf-f45f9fbc410a oxz_crucible_7b2ff9b7-9c3e-44e4-9f24-dc096c36ae31 291aee84-4fb2-4005-a308-a41314719711 
DESTINATION VOLUME VCR:

VCR from volume ID e24b0c85-05d4-4f32-9667-19c67bc66621
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
e24b0c85-05d4-4f32-9667-19c67bc66621 512 1           false            

SUB VOLUME 0
    ID                                   BS  BPE    EC GEN READ_ONLY 
    e24b0c85-05d4-4f32-9667-19c67bc66621 512 131072 80 1   false     
    [fd00:1122:3344:101::18]:19005
    [fd00:1122:3344:101::16]:19001
    [fd00:1122:3344:101::15]:19003
```
