### PR TITLE
[omicron-zones] ensure name_prefix for clickhouse-server is valid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5140,6 +5140,7 @@ dependencies = [
  "schemars",
  "serde",
  "sled-hardware-types",
+ "strum",
  "uuid",
 ]
 

--- a/nexus-sled-agent-shared/Cargo.toml
+++ b/nexus-sled-agent-shared/Cargo.toml
@@ -14,4 +14,5 @@ omicron-workspace-hack.workspace = true
 schemars.workspace = true
 serde.workspace = true
 sled-hardware-types.workspace = true
+strum.workspace = true
 uuid.workspace = true

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 // Export this type for convenience -- this way, dependents don't have to
 // depend on sled-hardware-types.
 pub use sled_hardware_types::Baseboard;
+use strum::EnumIter;
 use uuid::Uuid;
 
 /// Identifies information about disks which may be attached to Sleds.
@@ -381,7 +382,9 @@ impl OmicronZoneType {
 /// the four representations if at all possible. If you must add a new one,
 /// please add it here rather than doing something ad-hoc in the calling code
 /// so it's more legible.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, EnumIter,
+)]
 pub enum ZoneKind {
     BoundaryNtp,
     Clickhouse,
@@ -453,7 +456,7 @@ impl ZoneKind {
             ZoneKind::BoundaryNtp | ZoneKind::InternalNtp => Self::NTP_PREFIX,
             ZoneKind::Clickhouse => "clickhouse",
             ZoneKind::ClickhouseKeeper => "clickhouse-keeper",
-            ZoneKind::ClickhouseServer => "clickhouse_server",
+            ZoneKind::ClickhouseServer => "clickhouse-server",
             // Note "cockroach" for historical reasons.
             ZoneKind::CockroachDb => "cockroach",
             ZoneKind::Crucible => "crucible",
@@ -483,6 +486,27 @@ impl ZoneKind {
             ZoneKind::InternalNtp => "internal_ntp",
             ZoneKind::Nexus => "nexus",
             ZoneKind::Oximeter => "oximeter",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use omicron_common::api::external::Name;
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    #[test]
+    fn test_name_prefixes() {
+        for zone_kind in ZoneKind::iter() {
+            let name_prefix = zone_kind.name_prefix();
+            name_prefix.parse::<Name>().unwrap_or_else(|e| {
+                panic!(
+                    "failed to parse name prefix {:?} for zone kind {:?}: {}",
+                    name_prefix, zone_kind, e
+                );
+            });
         }
     }
 }


### PR DESCRIPTION
Followup from #6297 -- `name_prefix` requires dashes.