### PR TITLE
Add LLDP configuration support

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -29,6 +29,7 @@ progenitor::generate_api!(
         BfdPeerConfig = { derives = [Eq, Hash] },
         BgpConfig = { derives = [Eq, Hash] },
         BgpPeerConfig = { derives = [Eq, Hash] },
+        LldpPortConfig = { derives = [Eq, Hash, PartialOrd, Ord] },
         OmicronPhysicalDiskConfig = { derives = [Eq, Hash, PartialOrd, Ord] },
         PortConfigV2 = { derives = [Eq, Hash] },
         RouteConfig = { derives = [Eq, Hash] },

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2229,7 +2229,7 @@ pub struct SwitchPortSettingsView {
     pub links: Vec<SwitchPortLinkConfig>,
 
     /// Link-layer discovery protocol (LLDP) settings.
-    pub link_lldp: Vec<LldpServiceConfig>,
+    pub link_lldp: Vec<LldpLinkConfig>,
 
     /// Layer 3 interface settings.
     pub interfaces: Vec<SwitchInterfaceConfig>,
@@ -2371,7 +2371,7 @@ pub struct SwitchPortLinkConfig {
 
     /// The link-layer discovery protocol service configuration id for this
     /// link.
-    pub lldp_service_config_id: Uuid,
+    pub lldp_link_config_id: Uuid,
 
     /// The name of this link.
     pub link_name: String,
@@ -2391,34 +2391,30 @@ pub struct SwitchPortLinkConfig {
 
 /// A link layer discovery protocol (LLDP) service configuration.
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
-pub struct LldpServiceConfig {
+pub struct LldpLinkConfig {
     /// The id of this LLDP service instance.
     pub id: Uuid,
 
-    /// The link-layer discovery protocol configuration for this service.
-    pub lldp_config_id: Option<Uuid>,
-
     /// Whether or not the LLDP service is enabled.
     pub enabled: bool,
-}
 
-/// A link layer discovery protocol (LLDP) base configuration.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
-pub struct LldpConfig {
-    #[serde(flatten)]
-    pub identity: IdentityMetadata,
+    /// The LLDP link name TLV.
+    pub link_name: Option<String>,
+
+    /// The LLDP link description TLV.
+    pub link_description: Option<String>,
 
     /// The LLDP chassis identifier TLV.
-    pub chassis_id: String,
+    pub chassis_id: Option<String>,
 
-    /// THE LLDP system name TLV.
-    pub system_name: String,
+    /// The LLDP system name TLV.
+    pub system_name: Option<String>,
 
-    /// THE LLDP system description TLV.
-    pub system_description: String,
+    /// The LLDP system description TLV.
+    pub system_description: Option<String>,
 
-    /// THE LLDP management IP TLV.
-    pub management_ip: oxnet::IpNet,
+    /// The LLDP management IP TLV.
+    pub management_ip: Option<oxnet::IpNet>,
 }
 
 /// Describes the kind of an switch interface.

--- a/illumos-utils/src/smf_helper.rs
+++ b/illumos-utils/src/smf_helper.rs
@@ -77,7 +77,7 @@ impl<'t> SmfHelper<'t> {
                 "addpropvalue",
                 &prop.to_string(),
                 &format!("{}:", valtype.to_string()),
-                &val.to_string(),
+                &format!("\"{}\"", val.to_string()),
             ])
             .map_err(|err| Error::ZoneCommand {
                 intent: format!("add {} smf property value", prop.to_string()),

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -139,35 +139,28 @@ table! {
 table! {
     switch_port_settings_link_config (port_settings_id, link_name) {
         port_settings_id -> Uuid,
-        lldp_service_config_id -> Uuid,
         link_name -> Text,
         mtu -> Int4,
         fec -> crate::SwitchLinkFecEnum,
         speed -> crate::SwitchLinkSpeedEnum,
         autoneg -> Bool,
+        lldp_link_config_id -> Uuid,
     }
 }
 
 table! {
-    lldp_service_config (id) {
+    lldp_link_config (id) {
         id -> Uuid,
         enabled -> Bool,
-        lldp_config_id -> Nullable<Uuid>,
-    }
-}
-
-table! {
-    lldp_config (id) {
-        id -> Uuid,
-        name -> Text,
-        description -> Text,
+        link_name -> Nullable<Text>,
+        link_description -> Nullable<Text>,
+        chassis_id -> Nullable<Text>,
+        system_name -> Nullable<Text>,
+        system_description -> Nullable<Text>,
+        management_ip -> Nullable<Inet>,
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         time_deleted -> Nullable<Timestamptz>,
-        chassis_id -> Text,
-        system_name -> Text,
-        system_description -> Text,
-        management_ip -> Inet,
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(88, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(89, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(89, "collapse_lldp_settings"),
         KnownVersion::new(88, "route-local-pref"),
         KnownVersion::new(87, "add-clickhouse-server-enum-variants"),
         KnownVersion::new(86, "snapshot-replacement"),

--- a/nexus/db-model/src/switch_port.rs
+++ b/nexus/db-model/src/switch_port.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::schema::{
-    lldp_config, lldp_service_config, switch_port, switch_port_settings,
+    lldp_link_config, switch_port, switch_port_settings,
     switch_port_settings_address_config, switch_port_settings_bgp_peer_config,
     switch_port_settings_bgp_peer_config_allow_export,
     switch_port_settings_bgp_peer_config_allow_import,
@@ -14,6 +14,7 @@ use crate::schema::{
 };
 use crate::{impl_enum_type, SqlU32};
 use crate::{SqlU16, SqlU8};
+use chrono::{DateTime, Utc};
 use db_macros::Resource;
 use diesel::AsChangeset;
 use ipnetwork::IpNetwork;
@@ -380,7 +381,7 @@ impl Into<external::SwitchPortConfig> for SwitchPortConfig {
 #[diesel(table_name = switch_port_settings_link_config)]
 pub struct SwitchPortLinkConfig {
     pub port_settings_id: Uuid,
-    pub lldp_service_config_id: Uuid,
+    pub lldp_link_config_id: Uuid,
     pub link_name: String,
     pub mtu: SqlU16,
     pub fec: SwitchLinkFec,
@@ -391,7 +392,7 @@ pub struct SwitchPortLinkConfig {
 impl SwitchPortLinkConfig {
     pub fn new(
         port_settings_id: Uuid,
-        lldp_service_config_id: Uuid,
+        lldp_link_config_id: Uuid,
         link_name: String,
         mtu: u16,
         fec: SwitchLinkFec,
@@ -400,7 +401,7 @@ impl SwitchPortLinkConfig {
     ) -> Self {
         Self {
             port_settings_id,
-            lldp_service_config_id,
+            lldp_link_config_id,
             link_name,
             fec,
             speed,
@@ -414,7 +415,7 @@ impl Into<external::SwitchPortLinkConfig> for SwitchPortLinkConfig {
     fn into(self) -> external::SwitchPortLinkConfig {
         external::SwitchPortLinkConfig {
             port_settings_id: self.port_settings_id,
-            lldp_service_config_id: self.lldp_service_config_id,
+            lldp_link_config_id: self.lldp_link_config_id,
             link_name: self.link_name.clone(),
             mtu: self.mtu.into(),
             fec: self.fec.into(),
@@ -434,57 +435,61 @@ impl Into<external::SwitchPortLinkConfig> for SwitchPortLinkConfig {
     Deserialize,
     AsChangeset,
 )]
-#[diesel(table_name = lldp_service_config)]
-pub struct LldpServiceConfig {
+#[diesel(table_name = lldp_link_config)]
+pub struct LldpLinkConfig {
     pub id: Uuid,
     pub enabled: bool,
-    pub lldp_config_id: Option<Uuid>,
+    pub link_name: Option<String>,
+    pub link_description: Option<String>,
+    pub chassis_id: Option<String>,
+    pub system_name: Option<String>,
+    pub system_description: Option<String>,
+    pub management_ip: Option<IpNetwork>,
+    pub time_created: DateTime<Utc>,
+    pub time_modified: DateTime<Utc>,
+    pub time_deleted: Option<DateTime<Utc>>,
 }
 
-impl LldpServiceConfig {
-    pub fn new(enabled: bool, lldp_config_id: Option<Uuid>) -> Self {
-        Self { id: Uuid::new_v4(), enabled, lldp_config_id }
-    }
-}
-
-impl Into<external::LldpServiceConfig> for LldpServiceConfig {
-    fn into(self) -> external::LldpServiceConfig {
-        external::LldpServiceConfig {
-            id: self.id,
-            lldp_config_id: self.lldp_config_id,
-            enabled: self.enabled,
+impl LldpLinkConfig {
+    pub fn new(
+        enabled: bool,
+        link_name: Option<String>,
+        link_description: Option<String>,
+        chassis_id: Option<String>,
+        system_name: Option<String>,
+        system_description: Option<String>,
+        management_ip: Option<IpNetwork>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            enabled,
+            link_name,
+            link_description,
+            chassis_id,
+            system_name,
+            system_description,
+            management_ip,
+            time_created: now,
+            time_modified: now,
+            time_deleted: None,
         }
     }
 }
 
-#[derive(
-    Queryable,
-    Insertable,
-    Selectable,
-    Clone,
-    Debug,
-    Resource,
-    Serialize,
-    Deserialize,
-)]
-#[diesel(table_name = lldp_config)]
-pub struct LldpConfig {
-    #[diesel(embed)]
-    pub identity: LldpConfigIdentity,
-    pub chassis_id: String,
-    pub system_name: String,
-    pub system_description: String,
-    pub management_ip: IpNetwork,
-}
-
-impl Into<external::LldpConfig> for LldpConfig {
-    fn into(self) -> external::LldpConfig {
-        external::LldpConfig {
-            identity: self.identity(),
+// This converts the internal database version of the config into the
+// user-facing version.
+impl Into<external::LldpLinkConfig> for LldpLinkConfig {
+    fn into(self) -> external::LldpLinkConfig {
+        external::LldpLinkConfig {
+            id: self.id,
+            enabled: self.enabled,
+            link_name: self.link_name.clone(),
+            link_description: self.link_description.clone(),
             chassis_id: self.chassis_id.clone(),
             system_name: self.system_name.clone(),
             system_description: self.system_description.clone(),
-            management_ip: self.management_ip.into(),
+            management_ip: self.management_ip.map(|a| a.into()),
         }
     }
 }

--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -51,8 +51,9 @@ use omicron_common::{
 use serde_json::json;
 use sled_agent_client::types::{
     BgpConfig as SledBgpConfig, BgpPeerConfig as SledBgpPeerConfig,
-    EarlyNetworkConfig, EarlyNetworkConfigBody, HostPortConfig, PortConfigV2,
-    RackNetworkConfigV2, RouteConfig as SledRouteConfig, UplinkAddressConfig,
+    EarlyNetworkConfig, EarlyNetworkConfigBody, HostPortConfig,
+    LldpAdminStatus, LldpPortConfig, PortConfigV2, RackNetworkConfigV2,
+    RouteConfig as SledRouteConfig, UplinkAddressConfig,
 };
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
@@ -993,7 +994,23 @@ impl BackgroundTask for SwitchPortSettingsManager {
                             .map(|l| l.speed)
                             .unwrap_or(SwitchLinkSpeed::Speed100G)
                             .into(),
-                    };
+			lldp: info
+			    .link_lldp
+			    .get(0) //TODO https://github.com/oxidecomputer/omicron/issues/3062
+			    .map(|c|  LldpPortConfig {
+				status: match c.enabled {
+				    true => LldpAdminStatus::Enabled,
+				    false=> LldpAdminStatus::Disabled,
+				},
+				port_id: c.link_name.clone(),
+				port_description: c.link_description.clone(),
+				chassis_id: c.chassis_id.clone(),
+				system_name: c.system_name.clone(),
+				system_description: c.system_description.clone(),
+				management_addrs:c.management_ip.map(|a| vec![a.ip()]),
+			    })
+		    }
+                    ;
 
                     for peer in port_config.bgp_peers.iter_mut() {
                         peer.communities = match self
@@ -1412,6 +1429,29 @@ fn uplinks(
         let PortSettingsChange::Apply(config) = change else {
             continue;
         };
+
+        let lldp = if config.link_lldp.is_empty() {
+            None
+        } else {
+            let x = &config.link_lldp[0];
+            Some(LldpPortConfig {
+                status: if x.enabled {
+                    LldpAdminStatus::Enabled
+                } else {
+                    LldpAdminStatus::Disabled
+                },
+                port_id: x.link_name.clone(),
+                port_description: x.link_description.clone(),
+                chassis_id: x.chassis_id.clone(),
+                system_name: x.system_name.clone(),
+                system_description: x.system_description.clone(),
+                management_addrs: x.management_ip.map(|a| {
+                    let ip: oxnet::IpNet = a.into();
+                    vec![ip.addr()]
+                }),
+            })
+        };
+
         let config = HostPortConfig {
             port: port.port_name.clone(),
             addrs: config
@@ -1422,6 +1462,7 @@ fn uplinks(
                     vlan_id: a.vlan_id.map(|v| v.into()),
                 })
                 .collect(),
+            lldp,
         };
 
         match uplinks.entry(*location) {

--- a/nexus/tests/integration_tests/switch_port.rs
+++ b/nexus/tests/integration_tests/switch_port.rs
@@ -11,9 +11,9 @@ use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params::{
     Address, AddressConfig, AddressLotBlockCreate, AddressLotCreate,
     BgpAnnounceSetCreate, BgpAnnouncementCreate, BgpConfigCreate,
-    BgpPeerConfig, LinkConfigCreate, LldpServiceConfigCreate, Route,
-    RouteConfig, SwitchInterfaceConfigCreate, SwitchInterfaceKind,
-    SwitchPortApplySettings, SwitchPortSettingsCreate,
+    BgpPeerConfig, LinkConfigCreate, LldpLinkConfigCreate, Route, RouteConfig,
+    SwitchInterfaceConfigCreate, SwitchInterfaceKind, SwitchPortApplySettings,
+    SwitchPortSettingsCreate,
 };
 use nexus_types::external_api::views::Rack;
 use omicron_common::api::external::ImportExportPolicy;
@@ -118,7 +118,15 @@ async fn test_port_settings_basic_crud(ctx: &ControlPlaneTestContext) {
         "phy0".into(),
         LinkConfigCreate {
             mtu: 4700,
-            lldp: LldpServiceConfigCreate { enabled: false, lldp_config: None },
+            lldp: LldpLinkConfigCreate {
+                enabled: true,
+                link_name: Some("Link Name".into()),
+                link_description: Some("link_ Dscription".into()),
+                chassis_id: Some("Chassis ID".into()),
+                system_name: Some("System Name".into()),
+                system_description: Some("System description".into()),
+                management_ip: None,
+            },
             fec: LinkFec::None,
             speed: LinkSpeed::Speed100G,
             autoneg: false,
@@ -177,8 +185,16 @@ async fn test_port_settings_basic_crud(ctx: &ControlPlaneTestContext) {
     assert_eq!(link0.mtu, 4700);
 
     let lldp0 = &created.link_lldp[0];
-    assert_eq!(lldp0.enabled, false);
-    assert_eq!(lldp0.lldp_config_id, None);
+    assert_eq!(lldp0.enabled, true);
+    assert_eq!(lldp0.link_name, Some("Link Name".to_string()));
+    assert_eq!(lldp0.link_description, Some("Link Description".to_string()));
+    assert_eq!(lldp0.chassis_id, Some("Chassis ID".to_string()));
+    assert_eq!(lldp0.system_name, Some("System Name".to_string()));
+    assert_eq!(
+        lldp0.system_description,
+        Some("System Description".to_string())
+    );
+    assert_eq!(lldp0.management_ip, None);
 
     let ifx0 = &created.interfaces[0];
     assert_eq!(&ifx0.interface_name, "phy0");
@@ -213,8 +229,16 @@ async fn test_port_settings_basic_crud(ctx: &ControlPlaneTestContext) {
     assert_eq!(link0.mtu, 4700);
 
     let lldp0 = &roundtrip.link_lldp[0];
-    assert_eq!(lldp0.enabled, false);
-    assert_eq!(lldp0.lldp_config_id, None);
+    assert_eq!(lldp0.enabled, true);
+    assert_eq!(lldp0.link_name, Some("Link Name".to_string()));
+    assert_eq!(lldp0.link_description, Some("Link Description".to_string()));
+    assert_eq!(lldp0.chassis_id, Some("Chassis ID".to_string()));
+    assert_eq!(lldp0.system_name, Some("System Name".to_string()));
+    assert_eq!(
+        lldp0.system_description,
+        Some("System Description".to_string())
+    );
+    assert_eq!(lldp0.management_ip, None);
 
     let ifx0 = &roundtrip.interfaces[0];
     assert_eq!(&ifx0.interface_name, "phy0");

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1500,7 +1500,7 @@ pub struct LinkConfigCreate {
     pub mtu: u16,
 
     /// The link-layer discovery protocol (LLDP) configuration for the link.
-    pub lldp: LldpServiceConfigCreate,
+    pub lldp: LldpLinkConfigCreate,
 
     /// The forward error correction mode of the link.
     pub fec: LinkFec,
@@ -1512,16 +1512,29 @@ pub struct LinkConfigCreate {
     pub autoneg: bool,
 }
 
-/// The LLDP configuration associated with a port. LLDP may be either enabled or
-/// disabled, if enabled, an LLDP configuration must be provided by name or id.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct LldpServiceConfigCreate {
+/// The LLDP configuration associated with a port.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+pub struct LldpLinkConfigCreate {
     /// Whether or not LLDP is enabled.
     pub enabled: bool,
 
-    /// A reference to the LLDP configuration used. Must not be `None` when
-    /// `enabled` is `true`.
-    pub lldp_config: Option<NameOrId>,
+    /// The LLDP link name TLV.
+    pub link_name: Option<String>,
+
+    /// The LLDP link description TLV.
+    pub link_description: Option<String>,
+
+    /// The LLDP chassis identifier TLV.
+    pub chassis_id: Option<String>,
+
+    /// The LLDP system name TLV.
+    pub system_name: Option<String>,
+
+    /// The LLDP system description TLV.
+    pub system_description: Option<String>,
+
+    /// The LLDP management IP TLV.
+    pub management_ip: Option<IpAddr>,
 }
 
 /// A layer-3 switch interface configuration. When IPv6 is enabled, a link local

--- a/openapi/bootstrap-agent.json
+++ b/openapi/bootstrap-agent.json
@@ -732,6 +732,67 @@
           "last"
         ]
       },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
       "Name": {
         "title": "A name unique within the parent collection",
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
@@ -766,6 +827,15 @@
             "items": {
               "$ref": "#/components/schemas/BgpPeerConfig"
             }
+          },
+          "lldp": {
+            "nullable": true,
+            "description": "LLDP configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
           },
           "port": {
             "description": "Nmae of the port this config applies to.",

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -3749,6 +3749,67 @@
           "start_time"
         ]
       },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
       "MacAddr": {
         "example": "ff:ff:ff:ff:ff:ff",
         "title": "A MAC address",
@@ -4153,6 +4214,15 @@
             "items": {
               "$ref": "#/components/schemas/BgpPeerConfig"
             }
+          },
+          "lldp": {
+            "nullable": true,
+            "description": "LLDP configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
           },
           "port": {
             "description": "Nmae of the port this config applies to.",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -16026,7 +16026,7 @@
             "description": "The link-layer discovery protocol (LLDP) configuration for the link.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/LldpServiceConfigCreate"
+                "$ref": "#/components/schemas/LldpLinkConfigCreate"
               }
             ]
           },
@@ -16147,10 +16147,15 @@
           }
         ]
       },
-      "LldpServiceConfig": {
+      "LldpLinkConfig": {
         "description": "A link layer discovery protocol (LLDP) service configuration.",
         "type": "object",
         "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "The LLDP chassis identifier TLV.",
+            "type": "string"
+          },
           "enabled": {
             "description": "Whether or not the LLDP service is enabled.",
             "type": "boolean"
@@ -16160,11 +16165,34 @@
             "type": "string",
             "format": "uuid"
           },
-          "lldp_config_id": {
+          "link_description": {
             "nullable": true,
-            "description": "The link-layer discovery protocol configuration for this service.",
-            "type": "string",
-            "format": "uuid"
+            "description": "The LLDP link description TLV.",
+            "type": "string"
+          },
+          "link_name": {
+            "nullable": true,
+            "description": "The LLDP link name TLV.",
+            "type": "string"
+          },
+          "management_ip": {
+            "nullable": true,
+            "description": "The LLDP management IP TLV.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "The LLDP system description TLV.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "The LLDP system name TLV.",
+            "type": "string"
           }
         },
         "required": [
@@ -16172,22 +16200,44 @@
           "id"
         ]
       },
-      "LldpServiceConfigCreate": {
-        "description": "The LLDP configuration associated with a port. LLDP may be either enabled or disabled, if enabled, an LLDP configuration must be provided by name or id.",
+      "LldpLinkConfigCreate": {
+        "description": "The LLDP configuration associated with a port.",
         "type": "object",
         "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "The LLDP chassis identifier TLV.",
+            "type": "string"
+          },
           "enabled": {
             "description": "Whether or not LLDP is enabled.",
             "type": "boolean"
           },
-          "lldp_config": {
+          "link_description": {
             "nullable": true,
-            "description": "A reference to the LLDP configuration used. Must not be `None` when `enabled` is `true`.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/NameOrId"
-              }
-            ]
+            "description": "The LLDP link description TLV.",
+            "type": "string"
+          },
+          "link_name": {
+            "nullable": true,
+            "description": "The LLDP link name TLV.",
+            "type": "string"
+          },
+          "management_ip": {
+            "nullable": true,
+            "description": "The LLDP management IP TLV.",
+            "type": "string",
+            "format": "ip"
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "The LLDP system description TLV.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "The LLDP system name TLV.",
+            "type": "string"
           }
         },
         "required": [
@@ -19211,7 +19261,7 @@
             "description": "The name of this link.",
             "type": "string"
           },
-          "lldp_service_config_id": {
+          "lldp_link_config_id": {
             "description": "The link-layer discovery protocol service configuration id for this link.",
             "type": "string",
             "format": "uuid"
@@ -19240,7 +19290,7 @@
           "autoneg",
           "fec",
           "link_name",
-          "lldp_service_config_id",
+          "lldp_link_config_id",
           "mtu",
           "port_settings_id",
           "speed"
@@ -19502,7 +19552,7 @@
             "description": "Link-layer discovery protocol (LLDP) settings.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LldpServiceConfig"
+              "$ref": "#/components/schemas/LldpLinkConfig"
             }
           },
           "links": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2752,6 +2752,14 @@
               "$ref": "#/components/schemas/UplinkAddressConfig"
             }
           },
+          "lldp": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
+          },
           "port": {
             "description": "Switchport to use for external connectivity",
             "type": "string"
@@ -3403,6 +3411,67 @@
         "pattern": "^[0-9]{1,5}(-[0-9]{1,5})?$",
         "minLength": 1,
         "maxLength": 11
+      },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "MacAddr": {
         "example": "ff:ff:ff:ff:ff:ff",
@@ -4103,6 +4172,15 @@
             "items": {
               "$ref": "#/components/schemas/BgpPeerConfig"
             }
+          },
+          "lldp": {
+            "nullable": true,
+            "description": "LLDP configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
           },
           "port": {
             "description": "Nmae of the port this config applies to.",

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -1773,6 +1773,67 @@
           "last"
         ]
       },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
       "Name": {
         "title": "A name unique within the parent collection",
         "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
@@ -6303,6 +6364,15 @@
             "items": {
               "$ref": "#/components/schemas/UserSpecifiedBgpPeerConfig"
             }
+          },
+          "lldp": {
+            "nullable": true,
+            "default": null,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
           },
           "routes": {
             "type": "array",

--- a/oximeter/collector/tests/output/self-stat-schema.json
+++ b/oximeter/collector/tests/output/self-stat-schema.json
@@ -1,0 +1,91 @@
+{
+  "oximeter_collector:collections": {
+    "timeseries_name": "oximeter_collector:collections",
+    "field_schema": [
+      {
+        "name": "base_route",
+        "field_type": "string",
+        "source": "metric"
+      },
+      {
+        "name": "collector_id",
+        "field_type": "uuid",
+        "source": "target"
+      },
+      {
+        "name": "collector_ip",
+        "field_type": "ip_addr",
+        "source": "target"
+      },
+      {
+        "name": "collector_port",
+        "field_type": "u16",
+        "source": "target"
+      },
+      {
+        "name": "producer_id",
+        "field_type": "uuid",
+        "source": "metric"
+      },
+      {
+        "name": "producer_ip",
+        "field_type": "ip_addr",
+        "source": "metric"
+      },
+      {
+        "name": "producer_port",
+        "field_type": "u16",
+        "source": "metric"
+      }
+    ],
+    "datum_type": "cumulative_u64",
+    "created": "2024-06-24T17:15:06.069658599Z"
+  },
+  "oximeter_collector:failed_collections": {
+    "timeseries_name": "oximeter_collector:failed_collections",
+    "field_schema": [
+      {
+        "name": "base_route",
+        "field_type": "string",
+        "source": "metric"
+      },
+      {
+        "name": "collector_id",
+        "field_type": "uuid",
+        "source": "target"
+      },
+      {
+        "name": "collector_ip",
+        "field_type": "ip_addr",
+        "source": "target"
+      },
+      {
+        "name": "collector_port",
+        "field_type": "u16",
+        "source": "target"
+      },
+      {
+        "name": "producer_id",
+        "field_type": "uuid",
+        "source": "metric"
+      },
+      {
+        "name": "producer_ip",
+        "field_type": "ip_addr",
+        "source": "metric"
+      },
+      {
+        "name": "producer_port",
+        "field_type": "u16",
+        "source": "metric"
+      },
+      {
+        "name": "reason",
+        "field_type": "string",
+        "source": "metric"
+      }
+    ],
+    "datum_type": "cumulative_u64",
+    "created": "2024-06-24T17:15:06.070765692Z"
+  }
+}

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -670,8 +670,8 @@ output.intermediate_only = true
 service_name = "lldp"
 source.type = "prebuilt"
 source.repo = "lldp"
-source.commit = "30e5d89fae9190c69258ca77d5d5a1acec064742"
-source.sha256 = "f58bfd1b77748544b5b1a99a07e52bab8dc5673b9bd3a745ebbfdd614d492328"
+source.commit = "188f0f6d4c066f1515bd707050407cedd790fcf1"
+source.sha256 = "132d0760be5208f60b58bcaed98fa6384b09f41dd5febf51970f5cbf46138ecf"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/schema/crdb/collapse_lldp_settings/up1.sql
+++ b/schema/crdb/collapse_lldp_settings/up1.sql
@@ -1,0 +1,4 @@
+/*
+ * The old lldp_service_config_id is being replaced with lldp_link_config_id.
+ */
+ALTER TABLE omicron.public.switch_port_settings_link_config DROP COLUMN IF EXISTS lldp_service_config_id;

--- a/schema/crdb/collapse_lldp_settings/up2.sql
+++ b/schema/crdb/collapse_lldp_settings/up2.sql
@@ -1,0 +1,4 @@
+/*
+ * Add a pointer to this link's LLDP config settings.
+ */
+ALTER TABLE omicron.public.switch_port_settings_link_config ADD COLUMN IF NOT EXISTS lldp_link_config_id UUID NOT NULL;

--- a/schema/crdb/collapse_lldp_settings/up3.sql
+++ b/schema/crdb/collapse_lldp_settings/up3.sql
@@ -1,0 +1,5 @@
+/*
+ * Drop the old lldp_service_config table, which has been incorporated into the
+ * new lldp_link_config.
+ */
+DROP TABLE IF EXISTS omicron.public.lldp_service_config;

--- a/schema/crdb/collapse_lldp_settings/up4.sql
+++ b/schema/crdb/collapse_lldp_settings/up4.sql
@@ -1,0 +1,4 @@
+/*
+ * Drop the old lldp_config table, which has been replaced by lldp_link_config.
+ */
+DROP TABLE IF EXISTS omicron.public.lldp_config;

--- a/schema/crdb/collapse_lldp_settings/up5.sql
+++ b/schema/crdb/collapse_lldp_settings/up5.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS omicron.public.lldp_link_config (
+    id UUID PRIMARY KEY,
+    enabled BOOL NOT NULL,
+    link_name STRING(63),
+    link_description STRING(512),
+    chassis_id STRING(63),
+    system_name STRING(63),
+    system_description STRING(512),
+    management_ip TEXT,
+    time_created TIMESTAMPTZ NOT NULL,
+    time_modified TIMESTAMPTZ NOT NULL,
+    time_deleted TIMESTAMPTZ
+);

--- a/schema/crdb/collapse_lldp_settings/up6.sql
+++ b/schema/crdb/collapse_lldp_settings/up6.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lldp_config_by_name;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2650,39 +2650,29 @@ CREATE TYPE IF NOT EXISTS omicron.public.switch_link_speed AS ENUM (
 
 CREATE TABLE IF NOT EXISTS omicron.public.switch_port_settings_link_config (
     port_settings_id UUID,
-    lldp_service_config_id UUID NOT NULL,
     link_name TEXT,
     mtu INT4,
     fec omicron.public.switch_link_fec,
     speed omicron.public.switch_link_speed,
     autoneg BOOL NOT NULL DEFAULT false,
+    lldp_link_config_id UUID NOT NULL,
 
     PRIMARY KEY (port_settings_id, link_name)
 );
 
-CREATE TABLE IF NOT EXISTS omicron.public.lldp_service_config (
+CREATE TABLE IF NOT EXISTS omicron.public.lldp_link_config (
     id UUID PRIMARY KEY,
-    lldp_config_id UUID,
-    enabled BOOL NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS omicron.public.lldp_config (
-    id UUID PRIMARY KEY,
-    name STRING(63) NOT NULL,
-    description STRING(512) NOT NULL,
+    enabled BOOL NOT NULL,
+    link_name STRING(63),
+    link_description STRING(512),
+    chassis_id STRING(63),
+    system_name STRING(63),
+    system_description STRING(612),
+    management_ip TEXT,
     time_created TIMESTAMPTZ NOT NULL,
     time_modified TIMESTAMPTZ NOT NULL,
-    time_deleted TIMESTAMPTZ,
-    chassis_id TEXT,
-    system_name TEXT,
-    system_description TEXT,
-    management_ip TEXT
+    time_deleted TIMESTAMPTZ
 );
-
-CREATE UNIQUE INDEX IF NOT EXISTS lldp_config_by_name ON omicron.public.lldp_config (
-    name
-) WHERE
-    time_deleted IS NULL;
 
 CREATE TYPE IF NOT EXISTS omicron.public.switch_interface_kind AS ENUM (
     'primary',
@@ -4218,7 +4208,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '88.0.0', NULL)
+    (TRUE, NOW(), NOW(), '89.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/rss-sled-plan.json
+++ b/schema/rss-sled-plan.json
@@ -604,6 +604,79 @@
         }
       }
     },
+    "LldpAdminStatus": {
+      "description": "To what extent should this port participate in LLDP",
+      "type": "string",
+      "enum": [
+        "enabled",
+        "disabled",
+        "rx_only",
+        "tx_only"
+      ]
+    },
+    "LldpPortConfig": {
+      "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "chassis_id": {
+          "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "management_addrs": {
+          "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string",
+            "format": "ip"
+          }
+        },
+        "port_description": {
+          "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "port_id": {
+          "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "To what extent should this port participate in LLDP",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LldpAdminStatus"
+            }
+          ]
+        },
+        "system_description": {
+          "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "system_name": {
+          "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "Name": {
       "title": "A name unique within the parent collection",
       "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
@@ -647,6 +720,17 @@
           "items": {
             "$ref": "#/definitions/BgpPeerConfig"
           }
+        },
+        "lldp": {
+          "description": "LLDP configuration for this port",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LldpPortConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "port": {
           "description": "Nmae of the port this config applies to.",

--- a/sled-agent/src/rack_setup/plan/sled.rs
+++ b/sled-agent/src/rack_setup/plan/sled.rs
@@ -172,7 +172,7 @@ impl Plan {
 
         let mut ledger = Ledger::<Self>::new_with(log, paths, plan.clone());
         ledger.commit().await?;
-        info!(log, "Sled plan written to storage");
+        info!(log, "Sled plan written to storage: {plan:#?}");
         Ok(plan)
     }
 }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -99,6 +99,7 @@ use nexus_types::external_api::views::SledState;
 use omicron_common::address::get_sled_address;
 use omicron_common::api::external::Generation;
 use omicron_common::api::internal::shared::ExternalPortDiscovery;
+use omicron_common::api::internal::shared::LldpAdminStatus;
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
 };
@@ -750,7 +751,7 @@ impl ServiceInner {
                     .iter()
                     .map(|config| NexusTypes::PortConfigV2 {
                         port: config.port.clone(),
-			routes: config
+                        routes: config
                             .routes
                             .iter()
                             .map(|r| NexusTypes::RouteConfig {
@@ -760,14 +761,14 @@ impl ServiceInner {
                                 local_pref: r.local_pref,
                             })
                             .collect(),
-			addresses: config
-			    .addresses
-			    .iter()
-			    .map(|a| NexusTypes::UplinkAddressConfig {
-				    address: a.address,
-				    vlan_id: a.vlan_id
-			    })
-			    .collect(),
+                        addresses: config
+                            .addresses
+                            .iter()
+                            .map(|a| NexusTypes::UplinkAddressConfig {
+                                address: a.address,
+                                vlan_id: a.vlan_id,
+                            })
+                            .collect(),
                         switch: config.switch.into(),
                         uplink_port_speed: config.uplink_port_speed.into(),
                         uplink_port_fec: config.uplink_port_fec.into(),
@@ -787,7 +788,8 @@ impl ServiceInner {
                                 remote_asn: b.remote_asn,
                                 min_ttl: b.min_ttl,
                                 md5_auth_key: b.md5_auth_key.clone(),
-                                multi_exit_discriminator: b.multi_exit_discriminator,
+                                multi_exit_discriminator: b
+                                    .multi_exit_discriminator,
                                 local_pref: b.local_pref,
                                 enforce_first_as: b.enforce_first_as,
                                 communities: b.communities.clone(),
@@ -796,6 +798,32 @@ impl ServiceInner {
                                 vlan_id: b.vlan_id,
                             })
                             .collect(),
+                        lldp: config.lldp.as_ref().map(|lp| {
+                            NexusTypes::LldpPortConfig {
+                                status: match lp.status {
+                                    LldpAdminStatus::Enabled => {
+                                        NexusTypes::LldpAdminStatus::Enabled
+                                    }
+                                    LldpAdminStatus::Disabled => {
+                                        NexusTypes::LldpAdminStatus::Disabled
+                                    }
+                                    LldpAdminStatus::TxOnly => {
+                                        NexusTypes::LldpAdminStatus::TxOnly
+                                    }
+                                    LldpAdminStatus::RxOnly => {
+                                        NexusTypes::LldpAdminStatus::RxOnly
+                                    }
+                                },
+                                chassis_id: lp.chassis_id.clone(),
+                                port_id: lp.port_id.clone(),
+                                system_name: lp.system_name.clone(),
+                                system_description: lp
+                                    .system_description
+                                    .clone(),
+                                port_description: lp.port_description.clone(),
+                                management_addrs: lp.management_addrs.clone(),
+                            }
+                        }),
                     })
                     .collect(),
                 bgp: config
@@ -803,7 +831,12 @@ impl ServiceInner {
                     .iter()
                     .map(|config| NexusTypes::BgpConfig {
                         asn: config.asn,
-                        originate: config.originate.iter().cloned().map(Into::into).collect(),
+                        originate: config
+                            .originate
+                            .iter()
+                            .cloned()
+                            .map(Into::into)
+                            .collect(),
                         shaper: config.shaper.clone(),
                         checker: config.checker.clone(),
                     })
@@ -811,25 +844,26 @@ impl ServiceInner {
                 bfd: config
                     .bfd
                     .iter()
-                    .map(|spec| NexusTypes::BfdPeerConfig {
-                        detection_threshold: spec.detection_threshold,
-                        local: spec.local,
-                        mode: match spec.mode {
-                            omicron_common::api::external::BfdMode::SingleHop => {
-                                nexus_client::types::BfdMode::SingleHop
-                            }
-                            omicron_common::api::external::BfdMode::MultiHop => {
-                                nexus_client::types::BfdMode::MultiHop
-                            }
-                        },
-                        remote: spec.remote,
-                        required_rx: spec.required_rx,
-                        switch: spec.switch.into(),
+                    .map(|spec| {
+                        NexusTypes::BfdPeerConfig {
+                    detection_threshold: spec.detection_threshold,
+                    local: spec.local,
+                    mode: match spec.mode {
+                        omicron_common::api::external::BfdMode::SingleHop => {
+                            nexus_client::types::BfdMode::SingleHop
+                        }
+                        omicron_common::api::external::BfdMode::MultiHop => {
+                            nexus_client::types::BfdMode::MultiHop
+                        }
+                    },
+                    remote: spec.remote,
+                    required_rx: spec.required_rx,
+                    switch: spec.switch.into(),
+                }
                     })
                     .collect(),
             }
         };
-
         info!(self.log, "rack_network_config: {:#?}", rack_network_config);
 
         let physical_disks: Vec<_> = sled_configs_by_id

--- a/sled-agent/tests/integration_tests/early_network.rs
+++ b/sled-agent/tests/integration_tests/early_network.rs
@@ -154,6 +154,7 @@ fn current_config_example() -> (&'static str, EarlyNetworkConfig) {
                         vlan_id: None,
                     }],
                     autoneg: true,
+                    lldp: None,
                 }],
                 bgp: vec![BgpConfig {
                     asn: 20000,

--- a/sled-agent/tests/output/new-rss-sled-plans/madrid-rss-sled-plan.json
+++ b/sled-agent/tests/output/new-rss-sled-plans/madrid-rss-sled-plan.json
@@ -143,7 +143,8 @@
           "uplink_port_speed": "speed40_g",
           "uplink_port_fec": "none",
           "bgp_peers": [],
-          "autoneg": false
+          "autoneg": false,
+          "lldp": null
         },
         {
           "routes": [
@@ -165,7 +166,8 @@
           "uplink_port_speed": "speed40_g",
           "uplink_port_fec": "none",
           "bgp_peers": [],
-          "autoneg": false
+          "autoneg": false,
+          "lldp": null
         }
       ],
       "bgp": [],

--- a/sled-agent/types/src/early_networking.rs
+++ b/sled-agent/types/src/early_networking.rs
@@ -299,6 +299,7 @@ pub mod back_compat {
                 uplink_port_fec: v1.uplink_port_fec,
                 bgp_peers: v1.bgp_peers.clone(),
                 autoneg: v1.autoneg,
+                lldp: None,
             }
         }
     }
@@ -345,6 +346,7 @@ pub mod back_compat {
                 uplink_port_fec: value.uplink_port_fec,
                 bgp_peers: vec![],
                 autoneg: false,
+                lldp: None,
             }
         }
     }
@@ -517,6 +519,7 @@ mod tests {
                         uplink_port_fec: uplink.uplink_port_fec,
                         autoneg: false,
                         bgp_peers: vec![],
+                        lldp: None,
                     }],
                     bgp: vec![],
                     bfd: vec![],
@@ -598,6 +601,7 @@ mod tests {
                         uplink_port_fec: port.uplink_port_fec,
                         autoneg: false,
                         bgp_peers: vec![],
+                        lldp: None,
                     }],
                     bgp: vec![],
                     bfd: vec![],

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -118,6 +118,22 @@ switch = "switch0"
 # Neighbors we expect to peer with over BGP on this port.
 bgp_peers = []
 
+# LLDP settings for this port
+#[rack_network_config.switch0.qsfp0.lldp]
+#status = "Enabled"
+# Optional Port ID, overriding default of qsfpX/0
+#port_id = ""
+## Optional port description
+#port_description = "uplink 0"
+# Optional chassid ID, overriding the switch-level setting
+#chassis_id = ""
+# Optional system name, overriding the switch-level setting
+#system_name = ""
+# Optional system description, overriding the switch-level setting
+#system_description = ""
+# Optional management addresses to advertise, overriding switch-level setting
+#management_addrs = []
+
 # An allowlist of source IPs that can make requests to user-facing services can
 # be specified here. It can be written as the string "any" ...
 [allowed_source_ips]

--- a/tools/update_lldp.sh
+++ b/tools/update_lldp.sh
@@ -47,7 +47,9 @@ function main {
       esac
     done
 
-    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_COMMIT")
+    if [[ -z "$TARGET_COMMIT" ]]; then
+	    TARGET_COMMIT=$(get_latest_commit_from_gh "$REPO" "$TARGET_BRANCH")
+    fi
     install_toml2json
     do_update_packages "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${PACKAGES[@]}"
     do_update_crates "$TARGET_COMMIT" "$DRY_RUN" "$REPO" "${CRATES[@]}"

--- a/wicket-common/src/example.rs
+++ b/wicket-common/src/example.rs
@@ -12,7 +12,8 @@ use omicron_common::{
     api::{
         external::AllowedSourceIps,
         internal::shared::{
-            BgpConfig, BgpPeerConfig, PortFec, PortSpeed, RouteConfig,
+            BgpConfig, BgpPeerConfig, LldpAdminStatus, LldpPortConfig, PortFec,
+            PortSpeed, RouteConfig,
         },
     },
 };
@@ -166,13 +167,33 @@ impl ExampleRackSetupData {
             vlan_id: None,
         }];
 
+        let switch0_port0_lldp = Some(LldpPortConfig {
+            status: LldpAdminStatus::Enabled,
+            chassis_id: Some("chassid id override".to_string()),
+            port_id: Some("port id override".to_string()),
+            system_name: Some("system name override".to_string()),
+            system_description: Some("system description override".to_string()),
+            port_description: Some("port description override".to_string()),
+            management_addrs: None,
+        });
+
+        let switch1_port0_lldp = Some(LldpPortConfig {
+            status: LldpAdminStatus::Enabled,
+            chassis_id: Some("chassid id override".to_string()),
+            port_id: Some("port id override".to_string()),
+            system_name: Some("system name override".to_string()),
+            system_description: Some("system description override".to_string()),
+            port_description: Some("port description override".to_string()),
+            management_addrs: Some(vec!["172.32.0.4".parse().unwrap()]),
+        });
+
         let rack_network_config = UserSpecifiedRackNetworkConfig {
             infra_ip_first: "172.30.0.1".parse().unwrap(),
             infra_ip_last: "172.30.0.10".parse().unwrap(),
             switch0: btreemap! {
                 "port0".to_owned() => UserSpecifiedPortConfig {
-                    addresses: vec!["172.30.0.1/24".parse().unwrap()],
-                    routes: vec![RouteConfig {
+                addresses: vec!["172.30.0.1/24".parse().unwrap()],
+            routes: vec![RouteConfig {
                         destination: "0.0.0.0/0".parse().unwrap(),
                         nexthop: "172.30.0.10".parse().unwrap(),
                         vlan_id: Some(1),
@@ -181,9 +202,10 @@ impl ExampleRackSetupData {
                     bgp_peers: switch0_port0_bgp_peers,
                     uplink_port_speed: PortSpeed::Speed400G,
                     uplink_port_fec: PortFec::Firecode,
+            lldp: switch0_port0_lldp,
                     autoneg: true,
                 },
-            },
+             },
             switch1: btreemap! {
                 // Use the same port name as in switch0 to test that it doesn't
                 // collide.
@@ -198,6 +220,7 @@ impl ExampleRackSetupData {
                     bgp_peers: switch1_port0_bgp_peers,
                     uplink_port_speed: PortSpeed::Speed400G,
                     uplink_port_fec: PortFec::Firecode,
+                    lldp: switch1_port0_lldp,
                     autoneg: true,
                 },
             },

--- a/wicket-common/src/rack_setup.rs
+++ b/wicket-common/src/rack_setup.rs
@@ -11,6 +11,7 @@ use omicron_common::api::external::SwitchLocation;
 use omicron_common::api::internal::shared::AllowedSourceIps;
 use omicron_common::api::internal::shared::BgpConfig;
 use omicron_common::api::internal::shared::BgpPeerConfig;
+use omicron_common::api::internal::shared::LldpPortConfig;
 use omicron_common::api::internal::shared::PortFec;
 use omicron_common::api::internal::shared::PortSpeed;
 use omicron_common::api::internal::shared::RouteConfig;
@@ -185,6 +186,8 @@ pub struct UserSpecifiedPortConfig {
     pub autoneg: bool,
     #[serde(default)]
     pub bgp_peers: Vec<UserSpecifiedBgpPeerConfig>,
+    #[serde(default)]
+    pub lldp: Option<LldpPortConfig>,
 }
 
 /// User-specified version of [`BgpPeerConfig`].

--- a/wicket/src/cli/rack_setup/config_toml.rs
+++ b/wicket/src/cli/rack_setup/config_toml.rs
@@ -8,6 +8,7 @@
 use omicron_common::address::IpRange;
 use omicron_common::api::external::AllowedSourceIps;
 use omicron_common::api::internal::shared::BgpConfig;
+use omicron_common::api::internal::shared::LldpPortConfig;
 use omicron_common::api::internal::shared::RouteConfig;
 use omicron_common::api::internal::shared::UplinkAddressConfig;
 use serde::Serialize;
@@ -320,6 +321,7 @@ fn populate_uplink_table(cfg: &UserSpecifiedPortConfig) -> Table {
         uplink_port_fec,
         autoneg,
         bgp_peers,
+        lldp,
     } = cfg;
 
     let mut uplink = Table::new();
@@ -490,6 +492,46 @@ fn populate_uplink_table(cfg: &UserSpecifiedPortConfig) -> Table {
     }
 
     uplink.insert("bgp_peers", Item::ArrayOfTables(peers));
+
+    if let Some(l) = lldp {
+        let LldpPortConfig {
+            status,
+            chassis_id,
+            port_id,
+            system_name,
+            system_description,
+            port_description,
+            management_addrs,
+        } = l;
+        let mut lldp = Table::new();
+        lldp.insert("status", string_item(status));
+        if let Some(x) = chassis_id {
+            lldp.insert("chassis_id", string_item(x));
+        }
+        if let Some(x) = port_id {
+            lldp.insert("port_id", string_item(x));
+        }
+        if let Some(x) = system_name {
+            lldp.insert("system_name", string_item(x));
+        }
+        if let Some(x) = system_description {
+            lldp.insert("system_description", string_item(x));
+        }
+        if let Some(x) = port_description {
+            lldp.insert("port_description", string_item(x));
+        }
+        if let Some(addrs) = management_addrs {
+            let mut addresses_out = Array::new();
+            for a in addrs {
+                addresses_out.push(string_value(a));
+            }
+            lldp.insert(
+                "management_addrs",
+                Item::Value(Value::Array(addresses_out)),
+            );
+        }
+        uplink.insert("lldp", Item::Table(lldp));
+    }
 
     uplink
 }

--- a/wicket/src/ui/panes/rack_setup.rs
+++ b/wicket/src/ui/panes/rack_setup.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use omicron_common::address::IpRange;
 use omicron_common::api::internal::shared::AllowedSourceIps;
 use omicron_common::api::internal::shared::BgpConfig;
+use omicron_common::api::internal::shared::LldpPortConfig;
 use omicron_common::api::internal::shared::RouteConfig;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
@@ -740,6 +741,7 @@ fn rss_config_text<'a>(
                 uplink_port_fec,
                 autoneg,
                 bgp_peers,
+                lldp,
             } = uplink;
 
             let mut items = vec![
@@ -1034,6 +1036,68 @@ fn rss_config_text<'a>(
             items.extend(routes);
             items.extend(addresses);
             items.extend(peers);
+
+            if let Some(lp) = lldp {
+                let LldpPortConfig {
+                    status,
+                    chassis_id,
+                    port_id,
+                    system_name,
+                    system_description,
+                    port_description,
+                    management_addrs,
+                } = lp;
+
+                let mut lldp = vec![
+                    vec![Span::styled("  • LLDP port settings: ", label_style)],
+                    vec![
+                        Span::styled("    • Admin status      : ", label_style),
+                        Span::styled(status.to_string(), ok_style),
+                    ],
+                ];
+
+                if let Some(c) = chassis_id {
+                    lldp.push(vec![
+                        Span::styled("    • Chassis ID        : ", label_style),
+                        Span::styled(c.to_string(), ok_style),
+                    ])
+                }
+                if let Some(s) = system_name {
+                    lldp.push(vec![
+                        Span::styled("    • System name       : ", label_style),
+                        Span::styled(s.to_string(), ok_style),
+                    ])
+                }
+                if let Some(s) = system_description {
+                    lldp.push(vec![
+                        Span::styled("    • System description: ", label_style),
+                        Span::styled(s.to_string(), ok_style),
+                    ])
+                }
+                if let Some(p) = port_id {
+                    lldp.push(vec![
+                        Span::styled("    • Port ID           : ", label_style),
+                        Span::styled(p.to_string(), ok_style),
+                    ])
+                }
+                if let Some(p) = port_description {
+                    lldp.push(vec![
+                        Span::styled("    • Port description  : ", label_style),
+                        Span::styled(p.to_string(), ok_style),
+                    ])
+                }
+                if let Some(addrs) = management_addrs {
+                    let mut label = "    • Management addrs  : ";
+                    for a in addrs {
+                        lldp.push(vec![
+                            Span::styled(label, label_style),
+                            Span::styled(a.to_string(), ok_style),
+                        ]);
+                        label = "                        : ";
+                    }
+                }
+                items.extend(lldp);
+            }
 
             append_list(
                 &mut spans,

--- a/wicket/tests/output/example_non_empty.toml
+++ b/wicket/tests/output/example_non_empty.toml
@@ -111,6 +111,14 @@ allowed_export = []
 local_pref = 80
 enforce_first_as = true
 
+[rack_network_config.switch0.port0.lldp]
+status = "enabled"
+chassis_id = "chassid id override"
+port_id = "port id override"
+system_name = "system name override"
+system_description = "system description override"
+port_description = "port description override"
+
 [rack_network_config.switch1.port0]
 routes = [{ nexthop = "172.33.0.10", destination = "0.0.0.0/0", vlan_id = 1 }]
 addresses = [{ address = "172.32.0.1/24" }]
@@ -130,6 +138,15 @@ keepalive = 2
 auth_key_id = "bgp-key-1"
 allowed_import = ["224.0.0.0/4"]
 enforce_first_as = false
+
+[rack_network_config.switch1.port0.lldp]
+status = "enabled"
+chassis_id = "chassid id override"
+port_id = "port id override"
+system_name = "system name override"
+system_description = "system description override"
+port_description = "port description override"
+management_addrs = ["172.32.0.4"]
 
 [[rack_network_config.bgp]]
 asn = 47

--- a/wicketd/src/rss_config.rs
+++ b/wicketd/src/rss_config.rs
@@ -686,11 +686,14 @@ fn build_port_config(
     bgp_auth_keys: &BTreeMap<BgpAuthKeyId, Option<BgpAuthKey>>,
 ) -> BaPortConfigV2 {
     use bootstrap_agent_client::types::BgpPeerConfig as BaBgpPeerConfig;
+    use bootstrap_agent_client::types::LldpAdminStatus as BaLldpAdminStatus;
+    use bootstrap_agent_client::types::LldpPortConfig as BaLldpPortConfig;
     use bootstrap_agent_client::types::PortFec as BaPortFec;
     use bootstrap_agent_client::types::PortSpeed as BaPortSpeed;
     use bootstrap_agent_client::types::RouteConfig as BaRouteConfig;
     use bootstrap_agent_client::types::SwitchLocation as BaSwitchLocation;
     use bootstrap_agent_client::types::UplinkAddressConfig as BaUplinkAddressConfig;
+    use omicron_common::api::internal::shared::LldpAdminStatus;
     use omicron_common::api::internal::shared::PortFec;
     use omicron_common::api::internal::shared::PortSpeed;
 
@@ -780,6 +783,20 @@ fn build_port_config(
             PortFec::Rs => BaPortFec::Rs,
         },
         autoneg: config.autoneg,
+        lldp: config.lldp.as_ref().map(|c| BaLldpPortConfig {
+            status: match c.status {
+                LldpAdminStatus::Enabled => BaLldpAdminStatus::Enabled,
+                LldpAdminStatus::Disabled => BaLldpAdminStatus::Disabled,
+                LldpAdminStatus::TxOnly => BaLldpAdminStatus::TxOnly,
+                LldpAdminStatus::RxOnly => BaLldpAdminStatus::RxOnly,
+            },
+            chassis_id: c.chassis_id.clone(),
+            port_id: c.port_id.clone(),
+            system_name: c.system_name.clone(),
+            system_description: c.system_description.clone(),
+            port_description: c.port_description.clone(),
+            management_addrs: c.management_addrs.clone(),
+        }),
     }
 }
 


### PR DESCRIPTION
Several months ago, we added basic support for running `lldp` in the switch zone. That support consisted of plumbing through the chassis ID and sidecar revision, and starting the daemon.

This change adds support for enabling LLDP on individual ports, and for configuring per-port settings.  These settings are consumed by `wicket` and are plumbed through the bootstore and into `crdb`.  They are passed on to the daemon in the switch zone via SMF properties.

With this new functionality, we will be announcing our presence on a customer's network and should be visible through their network management tools.  The daemon running in the switch zone will be collecting information from its peers on their network, but that collected data is not yet plumbed back through the `oxide` API/CLI.  That will be addressed as follow-on work.
