### PR TITLE
clear `OMDB_` environment variables when running omdb tests

### DIFF
--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -520,7 +520,8 @@ fn clear_omdb_env() {
     // and we won't be if we're run with `cargo test`.  But we will be
     // single-threaded in `cargo nextest` (the officially supported runner).
     // And these interfaces are also safe on illumos anyway.
-    for (env_var, _) in std::env::vars().filter(|(k, _)| k.starts_with("OMDB_")) {
+    for (env_var, _) in std::env::vars().filter(|(k, _)| k.starts_with("OMDB_"))
+    {
         eprintln!("removing {:?} from environment", env_var);
         std::env::remove_var(env_var);
     }

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! Integration testing facilities for Nexus
 
+#[cfg(feature = "omicron-dev")]
 use anyhow::Context;
 use anyhow::Result;
 use camino::Utf8Path;


### PR DESCRIPTION
Prior to this, I happened to leave `OMDB_NEXUS_URL` set in the environment, and that would cause spurious test failures:

```
dap@ivanova omicron-merge $ OMDB_NEXUS_URL= cargo nextest run -p omicron-omdb
info: experimental features enabled: setup-scripts
   Compiling omicron-omdb v0.1.0 (/home/dap/omicron-merge/dev-tools/omdb)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 23.37s
    Starting 3 tests across 2 binaries (run ID: 6df449d3-d021-43c9-b3a1-1a4a0f3efcd9, nextest profile: default)
       SETUP [      1/1] crdb-seed: cargo run -p crdb-seed --profile test
             [ 00:00:00] [                                                                                                                                               ] 0/3:          Finished `test` profile [unoptimized + debuginfo] target(s) in 0.76s
     Running `target/debug/crdb-seed`
Aug 16 21:20:15.670 INFO Using existing CRDB seed tarball: `/dangerzone/omicron_tmp/crdb-base-dap/b7700187af915d7b8385d065ee657a04f893c52c4de7ff43476e2c7e47a43880.tar`
  SETUP PASS [      1/1] crdb-seed: cargo run -p crdb-seed --profile test
        FAIL [   3.250s] omicron-omdb::test_all_output test_omdb_usage_errors

--- STDOUT:              omicron-omdb::test_all_output test_omdb_usage_errors ---

running 1 test
@@ -437,61 +437,29 @@
 termination: Exited(2)
 ---------------------------------------------
 stdout:
 ---------------------------------------------
 stderr:
-Debug a specific Nexus instance
+error: 'omdb nexus' requires a subcommand but one was not provided
+  [subcommands: background-tasks, blueprints, sagas, sleds, help]
 
 Usage: omdb nexus [OPTIONS] <COMMAND>
 
-Commands:
-  background-tasks  print information about background tasks
-  blueprints        interact with blueprints
-  sagas             view sagas, create and complete demo sagas
-  sleds             interact with sleds
-  help              Print this message or the help of the given subcommand(s)
-
-Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help
-
-Connection Options:
-      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
-                                                 OMDB_NEXUS_URL=]
-      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
-
-Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+For more information, try '--help'.
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "background-tasks"]
 termination: Exited(2)
 ---------------------------------------------
 stdout:
 ---------------------------------------------
 stderr:
-print information about background tasks
+error: 'omdb nexus background-tasks' requires a subcommand but one was not provided
+  [subcommands: doc, list, show, activate, help]
 
 Usage: omdb nexus background-tasks [OPTIONS] <COMMAND>
 
-Commands:
-  doc       Show documentation about background tasks
-  list      Print a summary of the status of all background tasks
-  show      Print human-readable summary of the status of each background task
-  activate  Activate one or more background tasks
-  help      Print this message or the help of the given subcommand(s)
-
-Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help
-
-Connection Options:
-      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
-                                                 OMDB_NEXUS_URL=]
-      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
-
-Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+For more information, try '--help'.
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "--help"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
@@ -535,63 +503,29 @@
 termination: Exited(2)
 ---------------------------------------------
 stdout:
 ---------------------------------------------
 stderr:
-interact with blueprints
+error: 'omdb nexus blueprints' requires a subcommand but one was not provided
+  [subcommands: list, show, diff, delete, target, regenerate, import, help]
 
 Usage: omdb nexus blueprints [OPTIONS] <COMMAND>
 
-Commands:
-  list        List all blueprints
-  show        Show a blueprint
-  diff        Diff two blueprints
-  delete      Delete a blueprint
-  target      Interact with the current target blueprint
-  regenerate  Generate a new blueprint
-  import      Import a blueprint
-  help        Print this message or the help of the given subcommand(s)
-
-Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help
-
-Connection Options:
-      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
-                                                 OMDB_NEXUS_URL=]
-      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
-
-Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+For more information, try '--help'.
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "sagas"]
 termination: Exited(2)
 ---------------------------------------------
 stdout:
 ---------------------------------------------
 stderr:
-view sagas, create and complete demo sagas
+error: 'omdb nexus sagas' requires a subcommand but one was not provided
+  [subcommands: list, demo-create, demo-complete, help]
 
 Usage: omdb nexus sagas [OPTIONS] <COMMAND>
 
-Commands:
-  list           List sagas run by this Nexus
-  demo-create    Create a "demo" saga
-  demo-complete  Complete a demo saga started with "demo-create"
-  help           Print this message or the help of the given subcommand(s)
-
-Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help
-
-Connection Options:
-      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
-                                                 OMDB_NEXUS_URL=]
-      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
-
-Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+For more information, try '--help'.
 =============================================
 EXECUTING COMMAND: omdb ["nexus", "--nexus-internal-url", "http://[::1]:111", "sagas", "demo-create"]
 termination: Exited(1)
 ---------------------------------------------
 stdout:
@@ -604,32 +538,16 @@
 termination: Exited(2)
 ---------------------------------------------
 stdout:
 ---------------------------------------------
 stderr:
-interact with sleds
+error: 'omdb nexus sleds' requires a subcommand but one was not provided
+  [subcommands: list-uninitialized, add, expunge, expunge-disk, help]
 
 Usage: omdb nexus sleds [OPTIONS] <COMMAND>
 
-Commands:
-  list-uninitialized  List all uninitialized sleds
-  add                 Add an uninitialized sled
-  expunge             Expunge a sled (DANGEROUS)
-  expunge-disk        Expunge a disk (DANGEROUS)
-  help                Print this message or the help of the given subcommand(s)
-
-Options:
-      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
-  -h, --help                   Print help
-
-Connection Options:
-      --nexus-internal-url <NEXUS_INTERNAL_URL>  URL of the Nexus internal API [env:
-                                                 OMDB_NEXUS_URL=]
-      --dns-server <DNS_SERVER>                  [env: OMDB_DNS_SERVER=]
-
-Safety Options:
-  -w, --destructive  Allow potentially-destructive subcommands
+For more information, try '--help'.
 =============================================
 EXECUTING COMMAND: omdb ["sled-agent"]
 termination: Exited(2)
 ---------------------------------------------
 stdout:

test test_omdb_usage_errors ... FAILED

failures:

failures:
    test_omdb_usage_errors

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2 filtered out; finished in 3.22s


--- STDERR:              omicron-omdb::test_all_output test_omdb_usage_errors ---
thread 'test_omdb_usage_errors' panicked at dev-tools/omdb/tests/test_all_output.rs:110:5:
assertion failed: string doesn't match the contents of file: "tests/usage_errors.out" see diffset above
                set EXPECTORATE=overwrite if these changes are intentional
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

   Canceling due to test failure: 2 tests still running
```

In these cases, clap produced different help output because of the presence of the environment variable (see clap-rs/clap#5673).  This PR causes the omdb tests to clear all OMDB-related environment variables before doing anything else.  This is a good idea anyway since these affect many other omdb behaviors that are being tested.