### PR TITLE
Slim down the ClickHouse database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.10.2-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#52d900a470b8f08eddf021813470b2a9194f2cc0"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#06c8dab40e28d313f8bb0e15e1027eeace3bce89"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.10.2-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#52d900a470b8f08eddf021813470b2a9194f2cc0"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#06c8dab40e28d313f8bb0e15e1027eeace3bce89"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3520,7 +3520,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6415,6 +6415,7 @@ dependencies = [
  "similar",
  "slog",
  "smallvec 1.13.2",
+ "socket2 0.5.7",
  "spin 0.9.8",
  "string_cache",
  "subtle",

--- a/oximeter/db/schema/replicated/10/00_add_last_updated_column_to_fields_i64_local.sql
+++ b/oximeter/db/schema/replicated/10/00_add_last_updated_column_to_fields_i64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/01_materialize_last_updated_column_on_fields_i64_local.sql
+++ b/oximeter/db/schema/replicated/10/01_materialize_last_updated_column_on_fields_i64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/02_add_ttl_to_fields_i64_local.sql
+++ b/oximeter/db/schema/replicated/10/02_add_ttl_to_fields_i64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/03_add_last_updated_column_to_fields_uuid_local.sql
+++ b/oximeter/db/schema/replicated/10/03_add_last_updated_column_to_fields_uuid_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/04_materialize_last_updated_column_on_fields_uuid_local.sql
+++ b/oximeter/db/schema/replicated/10/04_materialize_last_updated_column_on_fields_uuid_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/05_add_ttl_to_fields_uuid_local.sql
+++ b/oximeter/db/schema/replicated/10/05_add_ttl_to_fields_uuid_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/06_add_last_updated_column_to_fields_bool_local.sql
+++ b/oximeter/db/schema/replicated/10/06_add_last_updated_column_to_fields_bool_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/07_materialize_last_updated_column_on_fields_bool_local.sql
+++ b/oximeter/db/schema/replicated/10/07_materialize_last_updated_column_on_fields_bool_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/08_add_ttl_to_fields_bool_local.sql
+++ b/oximeter/db/schema/replicated/10/08_add_ttl_to_fields_bool_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/09_add_last_updated_column_to_fields_ipaddr_local.sql
+++ b/oximeter/db/schema/replicated/10/09_add_last_updated_column_to_fields_ipaddr_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/10_materialize_last_updated_column_on_fields_ipaddr_local.sql
+++ b/oximeter/db/schema/replicated/10/10_materialize_last_updated_column_on_fields_ipaddr_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/11_add_ttl_to_fields_ipaddr_local.sql
+++ b/oximeter/db/schema/replicated/10/11_add_ttl_to_fields_ipaddr_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/12_add_last_updated_column_to_fields_string_local.sql
+++ b/oximeter/db/schema/replicated/10/12_add_last_updated_column_to_fields_string_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/13_materialize_last_updated_column_on_fields_string_local.sql
+++ b/oximeter/db/schema/replicated/10/13_materialize_last_updated_column_on_fields_string_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/14_add_ttl_to_fields_string_local.sql
+++ b/oximeter/db/schema/replicated/10/14_add_ttl_to_fields_string_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/15_add_last_updated_column_to_fields_i8_local.sql
+++ b/oximeter/db/schema/replicated/10/15_add_last_updated_column_to_fields_i8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/16_materialize_last_updated_column_on_fields_i8_local.sql
+++ b/oximeter/db/schema/replicated/10/16_materialize_last_updated_column_on_fields_i8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/17_add_ttl_to_fields_i8_local.sql
+++ b/oximeter/db/schema/replicated/10/17_add_ttl_to_fields_i8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/18_add_last_updated_column_to_fields_u8_local.sql
+++ b/oximeter/db/schema/replicated/10/18_add_last_updated_column_to_fields_u8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/19_materialize_last_updated_column_on_fields_u8_local.sql
+++ b/oximeter/db/schema/replicated/10/19_materialize_last_updated_column_on_fields_u8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/20_add_ttl_to_fields_u8_local.sql
+++ b/oximeter/db/schema/replicated/10/20_add_ttl_to_fields_u8_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/21_add_last_updated_column_to_fields_i16_local.sql
+++ b/oximeter/db/schema/replicated/10/21_add_last_updated_column_to_fields_i16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/22_materialize_last_updated_column_on_fields_i16_local.sql
+++ b/oximeter/db/schema/replicated/10/22_materialize_last_updated_column_on_fields_i16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/23_add_ttl_to_fields_i16_local.sql
+++ b/oximeter/db/schema/replicated/10/23_add_ttl_to_fields_i16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/24_add_last_updated_column_to_fields_u16_local.sql
+++ b/oximeter/db/schema/replicated/10/24_add_last_updated_column_to_fields_u16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/25_materialize_last_updated_column_on_fields_u16_local.sql
+++ b/oximeter/db/schema/replicated/10/25_materialize_last_updated_column_on_fields_u16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/26_add_ttl_to_fields_u16_local.sql
+++ b/oximeter/db/schema/replicated/10/26_add_ttl_to_fields_u16_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/27_add_last_updated_column_to_fields_i32_local.sql
+++ b/oximeter/db/schema/replicated/10/27_add_last_updated_column_to_fields_i32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/28_materialize_last_updated_column_on_fields_i32_local.sql
+++ b/oximeter/db/schema/replicated/10/28_materialize_last_updated_column_on_fields_i32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/29_add_ttl_to_fields_i32_local.sql
+++ b/oximeter/db/schema/replicated/10/29_add_ttl_to_fields_i32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/30_add_last_updated_column_to_fields_u32_local.sql
+++ b/oximeter/db/schema/replicated/10/30_add_last_updated_column_to_fields_u32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/31_materialize_last_updated_column_on_fields_u32_local.sql
+++ b/oximeter/db/schema/replicated/10/31_materialize_last_updated_column_on_fields_u32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/32_add_ttl_to_fields_u32_local.sql
+++ b/oximeter/db/schema/replicated/10/32_add_ttl_to_fields_u32_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/33_add_last_updated_column_to_fields_u64_local.sql
+++ b/oximeter/db/schema/replicated/10/33_add_last_updated_column_to_fields_u64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64_local ON CLUSTER oximeter_cluster ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/replicated/10/34_materialize_last_updated_column_on_fields_u64_local.sql
+++ b/oximeter/db/schema/replicated/10/34_materialize_last_updated_column_on_fields_u64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64_local ON CLUSTER oximeter_cluster MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/replicated/10/35_add_ttl_to_fields_u64_local.sql
+++ b/oximeter/db/schema/replicated/10/35_add_ttl_to_fields_u64_local.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64_local ON CLUSTER oximeter_cluster MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/replicated/10/timeseries-to-delete.txt
+++ b/oximeter/db/schema/replicated/10/timeseries-to-delete.txt
@@ -1,0 +1,1 @@
+http_service:request_latency_histogram

