### PR TITLE
[meta] update to Rust 1.80

### DIFF
--- a/bootstore/src/schemes/v0/peer_networking.rs
+++ b/bootstore/src/schemes/v0/peer_networking.rs
@@ -105,6 +105,9 @@ pub enum MainToConnMsg {
 // complete), or established connection (handshake complete - whether connecting
 // client or accepting server).
 pub struct PeerConnHandle {
+    // Hold onto this handle to indicate ownership (though note that dropping
+    // a Tokio handle does not cause the task to be cancelled).
+    #[allow(dead_code)]
     pub handle: JoinHandle<()>,
     pub tx: mpsc::Sender<MainToConnMsg>,
 
@@ -120,7 +123,9 @@ pub struct AcceptedConnHandle {
     pub handle: JoinHandle<()>,
     pub tx: mpsc::Sender<MainToConnMsg>,
 
-    // The canonical IP with ephemeral port of the peer
+    // The canonical IP with ephemeral port of the peer. Not currently used,
+    // but useful for debugging.
+    #[allow(dead_code)]
     pub addr: SocketAddrV6,
     // This is used to differentiate stale `ConnToMainMsg`s from cancelled tasks
     // with the same addr from each other

--- a/bootstore/tests/common/mod.rs
+++ b/bootstore/tests/common/mod.rs
@@ -39,7 +39,9 @@ pub struct CommonTestState {
     // The generated configuration
     pub config: FsmConfig,
 
-    // IDs of all initial members
+    // IDs of all initial members. Not currently used, but useful for
+    // debugging.
+    #[allow(dead_code)]
     pub initial_members: BTreeSet<Baseboard>,
 
     // Any peers connected to the SUT Fsm

--- a/dev-tools/omicron-dev/src/bin/omicron-dev.rs
+++ b/dev-tools/omicron-dev/src/bin/omicron-dev.rs
@@ -601,7 +601,7 @@ async fn cmd_cert_create(args: &CertCreateArgs) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg_attr(not(mac), allow(clippy::useless_conversion))]
+#[cfg_attr(not(target_os = "macos"), allow(clippy::useless_conversion))]
 fn write_private_file(
     path: &Utf8Path,
     contents: &[u8],

--- a/illumos-utils/build.rs
+++ b/illumos-utils/build.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(svcadm_autoclear)");
+}

--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -1529,10 +1529,7 @@ where
     D: Deserializer<'de>,
     T: Deserialize<'de>,
 {
-    Ok(match Option::<Vec<T>>::deserialize(de)? {
-        Some(v) => v,
-        None => vec![],
-    })
+    Ok(Option::<Vec<T>>::deserialize(de)?.unwrap_or_default())
 }
 
 impl DataStore {

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -357,9 +357,14 @@ impl DataStore {
         for (i, vni) in vnis.enumerate() {
             vpc.vni = Vni(vni);
             let id = usdt::UniqueId::new();
-            crate::probes::vni__search__range__start!(|| {
-                (&id, u32::from(vni), VniSearchIter::STEP_SIZE)
-            });
+            // TODO: silence this cast in usdt:
+            // https://github.com/oxidecomputer/usdt/issues/270
+            #[allow(clippy::cast_lossless)]
+            {
+                crate::probes::vni__search__range__start!(|| {
+                    (&id, u32::from(vni), VniSearchIter::STEP_SIZE)
+                });
+            }
             match self
                 .project_create_vpc_raw(
                     opctx,
@@ -369,9 +374,14 @@ impl DataStore {
                 .await
             {
                 Ok(Some((authz_vpc, vpc))) => {
-                    crate::probes::vni__search__range__found!(|| {
-                        (&id, u32::from(vpc.vni.0))
-                    });
+                    // TODO: silence this cast in usdt:
+                    // https://github.com/oxidecomputer/usdt/issues/270
+                    #[allow(clippy::cast_lossless)]
+                    {
+                        crate::probes::vni__search__range__found!(|| {
+                            (&id, u32::from(vpc.vni.0))
+                        });
+                    }
                     return Ok((authz_vpc, vpc));
                 }
                 Err(e) => return Err(e),

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1613,11 +1613,6 @@ async fn ip_pool_list(
         .await
 }
 
-#[derive(Deserialize, JsonSchema)]
-pub struct IpPoolPathParam {
-    pub pool_name: Name,
-}
-
 /// Create IP pool
 #[endpoint {
     method = POST,
@@ -6275,19 +6270,6 @@ async fn sled_physical_disk_list(
 }
 
 // Metrics
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SystemMetricParams {
-    /// A silo ID. If unspecified, get aggregate metrics across all silos.
-    pub silo_id: Option<Uuid>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SiloMetricParams {
-    /// A project ID. If unspecified, get aggregate metrics across all projects
-    /// in current silo.
-    pub project_id: Option<Uuid>,
-}
 
 #[derive(Display, Deserialize, JsonSchema)]
 #[display(style = "snake_case")]

--- a/oximeter/db/src/oxql/point.rs
+++ b/oximeter/db/src/oxql/point.rs
@@ -1739,8 +1739,8 @@ macro_rules! i64_dist_from {
                 Self {
                     bins: bins.into_iter().map(i64::from).collect(),
                     counts,
-                    min: Some(hist.min() as i64),
-                    max: Some(hist.max() as i64),
+                    min: Some(i64::from(hist.min())),
+                    max: Some(i64::from(hist.max())),
                     sum_of_samples: hist.sum_of_samples(),
                     squared_mean: hist.squared_mean(),
                     p50: Some(hist.p50q()),
@@ -1808,8 +1808,8 @@ macro_rules! f64_dist_from {
                 Self {
                     bins: bins.into_iter().map(f64::from).collect(),
                     counts,
-                    min: Some(hist.min() as f64),
-                    max: Some(hist.max() as f64),
+                    min: Some(f64::from(hist.min())),
+                    max: Some(f64::from(hist.max())),
                     sum_of_samples: hist.sum_of_samples() as f64,
                     squared_mean: hist.squared_mean(),
                     p50: Some(hist.p50q()),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.78.0"
+channel = "1.80.0"
 profile = "default"

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -165,6 +165,7 @@ enum NexusNotifierMsg {
 }
 
 #[derive(Debug)]
+#[allow(unused)]
 pub struct NexusNotifierTaskStatus {
     pub nexus_known_info: Option<NexusKnownInfo>,
     pub has_pending_notification: bool,

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1443,34 +1443,6 @@ impl SpHandler for Handler {
         Ok(val.len())
     }
 
-    #[cfg(any(feature = "no-caboose", feature = "old-state"))]
-    fn get_component_caboose_value(
-        &mut self,
-        component: SpComponent,
-        slot: u16,
-        key: [u8; 4],
-        buf: &mut [u8],
-    ) -> std::result::Result<usize, SpError> {
-        let val = match (component, &key, slot) {
-            (SpComponent::SP_ITSELF, b"GITC", 0) => SP_GITC0,
-            (SpComponent::SP_ITSELF, b"GITC", 1) => SP_GITC1,
-            (SpComponent::SP_ITSELF, b"BORD", _) => SP_BORD,
-            (SpComponent::SP_ITSELF, b"NAME", _) => SP_NAME,
-            (SpComponent::SP_ITSELF, b"VERS", 0) => SP_VERS0,
-            (SpComponent::SP_ITSELF, b"VERS", 1) => SP_VERS1,
-            (SpComponent::ROT, b"GITC", 0) => ROT_GITC0,
-            (SpComponent::ROT, b"GITC", 1) => ROT_GITC1,
-            (SpComponent::ROT, b"BORD", _) => ROT_BORD,
-            (SpComponent::ROT, b"NAME", _) => ROT_NAME,
-            (SpComponent::ROT, b"VERS", 0) => ROT_VERS0,
-            (SpComponent::ROT, b"VERS", 1) => ROT_VERS1,
-            _ => return Err(SpError::NoSuchCabooseKey(key)),
-        };
-
-        buf[..val.len()].copy_from_slice(val);
-        Ok(val.len())
-    }
-
     fn read_sensor(
         &mut self,
         _request: gateway_messages::SensorRequest,

--- a/wicketd/tests/integration_tests/setup.rs
+++ b/wicketd/tests/integration_tests/setup.rs
@@ -14,8 +14,12 @@ pub struct WicketdTestContext {
     pub wicketd_client: wicketd_client::Client,
     // This is not currently used but is kept here because it's easier to debug
     // this way.
+    #[allow(dead_code)]
     pub wicketd_raw_client: ClientTestContext,
     pub artifact_addr: SocketAddrV6,
+    // This is not currently used but is kept here because it's easier to debug
+    // this way.
+    #[allow(dead_code)]
     pub artifact_client: installinator_client::Client,
     pub server: wicketd::Server,
     pub gateway: GatewayTestContext,


### PR DESCRIPTION
The most interesting change here is that Rust now detects unused cfg flags.

* `sp-sim` referred to `no-caboose` and `old-state` features that no longer exist. Per @labbott this code is okay to remove.
* In `omicron-dev`, `cfg(mac)` is not valid -- replaced it with `target_os = "macos"`.

There were also a few new clippy warnings.