### PR TITLE
back out "Update Rust crate tokio to 1.39.2 (#6249)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6488,7 +6488,7 @@ dependencies = [
  "log",
  "managed",
  "memchr",
- "mio 1.0.2",
+ "mio 0.8.11",
  "nix 0.28.0",
  "nom",
  "num-bigint-dig",
@@ -10546,27 +10546,28 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio 0.8.11",
+ "num_cpus",
  "parking_lot 0.12.2",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -568,7 +568,7 @@ textwrap = "0.16.1"
 test-strategy = "0.3.1"
 thiserror = "1.0"
 tofino = { git = "https://github.com/oxidecomputer/tofino", branch = "main" }
-tokio = "1.39.2"
+tokio = "1.38.1"
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }
 tokio-stream = "0.1.15"
 tokio-tungstenite = "0.20"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -107,7 +107,7 @@ string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.74", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1.39.2", features = ["full", "test-util"] }
+tokio = { version = "1.38.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.11", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util"] }
@@ -216,7 +216,7 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.74", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
 time-macros = { version = "0.2.18", default-features = false, features = ["formatting", "parsing"] }
-tokio = { version = "1.39.2", features = ["full", "test-util"] }
+tokio = { version = "1.38.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.11", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util"] }
@@ -235,7 +235,7 @@ zeroize = { version = "1.7.0", features = ["std", "zeroize_derive"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
 linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std", "system"] }
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -244,35 +244,35 @@ signal-hook-mio = { version = "0.2.4", default-features = false, features = ["su
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
 linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std", "system"] }
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.x86_64-apple-darwin.dependencies]
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.aarch64-apple-darwin.dependencies]
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -280,7 +280,7 @@ signal-hook-mio = { version = "0.2.4", default-features = false, features = ["su
 
 [target.x86_64-unknown-illumos.dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -290,7 +290,7 @@ toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", featu
 
 [target.x86_64-unknown-illumos.build-dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
-mio = { version = "1.0.2", features = ["net", "os-ext"] }
+mio = { version = "0.8.11", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }


### PR DESCRIPTION
I'm having second thoughts about upgrading Tokio so close to release 10, so I
want to suggest backing it out for now and landing it early in the release 11
cycle. Putting up this PR so we have a place to discuss this.

This backs out commit d7d4beaf0dbfa82c6ae0da10a6ce43b3c5a89142.
