### PR TITLE
[xtask] compile even if `CARGO_HOME` is unset

### DIFF
--- a/dev-tools/xtask/src/check_features.rs
+++ b/dev-tools/xtask/src/check_features.rs
@@ -138,7 +138,7 @@ fn install_cargo_hack(cargo: &str, version: Option<String>) -> Result<()> {
         eprintln!(
             "installing cargo-hack at version {} to {}",
             version,
-            env!("CARGO_HOME")
+            option_env!("CARGO_HOME").unwrap_or("~/.cargo")
         );
         command.args(&["install", "cargo-hack", "--version", &version]);
         exec(command)


### PR DESCRIPTION
The `CARGO_HOME` environment variable is used to override where the
Cargo registry index and binaries are installed to. Generally, it's
unset unless the user has decided to explicitly override this location.

Omicron's `cargo xtask` contains a use of `env!("CARGO_HOME")` that's
used to print where a `cargo-hack` binary is installed to. However, the
`env!` macro expects an environment variable to always be set, and if
it's not, it results in a compiler error. This means that when
`CARGO_HOME` is unset --- which is the default --- Omicron's `xtask`
crate doesn't compile.

This commit fixes that by making the `eprintln!` use `option_env!` and
substitute the default path instead when `CARGO_HOME` is unset. This
way, the xtasks should build for people who aren't explicitly overriding `CARGO_HOME`.