### PR TITLE
Make virtual disk size configurable via the CLI

### DIFF
--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -49,6 +49,10 @@ enum Commands {
 
         #[clap(long, default_value = PXA_MAC_DEFAULT)]
         pxa_mac: String,
+
+        /// Size in bytes for created vdevs
+        #[clap(long, default_value_t = 20 * GB)]
+        vdev_size: u64,
     },
     /// Destroy virtual hardware which was initialized with "Create"
     Destroy,
@@ -89,10 +93,6 @@ pub struct Args {
     /// The directory in which virtual devices are stored
     #[clap(long, default_value = "/var/tmp")]
     vdev_dir: Utf8PathBuf,
-
-    /// Allow customization of the vdev size
-    #[clap(long, default_value_t = 20 * GB)]
-    vdev_size: u64,
 
     #[command(subcommand)]
     command: Commands,

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -176,11 +176,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
 
             println!("creating virtual hardware");
             if matches!(args.scope, Scope::All | Scope::Disks) {
-                ensure_vdevs(
-                    &sled_agent_config,
-                    &args.vdev_dir,
-                    vdev_size,
-                )?;
+                ensure_vdevs(&sled_agent_config, &args.vdev_dir, vdev_size)?;
             }
             if matches!(args.scope, Scope::All | Scope::Network)
                 && softnpu_mode == "zone"

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -175,7 +175,11 @@ pub fn run_cmd(args: Args) -> Result<()> {
 
             println!("creating virtual hardware");
             if matches!(args.scope, Scope::All | Scope::Disks) {
-                ensure_vdevs(&sled_agent_config, &args.vdev_dir, args.vdev_size)?;
+                ensure_vdevs(
+                    &sled_agent_config,
+                    &args.vdev_dir,
+                    args.vdev_size,
+                )?;
             }
             if matches!(args.scope, Scope::All | Scope::Network)
                 && softnpu_mode == "zone"

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -166,6 +166,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
             gateway_mac,
             pxa,
             pxa_mac,
+            vdev_size,
         } => {
             let physical_link = if let Some(l) = physical_link {
                 l
@@ -178,7 +179,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
                 ensure_vdevs(
                     &sled_agent_config,
                     &args.vdev_dir,
-                    args.vdev_size,
+                    vdev_size,
                 )?;
             }
             if matches!(args.scope, Scope::All | Scope::Network)


### PR DESCRIPTION
I have been playing around with omicron in a home lab and ran into an issue with the virtual disks being to small. This lets the size to be overridden via the CLI.  