### PR TITLE
[sled-agent] Remove non self-assembling zone code

### DIFF
--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -23,6 +23,7 @@ pub mod opte;
 pub mod route;
 pub mod running_zone;
 pub mod scf;
+pub mod smf_helper;
 pub mod svc;
 pub mod svcadm;
 pub mod vmm_reservoir;

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -12,7 +12,7 @@ use crate::dladm::Etherstub;
 use crate::link::{Link, VnicAllocator};
 use crate::opte::{Port, PortTicket};
 use crate::svc::wait_for_service;
-use crate::zone::{AddressRequest, IPADM, ZONE_PREFIX};
+use crate::zone::{AddressRequest, ZONE_PREFIX};
 use crate::zpool::{PathInPool, ZpoolName};
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
@@ -487,64 +487,11 @@ impl RunningZone {
                 zone: zone.name.to_string(),
             })?;
 
-        // TODO https://github.com/oxidecomputer/omicron/issues/1898:
-        // Remove all non-self assembling code
-
-        // If the zone is self-assembling, then SMF service(s) inside the zone
-        // will be creating the listen address for the zone's service(s),
-        // setting the appropriate ifprop MTU, and so on. The idea behind
-        // self-assembling zones is that once they boot there should be *no*
-        // zlogin required.
-
-        // Use the zone ID in order to check if /var/svc/profile/site.xml
-        // exists.
         let id = Zones::id(&zone.name)
             .await?
             .ok_or_else(|| BootError::NoZoneId { zone: zone.name.clone() })?;
-        let site_profile_xml_exists =
-            std::path::Path::new(&zone.site_profile_xml_path()).exists();
 
         let running_zone = RunningZone { id: Some(id), inner: zone };
-
-        if !site_profile_xml_exists {
-            // If the zone is not self-assembling, make sure the control vnic
-            // has an IP MTU of 9000 inside the zone.
-            const CONTROL_VNIC_MTU: usize = 9000;
-            let vnic = running_zone.inner.control_vnic.name().to_string();
-
-            let commands = vec![
-                vec![
-                    IPADM.to_string(),
-                    "create-if".to_string(),
-                    "-t".to_string(),
-                    vnic.clone(),
-                ],
-                vec![
-                    IPADM.to_string(),
-                    "set-ifprop".to_string(),
-                    "-t".to_string(),
-                    "-p".to_string(),
-                    format!("mtu={}", CONTROL_VNIC_MTU),
-                    "-m".to_string(),
-                    "ipv4".to_string(),
-                    vnic.clone(),
-                ],
-                vec![
-                    IPADM.to_string(),
-                    "set-ifprop".to_string(),
-                    "-t".to_string(),
-                    "-p".to_string(),
-                    format!("mtu={}", CONTROL_VNIC_MTU),
-                    "-m".to_string(),
-                    "ipv6".to_string(),
-                    vnic,
-                ],
-            ];
-
-            for args in &commands {
-                running_zone.run_cmd(args)?;
-            }
-        }
 
         Ok(running_zone)
     }

