### PR TITLE
Use `BlueprintZoneConfig` in RSS service plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,6 +5245,7 @@ dependencies = [
  "httptest",
  "internal-dns",
  "ipnet",
+ "newtype-uuid",
  "nexus-config",
  "nexus-db-model",
  "nexus-db-queries",

--- a/nexus/reconfigurator/execution/Cargo.toml
+++ b/nexus/reconfigurator/execution/Cargo.toml
@@ -16,6 +16,7 @@ dns-service-client.workspace = true
 chrono.workspace = true
 futures.workspace = true
 internal-dns.workspace = true
+newtype-uuid.workspace = true
 nexus-config.workspace = true
 nexus-db-model.workspace = true
 nexus-db-queries.workspace = true

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -467,6 +467,7 @@ mod test {
     use internal_dns::resolver::Resolver;
     use internal_dns::ServiceName;
     use internal_dns::DNS_ZONE;
+    use newtype_uuid::GenericUuid;
     use nexus_db_model::DnsGroup;
     use nexus_db_model::Silo;
     use nexus_db_queries::authn;
@@ -478,6 +479,8 @@ mod test {
     use nexus_reconfigurator_planning::blueprint_builder::EnsureMultiple;
     use nexus_reconfigurator_planning::example::example;
     use nexus_reconfigurator_preparation::PlanningInputFromDb;
+    use nexus_sled_agent_shared::inventory::OmicronZoneConfig;
+    use nexus_sled_agent_shared::inventory::OmicronZoneType;
     use nexus_sled_agent_shared::inventory::ZoneKind;
     use nexus_test_utils::resource_helpers::create_silo;
     use nexus_test_utils::resource_helpers::DiskTestBuilder;
@@ -490,6 +493,9 @@ mod test {
     use nexus_types::deployment::CockroachDbClusterVersion;
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
     use nexus_types::deployment::CockroachDbSettings;
+    pub use nexus_types::deployment::OmicronZoneExternalFloatingAddr;
+    pub use nexus_types::deployment::OmicronZoneExternalFloatingIp;
+    pub use nexus_types::deployment::OmicronZoneExternalSnatIp;
     use nexus_types::deployment::SledFilter;
     use nexus_types::external_api::params;
     use nexus_types::external_api::shared;
@@ -537,6 +543,212 @@ mod test {
                 records: HashMap::new(),
             }],
         }
+    }
+
+    /// **********************************************************************
+    /// DEPRECATION WARNING:
+    ///
+    /// Remove when `deprecated_omicron_zone_config_to_blueprint_zone_config`
+    /// is deleted.
+    /// **********************************************************************
+    ///
+    /// Errors from converting an [`OmicronZoneType`] into a [`BlueprintZoneType`].
+    #[derive(Debug, Clone)]
+    pub enum InvalidOmicronZoneType {
+        #[allow(unused)]
+        ExternalIpIdRequired { kind: ZoneKind },
+    }
+
+    /// **********************************************************************
+    /// DEPRECATION WARNING: Do not call this function in new code !!!
+    /// **********************************************************************
+    ///
+    /// Convert an [`OmicronZoneConfig`] to a [`BlueprintZoneConfig`].
+    ///
+    /// A `BlueprintZoneConfig` is a superset of `OmicronZoneConfig` and
+    /// contains auxiliary information not present in an `OmicronZoneConfig`.
+    /// Therefore, the only valid direction for a real system to take is a
+    /// lossy conversion from `BlueprintZoneConfig` to `OmicronZoneConfig`.
+    /// This function, however, does the opposite. We therefore have to inject
+    /// fake information to fill in the unknown fields in the generated
+    /// `OmicronZoneConfig`.
+    ///
+    /// This is bad, and we should generally feel bad for doing it :). At
+    /// the time this was done we were backporting the blueprint system into
+    /// RSS while trying not to change too much code. This was a judicious
+    /// shortcut used right before a release for stability reasons. As the
+    /// number of zones managed by the reconfigurator has grown, the use
+    /// of this function has become more egregious, and so it was removed
+    /// from the production code path and into this test module. This move
+    /// itself is a judicious shortcut. We have a test in this module,
+    /// `test_blueprint_internal_dns_basic`, that is the last caller of this
+    /// function, and so we have moved this function into this module.
+    ///
+    /// Ideally, we would get rid of this function altogether and use another
+    /// method for generating `BlueprintZoneConfig` structures. Unfortunately,
+    /// there are still a few remaining zones that need to be implemented in the
+    /// `BlueprintBuilder`, and some of them require custom code. Until that is
+    /// done, we don't have a good way of generating a test representation of
+    /// the real system that would properly serve this test. We could generate
+    /// a `BlueprintZoneConfig` by hand for each zone type in this test, on
+    /// top of the more modern `SystemDescription` setup, but that isn't much
+    /// different than what we do in this test. We'd also eventually remove it
+    /// for better test setup when our `BlueprintBuilder` is capable of properly
+    /// constructing all zone types. Instead, we do the simple thing, and reuse
+    /// what we alreaady have.
+    ///
+    /// # Errors
+    ///
+    /// If `config.zone_type` is a zone that has an external IP address (Nexus,
+    /// boundary NTP, external DNS), `external_ip_id` must be `Some(_)` or this
+    /// method will return an error.
+    pub fn deprecated_omicron_zone_config_to_blueprint_zone_config(
+        config: OmicronZoneConfig,
+        disposition: BlueprintZoneDisposition,
+        external_ip_id: Option<ExternalIpUuid>,
+    ) -> Result<BlueprintZoneConfig, InvalidOmicronZoneType> {
+        let kind = config.zone_type.kind();
+        let zone_type = match config.zone_type {
+            OmicronZoneType::BoundaryNtp {
+                address,
+                dns_servers,
+                domain,
+                nic,
+                ntp_servers,
+                snat_cfg,
+            } => {
+                let external_ip_id = external_ip_id.ok_or(
+                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
+                )?;
+                BlueprintZoneType::BoundaryNtp(
+                    blueprint_zone_type::BoundaryNtp {
+                        address,
+                        ntp_servers,
+                        dns_servers,
+                        domain,
+                        nic,
+                        external_ip: OmicronZoneExternalSnatIp {
+                            id: external_ip_id,
+                            snat_cfg,
+                        },
+                    },
+                )
+            }
+            OmicronZoneType::Clickhouse { address, dataset } => {
+                BlueprintZoneType::Clickhouse(blueprint_zone_type::Clickhouse {
+                    address,
+                    dataset,
+                })
+            }
+            OmicronZoneType::ClickhouseKeeper { address, dataset } => {
+                BlueprintZoneType::ClickhouseKeeper(
+                    blueprint_zone_type::ClickhouseKeeper { address, dataset },
+                )
+            }
+            OmicronZoneType::ClickhouseServer { address, dataset } => {
+                BlueprintZoneType::ClickhouseServer(
+                    blueprint_zone_type::ClickhouseServer { address, dataset },
+                )
+            }
+            OmicronZoneType::CockroachDb { address, dataset } => {
+                BlueprintZoneType::CockroachDb(
+                    blueprint_zone_type::CockroachDb { address, dataset },
+                )
+            }
+            OmicronZoneType::Crucible { address, dataset } => {
+                BlueprintZoneType::Crucible(blueprint_zone_type::Crucible {
+                    address,
+                    dataset,
+                })
+            }
+            OmicronZoneType::CruciblePantry { address } => {
+                BlueprintZoneType::CruciblePantry(
+                    blueprint_zone_type::CruciblePantry { address },
+                )
+            }
+            OmicronZoneType::ExternalDns {
+                dataset,
+                dns_address,
+                http_address,
+                nic,
+            } => {
+                let external_ip_id = external_ip_id.ok_or(
+                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
+                )?;
+                BlueprintZoneType::ExternalDns(
+                    blueprint_zone_type::ExternalDns {
+                        dataset,
+                        http_address,
+                        dns_address: OmicronZoneExternalFloatingAddr {
+                            id: external_ip_id,
+                            addr: dns_address,
+                        },
+                        nic,
+                    },
+                )
+            }
+            OmicronZoneType::InternalDns {
+                dataset,
+                dns_address,
+                gz_address,
+                gz_address_index,
+                http_address,
+            } => BlueprintZoneType::InternalDns(
+                blueprint_zone_type::InternalDns {
+                    dataset,
+                    http_address,
+                    dns_address,
+                    gz_address,
+                    gz_address_index,
+                },
+            ),
+            OmicronZoneType::InternalNtp {
+                address,
+                dns_servers,
+                domain,
+                ntp_servers,
+            } => BlueprintZoneType::InternalNtp(
+                blueprint_zone_type::InternalNtp {
+                    address,
+                    ntp_servers,
+                    dns_servers,
+                    domain,
+                },
+            ),
+            OmicronZoneType::Nexus {
+                external_dns_servers,
+                external_ip,
+                external_tls,
+                internal_address,
+                nic,
+            } => {
+                let external_ip_id = external_ip_id.ok_or(
+                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
+                )?;
+                BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
+                    internal_address,
+                    external_ip: OmicronZoneExternalFloatingIp {
+                        id: external_ip_id,
+                        ip: external_ip,
+                    },
+                    nic,
+                    external_tls,
+                    external_dns_servers,
+                })
+            }
+            OmicronZoneType::Oximeter { address } => {
+                BlueprintZoneType::Oximeter(blueprint_zone_type::Oximeter {
+                    address,
+                })
+            }
+        };
+        Ok(BlueprintZoneConfig {
+            disposition,
+            id: OmicronZoneUuid::from_untyped_uuid(config.id),
+            underlay_address: config.underlay_address,
+            filesystem_pool: config.filesystem_pool,
+            zone_type,
+        })
     }
 
     /// test blueprint_internal_dns_config(): trivial case of an empty blueprint
