### PR TITLE
Idempotently delete freed crucible regions

### DIFF
--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -27,6 +27,9 @@ use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
 use crate::app::sagas::declare_saga_actions;
+use nexus_db_model::Dataset;
+use nexus_db_model::Region;
+use nexus_db_model::RegionSnapshot;
 use nexus_db_queries::authn;
 use nexus_db_queries::db::datastore::CrucibleResources;
 use nexus_types::identity::Asset;
@@ -62,6 +65,9 @@ declare_saga_actions! {
     DELETE_CRUCIBLE_SNAPSHOT_RECORDS -> "no_result_4" {
         + svd_delete_crucible_snapshot_records
     }
+    FIND_FREED_CRUCIBLE_REGIONS -> "freed_crucible_regions" {
+        + svd_find_freed_crucible_regions
+    }
     DELETE_FREED_CRUCIBLE_REGIONS -> "no_result_5" {
         + svd_delete_freed_crucible_regions
     }
@@ -87,6 +93,7 @@ pub fn create_dag(
     // remove snapshot db records
     builder.append(delete_crucible_snapshot_records_action());
     // clean up regions that were freed by deleting snapshots
+    builder.append(find_freed_crucible_regions_action());
     builder.append(delete_freed_crucible_regions_action());
     builder.append(hard_delete_volume_record_action());
 
@@ -323,11 +330,14 @@ async fn svd_delete_crucible_snapshot_records(
     Ok(())
 }
 
+type FreedCrucibleRegions =
+    Vec<(Dataset, Region, Option<RegionSnapshot>, Uuid)>;
+
 /// Deleting region snapshots in a previous saga node may have freed up regions
 /// that were deleted in the DB but couldn't be deleted by the Crucible Agent
-/// because a snapshot existed. Look for those here, and delete them. These will
-/// be a different volume id (i.e. for a previously deleted disk) than the one
-/// in this saga's params struct.
+/// because a snapshot existed. Look for those here. These will be a different
+/// volume id (i.e. for a previously deleted disk) than the one in this saga's
+/// params struct.
 ///
 /// It's insufficient to rely on the struct of CrucibleResources to clean up
 /// that is returned as part of svd_decrease_crucible_resource_count. Imagine a
@@ -399,15 +409,16 @@ async fn svd_delete_crucible_snapshot_records(
 ///
 /// This is expected and normal: regions are "leaked" all the time due to
 /// snapshots preventing their deletion. This part of the saga detects when
-/// those regions can be cleaned up.
+/// those regions can be cleaned up - it must be stored in the output of this
+/// saga node as deleting volume records will affect what is returned by
+/// `find_deleted_volume_regions`.
 ///
 /// Note: each delete of a snapshot could trigger another delete of a region, if
 /// that region's use has gone to zero. A snapshot delete will never trigger
 /// another snapshot delete.
-async fn svd_delete_freed_crucible_regions(
+async fn svd_find_freed_crucible_regions(
     sagactx: NexusActionContext,
-) -> Result<(), ActionError> {
-    let log = sagactx.user_data().log();
+) -> Result<FreedCrucibleRegions, ActionError> {
     let osagactx = sagactx.user_data();
 
     // Find regions freed up for deletion by a previous saga node deleting the
@@ -422,7 +433,25 @@ async fn svd_delete_freed_crucible_regions(
             },
         )?;
 
-    for (dataset, region, region_snapshot, volume) in
+    // Don't serialize the whole Volume, as the data field contains key material!
+    Ok(freed_datasets_regions_and_volumes
+        .into_iter()
+        .map(|x| (x.0, x.1, x.2, x.3.id()))
+        .collect())
+}
+
+async fn svd_delete_freed_crucible_regions(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let log = sagactx.user_data().log();
+    let osagactx = sagactx.user_data();
+
+    // Find regions freed up for deletion by a previous saga node deleting the
+    // region snapshots.
+    let freed_datasets_regions_and_volumes =
+        sagactx.lookup::<FreedCrucibleRegions>("freed_crucible_regions")?;
+
+    for (dataset, region, region_snapshot, volume_id) in
         freed_datasets_regions_and_volumes
     {
         if region_snapshot.is_some() {
@@ -467,12 +496,11 @@ async fn svd_delete_freed_crucible_regions(
             })?;
 
         // Remove volume DB record
-        osagactx.datastore().volume_hard_delete(volume.id()).await.map_err(
+        osagactx.datastore().volume_hard_delete(volume_id).await.map_err(
             |e| {
                 ActionError::action_failed(format!(
                     "failed to volume_hard_delete {}: {:?}",
-                    volume.id(),
-                    e,
+                    volume_id, e,
                 ))
             },
         )?;


### PR DESCRIPTION
In the volume delete saga, separate detecting which freed crucible regions could maybe be cleaned up from the actual deletion step. The `find_deleted_volume_regions` function that returns which regions may be ready for clean up joins on the volume table, and part of the deletion step is to delete volume records - this affects the results of the query, so store those results in the output of a previous saga node.