--- a/oximeter/db/schema/replicated/db-init-1.sql
+++ b/oximeter/db/schema/replicated/db-init-1.sql
@@ -78,10 +78,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_i64_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int64
+    field_value Int64,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_i64_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i64 ON CLUSTER oximeter_cluster
 AS oximeter.fields_i64_local
@@ -93,10 +95,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_uuid_local ON CLUSTER oximeter_cluste
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UUID
+    field_value UUID,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_uuid_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_uuid ON CLUSTER oximeter_cluster
 AS oximeter.fields_uuid_local

--- a/oximeter/db/schema/replicated/db-init-2.sql
+++ b/oximeter/db/schema/replicated/db-init-2.sql
@@ -595,10 +595,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_bool_local ON CLUSTER oximeter_cluste
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8
+    field_value UInt8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_bool_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool ON CLUSTER oximeter_cluster
 AS oximeter.fields_bool_local
@@ -609,10 +611,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr_local ON CLUSTER oximeter_clus
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value IPv6
+    field_value IPv6,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_ipaddr_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr ON CLUSTER oximeter_cluster
 AS oximeter.fields_ipaddr_local
@@ -623,10 +627,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_string_local ON CLUSTER oximeter_clus
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value String
+    field_value String,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_string_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_string ON CLUSTER oximeter_cluster
 AS oximeter.fields_string_local
