### PR TITLE
move instance migration to internal API

### DIFF
--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -20,7 +20,7 @@ use nexus_types::{
     },
     internal_api::{
         params::{
-            InstanceMigrateParams, OximeterInfo, RackInitializationRequest,
+            InstanceMigrateRequest, OximeterInfo, RackInitializationRequest,
             SledAgentInfo, SwitchPutRequest, SwitchPutResponse,
         },
         views::{BackgroundTask, Ipv4NatEntryView, Saga},
@@ -125,7 +125,7 @@ pub trait NexusInternalApi {
     async fn instance_migrate(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
-        migrate_params: TypedBody<InstanceMigrateParams>,
+        migrate_params: TypedBody<InstanceMigrateRequest>,
     ) -> Result<HttpResponseOk<Instance>, HttpError>;
 
     /// Report updated state for a disk.

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -20,15 +20,15 @@ use nexus_types::{
     },
     internal_api::{
         params::{
-            OximeterInfo, RackInitializationRequest, SledAgentInfo,
-            SwitchPutRequest, SwitchPutResponse,
+            InstanceMigrateParams, OximeterInfo, RackInitializationRequest,
+            SledAgentInfo, SwitchPutRequest, SwitchPutResponse,
         },
         views::{BackgroundTask, Ipv4NatEntryView, Saga},
     },
 };
 use omicron_common::{
     api::{
-        external::http_pagination::PaginatedById,
+        external::{http_pagination::PaginatedById, Instance},
         internal::nexus::{
             DiskRuntimeState, DownstairsClientStopRequest,
             DownstairsClientStopped, ProducerEndpoint,
@@ -117,6 +117,16 @@ pub trait NexusInternalApi {
         path_params: Path<InstancePathParam>,
         new_runtime_state: TypedBody<SledInstanceState>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    #[endpoint {
+        method = POST,
+        path = "/instances/{instance_id}/migrate",
+    }]
+    async fn instance_migrate(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<InstancePathParam>,
+        migrate_params: TypedBody<InstanceMigrateParams>,
+    ) -> Result<HttpResponseOk<Instance>, HttpError>;
 
     /// Report updated state for a disk.
     #[endpoint {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -485,7 +485,7 @@ impl super::Nexus {
         self: &Arc<Self>,
         opctx: &OpContext,
         id: InstanceUuid,
-        params: nexus_types::internal_api::params::InstanceMigrateParams,
+        params: nexus_types::internal_api::params::InstanceMigrateRequest,
     ) -> UpdateResult<InstanceAndActiveVmm> {
         let (.., authz_instance) = LookupPath::new(&opctx, &self.db_datastore)
             .instance_id(id.into_untyped_uuid())

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -12,7 +12,7 @@ use crate::app::sagas::{
 };
 use nexus_db_queries::db::{identity::Resource, lookup::LookupPath};
 use nexus_db_queries::{authn, authz, db};
-use nexus_types::internal_api::params;
+use nexus_types::internal_api::params::InstanceMigrateRequest;
 use omicron_uuid_kinds::{GenericUuid, InstanceUuid, PropolisUuid, SledUuid};
 use serde::Deserialize;
 use serde::Serialize;
@@ -30,7 +30,7 @@ pub struct Params {
     pub serialized_authn: authn::saga::Serialized,
     pub instance: db::model::Instance,
     pub src_vmm: db::model::Vmm,
-    pub migrate_params: params::InstanceMigrateParams,
+    pub migrate_params: InstanceMigrateRequest,
 }
 
 // The migration saga is similar to the instance start saga: get a destination
@@ -570,7 +570,7 @@ async fn sim_instance_migrate(
 mod tests {
     use super::*;
     use crate::app::sagas::test_helpers;
-    use crate::external_api::params as ExternalParams;
+    use crate::external_api::params;
     use dropshot::test_util::ClientTestContext;
     use nexus_test_utils::resource_helpers::{
         create_default_ip_pool, create_project, object_create,
@@ -599,7 +599,7 @@ mod tests {
         object_create(
             client,
             &instances_url,
-            &ExternalParams::InstanceCreate {
+            &params::InstanceCreate {
                 identity: IdentityMetadataCreateParams {
                     name: INSTANCE_NAME.parse().unwrap(),
                     description: format!("instance {:?}", INSTANCE_NAME),
@@ -610,7 +610,7 @@ mod tests {
                 user_data: b"#cloud-config".to_vec(),
                 ssh_public_keys: Some(Vec::new()),
                 network_interfaces:
-                    ExternalParams::InstanceNetworkInterfaceAttachment::None,
+                    params::InstanceNetworkInterfaceAttachment::None,
                 external_ips: vec![],
                 disks: vec![],
                 start: true,
@@ -643,7 +643,7 @@ mod tests {
             serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
             instance: state.instance().clone(),
             src_vmm: vmm.clone(),
-            migrate_params: params::InstanceMigrateParams {
+            migrate_params: InstanceMigrateRequest {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             },
         };
@@ -712,7 +712,7 @@ mod tests {
                         ),
                         instance: old_instance.clone(),
                         src_vmm: old_vmm.clone(),
-                        migrate_params: params::InstanceMigrateParams {
+                        migrate_params: InstanceMigrateRequest {
                             dst_sled_id: dst_sled_id.into_untyped_uuid(),
                         },
                     }

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -10,9 +10,10 @@ use super::{
     instance_common::allocate_vmm_ipv6, NexusActionContext, NexusSaga,
     SagaInitError,
 };
-use crate::app::instance::InstanceEnsureRegisteredApiResources;
-use crate::app::instance::InstanceRegisterReason;
-use crate::app::instance::InstanceStateChangeError;
+use crate::app::instance::{
+    InstanceEnsureRegisteredApiResources, InstanceRegisterReason,
+    InstanceStateChangeError,
+};
 use crate::app::sagas::declare_saga_actions;
 use chrono::Utc;
 use nexus_db_queries::db::{identity::Resource, lookup::LookupPath};

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2358,9 +2358,10 @@ mod test {
                 serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
                 instance: state.instance().clone(),
                 src_vmm: vmm.clone(),
-                migrate_params: params::InstanceMigrate {
-                    dst_sled_id: dst_sled_id.into_untyped_uuid(),
-                },
+                migrate_params:
+                    nexus_types::internal_api::params::InstanceMigrateParams {
+                        dst_sled_id: dst_sled_id.into_untyped_uuid(),
+                    },
             };
 
             nexus

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1403,6 +1403,7 @@ mod test {
         create_default_ip_pool, create_project, object_create,
     };
     use nexus_test_utils_macros::nexus_test;
+    use nexus_types::internal_api::params::InstanceMigrateRequest;
     use omicron_common::api::internal::nexus::{
         MigrationRuntimeState, MigrationState, Migrations,
     };
@@ -2358,10 +2359,9 @@ mod test {
                 serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
                 instance: state.instance().clone(),
                 src_vmm: vmm.clone(),
-                migrate_params:
-                    nexus_types::internal_api::params::InstanceMigrateParams {
-                        dst_sled_id: dst_sled_id.into_untyped_uuid(),
-                    },
+                migrate_params: InstanceMigrateRequest {
+                    dst_sled_id: dst_sled_id.into_untyped_uuid(),
+                },
             };
 
             nexus

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -30,7 +30,7 @@ use nexus_types::external_api::params::UninitializedSledId;
 use nexus_types::external_api::shared::ProbeInfo;
 use nexus_types::external_api::shared::UninitializedSled;
 use nexus_types::external_api::views::SledPolicy;
-use nexus_types::internal_api::params::InstanceMigrateParams;
+use nexus_types::internal_api::params::InstanceMigrateRequest;
 use nexus_types::internal_api::params::SledAgentInfo;
 use nexus_types::internal_api::params::SwitchPutRequest;
 use nexus_types::internal_api::params::SwitchPutResponse;
@@ -194,7 +194,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
     async fn instance_migrate(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
-        migrate_params: TypedBody<InstanceMigrateParams>,
+        migrate_params: TypedBody<InstanceMigrateRequest>,
     ) -> Result<HttpResponseOk<Instance>, HttpError> {
         let apictx = &rqctx.context().context;
         let nexus = &apictx.nexus;

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -30,6 +30,7 @@ use nexus_types::external_api::params::UninitializedSledId;
 use nexus_types::external_api::shared::ProbeInfo;
 use nexus_types::external_api::shared::UninitializedSled;
 use nexus_types::external_api::views::SledPolicy;
+use nexus_types::internal_api::params::InstanceMigrateParams;
 use nexus_types::internal_api::params::SledAgentInfo;
 use nexus_types::internal_api::params::SwitchPutRequest;
 use nexus_types::internal_api::params::SwitchPutResponse;
@@ -41,6 +42,7 @@ use omicron_common::api::external::http_pagination::data_page_params_for;
 use omicron_common::api::external::http_pagination::PaginatedById;
 use omicron_common::api::external::http_pagination::ScanById;
 use omicron_common::api::external::http_pagination::ScanParams;
+use omicron_common::api::external::Instance;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::DownstairsClientStopRequest;
 use omicron_common::api::internal::nexus::DownstairsClientStopped;
@@ -182,6 +184,33 @@ impl NexusInternalApi for NexusInternalApiImpl {
                 )
                 .await?;
             Ok(HttpResponseUpdatedNoContent())
+        };
+        apictx
+            .internal_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
+    async fn instance_migrate(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<InstancePathParam>,
+        migrate_params: TypedBody<InstanceMigrateParams>,
+    ) -> Result<HttpResponseOk<Instance>, HttpError> {
+        let apictx = &rqctx.context().context;
+        let nexus = &apictx.nexus;
+        let path = path_params.into_inner();
+        let migrate = migrate_params.into_inner();
+        let handler = async {
+            let opctx =
+                crate::context::op_context_for_internal_api(&rqctx).await;
+            let instance = nexus
+                .instance_migrate(
+                    &opctx,
+                    InstanceUuid::from_untyped_uuid(path.instance_id),
+                    migrate,
+                )
+                .await?;
+            Ok(HttpResponseOk(instance.into()))
         };
         apictx
             .internal_latencies

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -359,12 +359,6 @@ pub static DEMO_INSTANCE_REBOOT_URL: Lazy<String> = Lazy::new(|| {
         *DEMO_INSTANCE_NAME, *DEMO_PROJECT_SELECTOR
     )
 });
-pub static DEMO_INSTANCE_MIGRATE_URL: Lazy<String> = Lazy::new(|| {
-    format!(
-        "/v1/instances/{}/migrate?{}",
-        *DEMO_INSTANCE_NAME, *DEMO_PROJECT_SELECTOR
-    )
-});
 pub static DEMO_INSTANCE_SERIAL_URL: Lazy<String> = Lazy::new(|| {
     format!(
         "/v1/instances/{}/serial-console?{}",
@@ -1821,18 +1815,6 @@ pub static VERIFY_ENDPOINTS: Lazy<Vec<VerifyEndpoint>> = Lazy::new(|| {
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Post(serde_json::Value::Null)
-            ],
-        },
-        VerifyEndpoint {
-            url: &DEMO_INSTANCE_MIGRATE_URL,
-            visibility: Visibility::Protected,
-            unprivileged_access: UnprivilegedAccess::None,
-            allowed_methods: vec![
-                AllowedMethod::Post(serde_json::to_value(
-                    params::InstanceMigrate {
-                        dst_sled_id: uuid::Uuid::new_v4(),
-                    }
-                ).unwrap()),
             ],
         },
         VerifyEndpoint {

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -48,6 +48,7 @@ use nexus_types::external_api::shared::SiloIdentityMode;
 use nexus_types::external_api::views::SshKey;
 use nexus_types::external_api::{params, views};
 use nexus_types::identity::Resource;
+use nexus_types::internal_api::params::InstanceMigrateParams;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Disk;
 use omicron_common::api::external::DiskState;
@@ -737,6 +738,7 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     }
 
     let client = &cptestctx.external_client;
+    let internal_client = &cptestctx.internal_client;
     let apictx = &cptestctx.server.server_context();
     let nexus = &apictx.nexus;
     let instance_name = "bird-ecology";
@@ -791,10 +793,10 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     };
 
     let migrate_url =
-        format!("/v1/instances/{}/migrate", &instance_id.to_string());
+        format!("/instances/{}/migrate", &instance_id.to_string());
     let instance = NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &migrate_url)
-            .body(Some(&params::InstanceMigrate {
+        RequestBuilder::new(internal_client, Method::POST, &migrate_url)
+            .body(Some(&InstanceMigrateParams {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),
@@ -907,6 +909,7 @@ async fn test_instance_migrate_v2p_and_routes(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
+    let internal_client = &cptestctx.internal_client;
     let apictx = &cptestctx.server.server_context();
     let nexus = &apictx.nexus;
     let datastore = nexus.datastore();
@@ -997,10 +1000,10 @@ async fn test_instance_migrate_v2p_and_routes(
 
     // Kick off migration and simulate its completion on the target.
     let migrate_url =
-        format!("/v1/instances/{}/migrate", &instance_id.to_string());
+        format!("/instances/{}/migrate", &instance_id.to_string());
     let _ = NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &migrate_url)
-            .body(Some(&params::InstanceMigrate {
+        RequestBuilder::new(internal_client, Method::POST, &migrate_url)
+            .body(Some(&InstanceMigrateParams {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),
@@ -1293,6 +1296,7 @@ async fn test_instance_metrics_with_migration(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
+    let internal_client = &cptestctx.internal_client;
     let apictx = &cptestctx.server.server_context();
     let nexus = &apictx.nexus;
     let instance_name = "bird-ecology";
@@ -1381,10 +1385,10 @@ async fn test_instance_metrics_with_migration(
     };
 
     let migrate_url =
-        format!("/v1/instances/{}/migrate", &instance_id.to_string());
+        format!("/instances/{}/migrate", &instance_id.to_string());
     let _ = NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &migrate_url)
-            .body(Some(&params::InstanceMigrate {
+        RequestBuilder::new(internal_client, Method::POST, &migrate_url)
+            .body(Some(&InstanceMigrateParams {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -48,7 +48,7 @@ use nexus_types::external_api::shared::SiloIdentityMode;
 use nexus_types::external_api::views::SshKey;
 use nexus_types::external_api::{params, views};
 use nexus_types::identity::Resource;
-use nexus_types::internal_api::params::InstanceMigrateParams;
+use nexus_types::internal_api::params::InstanceMigrateRequest;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Disk;
 use omicron_common::api::external::DiskState;
@@ -796,7 +796,7 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
         format!("/instances/{}/migrate", &instance_id.to_string());
     let instance = NexusRequest::new(
         RequestBuilder::new(internal_client, Method::POST, &migrate_url)
-            .body(Some(&InstanceMigrateParams {
+            .body(Some(&InstanceMigrateRequest {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),
@@ -1003,7 +1003,7 @@ async fn test_instance_migrate_v2p_and_routes(
         format!("/instances/{}/migrate", &instance_id.to_string());
     let _ = NexusRequest::new(
         RequestBuilder::new(internal_client, Method::POST, &migrate_url)
-            .body(Some(&InstanceMigrateParams {
+            .body(Some(&InstanceMigrateRequest {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),
@@ -1388,7 +1388,7 @@ async fn test_instance_metrics_with_migration(
         format!("/instances/{}/migrate", &instance_id.to_string());
     let _ = NexusRequest::new(
         RequestBuilder::new(internal_client, Method::POST, &migrate_url)
-            .body(Some(&InstanceMigrateParams {
+            .body(Some(&InstanceMigrateRequest {
                 dst_sled_id: dst_sled_id.into_untyped_uuid(),
             }))
             .expect_status(Some(StatusCode::OK)),

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -51,7 +51,6 @@ instance_ephemeral_ip_attach             POST     /v1/instances/{instance}/exter
 instance_ephemeral_ip_detach             DELETE   /v1/instances/{instance}/external-ips/ephemeral
 instance_external_ip_list                GET      /v1/instances/{instance}/external-ips
 instance_list                            GET      /v1/instances
-instance_migrate                         POST     /v1/instances/{instance}/migrate
 instance_network_interface_create        POST     /v1/network-interfaces
 instance_network_interface_delete        DELETE   /v1/network-interfaces/{interface}
 instance_network_interface_list          GET      /v1/network-interfaces

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1093,12 +1093,6 @@ impl JsonSchema for UserData {
     }
 }
 
-/// Migration parameters for an `Instance`
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceMigrate {
-    pub dst_sled_id: Uuid,
-}
-
 /// Forwarded to a propolis server to request the contents of an Instance's serial console.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct InstanceSerialConsoleRequest {

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -210,7 +210,7 @@ pub struct OximeterInfo {
 
 /// Parameters used when migrating an instance.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceMigrateParams {
+pub struct InstanceMigrateRequest {
     /// The ID of the sled to which to migrate the target instance.
     pub dst_sled_id: Uuid,
 }

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -207,3 +207,10 @@ pub struct OximeterInfo {
     /// The address on which this oximeter instance listens for requests
     pub address: SocketAddr,
 }
+
+/// Parameters used when migrating an instance.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateParams {
+    /// The ID of the sled to which to migrate the target instance.
+    pub dst_sled_id: Uuid,
+}

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -749,7 +749,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InstanceMigrateParams"
+                "$ref": "#/components/schemas/InstanceMigrateRequest"
               }
             }
           },
@@ -3311,7 +3311,7 @@
         "format": "uint16",
         "minimum": 0
       },
-      "InstanceMigrateParams": {
+      "InstanceMigrateRequest": {
         "description": "Parameters used when migrating an instance.",
         "type": "object",
         "properties": {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -731,6 +731,50 @@
         }
       }
     },
+    "/instances/{instance_id}/migrate": {
+      "post": {
+        "operationId": "instance_migrate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMigrateParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/metrics/collectors": {
       "post": {
         "summary": "Accept a notification of a new oximeter collection server.",
@@ -3179,6 +3223,179 @@
             "required": [
               "type",
               "value"
+            ]
+          }
+        ]
+      },
+      "Instance": {
+        "description": "View of an Instance",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "hostname": {
+            "description": "RFC1035-compliant hostname for the Instance.",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "memory": {
+            "description": "memory allocated for this Instance",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "ncpus": {
+            "description": "number of CPUs allocated for this Instance",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCpuCount"
+              }
+            ]
+          },
+          "project_id": {
+            "description": "id for the project containing this Instance",
+            "type": "string",
+            "format": "uuid"
+          },
+          "run_state": {
+            "$ref": "#/components/schemas/InstanceState"
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_run_state_updated": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "hostname",
+          "id",
+          "memory",
+          "name",
+          "ncpus",
+          "project_id",
+          "run_state",
+          "time_created",
+          "time_modified",
+          "time_run_state_updated"
+        ]
+      },
+      "InstanceCpuCount": {
+        "description": "The number of CPUs in an Instance",
+        "type": "integer",
+        "format": "uint16",
+        "minimum": 0
+      },
+      "InstanceMigrateParams": {
+        "description": "Parameters used when migrating an instance.",
+        "type": "object",
+        "properties": {
+          "dst_sled_id": {
+            "description": "The ID of the sled to which to migrate the target instance.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "dst_sled_id"
+        ]
+      },
+      "InstanceState": {
+        "description": "Running state of an Instance (primarily: booted or stopped)\n\nThis typically reflects whether it's starting, running, stopping, or stopped, but also includes states related to the Instance's lifecycle",
+        "oneOf": [
+          {
+            "description": "The instance is being created.",
+            "type": "string",
+            "enum": [
+              "creating"
+            ]
+          },
+          {
+            "description": "The instance is currently starting up.",
+            "type": "string",
+            "enum": [
+              "starting"
+            ]
+          },
+          {
+            "description": "The instance is currently running.",
+            "type": "string",
+            "enum": [
+              "running"
+            ]
+          },
+          {
+            "description": "The instance has been requested to stop and a transition to \"Stopped\" is imminent.",
+            "type": "string",
+            "enum": [
+              "stopping"
+            ]
+          },
+          {
+            "description": "The instance is currently stopped.",
+            "type": "string",
+            "enum": [
+              "stopped"
+            ]
+          },
+          {
+            "description": "The instance is in the process of rebooting - it will remain in the \"rebooting\" state until the VM is starting once more.",
+            "type": "string",
+            "enum": [
+              "rebooting"
+            ]
+          },
+          {
+            "description": "The instance is in the process of migrating - it will remain in the \"migrating\" state until the migration process is complete and the destination propolis is ready to continue execution.",
+            "type": "string",
+            "enum": [
+              "migrating"
+            ]
+          },
+          {
+            "description": "The instance is attempting to recover from a failure.",
+            "type": "string",
+            "enum": [
+              "repairing"
+            ]
+          },
+          {
+            "description": "The instance has encountered a failure.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The instance has been deleted.",
+            "type": "string",
+            "enum": [
+              "destroyed"
             ]
           }
         ]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2276,62 +2276,6 @@
         }
       }
     },
-    "/v1/instances/{instance}/migrate": {
-      "post": {
-        "tags": [
-          "instances"
-        ],
-        "summary": "Migrate an instance",
-        "operationId": "instance_migrate",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "project",
-            "description": "Name or ID of the project",
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          },
-          {
-            "in": "path",
-            "name": "instance",
-            "description": "Name or ID of the instance",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceMigrate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Instance"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/v1/instances/{instance}/reboot": {
       "post": {
         "tags": [
@@ -15269,19 +15213,6 @@
               "type"
             ]
           }
-        ]
-      },
-      "InstanceMigrate": {
-        "description": "Migration parameters for an `Instance`",
-        "type": "object",
-        "properties": {
-          "dst_sled_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "dst_sled_id"
         ]
       },
       "InstanceNetworkInterface": {


### PR DESCRIPTION
Move instance migration from the external API to the internal API per the determinations in RFD 494. This is almost a purely mechanical change (I have not, for example, changed any API signatures or return values); the only unusual bit is one small adjustment to `Nexus::instance_ensure_registered` to deal with the fact that migration no longer runs in a context where the caller is acting on behalf of a user in a silo.

Tests: cargo test; spun up a dev cluster and verified that (1) the migrate endpoint is gone from the external API, (2) it's present on the internal API and reachable from the switch zone, and (3) it behaves as it did before (at least to the extent I could test migration's behavior on a single-machine dev cluster).

Fixes #6173.