### PR TITLE
Add more switch link counters

### DIFF
--- a/oximeter/impl/src/schema/codegen.rs
+++ b/oximeter/impl/src/schema/codegen.rs
@@ -559,7 +559,10 @@ impl quote::ToTokens for TimeseriesSchema {
         let created = quote_creation_time(self.created);
         let toks = quote! {
             ::oximeter::schema::TimeseriesSchema {
-                timeseries_name: ::oximeter::TimeseriesName::try_from(#timeseries_name).unwrap(),
+                timeseries_name:
+                    <::oximeter::TimeseriesName as ::std::convert::TryFrom<&str>>::try_from(
+                        #timeseries_name
+                    ).unwrap(),
                 description: ::oximeter::schema::TimeseriesDescription {
                     target: String::from(#target_description),
                     metric: String::from(#metric_description),

--- a/oximeter/oximeter/schema/switch-data-link.toml
+++ b/oximeter/oximeter/schema/switch-data-link.toml
@@ -183,7 +183,7 @@ versions = [
 ]
 
 [[metrics]]
-name = "fec_aligned"
+name = "fec_sync_aligned"
 description = "All lanes synchronized and aligned"
 units = "none"
 datum_type = "bool"

--- a/oximeter/oximeter/schema/switch-data-link.toml
+++ b/oximeter/oximeter/schema/switch-data-link.toml
@@ -90,6 +90,15 @@ versions = [
 ]
 
 [[metrics]]
+name = "link_enabled"
+description = "Reports whether the link is currently enabled"
+units = "none"
+datum_type = "bool"
+versions = [
+    { added_in = 1, fields = [ "port_id", "link_id" ] }
+]
+
+[[metrics]]
 name = "link_fsm"
 description = """\
 Total entries into each state of the autonegotation / \
@@ -164,6 +173,51 @@ versions = [
     { added_in = 1, fields = [ "port_id", "link_id" ] }
 ]
 
+[[metrics]]
+name = "fec_high_symbol_errors"
+description = "FEC symbol error threshold exceeded"
+units = "none"
+datum_type = "bool"
+versions = [
+    { added_in = 1, fields = [ "port_id", "link_id" ] }
+]
+
+[[metrics]]
+name = "fec_aligned"
+description = "All lanes synchronized and aligned"
+units = "none"
+datum_type = "bool"
+versions = [
+    { added_in = 1, fields = [ "port_id", "link_id" ] }
+]
+
+[[metrics]]
+name = "fec_corrected_blocks"
+description = "Total number of FEC blocks that were corrected"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "port_id", "link_id" ] }
+]
+
+[[metrics]]
+name = "fec_uncorrected_blocks"
+description = "Total number of FEC blocks that were uncorrected"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "port_id", "link_id" ] }
+]
+
+[[metrics]]
+name = "fec_symbol_errors"
+description = "Total number of FEC symbol errors"
+units = "count"
+datum_type = "cumulative_u64"
+versions = [
+    { added_in = 1, fields = [ "port_id", "lane", "link_id" ] }
+]
+
 [fields.rack_id]
 type = "uuid"
 description = "ID of the rack the link's switch is in"
@@ -203,6 +257,10 @@ description = "Serial number of the switch the link is on"
 [fields.port_id]
 type = "string"
 description = "Physical switch port the link is on"
+
+[fields.lane]
+type = "u8"
+description = "Lane (Tx/Rx pair) within a single link"
 
 [fields.link_id]
 type = "u8"

--- a/smf/sled-agent/non-gimlet/config-rss.toml
+++ b/smf/sled-agent/non-gimlet/config-rss.toml
@@ -100,7 +100,7 @@ bgp = []
 # You can configure multiple uplinks by repeating the following stanza
 [[rack_network_config.ports]]
 # Routes associated with this port.
-routes = [{nexthop = "192.168.1.1", destination = "0.0.0.0/0"}]
+routes = [{nexthop = "192.168.1.199", destination = "0.0.0.0/0"}]
 # Addresses associated with this port.
 addresses = [{address = "192.168.1.30/24"}]
 # Name of the uplink port.  This should always be "qsfp0" when using softnpu.

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -84,7 +84,7 @@ data_links = ["net0", "net1"]
 request_body_max_bytes = 2_147_483_648
 
 [log]
-level = "debug"
+level = "info"
 mode = "file"
 path = "/dev/stdout"
 if_exists = "append"


### PR DESCRIPTION
- Add definitions of FEC-related counters
- Fully-qualify `TryFrom` conversion
- Adds stragger link-enabled timeseries
- Revert accidental commit of non-gimlet sled-agent config files