### PR TITLE
fix flaky test_demo_saga

### DIFF
--- a/nexus/src/app/saga.rs
+++ b/nexus/src/app/saga.rs
@@ -469,6 +469,10 @@ impl super::Nexus {
         // We don't need the handle that runnable_saga.start() returns because
         // we're not going to wait for the saga to finish here.
         let _ = runnable_saga.start().await?;
+
+        let mut demo_sagas = self.demo_sagas()?;
+        demo_sagas.preregister(demo_saga_id);
+
         Ok(DemoSaga { saga_id, demo_saga_id })
     }
 

--- a/nexus/src/app/sagas/demo.rs
+++ b/nexus/src/app/sagas/demo.rs
@@ -73,7 +73,7 @@ impl CompletingDemoSagas {
     }
 
     pub fn complete(&mut self, id: DemoSagaUuid) -> Result<(), Error> {
-        let sem = self.sagas.remove(&id).ok_or_else(|| {
+        let sem = self.sagas.get_mut(&id).ok_or_else(|| {
             Error::non_resourcetype_not_found(format!(
                 "demo saga with demo saga id {:?}",
                 id
@@ -159,10 +159,15 @@ mod test {
         // - demo saga starts and waits for completion (subscribe)
         // - complete demo saga
         let demo_saga_id = DemoSagaUuid::new_v4();
+        println!("demo saga: {demo_saga_id}");
         hub.preregister(demo_saga_id);
+        println!("demo saga: {demo_saga_id} preregistered");
         let subscribe = hub.subscribe(demo_saga_id);
+        println!("demo saga: {demo_saga_id} subscribed");
         assert!(hub.complete(demo_saga_id).is_ok());
+        println!("demo saga: {demo_saga_id} marked completed");
         subscribe.await.unwrap();
+        println!("demo saga: {demo_saga_id} done");
 
         // It's also possible that the completion request arrives before the
         // saga started waiting.  In that case, the sequence is:
@@ -173,23 +178,34 @@ mod test {
         //
         // This should work, too, with no errors.
         let demo_saga_id = DemoSagaUuid::new_v4();
+        println!("demo saga: {demo_saga_id}");
         hub.preregister(demo_saga_id);
+        println!("demo saga: {demo_saga_id} preregistered");
         assert!(hub.complete(demo_saga_id).is_ok());
+        println!("demo saga: {demo_saga_id} marked completed");
         let subscribe = hub.subscribe(demo_saga_id);
+        println!("demo saga: {demo_saga_id} subscribed");
         subscribe.await.unwrap();
+        println!("demo saga: {demo_saga_id} done");
 
         // It's also possible to have no preregistration at all.  This happens
         // if the demo saga was recovered.  That's fine, too, but then it will
         // only work if the completion arrives after the saga starts waiting.
         let demo_saga_id = DemoSagaUuid::new_v4();
+        println!("demo saga: {demo_saga_id}");
         let subscribe = hub.subscribe(demo_saga_id);
+        println!("demo saga: {demo_saga_id} subscribed");
         assert!(hub.complete(demo_saga_id).is_ok());
+        println!("demo saga: {demo_saga_id} marked completed");
         subscribe.await.unwrap();
+        println!("demo saga: {demo_saga_id} done");
 
         // If there's no preregistration and we get a completion request, then
         // that request should fail.
         let demo_saga_id = DemoSagaUuid::new_v4();
+        println!("demo saga: {demo_saga_id}");
         let error = hub.complete(demo_saga_id).unwrap_err();
         assert_matches!(error, Error::NotFound { .. });
+        println!("demo saga: {demo_saga_id} complete error: {:#}", error);
     }
 }

--- a/nexus/src/app/sagas/demo.rs
+++ b/nexus/src/app/sagas/demo.rs
@@ -21,56 +21,66 @@
 use super::NexusActionContext;
 use super::{ActionRegistry, NexusSaga, SagaInitError};
 use crate::app::sagas::declare_saga_actions;
-use anyhow::ensure;
+use anyhow::Context;
 use omicron_common::api::external::Error;
 use omicron_uuid_kinds::DemoSagaUuid;
 use serde::Deserialize;
 use serde::Serialize;
 use slog::info;
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::Arc;
 use steno::ActionError;
-use tokio::sync::oneshot;
+use tokio::sync::Semaphore;
 
-/// Set of demo sagas that have been marked completed
+/// Rendezvous point for demo sagas
 ///
-/// Nexus maintains one of these at the top level.  Individual demo sagas wait
-/// until their id shows up here, then remove it and proceed.
+/// This is where:
+///
+/// - demo sagas wait for a completion message
+/// - completion messages are recorded for demo sagas that haven't started
+///   waiting yet
+///
+/// Nexus maintains one of these structures at the top level.
 pub struct CompletingDemoSagas {
-    ids: BTreeMap<DemoSagaUuid, oneshot::Sender<()>>,
+    sagas: BTreeMap<DemoSagaUuid, Arc<Semaphore>>,
 }
 
 impl CompletingDemoSagas {
     pub fn new() -> CompletingDemoSagas {
-        CompletingDemoSagas { ids: BTreeMap::new() }
+        CompletingDemoSagas { sagas: BTreeMap::new() }
     }
 
-    pub fn complete(&mut self, id: DemoSagaUuid) -> Result<(), Error> {
-        self.ids
-            .remove(&id)
-            .ok_or_else(|| {
-                Error::non_resourcetype_not_found(format!(
-                    "demo saga with id {:?}",
-                    id
-                ))
-            })?
-            .send(())
-            .map_err(|_| {
-                Error::internal_error(
-                    "saga stopped listening (Nexus shutting down?)",
-                )
-            })
+    pub fn preregister(&mut self, id: DemoSagaUuid) {
+        assert!(self.sagas.insert(id, Arc::new(Semaphore::new(0))).is_none());
     }
 
     pub fn subscribe(
         &mut self,
         id: DemoSagaUuid,
-    ) -> Result<oneshot::Receiver<()>, anyhow::Error> {
-        let (tx, rx) = oneshot::channel();
-        ensure!(
-            self.ids.insert(id, tx).is_none(),
-            "multiple subscriptions for the same demo saga"
-        );
-        Ok(rx)
+    ) -> impl Future<Output = Result<(), anyhow::Error>> {
+        let sem =
+            self.sagas.entry(id).or_insert_with(|| Arc::new(Semaphore::new(0)));
+        let sem_clone = sem.clone();
+        async move {
+            sem_clone
+                .acquire()
+                .await
+                // We don't need the Semaphore permit once we've acquired it.
+                .map(|_| ())
+                .context("acquiring demo saga semaphore")
+        }
+    }
+
+    pub fn complete(&mut self, id: DemoSagaUuid) -> Result<(), Error> {
+        let sem = self.sagas.remove(&id).ok_or_else(|| {
+            Error::non_resourcetype_not_found(format!(
+                "demo saga with demo saga id {:?}",
+                id
+            ))
+        })?;
+        sem.add_permits(1);
+        Ok(())
     }
 }
 
@@ -115,21 +125,71 @@ async fn demo_wait(sagactx: NexusActionContext) -> Result<(), ActionError> {
             .nexus()
             .demo_sagas()
             .map_err(ActionError::action_failed)?;
-        demo_sagas.subscribe(demo_id).map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&format!(
-                "demo saga subscribe failed: {:#}",
-                e
-            )))
-        })?
+        demo_sagas.subscribe(demo_id)
     };
     match rx.await {
         Ok(_) => {
             info!(log, "demo saga: completing"; "id" => %demo_id);
+            Ok(())
         }
-        Err(_) => {
-            info!(log, "demo saga: waiting failed (Nexus shutting down?)";
-                "id" => %demo_id);
+        Err(error) => {
+            warn!(log, "demo saga: waiting failed (Nexus shutting down?)";
+                "id" => %demo_id,
+                "error" => #?error,
+            );
+            Err(ActionError::action_failed(Error::internal_error(&format!(
+                "demo saga wait failed: {:#}",
+                error
+            ))))
         }
     }
-    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[tokio::test]
+    async fn test_demo_saga_rendezvous() {
+        let mut hub = CompletingDemoSagas::new();
+
+        // The most straightforward sequence is:
+        // - create (preregister) demo saga
+        // - demo saga starts and waits for completion (subscribe)
+        // - complete demo saga
+        let demo_saga_id = DemoSagaUuid::new_v4();
+        hub.preregister(demo_saga_id);
+        let subscribe = hub.subscribe(demo_saga_id);
+        assert!(hub.complete(demo_saga_id).is_ok());
+        subscribe.await.unwrap();
+
+        // It's also possible that the completion request arrives before the
+        // saga started waiting.  In that case, the sequence is:
+        //
+        // - create (preregister) demo saga
+        // - complete demo saga
+        // - demo saga starts and waits for completion (subscribe)
+        //
+        // This should work, too, with no errors.
+        let demo_saga_id = DemoSagaUuid::new_v4();
+        hub.preregister(demo_saga_id);
+        assert!(hub.complete(demo_saga_id).is_ok());
+        let subscribe = hub.subscribe(demo_saga_id);
+        subscribe.await.unwrap();
+
+        // It's also possible to have no preregistration at all.  This happens
+        // if the demo saga was recovered.  That's fine, too, but then it will
+        // only work if the completion arrives after the saga starts waiting.
+        let demo_saga_id = DemoSagaUuid::new_v4();
+        let subscribe = hub.subscribe(demo_saga_id);
+        assert!(hub.complete(demo_saga_id).is_ok());
+        subscribe.await.unwrap();
+
+        // If there's no preregistration and we get a completion request, then
+        // that request should fail.
+        let demo_saga_id = DemoSagaUuid::new_v4();
+        let error = hub.complete(demo_saga_id).unwrap_err();
+        assert_matches!(error, Error::NotFound { .. });
+    }
 }

--- a/nexus/tests/integration_tests/demo_saga.rs
+++ b/nexus/tests/integration_tests/demo_saga.rs
@@ -44,33 +44,7 @@ async fn test_demo_saga(cptestctx: &ControlPlaneTestContext) {
     // have completed after that.  And then we've made the test suite take that
     // much longer.   But we can at least make sure that completing the saga
     // does cause it to finish.
-    //
-    // Note that `saga_demo_complete` will not succeed until the saga has gotten
-    // far enough through execution that it has registered itself as waiting for
-    // a completion message.  As a result, we have to keep trying until this
-    // works.  But it shouldn't take long -- the saga only has one action and
-    // this is all that it does.
-    wait_for_condition(
-        || async {
-            nexus_client
-                .saga_demo_complete(&demo_saga.demo_saga_id)
-                .await
-                .map_err(|err| {
-                    if let Some(status) = err.status() {
-                        if status == http::StatusCode::NOT_FOUND {
-                            eprintln!("transient 404 -- will try again");
-                            return CondCheckError::NotYet;
-                        }
-                    }
-
-                    CondCheckError::Failed(err)
-                })
-        },
-        &std::time::Duration::from_millis(20),
-        &std::time::Duration::from_secs(10),
-    )
-    .await
-    .unwrap();
+    nexus_client.saga_demo_complete(&demo_saga.demo_saga_id).await.unwrap();
 
     // Completion is not synchronous -- that just unblocked the saga.  So we
     // need to poll a bit to wait for it to actually finish.


### PR DESCRIPTION
Fixes #6383.

In that issue, it looks like the test successfully created the demo saga, but then when it went to complete it, it wasn't found in the `CompletingDemoSagas` struct.  I didn't appreciate that there's a race here: a newly-created demo saga does not register itself with `CompletingDemoSagas` until its (first and only) saga action starts running, but that's asynchronous with respect to the internal API HTTP request that creates the demo saga.  As a result, clients can get a 404 when they try to complete the demo saga, but if they retry after that first saga action starts running, then it will succeed.

The first fix I had here (9f6b11a) just has the test retry a 404 from this request, using `wait_for_condition` so that this won't hang nor sleep much longer than it needs to.  This works fine to fix the test and if we have to fall back to this then that's okay.  The only consumers of this API are probably humans (who won't be fast enough to hit this race) or other automated tests.  But I wanted to try to do better because this API kind of sucks: you create a thing, then you want to operate on it, but you have to wait for some other thing to happen first.  It's this weird eventual consistency pattern that we've avoid everywhere else.  And we'll have to replicate the retry behavior in other consumers (mainly, future automated tests).

So instead I've reworked the `CompletingDemoSagas` struct so that you can do the completion and subscription steps in either order.  The reason I hadn't done this before was that the obvious solution (create the entry for a demo saga id when _either_ of these events happen) creates a different, worse problem: if the consumer provides the wrong id (which is easier than you'd think with this API, for a few reasons), then the request would silently succeed, leading to implicit failures later (because you hadn't actually completed the saga you thought you had).  What I did instead here was add a preregistration step that happens when we create the demo saga.  If we get a request to complete a saga that hasn't started waiting _and_ isn't preregistered, then we produce the 404.  Notably, this doesn't cover the case that the demo saga was recovered (rather than created in this Nexus's lifetime).  There's no good way to do that, but I think it doesn't really matter since saga recovery is always asynchronous anyway.