@@ -637,10 +643,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_i8_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int8
+    field_value Int8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_i8_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i8 ON CLUSTER oximeter_cluster
 AS oximeter.fields_i8_local
@@ -651,10 +659,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_u8_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8
+    field_value UInt8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_u8_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u8 ON CLUSTER oximeter_cluster
 AS oximeter.fields_u8_local
@@ -665,10 +675,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_i16_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int16
+    field_value Int16,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_i16_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i16 ON CLUSTER oximeter_cluster
 AS oximeter.fields_i16_local
@@ -679,10 +691,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_u16_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt16
+    field_value UInt16,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_u16_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u16 ON CLUSTER oximeter_cluster
 AS oximeter.fields_u16_local
@@ -693,10 +707,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_i32_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int32
+    field_value Int32,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_i32_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i32 ON CLUSTER oximeter_cluster
 AS oximeter.fields_i32_local
@@ -707,10 +723,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_u32_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt32
+    field_value UInt32,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_u32_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u32 ON CLUSTER oximeter_cluster
 AS oximeter.fields_u32_local
@@ -721,10 +739,12 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_u64_local ON CLUSTER oximeter_cluster
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt64
+    field_value UInt64,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_u64_local', '{replica}')
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u64 ON CLUSTER oximeter_cluster
 AS oximeter.fields_u64_local

