### PR TITLE
Allow specifying a path to `xtask-downloader` via env var

### DIFF
--- a/dev-tools/xtask/src/external.rs
+++ b/dev-tools/xtask/src/external.rs
@@ -52,6 +52,10 @@ impl External {
         self
     }
 
+    pub fn trailing_args(&self) -> &[OsString] {
+        &self.args
+    }
+
     pub fn exec_example(self, example_target: impl AsRef<OsStr>) -> Result<()> {
         self.exec_common("--example", example_target.as_ref())
     }

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -9,6 +9,9 @@
 use anyhow::{Context, Result};
 use cargo_metadata::Metadata;
 use clap::{Parser, Subcommand};
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
 
 mod check_features;
 mod check_workspace_deps;
@@ -94,7 +97,20 @@ fn main() -> Result<()> {
         Cmds::Clippy(args) => clippy::run_cmd(args),
         Cmds::CheckFeatures(args) => check_features::run_cmd(args),
         Cmds::CheckWorkspaceDeps => check_workspace_deps::run_cmd(),
-        Cmds::Download(external) => external.exec_bin("xtask-downloader"),
+        Cmds::Download(external) => {
+            // Allow specialized environments (e.g., testbed/a4x2) that can't
+            // `cargo run ...` to specify a path to `xtask-downloader` via an
+            // environment variable.
+            if let Ok(bin_path) = env::var("XTASK_DOWNLOADER_BIN") {
+                let error = Command::new(&bin_path)
+                    .args(external.trailing_args())
+                    .exec();
+                Err(error)
+                    .with_context(|| format!("failed to exec `{bin_path}`"))
+            } else {
+                external.exec_bin("xtask-downloader")
+            }
+        }
         Cmds::Openapi(external) => external.exec_bin("openapi-manager"),
         #[cfg(target_os = "illumos")]
         Cmds::Releng(external) => {


### PR DESCRIPTION
#6171 accidentally broke a4x2, because it needs to run `xtask download softnpu`, which used to directly download softnpu bits and now tries to `cargo run --bin xtask-downloader ...`. `cargo` isn't available within a4x2 VMs, so this change allows that environment to specify a path to the `xtask-downloader` binary directly.

oxidecomputer/testbed#60 is the corresponding a4x2 PR to inject `xtask-downloader` and set the env var.