### PR TITLE
fix auto-mismerge of #6294 and #6327

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -968,6 +968,13 @@ task: "region_replacement_driver"
     number of region replacement finish sagas started ok: 0
     number of errors: 0
 
+task: "region_snapshot_replacement_start"
+  configured period: every <REDACTED_DURATION>s
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+    started at <REDACTED     TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+warning: unknown background task: "region_snapshot_replacement_start" (don't know how to interpret details: Object {"errors": Array [], "requests_created_ok": Array [], "start_invoked_ok": Array []})
+
 task: "saga_recovery"
   configured period: every 10m
   currently executing: no


### PR DESCRIPTION
#6327 added a block of `omdb nexus background-tasks show` output to the `omdb` success cases expectorate file.  But that PR was branched prior to #6294, which then landed before it.  #6294 added a new background task, which changes that output.  When #6327 was landed on "main", git saw no conflict, but the expectorate file was wrong and so tests are now failing on "main".  This PR fixes that.