### PR TITLE
add internal demo saga

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -42,6 +42,7 @@ progenitor::generate_api!(
         OmicronPhysicalDisksConfig = nexus_types::disk::OmicronPhysicalDisksConfig,
         RecoverySiloConfig = nexus_sled_agent_shared::recovery_silo::RecoverySiloConfig,
         TypedUuidForCollectionKind = omicron_uuid_kinds::CollectionUuid,
+        TypedUuidForDemoSagaKind = omicron_uuid_kinds::DemoSagaUuid,
         TypedUuidForDownstairsKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::DownstairsKind>,
         TypedUuidForPropolisKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::PropolisKind>,
         TypedUuidForSledKind = omicron_uuid_kinds::TypedUuid<omicron_uuid_kinds::SledKind>,

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -25,6 +25,7 @@ use nexus_client::types::BackgroundTasksActivateRequest;
 use nexus_client::types::CurrentStatus;
 use nexus_client::types::LastResult;
 use nexus_client::types::PhysicalDiskPath;
+use nexus_client::types::SagaState;
 use nexus_client::types::SledSelector;
 use nexus_client::types::UninitializedSledId;
 use nexus_db_queries::db::lookup::LookupPath;
@@ -34,6 +35,7 @@ use nexus_types::internal_api::background::LookupRegionPortStatus;
 use nexus_types::internal_api::background::RegionReplacementDriverStatus;
 use nexus_types::inventory::BaseboardId;
 use omicron_uuid_kinds::CollectionUuid;
+use omicron_uuid_kinds::DemoSagaUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SledUuid;
@@ -71,6 +73,8 @@ enum NexusCommands {
     BackgroundTasks(BackgroundTasksArgs),
     /// interact with blueprints
     Blueprints(BlueprintsArgs),
+    /// view sagas, create and complete demo sagas
+    Sagas(SagasArgs),
     /// interact with sleds
     Sleds(SledsArgs),
 }
@@ -245,6 +249,36 @@ struct BlueprintImportArgs {
 }
 
 #[derive(Debug, Args)]
+struct SagasArgs {
+    #[command(subcommand)]
+    command: SagasCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum SagasCommands {
+    /// List sagas run by this Nexus
+    ///
+    /// Note that this is reporting in-memory state about sagas run by *this*
+    /// Nexus instance.  You'll get different answers if you ask different Nexus
+    /// instances.
+    List,
+
+    /// Create a "demo" saga
+    ///
+    /// This saga will wait until it's explicitly completed using the
+    /// "demo-complete" subcommand.
+    DemoCreate,
+
+    /// Complete a demo saga started with "demo-create".
+    DemoComplete(DemoSagaIdArgs),
+}
+
+#[derive(Debug, Args)]
+struct DemoSagaIdArgs {
+    demo_saga_id: DemoSagaUuid,
+}
+
+#[derive(Debug, Args)]
 struct SledsArgs {
     #[command(subcommand)]
     command: SledsCommands,
@@ -400,6 +434,31 @@ impl NexusArgs {
             }) => {
                 let token = omdb.check_allow_destructive()?;
                 cmd_nexus_blueprints_import(&client, token, args).await
+            }
+
+            NexusCommands::Sagas(SagasArgs { command }) => {
+                if self.nexus_internal_url.is_none() {
+                    eprintln!(
+                        "{}",
+                        textwrap::wrap(
+                            "WARNING: A Nexus instance was selected from DNS \
+                            because a specific one was not specified.  But \
+                            the `omdb nexus sagas` commands usually only make \
+                            sense when targeting a specific Nexus instance.",
+                            80
+                        )
+                        .join("\n")
+                    );
+                }
+                match command {
+                    SagasCommands::List => cmd_nexus_sagas_list(&client).await,
+                    SagasCommands::DemoCreate => {
+                        cmd_nexus_sagas_demo_create(&client).await
+                    }
+                    SagasCommands::DemoComplete(args) => {
+                        cmd_nexus_sagas_demo_complete(&client, args).await
+                    }
+                }
             }
 
             NexusCommands::Sleds(SledsArgs {
@@ -1548,6 +1607,89 @@ async fn cmd_nexus_blueprints_import(
         .with_context(|| format!("upload {:?}", input_path))?;
     eprintln!("uploaded new blueprint {}", blueprint.id);
     Ok(())
+}
+
+/// Runs `omdb nexus sagas list`
+async fn cmd_nexus_sagas_list(
+    client: &nexus_client::Client,
+) -> Result<(), anyhow::Error> {
+    // We don't want users to confuse this with a general way to list all sagas.
+    // Such a command would read database state and it would go under "omdb db".
+    eprintln!(
+        "{}",
+        textwrap::wrap(
+            "NOTE: This command only reads in-memory state from the targeted \
+            Nexus instance.  Sagas may be missing if they were run by a \
+            different Nexus instance or if they finished before this Nexus \
+            instance last started up.",
+            80
+        )
+        .join("\n")
+    );
+
+    let saga_stream = client.saga_list_stream(None, None);
+    let sagas =
+        saga_stream.try_collect::<Vec<_>>().await.context("listing sagas")?;
+
+    #[derive(Tabled)]
+    #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct SagaRow {
+        saga_id: Uuid,
+        state: &'static str,
+    }
+    let rows = sagas.into_iter().map(|saga| SagaRow {
+        saga_id: saga.id,
+        state: match saga.state {
+            SagaState::Running => "running",
+            SagaState::Succeeded => "succeeded",
+            SagaState::Failed { .. } => "failed",
+            SagaState::Stuck { .. } => "stuck",
+        },
+    });
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+    println!("{}", table);
+    Ok(())
+}
+
+/// Runs `omdb nexus sagas demo-create`
+async fn cmd_nexus_sagas_demo_create(
+    client: &nexus_client::Client,
+) -> Result<(), anyhow::Error> {
+    let demo_saga =
+        client.saga_demo_create().await.context("creating demo saga")?;
+    println!("saga id:      {}", demo_saga.saga_id);
+    println!(
+        "demo saga id: {} (use this with `demo-complete`)",
+        demo_saga.demo_saga_id.to_string(),
+    );
+    Ok(())
+}
+
+/// Runs `omdb nexus sagas demo-complete`
+async fn cmd_nexus_sagas_demo_complete(
+    client: &nexus_client::Client,
+    args: &DemoSagaIdArgs,
+) -> Result<(), anyhow::Error> {
+    if let Err(error) = client
+        .saga_demo_complete(&args.demo_saga_id)
+        .await
+        .context("completing demo saga")
+    {
+        eprintln!("error: {:#}", error);
+        eprintln!(
+            "note: `demo-complete` must be run against the same Nexus \
+            instance that is currently running that saga."
+        );
+        eprintln!(
+            "note: Be sure that you're using the demo_saga_id, not the saga_id."
+        );
+        Err(error)
+    } else {
+        Ok(())
+    }
 }
 
 /// Runs `omdb nexus sleds list-uninitialized`

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -460,6 +460,22 @@ note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=d
 note: database schema version matches expected (<redacted database version>)
 note: listing all commissioned sleds (use -F to filter, e.g. -F in-service)
 =============================================
+EXECUTING COMMAND: omdb ["nexus", "sagas", "list"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+SAGA_ID STATE 
+---------------------------------------------
+stderr:
+note: Nexus URL not specified.  Will pick one from DNS.
+note: using Nexus URL http://[::ffff:127.0.0.1]:REDACTED_PORT
+WARNING: A Nexus instance was selected from DNS because a specific one was not
+specified.  But the `omdb nexus sagas` commands usually only make sense when
+targeting a specific Nexus instance.
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+=============================================
 EXECUTING COMMAND: omdb ["oximeter", "--oximeter-url", "junk", "list-producers"]
 termination: Exited(1)
 ---------------------------------------------

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -609,6 +609,41 @@ warning: unknown background task: "vpc_route_manager" (don't know how to interpr
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
+EXECUTING COMMAND: omdb ["nexus", "sagas", "list"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+SAGA_ID STATE 
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "sagas", "demo-create"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+saga id:      ..........<REDACTED_UUID>...........
+demo saga id: ..........<REDACTED_UUID>........... (use this with `demo-complete`)
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "sagas", "list"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+SAGA_ID                              STATE   
+..........<REDACTED_UUID>........... running 
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+=============================================
 EXECUTING COMMAND: omdb ["--destructive", "nexus", "background-tasks", "activate", "inventory_collection"]
 termination: Exited(0)
 ---------------------------------------------

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -621,7 +621,7 @@ NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they
 finished before this Nexus instance last started up.
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "sagas", "demo-create"]
+EXECUTING COMMAND: omdb ["--destructive", "nexus", "sagas", "demo-create"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -82,6 +82,15 @@ async fn test_omdb_usage_errors() {
         &["nexus", "background-tasks"],
         &["nexus", "blueprints"],
         &["nexus", "sagas"],
+        // Missing "--destructive" flag.  The URL is bogus but just ensures that
+        // we get far enough to hit the error we care about.
+        &[
+            "nexus",
+            "--nexus-internal-url",
+            "http://[::1]:111",
+            "sagas",
+            "demo-create",
+        ],
         &["nexus", "sleds"],
         &["sled-agent"],
         &["sled-agent", "zones"],
@@ -136,7 +145,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         &["nexus", "background-tasks", "doc"],
         &["nexus", "background-tasks", "show"],
         &["nexus", "sagas", "list"],
-        &["nexus", "sagas", "demo-create"],
+        &["--destructive", "nexus", "sagas", "demo-create"],
         &["nexus", "sagas", "list"],
         &[
             "--destructive",

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -81,6 +81,7 @@ async fn test_omdb_usage_errors() {
         &["nexus"],
         &["nexus", "background-tasks"],
         &["nexus", "blueprints"],
+        &["nexus", "sagas"],
         &["nexus", "sleds"],
         &["sled-agent"],
         &["sled-agent", "zones"],
@@ -134,6 +135,9 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         &["mgs", "inventory"],
         &["nexus", "background-tasks", "doc"],
         &["nexus", "background-tasks", "show"],
+        &["nexus", "sagas", "list"],
+        &["nexus", "sagas", "demo-create"],
+        &["nexus", "sagas", "list"],
         &[
             "--destructive",
             "nexus",
@@ -325,6 +329,16 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
 
     let args = &["--dns-server", &dns_sockaddr.to_string(), "db", "sleds"];
     do_run(&mut output, move |exec| exec, &cmd_path, args).await;
+
+    // That said, the "sagas" command prints an extra warning in this case.
+    let args = &["nexus", "sagas", "list"];
+    do_run(
+        &mut output,
+        move |exec| exec.env("OMDB_DNS_SERVER", &dns_sockaddr.to_string()),
+        &cmd_path,
+        args,
+    )
+    .await;
 
     // Case: specified in multiple places (command-line argument wins)
     let args = &["oximeter", "--oximeter-url", "junk", "list-producers"];

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -442,6 +442,7 @@ Usage: omdb nexus [OPTIONS] <COMMAND>
 Commands:
   background-tasks  print information about background tasks
   blueprints        interact with blueprints
+  sagas             view sagas, create and complete demo sagas
   sleds             interact with sleds
   help              Print this message or the help of the given subcommand(s)
 
@@ -505,6 +506,34 @@ Commands:
   regenerate  Generate a new blueprint
   import      Import a blueprint
   help        Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
+  -h, --help                   Print help
+
+Connection Options:
+      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
+                                                 OMDB_NEXUS_URL=]
+      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
+
+Safety Options:
+  -w, --destructive  Allow potentially-destructive subcommands
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "sagas"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+view sagas, create and complete demo sagas
+
+Usage: omdb nexus sagas [OPTIONS] <COMMAND>
+
+Commands:
+  list           List sagas run by this Nexus
+  demo-create    Create a "demo" saga
+  demo-complete  Complete a demo saga started with "demo-create"
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
       --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -547,6 +547,15 @@ Connection Options:
 Safety Options:
   -w, --destructive  Allow potentially-destructive subcommands
 =============================================
+EXECUTING COMMAND: omdb ["nexus", "--nexus-internal-url", "http://[::1]:111", "sagas", "demo-create"]
+termination: Exited(1)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+note: using Nexus URL http://[::1]:111
+Error: This command is potentially destructive. Pass the `-w` / `--destructive` flag to allow it.
+=============================================
 EXECUTING COMMAND: omdb ["nexus", "sleds"]
 termination: Exited(2)
 ---------------------------------------------

--- a/docs/demo-saga.adoc
+++ b/docs/demo-saga.adoc
@@ -15,12 +15,9 @@ In the example below, we'll:
 
 For steps 1-2, we're just following the https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#using-both-omicron-dev-run-all-and-running-nexus-manually[docs for running a simulated stack and a second Nexus].  First, run `omicron-dev run-all`:
 
-```
+```terminal
 $ cargo xtask omicron-dev run-all
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.62s
-     Running `target/debug/xtask omicron-dev run-all`
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
-     Running `target/debug/omicron-dev run-all`
+...
 omicron-dev: setting up all services ...
 log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.0.log
 note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.0.log"
@@ -50,7 +47,7 @@ omicron-dev: privileged user name:  test-privileged
 
 Then follow those docs to configure and start a second Nexus:
 
-```
+```terminal
 $ cargo run --bin=nexus -- config-second.toml
 ...
 Aug 12 20:16:25.405 INFO listening, local_addr: [::1]:12223, component: dropshot_internal, name: a4ef738a-1fb0-47b1-9da2-4919c7ec7c7f, file: /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/52d900a/dropshot/src/server.rs:205
@@ -59,16 +56,15 @@ Aug 12 20:16:25.405 INFO listening, local_addr: [::1]:12223, component: dropshot
 
 The rest of these instructions will use `omdb` pointed at the second Nexus instance, so we'll set OMDB_NEXUS_URL in the environment:
 
-```
+```terminal
 $ export OMDB_NEXUS_URL=http://[::1]:12223
 ```
 
 Now we can use `omdb nexus sagas list` to list the sagas that have run _in that second Nexus process_ only:
 
-```
+```terminal
 $ cargo run --bin=omdb -- nexus sagas list
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s
-     Running `target/debug/omdb nexus sagas list`
+...
 note: using Nexus URL http://[::1]:12223
 NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they
@@ -78,10 +74,9 @@ SAGA_ID STATE
 
 Now we can create a demo saga:
 
-```
+```terminal
 $ cargo run --bin=omdb -- --destructive nexus sagas demo-create
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
-     Running `target/debug/omdb --destructive nexus sagas demo-create`
+...
 note: using Nexus URL http://[::1]:12223
 saga id:      f7765d6a-6e45-4c13-8904-2677b79a97eb
 demo saga id: 88eddf09-dda3-4d70-8d99-1d3b441c57da (use this with `demo-complete`)
@@ -91,10 +86,9 @@ We have to use the `--destructive` option because this command by nature changes
 
 We can see the new saga in the list of sagas now.  It's running:
 
-```
-$ cargo run --bin=omdb -- --destructive nexus sagas list
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
-     Running `target/debug/omdb --destructive nexus sagas list`
+```terminal
+$ cargo run --bin=omdb -- nexus sagas list
+...
 note: using Nexus URL http://[::1]:12223
 NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they
@@ -105,19 +99,17 @@ f7765d6a-6e45-4c13-8904-2677b79a97eb running
 
 and it will stay running indefinitely until we run `demo-complete`.  Let's do that:
 
-```
+```terminal
 $ cargo run --bin=omdb -- --destructive nexus sagas demo-complete 88eddf09-dda3-4d70-8d99-1d3b441c57da
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.04s
-     Running `target/debug/omdb --destructive nexus sagas demo-complete 88eddf09-dda3-4d70-8d99-1d3b441c57da`
+...
 note: using Nexus URL http://[::1]:12223
 ```
 
 and then list sagas again:
 
-```
+```terminal
 $ cargo run --bin=omdb -- nexus sagas list
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.97s
-     Running `target/debug/omdb nexus sagas list`
+...
 note: using Nexus URL http://[::1]:12223
 NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they
@@ -128,11 +120,9 @@ f7765d6a-6e45-4c13-8904-2677b79a97eb succeeded
 
 It works across recovery, too.  You can go through the same loop again, but this time kill Nexus and start it again:
 
-```
-77b79a97eb succeeded 
-dap@ivanova omicron-merge $ cargo run --bin=omdb -- --destructive nexus sagas demo-create
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
-     Running `target/debug/omdb --destructive nexus sagas demo-create`
+```terminal
+$ cargo run --bin=omdb -- --destructive nexus sagas demo-create
+...
 note: using Nexus URL http://[::1]:12223
 saga id:      65253cb6-4428-4aa7-9afc-bf9b42166cb5
 demo saga id: 208ebc89-acc6-42d3-9f40-7f5567c8a39b (use this with `demo-complete`)
@@ -140,10 +130,9 @@ demo saga id: 208ebc89-acc6-42d3-9f40-7f5567c8a39b (use this with `demo-complete
 
 Now restart Nexus (^C the second invocation and run it again).  Now if we use `omdb we don't see the earlier saga because it was finished when this new Nexus process started.  But we see the one we created later because it was recovered:
 
-```
-dap@ivanova omicron-merge $ cargo run --bin=omdb -- nexus sagas list
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.97s
-     Running `target/debug/omdb nexus sagas list`
+```terminal
+$ cargo run --bin=omdb -- nexus sagas list
+...
 note: using Nexus URL http://[::1]:12223
 NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they
@@ -154,7 +143,7 @@ SAGA_ID                              STATE
 
 Side note: we can see it was recovered:
 
-```
+```terminal
 $ cargo run --bin=omdb -- nexus background-tasks show
 ...
 task: "saga_recovery"
@@ -184,15 +173,13 @@ task: "saga_recovery"
 
 Now we can complete that saga:
 
-```
+```terminal
 $ cargo run --bin=omdb -- --destructive nexus sagas demo-complete 208ebc89-acc6-42d3-9f40-7f5567c8a39b
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
-     Running `target/debug/omdb --destructive nexus sagas demo-complete 208ebc89-acc6-42d3-9f40-7f5567c8a39b`
+...
 note: using Nexus URL http://[::1]:12223
 
 $ cargo run --bin=omdb -- nexus sagas list
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
-     Running `target/debug/omdb nexus sagas list`
+...
 note: using Nexus URL http://[::1]:12223
 NOTE: This command only reads in-memory state from the targeted Nexus instance.
 Sagas may be missing if they were run by a different Nexus instance or if they

--- a/docs/demo-saga.adoc
+++ b/docs/demo-saga.adoc
@@ -1,0 +1,202 @@
+:showtitle:
+:numbered:
+:toc: left
+
+= Demo saga
+
+Nexus ships with a "demo" saga that can be used to interactively experiment with sagas, saga recovery, and saga transfer (after Nexus zone expungement).  The demo saga consists of a single action that blocks until it's instructed to proceed.  You instruct it to proceed using a request to the Nexus _internal_ API.
+
+In the example below, we'll:
+
+. Use `omicron-dev run-all` to run a simulated control plane stack
+. Start a second Nexus whose execution we can control precisely
+. Use the `omdb nexus sagas demo-create` command to kick off a demo saga
+. Use the `omdb nexus sagas demo-complete` command to instruct that saga to finish
+
+For steps 1-2, we're just following the https://github.com/oxidecomputer/omicron/blob/main/docs/how-to-run-simulated.adoc#using-both-omicron-dev-run-all-and-running-nexus-manually[docs for running a simulated stack and a second Nexus].  First, run `omicron-dev run-all`:
+
+```
+$ cargo xtask omicron-dev run-all
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.62s
+     Running `target/debug/xtask omicron-dev run-all`
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
+     Running `target/debug/omicron-dev run-all`
+omicron-dev: setting up all services ...
+log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.0.log
+note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.0.log"
+DB URL: postgresql://root@[::1]:43428/omicron?sslmode=disable
+DB address: [::1]:43428
+log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.2.log
+note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.2.log"
+log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.3.log
+note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.7162.3.log"
+omicron-dev: services are running.
+omicron-dev: nexus external API:    127.0.0.1:12220
+omicron-dev: nexus internal API:    [::1]:12221
+omicron-dev: cockroachdb pid:       7166
+omicron-dev: cockroachdb URL:       postgresql://root@[::1]:43428/omicron?sslmode=disable
+omicron-dev: cockroachdb directory: /dangerzone/omicron_tmp/.tmpkzPi6h
+omicron-dev: internal DNS HTTP:     http://[::1]:55952
+omicron-dev: internal DNS:          [::1]:36474
+omicron-dev: external DNS name:     oxide-dev.test
+omicron-dev: external DNS HTTP:     http://[::1]:64396
+omicron-dev: external DNS:          [::1]:35977
+omicron-dev:   e.g. `dig @::1 -p 35977 test-suite-silo.sys.oxide-dev.test`
+omicron-dev: management gateway:    http://[::1]:33325 (switch0)
+omicron-dev: management gateway:    http://[::1]:61144 (switch1)
+omicron-dev: silo name:             test-suite-silo
+omicron-dev: privileged user name:  test-privileged
+```
+
+Then follow those docs to configure and start a second Nexus:
+
+```
+$ cargo run --bin=nexus -- config-second.toml
+...
+Aug 12 20:16:25.405 INFO listening, local_addr: [::1]:12223, component: dropshot_internal, name: a4ef738a-1fb0-47b1-9da2-4919c7ec7c7f, file: /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/52d900a/dropshot/src/server.rs:205
+...
+```
+
+The rest of these instructions will use `omdb` pointed at the second Nexus instance, so we'll set OMDB_NEXUS_URL in the environment:
+
+```
+$ export OMDB_NEXUS_URL=http://[::1]:12223
+```
+
+Now we can use `omdb nexus sagas list` to list the sagas that have run _in that second Nexus process_ only:
+
+```
+$ cargo run --bin=omdb -- nexus sagas list
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s
+     Running `target/debug/omdb nexus sagas list`
+note: using Nexus URL http://[::1]:12223
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+SAGA_ID STATE
+```
+
+Now we can create a demo saga:
+
+```
+$ cargo run --bin=omdb -- --destructive nexus sagas demo-create
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
+     Running `target/debug/omdb --destructive nexus sagas demo-create`
+note: using Nexus URL http://[::1]:12223
+saga id:      f7765d6a-6e45-4c13-8904-2677b79a97eb
+demo saga id: 88eddf09-dda3-4d70-8d99-1d3b441c57da (use this with `demo-complete`)
+```
+
+We have to use the `--destructive` option because this command by nature changes state in Nexus and `omdb` won't allow commands that change state by default.
+
+We can see the new saga in the list of sagas now.  It's running:
+
+```
+$ cargo run --bin=omdb -- --destructive nexus sagas list
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
+     Running `target/debug/omdb --destructive nexus sagas list`
+note: using Nexus URL http://[::1]:12223
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+SAGA_ID                              STATE   
+f7765d6a-6e45-4c13-8904-2677b79a97eb running 
+```
+
+and it will stay running indefinitely until we run `demo-complete`.  Let's do that:
+
+```
+$ cargo run --bin=omdb -- --destructive nexus sagas demo-complete 88eddf09-dda3-4d70-8d99-1d3b441c57da
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.04s
+     Running `target/debug/omdb --destructive nexus sagas demo-complete 88eddf09-dda3-4d70-8d99-1d3b441c57da`
+note: using Nexus URL http://[::1]:12223
+```
+
+and then list sagas again:
+
+```
+$ cargo run --bin=omdb -- nexus sagas list
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.97s
+     Running `target/debug/omdb nexus sagas list`
+note: using Nexus URL http://[::1]:12223
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+SAGA_ID                              STATE     
+f7765d6a-6e45-4c13-8904-2677b79a97eb succeeded 
+```
+
+It works across recovery, too.  You can go through the same loop again, but this time kill Nexus and start it again:
+
+```
+77b79a97eb succeeded 
+dap@ivanova omicron-merge $ cargo run --bin=omdb -- --destructive nexus sagas demo-create
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
+     Running `target/debug/omdb --destructive nexus sagas demo-create`
+note: using Nexus URL http://[::1]:12223
+saga id:      65253cb6-4428-4aa7-9afc-bf9b42166cb5
+demo saga id: 208ebc89-acc6-42d3-9f40-7f5567c8a39b (use this with `demo-complete`)
+```
+
+Now restart Nexus (^C the second invocation and run it again).  Now if we use `omdb we don't see the earlier saga because it was finished when this new Nexus process started.  But we see the one we created later because it was recovered:
+
+```
+dap@ivanova omicron-merge $ cargo run --bin=omdb -- nexus sagas list
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.97s
+     Running `target/debug/omdb nexus sagas list`
+note: using Nexus URL http://[::1]:12223
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+SAGA_ID                              STATE   
+65253cb6-4428-4aa7-9afc-bf9b42166cb5 running 
+```
+
+Side note: we can see it was recovered:
+
+```
+$ cargo run --bin=omdb -- nexus background-tasks show
+...
+task: "saga_recovery"
+  configured period: every 10m
+  currently executing: no
+  last completed activation: iter 1, triggered by a periodic timer firing
+    started at 2024-08-12T20:20:41.714Z (44s ago) and ran for 79ms
+    since Nexus started:
+        sagas recovered:           1
+        sagas recovery errors:     0
+        sagas observed started:    0
+        sagas inferred finished:   0
+        missing from SEC:          0
+        bad state in SEC:          0
+    last pass:
+        found sagas:   1 (in-progress, assigned to this Nexus)
+        recovered:     1 (successfully)
+        failed:        0
+        skipped:       0 (already running)
+        removed:       0 (newly finished)
+    recently recovered sagas (1):
+        TIME                 SAGA_ID
+        2024-08-12T20:20:41Z 65253cb6-4428-4aa7-9afc-bf9b42166cb5
+    no saga recovery failures
+...
+```
+
+Now we can complete that saga:
+
+```
+$ cargo run --bin=omdb -- --destructive nexus sagas demo-complete 208ebc89-acc6-42d3-9f40-7f5567c8a39b
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
+     Running `target/debug/omdb --destructive nexus sagas demo-complete 208ebc89-acc6-42d3-9f40-7f5567c8a39b`
+note: using Nexus URL http://[::1]:12223
+
+$ cargo run --bin=omdb -- nexus sagas list
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
+     Running `target/debug/omdb nexus sagas list`
+note: using Nexus URL http://[::1]:12223
+NOTE: This command only reads in-memory state from the targeted Nexus instance.
+Sagas may be missing if they were run by a different Nexus instance or if they
+finished before this Nexus instance last started up.
+SAGA_ID                              STATE
+65253cb6-4428-4aa7-9afc-bf9b42166cb5 succeeded
+```

--- a/docs/demo-saga.adoc
+++ b/docs/demo-saga.adoc
@@ -128,7 +128,7 @@ saga id:      65253cb6-4428-4aa7-9afc-bf9b42166cb5
 demo saga id: 208ebc89-acc6-42d3-9f40-7f5567c8a39b (use this with `demo-complete`)
 ```
 
-Now restart Nexus (^C the second invocation and run it again).  Now if we use `omdb we don't see the earlier saga because it was finished when this new Nexus process started.  But we see the one we created later because it was recovered:
+Now restart Nexus (^C the second invocation and run it again).  Now if we use `omdb` we don't see the earlier saga because it was finished when this new Nexus process started.  But we see the one we created later because it was recovered:
 
 ```terminal
 $ cargo run --bin=omdb -- nexus sagas list
@@ -177,7 +177,11 @@ Now we can complete that saga:
 $ cargo run --bin=omdb -- --destructive nexus sagas demo-complete 208ebc89-acc6-42d3-9f40-7f5567c8a39b
 ...
 note: using Nexus URL http://[::1]:12223
+```
 
+and see it finish:
+
+```
 $ cargo run --bin=omdb -- nexus sagas list
 ...
 note: using Nexus URL http://[::1]:12223
@@ -187,3 +191,5 @@ finished before this Nexus instance last started up.
 SAGA_ID                              STATE
 65253cb6-4428-4aa7-9afc-bf9b42166cb5 succeeded
 ```
+
+Note too that the completion is not synchronous with the `demo-complete` command, though it usually _is_ pretty quick.  It's possible you'll catch it `running` if you run `nexus sagas list` right after running `nexus sagas demo-complete`, but you should quickly see it `succeeded` if you keep running `nexus sagas list`.

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -23,7 +23,7 @@ use nexus_types::{
             OximeterInfo, RackInitializationRequest, SledAgentInfo,
             SwitchPutRequest, SwitchPutResponse,
         },
-        views::{BackgroundTask, Ipv4NatEntryView, Saga},
+        views::{BackgroundTask, DemoSaga, Ipv4NatEntryView, Saga},
     },
 };
 use omicron_common::{
@@ -39,7 +39,8 @@ use omicron_common::{
     update::ArtifactId,
 };
 use omicron_uuid_kinds::{
-    DownstairsKind, SledUuid, TypedUuid, UpstairsKind, UpstairsRepairKind,
+    DemoSagaUuid, DownstairsKind, SledUuid, TypedUuid, UpstairsKind,
+    UpstairsRepairKind,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -281,6 +282,31 @@ pub trait NexusInternalApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<SagaPathParam>,
     ) -> Result<HttpResponseOk<Saga>, HttpError>;
+
+    /// Kick off an instance of the "demo" saga
+    ///
+    /// This saga is used for demo and testing.  The saga just waits until you
+    /// complete using the `saga_demo_complete` API.
+    #[endpoint {
+        method = POST,
+        path = "/demo-saga",
+    }]
+    async fn saga_demo_create(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<DemoSaga>, HttpError>;
+
+    /// Complete a waiting demo saga
+    ///
+    /// Note that the id used here is not the same as the id of the saga.  It's
+    /// the one returned by the `saga_demo_create` API.
+    #[endpoint {
+        method = POST,
+        path = "/demo-saga/{demo_saga_id}/complete",
+    }]
+    async fn saga_demo_complete(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<DemoSagaPathParam>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
     // Background Tasks
 
@@ -563,6 +589,12 @@ pub struct UpstairsDownstairsPathParam {
 pub struct SagaPathParam {
     #[serde(rename = "saga_id")]
     pub saga_id: Uuid,
+}
+
+/// Path parameters for DemoSaga requests
+#[derive(Deserialize, JsonSchema)]
+pub struct DemoSagaPathParam {
+    pub demo_saga_id: DemoSagaUuid,
 }
 
 /// Path parameters for Background Task requests

--- a/nexus/src/app/saga.rs
+++ b/nexus/src/app/saga.rs
@@ -58,12 +58,14 @@ use futures::FutureExt;
 use futures::StreamExt;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
+use nexus_types::internal_api::views::DemoSaga;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResult;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::ResourceType;
 use omicron_common::bail_unless;
+use omicron_uuid_kinds::DemoSagaUuid;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use steno::SagaDag;
@@ -296,7 +298,6 @@ pub(crate) struct RunnableSaga {
 }
 
 impl RunnableSaga {
-    #[cfg(test)]
     pub(crate) fn id(&self) -> SagaId {
         self.id
     }
@@ -462,5 +463,26 @@ impl super::Nexus {
     #[cfg(test)]
     pub(crate) fn sec(&self) -> &steno::SecClient {
         &self.sagas.sec_client
+    }
+
+    pub(crate) async fn saga_demo_create(&self) -> Result<DemoSaga, Error> {
+        use crate::app::sagas::demo;
+        let demo_saga_id = DemoSagaUuid::new_v4();
+        let saga_params = demo::Params { id: demo_saga_id };
+        let saga_dag = create_saga_dag::<demo::SagaDemo>(saga_params)?;
+        let runnable_saga = self.sagas.saga_prepare(saga_dag).await?;
+        let saga_id = runnable_saga.id().0;
+        // We don't need the handle that runnable_saga.start() returns because
+        // we're not going to wait for the saga to finish here.
+        let _ = runnable_saga.start().await?;
+        Ok(DemoSaga { saga_id, demo_saga_id })
+    }
+
+    pub(crate) fn saga_demo_complete(
+        &self,
+        demo_saga_id: DemoSagaUuid,
+    ) -> Result<(), Error> {
+        let mut demo_sagas = self.demo_sagas()?;
+        demo_sagas.complete(demo_saga_id)
     }
 }

--- a/nexus/src/app/sagas/demo.rs
+++ b/nexus/src/app/sagas/demo.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Demo saga, used for testing and interactive debugging
+//!
+//! The "Demo" saga exists so that developers and automated tests can create a
+//! saga that will not complete until they take some action to complete it.  The
+//! saga just waits until it gets the message that it should finish.  Users
+//! create demo sagas and complete them using requests to the internal API.
+//!
+//! The implementation is entirely in-memory, which means you have to send the
+//! completion message to the Nexus that's running the saga.  However, it does
+//! work across Nexus restarts, so this can be used to exercise the saga
+//! recovery path.
+//!
+//! It's tempting to build this only for development and not official releases,
+//! but that'd be more work, there's little downside to always including it, and
+//! it's conceivable that it'd be useful for production systems, too.
+
+use super::NexusActionContext;
+use super::{ActionRegistry, NexusSaga, SagaInitError};
+use crate::app::sagas::declare_saga_actions;
+use omicron_common::api::external::Error;
+use omicron_uuid_kinds::DemoSagaUuid;
+use serde::Deserialize;
+use serde::Serialize;
+use slog::info;
+use std::collections::BTreeMap;
+use steno::ActionError;
+use tokio::sync::oneshot;
+
+/// Set of demo sagas that have been marked completed
+///
+/// Nexus maintains one of these at the top level.  Individual demo sagas wait
+/// until their id shows up here, then remove it and proceed.
+pub struct CompletingDemoSagas {
+    ids: BTreeMap<DemoSagaUuid, oneshot::Sender<()>>,
+}
+
+impl CompletingDemoSagas {
+    pub fn new() -> CompletingDemoSagas {
+        CompletingDemoSagas { ids: BTreeMap::new() }
+    }
+
+    pub fn complete(&mut self, id: DemoSagaUuid) -> Result<(), Error> {
+        self.ids
+            .remove(&id)
+            .ok_or_else(|| {
+                Error::non_resourcetype_not_found(format!(
+                    "demo saga with id {:?}",
+                    id
+                ))
+            })?
+            .send(())
+            .map_err(|_| {
+                Error::internal_error(
+                    "saga stopped listening (Nexus shutting down?)",
+                )
+            })
+    }
+
+    pub fn subscribe(&mut self, id: DemoSagaUuid) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        assert!(
+            self.ids.insert(id, tx).is_none(),
+            "multiple subscriptions for the same demo saga"
+        );
+        rx
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Params {
+    pub id: DemoSagaUuid,
+}
+
+declare_saga_actions! {
+    demo;
+    DEMO_WAIT -> "demo_wait" {
+        + demo_wait
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SagaDemo;
+impl NexusSaga for SagaDemo {
+    const NAME: &'static str = "demo";
+    type Params = Params;
+
+    fn register_actions(registry: &mut ActionRegistry) {
+        demo_register_actions(registry);
+    }
+
+    fn make_saga_dag(
+        _params: &Self::Params,
+        mut builder: steno::DagBuilder,
+    ) -> Result<steno::Dag, SagaInitError> {
+        builder.append(demo_wait_action());
+        Ok(builder.build()?)
+    }
+}
+
+async fn demo_wait(sagactx: NexusActionContext) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let demo_id = sagactx.saga_params::<Params>()?.id;
+    let log = osagactx.log();
+    info!(log, "demo saga: begin wait"; "id" => %demo_id);
+    let rx = {
+        let mut demo_sagas = osagactx
+            .nexus()
+            .demo_sagas()
+            .map_err(ActionError::action_failed)?;
+        demo_sagas.subscribe(demo_id)
+    };
+    match rx.await {
+        Ok(_) => {
+            info!(log, "demo saga: completing"; "id" => %demo_id);
+        }
+        Err(_) => {
+            info!(log, "demo saga: waiting failed (Nexus shutting down?)";
+                "id" => %demo_id);
+        }
+    }
+    Ok(())
+}

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -22,6 +22,7 @@ use steno::SagaType;
 use thiserror::Error;
 use uuid::Uuid;
 
+pub mod demo;
 pub mod disk_create;
 pub mod disk_delete;
 pub mod finalize_disk;
@@ -133,6 +134,7 @@ fn make_action_registry() -> ActionRegistry {
     let mut registry = steno::ActionRegistry::new();
     registry.register(Arc::clone(&*ACTION_GENERATE_ID));
 
+    <demo::SagaDemo as NexusSaga>::register_actions(&mut registry);
     <disk_create::SagaDiskCreate as NexusSaga>::register_actions(&mut registry);
     <disk_delete::SagaDiskDelete as NexusSaga>::register_actions(&mut registry);
     <finalize_disk::SagaFinalizeDisk as NexusSaga>::register_actions(

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -35,6 +35,7 @@ use nexus_types::internal_api::params::SwitchPutRequest;
 use nexus_types::internal_api::params::SwitchPutResponse;
 use nexus_types::internal_api::views::to_list;
 use nexus_types::internal_api::views::BackgroundTask;
+use nexus_types::internal_api::views::DemoSaga;
 use nexus_types::internal_api::views::Ipv4NatEntryView;
 use nexus_types::internal_api::views::Saga;
 use omicron_common::api::external::http_pagination::data_page_params_for;
@@ -524,6 +525,40 @@ impl NexusInternalApi for NexusInternalApiImpl {
             let saga = nexus.saga_get(&opctx, path.saga_id).await?;
             Ok(HttpResponseOk(saga))
         };
+        apictx
+            .internal_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
+    async fn saga_demo_create(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<DemoSaga>, HttpError> {
+        let apictx = &rqctx.context().context;
+        let handler = async {
+            let nexus = &apictx.nexus;
+            let demo_saga = nexus.saga_demo_create().await?;
+            Ok(HttpResponseOk(demo_saga))
+        };
+
+        apictx
+            .internal_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
+    async fn saga_demo_complete(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<DemoSagaPathParam>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let apictx = &rqctx.context().context;
+        let handler = async {
+            let nexus = &apictx.nexus;
+            let path = path_params.into_inner();
+            nexus.saga_demo_complete(path.demo_saga_id)?;
+            Ok(HttpResponseUpdatedNoContent())
+        };
+
         apictx
             .internal_latencies
             .instrument_dropshot_handler(&rqctx, handler)

--- a/nexus/tests/integration_tests/demo_saga.rs
+++ b/nexus/tests/integration_tests/demo_saga.rs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Smoke test for the demo saga
+
+use futures::TryStreamExt;
+use nexus_client::types::Saga;
+use nexus_client::types::SagaState;
+use nexus_test_interface::NexusServer;
+use nexus_test_utils_macros::nexus_test;
+use omicron_test_utils::dev::poll::wait_for_condition;
+use omicron_test_utils::dev::poll::CondCheckError;
+use std::time::Duration;
+
+type ControlPlaneTestContext =
+    nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
+
+// Tests that we can create a demo saga, then mark it completed, and the actual
+// saga's state matches what we expect along the way.
+#[nexus_test]
+async fn test_demo_saga(cptestctx: &ControlPlaneTestContext) {
+    let log = &cptestctx.logctx.log;
+    let nexus_internal_url = format!(
+        "http://{}",
+        cptestctx.server.get_http_server_internal_address().await
+    );
+    let nexus_client =
+        nexus_client::Client::new(&nexus_internal_url, log.clone());
+
+    let sagas_before = list_sagas(&nexus_client).await;
+    eprintln!("found sagas (before): {:?}", sagas_before);
+    let demo_saga = nexus_client.saga_demo_create().await.unwrap();
+    let saga_id = demo_saga.saga_id;
+    assert!(sagas_before.into_iter().find(|s| s.id == saga_id).is_none());
+
+    let sagas_after = list_sagas(&nexus_client).await;
+    eprintln!("found sagas (after): {:?}", sagas_after);
+    let found = sagas_after.into_iter().find(|s| s.id == saga_id).unwrap();
+    assert!(matches!(found.state, SagaState::Running));
+
+    // It is hard to verify that the saga is not going to complete by itself.
+    // No matter how long we wait and make sure it didn't complete, it might
+    // have completed after that.  And then we've made the test suite take that
+    // much longer.   But we can at least make sure that completing the saga
+    // does cause it to finish.
+    nexus_client.saga_demo_complete(&demo_saga.demo_saga_id).await.unwrap();
+
+    // Completion is not synchronous -- that just unblocked the saga.  So we
+    // need to poll a bit to wait for it to actually finish.
+    let found = wait_for_condition(
+        || async {
+            let sagas = list_sagas(&nexus_client).await;
+            eprintln!("found sagas (last): {:?}", sagas);
+            let found = sagas.into_iter().find(|s| s.id == saga_id).unwrap();
+            if matches!(found.state, SagaState::Succeeded) {
+                Ok(found)
+            } else {
+                Err(CondCheckError::<()>::NotYet)
+            }
+        },
+        &Duration::from_millis(50),
+        &Duration::from_secs(30),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(found.id, saga_id);
+    assert!(matches!(found.state, SagaState::Succeeded));
+}
+
+async fn list_sagas(client: &nexus_client::Client) -> Vec<Saga> {
+    client.saga_list_stream(None, None).try_collect::<Vec<_>>().await.unwrap()
+}

--- a/nexus/tests/integration_tests/demo_saga.rs
+++ b/nexus/tests/integration_tests/demo_saga.rs
@@ -32,7 +32,7 @@ async fn test_demo_saga(cptestctx: &ControlPlaneTestContext) {
     eprintln!("found sagas (before): {:?}", sagas_before);
     let demo_saga = nexus_client.saga_demo_create().await.unwrap();
     let saga_id = demo_saga.saga_id;
-    assert!(sagas_before.into_iter().find(|s| s.id == saga_id).is_none());
+    assert!(!sagas_before.into_iter().any(|s| s.id == saga_id));
 
     let sagas_after = list_sagas(&nexus_client).await;
     eprintln!("found sagas (after): {:?}", sagas_after);

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -11,6 +11,7 @@ mod basic;
 mod certificates;
 mod commands;
 mod console_api;
+mod demo_saga;
 mod device_auth;
 mod disks;
 mod external_ips;

--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -9,6 +9,7 @@ use futures::stream::StreamExt;
 use omicron_common::api::external::MacAddr;
 use omicron_common::api::external::ObjectStream;
 use omicron_common::api::external::Vni;
+use omicron_uuid_kinds::DemoSagaUuid;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::net::Ipv4Addr;
@@ -150,6 +151,13 @@ impl From<steno::SagaStateView> for SagaState {
             },
         }
     }
+}
+
+/// Identifies an instance of the demo saga
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct DemoSaga {
+    pub saga_id: Uuid,
+    pub demo_saga_id: DemoSagaUuid,
 }
 
 /// Background tasks

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -364,6 +364,59 @@
         }
       }
     },
+    "/demo-saga": {
+      "post": {
+        "summary": "Kick off an instance of the \"demo\" saga",
+        "description": "This saga is used for demo and testing.  The saga just waits until you complete using the `saga_demo_complete` API.",
+        "operationId": "saga_demo_create",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemoSaga"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/demo-saga/{demo_saga_id}/complete": {
+      "post": {
+        "summary": "Complete a waiting demo saga",
+        "description": "Note that the id used here is not the same as the id of the saga.  It's the one returned by the `saga_demo_create` API.",
+        "operationId": "saga_demo_complete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "demo_saga_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForDemoSagaKind"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/deployment/blueprints/all": {
       "get": {
         "summary": "Lists blueprints",
@@ -2622,6 +2675,23 @@
         "required": [
           "address",
           "kind"
+        ]
+      },
+      "DemoSaga": {
+        "description": "Identifies an instance of the demo saga",
+        "type": "object",
+        "properties": {
+          "demo_saga_id": {
+            "$ref": "#/components/schemas/TypedUuidForDemoSagaKind"
+          },
+          "saga_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "demo_saga_id",
+          "saga_id"
         ]
       },
       "DiskIdentity": {
@@ -4965,6 +5035,10 @@
       },
       "SwitchPutResponse": {
         "type": "object"
+      },
+      "TypedUuidForDemoSagaKind": {
+        "type": "string",
+        "format": "uuid"
       },
       "TypedUuidForDownstairsRegionKind": {
         "type": "string",

--- a/uuid-kinds/src/lib.rs
+++ b/uuid-kinds/src/lib.rs
@@ -51,6 +51,7 @@ macro_rules! impl_typed_uuid_kind {
 impl_typed_uuid_kind! {
     Collection => "collection",
     Dataset => "dataset",
+    DemoSaga => "demo_saga",
     Downstairs => "downstairs",
     DownstairsRegion => "downstairs_region",
     ExternalIp => "external_ip",


### PR DESCRIPTION
This PR adds to Nexus "demo" saga, which is a one-node saga that sits and waits for a request (on the internal API) to tell it to finish.  The point of this saga is to help with testing saga recovery and #6215.  It's easiest to see with an omdb example.

First, I started `omicron-dev run-all`:

```
$ cargo run --bin=omicron-dev run-all
   Compiling omicron-nexus v0.1.0 (/home/dap/omicron-merge/nexus)
   Compiling omicron-dev v0.1.0 (/home/dap/omicron-merge/dev-tools/omicron-dev)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 56s
     Running `target/debug/omicron-dev run-all`
omicron-dev: setting up all services ... 
log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.0.log
note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.0.log"
DB URL: postgresql://root@[::1]:64409/omicron?sslmode=disable
DB address: [::1]:64409
log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.2.log
note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.2.log"
log file: /dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.3.log
note: configured to log to "/dangerzone/omicron_tmp/omicron-dev-omicron-dev.19549.3.log"
omicron-dev: services are running.
omicron-dev: nexus external API:    127.0.0.1:12220
omicron-dev: nexus internal API:    [::1]:12221
omicron-dev: cockroachdb pid:       19558
omicron-dev: cockroachdb URL:       postgresql://root@[::1]:64409/omicron?sslmode=disable
omicron-dev: cockroachdb directory: /dangerzone/omicron_tmp/.tmpNUCfme
omicron-dev: internal DNS HTTP:     http://[::1]:45884
omicron-dev: internal DNS:          [::1]:51490
omicron-dev: external DNS name:     oxide-dev.test
omicron-dev: external DNS HTTP:     http://[::1]:49886
omicron-dev: external DNS:          [::1]:58543
omicron-dev:   e.g. `dig @::1 -p 58543 test-suite-silo.sys.oxide-dev.test`
omicron-dev: management gateway:    http://[::1]:59318 (switch0)
omicron-dev: management gateway:    http://[::1]:36934 (switch1)
omicron-dev: silo name:             test-suite-silo
omicron-dev: privileged user name:  test-privileged
```

Then I started a second copy of Nexus using [the instructions](https://github.com/oxidecomputer/omicron/blob/9b595e985721f8ab83d13c4dc4f257cbf8ac525c/docs/how-to-run-simulated.adoc#using-both-omicron-dev-run-all-and-running-nexus-manually), just so I could more easily control its execution:

```
$ cargo run --bin=nexus -- config-second.toml 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `target/debug/nexus config-second.toml`
Aug 10 00:03:57.594 INFO setting up nexus server, name: a4ef738a-1fb0-47b1-9da2-4919c7ec7c7f, file: nexus/src/lib.rs:86
...
Aug 10 00:03:57.772 INFO listening, local_addr: [::1]:12223, component: dropshot_internal, name: a4ef738a-1fb0-47b1-9da2-4919c7ec7c7f, file: /home/dap/.cargo/git/checkouts/dropshot-a4a923d29dccc492/52d900a/dropshot/src/server.rs:205
...
```

As part of this I also added `omdb` subcommands to list the sagas that a Nexus instance knows about.  (This is not to be confused with a general command for listing all sagas.  It only lists the sagas that _this_ instance knows about in-memory, not anything that ran in a past life or in another Nexus.)  Start by listing them:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID STATE 
```

Now we can create a demo saga:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas demo-create
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/omdb -w nexus sagas demo-create`
note: using Nexus URL http://[::1]:12223
saga id:      24e9169b-bfb4-469d-8c85-7b23feac2ceb
demo saga id: e797f237-53fd-4f6c-9e89-60d58044c112 (use this with `demo-complete`)
```

We can see it in the list of sagas now.  It's running:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID                              STATE   
24e9169b-bfb4-469d-8c85-7b23feac2ceb running 
```

and it will stay running indefinitely until we run `demo-complete`.  Let's do that:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas demo-complete e797f237-53fd-4f6c-9e89-60d58044c112
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.99s
     Running `target/debug/omdb -w nexus sagas demo-complete e797f237-53fd-4f6c-9e89-60d58044c112`
note: using Nexus URL http://[::1]:12223
```

and then list sagas again:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.03s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID                              STATE     
24e9169b-bfb4-469d-8c85-7b23feac2ceb succeeded 
```

It works across recovery, too.  You can go through the same loop again, but this time kill Nexus and start it again:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas demo-create
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
     Running `target/debug/omdb -w nexus sagas demo-create`
note: using Nexus URL http://[::1]:12223
saga id:      b1dbcfd3-f0ab-4a8f-9b6f-60b109449f7c
demo saga id: 56179d38-e047-4d47-b54a-3b8218c93992 (use this with `demo-complete`)
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID                              STATE     
24e9169b-bfb4-469d-8c85-7b23feac2ceb succeeded 
b1dbcfd3-f0ab-4a8f-9b6f-60b109449f7c running   
```

After restarting Nexus, we don't see the earlier saga because it was finished when Nexus started.  But we see the one we created later because it was recovered:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID                              STATE   
b1dbcfd3-f0ab-4a8f-9b6f-60b109449f7c running 
```

Side note: we can see it was recovered:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus background-tasks show
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.02s
     Running `target/debug/omdb -w nexus background-tasks show`
note: using Nexus URL http://[::1]:12223
...
task: "saga_recovery"
  configured period: every 10m
  currently executing: no
  last completed activation: iter 1, triggered by a periodic timer firing
    started at 2024-08-10T00:07:53.867Z (54s ago) and ran for 86ms
    since Nexus started:
        sagas recovered:           1
        sagas recovery errors:     0
        sagas observed started:    0
        sagas inferred finished:   0
        missing from SEC:          0
        bad state in SEC:          0
    last pass:
        found sagas:   1 (in-progress, assigned to this Nexus)
        recovered:     1 (successfully)
        failed:        0
        skipped:       0 (already running)
        removed:       0 (newly finished)
    recently recovered sagas (1):
        TIME                 SAGA_ID                              
        2024-08-10T00:07:53Z b1dbcfd3-f0ab-4a8f-9b6f-60b109449f7c 
    no saga recovery failures
...
```

Now we can complete that saga:

```
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas demo-complete 56179d38-e047-4d47-b54a-3b8218c93992
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `target/debug/omdb -w nexus sagas demo-complete 56179d38-e047-4d47-b54a-3b8218c93992`
note: using Nexus URL http://[::1]:12223
$ OMDB_NEXUS_URL=http://[::1]:12223 cargo run --bin=omdb -- -w nexus sagas list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.98s
     Running `target/debug/omdb -w nexus sagas list`
note: using Nexus URL http://[::1]:12223
NOTE: This command only reads in-memory state from the targeted Nexus instance.
Sagas may be missing if they were run by a different Nexus instance or if they
finished before this Nexus instance last started up.
SAGA_ID                              STATE     
b1dbcfd3-f0ab-4a8f-9b6f-60b109449f7c succeeded 
```

---

I considered trying to only include this in development or something like that, but I don't think there's any harm to having it present all the time and it could conceivably even be useful in production (during support).