### PR TITLE
[oximeter] Add some units from physical reality

### DIFF
--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -19805,7 +19805,10 @@
               "count",
               "bytes",
               "seconds",
-              "nanoseconds"
+              "nanoseconds",
+              "volts",
+              "amps",
+              "degrees_celcius"
             ]
           },
           {
@@ -19813,6 +19816,13 @@
             "type": "string",
             "enum": [
               "none"
+            ]
+          },
+          {
+            "description": "Rotations per minute.",
+            "type": "string",
+            "enum": [
+              "rpm"
             ]
           }
         ]

--- a/oximeter/impl/src/schema/codegen.rs
+++ b/oximeter/impl/src/schema/codegen.rs
@@ -522,6 +522,12 @@ impl quote::ToTokens for Units {
             Units::Nanoseconds => {
                 quote! { ::oximeter::schema::Units::Nanoseconds }
             }
+            Units::Amps => quote! { ::oximeter::schema::Units::Amps },
+            Units::Volts => quote! { ::oximeter::schema::Units::Volts },
+            Units::DegreesCelcius => {
+                quote! { ::oximeter::schema::Units::DegreesCelcius }
+            }
+            Units::Rpm => quote! { ::oximeter::schema::Units::Rpm  },
         };
         toks.to_tokens(tokens);
     }

--- a/oximeter/impl/src/schema/mod.rs
+++ b/oximeter/impl/src/schema/mod.rs
@@ -179,7 +179,6 @@ pub struct TimeseriesDescription {
 /// Measurement units for timeseries samples.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
-// TODO-completeness: Include more units, such as power / temperature.
 // TODO-completeness: Decide whether and how to handle dimensional analysis
 // during queries, if needed.
 pub enum Units {
@@ -189,6 +188,11 @@ pub enum Units {
     Bytes,
     Seconds,
     Nanoseconds,
+    Volts,
+    Amps,
+    DegreesCelcius,
+    /// Rotations per minute.
+    Rpm,
 }
 
 /// The schema for a timeseries.


### PR DESCRIPTION
In service of future changes to record data from power, temperature, and
fan speed sensors in Oximeter, this branch adds some physical quantities
to the `Units` enum: `Volts`, `Amps`, `DegreesCelcius`, and `Rpm`. I've
added all of these as whole numbers of the measured quantities, with the
expectation that they will probably be recorded as floating-point. We
could consider instead using a smaller unit like `MilliAmps`, and
recording them as integers, but that introduces a bunch of dimensional
analysis that I'm not sure if we want to be doing.