@@ -589,7 +801,7 @@ mod test {
                         .zones
                         .into_iter()
                         .map(|config| -> BlueprintZoneConfig {
-                            BlueprintZoneConfig::from_omicron_zone_config(
+                            deprecated_omicron_zone_config_to_blueprint_zone_config(
                                 config,
                                 BlueprintZoneDisposition::InService,
                                 // We don't get external IP IDs in inventory

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -606,8 +606,6 @@ pub struct BlueprintZoneConfig {
     pub zone_type: BlueprintZoneType,
 }
 
-impl BlueprintZoneConfig {}
-
 impl From<BlueprintZoneConfig> for OmicronZoneConfig {
     fn from(z: BlueprintZoneConfig) -> Self {
         Self {

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -27,20 +27,17 @@ use omicron_common::api::external::Generation;
 use omicron_common::disk::DiskIdentity;
 use omicron_common::disk::OmicronPhysicalDisksConfig;
 use omicron_uuid_kinds::CollectionUuid;
-use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
-use slog_error_chain::SlogInlineError;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::net::Ipv6Addr;
 use strum::EnumIter;
 use strum::IntoEnumIterator;
-use thiserror::Error;
 use uuid::Uuid;
 
 mod blueprint_diff;
@@ -595,13 +592,6 @@ fn zone_sort_key<T: ZoneSortKey>(z: &T) -> impl Ord {
     (z.kind(), z.id())
 }
 
-/// Errors from converting an [`OmicronZoneType`] into a [`BlueprintZoneType`].
-#[derive(Debug, Clone, Error, SlogInlineError)]
-pub enum InvalidOmicronZoneType {
-    #[error("Omicron zone {} requires an external IP ID", kind.report_str())]
-    ExternalIpIdRequired { kind: ZoneKind },
-}
-
 /// Describes one Omicron-managed zone in a blueprint.
 ///
 /// Part of [`BlueprintZonesConfig`].
@@ -616,167 +606,7 @@ pub struct BlueprintZoneConfig {
     pub zone_type: BlueprintZoneType,
 }
 
-impl BlueprintZoneConfig {
-    /// Convert from an [`OmicronZoneConfig`].
-    ///
-    /// This method is annoying to call correctly and will become more so over
-    /// time. Ideally we'd remove all callers and then remove this method, but
-    /// for now we keep it.
-    ///
-    /// # Errors
-    ///
-    /// If `config.zone_type` is a zone that has an external IP address (Nexus,
-    /// boundary NTP, external DNS), `external_ip_id` must be `Some(_)` or this
-    /// method will return an error.
-    pub fn from_omicron_zone_config(
-        config: OmicronZoneConfig,
-        disposition: BlueprintZoneDisposition,
-        external_ip_id: Option<ExternalIpUuid>,
-    ) -> Result<Self, InvalidOmicronZoneType> {
-        let kind = config.zone_type.kind();
-        let zone_type = match config.zone_type {
-            OmicronZoneType::BoundaryNtp {
-                address,
-                dns_servers,
-                domain,
-                nic,
-                ntp_servers,
-                snat_cfg,
-            } => {
-                let external_ip_id = external_ip_id.ok_or(
-                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
-                )?;
-                BlueprintZoneType::BoundaryNtp(
-                    blueprint_zone_type::BoundaryNtp {
-                        address,
-                        ntp_servers,
-                        dns_servers,
-                        domain,
-                        nic,
-                        external_ip: OmicronZoneExternalSnatIp {
-                            id: external_ip_id,
-                            snat_cfg,
-                        },
-                    },
-                )
-            }
-            OmicronZoneType::Clickhouse { address, dataset } => {
-                BlueprintZoneType::Clickhouse(blueprint_zone_type::Clickhouse {
-                    address,
-                    dataset,
-                })
-            }
-            OmicronZoneType::ClickhouseKeeper { address, dataset } => {
-                BlueprintZoneType::ClickhouseKeeper(
-                    blueprint_zone_type::ClickhouseKeeper { address, dataset },
-                )
-            }
-            OmicronZoneType::ClickhouseServer { address, dataset } => {
-                BlueprintZoneType::ClickhouseServer(
-                    blueprint_zone_type::ClickhouseServer { address, dataset },
-                )
-            }
-            OmicronZoneType::CockroachDb { address, dataset } => {
-                BlueprintZoneType::CockroachDb(
-                    blueprint_zone_type::CockroachDb { address, dataset },
-                )
-            }
-            OmicronZoneType::Crucible { address, dataset } => {
-                BlueprintZoneType::Crucible(blueprint_zone_type::Crucible {
-                    address,
-                    dataset,
-                })
-            }
-            OmicronZoneType::CruciblePantry { address } => {
-                BlueprintZoneType::CruciblePantry(
-                    blueprint_zone_type::CruciblePantry { address },
-                )
-            }
-            OmicronZoneType::ExternalDns {
-                dataset,
-                dns_address,
-                http_address,
-                nic,
-            } => {
-                let external_ip_id = external_ip_id.ok_or(
-                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
-                )?;
-                BlueprintZoneType::ExternalDns(
-                    blueprint_zone_type::ExternalDns {
-                        dataset,
-                        http_address,
-                        dns_address: OmicronZoneExternalFloatingAddr {
-                            id: external_ip_id,
-                            addr: dns_address,
-                        },
-                        nic,
-                    },
-                )
-            }
-            OmicronZoneType::InternalDns {
-                dataset,
-                dns_address,
-                gz_address,
-                gz_address_index,
-                http_address,
-            } => BlueprintZoneType::InternalDns(
-                blueprint_zone_type::InternalDns {
-                    dataset,
-                    http_address,
-                    dns_address,
-                    gz_address,
-                    gz_address_index,
-                },
-            ),
-            OmicronZoneType::InternalNtp {
-                address,
-                dns_servers,
-                domain,
-                ntp_servers,
-            } => BlueprintZoneType::InternalNtp(
-                blueprint_zone_type::InternalNtp {
-                    address,
-                    ntp_servers,
-                    dns_servers,
-                    domain,
-                },
-            ),
-            OmicronZoneType::Nexus {
-                external_dns_servers,
-                external_ip,
-                external_tls,
-                internal_address,
-                nic,
-            } => {
-                let external_ip_id = external_ip_id.ok_or(
-                    InvalidOmicronZoneType::ExternalIpIdRequired { kind },
-                )?;
-                BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
-                    internal_address,
-                    external_ip: OmicronZoneExternalFloatingIp {
-                        id: external_ip_id,
-                        ip: external_ip,
-                    },
-                    nic,
-                    external_tls,
-                    external_dns_servers,
-                })
-            }
-            OmicronZoneType::Oximeter { address } => {
-                BlueprintZoneType::Oximeter(blueprint_zone_type::Oximeter {
-                    address,
-                })
-            }
-        };
-        Ok(Self {
-            disposition,
-            id: OmicronZoneUuid::from_untyped_uuid(config.id),
-            underlay_address: config.underlay_address,
-            filesystem_pool: config.filesystem_pool,
-            zone_type,
-        })
-    }
-}
+impl BlueprintZoneConfig {}
 
 impl From<BlueprintZoneConfig> for OmicronZoneConfig {
     fn from(z: BlueprintZoneConfig) -> Self {

--- a/schema/rss-service-plan-v4.json
+++ b/schema/rss-service-plan-v4.json
@@ -1,0 +1,999 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Plan",
+  "type": "object",
+  "required": [
+    "dns_config",
+    "services"
+  ],
+  "properties": {
+    "dns_config": {
+      "$ref": "#/definitions/DnsConfigParams"
+    },
+    "services": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SledConfig"
+      }
+    }
+  },
+  "definitions": {
+    "BlueprintZoneConfig": {
+      "description": "Describes one Omicron-managed zone in a blueprint.\n\nPart of [`BlueprintZonesConfig`].",
+      "type": "object",
+      "required": [
+        "disposition",
+        "id",
+        "underlay_address",
+        "zone_type"
+      ],
+      "properties": {
+        "disposition": {
+          "description": "The disposition (desired state) of this zone recorded in the blueprint.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BlueprintZoneDisposition"
+            }
+          ]
+        },
+        "filesystem_pool": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ZpoolName"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/TypedUuidForOmicronZoneKind"
+        },
+        "underlay_address": {
+          "type": "string",
+          "format": "ipv6"
+        },
+        "zone_type": {
+          "$ref": "#/definitions/BlueprintZoneType"
+        }
+      }
+    },
+    "BlueprintZoneDisposition": {
+      "description": "The desired state of an Omicron-managed zone in a blueprint.\n\nPart of [`BlueprintZoneConfig`].",
+      "oneOf": [
+        {
+          "description": "The zone is in-service.",
+          "type": "string",
+          "enum": [
+            "in_service"
+          ]
+        },
+        {
+          "description": "The zone is not in service.",
+          "type": "string",
+          "enum": [
+            "quiesced"
+          ]
+        },
+        {
+          "description": "The zone is permanently gone.",
+          "type": "string",
+          "enum": [
+            "expunged"
+          ]
+        }
+      ]
+    },
+    "BlueprintZoneType": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "dns_servers",
+            "external_ip",
+            "nic",
+            "ntp_servers",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dns_servers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "domain": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "external_ip": {
+              "$ref": "#/definitions/OmicronZoneExternalSnatIp"
+            },
+            "nic": {
+              "description": "The service vNIC providing outbound connectivity using OPTE.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NetworkInterface"
+                }
+              ]
+            },
+            "ntp_servers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "boundary_ntp"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Used in single-node clickhouse setups",
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse_keeper"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Used in replicated clickhouse setups",
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse_server"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "cockroach_db"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "dataset",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "crucible"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "crucible_pantry"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "dataset",
+            "dns_address",
+            "http_address",
+            "nic",
+            "type"
+          ],
+          "properties": {
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "dns_address": {
+              "description": "The address at which the external DNS server is reachable.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OmicronZoneExternalFloatingAddr"
+                }
+              ]
+            },
+            "http_address": {
+              "description": "The address at which the external DNS server API is reachable.",
+              "type": "string"
+            },
+            "nic": {
+              "description": "The service vNIC providing external connectivity using OPTE.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NetworkInterface"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "external_dns"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "dataset",
+            "dns_address",
+            "gz_address",
+            "gz_address_index",
+            "http_address",
+            "type"
+          ],
+          "properties": {
+            "dataset": {
+              "$ref": "#/definitions/OmicronZoneDataset"
+            },
+            "dns_address": {
+              "type": "string"
+            },
+            "gz_address": {
+              "description": "The addresses in the global zone which should be created\n\nFor the DNS service, which exists outside the sleds's typical subnet - adding an address in the GZ is necessary to allow inter-zone traffic routing.",
+              "type": "string",
+              "format": "ipv6"
+            },
+            "gz_address_index": {
+              "description": "The address is also identified with an auxiliary bit of information to ensure that the created global zone address can have a unique name.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "http_address": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "internal_dns"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "dns_servers",
+            "ntp_servers",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "dns_servers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "domain": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ntp_servers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "internal_ntp"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "external_dns_servers",
+            "external_ip",
+            "external_tls",
+            "internal_address",
+            "nic",
+            "type"
+          ],
+          "properties": {
+            "external_dns_servers": {
+              "description": "External DNS servers Nexus can use to resolve external hosts.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "external_ip": {
+              "description": "The address at which the external nexus server is reachable.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OmicronZoneExternalFloatingIp"
+                }
+              ]
+            },
+            "external_tls": {
+              "description": "Whether Nexus's external endpoint should use TLS",
+              "type": "boolean"
+            },
+            "internal_address": {
+              "description": "The address at which the internal nexus server is reachable.",
+              "type": "string"
+            },
+            "nic": {
+              "description": "The service vNIC providing external connectivity using OPTE.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NetworkInterface"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "nexus"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "type"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "oximeter"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "DiskIdentity": {
+      "description": "Uniquely identifies a disk.",
+      "type": "object",
+      "required": [
+        "model",
+        "serial",
+        "vendor"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "serial": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        }
+      }
+    },
+    "DnsConfigParams": {
+      "description": "DnsConfigParams\n\n<details><summary>JSON schema</summary>\n\n```json { \"type\": \"object\", \"required\": [ \"generation\", \"time_created\", \"zones\" ], \"properties\": { \"generation\": { \"type\": \"integer\", \"format\": \"uint64\", \"minimum\": 0.0 }, \"time_created\": { \"type\": \"string\", \"format\": \"date-time\" }, \"zones\": { \"type\": \"array\", \"items\": { \"$ref\": \"#/components/schemas/DnsConfigZone\" } } } } ``` </details>",
+      "type": "object",
+      "required": [
+        "generation",
+        "time_created",
+        "zones"
+      ],
+      "properties": {
+        "generation": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "time_created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DnsConfigZone"
+          }
+        }
+      }
+    },
+    "DnsConfigZone": {
+      "description": "DnsConfigZone\n\n<details><summary>JSON schema</summary>\n\n```json { \"type\": \"object\", \"required\": [ \"records\", \"zone_name\" ], \"properties\": { \"records\": { \"type\": \"object\", \"additionalProperties\": { \"type\": \"array\", \"items\": { \"$ref\": \"#/components/schemas/DnsRecord\" } } }, \"zone_name\": { \"type\": \"string\" } } } ``` </details>",
+      "type": "object",
+      "required": [
+        "records",
+        "zone_name"
+      ],
+      "properties": {
+        "records": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/DnsRecord"
+            }
+          }
+        },
+        "zone_name": {
+          "type": "string"
+        }
+      }
+    },
+    "DnsRecord": {
+      "description": "DnsRecord\n\n<details><summary>JSON schema</summary>\n\n```json { \"oneOf\": [ { \"type\": \"object\", \"required\": [ \"data\", \"type\" ], \"properties\": { \"data\": { \"type\": \"string\", \"format\": \"ipv4\" }, \"type\": { \"type\": \"string\", \"enum\": [ \"A\" ] } } }, { \"type\": \"object\", \"required\": [ \"data\", \"type\" ], \"properties\": { \"data\": { \"type\": \"string\", \"format\": \"ipv6\" }, \"type\": { \"type\": \"string\", \"enum\": [ \"AAAA\" ] } } }, { \"type\": \"object\", \"required\": [ \"data\", \"type\" ], \"properties\": { \"data\": { \"$ref\": \"#/components/schemas/Srv\" }, \"type\": { \"type\": \"string\", \"enum\": [ \"SRV\" ] } } } ] } ``` </details>",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "data",
+            "type"
+          ],
+          "properties": {
+            "data": {
+              "type": "string",
+              "format": "ipv4"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "A"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "data",
+            "type"
+          ],
+          "properties": {
+            "data": {
+              "type": "string",
+              "format": "ipv6"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "AAAA"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "data",
+            "type"
+          ],
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/Srv"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "SRV"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Generation": {
+      "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "IpNet": {
+      "oneOf": [
+        {
+          "title": "v4",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Ipv4Net"
+            }
+          ]
+        },
+        {
+          "title": "v6",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Ipv6Net"
+            }
+          ]
+        }
+      ],
+      "x-rust-type": {
+        "crate": "oxnet",
+        "path": "oxnet::IpNet",
+        "version": "0.1.0"
+      }
+    },
+    "Ipv4Net": {
+      "title": "An IPv4 subnet",
+      "description": "An IPv4 subnet, including prefix and prefix length",
+      "examples": [
+        "192.168.1.0/24"
+      ],
+      "type": "string",
+      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|1[0-9]|2[0-9]|3[0-2])$",
+      "x-rust-type": {
+        "crate": "oxnet",
+        "path": "oxnet::Ipv4Net",
+        "version": "0.1.0"
+      }
+    },
+    "Ipv6Net": {
+      "title": "An IPv6 subnet",
+      "description": "An IPv6 subnet, including prefix and subnet mask",
+      "examples": [
+        "fd12:3456::/64"
+      ],
+      "type": "string",
+      "pattern": "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$",
+      "x-rust-type": {
+        "crate": "oxnet",
+        "path": "oxnet::Ipv6Net",
+        "version": "0.1.0"
+      }
+    },
+    "MacAddr": {
+      "title": "A MAC address",
+      "description": "A Media Access Control address, in EUI-48 format",
+      "examples": [
+        "ff:ff:ff:ff:ff:ff"
+      ],
+      "type": "string",
+      "maxLength": 17,
+      "minLength": 5,
+      "pattern": "^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$"
+    },
+    "Name": {
+      "title": "A name unique within the parent collection",
+      "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
+      "type": "string",
+      "maxLength": 63,
+      "minLength": 1,
+      "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$"
+    },
+    "NetworkInterface": {
+      "description": "Information required to construct a virtual network interface",
+      "type": "object",
+      "required": [
+        "id",
+        "ip",
+        "kind",
+        "mac",
+        "name",
+        "primary",
+        "slot",
+        "subnet",
+        "vni"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "ip": {
+          "type": "string",
+          "format": "ip"
+        },
+        "kind": {
+          "$ref": "#/definitions/NetworkInterfaceKind"
+        },
+        "mac": {
+          "$ref": "#/definitions/MacAddr"
+        },
+        "name": {
+          "$ref": "#/definitions/Name"
+        },
+        "primary": {
+          "type": "boolean"
+        },
+        "slot": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "subnet": {
+          "$ref": "#/definitions/IpNet"
+        },
+        "transit_ips": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpNet"
+          }
+        },
+        "vni": {
+          "$ref": "#/definitions/Vni"
+        }
+      }
+    },
+    "NetworkInterfaceKind": {
+      "description": "The type of network interface",
+      "oneOf": [
+        {
+          "description": "A vNIC attached to a guest instance",
+          "type": "object",
+          "required": [
+            "id",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "instance"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A vNIC associated with an internal service",
+          "type": "object",
+          "required": [
+            "id",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "service"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A vNIC associated with a probe",
+          "type": "object",
+          "required": [
+            "id",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "probe"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "OmicronPhysicalDiskConfig": {
+      "type": "object",
+      "required": [
+        "id",
+        "identity",
+        "pool_id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "identity": {
+          "$ref": "#/definitions/DiskIdentity"
+        },
+        "pool_id": {
+          "$ref": "#/definitions/TypedUuidForZpoolKind"
+        }
+      }
+    },
+    "OmicronPhysicalDisksConfig": {
+      "type": "object",
+      "required": [
+        "disks",
+        "generation"
+      ],
+      "properties": {
+        "disks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OmicronPhysicalDiskConfig"
+          }
+        },
+        "generation": {
+          "description": "generation number of this configuration\n\nThis generation number is owned by the control plane (i.e., RSS or Nexus, depending on whether RSS-to-Nexus handoff has happened).  It should not be bumped within Sled Agent.\n\nSled Agent rejects attempts to set the configuration to a generation older than the one it's currently running.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Generation"
+            }
+          ]
+        }
+      }
+    },
+    "OmicronZoneDataset": {
+      "description": "Describes a persistent ZFS dataset associated with an Omicron zone",
+      "type": "object",
+      "required": [
+        "pool_name"
+      ],
+      "properties": {
+        "pool_name": {
+          "$ref": "#/definitions/ZpoolName"
+        }
+      }
+    },
+    "OmicronZoneExternalFloatingAddr": {
+      "description": "Floating external address with port allocated to an Omicron-managed zone.",
+      "type": "object",
+      "required": [
+        "addr",
+        "id"
+      ],
+      "properties": {
+        "addr": {
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/definitions/TypedUuidForExternalIpKind"
+        }
+      }
+    },
+    "OmicronZoneExternalFloatingIp": {
+      "description": "Floating external IP allocated to an Omicron-managed zone.\n\nThis is a slimmer `nexus_db_model::ExternalIp` that only stores the fields necessary for blueprint planning, and requires that the zone have a single IP.",
+      "type": "object",
+      "required": [
+        "id",
+        "ip"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/TypedUuidForExternalIpKind"
+        },
+        "ip": {
+          "type": "string",
+          "format": "ip"
+        }
+      }
+    },
+    "OmicronZoneExternalSnatIp": {
+      "description": "SNAT (outbound) external IP allocated to an Omicron-managed zone.\n\nThis is a slimmer `nexus_db_model::ExternalIp` that only stores the fields necessary for blueprint planning, and requires that the zone have a single IP.",
+      "type": "object",
+      "required": [
+        "id",
+        "snat_cfg"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/TypedUuidForExternalIpKind"
+        },
+        "snat_cfg": {
+          "$ref": "#/definitions/SourceNatConfig"
+        }
+      }
+    },
+    "SledConfig": {
+      "type": "object",
+      "required": [
+        "disks",
+        "zones"
+      ],
+      "properties": {
+        "disks": {
+          "description": "Control plane disks configured for this sled",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OmicronPhysicalDisksConfig"
+            }
+          ]
+        },
+        "zones": {
+          "description": "zones configured for this sled",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BlueprintZoneConfig"
+          }
+        }
+      }
+    },
+    "SourceNatConfig": {
+      "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+      "type": "object",
+      "required": [
+        "first_port",
+        "ip",
+        "last_port"
+      ],
+      "properties": {
+        "first_port": {
+          "description": "The first port used for source NAT, inclusive.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "ip": {
+          "description": "The external address provided to the instance or service.",
+          "type": "string",
+          "format": "ip"
+        },
+        "last_port": {
+          "description": "The last port used for source NAT, also inclusive.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Srv": {
+      "description": "Srv\n\n<details><summary>JSON schema</summary>\n\n```json { \"type\": \"object\", \"required\": [ \"port\", \"prio\", \"target\", \"weight\" ], \"properties\": { \"port\": { \"type\": \"integer\", \"format\": \"uint16\", \"minimum\": 0.0 }, \"prio\": { \"type\": \"integer\", \"format\": \"uint16\", \"minimum\": 0.0 }, \"target\": { \"type\": \"string\" }, \"weight\": { \"type\": \"integer\", \"format\": \"uint16\", \"minimum\": 0.0 } } } ``` </details>",
+      "type": "object",
+      "required": [
+        "port",
+        "prio",
+        "target",
+        "weight"
+      ],
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "prio": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "target": {
+          "type": "string"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      }
+    },
+    "TypedUuidForExternalIpKind": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "TypedUuidForOmicronZoneKind": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "TypedUuidForZpoolKind": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "Vni": {
+      "description": "A Geneve Virtual Network Identifier",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "ZpoolName": {
+      "title": "The name of a Zpool",
+      "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
+      "type": "string",
+      "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    }
+  }
+}

--- a/sled-agent/src/rack_setup/mod.rs
+++ b/sled-agent/src/rack_setup/mod.rs
@@ -9,3 +9,8 @@ mod plan;
 pub mod service;
 
 pub use plan::service::SledConfig;
+pub use plan::service::{
+    from_ipaddr_to_external_floating_ip,
+    from_sockaddr_to_external_floating_addr,
+    from_source_nat_config_to_external_snat_ip,
+};

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -1494,10 +1494,10 @@ mod tests {
     }
 
     #[test]
-    fn test_rss_service_plan_v3_schema() {
+    fn test_rss_service_plan_v4_schema() {
         let schema = schemars::schema_for!(Plan);
         expectorate::assert_contents(
-            "../schema/rss-service-plan-v3.json",
+            "../schema/rss-service-plan-v4.json",
             &serde_json::to_string_pretty(&schema).unwrap(),
         );
     }

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -10,7 +10,13 @@ use illumos_utils::zpool::ZpoolName;
 use internal_dns::config::{Host, Zone};
 use internal_dns::ServiceName;
 use nexus_sled_agent_shared::inventory::{
-    Inventory, OmicronZoneConfig, OmicronZoneDataset, OmicronZoneType, SledRole,
+    Inventory, OmicronZoneDataset, SledRole,
+};
+use nexus_types::deployment::{
+    blueprint_zone_type, BlueprintPhysicalDisksConfig, BlueprintZoneConfig,
+    BlueprintZoneDisposition, BlueprintZoneType,
+    OmicronZoneExternalFloatingAddr, OmicronZoneExternalFloatingIp,
+    OmicronZoneExternalSnatIp,
 };
 use omicron_common::address::{
     get_sled_address, get_switch_zone_address, Ipv6Subnet, ReservedRackSubnet,
@@ -33,7 +39,9 @@ use omicron_common::policy::{
     BOUNDARY_NTP_REDUNDANCY, COCKROACHDB_REDUNDANCY, DNS_REDUNDANCY,
     MAX_DNS_REDUNDANCY, NEXUS_REDUNDANCY,
 };
-use omicron_uuid_kinds::{GenericUuid, OmicronZoneUuid, SledUuid, ZpoolUuid};
+use omicron_uuid_kinds::{
+    ExternalIpUuid, GenericUuid, OmicronZoneUuid, SledUuid, ZpoolUuid,
+};
 use rand::prelude::SliceRandom;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -120,10 +128,10 @@ pub enum PlanError {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SledConfig {
     /// Control plane disks configured for this sled
-    pub disks: OmicronPhysicalDisksConfig,
+    pub disks: BlueprintPhysicalDisksConfig,
 
     /// zones configured for this sled
-    pub zones: Vec<OmicronZoneConfig>,
+    pub zones: Vec<BlueprintZoneConfig>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -140,7 +148,53 @@ impl Ledgerable for Plan {
 }
 const RSS_SERVICE_PLAN_V1_FILENAME: &str = "rss-service-plan.json";
 const RSS_SERVICE_PLAN_V2_FILENAME: &str = "rss-service-plan-v2.json";
-const RSS_SERVICE_PLAN_FILENAME: &str = "rss-service-plan-v3.json";
+const RSS_SERVICE_PLAN_V3_FILENAME: &str = "rss-service-plan-v3.json";
+const RSS_SERVICE_PLAN_FILENAME: &str = "rss-service-plan-v4.json";
+
+pub fn from_sockaddr_to_external_floating_addr(
+    addr: SocketAddr,
+) -> OmicronZoneExternalFloatingAddr {
+    // This is pretty weird: IP IDs don't exist yet, so it's fine for us
+    // to make them up (Nexus will record them as a part of the
+    // handoff). We could pass `None` here for some zone types, but it's
+    // a little simpler to just always pass a new ID, which will only be
+    // used if the zone type has an external IP.
+    //
+    // This should all go away once RSS starts using blueprints more
+    // directly (instead of this conversion after the fact):
+    // https://github.com/oxidecomputer/omicron/issues/5272
+    OmicronZoneExternalFloatingAddr { id: ExternalIpUuid::new_v4(), addr }
+}
+
+pub fn from_ipaddr_to_external_floating_ip(
+    ip: IpAddr,
+) -> OmicronZoneExternalFloatingIp {
+    // This is pretty weird: IP IDs don't exist yet, so it's fine for us
+    // to make them up (Nexus will record them as a part of the
+    // handoff). We could pass `None` here for some zone types, but it's
+    // a little simpler to just always pass a new ID, which will only be
+    // used if the zone type has an external IP.
+    //
+    // This should all go away once RSS starts using blueprints more
+    // directly (instead of this conversion after the fact):
+    // https://github.com/oxidecomputer/omicron/issues/5272
+    OmicronZoneExternalFloatingIp { id: ExternalIpUuid::new_v4(), ip }
+}
+
+pub fn from_source_nat_config_to_external_snat_ip(
+    snat_cfg: SourceNatConfig,
+) -> OmicronZoneExternalSnatIp {
+    // This is pretty weird: IP IDs don't exist yet, so it's fine for us
+    // to make them up (Nexus will record them as a part of the
+    // handoff). We could pass `None` here for some zone types, but it's
+    // a little simpler to just always pass a new ID, which will only be
+    // used if the zone type has an external IP.
+    //
+    // This should all go away once RSS starts using blueprints more
+    // directly (instead of this conversion after the fact):
+    // https://github.com/oxidecomputer/omicron/issues/5272
+    OmicronZoneExternalSnatIp { id: ExternalIpUuid::new_v4(), snat_cfg }
+}
 
 impl Plan {
     pub async fn load(
@@ -200,6 +254,14 @@ impl Plan {
             }
         })? {
             Err(PlanError::FoundV2)
+        } else if Self::has_v3(storage_manager).await.map_err(|err| {
+            // Same as the comment above, but for version 3.
+            PlanError::Io {
+                message: String::from("looking for v3 RSS plan"),
+                err,
+            }
+        })? {
+            Err(PlanError::FoundV2)
         } else {
             Ok(None)
         }
@@ -233,6 +295,25 @@ impl Plan {
             .all_m2_mountpoints(CONFIG_DATASET)
             .into_iter()
             .map(|p| p.join(RSS_SERVICE_PLAN_V2_FILENAME));
+
+        for p in paths {
+            if p.try_exists()? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    async fn has_v3(
+        storage_manager: &StorageHandle,
+    ) -> Result<bool, std::io::Error> {
+        let paths = storage_manager
+            .get_latest_disks()
+            .await
+            .all_m2_mountpoints(CONFIG_DATASET)
+            .into_iter()
+            .map(|p| p.join(RSS_SERVICE_PLAN_V3_FILENAME));
 
         for p in paths {
             if p.try_exists()? {
@@ -419,20 +500,22 @@ impl Plan {
                 sled.alloc_dataset_from_u2s(DatasetType::InternalDns)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
 
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: ip,
-                zone_type: OmicronZoneType::InternalDns {
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
-                    },
-                    http_address,
-                    dns_address,
-                    gz_address: dns_subnet.gz_address(),
-                    gz_address_index: i.try_into().expect("Giant indices?"),
-                },
                 filesystem_pool,
+                zone_type: BlueprintZoneType::InternalDns(
+                    blueprint_zone_type::InternalDns {
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
+                        http_address,
+                        dns_address,
+                        gz_address: dns_subnet.gz_address(),
+                        gz_address_index: i.try_into().expect("Giant indices?"),
+                    },
+                ),
             });
         }
 
@@ -458,16 +541,19 @@ impl Plan {
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetType::CockroachDb)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
-            sled.request.zones.push(OmicronZoneConfig {
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
                 // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+                id,
                 underlay_address: ip,
-                zone_type: OmicronZoneType::CockroachDb {
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
+                zone_type: BlueprintZoneType::CockroachDb(
+                    blueprint_zone_type::CockroachDb {
+                        address,
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
                     },
-                    address,
-                },
+                ),
                 filesystem_pool,
             });
         }
@@ -499,23 +585,27 @@ impl Plan {
                 )
                 .unwrap();
             let dns_port = omicron_common::address::DNS_PORT;
-            let dns_address = SocketAddr::new(external_ip, dns_port);
+            let dns_address = from_sockaddr_to_external_floating_addr(
+                SocketAddr::new(external_ip, dns_port),
+            );
             let dataset_kind = DatasetType::ExternalDns;
             let dataset_name = sled.alloc_dataset_from_u2s(dataset_kind)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
 
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: *http_address.ip(),
-                zone_type: OmicronZoneType::ExternalDns {
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
+                zone_type: BlueprintZoneType::ExternalDns(
+                    blueprint_zone_type::ExternalDns {
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
+                        http_address,
+                        dns_address,
+                        nic,
                     },
-                    http_address,
-                    dns_address,
-                    nic,
-                },
+                ),
                 filesystem_pool,
             });
         }
@@ -539,28 +629,32 @@ impl Plan {
                 .unwrap();
             let (nic, external_ip) = svc_port_builder.next_nexus(id)?;
             let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: address,
-                zone_type: OmicronZoneType::Nexus {
-                    internal_address: SocketAddrV6::new(
-                        address,
-                        omicron_common::address::NEXUS_INTERNAL_PORT,
-                        0,
-                        0,
-                    ),
-                    external_ip,
-                    nic,
-                    // Tell Nexus to use TLS if and only if the caller
-                    // provided TLS certificates.  This effectively
-                    // determines the status of TLS for the lifetime of
-                    // the rack.  In production-like deployments, we'd
-                    // always expect TLS to be enabled.  It's only in
-                    // development that it might not be.
-                    external_tls: !config.external_certificates.is_empty(),
-                    external_dns_servers: config.dns_servers.clone(),
-                },
+                zone_type: BlueprintZoneType::Nexus(
+                    blueprint_zone_type::Nexus {
+                        internal_address: SocketAddrV6::new(
+                            address,
+                            omicron_common::address::NEXUS_INTERNAL_PORT,
+                            0,
+                            0,
+                        ),
+                        external_ip: from_ipaddr_to_external_floating_ip(
+                            external_ip,
+                        ),
+                        nic,
+                        // Tell Nexus to use TLS if and only if the caller
+                        // provided TLS certificates.  This effectively
+                        // determines the status of TLS for the lifetime of
+                        // the rack.  In production-like deployments, we'd
+                        // always expect TLS to be enabled.  It's only in
+                        // development that it might not be.
+                        external_tls: !config.external_certificates.is_empty(),
+                        external_dns_servers: config.dns_servers.clone(),
+                    },
+                ),
                 filesystem_pool,
             });
         }
@@ -584,18 +678,20 @@ impl Plan {
                 )
                 .unwrap();
             let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: address,
-                zone_type: OmicronZoneType::Oximeter {
-                    address: SocketAddrV6::new(
-                        address,
-                        omicron_common::address::OXIMETER_PORT,
-                        0,
-                        0,
-                    ),
-                },
+                zone_type: BlueprintZoneType::Oximeter(
+                    blueprint_zone_type::Oximeter {
+                        address: SocketAddrV6::new(
+                            address,
+                            omicron_common::address::OXIMETER_PORT,
+                            0,
+                            0,
+                        ),
+                    },
+                ),
                 filesystem_pool,
             })
         }