--- a/illumos-utils/src/smf_helper.rs
+++ b/illumos-utils/src/smf_helper.rs
@@ -203,12 +203,7 @@ impl<'t> SmfHelper<'t> {
 
     pub fn refresh(&self) -> Result<(), Error> {
         self.running_zone
-            .run_cmd(&[
-                SVCCFG,
-                "-s",
-                &self.default_smf_name,
-                "refresh",
-            ])
+            .run_cmd(&[SVCCFG, "-s", &self.default_smf_name, "refresh"])
             .map_err(|err| Error::ZoneCommand {
                 intent: format!(
                     "Refresh SMF manifest {}",

--- a/illumos-utils/src/smf_helper.rs
+++ b/illumos-utils/src/smf_helper.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use illumos_utils::running_zone::RunningZone;
+use crate::running_zone::RunningZone;
+use crate::zone::SVCCFG;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -10,7 +11,7 @@ pub enum Error {
     ZoneCommand {
         intent: String,
         #[source]
-        err: illumos_utils::running_zone::RunCommandError,
+        err: crate::running_zone::RunCommandError,
     },
 }
 
@@ -44,7 +45,7 @@ impl<'t> SmfHelper<'t> {
     {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.default_smf_name,
                 "setprop",
@@ -70,7 +71,7 @@ impl<'t> SmfHelper<'t> {
     {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.smf_name,
                 "addpropvalue",
@@ -98,7 +99,7 @@ impl<'t> SmfHelper<'t> {
     {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.default_smf_name,
                 "addpropvalue",
@@ -124,7 +125,7 @@ impl<'t> SmfHelper<'t> {
     {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.smf_name,
                 "addpg",
@@ -148,7 +149,7 @@ impl<'t> SmfHelper<'t> {
     {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.smf_name,
                 "delpg",
@@ -176,7 +177,7 @@ impl<'t> SmfHelper<'t> {
         match self
             .running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.default_smf_name,
                 "delpropvalue",
@@ -203,7 +204,7 @@ impl<'t> SmfHelper<'t> {
     pub fn refresh(&self) -> Result<(), Error> {
         self.running_zone
             .run_cmd(&[
-                illumos_utils::zone::SVCCFG,
+                SVCCFG,
                 "-s",
                 &self.default_smf_name,
                 "refresh",

--- a/sled-agent/src/lib.rs
+++ b/sled-agent/src/lib.rs
@@ -34,7 +34,6 @@ pub mod rack_setup;
 pub mod server;
 pub mod services;
 mod sled_agent;
-mod smf_helper;
 mod storage_monitor;
 mod swap_device;
 mod updates;

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -333,15 +333,6 @@ impl OmicronZoneTypeExt for OmicronZoneConfig {
     }
 }
 
-impl crate::smf_helper::Service for OmicronZoneType {
-    fn service_name(&self) -> String {
-        self.kind().service_prefix().to_owned()
-    }
-    fn smf_name(&self) -> String {
-        format!("svc:/oxide/{}", self.service_name())
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct TimeSync {
     /// The synchronization state of the sled, true when the system clock

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -35,7 +35,7 @@ use crate::params::{
     ZoneBundleCause, ZoneBundleMetadata,
 };
 use crate::profile::*;
-use crate::smf_helper::SmfHelper;
+use illumos_utils::smf_helper::SmfHelper;
 use crate::zone_bundle::BundleError;
 use crate::zone_bundle::ZoneBundler;
 use anyhow::anyhow;
@@ -157,7 +157,7 @@ pub enum Error {
     SledLocalZone(anyhow::Error),
 
     #[error("Failed to issue SMF command: {0}")]
-    SmfCommand(#[from] crate::smf_helper::Error),
+    SmfCommand(#[from] illumos_utils::smf_helper::Error),
 
     #[error("{}", display_zone_init_errors(.0))]
     ZoneInitialize(Vec<(String, Box<Error>)>),
@@ -498,7 +498,7 @@ enum SwitchService {
     SpSim,
 }
 
-impl crate::smf_helper::Service for SwitchService {
+impl illumos_utils::smf_helper::Service for SwitchService {
     fn service_name(&self) -> String {
         match self {
             SwitchService::ManagementGatewayService => "mgs",

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -35,7 +35,6 @@ use crate::params::{
     ZoneBundleCause, ZoneBundleMetadata,
 };
 use crate::profile::*;
-use illumos_utils::smf_helper::SmfHelper;
 use crate::zone_bundle::BundleError;
 use crate::zone_bundle::ZoneBundler;
 use anyhow::anyhow;
@@ -55,6 +54,7 @@ use illumos_utils::running_zone::{
     EnsureAddressError, InstalledZone, RunCommandError, RunningZone,
     ZoneBuilderFactory,
 };
+use illumos_utils::smf_helper::SmfHelper;
 use illumos_utils::zfs::ZONE_ZFS_RAMDISK_DATASET_MOUNTPOINT;
 use illumos_utils::zone::AddressRequest;
 use illumos_utils::zpool::{PathInPool, ZpoolName};

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1507,10 +1507,6 @@ impl ServiceManager {
             ServiceBuilder::new("network/dns/client")
                 .add_instance(ServiceInstanceBuilder::new("default"));
 
-        // TODO(https://github.com/oxidecomputer/omicron/issues/1898):
-        //
-        // These zones are self-assembling -- after they boot, there should
-        // be no "zlogin" necessary to initialize.
         match &request {
             ZoneArgs::Omicron(OmicronZoneConfigLocal {
                 zone:


### PR DESCRIPTION
This commit removes all code that is no longer necessary now that the self assembling zone work is finished.

Additionally, the `smf_helper` module has been moved to `illumos_utils` where all the Illumos helper code lives.

Closes: https://github.com/oxidecomputer/omicron/issues/1898