### PR TITLE
wicket cli: add "inventory configured-bootstrap-sleds"

### DIFF
--- a/wicket/src/cli/command.rs
+++ b/wicket/src/cli/command.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use clap::{Args, ColorChoice, Parser, Subcommand};
 
 use super::{
-    preflight::PreflightArgs, rack_setup::SetupArgs,
+    inventory::InventoryArgs, preflight::PreflightArgs, rack_setup::SetupArgs,
     rack_update::RackUpdateArgs, upload::UploadArgs,
 };
 
@@ -49,6 +49,7 @@ impl ShellApp {
                 args.exec(log, wicketd_addr, self.global_opts).await
             }
             ShellCommand::Preflight(args) => args.exec(log, wicketd_addr).await,
+            ShellCommand::Inventory(args) => args.exec(log, wicketd_addr).await,
         }
     }
 }
@@ -100,4 +101,8 @@ enum ShellCommand {
     /// Run checks prior to setting up the rack.
     #[command(subcommand)]
     Preflight(PreflightArgs),
+
+    /// Enumerate rack components
+    #[command(subcommand)]
+    Inventory(InventoryArgs),
 }

--- a/wicket/src/cli/command.rs
+++ b/wicket/src/cli/command.rs
@@ -49,7 +49,9 @@ impl ShellApp {
                 args.exec(log, wicketd_addr, self.global_opts).await
             }
             ShellCommand::Preflight(args) => args.exec(log, wicketd_addr).await,
