### PR TITLE
[oximeter] spell "Celsius" correctly

### DIFF
--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -19934,7 +19934,7 @@
               "nanoseconds",
               "volts",
               "amps",
-              "degrees_celcius"
+              "degrees_celsius"
             ]
           },
           {

--- a/oximeter/schema/src/codegen.rs
+++ b/oximeter/schema/src/codegen.rs
@@ -512,8 +512,8 @@ fn quote_units(units: Units) -> TokenStream {
         }
         Units::Amps => quote! { ::oximeter::schema::Units::Amps },
         Units::Volts => quote! { ::oximeter::schema::Units::Volts },
-        Units::DegreesCelcius => {
-            quote! { ::oximeter::schema::Units::DegreesCelcius }
+        Units::DegreesCelsius => {
+            quote! { ::oximeter::schema::Units::DegreesCelsius }
         }
         Units::Rpm => quote! { ::oximeter::schema::Units::Rpm },
     }

--- a/oximeter/types/src/schema.rs
+++ b/oximeter/types/src/schema.rs
@@ -189,7 +189,7 @@ pub enum Units {
     Nanoseconds,
     Volts,
     Amps,
-    DegreesCelcius,
+    DegreesCelsius,
     /// Rotations per minute.
     Rpm,
 }


### PR DESCRIPTION
Thanks to @elaine-oxide for catching this --- I had misspelt "Celsius"
as "Celcius" and it had made it all the way into the CLI thanks to its
dependency on the Nexus API.

This commit corrects the misspelling.