### PR TITLE
build end-to-end tests and live tests by default

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -43,10 +43,6 @@ filter = 'package(oximeter-db) and test(replicated)'
 test-group = 'clickhouse-cluster'
 
 [[profile.default.overrides]]
-filter = 'package(omicron-live-tests)'
-test-group = 'live-tests'
-
-[[profile.default.overrides]]
 # These tests can time out under heavy contention.
 filter = 'binary_id(omicron-nexus::test_all) and test(::schema::)'
 threads-required = 4
@@ -56,3 +52,10 @@ filter = 'binary_id(omicron-nexus::test_all)'
 # As of 2023-01-08, the slowest test in test_all takes 196s on a Ryzen 7950X.
 # 900s is a good upper limit that adds a comfortable buffer.
 slow-timeout = { period = '60s', terminate-after = 15 }
+
+[profile.live-tests]
+default-set = 'package(omicron-live-tests)'
+
+[[profile.live-tests.overrides]]
+filter = 'package(omicron-live-tests)'
+test-group = 'live-tests'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.64", recommended = "0.9.70" }
+nextest-version = { required = "0.9.76", recommended = "0.9.76" }
 
 experimental = ["setup-scripts"]
 
@@ -34,6 +34,9 @@ clickhouse-cluster = { max-threads = 1 }
 # live-tests operate on a more realistic, shared control plane and test
 # behaviors that conflict with each other.  They need to be run serially.
 live-tests = { max-threads = 1 }
+
+#[profile.default]
+#default-set = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
 
 [[profile.default.overrides]]
 filter = 'package(oximeter-db) and test(replicated)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -35,8 +35,8 @@ clickhouse-cluster = { max-threads = 1 }
 # behaviors that conflict with each other.  They need to be run serially.
 live-tests = { max-threads = 1 }
 
-#[profile.default]
-#default-set = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
+[profile.default]
+default-set = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
 
 [[profile.default.overrides]]
 filter = 'package(oximeter-db) and test(replicated)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.76", recommended = "0.9.76" }
+nextest-version = { required = "0.9.77", recommended = "0.9.77" }
 
 experimental = ["setup-scripts"]
 
@@ -36,7 +36,7 @@ clickhouse-cluster = { max-threads = 1 }
 live-tests = { max-threads = 1 }
 
 [profile.default]
-default-set = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
+default-filter = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
 
 [[profile.default.overrides]]
 filter = 'package(oximeter-db) and test(replicated)'
@@ -54,7 +54,7 @@ filter = 'binary_id(omicron-nexus::test_all)'
 slow-timeout = { period = '60s', terminate-after = 15 }
 
 [profile.live-tests]
-default-set = 'package(omicron-live-tests)'
+default-filter = 'package(omicron-live-tests)'
 
 [[profile.live-tests.overrides]]
 filter = 'package(omicron-live-tests)'

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -9,7 +9,7 @@ target_os=$1
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.70'
+NEXTEST_VERSION='0.9.76'
 
 cargo --version
 rustc --version

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -9,7 +9,7 @@ target_os=$1
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.76'
+NEXTEST_VERSION='0.9.77'
 
 cargo --version
 rustc --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,7 @@ default-members = [
     # See omicron#4392.
     "dns-server",
     "dns-server-api",
-    # Do not include end-to-end-tests in the list of default members, as its
-    # tests only work on a deployed control plane.
+    "end-to-end-tests",
     "gateway",
     "gateway-api",
     "gateway-cli",
@@ -172,8 +171,7 @@ default-members = [
     "internal-dns",
     "ipcc",
     "key-manager",
-    # Do not include live-tests in the list of default members because its tests
-    # only work in a deployed system.  The macros can be here, though.
+    "live-tests",
     "live-tests/macros",
     "nexus",
     "nexus-config",

--- a/dev-tools/xtask/src/check_workspace_deps.rs
+++ b/dev-tools/xtask/src/check_workspace_deps.rs
@@ -125,10 +125,6 @@ pub fn run_cmd() -> Result<()> {
                 // Including xtask causes hakari to not work as well and build
                 // times to be longer (omicron#4392).
                 "xtask",
-                // The tests here should not be run by default, as they require
-                // a running control plane.
-                "end-to-end-tests",
-                "omicron-live-tests",
             ]
             .contains(&package.name.as_str())
             .then_some(&package.id)

--- a/dev-tools/xtask/src/live_tests.rs
+++ b/dev-tools/xtask/src/live_tests.rs
@@ -134,8 +134,11 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     // TMPDIR=/var/tmp puts stuff on disk, cached as needed, rather than the
     // default /tmp which requires that stuff be in-memory.  That can lead to
     // great sadness if the tests wind up writing a lot of data.
+    //
+    // --bound=all is required to cause nextest to *not* ignore these tests,
+    // since they're not in the default filter set.
     let raw = &[
-        "TMPDIR=/var/tmp ./cargo-nextest nextest run \\",
+        "TMPDIR=/var/tmp ./cargo-nextest nextest run --bound=all \\",
         &format!(
             "--archive-file {}/{} \\",
             NAME,

--- a/dev-tools/xtask/src/live_tests.rs
+++ b/dev-tools/xtask/src/live_tests.rs
@@ -135,10 +135,10 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     // default /tmp which requires that stuff be in-memory.  That can lead to
     // great sadness if the tests wind up writing a lot of data.
     //
-    // --bound=all is required to cause nextest to *not* ignore these tests,
-    // since they're not in the default filter set.
+    // nextest configuration for these tests is specified in the "live-tests"
+    // profile.
     let raw = &[
-        "TMPDIR=/var/tmp ./cargo-nextest nextest run --bound=all \\",
+        "TMPDIR=/var/tmp ./cargo-nextest nextest run --profile=live-tests \\",
         &format!(
             "--archive-file {}/{} \\",
             NAME,

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -57,7 +57,7 @@ To use this:
 
 4. On that system, run tests with:
 
-     TMPDIR=/var/tmp ./cargo-nextest nextest run \
+     TMPDIR=/var/tmp ./cargo-nextest nextest run --bound=all \
          --archive-file live-tests-archive/omicron-live-tests.tar.zst \
          --workspace-remap live-tests-archive
 ```

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -57,7 +57,7 @@ To use this:
 
 4. On that system, run tests with:
 
-     TMPDIR=/var/tmp ./cargo-nextest nextest run --bound=all \
+     TMPDIR=/var/tmp ./cargo-nextest nextest run --profile=live-tests \
          --archive-file live-tests-archive/omicron-live-tests.tar.zst \
          --workspace-remap live-tests-archive
 ```


### PR DESCRIPTION
Thanks to recent nextest work by @sunshowers, we can add end-to-end-tests and live-tests to the workspace default members (so that they get built with `cargo check`, for example) without running their tests by default.  These had previously been excluded from the default members because their tests don't work in dev environments.