### PR TITLE
[sled-agent] drain queue when instances terminate

### DIFF
--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -179,6 +179,7 @@ impl From<Error> for omicron_common::api::external::Error {
 // Provide a more specific HTTP error for some sled agent errors.
 impl From<Error> for dropshot::HttpError {
     fn from(err: Error) -> Self {
+        const NO_SUCH_INSTANCE: &str = "NO_SUCH_INSTANCE";
         match err {
             Error::Instance(crate::instance_manager::Error::Instance(
                 instance_error,
@@ -211,13 +212,20 @@ impl From<Error> for dropshot::HttpError {
                         // Progenitor client error it gets back.
                         HttpError::from(omicron_error)
                     }
+                    crate::instance::Error::Terminating(t) => {
+                        HttpError::for_client_error(
+                            Some(NO_SUCH_INSTANCE.to_string()),
+                            http::StatusCode::GONE,
+                            t.to_string(),
+                        )
+                    }
                     e => HttpError::for_internal_error(e.to_string()),
                 }
             }
             Error::Instance(
                 e @ crate::instance_manager::Error::NoSuchInstance(_),
             ) => HttpError::for_not_found(
-                Some("NO_SUCH_INSTANCE".to_string()),
+                Some(NO_SUCH_INSTANCE.to_string()),
                 e.to_string(),
             ),
             Error::ZoneBundle(ref inner) => match inner {
@@ -231,6 +239,11 @@ impl From<Error> for dropshot::HttpError {
                 | BundleError::InvalidCleanupPeriod => {
                     HttpError::for_bad_request(None, inner.to_string())
                 }
+                BundleError::Terminating(t) => HttpError::for_client_error(
+                    Some(NO_SUCH_INSTANCE.to_string()),
+                    http::StatusCode::GONE,
+                    t.to_string(),
+                ),
                 _ => HttpError::for_internal_error(err.to_string()),
             },
             e => HttpError::for_internal_error(e.to_string()),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -212,11 +212,11 @@ impl From<Error> for dropshot::HttpError {
                         // Progenitor client error it gets back.
                         HttpError::from(omicron_error)
                     }
-                    crate::instance::Error::Terminating(t) => {
+                    crate::instance::Error::Terminating => {
                         HttpError::for_client_error(
                             Some(NO_SUCH_INSTANCE.to_string()),
                             http::StatusCode::GONE,
-                            t.to_string(),
+                            instance_error.to_string(),
                         )
                     }
                     e => HttpError::for_internal_error(e.to_string()),
@@ -239,11 +239,13 @@ impl From<Error> for dropshot::HttpError {
                 | BundleError::InvalidCleanupPeriod => {
                     HttpError::for_bad_request(None, inner.to_string())
                 }
-                BundleError::Terminating(t) => HttpError::for_client_error(
-                    Some(NO_SUCH_INSTANCE.to_string()),
-                    http::StatusCode::GONE,
-                    t.to_string(),
-                ),
+                BundleError::InstanceTerminating => {
+                    HttpError::for_client_error(
+                        Some(NO_SUCH_INSTANCE.to_string()),
+                        http::StatusCode::GONE,
+                        inner.to_string(),
+                    )
+                }
                 _ => HttpError::for_internal_error(err.to_string()),
             },
             e => HttpError::for_internal_error(e.to_string()),

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -692,8 +692,8 @@ pub enum BundleError {
     #[error("Failed to get ZFS property value")]
     GetProperty(#[from] GetValueError),
 
-    #[error(transparent)]
-    Terminating(#[from] crate::instance::Terminating),
+    #[error("Instance is terminating")]
+    InstanceTerminating,
 }
 
 // Helper function to write an array of bytes into the tar archive, with

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -691,6 +691,9 @@ pub enum BundleError {
 
     #[error("Failed to get ZFS property value")]
     GetProperty(#[from] GetValueError),
+
+    #[error(transparent)]
+    Terminating(#[from] crate::instance::Terminating),
 }
 
 // Helper function to write an array of bytes into the tar archive, with


### PR DESCRIPTION
Presently, when sled-agent observes a VMM shut down, the `InstanceRunner` task
terminates more or less immediately. This results in any outstanding requests in
that task's queue being dropped abruptly, failing with an error that's converted
into an HTTP 500 Internal Server Error with a generic message when returned to a
client. Any Nexus that placed those requests to the sled-agent then just blindly
passes along the 500, but not before stopping to decide to transition the
instance to `Failed`.

This commit changes this so that a sled-agent `InstanceRunner` that observes VMM
termination and starts shutting down proactively drains its queue, failing
requests with a more useful error that indicates the instance is terminating.
These errors will instead synthesize a 410 Gone HTTP error, so Nexus doesn't
aggressively transition the instance to `Failed`. This allows it to shut down
gracefully even when it has outstanding state change requests queued.

Fixes #6165