### PR TITLE
BUGFIX: 6316 - be more specific when checking `allow_export_list_active`

### DIFF
--- a/nexus/db-model/src/switch_port.rs
+++ b/nexus/db-model/src/switch_port.rs
@@ -642,9 +642,13 @@ pub struct SwitchPortBgpPeerConfigCommunity {
 )]
 #[diesel(table_name = switch_port_settings_bgp_peer_config_allow_export)]
 pub struct SwitchPortBgpPeerConfigAllowExport {
+    /// Parent switch port configuration
     pub port_settings_id: Uuid,
+    /// Interface peer is reachable on
     pub interface_name: String,
+    /// Peer Address
     pub addr: IpNetwork,
+    /// Allowed Prefix
     pub prefix: IpNetwork,
 }
 
@@ -660,9 +664,13 @@ pub struct SwitchPortBgpPeerConfigAllowExport {
 )]
 #[diesel(table_name = switch_port_settings_bgp_peer_config_allow_import)]
 pub struct SwitchPortBgpPeerConfigAllowImport {
+    /// Parent switch port configuration
     pub port_settings_id: Uuid,
+    /// Interface peer is reachable on
     pub interface_name: String,
+    /// Peer Address
     pub addr: IpNetwork,
+    /// Allowed Prefix
     pub prefix: IpNetwork,
 }
 

--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -606,6 +606,7 @@ impl DataStore {
             .transaction(&conn, |conn| async move {
                 let active = peer_dsl::switch_port_settings_bgp_peer_config
                     .filter(db_peer::port_settings_id.eq(port_settings_id))
+                    .filter(db_peer::addr.eq(addr))
                     .select(db_peer::allow_export_list_active)
                     .limit(1)
                     .first_async::<bool>(&conn)
@@ -652,6 +653,7 @@ impl DataStore {
             .transaction(&conn, |conn| async move {
                 let active = peer_dsl::switch_port_settings_bgp_peer_config
                     .filter(db_peer::port_settings_id.eq(port_settings_id))
+                    .filter(db_peer::addr.eq(addr))
                     .select(db_peer::allow_import_list_active)
                     .limit(1)
                     .first_async::<bool>(&conn)


### PR DESCRIPTION
This change updates the queries to lookup peers by `switch_port_settings_id` AND peer `address` when checking `allow_export_list_active` column.

Related
---
#6316 