### PR TITLE
[meta] remove profile override for rand_hc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,8 +734,6 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.rand_core]
 opt-level = 3
-[profile.dev.package.rand_hc]
-opt-level = 3
 [profile.dev.package.rand_xorshift]
 opt-level = 3
 [profile.dev.package.rsa]


### PR DESCRIPTION
rand_hc is no longer in our dependency graph. (Thanks @ahl for pointing this out!)