@@ -623,16 +719,18 @@ impl Plan {
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetType::Clickhouse)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: ip,
-                zone_type: OmicronZoneType::Clickhouse {
-                    address,
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
+                zone_type: BlueprintZoneType::Clickhouse(
+                    blueprint_zone_type::Clickhouse {
+                        address,
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
                     },
-                },
+                ),
                 filesystem_pool,
             });
         }
@@ -664,16 +762,18 @@ impl Plan {
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetType::ClickhouseServer)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: ip,
-                zone_type: OmicronZoneType::ClickhouseServer {
-                    address,
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
+                zone_type: BlueprintZoneType::ClickhouseServer(
+                    blueprint_zone_type::ClickhouseServer {
+                        address,
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
                     },
-                },
+                ),
                 filesystem_pool,
             });
         }
@@ -703,16 +803,18 @@ impl Plan {
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetType::ClickhouseKeeper)?;
             let filesystem_pool = Some(dataset_name.pool().clone());
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: ip,
-                zone_type: OmicronZoneType::ClickhouseKeeper {
-                    address,
-                    dataset: OmicronZoneDataset {
-                        pool_name: dataset_name.pool().clone(),
+                zone_type: BlueprintZoneType::ClickhouseKeeper(
+                    blueprint_zone_type::ClickhouseKeeper {
+                        address,
+                        dataset: OmicronZoneDataset {
+                            pool_name: dataset_name.pool().clone(),
+                        },
                     },
-                },
+                ),
                 filesystem_pool,
             });
         }
