### PR TITLE
[sp-sim] Update README instructions

### DIFF
--- a/sp-sim/README.adoc
+++ b/sp-sim/README.adoc
@@ -13,15 +13,15 @@ Start a simulated sidecar SP:
 
 [source,text]
 ----
-$ cargo run --bin sp-sim -- sp-sim/examples/sidecar.toml
+$ cargo run --bin sp-sim -- sp-sim/examples/config.toml
 ----
 
 Start the MGS (its config file should have an IP/port that matches
-`sidecar.toml` above):
+`config.toml` above):
 
 [source,text]
 ----
-$ cargo run --bin gateway -- gateway/examples/config.toml
+$ cargo run --bin mgs -- run gateway/examples/config.toml --address "[::]:11111" --id $(uuidgen -r)
 ----
 
 Ask MGS for the ignition state of the sole simulated sidecar SP:


### PR DESCRIPTION
The instructions for running MGS currently given in `sp-sim/README.adoc` seem to have bitrotted: the MGS binary is no longer named `gateway`, and is now called `mgs`, and it now requires `--address <IPv6 addr>` and `--id <UUID>` arguments as well.

Furthermore, the config file provided with the SP simulator is now called `config.toml`, rather than `sidecar.toml`; as it contains configurations for both a simulated Sidecar *and* two simulated Gimlets.

This commit updates the instructions in the README to match the current reality.