--- a/oximeter/db/schema/single-node/10/00_add_last_updated_column_to_fields_bool.sql
+++ b/oximeter/db/schema/single-node/10/00_add_last_updated_column_to_fields_bool.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/01_materialize_last_updated_column_on_fields_bool.sql
+++ b/oximeter/db/schema/single-node/10/01_materialize_last_updated_column_on_fields_bool.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/02_add_ttl_to_fields_bool.sql
+++ b/oximeter/db/schema/single-node/10/02_add_ttl_to_fields_bool.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/03_add_last_updated_column_to_fields_i8.sql
+++ b/oximeter/db/schema/single-node/10/03_add_last_updated_column_to_fields_i8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/04_materialize_last_updated_column_on_fields_i8.sql
+++ b/oximeter/db/schema/single-node/10/04_materialize_last_updated_column_on_fields_i8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/05_add_ttl_to_fields_i8.sql
+++ b/oximeter/db/schema/single-node/10/05_add_ttl_to_fields_i8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i8 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/06_add_last_updated_column_to_fields_u8.sql
+++ b/oximeter/db/schema/single-node/10/06_add_last_updated_column_to_fields_u8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/07_materialize_last_updated_column_on_fields_u8.sql
+++ b/oximeter/db/schema/single-node/10/07_materialize_last_updated_column_on_fields_u8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/08_add_ttl_to_fields_u8.sql
+++ b/oximeter/db/schema/single-node/10/08_add_ttl_to_fields_u8.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u8 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/09_add_last_updated_column_to_fields_i16.sql
+++ b/oximeter/db/schema/single-node/10/09_add_last_updated_column_to_fields_i16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/10_materialize_last_updated_column_on_fields_i16.sql
+++ b/oximeter/db/schema/single-node/10/10_materialize_last_updated_column_on_fields_i16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/11_add_ttl_to_fields_i16.sql
+++ b/oximeter/db/schema/single-node/10/11_add_ttl_to_fields_i16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i16 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/12_add_last_updated_column_to_fields_u16.sql
+++ b/oximeter/db/schema/single-node/10/12_add_last_updated_column_to_fields_u16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/13_materialize_last_updated_column_on_fields_u16.sql
+++ b/oximeter/db/schema/single-node/10/13_materialize_last_updated_column_on_fields_u16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/14_add_ttl_to_fields_u16.sql
+++ b/oximeter/db/schema/single-node/10/14_add_ttl_to_fields_u16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u16 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/15_add_last_updated_column_to_fields_i32.sql
+++ b/oximeter/db/schema/single-node/10/15_add_last_updated_column_to_fields_i32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/16_materialize_last_updated_column_on_fields_i32.sql
+++ b/oximeter/db/schema/single-node/10/16_materialize_last_updated_column_on_fields_i32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/17_add_ttl_to_fields_i32.sql
+++ b/oximeter/db/schema/single-node/10/17_add_ttl_to_fields_i32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i32 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/18_add_last_updated_column_to_fields_u32.sql
+++ b/oximeter/db/schema/single-node/10/18_add_last_updated_column_to_fields_u32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/19_materialize_last_updated_column_on_fields_u32.sql
+++ b/oximeter/db/schema/single-node/10/19_materialize_last_updated_column_on_fields_u32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/20_add_ttl_to_fields_u32.sql
+++ b/oximeter/db/schema/single-node/10/20_add_ttl_to_fields_u32.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u32 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/21_add_last_updated_column_to_fields_i64.sql
+++ b/oximeter/db/schema/single-node/10/21_add_last_updated_column_to_fields_i64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/22_materialize_last_updated_column_on_fields_i64.sql
+++ b/oximeter/db/schema/single-node/10/22_materialize_last_updated_column_on_fields_i64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/23_add_ttl_to_fields_i64.sql
+++ b/oximeter/db/schema/single-node/10/23_add_ttl_to_fields_i64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_i64 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/24_add_last_updated_column_to_fields_u64.sql
+++ b/oximeter/db/schema/single-node/10/24_add_last_updated_column_to_fields_u64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64 ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/25_materialize_last_updated_column_on_fields_u64.sql
+++ b/oximeter/db/schema/single-node/10/25_materialize_last_updated_column_on_fields_u64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64 MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/26_add_ttl_to_fields_u64.sql
+++ b/oximeter/db/schema/single-node/10/26_add_ttl_to_fields_u64.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_u64 MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/27_add_last_updated_column_to_fields_ipaddr.sql
+++ b/oximeter/db/schema/single-node/10/27_add_last_updated_column_to_fields_ipaddr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/28_materialize_last_updated_column_on_fields_ipaddr.sql
+++ b/oximeter/db/schema/single-node/10/28_materialize_last_updated_column_on_fields_ipaddr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/29_add_ttl_to_fields_ipaddr.sql
+++ b/oximeter/db/schema/single-node/10/29_add_ttl_to_fields_ipaddr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_ipaddr MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/30_add_last_updated_column_to_fields_string.sql
+++ b/oximeter/db/schema/single-node/10/30_add_last_updated_column_to_fields_string.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/31_materialize_last_updated_column_on_fields_string.sql
+++ b/oximeter/db/schema/single-node/10/31_materialize_last_updated_column_on_fields_string.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/32_add_ttl_to_fields_string.sql
+++ b/oximeter/db/schema/single-node/10/32_add_ttl_to_fields_string.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_string MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/33_add_last_updated_column_to_fields_uuid.sql
+++ b/oximeter/db/schema/single-node/10/33_add_last_updated_column_to_fields_uuid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid ADD COLUMN IF NOT EXISTS last_updated_at DateTime MATERIALIZED now();

--- a/oximeter/db/schema/single-node/10/34_materialize_last_updated_column_on_fields_uuid.sql
+++ b/oximeter/db/schema/single-node/10/34_materialize_last_updated_column_on_fields_uuid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid MATERIALIZE COLUMN last_updated_at;

--- a/oximeter/db/schema/single-node/10/35_add_ttl_to_fields_uuid.sql
+++ b/oximeter/db/schema/single-node/10/35_add_ttl_to_fields_uuid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_uuid MODIFY TTL last_updated_at + INTERVAL 30 DAY;

--- a/oximeter/db/schema/single-node/10/timeseries-to-delete.txt
+++ b/oximeter/db/schema/single-node/10/timeseries-to-delete.txt
@@ -1,0 +1,1 @@
+http_service:request_latency_histogram

