### PR TITLE
remove `patch.crates-io.zone`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12521,7 +12521,8 @@ dependencies = [
 [[package]]
 name = "zone"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/zone?branch=state-derive-eq-hash#f1920d5636c69ea8179f8ec659702dcdef43268c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62a428a79ea2224ce8ab05d6d8a21bdd7b4b68a8dbc1230511677a56e72ef22"
 dependencies = [
  "itertools 0.10.5",
  "thiserror",
@@ -12566,7 +12567,8 @@ dependencies = [
 [[package]]
 name = "zone_cfg_derive"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/zone?branch=state-derive-eq-hash#f1920d5636c69ea8179f8ec659702dcdef43268c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c4f01d3785e222d5aca11c9813e9c46b69abfe258756c99c9b628683626cc8"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -839,7 +839,3 @@ path = "workspace-hack"
 [patch."https://github.com/oxidecomputer/omicron"]
 omicron-uuid-kinds = { path = "uuid-kinds" }
 omicron-common = { path = "common" }
-
-[patch.crates-io.zone]
-git = 'https://github.com/oxidecomputer/zone'
-branch = 'state-derive-eq-hash'


### PR DESCRIPTION
While looking at doing lockfile maintenance for R11 I noticed that we patch the `zone` package to be a branch that adds Eq and Hash to `zone::State`. This branch was never merged into the main branch of oxidecomputer/zone, and also appears to be unnecessary for Omicron to build at present. This switches us back to the released version on crates.io.