### PR TITLE
[meta] update tokio to 1.39.3 (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,7 +3616,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -6501,7 +6501,7 @@ dependencies = [
  "log",
  "managed",
  "memchr",
- "mio 0.8.11",
+ "mio 1.0.2",
  "nix 0.28.0",
  "nom",
  "num-bigint-dig",
@@ -6536,7 +6536,6 @@ dependencies = [
  "similar",
  "slog",
  "smallvec 1.13.2",
- "socket2 0.5.7",
  "spin 0.9.8",
  "string_cache",
  "subtle",
@@ -10623,28 +10622,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.11",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot 0.12.2",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -580,7 +580,7 @@ textwrap = "0.16.1"
 test-strategy = "0.3.1"
 thiserror = "1.0"
 tofino = { git = "https://github.com/oxidecomputer/tofino", branch = "main" }
-tokio = "1.38.1"
+tokio = "1.39.3"
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }
 tokio-stream = "0.1.15"
 tokio-tungstenite = "0.20"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -102,13 +102,12 @@ sha2 = { version = "0.10.8", features = ["oid"] }
 similar = { version = "2.6.0", features = ["bytes", "inline", "unicode"] }
 slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug", "release_max_level_trace"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new"] }
-socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.74", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1.38.1", features = ["full", "test-util"] }
+tokio = { version = "1.39.3", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.11", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util"] }
@@ -211,7 +210,6 @@ sha2 = { version = "0.10.8", features = ["oid"] }
 similar = { version = "2.6.0", features = ["bytes", "inline", "unicode"] }
 slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug", "release_max_level_trace"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new"] }
-socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.7" }
 subtle = { version = "2.5.0" }
@@ -219,7 +217,7 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.74", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
 time-macros = { version = "0.2.18", default-features = false, features = ["formatting", "parsing"] }
-tokio = { version = "1.38.1", features = ["full", "test-util"] }
+tokio = { version = "1.39.3", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.11", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util"] }
@@ -239,7 +237,7 @@ zeroize = { version = "1.7.0", features = ["std", "zeroize_derive"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
 linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std", "system"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -248,35 +246,35 @@ signal-hook-mio = { version = "0.2.4", default-features = false, features = ["su
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
 linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std", "system"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.x86_64-apple-darwin.dependencies]
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.aarch64-apple-darwin.dependencies]
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -284,7 +282,7 @@ signal-hook-mio = { version = "0.2.4", default-features = false, features = ["su
 
 [target.x86_64-unknown-illumos.dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }
@@ -293,7 +291,7 @@ toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", featu
 
 [target.x86_64-unknown-illumos.build-dependencies]
 dof = { version = "0.3.0", default-features = false, features = ["des"] }
-mio = { version = "0.8.11", features = ["net", "os-ext"] }
+mio = { version = "1.0.2", features = ["net", "os-ext"] }
 nix = { version = "0.28.0", features = ["feature", "fs", "ioctl", "poll", "signal", "term", "uio"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["fs", "stdio", "system", "termios"] }


### PR DESCRIPTION
Tokio 1.39/mio 1.0 switches out the illumos impl to being eventfd based. For release 10 we decided that that was too risky, so we switched back to Tokio 1.38.

Now that the r10 branch has been cut, we can go back and update Tokio to 1.39.3. We'd like to land this early in the cycle to get as much soak time as possible.

See:

* #6356
* #6249
* https://github.com/oxidecomputer/helios/issues/169
* https://github.com/oxidecomputer/helios/pull/171
* #6391