### PR TITLE
sled agent: index running VMMs by VMM ID, not instance ID

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -131,12 +131,10 @@ impl From<omicron_common::api::internal::nexus::VmmRuntimeState>
     }
 }
 
-impl From<omicron_common::api::internal::nexus::SledInstanceState>
-    for types::SledInstanceState
+impl From<omicron_common::api::internal::nexus::SledVmmState>
+    for types::SledVmmState
 {
-    fn from(
-        s: omicron_common::api::internal::nexus::SledInstanceState,
-    ) -> Self {
+    fn from(s: omicron_common::api::internal::nexus::SledVmmState) -> Self {
         Self {
             vmm_state: s.vmm_state.into(),
             migration_in: s.migration_in.map(Into::into),

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -138,7 +138,6 @@ impl From<omicron_common::api::internal::nexus::SledInstanceState>
         s: omicron_common::api::internal::nexus::SledInstanceState,
     ) -> Self {
         Self {
-            propolis_id: s.propolis_id,
             vmm_state: s.vmm_state.into(),
             migration_in: s.migration_in.map(Into::into),
             migration_out: s.migration_out.map(Into::into),

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -5,6 +5,7 @@
 //! Interface for making API requests to a Sled Agent
 
 use async_trait::async_trait;
+use omicron_uuid_kinds::PropolisUuid;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -448,11 +449,11 @@ impl From<types::SledIdentifiers>
 /// are bonus endpoints, not generated in the real client.
 #[async_trait]
 pub trait TestInterfaces {
-    async fn instance_single_step(&self, id: Uuid);
-    async fn instance_finish_transition(&self, id: Uuid);
-    async fn instance_simulate_migration_source(
+    async fn vmm_single_step(&self, id: PropolisUuid);
+    async fn vmm_finish_transition(&self, id: PropolisUuid);
+    async fn vmm_simulate_migration_source(
         &self,
-        id: Uuid,
+        id: PropolisUuid,
         params: SimulateMigrationSource,
     );
     async fn disk_finish_transition(&self, id: Uuid);
@@ -460,10 +461,10 @@ pub trait TestInterfaces {
 
 #[async_trait]
 impl TestInterfaces for Client {
-    async fn instance_single_step(&self, id: Uuid) {
+    async fn vmm_single_step(&self, id: PropolisUuid) {
         let baseurl = self.baseurl();
         let client = self.client();
-        let url = format!("{}/instances/{}/poke-single-step", baseurl, id);
+        let url = format!("{}/vmms/{}/poke-single-step", baseurl, id);
         client
             .post(url)
             .send()
@@ -471,10 +472,10 @@ impl TestInterfaces for Client {
             .expect("instance_single_step() failed unexpectedly");
     }
 
-    async fn instance_finish_transition(&self, id: Uuid) {
+    async fn vmm_finish_transition(&self, id: PropolisUuid) {
         let baseurl = self.baseurl();
         let client = self.client();
-        let url = format!("{}/instances/{}/poke", baseurl, id);
+        let url = format!("{}/vmms/{}/poke", baseurl, id);
         client
             .post(url)
             .send()
@@ -493,14 +494,14 @@ impl TestInterfaces for Client {
             .expect("disk_finish_transition() failed unexpectedly");
     }
 
-    async fn instance_simulate_migration_source(
+    async fn vmm_simulate_migration_source(
         &self,
-        id: Uuid,
+        id: PropolisUuid,
         params: SimulateMigrationSource,
     ) {
         let baseurl = self.baseurl();
         let client = self.client();
-        let url = format!("{baseurl}/instances/{id}/sim-migration-source");
+        let url = format!("{baseurl}/vmms/{id}/sim-migration-source");
         client
             .post(url)
             .json(&params)

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -167,7 +167,6 @@ impl From<types::SledInstanceState>
 {
     fn from(s: types::SledInstanceState) -> Self {
         Self {
-            propolis_id: s.propolis_id,
             vmm_state: s.vmm_state.into(),
             migration_in: s.migration_in.map(Into::into),
             migration_out: s.migration_out.map(Into::into),

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -162,10 +162,10 @@ impl From<types::VmmRuntimeState>
     }
 }
 
-impl From<types::SledInstanceState>
-    for omicron_common::api::internal::nexus::SledInstanceState
+impl From<types::SledVmmState>
+    for omicron_common::api::internal::nexus::SledVmmState
 {
-    fn from(s: types::SledInstanceState) -> Self {
+    fn from(s: types::SledVmmState) -> Self {
         Self {
             vmm_state: s.vmm_state.into(),
             migration_in: s.migration_in.map(Into::into),

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -113,10 +113,9 @@ pub struct VmmRuntimeState {
     pub time_updated: DateTime<Utc>,
 }
 
-/// A wrapper type containing a sled's total knowledge of the state of a
-/// specific VMM and the instance it incarnates.
+/// A wrapper type containing a sled's total knowledge of the state of a VMM.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct SledInstanceState {
+pub struct SledVmmState {
     /// The most recent state of the sled's VMM process.
     pub vmm_state: VmmRuntimeState,
 
@@ -139,7 +138,7 @@ impl Migrations<'_> {
     }
 }
 
-impl SledInstanceState {
+impl SledVmmState {
     pub fn migrations(&self) -> Migrations<'_> {
         Migrations {
             migration_in: self.migration_in.as_ref(),

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -117,6 +117,7 @@ pub struct VmmRuntimeState {
 /// specific VMM and the instance it incarnates.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SledInstanceState {
+    // TODO(gjc) this is probably redundant now
     /// The ID of the VMM whose state is being reported.
     pub propolis_id: PropolisUuid,
 

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -117,10 +117,6 @@ pub struct VmmRuntimeState {
 /// specific VMM and the instance it incarnates.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct SledInstanceState {
-    // TODO(gjc) this is probably redundant now
-    /// The ID of the VMM whose state is being reported.
-    pub propolis_id: PropolisUuid,
-
     /// The most recent state of the sled's VMM process.
     pub vmm_state: VmmRuntimeState,
 

--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -5,7 +5,6 @@
 //! [`DataStore`] helpers for working with VMM records.
 
 use super::DataStore;
-use crate::authz;
 use crate::context::OpContext;
 use crate::db;
 use crate::db::error::public_error_from_diesel;
@@ -108,14 +107,10 @@ impl DataStore {
     pub async fn vmm_fetch(
         &self,
         opctx: &OpContext,
-        authz_instance: &authz::Instance,
         vmm_id: &PropolisUuid,
     ) -> LookupResult<Vmm> {
-        opctx.authorize(authz::Action::Read, authz_instance).await?;
-
         let vmm = dsl::vmm
             .filter(dsl::id.eq(vmm_id.into_untyped_uuid()))
-            .filter(dsl::instance_id.eq(authz_instance.id()))
             .filter(dsl::time_deleted.is_null())
             .select(Vmm::as_select())
             .get_result_async(&*self.pool_connection_authorized(opctx).await?)

--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -39,8 +39,13 @@ use uuid::Uuid;
 
 /// The result of an [`DataStore::vmm_and_migration_update_runtime`] call,
 /// indicating which records were updated.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct VmmStateUpdateResult {
+    /// The VMM record that the update query found and possibly updated.
+    ///
+    /// NOTE: This is the record prior to the update!
+    pub found_vmm: Vmm,
+
     /// `true` if the VMM record was updated, `false` otherwise.
     pub vmm_updated: bool,
 
@@ -228,13 +233,21 @@ impl DataStore {
             .transaction(&conn, |conn| {
                 let err = err.clone();
                 async move {
-                let vmm_updated = self
+                let vmm_update_result = self
                     .vmm_update_runtime_on_connection(
                         &conn,
                         &vmm_id,
                         new_runtime,
                     )
-                    .await.map(|r| match r.status { UpdateStatus::Updated => true, UpdateStatus::NotUpdatedButExists => false })?;
+                    .await?;
+
+
+                let found_vmm = vmm_update_result.found;
+                let vmm_updated = match vmm_update_result.status {
+                     UpdateStatus::Updated => true,
+                     UpdateStatus::NotUpdatedButExists => false
+                };
+
                 let migration_out_updated = match migration_out {
                     Some(migration) => {
                         let r = self.migration_update_source_on_connection(
@@ -282,6 +295,7 @@ impl DataStore {
                     None => false,
                 };
                 Ok(VmmStateUpdateResult {
+                    found_vmm,
                     vmm_updated,
                     migration_in_updated,
                     migration_out_updated,

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -33,7 +33,7 @@ use omicron_common::{
             DiskRuntimeState, DownstairsClientStopRequest,
             DownstairsClientStopped, ProducerEndpoint,
             ProducerRegistrationResponse, RepairFinishInfo, RepairProgress,
-            RepairStartInfo, SledInstanceState,
+            RepairStartInfo, SledVmmState,
         },
     },
     update::ArtifactId,
@@ -116,7 +116,7 @@ pub trait NexusInternalApi {
     async fn cpapi_instances_put(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        new_runtime_state: TypedBody<SledInstanceState>,
+        new_runtime_state: TypedBody<SledVmmState>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
     #[endpoint {

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -39,8 +39,8 @@ use omicron_common::{
     update::ArtifactId,
 };
 use omicron_uuid_kinds::{
-    DemoSagaUuid, DownstairsKind, SledUuid, TypedUuid, UpstairsKind,
-    UpstairsRepairKind,
+    DemoSagaUuid, DownstairsKind, PropolisUuid, SledUuid, TypedUuid,
+    UpstairsKind, UpstairsRepairKind,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -108,14 +108,14 @@ pub trait NexusInternalApi {
         body: TypedBody<SwitchPutRequest>,
     ) -> Result<HttpResponseOk<SwitchPutResponse>, HttpError>;
 
-    /// Report updated state for an instance.
+    /// Report updated state for a VMM.
     #[endpoint {
         method = PUT,
-        path = "/instances/{instance_id}",
+        path = "/vmms/{propolis_id}",
     }]
     async fn cpapi_instances_put(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         new_runtime_state: TypedBody<SledInstanceState>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
@@ -566,6 +566,12 @@ pub struct SwitchPathParam {
 #[derive(Deserialize, JsonSchema)]
 pub struct InstancePathParam {
     pub instance_id: Uuid,
+}
+
+/// Path parameters for VMM requests (internal API)
+#[derive(Deserialize, JsonSchema)]
+pub struct VmmPathParam {
+    pub propolis_id: PropolisUuid,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]

--- a/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
@@ -28,8 +28,8 @@
 //! remains alive and continues to own its virtual provisioning resources.
 //!
 //! Cleanup of instance resources when an instance's *active* VMM is destroyed
-//! is handled elsewhere, by `notify_vmm_updated` and (eventually) the
-//! `instance-update` saga.
+//! is handled elsewhere, by `process_vmm_update` and the `instance-update`
+//! saga.
 
 use crate::app::background::BackgroundTask;
 use anyhow::Context;

--- a/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
@@ -28,7 +28,7 @@
 //! remains alive and continues to own its virtual provisioning resources.
 //!
 //! Cleanup of instance resources when an instance's *active* VMM is destroyed
-//! is handled elsewhere, by `notify_instance_updated` and (eventually) the
+//! is handled elsewhere, by `notify_vmm_updated` and (eventually) the
 //! `instance-update` saga.
 
 use crate::app::background::BackgroundTask;

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -22,6 +22,7 @@ use omicron_common::api::external::InstanceState;
 use omicron_common::api::internal::nexus::SledInstanceState;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::InstanceUuid;
+use omicron_uuid_kinds::PropolisUuid;
 use oximeter::types::ProducerRegistry;
 use sled_agent_client::Client as SledAgentClient;
 use std::borrow::Cow;
@@ -83,9 +84,7 @@ impl InstanceWatcher {
         async move {
             slog::trace!(opctx.log, "checking on instance...");
             let rsp = client
-                .instance_get_state(&InstanceUuid::from_untyped_uuid(
-                    target.instance_id,
-                ))
+                .vmm_get_state(&PropolisUuid::from_untyped_uuid(target.vmm_id))
                 .await;
             let mut check = Check {
                 target,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1861,6 +1861,13 @@ pub(crate) async fn process_vmm_update(
 
     // If an instance-update saga must be executed as a result of this update,
     // prepare and return it.
+    //
+    // It's safe to refetch the VMM record to get the instance ID at this point
+    // even though the VMM may now be Destroyed, because the record itself won't
+    // be deleted until the instance update saga retires it. If this update
+    // marked the VMM as Destroyed and then the fetch failed, then another
+    // update saga has already observed what this routine published, so there's
+    // no need to schedule another saga.
     if instance_update::update_saga_needed(
         &opctx.log,
         propolis_id,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1830,8 +1830,8 @@ impl super::Nexus {
     }
 }
 
-/// Publishes the VMM and migration state supplied in `new_runtime_state` to the
-/// database.
+/// Writes the VMM and migration state supplied in `new_runtime_state` to the
+/// database (provided that it's newer than what's already there).
 ///
 /// # Return value
 ///

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1863,6 +1863,7 @@ pub(crate) async fn process_vmm_update(
     // prepare and return it.
     if instance_update::update_saga_needed(
         &opctx.log,
+        propolis_id,
         new_runtime_state,
         &result,
     ) {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1868,13 +1868,6 @@ pub(crate) async fn process_vmm_update(
 
     // If an instance-update saga must be executed as a result of this update,
     // prepare and return it.
-    //
-    // It's safe to fetch the VMM record to get the instance ID at this point
-    // even though the VMM may now be Destroyed, because the record itself won't
-    // be deleted until the instance update saga retires it. If this update
-    // marked the VMM as Destroyed and then the fetch failed, then another
-    // update saga has already observed what this routine published, so there's
-    // no need to schedule another saga.
     if instance_update::update_saga_needed(
         &opctx.log,
         propolis_id,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1881,9 +1881,8 @@ pub(crate) async fn process_vmm_update(
         new_runtime_state,
         &result,
     ) {
-        let instance_id = InstanceUuid::from_untyped_uuid(
-            datastore.vmm_fetch(&opctx, &propolis_id).await?.instance_id,
-        );
+        let instance_id =
+            InstanceUuid::from_untyped_uuid(result.found_vmm.instance_id);
 
         let (.., authz_instance) = LookupPath::new(&opctx, datastore)
             .instance_id(instance_id.into_untyped_uuid())

--- a/nexus/src/app/sagas/instance_common.rs
+++ b/nexus/src/app/sagas/instance_common.rs
@@ -25,6 +25,12 @@ use super::NexusActionContext;
 /// The port propolis-server listens on inside the propolis zone.
 const DEFAULT_PROPOLIS_PORT: u16 = 12400;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(super) struct PropolisAndSledId {
+    pub(super) propolis_id: PropolisUuid,
+    pub(super) sled_id: SledUuid,
+}
+
 /// Reserves resources for a new VMM whose instance has `ncpus` guest logical
 /// processors and `guest_memory` bytes of guest RAM. The selected sled is
 /// random within the set of sleds allowed by the supplied `constraints`.
@@ -213,12 +219,12 @@ pub async fn instance_ip_move_state(
 /// the Attaching or Detaching state so that concurrent attempts to start the
 /// instance will notice that the IP state is in flux and ask the caller to
 /// retry.
-pub async fn instance_ip_get_instance_state(
+pub(super) async fn instance_ip_get_instance_state(
     sagactx: &NexusActionContext,
     serialized_authn: &authn::saga::Serialized,
     authz_instance: &authz::Instance,
     verb: &str,
-) -> Result<Option<SledUuid>, ActionError> {
+) -> Result<Option<PropolisAndSledId>, ActionError> {
     // XXX: we can get instance state (but not sled ID) in same transaction
     //      as attach (but not detach) wth current design. We need to re-query
     //      for sled ID anyhow, so keep consistent between attach/detach.
@@ -236,7 +242,11 @@ pub async fn instance_ip_get_instance_state(
         inst_and_vmm.vmm().as_ref().map(|vmm| vmm.runtime.state);
     let found_instance_state =
         inst_and_vmm.instance().runtime_state.nexus_state;
-    let mut sled_id = inst_and_vmm.sled_id();
+    let mut propolis_and_sled_id =
+        inst_and_vmm.vmm().as_ref().map(|vmm| PropolisAndSledId {
+            propolis_id: PropolisUuid::from_untyped_uuid(vmm.id),
+            sled_id: SledUuid::from_untyped_uuid(vmm.sled_id),
+        });
 
     slog::debug!(
         osagactx.log(), "evaluating instance state for IP attach/detach";
@@ -257,7 +267,7 @@ pub async fn instance_ip_get_instance_state(
     match (found_instance_state, found_vmm_state) {
         // If there's no VMM, the instance is definitely not on any sled.
         (InstanceState::NoVmm, _) | (_, Some(VmmState::SagaUnwound)) => {
-            sled_id = None;
+            propolis_and_sled_id = None;
         }
 
         // If the instance is running normally or rebooting, it's resident on
@@ -340,7 +350,7 @@ pub async fn instance_ip_get_instance_state(
         }
     }
 
-    Ok(sled_id)
+    Ok(propolis_and_sled_id)
 }
 
 /// Adds a NAT entry to DPD, routing packets bound for `target_ip` to a
@@ -441,18 +451,19 @@ pub async fn instance_ip_remove_nat(
 /// Inform the OPTE port for a running instance that it should start
 /// sending/receiving traffic on a given IP address.
 ///
-/// This call is a no-op if `sled_uuid` is `None` or the saga is explicitly
-/// set to be inactive in event of double attach/detach (`!target_ip.do_saga`).
-pub async fn instance_ip_add_opte(
+/// This call is a no-op if the instance is not active (`propolis_and_sled` is
+/// `None`) or the calling saga is explicitly set to be inactive in the event of
+/// a double attach/detach (`!target_ip.do_saga`).
+pub(super) async fn instance_ip_add_opte(
     sagactx: &NexusActionContext,
-    authz_instance: &authz::Instance,
-    sled_uuid: Option<SledUuid>,
+    propolis_and_sled: Option<PropolisAndSledId>,
     target_ip: ModifyStateForExternalIp,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
 
     // No physical sled? Don't inform OPTE.
-    let Some(sled_uuid) = sled_uuid else {
+    let Some(PropolisAndSledId { propolis_id, sled_id }) = propolis_and_sled
+    else {
         return Ok(());
     };
 
@@ -470,17 +481,14 @@ pub async fn instance_ip_add_opte(
 
     osagactx
         .nexus()
-        .sled_client(&sled_uuid)
+        .sled_client(&sled_id)
         .await
         .map_err(|_| {
             ActionError::action_failed(Error::unavail(
                 "sled agent client went away mid-attach/detach",
             ))
         })?
-        .instance_put_external_ip(
-            &InstanceUuid::from_untyped_uuid(authz_instance.id()),
-            &sled_agent_body,
-        )
+        .vmm_put_external_ip(&propolis_id, &sled_agent_body)
         .await
         .map_err(|e| {
             ActionError::action_failed(match e {
@@ -499,18 +507,19 @@ pub async fn instance_ip_add_opte(
 /// Inform the OPTE port for a running instance that it should cease
 /// sending/receiving traffic on a given IP address.
 ///
-/// This call is a no-op if `sled_uuid` is `None` or the saga is explicitly
-/// set to be inactive in event of double attach/detach (`!target_ip.do_saga`).
-pub async fn instance_ip_remove_opte(
+/// This call is a no-op if the instance is not active (`propolis_and_sled` is
+/// `None`) or the calling saga is explicitly set to be inactive in the event of
+/// a double attach/detach (`!target_ip.do_saga`).
+pub(super) async fn instance_ip_remove_opte(
     sagactx: &NexusActionContext,
-    authz_instance: &authz::Instance,
-    sled_uuid: Option<SledUuid>,
+    propolis_and_sled: Option<PropolisAndSledId>,
     target_ip: ModifyStateForExternalIp,
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
 
     // No physical sled? Don't inform OPTE.
-    let Some(sled_uuid) = sled_uuid else {
+    let Some(PropolisAndSledId { propolis_id, sled_id }) = propolis_and_sled
+    else {
         return Ok(());
     };
 
@@ -528,17 +537,14 @@ pub async fn instance_ip_remove_opte(
 
     osagactx
         .nexus()
-        .sled_client(&sled_uuid)
+        .sled_client(&sled_id)
         .await
         .map_err(|_| {
             ActionError::action_failed(Error::unavail(
                 "sled agent client went away mid-attach/detach",
             ))
         })?
-        .instance_delete_external_ip(
-            &InstanceUuid::from_untyped_uuid(authz_instance.id()),
-            &sled_agent_body,
-        )
+        .vmm_delete_external_ip(&propolis_id, &sled_agent_body)
         .await
         .map_err(|e| {
             ActionError::action_failed(match e {

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -1220,8 +1220,7 @@ pub mod test {
     }
 
     async fn no_instances_or_disks_on_sled(sled_agent: &SledAgent) -> bool {
-        sled_agent.instance_count().await == 0
-            && sled_agent.disk_count().await == 0
+        sled_agent.vmm_count().await == 0 && sled_agent.disk_count().await == 0
     }
 
     pub(crate) async fn verify_clean_slate(

--- a/nexus/src/app/sagas/instance_ip_detach.rs
+++ b/nexus/src/app/sagas/instance_ip_detach.rs
@@ -5,7 +5,7 @@
 use super::instance_common::{
     instance_ip_add_nat, instance_ip_add_opte, instance_ip_get_instance_state,
     instance_ip_move_state, instance_ip_remove_nat, instance_ip_remove_opte,
-    ModifyStateForExternalIp,
+    ModifyStateForExternalIp, PropolisAndSledId,
 };
 use super::{ActionRegistry, NexusActionContext, NexusSaga};
 use crate::app::sagas::declare_saga_actions;
@@ -155,7 +155,7 @@ async fn siid_begin_detach_ip_undo(
 
 async fn siid_get_instance_state(
     sagactx: NexusActionContext,
-) -> Result<Option<SledUuid>, ActionError> {
+) -> Result<Option<PropolisAndSledId>, ActionError> {
     let params = sagactx.saga_params::<Params>()?;
     instance_ip_get_instance_state(
         &sagactx,
@@ -184,7 +184,9 @@ async fn siid_nat_undo(
 ) -> Result<(), anyhow::Error> {
     let log = sagactx.user_data().log();
     let params = sagactx.saga_params::<Params>()?;
-    let sled_id = sagactx.lookup::<Option<SledUuid>>("instance_state")?;
+    let sled_id = sagactx
+        .lookup::<Option<PropolisAndSledId>>("instance_state")?
+        .map(|ids| ids.sled_id);
     let target_ip = sagactx.lookup::<ModifyStateForExternalIp>("target_ip")?;
     if let Err(e) = instance_ip_add_nat(
         &sagactx,
@@ -204,33 +206,18 @@ async fn siid_nat_undo(
 async fn siid_update_opte(
     sagactx: NexusActionContext,
 ) -> Result<(), ActionError> {
-    let params = sagactx.saga_params::<Params>()?;
-    let sled_id = sagactx.lookup::<Option<SledUuid>>("instance_state")?;
+    let ids = sagactx.lookup::<Option<PropolisAndSledId>>("instance_state")?;
     let target_ip = sagactx.lookup::<ModifyStateForExternalIp>("target_ip")?;
-    instance_ip_remove_opte(
-        &sagactx,
-        &params.authz_instance,
-        sled_id,
-        target_ip,
-    )
-    .await
+    instance_ip_remove_opte(&sagactx, ids, target_ip).await
 }
 
 async fn siid_update_opte_undo(
     sagactx: NexusActionContext,
 ) -> Result<(), anyhow::Error> {
     let log = sagactx.user_data().log();
-    let params = sagactx.saga_params::<Params>()?;
-    let sled_id = sagactx.lookup::<Option<SledUuid>>("instance_state")?;
+    let ids = sagactx.lookup::<Option<PropolisAndSledId>>("instance_state")?;
     let target_ip = sagactx.lookup::<ModifyStateForExternalIp>("target_ip")?;
-    if let Err(e) = instance_ip_add_opte(
-        &sagactx,
-        &params.authz_instance,
-        sled_id,
-        target_ip,
-    )
-    .await
-    {
+    if let Err(e) = instance_ip_add_opte(&sagactx, ids, target_ip).await {
         error!(log, "siid_update_opte_undo: failed to notify sled-agent: {e}");
     }
     Ok(())

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -437,20 +437,10 @@ async fn sim_ensure_destination_propolis_undo(
     sagactx: NexusActionContext,
 ) -> Result<(), anyhow::Error> {
     let osagactx = sagactx.user_data();
-    let params = sagactx.saga_params::<Params>()?;
-    let opctx = crate::context::op_context_for_saga_action(
-        &sagactx,
-        &params.serialized_authn,
-    );
-
+    let dst_propolis_id = sagactx.lookup::<PropolisUuid>("dst_propolis_id")?;
     let dst_sled_id = sagactx.lookup::<SledUuid>("dst_sled_id")?;
     let db_instance =
         sagactx.lookup::<db::model::Instance>("set_migration_ids")?;
-    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
-        .instance_id(db_instance.id())
-        .lookup_for(authz::Action::Modify)
-        .await
-        .map_err(ActionError::action_failed)?;
 
     info!(osagactx.log(), "unregistering destination vmm for migration unwind";
           "instance_id" => %db_instance.id(),
@@ -465,7 +455,7 @@ async fn sim_ensure_destination_propolis_undo(
     // needed.
     match osagactx
         .nexus()
-        .instance_ensure_unregistered(&opctx, &authz_instance, &dst_sled_id)
+        .instance_ensure_unregistered(&dst_propolis_id, &dst_sled_id)
         .await
     {
         Ok(_) => Ok(()),

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -490,12 +490,6 @@ async fn sim_instance_migrate(
 
     let src_propolis_id = db_instance.runtime().propolis_id.unwrap();
     let dst_vmm = sagactx.lookup::<db::model::Vmm>("dst_vmm_record")?;
-    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
-        .instance_id(db_instance.id())
-        .lookup_for(authz::Action::Modify)
-        .await
-        .map_err(ActionError::action_failed)?;
-
     info!(osagactx.log(), "initiating migration from destination sled";
           "instance_id" => %db_instance.id(),
           "dst_vmm_record" => ?dst_vmm,
@@ -519,7 +513,6 @@ async fn sim_instance_migrate(
         .nexus()
         .instance_request_state(
             &opctx,
-            &authz_instance,
             &db_instance,
             &Some(dst_vmm),
             InstanceStateChangeRequest::Migrate(

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -646,7 +646,6 @@ async fn sis_ensure_running(
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
     let params = sagactx.saga_params::<Params>()?;
-    let datastore = osagactx.datastore();
     let opctx = crate::context::op_context_for_saga_action(
         &sagactx,
         &params.serialized_authn,
@@ -661,17 +660,10 @@ async fn sis_ensure_running(
           "instance_id" => %instance_id,
           "sled_id" => %sled_id);
 
-    let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
-        .instance_id(instance_id.into_untyped_uuid())
-        .lookup_for(authz::Action::Modify)
-        .await
-        .map_err(ActionError::action_failed)?;
-
     match osagactx
         .nexus()
         .instance_request_state(
             &opctx,
-            &authz_instance,
             &db_instance,
             &Some(db_vmm),
             crate::app::instance::InstanceStateChangeRequest::Run,

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -30,10 +30,9 @@
 //! Nexus' `cpapi_instances_put` internal API endpoint, when a Nexus'
 //! `instance-watcher` background task *pulls* instance states from sled-agents
 //! periodically, or as the return value of an API call from Nexus to a
-//! sled-agent. When a Nexus receives a new [`SledInstanceState`] from a
-//! sled-agent through any of these mechanisms, the Nexus will write any changed
-//! state to the `vmm` and/or `migration` tables directly on behalf of the
-//! sled-agent.
+//! sled-agent. When a Nexus receives a new [`SledVmmState`] from a sled-agent
+//! through any of these mechanisms, the Nexus will write any changed state to
+//! the `vmm` and/or `migration` tables directly on behalf of the sled-agent.
 //!
 //! Although Nexus is technically the party responsible for the database query
 //! that writes VMM and migration state updates received from sled-agent, it is
@@ -326,6 +325,7 @@
 //!     crate::app::db::datastore::DataStore::instance_updater_inherit_lock
 //! [instance_updater_unlock]:
 //!     crate::app::db::datastore::DataStore::instance_updater_unlock
+//! [`notify_vmm_updated`]: crate::app::Nexus::notify_vmm_updated
 //! [`process_vmm_update`]: crate::app::instance::process_vmm_update
 //!
 //! [dist-locking]:
@@ -388,8 +388,8 @@ pub(crate) use self::start::{Params, SagaInstanceUpdate};
 mod destroyed;
 
 /// Returns `true` if an `instance-update` saga should be executed as a result
-/// of writing the provided [`SledInstanceState`] to the database with the
-/// provided [`VmmStateUpdateResult`].
+/// of writing the provided [`SledVmmState`] to the database with the provided
+/// [`VmmStateUpdateResult`].
 ///
 /// We determine this only after actually updating the database records,
 /// because we don't know whether a particular VMM or migration state is

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -236,7 +236,7 @@
 //! updates is perhaps the simplest one: _avoiding unnecessary update sagas_.
 //! The `cpapi_instances_put` API endpoint and instance-watcher background tasks
 //! handle changes to VMM and migration states by calling the
-//! [`notify_instance_updated`] method, which writes the new states to the
+//! [`notify_vmm_updated`] method, which writes the new states to the
 //! database and (potentially) starts an update saga. Naively, this method would
 //! *always* start an update saga, but remember that --- as we discussed
 //! [above](#background) --- many VMM/migration state changes don't actually
@@ -271,7 +271,7 @@
 //! delayed. To improve the timeliness of update sagas, we will also explicitly
 //! activate the background task at any point where we know that an update saga
 //! *should* run but we were not able to run it. If an update saga cannot be
-//! started, whether by [`notify_instance_updated`], a `start-instance-update`
+//! started, whether by [`notify_vmm_updated`], a `start-instance-update`
 //! saga attempting to start its real saga, or an `instance-update` saga
 //! chaining into a new one as its last action, the `instance-watcher`
 //! background task is activated. Similarly, when a `start-instance-update` saga
@@ -326,7 +326,7 @@
 //!     crate::app::db::datastore::DataStore::instance_updater_inherit_lock
 //! [instance_updater_unlock]:
 //!     crate::app::db::datastore::DataStore::instance_updater_unlock
-//! [`notify_instance_updated`]: crate::app::Nexus::notify_instance_updated
+//! [`notify_vmm_updated`]: crate::app::Nexus::notify_vmm_updated
 //!
 //! [dist-locking]:
 //!     https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -407,7 +407,6 @@ mod destroyed;
 /// VMM/migration states.
 pub fn update_saga_needed(
     log: &slog::Logger,
-    instance_id: InstanceUuid,
     state: &SledInstanceState,
     result: &VmmStateUpdateResult,
 ) -> bool {
@@ -443,7 +442,6 @@ pub fn update_saga_needed(
         debug!(log,
             "new VMM runtime state from sled agent requires an \
              instance-update saga";
-            "instance_id" => %instance_id,
             "propolis_id" => %state.propolis_id,
             "vmm_needs_update" => vmm_needs_update,
             "migration_in_needs_update" => migration_in_needs_update,

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -407,6 +407,7 @@ mod destroyed;
 /// VMM/migration states.
 pub fn update_saga_needed(
     log: &slog::Logger,
+    propolis_id: PropolisUuid,
     state: &SledInstanceState,
     result: &VmmStateUpdateResult,
 ) -> bool {
@@ -442,7 +443,7 @@ pub fn update_saga_needed(
         debug!(log,
             "new VMM runtime state from sled agent requires an \
              instance-update saga";
-            "propolis_id" => %state.propolis_id,
+            "propolis_id" => %propolis_id,
             "vmm_needs_update" => vmm_needs_update,
             "migration_in_needs_update" => migration_in_needs_update,
             "migration_out_needs_update" => migration_out_needs_update,

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -2156,12 +2156,15 @@ mod test {
             .await
             .unwrap();
 
-        let sled_id = instance_state
-            .sled_id()
-            .expect("starting instance should have a sled");
+        let vmm_state = instance_state
+            .vmm()
+            .as_ref()
+            .expect("starting instance should have a vmm");
+        let propolis_id = PropolisUuid::from_untyped_uuid(vmm_state.id);
+        let sled_id = SledUuid::from_untyped_uuid(vmm_state.sled_id);
         let sa = nexus.sled_client(&sled_id).await.unwrap();
+        sa.vmm_finish_transition(propolis_id).await;
 
-        sa.instance_finish_transition(instance.identity.id).await;
         let instance_state = nexus
             .datastore()
             .instance_fetch_with_vmm(&opctx, &authz_instance)

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -862,7 +862,7 @@ async fn ssc_send_snapshot_request_to_sled_agent(
         sled_agent_client
             .vmm_issue_disk_snapshot_request(
                 &PropolisUuid::from_untyped_uuid(propolis_id),
-                &attach_instance_id,
+                &params.disk_id,
                 &VmmIssueDiskSnapshotRequestBody { snapshot_id },
             )
             .await

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -220,7 +220,7 @@ pub async fn instance_fetch(
     db_state
 }
 
-async fn instance_fetch_vmm_and_sled_ids(
+pub(super) async fn instance_fetch_vmm_and_sled_ids(
     cptestctx: &ControlPlaneTestContext,
     instance_id: &InstanceUuid,
 ) -> (PropolisUuid, SledUuid) {

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -5,7 +5,7 @@
 //! Helper functions for writing saga undo tests and working with instances in
 //! saga tests.
 
-use super::NexusSaga;
+use super::{instance_common::VmmAndSledIds, NexusSaga};
 use crate::{app::saga::create_saga_dag, Nexus};
 use async_bb8_diesel::{AsyncRunQueryDsl, AsyncSimpleConnection};
 use camino::Utf8Path;
@@ -134,14 +134,14 @@ pub(crate) async fn instance_simulate(
     info!(&cptestctx.logctx.log, "Poking simulated instance";
           "instance_id" => %instance_id);
     let nexus = &cptestctx.server.server_context().nexus;
-    let (propolis_id, sled_id) =
+    let VmmAndSledIds { vmm_id, sled_id } =
         instance_fetch_vmm_and_sled_ids(cptestctx, instance_id).await;
     let sa = nexus
         .sled_client(&sled_id)
         .await
         .expect("instance must be on a sled to simulate a state change");
 
-    sa.vmm_finish_transition(propolis_id).await;
+    sa.vmm_finish_transition(vmm_id).await;
 }
 
 pub(crate) async fn instance_single_step_on_sled(
@@ -156,14 +156,14 @@ pub(crate) async fn instance_single_step_on_sled(
         "sled_id" => %sled_id,
     );
     let nexus = &cptestctx.server.server_context().nexus;
-    let (propolis_id, sled_id) =
+    let VmmAndSledIds { vmm_id, sled_id } =
         instance_fetch_vmm_and_sled_ids(cptestctx, instance_id).await;
     let sa = nexus
         .sled_client(&sled_id)
         .await
         .expect("instance must be on a sled to simulate a state change");
 
-    sa.vmm_single_step(propolis_id).await;
+    sa.vmm_single_step(vmm_id).await;
 }
 
 pub(crate) async fn instance_simulate_by_name(
@@ -187,13 +187,13 @@ pub(crate) async fn instance_simulate_by_name(
         nexus.instance_lookup(&opctx, instance_selector).unwrap();
     let (.., instance) = instance_lookup.fetch().await.unwrap();
     let instance_id = InstanceUuid::from_untyped_uuid(instance.id());
-    let (propolis_id, sled_id) =
+    let VmmAndSledIds { vmm_id, sled_id } =
         instance_fetch_vmm_and_sled_ids(cptestctx, &instance_id).await;
     let sa = nexus
         .sled_client(&sled_id)
         .await
         .expect("instance must be on a sled to simulate a state change");
-    sa.vmm_finish_transition(propolis_id).await;
+    sa.vmm_finish_transition(vmm_id).await;
 }
 
 pub async fn instance_fetch(
@@ -223,16 +223,16 @@ pub async fn instance_fetch(
 pub(super) async fn instance_fetch_vmm_and_sled_ids(
     cptestctx: &ControlPlaneTestContext,
     instance_id: &InstanceUuid,
-) -> (PropolisUuid, SledUuid) {
+) -> VmmAndSledIds {
     let instance_and_vmm = instance_fetch(cptestctx, *instance_id).await;
     let vmm = instance_and_vmm
         .vmm()
         .as_ref()
-        .expect("simulating an instance requires an active vmm");
+        .expect("can only fetch VMM and sled IDs for an active instance");
 
-    let propolis_id = PropolisUuid::from_untyped_uuid(vmm.id);
+    let vmm_id = PropolisUuid::from_untyped_uuid(vmm.id);
     let sled_id = SledUuid::from_untyped_uuid(vmm.sled_id);
-    (propolis_id, sled_id)
+    VmmAndSledIds { vmm_id, sled_id }
 }
 
 pub async fn instance_fetch_all(

--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -107,8 +107,11 @@ impl super::Nexus {
                 .instance_fetch_with_vmm(&opctx, &authz_instance)
                 .await?;
 
+            // If a Propolis _may_ exist, send the snapshot request there,
+            // otherwise use the pantry.
             instance_state.vmm().is_none()
         } else {
+            // This disk is not attached to an instance, use the pantry.
             true
         };
 

--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -107,11 +107,8 @@ impl super::Nexus {
                 .instance_fetch_with_vmm(&opctx, &authz_instance)
                 .await?;
 
-            // If a Propolis _may_ exist, send the snapshot request there,
-            // otherwise use the pantry.
-            !instance_state.vmm().is_some()
+            instance_state.vmm().is_none()
         } else {
-            // This disk is not attached to an instance, use the pantry.
             true
         };
 

--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -6,8 +6,7 @@ use async_trait::async_trait;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::lookup::LookupPath;
 use omicron_common::api::external::Error;
-use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::{InstanceUuid, SledUuid};
+use omicron_uuid_kinds::{GenericUuid, InstanceUuid, PropolisUuid, SledUuid};
 use sled_agent_client::Client as SledAgentClient;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -19,25 +18,47 @@ pub use super::update::SpUpdater;
 pub use super::update::UpdateProgress;
 pub use gateway_client::types::SpType;
 
+/// The information needed to talk to a sled agent about an instance that is
+/// active on that sled.
+pub struct InstanceSledAgentInfo {
+    /// The ID of the Propolis job to send to sled agent.
+    pub propolis_id: PropolisUuid,
+
+    /// The ID of the sled where the Propolis job is running.
+    pub sled_id: SledUuid,
+
+    /// A client for talking to the Propolis's host sled.
+    pub sled_client: Arc<SledAgentClient>,
+
+    /// The ID of the instance's migration target Propolis, if it has one.
+    pub dst_propolis_id: Option<PropolisUuid>,
+}
+
 /// Exposes additional [`super::Nexus`] interfaces for use by the test suite
 #[async_trait]
 pub trait TestInterfaces {
     /// Access the Rack ID of the currently executing Nexus.
     fn rack_id(&self) -> Uuid;
 
-    /// Returns the SledAgentClient for an Instance from its id.  We may also
-    /// want to split this up into instance_lookup_by_id() and instance_sled(),
-    /// but after all it's a test suite special to begin with.
-    async fn instance_sled_by_id(
+    /// Attempts to obtain the Propolis ID and sled agent information for an
+    /// instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `id`: The ID of the instance of interest.
+    /// - `opctx`: An optional operation context to use for authorization
+    ///   checks. If `None`, this routine supplies the default test opctx.
+    ///
+    /// # Return value
+    ///
+    /// - `Ok(Some(info))` if the instance has an active Propolis.
+    /// - `Ok(None)` if the instance has no active Propolis.
+    /// - `Err` if an error occurred.
+    async fn active_instance_info(
         &self,
         id: &InstanceUuid,
-    ) -> Result<Option<Arc<SledAgentClient>>, Error>;
-
-    async fn instance_sled_by_id_with_opctx(
-        &self,
-        id: &InstanceUuid,
-        opctx: &OpContext,
-    ) -> Result<Option<Arc<SledAgentClient>>, Error>;
+        opctx: Option<&OpContext>,
+    ) -> Result<Option<InstanceSledAgentInfo>, Error>;
 
     /// Returns the SledAgentClient for the sled running an instance to which a
     /// disk is attached.
@@ -45,18 +66,6 @@ pub trait TestInterfaces {
         &self,
         id: &Uuid,
     ) -> Result<Option<Arc<SledAgentClient>>, Error>;
-
-    /// Returns the supplied instance's current active sled ID.
-    async fn instance_sled_id(
-        &self,
-        instance_id: &InstanceUuid,
-    ) -> Result<Option<SledUuid>, Error>;
-
-    async fn instance_sled_id_with_opctx(
-        &self,
-        instance_id: &InstanceUuid,
-        opctx: &OpContext,
-    ) -> Result<Option<SledUuid>, Error>;
 
     async fn set_disk_as_faulted(&self, disk_id: &Uuid) -> Result<bool, Error>;
 
@@ -69,30 +78,49 @@ impl TestInterfaces for super::Nexus {
         self.rack_id
     }
 
-    async fn instance_sled_by_id(
+    async fn active_instance_info(
         &self,
         id: &InstanceUuid,
-    ) -> Result<Option<Arc<SledAgentClient>>, Error> {
-        let opctx = OpContext::for_tests(
-            self.log.new(o!()),
-            Arc::clone(&self.db_datastore)
-                as Arc<dyn nexus_auth::storage::Storage>,
-        );
+        opctx: Option<&OpContext>,
+    ) -> Result<Option<InstanceSledAgentInfo>, Error> {
+        let local_opctx;
+        let opctx = match opctx {
+            Some(o) => o,
+            None => {
+                local_opctx = OpContext::for_tests(
+                    self.log.new(o!()),
+                    Arc::clone(&self.db_datastore)
+                        as Arc<dyn nexus_auth::storage::Storage>,
+                );
+                &local_opctx
+            }
+        };
 
-        self.instance_sled_by_id_with_opctx(id, &opctx).await
-    }
+        let (.., authz_instance) = LookupPath::new(&opctx, &self.db_datastore)
+            .instance_id(id.into_untyped_uuid())
+            .lookup_for(nexus_db_queries::authz::Action::Read)
+            .await?;
 
-    async fn instance_sled_by_id_with_opctx(
-        &self,
-        id: &InstanceUuid,
-        opctx: &OpContext,
-    ) -> Result<Option<Arc<SledAgentClient>>, Error> {
-        let sled_id = self.instance_sled_id_with_opctx(id, opctx).await?;
-        if let Some(sled_id) = sled_id {
-            Ok(Some(self.sled_client(&sled_id).await?))
-        } else {
-            Ok(None)
-        }
+        let state = self
+            .datastore()
+            .instance_fetch_with_vmm(opctx, &authz_instance)
+            .await?;
+
+        let Some(vmm) = state.vmm() else {
+            return Ok(None);
+        };
+
+        let sled_id = SledUuid::from_untyped_uuid(vmm.sled_id);
+        Ok(Some(InstanceSledAgentInfo {
+            propolis_id: PropolisUuid::from_untyped_uuid(vmm.id),
+            sled_id,
+            sled_client: self.sled_client(&sled_id).await?,
+            dst_propolis_id: state
+                .instance()
+                .runtime()
+                .dst_propolis_id
+                .map(PropolisUuid::from_untyped_uuid),
+        }))
     }
 
     async fn disk_sled_by_id(
@@ -112,37 +140,11 @@ impl TestInterfaces for super::Nexus {
         let instance_id = InstanceUuid::from_untyped_uuid(
             db_disk.runtime().attach_instance_id.unwrap(),
         );
-        self.instance_sled_by_id(&instance_id).await
-    }
-
-    async fn instance_sled_id(
-        &self,
-        id: &InstanceUuid,
-    ) -> Result<Option<SledUuid>, Error> {
-        let opctx = OpContext::for_tests(
-            self.log.new(o!()),
-            Arc::clone(&self.db_datastore)
-                as Arc<dyn nexus_auth::storage::Storage>,
-        );
-
-        self.instance_sled_id_with_opctx(id, &opctx).await
-    }
-
-    async fn instance_sled_id_with_opctx(
-        &self,
-        id: &InstanceUuid,
-        opctx: &OpContext,
-    ) -> Result<Option<SledUuid>, Error> {
-        let (.., authz_instance) = LookupPath::new(&opctx, &self.db_datastore)
-            .instance_id(id.into_untyped_uuid())
-            .lookup_for(nexus_db_queries::authz::Action::Read)
-            .await?;
 
         Ok(self
-            .datastore()
-            .instance_fetch_with_vmm(opctx, &authz_instance)
+            .active_instance_info(&instance_id, Some(&opctx))
             .await?
-            .sled_id())
+            .map(|info| info.sled_client))
     }
 
     async fn set_disk_as_faulted(&self, disk_id: &Uuid) -> Result<bool, Error> {

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -52,7 +52,7 @@ use omicron_common::api::internal::nexus::ProducerRegistrationResponse;
 use omicron_common::api::internal::nexus::RepairFinishInfo;
 use omicron_common::api::internal::nexus::RepairProgress;
 use omicron_common::api::internal::nexus::RepairStartInfo;
-use omicron_common::api::internal::nexus::SledInstanceState;
+use omicron_common::api::internal::nexus::SledVmmState;
 use omicron_common::update::ArtifactId;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::InstanceUuid;
@@ -169,7 +169,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
     async fn cpapi_instances_put(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        new_runtime_state: TypedBody<SledInstanceState>,
+        new_runtime_state: TypedBody<SledVmmState>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let apictx = &rqctx.context().context;
         let nexus = &apictx.nexus;

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -168,7 +168,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
 
     async fn cpapi_instances_put(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         new_runtime_state: TypedBody<SledInstanceState>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let apictx = &rqctx.context().context;
@@ -178,11 +178,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
         let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
         let handler = async {
             nexus
-                .notify_instance_updated(
-                    &opctx,
-                    InstanceUuid::from_untyped_uuid(path.instance_id),
-                    &new_state,
-                )
+                .notify_vmm_updated(&opctx, path.propolis_id, &new_state)
                 .await?;
             Ok(HttpResponseUpdatedNoContent())
         };

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -188,12 +188,12 @@ async fn set_instance_state(
 }
 
 async fn instance_simulate(nexus: &Arc<Nexus>, id: &InstanceUuid) {
-    let sa = nexus
-        .instance_sled_by_id(id)
+    let info = nexus.active_instance_info(id, None)
         .await
         .unwrap()
         .expect("instance must be on a sled to simulate a state change");
-    sa.instance_finish_transition(id.into_untyped_uuid()).await;
+
+    info.sled_client.vmm_finish_transition(info.propolis_id).await;
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -188,7 +188,8 @@ async fn set_instance_state(
 }
 
 async fn instance_simulate(nexus: &Arc<Nexus>, id: &InstanceUuid) {
-    let info = nexus.active_instance_info(id, None)
+    let info = nexus
+        .active_instance_info(id, None)
         .await
         .unwrap()
         .expect("instance must be on a sled to simulate a state change");

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -898,7 +898,7 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(instance.runtime.run_state, InstanceState::Migrating);
 
     // Move the target to "completed".
-    vmm_simulate_on_sled(cptestctx, nexus, dst_sled_id, src_propolis_id).await;
+    vmm_simulate_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id).await;
 
     instance_wait_for_state(&client, instance_id, InstanceState::Running).await;
 
@@ -995,7 +995,8 @@ async fn test_instance_migrate_v2p_and_routes(
         .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("running instance should have a sled").sled_id;
+        .expect("running instance should have a sled")
+        .sled_id;
 
     let mut sled_agents = vec![cptestctx.sled_agent.sled_agent.clone()];
     sled_agents.extend(other_sleds.iter().map(|tup| tup.1.sled_agent.clone()));
@@ -1465,8 +1466,10 @@ async fn test_instance_metrics_with_migration(
         migration_id,
     )
     .await;
-    vmm_single_step_on_sled(cptestctx, nexus, original_sled, src_propolis_id).await;
-    vmm_single_step_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id).await;
+    vmm_single_step_on_sled(cptestctx, nexus, original_sled, src_propolis_id)
+        .await;
+    vmm_single_step_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id)
+        .await;
     instance_wait_for_state(&client, instance_id, InstanceState::Migrating)
         .await;
 

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -780,12 +780,13 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     let instance_next = instance_get(&client, &instance_url).await;
     assert_eq!(instance_next.runtime.run_state, InstanceState::Running);
 
-    let original_sled = nexus
-        .instance_sled_id(&instance_id)
+    let sled_info = nexus
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
         .expect("running instance should have a sled");
 
+    let original_sled = sled_info.sled_id;
     let dst_sled_id = if original_sled == default_sled_id {
         other_sled_id
     } else {
@@ -808,12 +809,13 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     .parsed_body::<Instance>()
     .unwrap();
 
-    let current_sled = nexus
-        .instance_sled_id(&instance_id)
+    let new_sled_info = nexus
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
         .expect("running instance should have a sled");
 
+    let current_sled = new_sled_info.sled_id;
     assert_eq!(current_sled, original_sled);
 
     // Ensure that both sled agents report that the migration is in progress.
@@ -840,6 +842,15 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(migration.target_state, MigrationState::Pending.into());
     assert_eq!(migration.source_state, MigrationState::Pending.into());
 
+    let info = nexus
+        .active_instance_info(&instance_id, None)
+        .await
+        .unwrap()
+        .expect("instance should be on a sled");
+    let src_propolis_id = info.propolis_id;
+    let dst_propolis_id =
+        info.dst_propolis_id.expect("instance should have a migration target");
+
     // Simulate the migration. We will use `instance_single_step_on_sled` to
     // single-step both sled-agents through the migration state machine and
     // ensure that the migration state looks nice at each step.
@@ -847,15 +858,15 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
         cptestctx,
         nexus,
         original_sled,
-        instance_id,
+        src_propolis_id,
         migration_id,
     )
     .await;
 
     // Move source to "migrating".
-    instance_single_step_on_sled(cptestctx, nexus, original_sled, instance_id)
+    vmm_single_step_on_sled(cptestctx, nexus, original_sled, src_propolis_id)
         .await;
-    instance_single_step_on_sled(cptestctx, nexus, original_sled, instance_id)
+    vmm_single_step_on_sled(cptestctx, nexus, original_sled, src_propolis_id)
         .await;
 
     let migration = dbg!(migration_fetch(cptestctx, migration_id).await);
@@ -865,9 +876,9 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(instance.runtime.run_state, InstanceState::Migrating);
 
     // Move target to "migrating".
-    instance_single_step_on_sled(cptestctx, nexus, dst_sled_id, instance_id)
+    vmm_single_step_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id)
         .await;
-    instance_single_step_on_sled(cptestctx, nexus, dst_sled_id, instance_id)
+    vmm_single_step_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id)
         .await;
 
     let migration = dbg!(migration_fetch(cptestctx, migration_id).await);
@@ -877,7 +888,7 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(instance.runtime.run_state, InstanceState::Migrating);
 
     // Move the source to "completed"
-    instance_simulate_on_sled(cptestctx, nexus, original_sled, instance_id)
+    vmm_simulate_on_sled(cptestctx, nexus, original_sled, src_propolis_id)
         .await;
 
     let migration = dbg!(migration_fetch(cptestctx, migration_id).await);
@@ -887,15 +898,16 @@ async fn test_instance_migrate(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(instance.runtime.run_state, InstanceState::Migrating);
 
     // Move the target to "completed".
-    instance_simulate_on_sled(cptestctx, nexus, dst_sled_id, instance_id).await;
+    vmm_simulate_on_sled(cptestctx, nexus, dst_sled_id, src_propolis_id).await;
 
     instance_wait_for_state(&client, instance_id, InstanceState::Running).await;
 
     let current_sled = nexus
-        .instance_sled_id(&instance_id)
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("migrated instance should still have a sled");
+        .expect("migrated instance should still have a sled")
+        .sled_id;
 
     assert_eq!(current_sled, dst_sled_id);
 
@@ -978,11 +990,12 @@ async fn test_instance_migrate_v2p_and_routes(
         .derive_guest_network_interface_info(&opctx, &authz_instance)
         .await
         .unwrap();
+
     let original_sled_id = nexus
-        .instance_sled_id(&instance_id)
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("running instance should have a sled");
+        .expect("running instance should have a sled").sled_id;
 
     let mut sled_agents = vec![cptestctx.sled_agent.sled_agent.clone()];
     sled_agents.extend(other_sleds.iter().map(|tup| tup.1.sled_agent.clone()));
@@ -1035,25 +1048,35 @@ async fn test_instance_migrate_v2p_and_routes(
             .expect("since we've started a migration, the instance record must have a migration id!")
     };
 
+    let info = nexus
+        .active_instance_info(&instance_id, None)
+        .await
+        .unwrap()
+        .expect("instance should be on a sled");
+    let src_propolis_id = info.propolis_id;
+    let dst_propolis_id =
+        info.dst_propolis_id.expect("instance should have a migration target");
+
     // Tell both sled-agents to pretend to do the migration.
     instance_simulate_migration_source(
         cptestctx,
         nexus,
         original_sled_id,
-        instance_id,
+        src_propolis_id,
         migration_id,
     )
     .await;
-    instance_simulate_on_sled(cptestctx, nexus, original_sled_id, instance_id)
+    vmm_simulate_on_sled(cptestctx, nexus, original_sled_id, src_propolis_id)
         .await;
-    instance_simulate_on_sled(cptestctx, nexus, dst_sled_id, instance_id).await;
+    vmm_simulate_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id).await;
     instance_wait_for_state(&client, instance_id, InstanceState::Running).await;
 
     let current_sled = nexus
-        .instance_sled_id(&instance_id)
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("migrated instance should have a sled");
+        .expect("migrated instance should have a sled")
+        .sled_id;
     assert_eq!(current_sled, dst_sled_id);
 
     for sled_agent in &sled_agents {
@@ -1373,10 +1396,11 @@ async fn test_instance_metrics_with_migration(
     // Request migration to the other sled. This reserves resources on the
     // target sled, but shouldn't change the virtual provisioning counters.
     let original_sled = nexus
-        .instance_sled_id(&instance_id)
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("running instance should have a sled");
+        .expect("running instance should have a sled")
+        .sled_id;
 
     let dst_sled_id = if original_sled == default_sled_id {
         other_sled_id
@@ -1420,6 +1444,15 @@ async fn test_instance_metrics_with_migration(
             .expect("since we've started a migration, the instance record must have a migration id!")
     };
 
+    let info = nexus
+        .active_instance_info(&instance_id, None)
+        .await
+        .unwrap()
+        .expect("instance should be on a sled");
+    let src_propolis_id = info.propolis_id;
+    let dst_propolis_id =
+        info.dst_propolis_id.expect("instance should have a migration target");
+
     // Wait for the instance to be in the `Migrating` state. Otherwise, the
     // subsequent `instance_wait_for_state(..., Running)` may see the `Running`
     // state from the *old* VMM, rather than waiting for the migration to
@@ -1428,14 +1461,12 @@ async fn test_instance_metrics_with_migration(
         cptestctx,
         nexus,
         original_sled,
-        instance_id,
+        src_propolis_id,
         migration_id,
     )
     .await;
-    instance_single_step_on_sled(cptestctx, nexus, original_sled, instance_id)
-        .await;
-    instance_single_step_on_sled(cptestctx, nexus, dst_sled_id, instance_id)
-        .await;
+    vmm_single_step_on_sled(cptestctx, nexus, original_sled, src_propolis_id).await;
+    vmm_single_step_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id).await;
     instance_wait_for_state(&client, instance_id, InstanceState::Migrating)
         .await;
 
@@ -1444,9 +1475,9 @@ async fn test_instance_metrics_with_migration(
     // Complete migration on the target. Simulated migrations always succeed.
     // After this the instance should be running and should continue to appear
     // to be provisioned.
-    instance_simulate_on_sled(cptestctx, nexus, original_sled, instance_id)
+    vmm_simulate_on_sled(cptestctx, nexus, original_sled, src_propolis_id)
         .await;
-    instance_simulate_on_sled(cptestctx, nexus, dst_sled_id, instance_id).await;
+    vmm_simulate_on_sled(cptestctx, nexus, dst_sled_id, dst_propolis_id).await;
     instance_wait_for_state(&client, instance_id, InstanceState::Running).await;
 
     check_provisioning_state(4, 1).await;
@@ -3337,10 +3368,11 @@ async fn test_disks_detached_when_instance_destroyed(
     let apictx = &cptestctx.server.server_context();
     let nexus = &apictx.nexus;
     let sa = nexus
-        .instance_sled_by_id(&instance_id)
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
-        .expect("instance should be on a sled while it's running");
+        .expect("instance should be on a sled while it's running")
+        .sled_client;
 
     // Stop and delete instance
     instance_post(&client, instance_name, InstanceOp::Stop).await;
@@ -5080,28 +5112,29 @@ pub async fn assert_sled_vpc_routes(
 /// instance, and then tell it to finish simulating whatever async transition is
 /// going on.
 pub async fn instance_simulate(nexus: &Arc<Nexus>, id: &InstanceUuid) {
-    let sa = nexus
-        .instance_sled_by_id(id)
+    let sled_info = nexus
+        .active_instance_info(id, None)
         .await
         .unwrap()
         .expect("instance must be on a sled to simulate a state change");
-    sa.instance_finish_transition(id.into_untyped_uuid()).await;
+
+    sled_info.sled_client.vmm_finish_transition(sled_info.propolis_id).await;
 }
 
 /// Simulate one step of an ongoing instance state transition.  To do this, we
 /// have to look up the instance, then get the sled agent associated with that
 /// instance, and then tell it to finish simulating whatever async transition is
 /// going on.
-async fn instance_single_step_on_sled(
+async fn vmm_single_step_on_sled(
     cptestctx: &ControlPlaneTestContext,
     nexus: &Arc<Nexus>,
     sled_id: SledUuid,
-    instance_id: InstanceUuid,
+    propolis_id: PropolisUuid,
 ) {
     info!(&cptestctx.logctx.log, "Single-stepping simulated instance on sled";
-          "instance_id" => %instance_id, "sled_id" => %sled_id);
+          "propolis_id" => %propolis_id, "sled_id" => %sled_id);
     let sa = nexus.sled_client(&sled_id).await.unwrap();
-    sa.instance_single_step(instance_id.into_untyped_uuid()).await;
+    sa.vmm_single_step(propolis_id).await;
 }
 
 pub async fn instance_simulate_with_opctx(
@@ -5109,27 +5142,28 @@ pub async fn instance_simulate_with_opctx(
     id: &InstanceUuid,
     opctx: &OpContext,
 ) {
-    let sa = nexus
-        .instance_sled_by_id_with_opctx(id, opctx)
+    let sled_info = nexus
+        .active_instance_info(id, Some(opctx))
         .await
         .unwrap()
         .expect("instance must be on a sled to simulate a state change");
-    sa.instance_finish_transition(id.into_untyped_uuid()).await;
+
+    sled_info.sled_client.vmm_finish_transition(sled_info.propolis_id).await;
 }
 
 /// Simulates state transitions for the incarnation of the instance on the
 /// supplied sled (which may not be the sled ID currently stored in the
 /// instance's CRDB record).
-async fn instance_simulate_on_sled(
+async fn vmm_simulate_on_sled(
     cptestctx: &ControlPlaneTestContext,
     nexus: &Arc<Nexus>,
     sled_id: SledUuid,
-    instance_id: InstanceUuid,
+    propolis_id: PropolisUuid,
 ) {
     info!(&cptestctx.logctx.log, "Poking simulated instance on sled";
-          "instance_id" => %instance_id, "sled_id" => %sled_id);
+          "propolis_id" => %propolis_id, "sled_id" => %sled_id);
     let sa = nexus.sled_client(&sled_id).await.unwrap();
-    sa.instance_finish_transition(instance_id.into_untyped_uuid()).await;
+    sa.vmm_finish_transition(propolis_id).await;
 }
 
 /// Simulates a migration source for the provided instance ID, sled ID, and
@@ -5138,19 +5172,19 @@ async fn instance_simulate_migration_source(
     cptestctx: &ControlPlaneTestContext,
     nexus: &Arc<Nexus>,
     sled_id: SledUuid,
-    instance_id: InstanceUuid,
+    propolis_id: PropolisUuid,
     migration_id: Uuid,
 ) {
     info!(
         &cptestctx.logctx.log,
         "Simulating migration source sled";
-        "instance_id" => %instance_id,
+        "propolis_id" => %propolis_id,
         "sled_id" => %sled_id,
         "migration_id" => %migration_id,
     );
     let sa = nexus.sled_client(&sled_id).await.unwrap();
-    sa.instance_simulate_migration_source(
-        instance_id.into_untyped_uuid(),
+    sa.vmm_simulate_migration_source(
+        propolis_id,
         sled_agent_client::SimulateMigrationSource {
             migration_id,
             result: sled_agent_client::SimulatedMigrationResult::Success,

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -1344,12 +1344,12 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
     .expect("Failed to stop instance");
 
     // Simulate the transition, wait until it is in fact stopped.
-    let sa = nexus
-        .instance_sled_by_id(&instance_id)
+    let info = nexus
+        .active_instance_info(&instance_id, None)
         .await
         .unwrap()
         .expect("running instance should be on a sled");
-    sa.instance_finish_transition(instance.identity.id).await;
+    info.sled_client.vmm_finish_transition(info.propolis_id).await;
     instance_wait_for_state(client, instance_id, InstanceState::Stopped).await;
 
     // Delete the instance

--- a/nexus/tests/integration_tests/pantry.rs
+++ b/nexus/tests/integration_tests/pantry.rs
@@ -88,12 +88,12 @@ async fn set_instance_state(
 }
 
 async fn instance_simulate(nexus: &Arc<Nexus>, id: &InstanceUuid) {
-    let sa = nexus
-        .instance_sled_by_id(id)
+    let info = nexus
+        .active_instance_info(id, None)
         .await
         .unwrap()
         .expect("instance must be on a sled to simulate a state change");
-    sa.instance_finish_transition(id.into_untyped_uuid()).await;
+    info.sled_client.vmm_finish_transition(info.propolis_id).await;
 }
 
 async fn disk_get(client: &ClientTestContext, disk_url: &str) -> Disk {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -746,44 +746,6 @@
         }
       }
     },
-    "/instances/{instance_id}": {
-      "put": {
-        "summary": "Report updated state for an instance.",
-        "operationId": "cpapi_instances_put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SledInstanceState"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/instances/{instance_id}/migrate": {
       "post": {
         "operationId": "instance_migrate",
@@ -1460,6 +1422,43 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}": {
+      "put": {
+        "summary": "Report updated state for a VMM.",
+        "operationId": "cpapi_instances_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SledInstanceState"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -5076,14 +5076,6 @@
               }
             ]
           },
-          "propolis_id": {
-            "description": "The ID of the VMM whose state is being reported.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForPropolisKind"
-              }
-            ]
-          },
           "vmm_state": {
             "description": "The most recent state of the sled's VMM process.",
             "allOf": [
@@ -5094,7 +5086,6 @@
           }
         },
         "required": [
-          "propolis_id",
           "vmm_state"
         ]
       },
@@ -5321,10 +5312,6 @@
         "format": "uuid"
       },
       "TypedUuidForOmicronZoneKind": {
-        "type": "string",
-        "format": "uuid"
-      },
-      "TypedUuidForPropolisKind": {
         "type": "string",
         "format": "uuid"
       },
@@ -5589,6 +5576,10 @@
             ]
           }
         ]
+      },
+      "TypedUuidForPropolisKind": {
+        "type": "string",
+        "format": "uuid"
       }
     },
     "responses": {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1450,7 +1450,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SledInstanceState"
+                "$ref": "#/components/schemas/SledVmmState"
               }
             }
           },
@@ -5054,41 +5054,6 @@
           "id"
         ]
       },
-      "SledInstanceState": {
-        "description": "A wrapper type containing a sled's total knowledge of the state of a specific VMM and the instance it incarnates.",
-        "type": "object",
-        "properties": {
-          "migration_in": {
-            "nullable": true,
-            "description": "The current state of any inbound migration to this VMM.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MigrationRuntimeState"
-              }
-            ]
-          },
-          "migration_out": {
-            "nullable": true,
-            "description": "The state of any outbound migration from this VMM.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MigrationRuntimeState"
-              }
-            ]
-          },
-          "vmm_state": {
-            "description": "The most recent state of the sled's VMM process.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VmmRuntimeState"
-              }
-            ]
-          }
-        },
-        "required": [
-          "vmm_state"
-        ]
-      },
       "SledPolicy": {
         "description": "The operator-defined policy of a sled.",
         "oneOf": [
@@ -5201,6 +5166,41 @@
               "decommissioned"
             ]
           }
+        ]
+      },
+      "SledVmmState": {
+        "description": "A wrapper type containing a sled's total knowledge of the state of a VMM.",
+        "type": "object",
+        "properties": {
+          "migration_in": {
+            "nullable": true,
+            "description": "The current state of any inbound migration to this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "migration_out": {
+            "nullable": true,
+            "description": "The state of any outbound migration from this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "vmm_state": {
+            "description": "The most recent state of the sled's VMM process.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmRuntimeState"
+              }
+            ]
+          }
+        },
+        "required": [
+          "vmm_state"
         ]
       },
       "SourceNatConfig": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -650,7 +650,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SledInstanceState"
+                  "$ref": "#/components/schemas/SledVmmState"
                 }
               }
             }
@@ -681,7 +681,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstanceUnregisterResponse"
+                  "$ref": "#/components/schemas/VmmUnregisterResponse"
                 }
               }
             }
@@ -837,7 +837,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SledInstanceState"
+                  "$ref": "#/components/schemas/SledVmmState"
                 }
               }
             }
@@ -866,7 +866,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/InstancePutStateBody"
+                "$ref": "#/components/schemas/VmmPutStateBody"
               }
             }
           },
@@ -878,7 +878,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstancePutStateResponse"
+                  "$ref": "#/components/schemas/VmmPutStateResponse"
                 }
               }
             }
@@ -3046,38 +3046,6 @@
           "ncpus"
         ]
       },
-      "InstancePutStateBody": {
-        "description": "The body of a request to move a previously-ensured instance into a specific runtime state.",
-        "type": "object",
-        "properties": {
-          "state": {
-            "description": "The state into which the instance should be driven.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/InstanceStateRequested"
-              }
-            ]
-          }
-        },
-        "required": [
-          "state"
-        ]
-      },
-      "InstancePutStateResponse": {
-        "description": "The response sent from a request to move an instance into a specific runtime state.",
-        "type": "object",
-        "properties": {
-          "updated_runtime": {
-            "nullable": true,
-            "description": "The current runtime state of the instance after handling the request to change its state. If the instance's state did not change, this field is `None`.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SledInstanceState"
-              }
-            ]
-          }
-        }
-      },
       "InstanceRuntimeState": {
         "description": "The dynamic runtime properties of an instance: its current VMM ID (if any), migration information (if any), and the instance state to report if there is no active VMM.",
         "type": "object",
@@ -3124,90 +3092,6 @@
           "gen",
           "time_updated"
         ]
-      },
-      "InstanceStateRequested": {
-        "description": "Requestable running state of an Instance.\n\nA subset of [`omicron_common::api::external::InstanceState`].",
-        "oneOf": [
-          {
-            "description": "Run this instance by migrating in from a previous running incarnation of the instance.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "migration_target"
-                ]
-              },
-              "value": {
-                "$ref": "#/components/schemas/InstanceMigrationTargetParams"
-              }
-            },
-            "required": [
-              "type",
-              "value"
-            ]
-          },
-          {
-            "description": "Start the instance if it is not already running.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "running"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "description": "Stop the instance.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "stopped"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "description": "Immediately reset the instance, as though it had stopped and immediately began to run again.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "reboot"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
-        ]
-      },
-      "InstanceUnregisterResponse": {
-        "description": "The response sent from a request to unregister an instance.",
-        "type": "object",
-        "properties": {
-          "updated_runtime": {
-            "nullable": true,
-            "description": "The current state of the instance after handling the request to unregister it. If the instance's state did not change, this field is `None`.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SledInstanceState"
-              }
-            ]
-          }
-        }
       },
       "Inventory": {
         "description": "Identity and basic status information about this sled agent",
@@ -4642,8 +4526,27 @@
           "sled_id"
         ]
       },
-      "SledInstanceState": {
-        "description": "A wrapper type containing a sled's total knowledge of the state of a specific VMM and the instance it incarnates.",
+      "SledRole": {
+        "description": "Describes the role of the sled within the rack.\n\nNote that this may change if the sled is physically moved within the rack.",
+        "oneOf": [
+          {
+            "description": "The sled is a general compute sled.",
+            "type": "string",
+            "enum": [
+              "gimlet"
+            ]
+          },
+          {
+            "description": "The sled is attached to the network switch, and has additional responsibilities.",
+            "type": "string",
+            "enum": [
+              "scrimlet"
+            ]
+          }
+        ]
+      },
+      "SledVmmState": {
+        "description": "A wrapper type containing a sled's total knowledge of the state of a VMM.",
         "type": "object",
         "properties": {
           "migration_in": {
@@ -4675,25 +4578,6 @@
         },
         "required": [
           "vmm_state"
-        ]
-      },
-      "SledRole": {
-        "description": "Describes the role of the sled within the rack.\n\nNote that this may change if the sled is physically moved within the rack.",
-        "oneOf": [
-          {
-            "description": "The sled is a general compute sled.",
-            "type": "string",
-            "enum": [
-              "gimlet"
-            ]
-          },
-          {
-            "description": "The sled is attached to the network switch, and has additional responsibilities.",
-            "type": "string",
-            "enum": [
-              "scrimlet"
-            ]
-          }
         ]
       },
       "Slot": {
@@ -4990,6 +4874,38 @@
           "snapshot_id"
         ]
       },
+      "VmmPutStateBody": {
+        "description": "The body of a request to move a previously-ensured instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "description": "The state into which the instance should be driven.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmStateRequested"
+              }
+            ]
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "VmmPutStateResponse": {
+        "description": "The response sent from a request to move an instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current runtime state of the instance after handling the request to change its state. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
+      },
       "VmmRuntimeState": {
         "description": "The dynamic runtime properties of an individual VMM process.",
         "type": "object",
@@ -5082,6 +4998,90 @@
             ]
           }
         ]
+      },
+      "VmmStateRequested": {
+        "description": "Requestable running state of an Instance.\n\nA subset of [`omicron_common::api::external::InstanceState`].",
+        "oneOf": [
+          {
+            "description": "Run this instance by migrating in from a previous running incarnation of the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "migration_target"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/InstanceMigrationTargetParams"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Start the instance if it is not already running.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Stop the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stopped"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Immediately reset the instance, as though it had stopped and immediately began to run again.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reboot"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "VmmUnregisterResponse": {
+        "description": "The response sent from a request to unregister an instance.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current state of the instance after handling the request to unregister it. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
       },
       "Vni": {
         "description": "A Geneve Virtual Network Identifier",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -220,278 +220,6 @@
         }
       }
     },
-    "/instances/{instance_id}": {
-      "put": {
-        "operationId": "instance_register",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceEnsureBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SledInstanceState"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "delete": {
-        "operationId": "instance_unregister",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstanceUnregisterResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/instances/{instance_id}/disks/{disk_id}/snapshot": {
-      "post": {
-        "summary": "Take a snapshot of a disk that is attached to an instance",
-        "operationId": "instance_issue_disk_snapshot_request",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "disk_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceIssueDiskSnapshotRequestBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstanceIssueDiskSnapshotRequestResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/instances/{instance_id}/external-ip": {
-      "put": {
-        "operationId": "instance_put_external_ip",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceExternalIpBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "delete": {
-        "operationId": "instance_delete_external_ip",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceExternalIpBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/instances/{instance_id}/state": {
-      "get": {
-        "operationId": "instance_get_state",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SledInstanceState"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "put": {
-        "operationId": "instance_put_state",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "instance_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/TypedUuidForInstanceKind"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstancePutStateBody"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstancePutStateResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/inventory": {
       "get": {
         "summary": "Fetch basic information about this sled",
@@ -883,6 +611,277 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}": {
+      "put": {
+        "operationId": "vmm_register",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledInstanceState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_unregister",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceUnregisterResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/disks/{disk_id}/snapshot": {
+      "post": {
+        "summary": "Take a snapshot of a disk that is attached to an instance",
+        "operationId": "vmm_issue_disk_snapshot_request",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/external-ip": {
+      "put": {
+        "operationId": "vmm_put_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_delete_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/state": {
+      "get": {
+        "operationId": "vmm_get_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledInstanceState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "vmm_put_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TypedUuidForPropolisKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstancePutStateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstancePutStateResponse"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -2837,6 +2836,14 @@
               }
             ]
           },
+          "instance_id": {
+            "description": "The ID of the instance for which this VMM is being created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TypedUuidForInstanceKind"
+              }
+            ]
+          },
           "instance_runtime": {
             "description": "The instance runtime state for the instance being registered.",
             "allOf": [
@@ -2857,14 +2864,6 @@
             "description": "The address at which this VMM should serve a Propolis server API.",
             "type": "string"
           },
-          "propolis_id": {
-            "description": "The ID of the VMM being registered. This may not be the active VMM ID in the instance runtime state (e.g. if the new VMM is going to be a migration target).",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForPropolisKind"
-              }
-            ]
-          },
           "vmm_runtime": {
             "description": "The initial VMM runtime state for the VMM being registered.",
             "allOf": [
@@ -2876,10 +2875,10 @@
         },
         "required": [
           "hardware",
+          "instance_id",
           "instance_runtime",
           "metadata",
           "propolis_addr",
-          "propolis_id",
           "vmm_runtime"
         ]
       },
@@ -2983,30 +2982,6 @@
           "nics",
           "properties",
           "source_nat"
-        ]
-      },
-      "InstanceIssueDiskSnapshotRequestBody": {
-        "type": "object",
-        "properties": {
-          "snapshot_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "snapshot_id"
-        ]
-      },
-      "InstanceIssueDiskSnapshotRequestResponse": {
-        "type": "object",
-        "properties": {
-          "snapshot_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "snapshot_id"
         ]
       },
       "InstanceMetadata": {
@@ -4912,6 +4887,10 @@
           "sync"
         ]
       },
+      "TypedUuidForInstanceKind": {
+        "type": "string",
+        "format": "uuid"
+      },
       "TypedUuidForPropolisKind": {
         "type": "string",
         "format": "uuid"
@@ -4994,6 +4973,30 @@
           "virtual_ip",
           "virtual_mac",
           "vni"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestBody": {
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestResponse": {
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
         ]
       },
       "VmmRuntimeState": {
@@ -5408,10 +5411,6 @@
           "A",
           "B"
         ]
-      },
-      "TypedUuidForInstanceKind": {
-        "type": "string",
-        "format": "uuid"
       }
     },
     "responses": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4664,14 +4664,6 @@
               }
             ]
           },
-          "propolis_id": {
-            "description": "The ID of the VMM whose state is being reported.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForPropolisKind"
-              }
-            ]
-          },
           "vmm_state": {
             "description": "The most recent state of the sled's VMM process.",
             "allOf": [
@@ -4682,7 +4674,6 @@
           }
         },
         "required": [
-          "propolis_id",
           "vmm_state"
         ]
       },

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -296,10 +296,7 @@ pub trait SledAgentApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmIssueDiskSnapshotRequestPathParam>,
         body: TypedBody<VmmIssueDiskSnapshotRequestBody>,
-    ) -> Result<
-        HttpResponseOk<VmmIssueDiskSnapshotRequestResponse>,
-        HttpError,
-    >;
+    ) -> Result<HttpResponseOk<VmmIssueDiskSnapshotRequestResponse>, HttpError>;
 
     #[endpoint {
         method = PUT,

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -23,7 +23,7 @@ use omicron_common::{
     },
     disk::{DiskVariant, DisksManagementResult, OmicronPhysicalDisksConfig},
 };
-use omicron_uuid_kinds::{InstanceUuid, ZpoolUuid};
+use omicron_uuid_kinds::{PropolisUuid, ZpoolUuid};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sled_agent_types::{
@@ -212,59 +212,59 @@ pub trait SledAgentApi {
 
     #[endpoint {
         method = PUT,
-        path = "/instances/{instance_id}",
+        path = "/vmms/{propolis_id}",
     }]
-    async fn instance_register(
+    async fn vmm_register(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError>;
 
     #[endpoint {
         method = DELETE,
-        path = "/instances/{instance_id}",
+        path = "/vmms/{propolis_id}",
     }]
-    async fn instance_unregister(
+    async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError>;
 
     #[endpoint {
         method = PUT,
-        path = "/instances/{instance_id}/state",
+        path = "/vmms/{propolis_id}/state",
     }]
-    async fn instance_put_state(
+    async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstancePutStateBody>,
     ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError>;
 
     #[endpoint {
         method = GET,
-        path = "/instances/{instance_id}/state",
+        path = "/vmms/{propolis_id}/state",
     }]
-    async fn instance_get_state(
+    async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError>;
 
     #[endpoint {
         method = PUT,
-        path = "/instances/{instance_id}/external-ip",
+        path = "/vmms/{propolis_id}/external-ip",
     }]
-    async fn instance_put_external_ip(
+    async fn vmm_put_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
     #[endpoint {
         method = DELETE,
-        path = "/instances/{instance_id}/external-ip",
+        path = "/vmms/{propolis_id}/external-ip",
     }]
-    async fn instance_delete_external_ip(
+    async fn vmm_delete_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
@@ -290,14 +290,14 @@ pub trait SledAgentApi {
     /// Take a snapshot of a disk that is attached to an instance
     #[endpoint {
         method = POST,
-        path = "/instances/{instance_id}/disks/{disk_id}/snapshot",
+        path = "/vmms/{propolis_id}/disks/{disk_id}/snapshot",
     }]
-    async fn instance_issue_disk_snapshot_request(
+    async fn vmm_issue_disk_snapshot_request(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
-        body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
+        path_params: Path<VmmIssueDiskSnapshotRequestPathParam>,
+        body: TypedBody<VmmIssueDiskSnapshotRequestBody>,
     ) -> Result<
-        HttpResponseOk<InstanceIssueDiskSnapshotRequestResponse>,
+        HttpResponseOk<VmmIssueDiskSnapshotRequestResponse>,
         HttpError,
     >;
 
@@ -516,8 +516,8 @@ impl From<DiskVariant> for DiskType {
 
 /// Path parameters for Instance requests (sled agent API)
 #[derive(Deserialize, JsonSchema)]
-pub struct InstancePathParam {
-    pub instance_id: InstanceUuid,
+pub struct VmmPathParam {
+    pub propolis_id: PropolisUuid,
 }
 
 /// Path parameters for Disk requests (sled agent API)
@@ -527,18 +527,18 @@ pub struct DiskPathParam {
 }
 
 #[derive(Deserialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestPathParam {
-    pub instance_id: Uuid,
+pub struct VmmIssueDiskSnapshotRequestPathParam {
+    pub propolis_id: PropolisUuid,
     pub disk_id: Uuid,
 }
 
 #[derive(Deserialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestBody {
+pub struct VmmIssueDiskSnapshotRequestBody {
     pub snapshot_id: Uuid,
 }
 
 #[derive(Serialize, JsonSchema)]
-pub struct InstanceIssueDiskSnapshotRequestResponse {
+pub struct VmmIssueDiskSnapshotRequestResponse {
     pub snapshot_id: Uuid,
 }
 

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -15,7 +15,7 @@ use nexus_sled_agent_shared::inventory::{
 };
 use omicron_common::{
     api::internal::{
-        nexus::{DiskRuntimeState, SledInstanceState, UpdateArtifactId},
+        nexus::{DiskRuntimeState, SledVmmState, UpdateArtifactId},
         shared::{
             ResolvedVpcRouteSet, ResolvedVpcRouteState, SledIdentifiers,
             SwitchPorts, VirtualNetworkInterfaceHost,
@@ -36,8 +36,8 @@ use sled_agent_types::{
     early_networking::EarlyNetworkConfig,
     firewall_rules::VpcFirewallRulesEnsureBody,
     instance::{
-        InstanceEnsureBody, InstanceExternalIpBody, InstancePutStateBody,
-        InstancePutStateResponse, InstanceUnregisterResponse,
+        InstanceEnsureBody, InstanceExternalIpBody, VmmPutStateBody,
+        VmmPutStateResponse, VmmUnregisterResponse,
     },
     sled::AddSledRequest,
     time_sync::TimeSync,
@@ -218,7 +218,7 @@ pub trait SledAgentApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError>;
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError>;
 
     #[endpoint {
         method = DELETE,
@@ -227,7 +227,7 @@ pub trait SledAgentApi {
     async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError>;
+    ) -> Result<HttpResponseOk<VmmUnregisterResponse>, HttpError>;
 
     #[endpoint {
         method = PUT,
@@ -236,8 +236,8 @@ pub trait SledAgentApi {
     async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        body: TypedBody<InstancePutStateBody>,
-    ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError>;
+        body: TypedBody<VmmPutStateBody>,
+    ) -> Result<HttpResponseOk<VmmPutStateResponse>, HttpError>;
 
     #[endpoint {
         method = GET,
@@ -246,7 +246,7 @@ pub trait SledAgentApi {
     async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError>;
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError>;
 
     #[endpoint {
         method = PUT,

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -10,7 +10,6 @@ use omicron_common::api::internal::nexus::{
     MigrationRuntimeState, MigrationState, SledInstanceState, VmmRuntimeState,
     VmmState,
 };
-use omicron_uuid_kinds::PropolisUuid;
 use propolis_client::types::{
     InstanceMigrationStatus, InstanceState as PropolisApiState,
     InstanceStateMonitorResponse, MigrationState as PropolisMigrationState,
@@ -21,7 +20,6 @@ use uuid::Uuid;
 #[derive(Clone, Debug)]
 pub struct InstanceStates {
     vmm: VmmRuntimeState,
-    propolis_id: PropolisUuid,
     migration_in: Option<MigrationRuntimeState>,
     migration_out: Option<MigrationRuntimeState>,
 }
@@ -173,11 +171,7 @@ pub enum Action {
 }
 
 impl InstanceStates {
-    pub fn new(
-        vmm: VmmRuntimeState,
-        propolis_id: PropolisUuid,
-        migration_id: Option<Uuid>,
-    ) -> Self {
+    pub fn new(vmm: VmmRuntimeState, migration_id: Option<Uuid>) -> Self {
         // If this instance is created with a migration ID, we are the intended
         // target of a migration in. Set that up now.
         let migration_in =
@@ -187,15 +181,11 @@ impl InstanceStates {
                 gen: Generation::new(),
                 time_updated: Utc::now(),
             });
-        InstanceStates { vmm, propolis_id, migration_in, migration_out: None }
+        InstanceStates { vmm, migration_in, migration_out: None }
     }
 
     pub fn vmm(&self) -> &VmmRuntimeState {
         &self.vmm
-    }
-
-    pub fn propolis_id(&self) -> PropolisUuid {
-        self.propolis_id
     }
 
     pub fn migration_in(&self) -> Option<&MigrationRuntimeState> {
@@ -212,7 +202,6 @@ impl InstanceStates {
     pub fn sled_instance_state(&self) -> SledInstanceState {
         SledInstanceState {
             vmm_state: self.vmm.clone(),
-            propolis_id: self.propolis_id,
             migration_in: self.migration_in.clone(),
             migration_out: self.migration_out.clone(),
         }
@@ -377,7 +366,6 @@ mod test {
     use uuid::Uuid;
 
     fn make_instance() -> InstanceStates {
-        let propolis_id = PropolisUuid::new_v4();
         let now = Utc::now();
 
         let vmm = VmmRuntimeState {
@@ -386,7 +374,7 @@ mod test {
             time_updated: now,
         };
 
-        InstanceStates::new(vmm, propolis_id, None)
+        InstanceStates::new(vmm, None)
     }
 
     fn make_migration_source_instance() -> InstanceStates {
@@ -406,7 +394,6 @@ mod test {
     }
 
     fn make_migration_target_instance() -> InstanceStates {
-        let propolis_id = PropolisUuid::new_v4();
         let now = Utc::now();
 
         let vmm = VmmRuntimeState {
@@ -415,7 +402,7 @@ mod test {
             time_updated: now,
         };
 
-        InstanceStates::new(vmm, propolis_id, Some(Uuid::new_v4()))
+        InstanceStates::new(vmm, Some(Uuid::new_v4()))
     }
 
     fn make_observed_state(

--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -7,7 +7,7 @@
 use chrono::{DateTime, Utc};
 use omicron_common::api::external::Generation;
 use omicron_common::api::internal::nexus::{
-    MigrationRuntimeState, MigrationState, SledInstanceState, VmmRuntimeState,
+    MigrationRuntimeState, MigrationState, SledVmmState, VmmRuntimeState,
     VmmState,
 };
 use propolis_client::types::{
@@ -199,8 +199,8 @@ impl InstanceStates {
     /// Creates a `SledInstanceState` structure containing the entirety of this
     /// structure's runtime state. This requires cloning; for simple read access
     /// use the `instance` or `vmm` accessors instead.
-    pub fn sled_instance_state(&self) -> SledInstanceState {
-        SledInstanceState {
+    pub fn sled_instance_state(&self) -> SledVmmState {
+        SledVmmState {
             vmm_state: self.vmm.clone(),
             migration_in: self.migration_in.clone(),
             migration_out: self.migration_out.clone(),

--- a/sled-agent/src/fakes/nexus.rs
+++ b/sled-agent/src/fakes/nexus.rs
@@ -15,9 +15,7 @@ use hyper::Body;
 use internal_dns::ServiceName;
 use nexus_client::types::SledAgentInfo;
 use omicron_common::api::external::Error;
-use omicron_common::api::internal::nexus::{
-    SledInstanceState, UpdateArtifactId,
-};
+use omicron_common::api::internal::nexus::{SledVmmState, UpdateArtifactId};
 use omicron_uuid_kinds::{OmicronZoneUuid, PropolisUuid};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -52,7 +50,7 @@ pub trait FakeNexusServer: Send + Sync {
     fn cpapi_instances_put(
         &self,
         _propolis_id: PropolisUuid,
-        _new_runtime_state: SledInstanceState,
+        _new_runtime_state: SledVmmState,
     ) -> Result<(), Error> {
         Err(Error::internal_error("Not implemented"))
     }
@@ -126,7 +124,7 @@ async fn sled_agent_put(
 async fn cpapi_instances_put(
     request_context: RequestContext<ServerContext>,
     path_params: Path<VmmPathParam>,
-    new_runtime_state: TypedBody<SledInstanceState>,
+    new_runtime_state: TypedBody<SledVmmState>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let context = request_context.context();
     context.cpapi_instances_put(

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -21,7 +21,7 @@ use nexus_sled_agent_shared::inventory::{
 };
 use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::{
-    DiskRuntimeState, SledInstanceState, UpdateArtifactId,
+    DiskRuntimeState, SledVmmState, UpdateArtifactId,
 };
 use omicron_common::api::internal::shared::{
     ResolvedVpcRouteSet, ResolvedVpcRouteState, SledIdentifiers, SwitchPorts,
@@ -40,8 +40,8 @@ use sled_agent_types::disk::DiskEnsureBody;
 use sled_agent_types::early_networking::EarlyNetworkConfig;
 use sled_agent_types::firewall_rules::VpcFirewallRulesEnsureBody;
 use sled_agent_types::instance::{
-    InstanceEnsureBody, InstanceExternalIpBody, InstancePutStateBody,
-    InstancePutStateResponse, InstanceUnregisterResponse,
+    InstanceEnsureBody, InstanceExternalIpBody, VmmPutStateBody,
+    VmmPutStateResponse, VmmUnregisterResponse,
 };
 use sled_agent_types::sled::AddSledRequest;
 use sled_agent_types::time_sync::TimeSync;
@@ -297,7 +297,7 @@ impl SledAgentApi for SledAgentImpl {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError> {
         let sa = rqctx.context();
         let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
@@ -318,7 +318,7 @@ impl SledAgentApi for SledAgentImpl {
     async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
+    ) -> Result<HttpResponseOk<VmmUnregisterResponse>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         Ok(HttpResponseOk(sa.instance_ensure_unregistered(id).await?))
@@ -327,8 +327,8 @@ impl SledAgentApi for SledAgentImpl {
     async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        body: TypedBody<InstancePutStateBody>,
-    ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
+        body: TypedBody<VmmPutStateBody>,
+    ) -> Result<HttpResponseOk<VmmPutStateResponse>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
@@ -338,7 +338,7 @@ impl SledAgentApi for SledAgentImpl {
     async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         Ok(HttpResponseOk(sa.instance_get_state(id).await?))

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -30,7 +30,6 @@ use omicron_common::api::internal::shared::{
 use omicron_common::disk::{
     DiskVariant, DisksManagementResult, M2Slot, OmicronPhysicalDisksConfig,
 };
-use omicron_uuid_kinds::{GenericUuid, InstanceUuid};
 use sled_agent_api::*;
 use sled_agent_types::boot_disk::{
     BootDiskOsWriteStatus, BootDiskPathParams, BootDiskUpdatePathParams,
@@ -294,18 +293,18 @@ impl SledAgentApi for SledAgentImpl {
         Ok(HttpResponseUpdatedNoContent())
     }
 
-    async fn instance_register(
+    async fn vmm_register(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
         Ok(HttpResponseOk(
             sa.instance_ensure_registered(
-                instance_id,
-                body_args.propolis_id,
+                body_args.instance_id,
+                propolis_id,
                 body_args.hardware,
                 body_args.instance_runtime,
                 body_args.vmm_runtime,
@@ -316,58 +315,56 @@ impl SledAgentApi for SledAgentImpl {
         ))
     }
 
-    async fn instance_unregister(
+    async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
-        Ok(HttpResponseOk(sa.instance_ensure_unregistered(instance_id).await?))
+        let id = path_params.into_inner().propolis_id;
+        Ok(HttpResponseOk(sa.instance_ensure_unregistered(id).await?))
     }
 
-    async fn instance_put_state(
+    async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstancePutStateBody>,
     ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        Ok(HttpResponseOk(
-            sa.instance_ensure_state(instance_id, body_args.state).await?,
-        ))
+        Ok(HttpResponseOk(sa.instance_ensure_state(id, body_args.state).await?))
     }
 
-    async fn instance_get_state(
+    async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
-        Ok(HttpResponseOk(sa.instance_get_state(instance_id).await?))
+        let id = path_params.into_inner().propolis_id;
+        Ok(HttpResponseOk(sa.instance_get_state(id).await?))
     }
 
-    async fn instance_put_external_ip(
+    async fn vmm_put_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        sa.instance_put_external_ip(instance_id, &body_args).await?;
+        sa.instance_put_external_ip(id, &body_args).await?;
         Ok(HttpResponseUpdatedNoContent())
     }
 
-    async fn instance_delete_external_ip(
+    async fn vmm_delete_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        sa.instance_delete_external_ip(instance_id, &body_args).await?;
+        sa.instance_delete_external_ip(id, &body_args).await?;
         Ok(HttpResponseUpdatedNoContent())
     }
 
@@ -399,26 +396,24 @@ impl SledAgentApi for SledAgentImpl {
         Ok(HttpResponseUpdatedNoContent())
     }
 
-    async fn instance_issue_disk_snapshot_request(
+    async fn vmm_issue_disk_snapshot_request(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
-        body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
-    ) -> Result<
-        HttpResponseOk<InstanceIssueDiskSnapshotRequestResponse>,
-        HttpError,
-    > {
+        path_params: Path<VmmIssueDiskSnapshotRequestPathParam>,
+        body: TypedBody<VmmIssueDiskSnapshotRequestBody>,
+    ) -> Result<HttpResponseOk<VmmIssueDiskSnapshotRequestResponse>, HttpError>
+    {
         let sa = rqctx.context();
         let path_params = path_params.into_inner();
         let body = body.into_inner();
 
-        sa.instance_issue_disk_snapshot_request(
-            InstanceUuid::from_untyped_uuid(path_params.instance_id),
+        sa.vmm_issue_disk_snapshot_request(
+            path_params.propolis_id,
             path_params.disk_id,
             body.snapshot_id,
         )
         .await?;
 
-        Ok(HttpResponseOk(InstanceIssueDiskSnapshotRequestResponse {
+        Ok(HttpResponseOk(VmmIssueDiskSnapshotRequestResponse {
             snapshot_id: body.snapshot_id,
         }))
     }

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -514,12 +514,13 @@ impl InstanceRunner {
                 let state = self.state.sled_instance_state();
                 info!(self.log, "Publishing instance state update to Nexus";
                     "instance_id" => %self.instance_id(),
+                    "propolis_id" => %self.state.propolis_id(),
                     "state" => ?state,
                 );
 
                 self.nexus_client
                     .cpapi_instances_put(
-                        &self.instance_id().into_untyped_uuid(),
+                        &self.state.propolis_id(),
                         &state.into(),
                     )
                     .await
@@ -1613,7 +1614,7 @@ mod tests {
     impl FakeNexusServer for NexusServer {
         fn cpapi_instances_put(
             &self,
-            _instance_id: Uuid,
+            _propolis_id: PropolisUuid,
             new_runtime_state: SledInstanceState,
         ) -> Result<(), omicron_common::api::external::Error> {
             self.observed_runtime_state

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -514,15 +514,12 @@ impl InstanceRunner {
                 let state = self.state.sled_instance_state();
                 info!(self.log, "Publishing instance state update to Nexus";
                     "instance_id" => %self.instance_id(),
-                    "propolis_id" => %self.state.propolis_id(),
+                    "propolis_id" => %self.propolis_id,
                     "state" => ?state,
                 );
 
                 self.nexus_client
-                    .cpapi_instances_put(
-                        &self.state.propolis_id(),
-                        &state.into(),
-                    )
+                    .cpapi_instances_put(&self.propolis_id, &state.into())
                     .await
                     .map_err(|err| -> backoff::BackoffError<Error> {
                         match &err {
@@ -618,7 +615,7 @@ impl InstanceRunner {
         info!(
             self.log,
             "updated state after observing Propolis state change";
-            "propolis_id" => %self.state.propolis_id(),
+            "propolis_id" => %self.propolis_id,
             "new_vmm_state" => ?self.state.vmm()
         );
 
@@ -1089,7 +1086,7 @@ impl Instance {
             dhcp_config,
             requested_disks: hardware.disks,
             cloud_init_bytes: hardware.cloud_init_bytes,
-            state: InstanceStates::new(vmm_runtime, propolis_id, migration_id),
+            state: InstanceStates::new(vmm_runtime, migration_id),
             running_state: None,
             nexus_client,
             storage,

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -733,11 +733,9 @@ impl InstanceManagerRunner {
         // name to capture into a bundle, so return a `NoSuchZone` error.
         let vmm_id: PropolisUuid = name
             .strip_prefix(PROPOLIS_ZONE_PREFIX)
-            .ok_or_else(|| BundleError::NoSuchZone { name: name.to_string() })
-            .and_then(|uuid_str| {
-                uuid_str.parse::<PropolisUuid>().map_err(|_| {
-                    BundleError::NoSuchZone { name: name.to_string() }
-                })
+            .and_then(|uuid_str| uuid_str.parse::<PropolisUuid>().ok())
+            .ok_or_else(|| BundleError::NoSuchZone {
+                name: name.to_string(),
             })?;
 
         let Some(instance) = self.jobs.get(&vmm_id) else {

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -364,35 +364,6 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     pub async fn contains_key(self: &Arc<Self>, id: &Uuid) -> bool {
         self.objects.lock().await.contains_key(id)
     }
-
-    /// Iterates over all of the existing objects in the collection and, for any
-    /// that meet `condition`, asks to transition them into the supplied target
-    /// state.
-    ///
-    /// If any such transition fails, this routine short-circuits and does not
-    /// attempt to transition any other objects.
-    //
-    // TODO: It's likely more idiomatic to have an `iter_mut` routine that
-    // returns a struct that impls Iterator and yields &mut S references. The
-    // tricky bit is that the struct must hold the objects lock during the
-    // iteration. Figure out if there's a better way to arrange all this.
-    pub async fn sim_ensure_for_each_where<C>(
-        self: &Arc<Self>,
-        condition: C,
-        target: &S::RequestedState,
-    ) -> Result<(), Error>
-    where
-        C: Fn(&S) -> bool,
-    {
-        let mut objects = self.objects.lock().await;
-        for o in objects.values_mut() {
-            if condition(&o.object) {
-                o.transition(target.clone())?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl<S: Simulatable + Clone + 'static> SimCollection<S> {

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -396,14 +396,12 @@ mod test {
     use omicron_common::api::internal::nexus::VmmRuntimeState;
     use omicron_common::api::internal::nexus::VmmState;
     use omicron_test_utils::dev::test_setup_log;
-    use omicron_uuid_kinds::PropolisUuid;
     use sled_agent_types::disk::DiskStateRequested;
     use sled_agent_types::instance::InstanceStateRequested;
 
     fn make_instance(
         logctx: &LogContext,
     ) -> (SimObject<SimInstance>, Receiver<()>) {
-        let propolis_id = PropolisUuid::new_v4();
         let vmm_state = VmmRuntimeState {
             state: VmmState::Starting,
             gen: Generation::new(),
@@ -412,7 +410,6 @@ mod test {
 
         let state = SledInstanceState {
             vmm_state,
-            propolis_id,
             migration_in: None,
             migration_out: None,
         };

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -32,7 +32,6 @@ use omicron_common::api::internal::shared::{
 };
 use omicron_common::disk::DisksManagementResult;
 use omicron_common::disk::OmicronPhysicalDisksConfig;
-use omicron_uuid_kinds::{GenericUuid, InstanceUuid};
 use sled_agent_api::*;
 use sled_agent_types::boot_disk::BootDiskOsWriteStatus;
 use sled_agent_types::boot_disk::BootDiskPathParams;
@@ -83,18 +82,18 @@ enum SledAgentSimImpl {}
 impl SledAgentApi for SledAgentSimImpl {
     type Context = Arc<SledAgent>;
 
-    async fn instance_register(
+    async fn vmm_register(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
         Ok(HttpResponseOk(
             sa.instance_register(
-                instance_id,
-                body_args.propolis_id,
+                body_args.instance_id,
+                propolis_id,
                 body_args.hardware,
                 body_args.instance_runtime,
                 body_args.vmm_runtime,
@@ -104,58 +103,56 @@ impl SledAgentApi for SledAgentSimImpl {
         ))
     }
 
-    async fn instance_unregister(
+    async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
-        Ok(HttpResponseOk(sa.instance_unregister(instance_id).await?))
+        let id = path_params.into_inner().propolis_id;
+        Ok(HttpResponseOk(sa.instance_unregister(id).await?))
     }
 
-    async fn instance_put_state(
+    async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstancePutStateBody>,
     ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        Ok(HttpResponseOk(
-            sa.instance_ensure_state(instance_id, body_args.state).await?,
-        ))
+        Ok(HttpResponseOk(sa.instance_ensure_state(id, body_args.state).await?))
     }
 
-    async fn instance_get_state(
+    async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
     ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
-        Ok(HttpResponseOk(sa.instance_get_state(instance_id).await?))
+        let id = path_params.into_inner().propolis_id;
+        Ok(HttpResponseOk(sa.instance_get_state(id).await?))
     }
 
-    async fn instance_put_external_ip(
+    async fn vmm_put_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        sa.instance_put_external_ip(instance_id, &body_args).await?;
+        sa.instance_put_external_ip(id, &body_args).await?;
         Ok(HttpResponseUpdatedNoContent())
     }
 
-    async fn instance_delete_external_ip(
+    async fn vmm_delete_external_ip(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstancePathParam>,
+        path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceExternalIpBody>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let sa = rqctx.context();
-        let instance_id = path_params.into_inner().instance_id;
+        let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        sa.instance_delete_external_ip(instance_id, &body_args).await?;
+        sa.instance_delete_external_ip(id, &body_args).await?;
         Ok(HttpResponseUpdatedNoContent())
     }
 
@@ -192,27 +189,25 @@ impl SledAgentApi for SledAgentSimImpl {
         Ok(HttpResponseUpdatedNoContent())
     }
 
-    async fn instance_issue_disk_snapshot_request(
+    async fn vmm_issue_disk_snapshot_request(
         rqctx: RequestContext<Self::Context>,
-        path_params: Path<InstanceIssueDiskSnapshotRequestPathParam>,
-        body: TypedBody<InstanceIssueDiskSnapshotRequestBody>,
-    ) -> Result<
-        HttpResponseOk<InstanceIssueDiskSnapshotRequestResponse>,
-        HttpError,
-    > {
+        path_params: Path<VmmIssueDiskSnapshotRequestPathParam>,
+        body: TypedBody<VmmIssueDiskSnapshotRequestBody>,
+    ) -> Result<HttpResponseOk<VmmIssueDiskSnapshotRequestResponse>, HttpError>
+    {
         let sa = rqctx.context();
         let path_params = path_params.into_inner();
         let body = body.into_inner();
 
         sa.instance_issue_disk_snapshot_request(
-            InstanceUuid::from_untyped_uuid(path_params.instance_id),
+            path_params.propolis_id,
             path_params.disk_id,
             body.snapshot_id,
         )
         .await
         .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
-        Ok(HttpResponseOk(InstanceIssueDiskSnapshotRequestResponse {
+        Ok(HttpResponseOk(VmmIssueDiskSnapshotRequestResponse {
             snapshot_id: body.snapshot_id,
         }))
     }
@@ -512,45 +507,44 @@ fn method_unimplemented<T>() -> Result<T, HttpError> {
 
 #[endpoint {
     method = POST,
-    path = "/instances/{instance_id}/poke",
+    path = "/vmms/{propolis_id}/poke",
 }]
 async fn instance_poke_post(
     rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
+    path_params: Path<VmmPathParam>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    sa.instance_poke(instance_id, PokeMode::Drain).await;
+    let id = path_params.into_inner().propolis_id;
+    sa.vmm_poke(id, PokeMode::Drain).await;
     Ok(HttpResponseUpdatedNoContent())
 }
 
 #[endpoint {
     method = POST,
-    path = "/instances/{instance_id}/poke-single-step",
+    path = "/vmms/{propolis_id}/poke-single-step",
 }]
 async fn instance_poke_single_step_post(
     rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
+    path_params: Path<VmmPathParam>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    sa.instance_poke(instance_id, PokeMode::SingleStep).await;
+    let id = path_params.into_inner().propolis_id;
+    sa.vmm_poke(id, PokeMode::SingleStep).await;
     Ok(HttpResponseUpdatedNoContent())
 }
 
 #[endpoint {
     method = POST,
-    path = "/instances/{instance_id}/sim-migration-source",
+    path = "/vmms/{propolis_id}/sim-migration-source",
 }]
 async fn instance_post_sim_migration_source(
     rqctx: RequestContext<Arc<SledAgent>>,
-    path_params: Path<InstancePathParam>,
+    path_params: Path<VmmPathParam>,
     body: TypedBody<super::instance::SimulateMigrationSource>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let sa = rqctx.context();
-    let instance_id = path_params.into_inner().instance_id;
-    sa.instance_simulate_migration_source(instance_id, body.into_inner())
-        .await?;
+    let id = path_params.into_inner().propolis_id;
+    sa.instance_simulate_migration_source(id, body.into_inner()).await?;
     Ok(HttpResponseUpdatedNoContent())
 }
 

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -23,7 +23,7 @@ use dropshot::TypedBody;
 use nexus_sled_agent_shared::inventory::SledRole;
 use nexus_sled_agent_shared::inventory::{Inventory, OmicronZonesConfig};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
-use omicron_common::api::internal::nexus::SledInstanceState;
+use omicron_common::api::internal::nexus::SledVmmState;
 use omicron_common::api::internal::nexus::UpdateArtifactId;
 use omicron_common::api::internal::shared::SledIdentifiers;
 use omicron_common::api::internal::shared::VirtualNetworkInterfaceHost;
@@ -43,9 +43,9 @@ use sled_agent_types::early_networking::EarlyNetworkConfig;
 use sled_agent_types::firewall_rules::VpcFirewallRulesEnsureBody;
 use sled_agent_types::instance::InstanceEnsureBody;
 use sled_agent_types::instance::InstanceExternalIpBody;
-use sled_agent_types::instance::InstancePutStateBody;
-use sled_agent_types::instance::InstancePutStateResponse;
-use sled_agent_types::instance::InstanceUnregisterResponse;
+use sled_agent_types::instance::VmmPutStateBody;
+use sled_agent_types::instance::VmmPutStateResponse;
+use sled_agent_types::instance::VmmUnregisterResponse;
 use sled_agent_types::sled::AddSledRequest;
 use sled_agent_types::time_sync::TimeSync;
 use sled_agent_types::zone_bundle::BundleUtilization;
@@ -86,7 +86,7 @@ impl SledAgentApi for SledAgentSimImpl {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
         body: TypedBody<InstanceEnsureBody>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError> {
         let sa = rqctx.context();
         let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
@@ -106,7 +106,7 @@ impl SledAgentApi for SledAgentSimImpl {
     async fn vmm_unregister(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<InstanceUnregisterResponse>, HttpError> {
+    ) -> Result<HttpResponseOk<VmmUnregisterResponse>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         Ok(HttpResponseOk(sa.instance_unregister(id).await?))
@@ -115,8 +115,8 @@ impl SledAgentApi for SledAgentSimImpl {
     async fn vmm_put_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        body: TypedBody<InstancePutStateBody>,
-    ) -> Result<HttpResponseOk<InstancePutStateResponse>, HttpError> {
+        body: TypedBody<VmmPutStateBody>,
+    ) -> Result<HttpResponseOk<VmmPutStateResponse>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
@@ -126,7 +126,7 @@ impl SledAgentApi for SledAgentSimImpl {
     async fn vmm_get_state(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-    ) -> Result<HttpResponseOk<SledInstanceState>, HttpError> {
+    ) -> Result<HttpResponseOk<SledVmmState>, HttpError> {
         let sa = rqctx.context();
         let id = path_params.into_inner().propolis_id;
         Ok(HttpResponseOk(sa.instance_get_state(id).await?))

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -15,6 +15,7 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::Generation;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::internal::nexus::{SledInstanceState, VmmState};
+use omicron_uuid_kinds::{GenericUuid, PropolisUuid};
 use propolis_client::types::{
     InstanceMigrateStatusResponse as PropolisMigrateResponse,
     InstanceMigrationStatus as PropolisMigrationStatus,
@@ -512,7 +513,7 @@ impl Simulatable for SimInstance {
     ) -> Result<(), Error> {
         nexus_client
             .cpapi_instances_put(
-                id,
+                &PropolisUuid::from_untyped_uuid(*id),
                 &nexus_client::types::SledInstanceState::from(current),
             )
             .await

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -454,7 +454,6 @@ impl Simulatable for SimInstance {
             inner: Arc::new(Mutex::new(SimInstanceInner {
                 state: InstanceStates::new(
                     current.vmm_state,
-                    current.propolis_id,
                     current.migration_in.map(|m| m.migration_id),
                 ),
                 last_response: InstanceStateMonitorResponse {

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -381,7 +381,6 @@ impl SledAgent {
                 &propolis_id.into_untyped_uuid(),
                 SledInstanceState {
                     vmm_state: vmm_runtime,
-                    propolis_id,
                     migration_in,
                     migration_out: None,
                 },

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -84,7 +84,8 @@ pub struct SledAgent {
     mock_propolis:
         Mutex<Option<(HttpServer<Arc<PropolisContext>>, PropolisClient)>>,
     /// lists of external IPs assigned to instances
-    pub external_ips: Mutex<HashMap<Uuid, HashSet<InstanceExternalIpBody>>>,
+    pub external_ips:
+        Mutex<HashMap<PropolisUuid, HashSet<InstanceExternalIpBody>>>,
     pub vpc_routes: Mutex<HashMap<RouterId, RouteSet>>,
     config: Config,
     fake_zones: Mutex<OmicronZonesConfig>,
@@ -740,7 +741,7 @@ impl SledAgent {
         }
 
         let mut eips = self.external_ips.lock().await;
-        let my_eips = eips.entry(propolis_id.into_untyped_uuid()).or_default();
+        let my_eips = eips.entry(propolis_id).or_default();
 
         // High-level behaviour: this should always succeed UNLESS
         // trying to add a double ephemeral.
@@ -773,7 +774,7 @@ impl SledAgent {
         }
 
         let mut eips = self.external_ips.lock().await;
-        let my_eips = eips.entry(propolis_id.into_untyped_uuid()).or_default();
+        let my_eips = eips.entry(propolis_id).or_default();
 
         my_eips.remove(&body_args);
 

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -453,9 +453,7 @@ impl SledAgent {
             Ok(i) => i.current().clone(),
             Err(_) => match state {
                 VmmStateRequested::Stopped => {
-                    return Ok(VmmPutStateResponse {
-                        updated_runtime: None,
-                    });
+                    return Ok(VmmPutStateResponse { updated_runtime: None });
                 }
                 _ => {
                     return Err(Error::invalid_request(&format!(
@@ -498,9 +496,7 @@ impl SledAgent {
                             }
                         }
                     });
-                    return Ok(VmmPutStateResponse {
-                        updated_runtime: None,
-                    });
+                    return Ok(VmmPutStateResponse { updated_runtime: None });
                 }
                 VmmStateRequested::Stopped => {
                     propolis_client::types::InstanceStateRequested::Stop

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -24,8 +24,8 @@ use omicron_common::disk::DiskVariant;
 use omicron_common::disk::DisksManagementResult;
 use omicron_common::disk::OmicronPhysicalDisksConfig;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::InstanceUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::PropolisUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use propolis_client::types::VolumeConstructionRequest;
 use slog::Logger;
@@ -869,7 +869,7 @@ impl Pantry {
 
         self.sled_agent
             .instance_issue_disk_snapshot_request(
-                InstanceUuid::new_v4(), // instance id, not used by function
+                PropolisUuid::new_v4(), // instance id, not used by function
                 volume_id.parse().unwrap(),
                 snapshot_id.parse().unwrap(),
             )

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -990,11 +990,11 @@ impl SledAgent {
     /// rudely terminates the instance.
     pub async fn instance_ensure_unregistered(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
     ) -> Result<InstanceUnregisterResponse, Error> {
         self.inner
             .instances
-            .ensure_unregistered(instance_id)
+            .ensure_unregistered(propolis_id)
             .await
             .map_err(|e| Error::Instance(e))
     }
@@ -1003,12 +1003,12 @@ impl SledAgent {
     /// state.
     pub async fn instance_ensure_state(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
         target: InstanceStateRequested,
     ) -> Result<InstancePutStateResponse, Error> {
         self.inner
             .instances
-            .ensure_state(instance_id, target)
+            .ensure_state(propolis_id, target)
             .await
             .map_err(|e| Error::Instance(e))
     }
@@ -1020,12 +1020,12 @@ impl SledAgent {
     /// does not match the current ephemeral IP.
     pub async fn instance_put_external_ip(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
         external_ip: &InstanceExternalIpBody,
     ) -> Result<(), Error> {
         self.inner
             .instances
-            .add_external_ip(instance_id, external_ip)
+            .add_external_ip(propolis_id, external_ip)
             .await
             .map_err(|e| Error::Instance(e))
     }
@@ -1034,12 +1034,12 @@ impl SledAgent {
     /// specified external IP address in either its ephemeral or floating IP set.
     pub async fn instance_delete_external_ip(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
         external_ip: &InstanceExternalIpBody,
     ) -> Result<(), Error> {
         self.inner
             .instances
-            .delete_external_ip(instance_id, external_ip)
+            .delete_external_ip(propolis_id, external_ip)
             .await
             .map_err(|e| Error::Instance(e))
     }
@@ -1047,11 +1047,11 @@ impl SledAgent {
     /// Returns the state of the instance with the provided ID.
     pub async fn instance_get_state(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
     ) -> Result<SledInstanceState, Error> {
         self.inner
             .instances
-            .get_instance_state(instance_id)
+            .get_instance_state(propolis_id)
             .await
             .map_err(|e| Error::Instance(e))
     }
@@ -1082,19 +1082,15 @@ impl SledAgent {
     }
 
     /// Issue a snapshot request for a Crucible disk attached to an instance
-    pub async fn instance_issue_disk_snapshot_request(
+    pub async fn vmm_issue_disk_snapshot_request(
         &self,
-        instance_id: InstanceUuid,
+        propolis_id: PropolisUuid,
         disk_id: Uuid,
         snapshot_id: Uuid,
     ) -> Result<(), Error> {
         self.inner
             .instances
-            .instance_issue_disk_snapshot_request(
-                instance_id,
-                disk_id,
-                snapshot_id,
-            )
+            .issue_disk_snapshot_request(propolis_id, disk_id, snapshot_id)
             .await
             .map_err(Error::from)
     }

--- a/sled-agent/types/src/instance.rs
+++ b/sled-agent/types/src/instance.rs
@@ -18,7 +18,7 @@ use omicron_common::api::internal::{
         DhcpConfig, NetworkInterface, ResolvedVpcFirewallRule, SourceNatConfig,
     },
 };
-use omicron_uuid_kinds::PropolisUuid;
+use omicron_uuid_kinds::InstanceUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -37,10 +37,8 @@ pub struct InstanceEnsureBody {
     /// The initial VMM runtime state for the VMM being registered.
     pub vmm_runtime: VmmRuntimeState,
 
-    /// The ID of the VMM being registered. This may not be the active VMM ID in
-    /// the instance runtime state (e.g. if the new VMM is going to be a
-    /// migration target).
-    pub propolis_id: PropolisUuid,
+    /// The ID of the instance for which this VMM is being created.
+    pub instance_id: InstanceUuid,
 
     /// The address at which this VMM should serve a Propolis server API.
     pub propolis_addr: SocketAddr,

--- a/sled-agent/types/src/instance.rs
+++ b/sled-agent/types/src/instance.rs
@@ -11,8 +11,7 @@ use std::{
 
 use omicron_common::api::internal::{
     nexus::{
-        InstanceProperties, InstanceRuntimeState, SledInstanceState,
-        VmmRuntimeState,
+        InstanceProperties, InstanceRuntimeState, SledVmmState, VmmRuntimeState,
     },
     shared::{
         DhcpConfig, NetworkInterface, ResolvedVpcFirewallRule, SourceNatConfig,
@@ -78,19 +77,19 @@ pub struct InstanceMetadata {
 /// The body of a request to move a previously-ensured instance into a specific
 /// runtime state.
 #[derive(Serialize, Deserialize, JsonSchema)]
-pub struct InstancePutStateBody {
+pub struct VmmPutStateBody {
     /// The state into which the instance should be driven.
-    pub state: InstanceStateRequested,
+    pub state: VmmStateRequested,
 }
 
 /// The response sent from a request to move an instance into a specific runtime
 /// state.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct InstancePutStateResponse {
+pub struct VmmPutStateResponse {
     /// The current runtime state of the instance after handling the request to
     /// change its state. If the instance's state did not change, this field is
     /// `None`.
-    pub updated_runtime: Option<SledInstanceState>,
+    pub updated_runtime: Option<SledVmmState>,
 }
 
 /// Requestable running state of an Instance.
@@ -98,7 +97,7 @@ pub struct InstancePutStateResponse {
 /// A subset of [`omicron_common::api::external::InstanceState`].
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum InstanceStateRequested {
+pub enum VmmStateRequested {
     /// Run this instance by migrating in from a previous running incarnation of
     /// the instance.
     MigrationTarget(InstanceMigrationTargetParams),
@@ -111,40 +110,40 @@ pub enum InstanceStateRequested {
     Reboot,
 }
 
-impl fmt::Display for InstanceStateRequested {
+impl fmt::Display for VmmStateRequested {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.label())
     }
 }
 
-impl InstanceStateRequested {
+impl VmmStateRequested {
     fn label(&self) -> &str {
         match self {
-            InstanceStateRequested::MigrationTarget(_) => "migrating in",
-            InstanceStateRequested::Running => "running",
-            InstanceStateRequested::Stopped => "stopped",
-            InstanceStateRequested::Reboot => "reboot",
+            VmmStateRequested::MigrationTarget(_) => "migrating in",
+            VmmStateRequested::Running => "running",
+            VmmStateRequested::Stopped => "stopped",
+            VmmStateRequested::Reboot => "reboot",
         }
     }
 
     /// Returns true if the state represents a stopped Instance.
     pub fn is_stopped(&self) -> bool {
         match self {
-            InstanceStateRequested::MigrationTarget(_) => false,
-            InstanceStateRequested::Running => false,
-            InstanceStateRequested::Stopped => true,
-            InstanceStateRequested::Reboot => false,
+            VmmStateRequested::MigrationTarget(_) => false,
+            VmmStateRequested::Running => false,
+            VmmStateRequested::Stopped => true,
+            VmmStateRequested::Reboot => false,
         }
     }
 }
 
 /// The response sent from a request to unregister an instance.
 #[derive(Serialize, Deserialize, JsonSchema)]
-pub struct InstanceUnregisterResponse {
+pub struct VmmUnregisterResponse {
     /// The current state of the instance after handling the request to
     /// unregister it. If the instance's state did not change, this field is
     /// `None`.
-    pub updated_runtime: Option<SledInstanceState>,
+    pub updated_runtime: Option<SledVmmState>,
 }
 
 /// Parameters used when directing Propolis to initialize itself via live


### PR DESCRIPTION
Change sled agent's instance lookup tables so that Propolis jobs are indexed by Propolis/VMM IDs instead of instance IDs. 
This is a prerequisite to revisiting how the Failed instance state works. See RFD 486 section 6.1 for all the details of why this is needed, but very broadly: when an instance's VMM is Destroyed, we'd like sled agent to tell Nexus that *before* the agent deregisters the instance from the sled, for reasons described in the RFD; but if we do that with no other changes, there's a race where Nexus may try to restart the instance on the same sled before sled agent can update its instance table, causing instance start to fail.

To achieve this:

- In sled agent, change the `InstanceManagerRunner`'s instance map to a `BTreeMap<PropolisUuid, Instance>`, then clean up all the compilation errors.
- In Nexus:
  - Make callers of instance APIs furnish a Propolis ID instead of an instance ID. This is generally very straightforward because they already had to get a VMM record to figure out what sled to talk to.
  - Change `cpapi_instances_put` to take a Propolis ID instead of an instance ID. Regular sled agent still has both IDs, but with these changes, simulated sled agents only have a Propolis ID to work with, and plumbing an instance ID down to them requires significant code changes.
- Update test code:
  - Unify the Nexus helper routines that let integration tests get sled agent clients or sled IDs; now they get a single struct containing both of those and the instance's Propolis IDs.
  - Update users of the simulated agent's `poke` endpoints to use Propolis IDs.
  - Delete the "detach disks on instance stop" bits of simulated sled agent. These don't appear to be load-bearing, they don't correspond to any behavior in the actual sled agent (which doesn't manage disk attachment or detachment), and it was a pain to rework them to work with Propolis IDs.

Tests: cargo nextest.

Related: #4226 and #4872, among others.