### PR TITLE
[oximeter] Use `fmt::Display` for TOML errors

### DIFF
--- a/oximeter/timeseries-macro/src/lib.rs
+++ b/oximeter/timeseries-macro/src/lib.rs
@@ -59,9 +59,8 @@ pub fn use_timeseries(
                 Err(e) => {
                     let msg = format!(
                         "Failed to generate timeseries types \
-                        from '{}': {:?}",
+                        from '{}': {e}",
                         path.display(),
-                        e,
                     );
                     return syn::Error::new(token.span(), msg)
                         .into_compile_error()


### PR DESCRIPTION
Currently, the `oximeter::use_timeseries!` macro uses `fmt::Debug` to display errors generating timeseries types, such as errors parsing the TOML schema. This results in kind of hard to interpret error output. For example:

```
error: Failed to generate timeseries types from '/home/eliza/Code/oxide/omicron/oximeter/impl/../oximeter/schema/sensor-measurement.toml': Toml("TOML parse error at line 8, column 6\n  |\n8 |     {\n  |      ^\ninvalid inline table\nexpected `}`\n")
 --> gateway/src/metrics.rs:7:27
  |
7 | oximeter::use_timeseries!("sensor-measurement.toml");
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^

```

Note that the `toml` crate very kindly tries to give us a nice ASCII graphic pointing at the location where the parse error occurred, but because the strings are formatted using `fmt::Debug`, it's not particularly comprehensible.

This commit changes the macro to use `fmt::Display`, instead, so that the multi-line diagnostic output from the TOML parser is more readable. Now, it looks like this:
```
error: Failed to generate timeseries types from '/home/eliza/Code/oxide/omicron/oximeter/impl/../oximeter/schema/sensor-measurement.toml':
       TOML deserialization error: TOML parse error at line 8, column 6
         |
       8 |     {
         |      ^
       invalid inline table
       expected `}`
 --> gateway/src/metrics.rs:7:27
  |
7 | oximeter::use_timeseries!("sensor-measurement.toml");
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^

```

I cherry-picked this change from #6354, since it seemed like a self-contained change that could easily land  on its own.