@@ -737,13 +839,15 @@ impl Plan {
                     port,
                 )
                 .unwrap();
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: address,
-                zone_type: OmicronZoneType::CruciblePantry {
-                    address: SocketAddrV6::new(address, port, 0, 0),
-                },
+                zone_type: BlueprintZoneType::CruciblePantry(
+                    blueprint_zone_type::CruciblePantry {
+                        address: SocketAddrV6::new(address, port, 0, 0),
+                    },
+                ),
                 filesystem_pool,
             });
         }
@@ -765,14 +869,18 @@ impl Plan {
                     )
                     .unwrap();
 
-                sled.request.zones.push(OmicronZoneConfig {
-                    // TODO-cleanup use TypedUuid everywhere
-                    id: id.into_untyped_uuid(),
+                sled.request.zones.push(BlueprintZoneConfig {
+                    disposition: BlueprintZoneDisposition::InService,
+                    id,
                     underlay_address: ip,
-                    zone_type: OmicronZoneType::Crucible {
-                        address,
-                        dataset: OmicronZoneDataset { pool_name: pool.clone() },
-                    },
+                    zone_type: BlueprintZoneType::Crucible(
+                        blueprint_zone_type::Crucible {
+                            address,
+                            dataset: OmicronZoneDataset {
+                                pool_name: pool.clone(),
+                            },
+                        },
+                    ),
                     filesystem_pool: Some(pool.clone()),
                 });
             }
@@ -793,24 +901,31 @@ impl Plan {
                     .push(Host::for_zone(Zone::Other(id)).fqdn());
                 let (nic, snat_cfg) = svc_port_builder.next_snat(id)?;
                 (
-                    OmicronZoneType::BoundaryNtp {
-                        address: ntp_address,
-                        ntp_servers: config.ntp_servers.clone(),
-                        dns_servers: config.dns_servers.clone(),
-                        domain: None,
-                        nic,
-                        snat_cfg,
-                    },
+                    BlueprintZoneType::BoundaryNtp(
+                        blueprint_zone_type::BoundaryNtp {
+                            address: ntp_address,
+                            ntp_servers: config.ntp_servers.clone(),
+                            dns_servers: config.dns_servers.clone(),
+                            domain: None,
+                            nic,
+                            external_ip:
+                                from_source_nat_config_to_external_snat_ip(
+                                    snat_cfg,
+                                ),
+                        },
+                    ),
                     ServiceName::BoundaryNtp,
                 )
             } else {
                 (
-                    OmicronZoneType::InternalNtp {
-                        address: ntp_address,
-                        ntp_servers: boundary_ntp_servers.clone(),
-                        dns_servers: rack_dns_servers.clone(),
-                        domain: None,
-                    },
+                    BlueprintZoneType::InternalNtp(
+                        blueprint_zone_type::InternalNtp {
+                            address: ntp_address,
+                            ntp_servers: boundary_ntp_servers.clone(),
+                            dns_servers: rack_dns_servers.clone(),
+                            domain: None,
+                        },
+                    ),
                     ServiceName::InternalNtp,
                 )
             };
@@ -819,9 +934,9 @@ impl Plan {
                 .host_zone_with_one_backend(id, address, svcname, NTP_PORT)
                 .unwrap();
 
-            sled.request.zones.push(OmicronZoneConfig {
-                // TODO-cleanup use TypedUuid everywhere
-                id: id.into_untyped_uuid(),
+            sled.request.zones.push(BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id,
                 underlay_address: address,
                 zone_type,
                 filesystem_pool,

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -543,7 +543,6 @@ impl Plan {
             let filesystem_pool = Some(dataset_name.pool().clone());
             sled.request.zones.push(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
-                // TODO-cleanup use TypedUuid everywhere
                 id,
                 underlay_address: ip,
                 zone_type: BlueprintZoneType::CockroachDb(


### PR DESCRIPTION
In anticipation of adding more `BlueprintZoneConfig` variants with more auxiliary information, we stop converting from `OmicronZoneConfig` to `BlueprintZoneConfig` which is not going to be feasible for much longer.

Instead we change the one production code place we do this, RSS, to directly construct `BlueprintZoneConfig` structs rather than do the conversion.

This has some ripple effects, and results in a new persistent v4 sled service plan.

There is one test that still does this conversion, but the function that does it is now moved into that test module and commented heavily. We hope to remove it shortly.