### PR TITLE
add external API to resize a stopped instance

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -649,6 +649,28 @@ impl super::Nexus {
         self.db_datastore.instance_fetch_with_vmm(opctx, &authz_instance).await
     }
 
+    /// Resizes the requested instance.
+    pub(crate) async fn instance_resize(
+        &self,
+        opctx: &OpContext,
+        instance_lookup: &lookup::Instance<'_>,
+        new_size: params::InstanceResize,
+    ) -> UpdateResult<InstanceAndActiveVmm> {
+        let (.., authz_instance) =
+            instance_lookup.lookup_for(authz::Action::Modify).await?;
+
+        self.db_datastore
+            .instance_resize(
+                opctx,
+                InstanceUuid::from_untyped_uuid(authz_instance.id()),
+                new_size.ncpus.into(),
+                new_size.memory.into(),
+            )
+            .await?;
+
+        self.db_datastore.instance_fetch_with_vmm(opctx, &authz_instance).await
+    }
+
     /// Idempotently ensures that the sled specified in `db_instance` does not
     /// have a record of the instance. If the instance is currently running on
     /// this sled, this operation rudely terminates it.

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2870,7 +2870,7 @@ async fn instance_delete(
 /// Resize instance
 #[endpoint {
     method = PUT,
-    path = "/v1/instances/{instance}",
+    path = "/v1/instances/{instance}/resize",
     tags = ["instances"],
 }]
 async fn instance_resize(

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -359,6 +359,12 @@ pub static DEMO_INSTANCE_REBOOT_URL: Lazy<String> = Lazy::new(|| {
         *DEMO_INSTANCE_NAME, *DEMO_PROJECT_SELECTOR
     )
 });
+pub static DEMO_INSTANCE_RESIZE_URL: Lazy<String> = Lazy::new(|| {
+    format!(
+        "/v1/instances/{}/resize?{}",
+        *DEMO_INSTANCE_NAME, *DEMO_PROJECT_SELECTOR
+    )
+});
 pub static DEMO_INSTANCE_MIGRATE_URL: Lazy<String> = Lazy::new(|| {
     format!(
         "/v1/instances/{}/migrate?{}",
@@ -1821,6 +1827,17 @@ pub static VERIFY_ENDPOINTS: Lazy<Vec<VerifyEndpoint>> = Lazy::new(|| {
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Post(serde_json::Value::Null)
+            ],
+        },
+        VerifyEndpoint {
+            url: &DEMO_INSTANCE_RESIZE_URL,
+            visibility: Visibility::Protected,
+            unprivileged_access: UnprivilegedAccess::None,
+            allowed_methods: vec![
+                AllowedMethod::Put(serde_json::to_value(params::InstanceResize {
+                    ncpus: InstanceCpuCount(1), 
+                    memory: ByteCount::from_gibibytes_u32(1)
+                }).unwrap())
             ],
         },
         VerifyEndpoint {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1835,7 +1835,7 @@ pub static VERIFY_ENDPOINTS: Lazy<Vec<VerifyEndpoint>> = Lazy::new(|| {
             unprivileged_access: UnprivilegedAccess::None,
             allowed_methods: vec![
                 AllowedMethod::Put(serde_json::to_value(params::InstanceResize {
-                    ncpus: InstanceCpuCount(1), 
+                    ncpus: InstanceCpuCount(1),
                     memory: ByteCount::from_gibibytes_u32(1)
                 }).unwrap())
             ],

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -58,6 +58,7 @@ instance_network_interface_list          GET      /v1/network-interfaces
 instance_network_interface_update        PUT      /v1/network-interfaces/{interface}
 instance_network_interface_view          GET      /v1/network-interfaces/{interface}
 instance_reboot                          POST     /v1/instances/{instance}/reboot
+instance_resize                          PUT      /v1/instances/{instance}
 instance_serial_console                  GET      /v1/instances/{instance}/serial-console
 instance_serial_console_stream           GET      /v1/instances/{instance}/serial-console/stream
 instance_ssh_public_key_list             GET      /v1/instances/{instance}/ssh-public-keys

--- a/nexus/tests/output/nexus_tags.txt
+++ b/nexus/tests/output/nexus_tags.txt
@@ -58,7 +58,7 @@ instance_network_interface_list          GET      /v1/network-interfaces
 instance_network_interface_update        PUT      /v1/network-interfaces/{interface}
 instance_network_interface_view          GET      /v1/network-interfaces/{interface}
 instance_reboot                          POST     /v1/instances/{instance}/reboot
-instance_resize                          PUT      /v1/instances/{instance}
+instance_resize                          PUT      /v1/instances/{instance}/resize
 instance_serial_console                  GET      /v1/instances/{instance}/serial-console
 instance_serial_console_stream           GET      /v1/instances/{instance}/serial-console/stream
 instance_ssh_public_key_list             GET      /v1/instances/{instance}/ssh-public-keys

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1093,6 +1093,16 @@ impl JsonSchema for UserData {
     }
 }
 
+/// Parameters for resizing an instance.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceResize {
+    /// The number of CPUs to assign to this instance.
+    pub ncpus: InstanceCpuCount,
+
+    /// The amount of memory to assign to this instance.
+    pub memory: ByteCount,
+}
+
 /// Migration parameters for an `Instance`
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceMigrate {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1911,6 +1911,60 @@
           }
         }
       },
+      "put": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Resize instance",
+        "operationId": "instance_resize",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instance",
+            "description": "Name or ID of the instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceResize"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "delete": {
         "tags": [
           "instances"
@@ -15518,6 +15572,32 @@
             }
           }
         }
+      },
+      "InstanceResize": {
+        "description": "Parameters for resizing an instance.",
+        "type": "object",
+        "properties": {
+          "memory": {
+            "description": "The amount of memory to assign to this instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "ncpus": {
+            "description": "The number of CPUs to assign to this instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCpuCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "memory",
+          "ncpus"
+        ]
       },
       "InstanceResultsPage": {
         "description": "A single page of results",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -1911,60 +1911,6 @@
           }
         }
       },
-      "put": {
-        "tags": [
-          "instances"
-        ],
-        "summary": "Resize instance",
-        "operationId": "instance_resize",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "project",
-            "description": "Name or ID of the project",
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          },
-          {
-            "in": "path",
-            "name": "instance",
-            "description": "Name or ID of the instance",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceResize"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Instance"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
       "delete": {
         "tags": [
           "instances"
@@ -2415,6 +2361,62 @@
         "responses": {
           "202": {
             "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/instances/{instance}/resize": {
+      "put": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Resize instance",
+        "operationId": "instance_resize",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "project",
+            "description": "Name or ID of the project",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instance",
+            "description": "Name or ID of the instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceResize"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Add an API to change the CPU/memory sizes for an existing instance (provided it's halted--no CPU hot-add or hot-remove for now, sorry).

Putting this in draft for now since I still want to manually test it (and I'd also like to refine the integration tests a bit).

Fixes #3769.