### PR TITLE
[dns-server] only return answers to the incoming question

### DIFF
--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -274,6 +274,19 @@ async fn handle_dns_message(
     let mut additional_records = vec![];
     let response_records = records
         .into_iter()
+        .filter(|record| {
+            let ty = query.query_type();
+            if ty == RecordType::ANY {
+                return true;
+            }
+
+            match (ty, record) {
+                (RecordType::A, DnsRecord::A(_)) => true,
+                (RecordType::AAAA, DnsRecord::Aaaa(_)) => true,
+                (RecordType::SRV, DnsRecord::Srv(_)) => true,
+                _ => false,
+            }
+        })
         .map(|record| {
             let record = dns_record_to_record(&name, record)?;
 


### PR DESCRIPTION
As noted in https://github.com/oxidecomputer/omicron/issues/4051, queries to the internal DNS server would get any records we have for a name in response, rather than only records matching the query incoming query type. That behavior is confusing, but worse, wrong.

Subtly, this is not actually a misbehavior I believe we can observe through `trust_dns_resolver`: the resolver from that crate includes its own `CachingClient`. As a side effect of upstream answers going through that caching client, incorrect Answers records are cached and only correct answers actually make it out to us as consumers of `trust_dns_resolver`.

But as is plenty clear in #4051, `dig` and other DNS clients can get incoherent answers!

Simple enough to fix: only return answers that are answers to the question we were asked.