### PR TITLE
Factor out generic `activate_background_task`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,6 +5405,7 @@ dependencies = [
  "hyper 0.14.30",
  "illumos-utils",
  "internal-dns",
+ "nexus-client",
  "nexus-config",
  "nexus-db-queries",
  "nexus-sled-agent-shared",

--- a/nexus/test-utils/Cargo.toml
+++ b/nexus/test-utils/Cargo.toml
@@ -25,6 +25,7 @@ http.workspace = true
 hyper.workspace = true
 illumos-utils.workspace = true
 internal-dns.workspace = true
+nexus-client.workspace = true
 nexus-config.workspace = true
 nexus-db-queries.workspace = true
 nexus-sled-agent-shared.workspace = true

--- a/nexus/test-utils/src/background.rs
+++ b/nexus/test-utils/src/background.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Helper functions related to Nexus background tasks
+
+use crate::http_testing::NexusRequest;
+use dropshot::test_util::ClientTestContext;
+use nexus_client::types::BackgroundTask;
+use nexus_client::types::CurrentStatus;
+use nexus_client::types::CurrentStatusRunning;
+use nexus_client::types::LastResult;
+use nexus_client::types::LastResultCompleted;
+use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
+use std::time::Duration;
+
+/// Return the most recent start time for a background task
+fn most_recent_start_time(
+    task: &BackgroundTask,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    match task.current {
+        CurrentStatus::Idle => match task.last {
+            LastResult::Completed(LastResultCompleted {
+                start_time, ..
+            }) => Some(start_time),
+            LastResult::NeverCompleted => None,
+        },
+        CurrentStatus::Running(CurrentStatusRunning { start_time, .. }) => {
+            Some(start_time)
+        }
+    }
+}
+
+/// Given the name of a background task, activate it, then wait for it to
+/// complete. Return the last polled `BackgroundTask` object.
+pub async fn activate_background_task(
+    internal_client: &ClientTestContext,
+    task_name: &str,
+) -> BackgroundTask {
+    let task = NexusRequest::object_get(
+        internal_client,
+        &format!("/bgtasks/view/{task_name}"),
+    )
+    .execute_and_parse_unwrap::<BackgroundTask>()
+    .await;
+
+    let last_start = most_recent_start_time(&task);
+
+    internal_client
+        .make_request(
+            http::Method::POST,
+            "/bgtasks/activate",
+            Some(serde_json::json!({
+                "bgtask_names": vec![String::from(task_name)]
+            })),
+            http::StatusCode::NO_CONTENT,
+        )
+        .await
+        .unwrap();
+
+    // Wait for the task to finish
+    let last_task_poll = wait_for_condition(
+        || async {
+            let task = NexusRequest::object_get(
+                internal_client,
+                &format!("/bgtasks/view/{task_name}"),
+            )
+            .execute_and_parse_unwrap::<BackgroundTask>()
+            .await;
+
+            if matches!(&task.current, CurrentStatus::Idle)
+                && most_recent_start_time(&task) > last_start
+            {
+                Ok(task)
+            } else {
+                Err(CondCheckError::<()>::NotYet)
+            }
+        },
+        &Duration::from_millis(500),
+        &Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+
+    last_task_poll
+}

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -84,6 +84,7 @@ use uuid::Uuid;
 pub use sim::TEST_HARDWARE_THREADS;
 pub use sim::TEST_RESERVOIR_RAM;
 
+pub mod background;
 pub mod db;
 pub mod http_testing;
 pub mod resource_helpers;


### PR DESCRIPTION
Factor out a function that, given the name of a background task, activates it and runs it to completion (in a test context).