### PR TITLE
Add a new `ClickhouseServer` Omicron Zone

### DIFF
--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -710,8 +710,12 @@ pub struct ResolvedVpcRouteSet {
 pub enum DatasetKind {
     Crucible,
     Cockroach,
+    /// Used for single-node clickhouse deployments
     Clickhouse,
+    /// Used for replicated clickhouse deployments
     ClickhouseKeeper,
+    /// Used for replicated clickhouse deployments
+    ClickhouseServer,
     ExternalDns,
     InternalDns,
 }
@@ -724,6 +728,7 @@ impl fmt::Display for DatasetKind {
             Cockroach => "cockroach",
             Clickhouse => "clickhouse",
             ClickhouseKeeper => "clickhouse_keeper",
+            ClickhouseServer => "clickhouse_server",
             ExternalDns => "external_dns",
             InternalDns => "internal_dns",
         };

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1106,6 +1106,7 @@ async fn lookup_service_info(
         | BlueprintZoneType::InternalNtp(_) => ServiceKind::Ntp,
         BlueprintZoneType::Clickhouse(_) => ServiceKind::Clickhouse,
         BlueprintZoneType::ClickhouseKeeper(_) => ServiceKind::ClickhouseKeeper,
+        BlueprintZoneType::ClickhouseServer(_) => ServiceKind::ClickhouseServer,
         BlueprintZoneType::CockroachDb(_) => ServiceKind::Cockroach,
         BlueprintZoneType::Crucible(_) => ServiceKind::Crucible,
         BlueprintZoneType::CruciblePantry(_) => ServiceKind::CruciblePantry,

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -25,6 +25,7 @@ pub const DNS_ZONE_EXTERNAL_TESTING: &str = "oxide-dev.test";
 pub enum ServiceName {
     Clickhouse,
     ClickhouseKeeper,
+    ClickhouseServer,
     Cockroach,
     InternalDns,
     ExternalDns,
@@ -48,6 +49,7 @@ impl ServiceName {
         match self {
             ServiceName::Clickhouse => "clickhouse",
             ServiceName::ClickhouseKeeper => "clickhouse-keeper",
+            ServiceName::ClickhouseServer => "clickhouse-server",
             ServiceName::Cockroach => "cockroach",
             ServiceName::ExternalDns => "external-dns",
             ServiceName::InternalDns => "nameservice",
@@ -73,6 +75,7 @@ impl ServiceName {
         match self {
             ServiceName::Clickhouse
             | ServiceName::ClickhouseKeeper
+            | ServiceName::ClickhouseServer
             | ServiceName::Cockroach
             | ServiceName::InternalDns
             | ServiceName::ExternalDns

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -134,15 +134,26 @@ pub enum OmicronZoneType {
         snat_cfg: SourceNatConfig,
     },
 
+    /// Type of clickhouse zone used for a single node clickhouse deployment
     Clickhouse {
         address: SocketAddrV6,
         dataset: OmicronZoneDataset,
     },
 
+    /// A zone used to run a Clickhouse Keeper node
+    ///
+    /// Keepers are only used in replicated clickhouse setups
     ClickhouseKeeper {
         address: SocketAddrV6,
         dataset: OmicronZoneDataset,
     },
+
+    /// A zone used to run a Clickhouse Server in a replicated deployment
+    ClickhouseServer {
+        address: SocketAddrV6,
+        dataset: OmicronZoneDataset,
+    },
+
     CockroachDb {
         address: SocketAddrV6,
         dataset: OmicronZoneDataset,
@@ -212,6 +223,9 @@ impl OmicronZoneType {
             OmicronZoneType::ClickhouseKeeper { .. } => {
                 ZoneKind::ClickhouseKeeper
             }
+            OmicronZoneType::ClickhouseServer { .. } => {
+                ZoneKind::ClickhouseServer
+            }
             OmicronZoneType::CockroachDb { .. } => ZoneKind::CockroachDb,
             OmicronZoneType::Crucible { .. } => ZoneKind::Crucible,
             OmicronZoneType::CruciblePantry { .. } => ZoneKind::CruciblePantry,
@@ -252,6 +266,7 @@ impl OmicronZoneType {
 
             OmicronZoneType::Clickhouse { .. }
             | OmicronZoneType::ClickhouseKeeper { .. }
+            | OmicronZoneType::ClickhouseServer { .. }
             | OmicronZoneType::CockroachDb { .. }
             | OmicronZoneType::Crucible { .. }
             | OmicronZoneType::CruciblePantry { .. }
@@ -271,6 +286,7 @@ impl OmicronZoneType {
             | OmicronZoneType::InternalNtp { .. }
             | OmicronZoneType::Clickhouse { .. }
             | OmicronZoneType::ClickhouseKeeper { .. }
+            | OmicronZoneType::ClickhouseServer { .. }
             | OmicronZoneType::CockroachDb { .. }
             | OmicronZoneType::Crucible { .. }
             | OmicronZoneType::CruciblePantry { .. }
@@ -289,6 +305,7 @@ impl OmicronZoneType {
             | OmicronZoneType::InternalNtp { .. }
             | OmicronZoneType::Clickhouse { .. }
             | OmicronZoneType::ClickhouseKeeper { .. }
+            | OmicronZoneType::ClickhouseServer { .. }
             | OmicronZoneType::CockroachDb { .. }
             | OmicronZoneType::CruciblePantry { .. }
             | OmicronZoneType::ExternalDns { .. }
@@ -310,6 +327,7 @@ impl OmicronZoneType {
             OmicronZoneType::InternalNtp { .. }
             | OmicronZoneType::Clickhouse { .. }
             | OmicronZoneType::ClickhouseKeeper { .. }
+            | OmicronZoneType::ClickhouseServer { .. }
             | OmicronZoneType::CockroachDb { .. }
             | OmicronZoneType::Crucible { .. }
             | OmicronZoneType::CruciblePantry { .. }
@@ -328,6 +346,7 @@ impl OmicronZoneType {
             OmicronZoneType::InternalNtp { .. }
             | OmicronZoneType::Clickhouse { .. }
             | OmicronZoneType::ClickhouseKeeper { .. }
+            | OmicronZoneType::ClickhouseServer { .. }
             | OmicronZoneType::CockroachDb { .. }
             | OmicronZoneType::Crucible { .. }
             | OmicronZoneType::CruciblePantry { .. }
@@ -367,6 +386,7 @@ pub enum ZoneKind {
     BoundaryNtp,
     Clickhouse,
     ClickhouseKeeper,
+    ClickhouseServer,
     CockroachDb,
     Crucible,
     CruciblePantry,
@@ -390,6 +410,7 @@ impl ZoneKind {
             ZoneKind::BoundaryNtp | ZoneKind::InternalNtp => Self::NTP_PREFIX,
             ZoneKind::Clickhouse => "clickhouse",
             ZoneKind::ClickhouseKeeper => "clickhouse_keeper",
+            ZoneKind::ClickhouseServer => "clickhouse_server",
             // Note "cockroachdb" for historical reasons.
             ZoneKind::CockroachDb => "cockroachdb",
             ZoneKind::Crucible => "crucible",
@@ -409,6 +430,7 @@ impl ZoneKind {
             ZoneKind::BoundaryNtp | ZoneKind::InternalNtp => Self::NTP_PREFIX,
             ZoneKind::Clickhouse => "clickhouse",
             ZoneKind::ClickhouseKeeper => "clickhouse_keeper",
+            ZoneKind::ClickhouseServer => "clickhouse_server",
             // Note "cockroachdb" for historical reasons.
             ZoneKind::CockroachDb => "cockroachdb",
             ZoneKind::Crucible => "crucible",
@@ -431,6 +453,7 @@ impl ZoneKind {
             ZoneKind::BoundaryNtp | ZoneKind::InternalNtp => Self::NTP_PREFIX,
             ZoneKind::Clickhouse => "clickhouse",
             ZoneKind::ClickhouseKeeper => "clickhouse-keeper",
+            ZoneKind::ClickhouseServer => "clickhouse_server",
             // Note "cockroach" for historical reasons.
             ZoneKind::CockroachDb => "cockroach",
             ZoneKind::Crucible => "crucible",
@@ -451,6 +474,7 @@ impl ZoneKind {
             ZoneKind::BoundaryNtp => "boundary_ntp",
             ZoneKind::Clickhouse => "clickhouse",
             ZoneKind::ClickhouseKeeper => "clickhouse_keeper",
+            ZoneKind::ClickhouseServer => "clickhouse_server",
             ZoneKind::CockroachDb => "cockroach_db",
             ZoneKind::Crucible => "crucible",
             ZoneKind::CruciblePantry => "crucible_pantry",

--- a/nexus/db-model/src/dataset_kind.rs
+++ b/nexus/db-model/src/dataset_kind.rs
@@ -20,6 +20,7 @@ impl_enum_type!(
     Cockroach => b"cockroach"
     Clickhouse => b"clickhouse"
     ClickhouseKeeper => b"clickhouse_keeper"
+    ClickhouseServer => b"clickhouse_server"
     ExternalDns => b"external_dns"
     InternalDns => b"internal_dns"
 );
@@ -34,6 +35,9 @@ impl From<internal::shared::DatasetKind> for DatasetKind {
             }
             internal::shared::DatasetKind::ClickhouseKeeper => {
                 DatasetKind::ClickhouseKeeper
+            }
+            internal::shared::DatasetKind::ClickhouseServer => {
+                DatasetKind::ClickhouseServer
             }
             internal::shared::DatasetKind::ExternalDns => {
                 DatasetKind::ExternalDns

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -985,6 +985,7 @@ impl_enum_type!(
     BoundaryNtp => b"boundary_ntp"
     Clickhouse => b"clickhouse"
     ClickhouseKeeper => b"clickhouse_keeper"
+    ClickhouseServer => b"clickhouse_server"
     CockroachDb => b"cockroach_db"
     Crucible => b"crucible"
     CruciblePantry => b"crucible_pantry"
@@ -1001,6 +1002,7 @@ impl From<ZoneType> for ServiceKind {
             ZoneType::BoundaryNtp | ZoneType::InternalNtp => Self::Ntp,
             ZoneType::Clickhouse => Self::Clickhouse,
             ZoneType::ClickhouseKeeper => Self::ClickhouseKeeper,
+            ZoneType::ClickhouseServer => Self::ClickhouseServer,
             ZoneType::CockroachDb => Self::Cockroach,
             ZoneType::Crucible => Self::Crucible,
             ZoneType::CruciblePantry => Self::CruciblePantry,
@@ -1020,6 +1022,7 @@ impl From<ZoneType> for nexus_sled_agent_shared::inventory::ZoneKind {
             ZoneType::BoundaryNtp => BoundaryNtp,
             ZoneType::Clickhouse => Clickhouse,
             ZoneType::ClickhouseKeeper => ClickhouseKeeper,
+            ZoneType::ClickhouseServer => ClickhouseServer,
             ZoneType::CockroachDb => CockroachDb,
             ZoneType::Crucible => Crucible,
             ZoneType::CruciblePantry => CruciblePantry,
@@ -1040,6 +1043,7 @@ impl From<nexus_sled_agent_shared::inventory::ZoneKind> for ZoneType {
             BoundaryNtp => ZoneType::BoundaryNtp,
             Clickhouse => ZoneType::Clickhouse,
             ClickhouseKeeper => ZoneType::ClickhouseKeeper,
+            ClickhouseServer => ZoneType::ClickhouseServer,
             CockroachDb => ZoneType::CockroachDb,
             Crucible => ZoneType::Crucible,
             CruciblePantry => ZoneType::CruciblePantry,

--- a/nexus/db-model/src/omicron_zone_config.rs
+++ b/nexus/db-model/src/omicron_zone_config.rs
@@ -109,6 +109,9 @@ impl OmicronZone {
             OmicronZoneType::ClickhouseKeeper { address, dataset } => {
                 (ZoneType::ClickhouseKeeper, address, Some(dataset))
             }
+            OmicronZoneType::ClickhouseServer { address, dataset } => {
+                (ZoneType::ClickhouseServer, address, Some(dataset))
+            }
             OmicronZoneType::CockroachDb { address, dataset } => {
                 (ZoneType::CockroachDb, address, Some(dataset))
             }
@@ -258,6 +261,12 @@ impl OmicronZone {
                     dataset: common.dataset?,
                 },
             ),
+            ZoneType::ClickhouseServer => BlueprintZoneType::ClickhouseServer(
+                blueprint_zone_type::ClickhouseServer {
+                    address,
+                    dataset: common.dataset?,
+                },
+            ),
             ZoneType::CockroachDb => BlueprintZoneType::CockroachDb(
                 blueprint_zone_type::CockroachDb {
                     address,
@@ -389,6 +398,10 @@ impl OmicronZone {
                 dataset: common.dataset?,
             },
             ZoneType::ClickhouseKeeper => OmicronZoneType::ClickhouseKeeper {
+                address,
+                dataset: common.dataset?,
+            },
+            ZoneType::ClickhouseServer => OmicronZoneType::ClickhouseServer {
                 address,
                 dataset: common.dataset?,
             },

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(86, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(87, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(87, "add-clickhouse-server-enum-variants"),
         KnownVersion::new(86, "snapshot-replacement"),
         KnownVersion::new(85, "add-migrations-by-time-created-index"),
         KnownVersion::new(84, "region-read-only"),

--- a/nexus/db-model/src/service_kind.rs
+++ b/nexus/db-model/src/service_kind.rs
@@ -20,6 +20,7 @@ impl_enum_type!(
     // Enum values
     Clickhouse => b"clickhouse"
     ClickhouseKeeper => b"clickhouse_keeper"
+    ClickhouseServer => b"clickhouse_server"
     Cockroach => b"cockroach"
     Crucible => b"crucible"
     CruciblePantry => b"crucible_pantry"

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -327,6 +327,7 @@ impl DataStore {
             ZoneKind::Nexus => &*NEXUS_VPC_SUBNET,
             ZoneKind::Clickhouse
             | ZoneKind::ClickhouseKeeper
+            | ZoneKind::ClickhouseServer
             | ZoneKind::CockroachDb
             | ZoneKind::Crucible
             | ZoneKind::CruciblePantry

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -595,6 +595,7 @@ impl DataStore {
             BlueprintZoneType::InternalNtp(_)
             | BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CockroachDb(_)
             | BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::CruciblePantry(_)

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -275,6 +275,9 @@ pub fn blueprint_internal_dns_config(
             BlueprintZoneType::ClickhouseKeeper(
                 blueprint_zone_type::ClickhouseKeeper { address, .. },
             ) => (ServiceName::ClickhouseKeeper, address.port()),
+            BlueprintZoneType::ClickhouseServer(
+                blueprint_zone_type::ClickhouseServer { address, .. },
+            ) => (ServiceName::ClickhouseServer, address.port()),
             BlueprintZoneType::CockroachDb(
                 blueprint_zone_type::CockroachDb { address, .. },
             ) => (ServiceName::Cockroach, address.port()),

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -138,6 +138,7 @@ pub(crate) async fn clean_up_expunged_zones<R: CleanupResolver>(
                 BlueprintZoneType::BoundaryNtp(_)
                 | BlueprintZoneType::Clickhouse(_)
                 | BlueprintZoneType::ClickhouseKeeper(_)
+                | BlueprintZoneType::ClickhouseServer(_)
                 | BlueprintZoneType::Crucible(_)
                 | BlueprintZoneType::CruciblePantry(_)
                 | BlueprintZoneType::ExternalDns(_)

--- a/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
+++ b/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
@@ -31,6 +31,7 @@ impl DiscretionaryOmicronZone {
             // Zones that we should place but don't yet.
             BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CruciblePantry(_)
             | BlueprintZoneType::ExternalDns(_)
             | BlueprintZoneType::InternalDns(_)

--- a/nexus/src/app/background/tasks/sync_service_zone_nat.rs
+++ b/nexus/src/app/background/tasks/sync_service_zone_nat.rs
@@ -239,6 +239,7 @@ impl BackgroundTask for ServiceZoneNatTracker {
                         // well
                         OmicronZoneType::Clickhouse {..} => continue,
                         OmicronZoneType::ClickhouseKeeper {..} => continue,
+                        OmicronZoneType::ClickhouseServer{..} => continue,
                         OmicronZoneType::CockroachDb {..} => continue,
                         OmicronZoneType::Crucible {..} => continue,
                         OmicronZoneType::CruciblePantry {..} => continue,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -671,6 +671,11 @@ impl BlueprintZoneConfig {
                     blueprint_zone_type::ClickhouseKeeper { address, dataset },
                 )
             }
+            OmicronZoneType::ClickhouseServer { address, dataset } => {
+                BlueprintZoneType::ClickhouseServer(
+                    blueprint_zone_type::ClickhouseServer { address, dataset },
+                )
+            }
             OmicronZoneType::CockroachDb { address, dataset } => {
                 BlueprintZoneType::CockroachDb(
                     blueprint_zone_type::CockroachDb { address, dataset },

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -25,6 +25,7 @@ pub enum BlueprintZoneType {
     BoundaryNtp(blueprint_zone_type::BoundaryNtp),
     Clickhouse(blueprint_zone_type::Clickhouse),
     ClickhouseKeeper(blueprint_zone_type::ClickhouseKeeper),
+    ClickhouseServer(blueprint_zone_type::ClickhouseServer),
     CockroachDb(blueprint_zone_type::CockroachDb),
     Crucible(blueprint_zone_type::Crucible),
     CruciblePantry(blueprint_zone_type::CruciblePantry),
@@ -60,6 +61,7 @@ impl BlueprintZoneType {
             }
             BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CockroachDb(_)
             | BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::CruciblePantry(_)
@@ -78,6 +80,7 @@ impl BlueprintZoneType {
             | BlueprintZoneType::ExternalDns(_)
             | BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CockroachDb(_)
             | BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::CruciblePantry(_)
@@ -94,6 +97,7 @@ impl BlueprintZoneType {
             | BlueprintZoneType::ExternalDns(_)
             | BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CockroachDb(_)
             | BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::CruciblePantry(_)
@@ -110,6 +114,7 @@ impl BlueprintZoneType {
             BlueprintZoneType::BoundaryNtp(_)
             | BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::ClickhouseKeeper(_)
+            | BlueprintZoneType::ClickhouseServer(_)
             | BlueprintZoneType::CockroachDb(_)
             | BlueprintZoneType::CruciblePantry(_)
             | BlueprintZoneType::ExternalDns(_)
@@ -129,6 +134,9 @@ impl BlueprintZoneType {
             BlueprintZoneType::ClickhouseKeeper(
                 blueprint_zone_type::ClickhouseKeeper { dataset, address },
             ) => (dataset, DatasetKind::ClickhouseKeeper, address),
+            BlueprintZoneType::ClickhouseServer(
+                blueprint_zone_type::ClickhouseServer { dataset, address },
+            ) => (dataset, DatasetKind::ClickhouseServer, address),
             BlueprintZoneType::CockroachDb(
                 blueprint_zone_type::CockroachDb { dataset, address },
             ) => (dataset, DatasetKind::Cockroach, address),
@@ -185,6 +193,12 @@ impl From<BlueprintZoneType> for OmicronZoneType {
                     dataset: zone.dataset,
                 }
             }
+            BlueprintZoneType::ClickhouseServer(zone) => {
+                Self::ClickhouseServer {
+                    address: zone.address,
+                    dataset: zone.dataset,
+                }
+            }
             BlueprintZoneType::CockroachDb(zone) => Self::CockroachDb {
                 address: zone.address,
                 dataset: zone.dataset,
@@ -235,6 +249,7 @@ impl BlueprintZoneType {
             Self::BoundaryNtp(_) => ZoneKind::BoundaryNtp,
             Self::Clickhouse(_) => ZoneKind::Clickhouse,
             Self::ClickhouseKeeper(_) => ZoneKind::ClickhouseKeeper,
+            Self::ClickhouseServer(_) => ZoneKind::ClickhouseServer,
             Self::CockroachDb(_) => ZoneKind::CockroachDb,
             Self::Crucible(_) => ZoneKind::Crucible,
             Self::CruciblePantry(_) => ZoneKind::CruciblePantry,
@@ -273,6 +288,7 @@ pub mod blueprint_zone_type {
         pub external_ip: OmicronZoneExternalSnatIp,
     }
 
+    /// Used in single-node clickhouse setups
     #[derive(
         Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
     )]
@@ -285,6 +301,15 @@ pub mod blueprint_zone_type {
         Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
     )]
     pub struct ClickhouseKeeper {
+        pub address: SocketAddrV6,
+        pub dataset: OmicronZoneDataset,
+    }
+
+    /// Used in replicated clickhouse setups
+    #[derive(
+        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+    )]
+    pub struct ClickhouseServer {
         pub address: SocketAddrV6,
         pub dataset: OmicronZoneDataset,
     }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2101,6 +2101,7 @@
             ]
           },
           {
+            "description": "Used in single-node clickhouse setups",
             "type": "object",
             "properties": {
               "address": {
@@ -2135,6 +2136,29 @@
                 "type": "string",
                 "enum": [
                   "clickhouse_keeper"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "Used in replicated clickhouse setups",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_server"
                 ]
               }
             },
@@ -2592,14 +2616,37 @@
       },
       "DatasetKind": {
         "description": "Describes the purpose of the dataset.",
-        "type": "string",
-        "enum": [
-          "crucible",
-          "cockroach",
-          "clickhouse",
-          "clickhouse_keeper",
-          "external_dns",
-          "internal_dns"
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "crucible",
+              "cockroach",
+              "external_dns",
+              "internal_dns"
+            ]
+          },
+          {
+            "description": "Used for single-node clickhouse deployments",
+            "type": "string",
+            "enum": [
+              "clickhouse"
+            ]
+          },
+          {
+            "description": "Used for replicated clickhouse deployments",
+            "type": "string",
+            "enum": [
+              "clickhouse_keeper"
+            ]
+          },
+          {
+            "description": "Used for replicated clickhouse deployments",
+            "type": "string",
+            "enum": [
+              "clickhouse_server"
+            ]
+          }
         ]
       },
       "DatasetPutRequest": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3747,6 +3747,7 @@
             ]
           },
           {
+            "description": "Type of clickhouse zone used for a single node clickhouse deployment",
             "type": "object",
             "properties": {
               "address": {
@@ -3769,6 +3770,7 @@
             ]
           },
           {
+            "description": "A zone used to run a Clickhouse Keeper node\n\nKeepers are only used in replicated clickhouse setups",
             "type": "object",
             "properties": {
               "address": {
@@ -3781,6 +3783,29 @@
                 "type": "string",
                 "enum": [
                   "clickhouse_keeper"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "A zone used to run a Clickhouse Server in a replicated deployment",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_server"
                 ]
               }
             },

--- a/schema/all-zones-requests.json
+++ b/schema/all-zones-requests.json
@@ -353,6 +353,7 @@
           }
         },
         {
+          "description": "Type of clickhouse zone used for a single node clickhouse deployment",
           "type": "object",
           "required": [
             "address",
@@ -375,6 +376,7 @@
           }
         },
         {
+          "description": "A zone used to run a Clickhouse Keeper node\n\nKeepers are only used in replicated clickhouse setups",
           "type": "object",
           "required": [
             "address",
@@ -392,6 +394,29 @@
               "type": "string",
               "enum": [
                 "clickhouse_keeper"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A zone used to run a Clickhouse Server in a replicated deployment",
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse_server"
               ]
             }
           }

--- a/schema/crdb/add-clickhouse-server-enum-variants/up1.sql
+++ b/schema/crdb/add-clickhouse-server-enum-variants/up1.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.service_kind ADD VALUE IF NOT EXISTS 'clickhouse_server' AFTER 'clickhouse_keeper';

--- a/schema/crdb/add-clickhouse-server-enum-variants/up2.sql
+++ b/schema/crdb/add-clickhouse-server-enum-variants/up2.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind ADD VALUE IF NOT EXISTS 'clickhouse_server' AFTER 'clickhouse_keeper';

--- a/schema/crdb/add-clickhouse-server-enum-variants/up3.sql
+++ b/schema/crdb/add-clickhouse-server-enum-variants/up3.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.zone_type ADD VALUE IF NOT EXISTS 'clickhouse_server' AFTER 'clickhouse_keeper';

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -288,6 +288,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS lookup_switch_by_rack ON omicron.public.switch
 CREATE TYPE IF NOT EXISTS omicron.public.service_kind AS ENUM (
   'clickhouse',
   'clickhouse_keeper',
+  'clickhouse_server',
   'cockroach',
   'crucible',
   'crucible_pantry',
@@ -506,6 +507,7 @@ CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'cockroach',
   'clickhouse',
   'clickhouse_keeper',
+  'clickhouse_server',
   'external_dns',
   'internal_dns'
 );
@@ -3209,6 +3211,7 @@ CREATE TYPE IF NOT EXISTS omicron.public.zone_type AS ENUM (
   'boundary_ntp',
   'clickhouse',
   'clickhouse_keeper',
+  'clickhouse_server',
   'cockroach_db',
   'crucible',
   'crucible_pantry',

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4217,7 +4217,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '86.0.0', NULL)
+    (TRUE, NOW(), NOW(), '87.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/rss-service-plan-v3.json
+++ b/schema/rss-service-plan-v3.json
@@ -494,6 +494,7 @@
           }
         },
         {
+          "description": "Type of clickhouse zone used for a single node clickhouse deployment",
           "type": "object",
           "required": [
             "address",
@@ -516,6 +517,7 @@
           }
         },
         {
+          "description": "A zone used to run a Clickhouse Keeper node\n\nKeepers are only used in replicated clickhouse setups",
           "type": "object",
           "required": [
             "address",
@@ -533,6 +535,29 @@
               "type": "string",
               "enum": [
                 "clickhouse_keeper"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A zone used to run a Clickhouse Server in a replicated deployment",
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse_server"
               ]
             }
           }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -277,6 +277,9 @@ pub(crate) trait OmicronZoneTypeExt {
             OmicronZoneType::ClickhouseKeeper { dataset, address, .. } => {
                 Some((dataset, DatasetType::ClickhouseKeeper, address))
             }
+            OmicronZoneType::ClickhouseServer { dataset, address, .. } => {
+                Some((dataset, DatasetType::ClickhouseServer, address))
+            }
             OmicronZoneType::CockroachDb { dataset, address, .. } => {
                 Some((dataset, DatasetType::CockroachDb, address))
             }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1590,6 +1590,24 @@ impl ServiceManager {
             ZoneArgs::Omicron(OmicronZoneConfigLocal {
                 zone:
                     OmicronZoneConfig {
+                        zone_type: OmicronZoneType::ClickhouseServer { .. },
+                        underlay_address: _,
+                        ..
+                    },
+                ..
+            }) => {
+                // We aren't yet deploying this service
+                error!(
+                    &self.inner.log,
+                    "Deploying ClickhouseServer zones is not yet supported"
+                );
+
+                todo!()
+            }
+
+            ZoneArgs::Omicron(OmicronZoneConfigLocal {
+                zone:
+                    OmicronZoneConfig {
                         zone_type: OmicronZoneType::ClickhouseKeeper { .. },
                         underlay_address,
                         ..

--- a/sled-storage/src/dataset.rs
+++ b/sled-storage/src/dataset.rs
@@ -142,6 +142,7 @@ pub enum DatasetType {
     Crucible,
     Clickhouse,
     ClickhouseKeeper,
+    ClickhouseServer,
     ExternalDns,
     InternalDns,
 }
@@ -164,6 +165,7 @@ impl DatasetType {
             Self::CockroachDb => DatasetKind::Cockroach,
             Self::Clickhouse => DatasetKind::Clickhouse,
             Self::ClickhouseKeeper => DatasetKind::ClickhouseKeeper,
+            Self::ClickhouseServer => DatasetKind::ClickhouseServer,
             Self::ExternalDns => DatasetKind::ExternalDns,
             Self::InternalDns => DatasetKind::InternalDns,
         }
@@ -206,6 +208,7 @@ impl std::fmt::Display for DatasetType {
             CockroachDb => "cockroachdb",
             Clickhouse => "clickhouse",
             ClickhouseKeeper => "clickhouse_keeper",
+            ClickhouseServer => "clickhouse_server",
             ExternalDns => "external_dns",
             InternalDns => "internal_dns",
         };


### PR DESCRIPTION
The new zone type reflects the zone with which we'll deploy clickhouse server nodes in a replicated setup. We decided on using a new zone type rather than adding a boolean field to the existing `Clickhouse` zone type that is used for single server deployments in last Tuesday's (Aug 6, 2024) update huddle.

This is the fist part of the work to be done for replicated clickhouse deployments that are automated via reconfigurator. As such, the actual zone deployment is left as a `todo`.