### PR TITLE
stop logging `cloud_init_bytes` in sled-agent

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -122,6 +122,11 @@ async fn never_bail() -> Result<bool, Error> {
 /// A wrapper struct that does nothing other than elide the inner value from
 /// [`std::fmt::Debug`] output.
 ///
+/// We define this within Omicron instead of using one of the many available
+/// crates that do the same thing because it's trivial to do so, and we want the
+/// flexibility to add traits to this type without needing to wait on upstream
+/// to add an optional dependency.
+///
 /// If you want to use this for secrets, consider that it might not do
 /// everything you expect (it does not zeroize memory on drop, nor get in the
 /// way of you removing the inner value from this wrapper struct).

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -118,3 +118,22 @@ where
 async fn never_bail() -> Result<bool, Error> {
     Ok(false)
 }
+
+/// A wrapper struct that does nothing other than elide the inner value from
+/// [`std::debug::Debug`] output.
+///
+/// If you want to use this for secrets, consider that it might not do
+/// everything you expect (it does not zeroize memory on drop, nor get in the
+/// way of you removing the inner value from this wrapper struct).
+#[derive(
+    Clone, Copy, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct NoDebug<T>(pub T);
+
+impl<T> std::fmt::Debug for NoDebug<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "..")
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -120,7 +120,7 @@ async fn never_bail() -> Result<bool, Error> {
 }
 
 /// A wrapper struct that does nothing other than elide the inner value from
-/// [`std::debug::Debug`] output.
+/// [`std::fmt::Debug`] output.
 ///
 /// If you want to use this for secrets, consider that it might not do
 /// everything you expect (it does not zeroize memory on drop, nor get in the

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -33,6 +33,7 @@ use omicron_common::api::internal::shared::{
 };
 use omicron_common::backoff;
 use omicron_common::zpool_name::ZpoolName;
+use omicron_common::NoDebug;
 use omicron_uuid_kinds::{GenericUuid, InstanceUuid, PropolisUuid};
 use propolis_client::Client as PropolisClient;
 use rand::prelude::IteratorRandom;
@@ -337,7 +338,7 @@ struct InstanceRunner {
 
     // Disk related properties
     requested_disks: Vec<propolis_client::types::DiskRequest>,
-    cloud_init_bytes: Option<String>,
+    cloud_init_bytes: Option<NoDebug<String>>,
 
     // Internal State management
     state: InstanceStates,
@@ -724,10 +725,10 @@ impl InstanceRunner {
                 .map(Into::into)
                 .collect(),
             migrate,
-            cloud_init_bytes: self.cloud_init_bytes.clone(),
+            cloud_init_bytes: self.cloud_init_bytes.clone().map(|x| x.0),
         };
 
-        info!(self.log, "Sending ensure request to propolis: {:?}", request);
+        debug!(self.log, "Sending ensure request to propolis: {:?}", request);
         let result = client.instance_ensure().body(request).send().await;
         info!(self.log, "result of instance_ensure call is {:?}", result);
         result?;

--- a/sled-agent/types/src/instance.rs
+++ b/sled-agent/types/src/instance.rs
@@ -18,6 +18,7 @@ use omicron_common::api::internal::{
         DhcpConfig, NetworkInterface, ResolvedVpcFirewallRule, SourceNatConfig,
     },
 };
+use omicron_common::NoDebug;
 use omicron_uuid_kinds::PropolisUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -63,7 +64,7 @@ pub struct InstanceHardware {
     pub dhcp_config: DhcpConfig,
     // TODO: replace `propolis_client::*` with locally-modeled request type
     pub disks: Vec<propolis_client::types::DiskRequest>,
-    pub cloud_init_bytes: Option<String>,
+    pub cloud_init_bytes: Option<NoDebug<String>>,
 }
 
 /// Metadata used to track statistics about an instance.


### PR DESCRIPTION
aka "want sled-agent to stop screaming at base64 floppy disks"

Fixes #6387.

1. Create a `NoDebug` wrapper struct for this purpose in omicron-common. (Note that the OpenAPI schema for sled-agent does not change; schemars seems to honor `#[serde(transparent)]`.)
2. Apply `NoDebug` inside the `cloud_init_bytes` `Option`. Thus we log everything else about the instance hardware, and whether or not there is cidata, but not the cidata itself.
3. Demote an INFO-level log of the Propolis client's `InstanceEnsureRequest` to DEBUG.