### PR TITLE
Return a 409 instead of 500 when grabbing lock

### DIFF
--- a/nexus/db-queries/src/db/datastore/volume_repair.rs
+++ b/nexus/db-queries/src/db/datastore/volume_repair.rs
@@ -39,7 +39,16 @@ impl DataStore {
             .execute_async(&*conn)
             .await
             .map(|_| ())
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+            .map_err(|e| {
+                if e.to_string().contains(
+                    "duplicate key value violates \
+                    unique constraint \"volume_repair_pkey\"",
+                ) {
+                    Error::conflict("volume repair lock")
+                } else {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                }
+            })
     }
 
     pub(super) fn volume_repair_delete_query(
@@ -81,5 +90,37 @@ impl DataStore {
             .filter(dsl::volume_id.eq(volume_id))
             .first_async::<VolumeRepair>(conn)
             .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::db::datastore::test_utils::datastore_test;
+    use nexus_test_utils::db::test_setup_database;
+    use omicron_test_utils::dev;
+
+    #[tokio::test]
+    async fn volume_lock_conflict_error_returned() {
+        let logctx = dev::test_setup_log("volume_lock_conflict_error_returned");
+        let mut db = test_setup_database(&logctx.log).await;
+        let (opctx, datastore) = datastore_test(&logctx, &db).await;
+
+        let lock_1 = Uuid::new_v4();
+        let lock_2 = Uuid::new_v4();
+        let volume_id = Uuid::new_v4();
+
+        datastore.volume_repair_lock(&opctx, volume_id, lock_1).await.unwrap();
+
+        let err = datastore
+            .volume_repair_lock(&opctx, volume_id, lock_2)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::Conflict { .. }));
+
+        db.cleanup().await.unwrap();
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/db-queries/src/db/datastore/volume_repair.rs
+++ b/nexus/db-queries/src/db/datastore/volume_repair.rs
@@ -44,13 +44,11 @@ impl DataStore {
                 DieselError::DatabaseError(
                     DatabaseErrorKind::UniqueViolation,
                     ref error_information,
-                ) => match error_information.constraint_name() {
-                    Some("volume_repair_pkey") => {
-                        Error::conflict("volume repair lock")
-                    }
-
-                    _ => public_error_from_diesel(e, ErrorHandler::Server),
-                },
+                ) if error_information.constraint_name()
+                    == Some("volume_repair_pkey") =>
+                {
+                    Error::conflict("volume repair lock")
+                }
 
                 _ => public_error_from_diesel(e, ErrorHandler::Server),
             })


### PR DESCRIPTION
Return a `409 Conflict` instead of a `500 Internal Error` when grabbing a volume repair lock that's already grabbed. 500s were seen trying to run the snapshot antagonist from omicron-stress, and a 409 makes more sense in this context.