### PR TITLE
Centralise IP address object address retrieval and existence checks.

### DIFF
--- a/illumos-utils/src/ipadm.rs
+++ b/illumos-utils/src/ipadm.rs
@@ -23,7 +23,7 @@ const ADDROBJ_NOT_FOUND_ERR2: &str = "Address object not found";
 /// Expected error message when an interface already exists.
 const INTERFACE_ALREADY_EXISTS: &str = "Interface already exists";
 
-/// Expected error message when an addrobj already eixsts.
+/// Expected error message when an addrobj already exists.
 const ADDROBJ_ALREADY_EXISTS: &str = "Address object already exists";
 
 pub enum AddrObjType {
@@ -51,9 +51,10 @@ impl Ipadm {
         }
     }
 
-    /// Ensure that a particular address object exists. Note that this checks
-    /// whether an address object with the provided name already exists but
-    /// does not validate its properties.
+    /// Create an address object with the provided parameters. If an object
+    /// with the requested name already exists, return success. Note that in
+    /// this case, the existing object is not checked to ensure it is
+    /// consistent with the provided parameters.
     pub fn ensure_ip_addrobj_exists(
         addrobj: &str,
         addrtype: AddrObjType,

--- a/illumos-utils/src/lib.rs
+++ b/illumos-utils/src/lib.rs
@@ -64,6 +64,9 @@ pub enum ExecutionError {
     #[error("Failed to manipulate process contract: {err}")]
     ContractFailure { err: std::io::Error },
 
+    #[error("Failed to parse command output")]
+    ParseFailure(String),
+
     #[error("Zone is not running")]
     NotRunning,
 }

--- a/sled-agent/src/bin/zone-bundle.rs
+++ b/sled-agent/src/bin/zone-bundle.rs
@@ -16,8 +16,6 @@ use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 use futures::stream::StreamExt;
-#[cfg(target_os = "illumos")]
-use illumos_utils::ipadm::Ipadm;
 use omicron_common::address::SLED_AGENT_PORT;
 use sled_agent_client::types::CleanupContextUpdate;
 use sled_agent_client::types::Duration;
@@ -31,8 +29,6 @@ use slog::Logger;
 use slog_term::FullFormat;
 use slog_term::TermDecorator;
 use std::collections::BTreeSet;
-#[cfg(target_os = "illumos")]
-use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::time::SystemTime;
 use tar::Builder;
@@ -250,6 +246,8 @@ async fn fetch_underlay_address() -> anyhow::Result<Ipv6Addr> {
     return Ok(Ipv6Addr::LOCALHOST);
     #[cfg(target_os = "illumos")]
     {
+        use illumos_utils::ipadm::Ipadm;
+        use std::net::IpAddr;
         const EXPECTED_ADDR_OBJ: &str = "underlay0/sled6";
         match Ipadm::addrobj_addr(EXPECTED_ADDR_OBJ) {
             // If we failed because there was no such interface, then fall back


### PR DESCRIPTION
Following [illumos 16677](https://www.illumos.org/issues/16677), the error message that indicates that
an address object does not exist has been changed to be
consistent, whereas it was previously one of two different messages
or sometimes even completely blank.

A couple of places in omicron relied on the specific error
message so this change centralises the check, and updates it
to cater for illumos pre- and post-16677. Longer term this
could be replaced by bindings to libipadm.