--- a/oximeter/db/schema/single-node/db-init.sql
+++ b/oximeter/db/schema/single-node/db-init.sql
@@ -504,126 +504,158 @@ TTL toDateTime(timestamp) + INTERVAL 30 DAY;
  * timeseries name and then key, since it would improve lookups where one
  * already has the key. Realistically though, these tables are quite small and
  * so performance benefits will be low in absolute terms.
+ *
+ * TTL: We use a materialized column to expire old field table records. This
+ * column is generated automatically by the database whenever a new row is
+ * inserted. It cannot be inserted directly, nor is it returned in a `SELECT *`
+ * query. Since these tables are `ReplacingMergeTree`s, that means the last
+ * record will remain during a deduplication, which will have the last
+ * timestamp. ClickHouse will then expire old data for us, similar to the
+ * measurement tables.
  */
 CREATE TABLE IF NOT EXISTS oximeter.fields_bool
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8
+    field_value UInt8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i8
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int8
+    field_value Int8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u8
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8
+    field_value UInt8,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i16
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int16
+    field_value Int16,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u16
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt16
+    field_value UInt16,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i32
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int32
+    field_value Int32,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u32
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt32
+    field_value UInt32,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_i64
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value Int64
+    field_value Int64,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_u64
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt64
+    field_value UInt64,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_ipaddr
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value IPv6
+    field_value IPv6,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_string
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value String
+    field_value String,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS oximeter.fields_uuid
 (
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UUID
+    field_value UUID,
+    last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()
-ORDER BY (timeseries_name, field_name, field_value, timeseries_key);
+ORDER BY (timeseries_name, field_name, field_value, timeseries_key)
+TTL last_updated_at + INTERVAL 30 DAY;
 
 /* The timeseries schema table stores the extracted schema for the samples
  * oximeter collects.

--- a/oximeter/db/src/model.rs
+++ b/oximeter/db/src/model.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 /// - [`crate::Client::initialize_db_with_version`]
 /// - [`crate::Client::ensure_schema`]
 /// - The `clickhouse-schema-updater` binary in this crate
-pub const OXIMETER_VERSION: u64 = 9;
+pub const OXIMETER_VERSION: u64 = 10;
 
 // Wrapper type to represent a boolean in the database.
 //

--- a/oximeter/oximeter/schema/http-service.toml
+++ b/oximeter/oximeter/schema/http-service.toml
@@ -14,7 +14,7 @@ description = "Duration for the server to handle a request"
 units = "seconds"
 datum_type = "histogram_f64"
 versions = [
-    { added_in = 1, fields = [ "route", "method", "status_code" ] }
+    { added_in = 1, fields = [ "operation_id", "status_code" ] }
 ]
 
 [fields.name]
@@ -25,14 +25,15 @@ description = "The name of the HTTP server, or program running it"
 type = "uuid"
 description = "UUID of the HTTP server"
 
-[fields.route]
+[fields.operation_id]
 type = "string"
-description = "HTTP route in the request"
+description = """\
+The identifier for the HTTP operation.\
 
-[fields.method]
-type = "string"
-description = "HTTP method in the request"
+In most cases, this the OpenAPI `operationId` field that uniquely identifies the
+endpoint the request is targeted to and the HTTP method used.
+"""
 
 [fields.status_code]
-type = "i64"
+type = "u16"
 description = "HTTP status code in the server's response"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -101,6 +101,7 @@ sha2 = { version = "0.10.8", features = ["oid"] }
 similar = { version = "2.5.0", features = ["bytes", "inline", "unicode"] }
 slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug", "release_max_level_trace"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new"] }
+socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
@@ -208,6 +209,7 @@ sha2 = { version = "0.10.8", features = ["oid"] }
 similar = { version = "2.5.0", features = ["bytes", "inline", "unicode"] }
 slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug", "release_max_level_trace"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new"] }
+socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }


### PR DESCRIPTION
- Add TTLs to all field tables, by using a materialized column with the time each record is inserted. ClickHouse will retain the latest timestamp, so when we stop inserting, the TTL clock will start counting down on those timeseries records.
- Update Dropshot dependency.
- Add operation ID to HTTP service timeseries, remove other fields. Expunge the old timeseries too.
- Remove unnecessary stingifying of URIs in latency tracking.