### PR TITLE
[sled-agent] make sled-agent-sim implement the sled-agent API trait

### DIFF
--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -84,7 +84,7 @@ impl SledAgentApi for SledAgentSimImpl {
     type Context = Arc<SledAgent>;
 
     async fn instance_register(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
         body: TypedBody<InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
@@ -105,7 +105,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_unregister(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
     ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
         let sa = rqctx.context();
@@ -114,7 +114,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_put_state(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
         body: TypedBody<InstancePutStateBody>,
     ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
@@ -127,7 +127,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_get_state(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
         let sa = rqctx.context();
@@ -136,7 +136,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_put_external_ip(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
@@ -148,7 +148,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_delete_external_ip(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstancePathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
@@ -160,7 +160,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn disk_put(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<DiskPathParam>,
         body: TypedBody<DiskEnsureBody>,
     ) -> Result<HttpResponseOk<DiskRuntimeState>, HttpError> {
@@ -178,7 +178,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn update_artifact(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         artifact: TypedBody<UpdateArtifactId>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
@@ -193,7 +193,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn instance_issue_disk_snapshot_request(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
         body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
     ) -> Result<
@@ -218,7 +218,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn vpc_firewall_rules_put(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         path_params: Path<VpcPathParam>,
         body: TypedBody<VpcFirewallRulesEnsureBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
@@ -230,7 +230,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn set_v2p(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<VirtualNetworkInterfaceHost>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
@@ -244,7 +244,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn del_v2p(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<VirtualNetworkInterfaceHost>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
@@ -258,7 +258,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn list_v2p(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<Vec<VirtualNetworkInterfaceHost>>, HttpError>
     {
         let sa = rqctx.context();
@@ -269,14 +269,14 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn uplink_ensure(
-        _rqctx: RequestContext<Arc<SledAgent>>,
+        _rqctx: RequestContext<Self::Context>,
         _body: TypedBody<SwitchPorts>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         Ok(HttpResponseUpdatedNoContent())
     }
 
     async fn read_network_bootstore_config_cache(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<EarlyNetworkConfig>, HttpError> {
         let config =
             rqctx.context().bootstore_network_config.lock().await.clone();
@@ -284,7 +284,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn write_network_bootstore_config(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<EarlyNetworkConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let mut config = rqctx.context().bootstore_network_config.lock().await;
@@ -294,7 +294,7 @@ impl SledAgentApi for SledAgentSimImpl {
 
     /// Fetch basic information about this sled
     async fn inventory(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<Inventory>, HttpError> {
         let sa = rqctx.context();
         Ok(HttpResponseOk(
@@ -305,7 +305,7 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn omicron_physical_disks_put(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<OmicronPhysicalDisksConfig>,
     ) -> Result<HttpResponseOk<DisksManagementResult>, HttpError> {
         let sa = rqctx.context();
@@ -315,21 +315,21 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn omicron_physical_disks_get(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<OmicronPhysicalDisksConfig>, HttpError> {
         let sa = rqctx.context();
         Ok(HttpResponseOk(sa.omicron_physical_disks_list().await?))
     }
 
     async fn omicron_zones_get(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<OmicronZonesConfig>, HttpError> {
         let sa = rqctx.context();
         Ok(HttpResponseOk(sa.omicron_zones_list().await))
     }
 
     async fn omicron_zones_put(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<OmicronZonesConfig>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
@@ -339,21 +339,21 @@ impl SledAgentApi for SledAgentSimImpl {
     }
 
     async fn sled_add(
-        _rqctx: RequestContext<Arc<SledAgent>>,
+        _rqctx: RequestContext<Self::Context>,
         _body: TypedBody<AddSledRequest>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         Ok(HttpResponseUpdatedNoContent())
     }
 
     async fn list_vpc_routes(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<Vec<ResolvedVpcRouteState>>, HttpError> {
         let sa = rqctx.context();
         Ok(HttpResponseOk(sa.list_vpc_routes().await))
     }
 
     async fn set_vpc_routes(
-        rqctx: RequestContext<Arc<SledAgent>>,
+        rqctx: RequestContext<Self::Context>,
         body: TypedBody<Vec<ResolvedVpcRouteSet>>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -5,18 +5,27 @@
 //! HTTP entrypoint functions for the sled agent's exposed API
 
 use super::collection::PokeMode;
+use camino::Utf8PathBuf;
+use dropshot::endpoint;
 use dropshot::ApiDescription;
+use dropshot::FreeformBody;
 use dropshot::HttpError;
+use dropshot::HttpResponseCreated;
+use dropshot::HttpResponseDeleted;
+use dropshot::HttpResponseHeaders;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::Path;
+use dropshot::Query;
 use dropshot::RequestContext;
+use dropshot::StreamingBody;
 use dropshot::TypedBody;
-use dropshot::{endpoint, ApiDescriptionRegisterError};
+use nexus_sled_agent_shared::inventory::SledRole;
 use nexus_sled_agent_shared::inventory::{Inventory, OmicronZonesConfig};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::SledInstanceState;
 use omicron_common::api::internal::nexus::UpdateArtifactId;
+use omicron_common::api::internal::shared::SledIdentifiers;
 use omicron_common::api::internal::shared::VirtualNetworkInterfaceHost;
 use omicron_common::api::internal::shared::{
     ResolvedVpcRouteSet, ResolvedVpcRouteState, SwitchPorts,
@@ -24,8 +33,12 @@ use omicron_common::api::internal::shared::{
 use omicron_common::disk::DisksManagementResult;
 use omicron_common::disk::OmicronPhysicalDisksConfig;
 use omicron_uuid_kinds::{GenericUuid, InstanceUuid};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use sled_agent_api::*;
+use sled_agent_types::boot_disk::BootDiskOsWriteStatus;
+use sled_agent_types::boot_disk::BootDiskPathParams;
+use sled_agent_types::boot_disk::BootDiskUpdatePathParams;
+use sled_agent_types::boot_disk::BootDiskWriteStartQueryParams;
+use sled_agent_types::bootstore::BootstoreStatus;
 use sled_agent_types::disk::DiskEnsureBody;
 use sled_agent_types::early_networking::EarlyNetworkConfig;
 use sled_agent_types::firewall_rules::VpcFirewallRulesEnsureBody;
@@ -35,8 +48,14 @@ use sled_agent_types::instance::InstancePutStateBody;
 use sled_agent_types::instance::InstancePutStateResponse;
 use sled_agent_types::instance::InstanceUnregisterResponse;
 use sled_agent_types::sled::AddSledRequest;
+use sled_agent_types::time_sync::TimeSync;
+use sled_agent_types::zone_bundle::BundleUtilization;
+use sled_agent_types::zone_bundle::CleanupContext;
+use sled_agent_types::zone_bundle::CleanupCount;
+use sled_agent_types::zone_bundle::ZoneBundleId;
+use sled_agent_types::zone_bundle::ZoneBundleMetadata;
+use std::collections::BTreeMap;
 use std::sync::Arc;
-use uuid::Uuid;
 
 use super::sled_agent::SledAgent;
 
@@ -44,153 +63,452 @@ type SledApiDescription = ApiDescription<Arc<SledAgent>>;
 
 /// Returns a description of the sled agent API
 pub fn api() -> SledApiDescription {
-    fn register_endpoints(
-        api: &mut SledApiDescription,
-    ) -> Result<(), ApiDescriptionRegisterError> {
-        api.register(instance_put_state)?;
-        api.register(instance_get_state)?;
-        api.register(instance_register)?;
-        api.register(instance_unregister)?;
-        api.register(instance_put_external_ip)?;
-        api.register(instance_delete_external_ip)?;
+    fn register_endpoints() -> Result<SledApiDescription, anyhow::Error> {
+        let mut api = sled_agent_api::sled_agent_api_mod::api_description::<
+            SledAgentSimImpl,
+        >()?;
         api.register(instance_poke_post)?;
         api.register(instance_poke_single_step_post)?;
         api.register(instance_post_sim_migration_source)?;
-        api.register(disk_put)?;
         api.register(disk_poke_post)?;
-        api.register(update_artifact)?;
-        api.register(instance_issue_disk_snapshot_request)?;
-        api.register(vpc_firewall_rules_put)?;
-        api.register(set_v2p)?;
-        api.register(del_v2p)?;
-        api.register(list_v2p)?;
-        api.register(uplink_ensure)?;
-        api.register(read_network_bootstore_config)?;
-        api.register(write_network_bootstore_config)?;
-        api.register(inventory)?;
-        api.register(omicron_physical_disks_get)?;
-        api.register(omicron_physical_disks_put)?;
-        api.register(omicron_zones_get)?;
-        api.register(omicron_zones_put)?;
-        api.register(sled_add)?;
-        api.register(list_vpc_routes)?;
-        api.register(set_vpc_routes)?;
 
-        Ok(())
+        Ok(api)
     }
 
-    let mut api = SledApiDescription::new();
-    if let Err(err) = register_endpoints(&mut api) {
-        panic!("failed to register entrypoints: {}", err);
+    register_endpoints().expect("failed to register entrypoints")
+}
+
+enum SledAgentSimImpl {}
+
+impl SledAgentApi for SledAgentSimImpl {
+    type Context = Arc<SledAgent>;
+
+    async fn instance_register(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+        body: TypedBody<InstanceEnsureBody>,
+    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        let body_args = body.into_inner();
+        Ok(HttpResponseOk(
+            sa.instance_register(
+                instance_id,
+                body_args.propolis_id,
+                body_args.hardware,
+                body_args.instance_runtime,
+                body_args.vmm_runtime,
+                body_args.metadata,
+            )
+            .await?,
+        ))
     }
-    api
-}
 
-/// Path parameters for Instance requests (sled agent API)
-#[derive(Deserialize, JsonSchema)]
-struct InstancePathParam {
-    instance_id: InstanceUuid,
-}
+    async fn instance_unregister(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+    ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        Ok(HttpResponseOk(sa.instance_unregister(instance_id).await?))
+    }
 
-#[endpoint {
-    method = PUT,
-    path = "/instances/{instance_id}",
-}]
-async fn instance_register(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-    body: TypedBody<InstanceEnsureBody>,
-) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    let body_args = body.into_inner();
-    Ok(HttpResponseOk(
-        sa.instance_register(
-            instance_id,
-            body_args.propolis_id,
-            body_args.hardware,
-            body_args.instance_runtime,
-            body_args.vmm_runtime,
-            body_args.metadata,
+    async fn instance_put_state(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+        body: TypedBody<InstancePutStateBody>,
+    ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        let body_args = body.into_inner();
+        Ok(HttpResponseOk(
+            sa.instance_ensure_state(instance_id, body_args.state).await?,
+        ))
+    }
+
+    async fn instance_get_state(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        Ok(HttpResponseOk(sa.instance_get_state(instance_id).await?))
+    }
+
+    async fn instance_put_external_ip(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+        body: TypedBody<InstanceExternalIpBody>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        let body_args = body.into_inner();
+        sa.instance_put_external_ip(instance_id, &body_args).await?;
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn instance_delete_external_ip(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstancePathParam>,
+        body: TypedBody<InstanceExternalIpBody>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        let instance_id = path_params.into_inner().instance_id;
+        let body_args = body.into_inner();
+        sa.instance_delete_external_ip(instance_id, &body_args).await?;
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn disk_put(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<DiskPathParam>,
+        body: TypedBody<DiskEnsureBody>,
+    ) -> Result<HttpResponseOk<DiskRuntimeState>, HttpError> {
+        let sa = rqctx.context();
+        let disk_id = path_params.into_inner().disk_id;
+        let body_args = body.into_inner();
+        Ok(HttpResponseOk(
+            sa.disk_ensure(
+                disk_id,
+                body_args.initial_runtime.clone(),
+                body_args.target.clone(),
+            )
+            .await?,
+        ))
+    }
+
+    async fn update_artifact(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        artifact: TypedBody<UpdateArtifactId>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        sa.updates()
+            .download_artifact(
+                artifact.into_inner(),
+                rqctx.context().nexus_client.as_ref(),
+            )
+            .await
+            .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn instance_issue_disk_snapshot_request(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
+        body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
+    ) -> Result<
+        HttpResponseOk<InstanceIssueDiskSnapshotRequestResponse>,
+        HttpError,
+    > {
+        let sa = rqctx.context();
+        let path_params = path_params.into_inner();
+        let body = body.into_inner();
+
+        sa.instance_issue_disk_snapshot_request(
+            InstanceUuid::from_untyped_uuid(path_params.instance_id),
+            path_params.disk_id,
+            body.snapshot_id,
         )
-        .await?,
-    ))
+        .await
+        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+        Ok(HttpResponseOk(InstanceIssueDiskSnapshotRequestResponse {
+            snapshot_id: body.snapshot_id,
+        }))
+    }
+
+    async fn vpc_firewall_rules_put(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        path_params: Path<VpcPathParam>,
+        body: TypedBody<VpcFirewallRulesEnsureBody>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let _sa = rqctx.context();
+        let _vpc_id = path_params.into_inner().vpc_id;
+        let _body_args = body.into_inner();
+
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn set_v2p(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<VirtualNetworkInterfaceHost>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        let body_args = body.into_inner();
+
+        sa.set_virtual_nic_host(&body_args)
+            .await
+            .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn del_v2p(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<VirtualNetworkInterfaceHost>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        let body_args = body.into_inner();
+
+        sa.unset_virtual_nic_host(&body_args)
+            .await
+            .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn list_v2p(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<Vec<VirtualNetworkInterfaceHost>>, HttpError>
+    {
+        let sa = rqctx.context();
+
+        let vnics = sa.list_virtual_nics().await.map_err(HttpError::from)?;
+
+        Ok(HttpResponseOk(vnics))
+    }
+
+    async fn uplink_ensure(
+        _rqctx: RequestContext<Arc<SledAgent>>,
+        _body: TypedBody<SwitchPorts>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn read_network_bootstore_config_cache(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<EarlyNetworkConfig>, HttpError> {
+        let config =
+            rqctx.context().bootstore_network_config.lock().await.clone();
+        Ok(HttpResponseOk(config))
+    }
+
+    async fn write_network_bootstore_config(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<EarlyNetworkConfig>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let mut config = rqctx.context().bootstore_network_config.lock().await;
+        *config = body.into_inner();
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    /// Fetch basic information about this sled
+    async fn inventory(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<Inventory>, HttpError> {
+        let sa = rqctx.context();
+        Ok(HttpResponseOk(
+            sa.inventory(rqctx.server.local_addr).await.map_err(|e| {
+                HttpError::for_internal_error(format!("{:#}", e))
+            })?,
+        ))
+    }
+
+    async fn omicron_physical_disks_put(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<OmicronPhysicalDisksConfig>,
+    ) -> Result<HttpResponseOk<DisksManagementResult>, HttpError> {
+        let sa = rqctx.context();
+        let body_args = body.into_inner();
+        let result = sa.omicron_physical_disks_ensure(body_args).await?;
+        Ok(HttpResponseOk(result))
+    }
+
+    async fn omicron_physical_disks_get(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<OmicronPhysicalDisksConfig>, HttpError> {
+        let sa = rqctx.context();
+        Ok(HttpResponseOk(sa.omicron_physical_disks_list().await?))
+    }
+
+    async fn omicron_zones_get(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<OmicronZonesConfig>, HttpError> {
+        let sa = rqctx.context();
+        Ok(HttpResponseOk(sa.omicron_zones_list().await))
+    }
+
+    async fn omicron_zones_put(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<OmicronZonesConfig>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        let body_args = body.into_inner();
+        sa.omicron_zones_ensure(body_args).await;
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn sled_add(
+        _rqctx: RequestContext<Arc<SledAgent>>,
+        _body: TypedBody<AddSledRequest>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    async fn list_vpc_routes(
+        rqctx: RequestContext<Arc<SledAgent>>,
+    ) -> Result<HttpResponseOk<Vec<ResolvedVpcRouteState>>, HttpError> {
+        let sa = rqctx.context();
+        Ok(HttpResponseOk(sa.list_vpc_routes().await))
+    }
+
+    async fn set_vpc_routes(
+        rqctx: RequestContext<Arc<SledAgent>>,
+        body: TypedBody<Vec<ResolvedVpcRouteSet>>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let sa = rqctx.context();
+        sa.set_vpc_routes(body.into_inner()).await;
+        Ok(HttpResponseUpdatedNoContent())
+    }
+
+    // --- Unimplemented endpoints ---
+
+    async fn zone_bundle_list_all(
+        _rqctx: RequestContext<Self::Context>,
+        _query: Query<ZoneBundleFilter>,
+    ) -> Result<HttpResponseOk<Vec<ZoneBundleMetadata>>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_list(
+        _rqctx: RequestContext<Self::Context>,
+        _params: Path<ZonePathParam>,
+    ) -> Result<HttpResponseOk<Vec<ZoneBundleMetadata>>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_create(
+        _rqctx: RequestContext<Self::Context>,
+        _params: Path<ZonePathParam>,
+    ) -> Result<HttpResponseCreated<ZoneBundleMetadata>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_get(
+        _rqctx: RequestContext<Self::Context>,
+        _params: Path<ZoneBundleId>,
+    ) -> Result<HttpResponseHeaders<HttpResponseOk<FreeformBody>>, HttpError>
+    {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_delete(
+        _rqctx: RequestContext<Self::Context>,
+        _params: Path<ZoneBundleId>,
+    ) -> Result<HttpResponseDeleted, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_utilization(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<
+        HttpResponseOk<BTreeMap<Utf8PathBuf, BundleUtilization>>,
+        HttpError,
+    > {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_cleanup_context(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<CleanupContext>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_cleanup_context_update(
+        _rqctx: RequestContext<Self::Context>,
+        _body: TypedBody<CleanupContextUpdate>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zone_bundle_cleanup(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<BTreeMap<Utf8PathBuf, CleanupCount>>, HttpError>
+    {
+        method_unimplemented()
+    }
+
+    async fn zones_list(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<Vec<String>>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn zpools_get(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<Vec<Zpool>>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn sled_role_get(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<SledRole>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn cockroachdb_init(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn timesync_get(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<TimeSync>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn host_os_write_start(
+        _rqctx: RequestContext<Self::Context>,
+        _path_params: Path<BootDiskPathParams>,
+        _query_params: Query<BootDiskWriteStartQueryParams>,
+        _body: StreamingBody,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn host_os_write_status_get(
+        _rqctx: RequestContext<Self::Context>,
+        _path_params: Path<BootDiskPathParams>,
+    ) -> Result<HttpResponseOk<BootDiskOsWriteStatus>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn host_os_write_status_delete(
+        _rqctx: RequestContext<Self::Context>,
+        _path_params: Path<BootDiskUpdatePathParams>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn sled_identifiers(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<SledIdentifiers>, HttpError> {
+        method_unimplemented()
+    }
+
+    async fn bootstore_status(
+        _rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<BootstoreStatus>, HttpError> {
+        method_unimplemented()
+    }
 }
 
-#[endpoint {
-    method = DELETE,
-    path = "/instances/{instance_id}",
-}]
-async fn instance_unregister(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    Ok(HttpResponseOk(sa.instance_unregister(instance_id).await?))
+fn method_unimplemented<T>() -> Result<T, HttpError> {
+    Err(HttpError {
+        // Use a client error here (405 Method Not Allowed vs 501 Not
+        // Implemented) even though it isn't strictly accurate here, so tests
+        // get to see the error message.
+        status_code: http::StatusCode::METHOD_NOT_ALLOWED,
+        error_code: None,
+        external_message: "Method not implemented in sled-agent-sim"
+            .to_string(),
+        internal_message: "Method not implemented in sled-agent-sim"
+            .to_string(),
+    })
 }
 
-#[endpoint {
-    method = PUT,
-    path = "/instances/{instance_id}/state",
-}]
-async fn instance_put_state(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-    body: TypedBody<InstancePutStateBody>,
-) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    let body_args = body.into_inner();
-    Ok(HttpResponseOk(
-        sa.instance_ensure_state(instance_id, body_args.state).await?,
-    ))
-}
-
-#[endpoint {
-    method = GET,
-    path = "/instances/{instance_id}/state",
-}]
-async fn instance_get_state(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    Ok(HttpResponseOk(sa.instance_get_state(instance_id).await?))
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/instances/{instance_id}/external-ip",
-}]
-async fn instance_put_external_ip(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-    body: TypedBody<InstanceExternalIpBody>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    let body_args = body.into_inner();
-    sa.instance_put_external_ip(instance_id, &body_args).await?;
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[endpoint {
-    method = DELETE,
-    path = "/instances/{instance_id}/external-ip",
-}]
-async fn instance_delete_external_ip(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
-    body: TypedBody<InstanceExternalIpBody>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    let body_args = body.into_inner();
-    sa.instance_delete_external_ip(instance_id, &body_args).await?;
-    Ok(HttpResponseUpdatedNoContent())
-}
+// --- Extra endpoints only available in the sim implementation ---
 
 #[endpoint {
     method = POST,
@@ -236,34 +554,6 @@ async fn instance_post_sim_migration_source(
     Ok(HttpResponseUpdatedNoContent())
 }
 
-/// Path parameters for Disk requests (sled agent API)
-#[derive(Deserialize, JsonSchema)]
-struct DiskPathParam {
-    disk_id: Uuid,
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/disks/{disk_id}",
-}]
-async fn disk_put(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<DiskPathParam>,
-    body: TypedBody<DiskEnsureBody>,
-) -> Result<HttpResponseOk<DiskRuntimeState>, HttpError> {
-    let sa = rqctx.context();
-    let disk_id = path_params.into_inner().disk_id;
-    let body_args = body.into_inner();
-    Ok(HttpResponseOk(
-        sa.disk_ensure(
-            disk_id,
-            body_args.initial_runtime.clone(),
-            body_args.target.clone(),
-        )
-        .await?,
-    ))
-}
-
 #[endpoint {
     method = POST,
     path = "/disks/{disk_id}/poke",
@@ -275,279 +565,5 @@ async fn disk_poke_post(
     let sa = rqctx.context();
     let disk_id = path_params.into_inner().disk_id;
     sa.disk_poke(disk_id).await;
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[endpoint {
-    method = POST,
-    path = "/update"
-}]
-async fn update_artifact(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    artifact: TypedBody<UpdateArtifactId>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    sa.updates()
-        .download_artifact(
-            artifact.into_inner(),
-            rqctx.context().nexus_client.as_ref(),
-        )
-        .await
-        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[derive(Deserialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestPathParam {
-    instance_id: Uuid,
-    disk_id: Uuid,
-}
-
-#[derive(Deserialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestBody {
-    snapshot_id: Uuid,
-}
-
-#[derive(Serialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestResponse {
-    snapshot_id: Uuid,
-}
-
-/// Take a snapshot of a disk that is attached to an instance
-#[endpoint {
-    method = POST,
-    path = "/instances/{instance_id}/disks/{disk_id}/snapshot",
-}]
-async fn instance_issue_disk_snapshot_request(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
-    body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
-) -> Result<HttpResponseOk<InstanceIssueDiskSnapshotRequestResponse>, HttpError>
-{
-    let sa = rqctx.context();
-    let path_params = path_params.into_inner();
-    let body = body.into_inner();
-
-    sa.instance_issue_disk_snapshot_request(
-        InstanceUuid::from_untyped_uuid(path_params.instance_id),
-        path_params.disk_id,
-        body.snapshot_id,
-    )
-    .await
-    .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-
-    Ok(HttpResponseOk(InstanceIssueDiskSnapshotRequestResponse {
-        snapshot_id: body.snapshot_id,
-    }))
-}
-
-/// Path parameters for VPC requests (sled agent API)
-#[derive(Deserialize, JsonSchema)]
-struct VpcPathParam {
-    vpc_id: Uuid,
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/vpc/{vpc_id}/firewall/rules",
-}]
-async fn vpc_firewall_rules_put(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<VpcPathParam>,
-    body: TypedBody<VpcFirewallRulesEnsureBody>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let _sa = rqctx.context();
-    let _vpc_id = path_params.into_inner().vpc_id;
-    let _body_args = body.into_inner();
-
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-/// Create a mapping from a virtual NIC to a physical host
-#[endpoint {
-    method = PUT,
-    path = "/v2p/",
-}]
-async fn set_v2p(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<VirtualNetworkInterfaceHost>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    let body_args = body.into_inner();
-
-    sa.set_virtual_nic_host(&body_args)
-        .await
-        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-/// Delete a mapping from a virtual NIC to a physical host
-#[endpoint {
-    method = DELETE,
-    path = "/v2p/",
-}]
-async fn del_v2p(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<VirtualNetworkInterfaceHost>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    let body_args = body.into_inner();
-
-    sa.unset_virtual_nic_host(&body_args)
-        .await
-        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-/// List v2p mappings present on sled
-#[endpoint {
-    method = GET,
-    path = "/v2p/",
-}]
-async fn list_v2p(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<Vec<VirtualNetworkInterfaceHost>>, HttpError> {
-    let sa = rqctx.context();
-
-    let vnics = sa.list_virtual_nics().await.map_err(HttpError::from)?;
-
-    Ok(HttpResponseOk(vnics))
-}
-
-#[endpoint {
-    method = POST,
-    path = "/switch-ports",
-}]
-async fn uplink_ensure(
-    _rqctx: RequestContext<Arc<SledAgent>>,
-    _body: TypedBody<SwitchPorts>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[endpoint {
-    method = GET,
-    path = "/network-bootstore-config",
-}]
-async fn read_network_bootstore_config(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<EarlyNetworkConfig>, HttpError> {
-    let config = rqctx.context().bootstore_network_config.lock().await.clone();
-    Ok(HttpResponseOk(config))
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/network-bootstore-config",
-}]
-async fn write_network_bootstore_config(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<EarlyNetworkConfig>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let mut config = rqctx.context().bootstore_network_config.lock().await;
-    *config = body.into_inner();
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-/// Fetch basic information about this sled
-#[endpoint {
-    method = GET,
-    path = "/inventory",
-}]
-async fn inventory(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<Inventory>, HttpError> {
-    let sa = rqctx.context();
-    Ok(HttpResponseOk(
-        sa.inventory(rqctx.server.local_addr)
-            .await
-            .map_err(|e| HttpError::for_internal_error(format!("{:#}", e)))?,
-    ))
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/omicron-physical-disks",
-}]
-async fn omicron_physical_disks_put(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<OmicronPhysicalDisksConfig>,
-) -> Result<HttpResponseOk<DisksManagementResult>, HttpError> {
-    let sa = rqctx.context();
-    let body_args = body.into_inner();
-    let result = sa.omicron_physical_disks_ensure(body_args).await?;
-    Ok(HttpResponseOk(result))
-}
-
-#[endpoint {
-    method = GET,
-    path = "/omicron-physical-disks",
-}]
-async fn omicron_physical_disks_get(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<OmicronPhysicalDisksConfig>, HttpError> {
-    let sa = rqctx.context();
-    Ok(HttpResponseOk(sa.omicron_physical_disks_list().await?))
-}
-
-#[endpoint {
-    method = GET,
-    path = "/omicron-zones",
-}]
-async fn omicron_zones_get(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<OmicronZonesConfig>, HttpError> {
-    let sa = rqctx.context();
-    Ok(HttpResponseOk(sa.omicron_zones_list().await))
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/omicron-zones",
-}]
-async fn omicron_zones_put(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<OmicronZonesConfig>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    let body_args = body.into_inner();
-    sa.omicron_zones_ensure(body_args).await;
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/sleds"
-}]
-async fn sled_add(
-    _rqctx: RequestContext<Arc<SledAgent>>,
-    _body: TypedBody<AddSledRequest>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    Ok(HttpResponseUpdatedNoContent())
-}
-
-#[endpoint {
-    method = GET,
-    path = "/vpc-routes",
-}]
-async fn list_vpc_routes(
-    rqctx: RequestContext<Arc<SledAgent>>,
-) -> Result<HttpResponseOk<Vec<ResolvedVpcRouteState>>, HttpError> {
-    let sa = rqctx.context();
-    Ok(HttpResponseOk(sa.list_vpc_routes().await))
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/vpc-routes",
-}]
-async fn set_vpc_routes(
-    rqctx: RequestContext<Arc<SledAgent>>,
-    body: TypedBody<Vec<ResolvedVpcRouteSet>>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-    let sa = rqctx.context();
-    sa.set_vpc_routes(body.into_inner()).await;
     Ok(HttpResponseUpdatedNoContent())
 }


### PR DESCRIPTION
`sled-agent-sim` is another implementation of the API, so it can be backed by
the same trait, reducing the likelihood of confusion.

I did have to add stub implementations for unimplemented methods, though -- I
think that's okay. (I'd like to address this via the `api_description` macro at
some point.)
