### PR TITLE
Tiny cleanup: remove unnecessary `result` check

### DIFF
--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -104,11 +104,9 @@ impl BlueprintExecutor {
             Ok(RealizeBlueprintOutput { needs_saga_recovery }) => {
                 // If executing the blueprint requires activating the saga
                 // recovery background task, do that now.
-                if let Ok(output) = &result {
-                    if output.needs_saga_recovery {
-                        info!(&opctx.log, "activating saga recovery task");
-                        self.saga_recovery.activate();
-                    }
+                if needs_saga_recovery {
+                    info!(&opctx.log, "activating saga recovery task");
+                    self.saga_recovery.activate();
                 }
 
                 json!({


### PR DESCRIPTION
We're already inside the `Ok(_)` arm of a `match result`, so we don't need to check for `Ok` again. (I think this is just leftover from this snippet moving around in #6395.)