### PR TITLE
[sled-agent] Replace `du(1)` with a Rust function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6525,6 +6525,7 @@ dependencies = [
  "toml 0.8.19",
  "usdt",
  "uuid",
+ "walkdir",
  "zeroize",
  "zone 0.3.0",
 ]

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -93,6 +93,7 @@ zone.workspace = true
 static_assertions.workspace = true
 omicron-workspace-hack.workspace = true
 slog-error-chain.workspace = true
+walkdir.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 opte-ioctl.workspace = true

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -1575,8 +1575,8 @@ async fn disk_usage(path: &Utf8PathBuf) -> Result<u64, BundleError> {
             };
             for entry in std::fs::read_dir(&dir).map_err(mk_dir_error)? {
                 let entry = entry.map_err(mk_dir_error)?;
-                let mk_error = |err| BundleError::ReadDirectory {
-                    directory: Utf8PathBuf::try_from(entry.path())
+                let mk_error = |err| BundleError::Metadata {
+                    path: Utf8PathBuf::try_from(entry.path())
                         .unwrap_or_else(|_| path.clone()),
                     err,
                 };
@@ -1745,7 +1745,7 @@ mod tests {
             dbg!(disk_usage_du(&path).await).expect("running du failed!");
         eprintln!("du -s {path} took {:?}", t0.elapsed());
 
-        // Round down the Rust disk usage result to `du`'s block size on this
+        // Round up the Rust disk usage result to `du`'s block size on this
         // system.
         let usage = if BLOCK_SIZE > 1 {
             eprintln!("rounding up to `du(1)`'s block size of {BLOCK_SIZE}B");

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -1564,9 +1564,7 @@ async fn dir_size(path: &Utf8PathBuf) -> Result<u64, BundleError> {
         let mut sum = 0;
         for entry in walkdir::WalkDir::new(&path).into_iter() {
             let entry = entry?;
-            if !entry.file_type().is_dir() {
-                sum += entry.metadata()?.len()
-            }
+            sum += entry.metadata()?.len()
         }
 
         Ok(sum)

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -1679,8 +1679,8 @@ mod tests {
             }
         }
 
+        const DU: &str = "du";
         async fn dir_size_du(path: &Utf8PathBuf) -> Result<u64, BundleError> {
-            const DU: &str = "du";
             let args = &[DU_ARG, "-s", path.as_str()];
             let output =
                 Command::new(DU).args(args).output().await.map_err(|err| {
@@ -1712,6 +1712,13 @@ mod tests {
                 .map(|x: u64| x.saturating_mul(BLOCK_SIZE))
                 .map_err(|_| err("failed to parse du output"))
         }
+
+        let du_output =
+            Command::new(DU).arg("--version").output().await.unwrap();
+        eprintln!(
+            "du --version:\n{}\n",
+            String::from_utf8_lossy(&du_output.stdout)
+        );
 
         let path =
             Utf8PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));


### PR DESCRIPTION
Currently, the `zone_bundle::disk_usage` function in sled-agent shells
out to `du(1)` and parses its output. This works fine, but it's a bit
flaky, especially when running the corresponding tests on "weird"
platforms such as NixOS, where the `du(1)` binary doesn't live in
`/usr/bin/du` (see #6479).

This commit replaces the code that shells out to `/usr/bin/du` with a
pure-Rust rewrite. There's a unit test that asserts that the disk usage
calculated by the new implementation matches the value calculated by
`du(1)`, with code for handling the potential inaccuracy due to `du(1)`
operating in terms of 512B blocks on macOS.

Closes #6479