-            ShellCommand::Inventory(args) => args.exec(log, wicketd_addr).await,
+            ShellCommand::Inventory(args) => {
+                args.exec(log, wicketd_addr, output).await
+            }
         }
     }
 }

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -109,8 +109,8 @@ fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
 
     // Print status indicator
     let status = match address {
-        None => format!("{}", 'o'.green()),
-        Some(_) => format!("{}", 'x'.red()),
+        None => format!("{}", '✔'.green()),
+        Some(_) => format!("{}", '⚠'.red()),
     };
 
     let addr_fmt = match address {

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Support for inventory checks via wicketd.
+
+use crate::wicketd::create_wicketd_client;
+use anyhow::Context;
+use anyhow::Result;
+use clap::Subcommand;
+use owo_colors::OwoColorize;
+use serde::Serialize;
+use sled_hardware_types::Baseboard;
+use slog::Logger;
+use std::net::Ipv6Addr;
+use std::net::SocketAddrV6;
+use std::time::Duration;
+
+const WICKETD_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum InventoryArgs {
+    /// List state of all bootstrap sleds, as configured with rack-setup
+    ConfiguredBootstrapSleds {
+        /// Print output as json
+        #[clap(long)]
+        json: bool,
+    },
+}
+
+impl InventoryArgs {
+    pub(crate) async fn exec(
+        self,
+        log: Logger,
+        wicketd_addr: SocketAddrV6,
+    ) -> Result<()> {
+        let client = create_wicketd_client(&log, wicketd_addr, WICKETD_TIMEOUT);
+
+        match self {
+            InventoryArgs::ConfiguredBootstrapSleds { json } => {
+                // We don't use the /bootstrap-sleds endpoint, because that
+                // gets all sleds visible on the bootstrap network. We want
+                // something different here.
+                // - We want the status of only sleds we've configured wicket
+                //   to use for setup. /bootstrap-sleds will give us sleds
+                //   we don't want
+                // - We want the status even if they aren't visible on the
+                //   bootstrap network yet.
+                //
+                // In other words, we want the sled information displayed at the
+                // bottom of the rack setup screen in the TUI.
+                let conf = client
+                    .get_rss_config()
+                    .await
+                    .context("failed to get rss config")?;
+
+                let bootstrap_sleds = &conf.insensitive.bootstrap_sleds;
+                let sled_data: Vec<ConfiguredBootstrapSledData> =
+                    bootstrap_sleds
+                        .iter()
+                        .map(|desc| {
+                            let cubby = desc.id.slot;
+
+                            let identifier = match &desc.baseboard {
+                                Baseboard::Gimlet { identifier, .. } => {
+                                    identifier.clone()
+                                }
+                                Baseboard::Pc { identifier, .. } => {
+                                    identifier.clone()
+                                }
+                                Baseboard::Unknown => "unknown".to_string(),
+                            };
+
+                            let address = desc.bootstrap_ip;
+
+                            ConfiguredBootstrapSledData {
+                                cubby,
+                                identifier,
+                                address,
+                            }
+                        })
+                        .collect();
+
+                if json {
+                    let json_str = serde_json::to_string(&sled_data)
+                        .context("serializing sled data")?;
+                    println!("{}", json_str);
+                } else {
+                    for sled in &sled_data {
+                        print_bootstrap_sled_data(sled);
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ConfiguredBootstrapSledData {
+    cubby: u32,
+    identifier: String,
+    address: Option<Ipv6Addr>,
+}
+
+fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
+    let ConfiguredBootstrapSledData { cubby, identifier, address } = data;
+
+    // Print status indicator
+    let status = match address {
+        None => format!("{}", '✔'.green()),
+        Some(_) => format!("{}", '⚠'.red()),
+    };
+
+    let addr_fmt = match address {
+        None => "".to_string(),
+        Some(addr) => format!("\t{}", addr),
+    };
+
+    // The rest of the data
+    println!("{status} Cubby {cubby}\t{identifier}{addr_fmt}");
+}

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -109,12 +109,12 @@ fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
 
     // Print status indicator
     let status = match address {
-        None => format!("{}", '✔'.green()),
-        Some(_) => format!("{}", '⚠'.red()),
+        None => format!("{}", 'o'.green()),
+        Some(_) => format!("{}", 'x'.red()),
     };
 
     let addr_fmt = match address {
-        None => "".to_string(),
+        None => "not_available".to_string(),
         Some(addr) => format!("\t{}", addr),
     };
 

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -109,8 +109,8 @@ fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
 
     // Print status indicator
     let status = match address {
-        None => format!("{}", '✔'.green()),
-        Some(_) => format!("{}", '⚠'.red()),
+        None => format!("{}", '⚠'.red()),
+        Some(_) => format!("{}", '✔'.green()),
     };
 
     let addr_fmt = match address {

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -119,5 +119,5 @@ fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
     };
 
     // The rest of the data
-    println!("{status} Cubby {cubby}\t{identifier}{addr_fmt}");
+    println!("{status} Cubby {:02}\t{identifier}{addr_fmt}", cubby);
 }

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -59,7 +59,7 @@ impl InventoryArgs {
                     bootstrap_sleds
                         .iter()
                         .map(|desc| {
-                            let cubby = desc.id.slot;
+                            let slot = desc.id.slot;
 
                             let identifier = match &desc.baseboard {
                                 Baseboard::Gimlet { identifier, .. } => {
@@ -74,7 +74,7 @@ impl InventoryArgs {
                             let address = desc.bootstrap_ip;
 
                             ConfiguredBootstrapSledData {
-                                cubby,
+                                slot,
                                 identifier,
                                 address,
                             }
@@ -99,13 +99,13 @@ impl InventoryArgs {
 
 #[derive(Serialize)]
 struct ConfiguredBootstrapSledData {
-    cubby: u32,
+    slot: u32,
     identifier: String,
     address: Option<Ipv6Addr>,
 }
 
 fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
-    let ConfiguredBootstrapSledData { cubby, identifier, address } = data;
+    let ConfiguredBootstrapSledData { slot, identifier, address } = data;
 
     // Print status indicator
     let status = match address {
@@ -114,10 +114,10 @@ fn print_bootstrap_sled_data(data: &ConfiguredBootstrapSledData) {
     };
 
     let addr_fmt = match address {
-        None => "not_available".to_string(),
+        None => "(not available)".to_string(),
         Some(addr) => format!("\t{}", addr),
     };
 
     // The rest of the data
-    println!("{status} Cubby {:02}\t{identifier}{addr_fmt}", cubby);
+    println!("{status} Cubby {:02}\t{identifier}{addr_fmt}", slot);
 }

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Subcommand;
 use owo_colors::OwoColorize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sled_hardware_types::Baseboard;
 use slog::Logger;
 use std::net::Ipv6Addr;
@@ -83,7 +83,7 @@ impl InventoryArgs {
 
                 if json {
                     let json_str = serde_json::to_string(&sled_data)
-                        .context("serializing sled data")?;
+                        .context("serializing sled data failed")?;
                     println!("{}", json_str);
                 } else {
                     for sled in &sled_data {

--- a/wicket/src/cli/inventory.rs
+++ b/wicket/src/cli/inventory.rs
@@ -12,6 +12,7 @@ use clap::{Subcommand, ValueEnum};
 use owo_colors::OwoColorize;
 use sled_hardware_types::Baseboard;
 use slog::Logger;
+use std::fmt;
 use std::net::SocketAddrV6;
 use std::time::Duration;
 use wicket_common::rack_setup::BootstrapSledDescription;
@@ -23,19 +24,27 @@ pub(crate) enum InventoryArgs {
     /// List state of all bootstrap sleds, as configured with rack-setup
     ConfiguredBootstrapSleds {
         /// Select output format
-        #[clap(long)]
+        #[clap(long, default_value_t = OutputFormat::Table)]
         format: OutputFormat,
     },
 }
 
-#[derive(Debug, ValueEnum, Default, Clone)]
+#[derive(Debug, ValueEnum, Clone)]
 pub enum OutputFormat {
     /// Print output as operator-readable table
-    #[default]
     Table,
 
     /// Print output as json
     Json,
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Table => write!(f, "table"),
+            OutputFormat::Json => write!(f, "json"),
+        }
+    }
 }
 
 impl InventoryArgs {

--- a/wicket/src/cli/mod.rs
+++ b/wicket/src/cli/mod.rs
@@ -11,6 +11,7 @@
 //! support for that.
 
 mod command;
+mod inventory;
 mod preflight;
 mod rack_setup;
 mod rack_update;

--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -49,9 +49,10 @@ async fn test_inventory() {
     // 4 SPs attached to the inventory.
     assert_eq!(inventory.sps.len(), 4);
 
-    // Test CLI command
+    // Test CLI with JSON output
     {
-        let args = vec!["inventory", "configured-bootstrap-sleds", "--json"];
+        let args =
+            vec!["inventory", "configured-bootstrap-sleds", "--format", "json"];
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let output = OutputKind::Captured {

--- a/wicketd/tests/integration_tests/inventory.rs
+++ b/wicketd/tests/integration_tests/inventory.rs
@@ -68,9 +68,6 @@ async fn test_inventory() {
         let response: Vec<BootstrapSledDescription> =
             serde_json::from_slice(&stdout).expect("stdout is valid JSON");
 
-        // This is the data we have today but I want it to be different from
-        // this to test having an address and such
-
         // This only tests the case that we get sleds back with no current
         // bootstrap IP. This does provide svalue: it check that the command
         // exists, accesses data within wicket, and returns it in the schema we


### PR DESCRIPTION
## This PR

My main motivation for adding: I am working on automating control plane deployment on london and madrid. Before we can start rack init, we need to know if all the sleds we are going to initialize are actually available. This information is something you can see from the rack init TUI, but there was no way to get it from the CLI.

I have added an `inventory` command with a `configured-bootstrap-sleds` subcommand, which presents exactly the same information accessible in the TUI's rack init screen.

(Note: there is no way to start rack init for the CLI yet, but I will add that in a future PR.)

In theory `inventory` could be expanded to provide other information.

Note, I am absolutely not attached to the command interface or data format. I only care about making this information accessible so I can use it in my scripts. Meaning, if *any* of this interface should be different from how I've done it in this initial PR, I will make those changes as asked.

### Example Usage

```
artemis@jeeves ~ $ ssh londonwicket inventory configured-bootstrap-sleds
⚠ Cubby 14      BRM42220036     not_available
✔ Cubby 15      BRM42220062     fdb0:a840:2504:312::1
✔ Cubby 16      BRM42220030     fdb0:a840:2504:257::1
✔ Cubby 17      BRM44220007     fdb0:a840:2504:492::1
```

```
artemis@jeeves ~ $ ssh londonwicket -- inventory configured-bootstrap-sleds --json | jq
[
  {
    "id": {
      "slot": 14,
      "type": "sled"
    },
    "baseboard": {
      "type": "gimlet",
      "identifier": "BRM42220036",
      "model": "913-0000019",
      "revision": 6
    },
    "bootstrap_ip": "fdb0:a840:2504:212::1"
  },
  {
    "id": {
      "slot": 15,
      "type": "sled"
    },
    "baseboard": {
      "type": "gimlet",
      "identifier": "BRM42220062",
      "model": "913-0000019",
      "revision": 6
    },
    "bootstrap_ip": "fdb0:a840:2504:312::1"
  },
  {
    "id": {
      "slot": 16,
      "type": "sled"
    },
    "baseboard": {
      "type": "gimlet",
      "identifier": "BRM42220030",
      "model": "913-0000019",
      "revision": 6
    },
    "bootstrap_ip": "fdb0:a840:2504:257::1"
  },
  {
    "id": {
      "slot": 17,
      "type": "sled"
    },
    "baseboard": {
      "type": "gimlet",
      "identifier": "BRM44220007",
      "model": "913-0000019",
      "revision": 6
    },
    "bootstrap_ip": "fdb0:a840:2504:492::1"
  }
]
```