### PR TITLE
Group system IP pools endpoints under their own tag

### DIFF
--- a/end-to-end-tests/src/bin/bootstrap.rs
+++ b/end-to-end-tests/src/bin/bootstrap.rs
@@ -8,8 +8,8 @@ use oxide_client::types::{
     NameOrId, SiloQuotasUpdate,
 };
 use oxide_client::{
-    ClientDisksExt, ClientHiddenExt, ClientProjectsExt,
-    ClientSystemNetworkingExt, ClientSystemSilosExt,
+    ClientDisksExt, ClientHiddenExt, ClientProjectsExt, ClientSystemIpPoolsExt,
+    ClientSystemSilosExt,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use std::time::Duration;

--- a/end-to-end-tests/src/bin/commtest.rs
+++ b/end-to-end-tests/src/bin/commtest.rs
@@ -9,7 +9,7 @@ use oxide_client::{
         UsernamePasswordCredentials,
     },
     ClientHiddenExt, ClientLoginExt, ClientProjectsExt,
-    ClientSystemHardwareExt, ClientSystemNetworkingExt, ClientSystemStatusExt,
+    ClientSystemHardwareExt, ClientSystemIpPoolsExt, ClientSystemStatusExt,
     ClientVpcsExt,
 };
 use std::{

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -146,11 +146,7 @@ sled_view                                GET      /v1/system/hardware/sleds/{sle
 switch_list                              GET      /v1/system/hardware/switches
 switch_view                              GET      /v1/system/hardware/switches/{switch_id}
 
-API operations found with tag "system/metrics"
-OPERATION ID                             METHOD   URL PATH
-system_metric                            GET      /v1/system/metrics/{metric_name}
-
-API operations found with tag "system/networking"
+API operations found with tag "system/ip-pools"
 OPERATION ID                             METHOD   URL PATH
 ip_pool_create                           POST     /v1/system/ip-pools
 ip_pool_delete                           DELETE   /v1/system/ip-pools/{pool}
@@ -169,6 +165,13 @@ ip_pool_silo_update                      PUT      /v1/system/ip-pools/{pool}/sil
 ip_pool_update                           PUT      /v1/system/ip-pools/{pool}
 ip_pool_utilization_view                 GET      /v1/system/ip-pools/{pool}/utilization
 ip_pool_view                             GET      /v1/system/ip-pools/{pool}
+
+API operations found with tag "system/metrics"
+OPERATION ID                             METHOD   URL PATH
+system_metric                            GET      /v1/system/metrics/{metric_name}
+
+API operations found with tag "system/networking"
+OPERATION ID                             METHOD   URL PATH
 networking_address_lot_block_list        GET      /v1/system/networking/address-lot/{address_lot}/blocks
 networking_address_lot_create            POST     /v1/system/networking/address-lot
 networking_address_lot_delete            DELETE   /v1/system/networking/address-lot/{address_lot}

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -175,6 +175,12 @@ pub const API_VERSION: &str = "20240821.0";
                     url = "http://docs.oxide.computer/api/system-metrics"
                 }
             },
+            "system/ip-pools" = {
+                description = "IP pools are collections of external IPs that can be assigned to silos. When a pool is linked to a silo, users in that silo can allocate IPs from the pool for their instances.",
+                external_docs = {
+                    url = "http://docs.oxide.computer/api/system-ip-pools"
+                }
+            },
             "system/networking" = {
                 description = "This provides rack-level network configuration.",
                 external_docs = {
@@ -630,7 +636,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_list(
         rqctx: RequestContext<Self::Context>,
@@ -641,7 +647,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_create(
         rqctx: RequestContext<Self::Context>,
@@ -652,7 +658,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools/{pool}",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_view(
         rqctx: RequestContext<Self::Context>,
@@ -663,7 +669,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = DELETE,
         path = "/v1/system/ip-pools/{pool}",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_delete(
         rqctx: RequestContext<Self::Context>,
@@ -674,7 +680,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = PUT,
         path = "/v1/system/ip-pools/{pool}",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_update(
         rqctx: RequestContext<Self::Context>,
@@ -686,7 +692,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools/{pool}/utilization",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_utilization_view(
         rqctx: RequestContext<Self::Context>,
@@ -697,7 +703,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools/{pool}/silos",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_silo_list(
         rqctx: RequestContext<Self::Context>,
@@ -723,7 +729,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools/{pool}/silos",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_silo_link(
         rqctx: RequestContext<Self::Context>,
@@ -737,7 +743,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = DELETE,
         path = "/v1/system/ip-pools/{pool}/silos/{silo}",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_silo_unlink(
         rqctx: RequestContext<Self::Context>,
@@ -754,7 +760,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = PUT,
         path = "/v1/system/ip-pools/{pool}/silos/{silo}",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_silo_update(
         rqctx: RequestContext<Self::Context>,
@@ -766,7 +772,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools-service",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_service_view(
         rqctx: RequestContext<Self::Context>,
@@ -778,7 +784,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools/{pool}/ranges",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_range_list(
         rqctx: RequestContext<Self::Context>,
@@ -792,7 +798,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools/{pool}/ranges/add",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_range_add(
         rqctx: RequestContext<Self::Context>,
@@ -804,7 +810,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools/{pool}/ranges/remove",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_range_remove(
         rqctx: RequestContext<Self::Context>,
@@ -818,7 +824,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/system/ip-pools-service/ranges",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_service_range_list(
         rqctx: RequestContext<Self::Context>,
@@ -831,7 +837,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools-service/ranges/add",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_service_range_add(
         rqctx: RequestContext<Self::Context>,
@@ -842,7 +848,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/system/ip-pools-service/ranges/remove",
-        tags = ["system/networking"],
+        tags = ["system/ip-pools"],
     }]
     async fn ip_pool_service_range_remove(
         rqctx: RequestContext<Self::Context>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5210,7 +5210,7 @@
     "/v1/system/ip-pools": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "List IP pools",
         "operationId": "ip_pool_list",
@@ -5267,7 +5267,7 @@
       },
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Create IP pool",
         "operationId": "ip_pool_create",
@@ -5304,7 +5304,7 @@
     "/v1/system/ip-pools/{pool}": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Fetch IP pool",
         "operationId": "ip_pool_view",
@@ -5340,7 +5340,7 @@
       },
       "put": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Update IP pool",
         "operationId": "ip_pool_update",
@@ -5386,7 +5386,7 @@
       },
       "delete": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Delete IP pool",
         "operationId": "ip_pool_delete",
@@ -5417,7 +5417,7 @@
     "/v1/system/ip-pools/{pool}/ranges": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "List ranges for IP pool",
         "description": "Ranges are ordered by their first address.",
@@ -5479,7 +5479,7 @@
     "/v1/system/ip-pools/{pool}/ranges/add": {
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Add range to IP pool",
         "description": "IPv6 ranges are not allowed yet.",
@@ -5528,7 +5528,7 @@
     "/v1/system/ip-pools/{pool}/ranges/remove": {
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Remove range from IP pool",
         "operationId": "ip_pool_range_remove",
@@ -5569,7 +5569,7 @@
     "/v1/system/ip-pools/{pool}/silos": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "List IP pool's linked silos",
         "operationId": "ip_pool_silo_list",
@@ -5635,7 +5635,7 @@
       },
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Link IP pool to silo",
         "description": "Users in linked silos can allocate external IPs from this pool for their instances. A silo can have at most one default pool. IPs are allocated from the default pool when users ask for one without specifying a pool.",
@@ -5684,7 +5684,7 @@
     "/v1/system/ip-pools/{pool}/silos/{silo}": {
       "put": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Make IP pool default for silo",
         "description": "When a user asks for an IP (e.g., at instance create time) without specifying a pool, the IP comes from the default pool if a default is configured. When a pool is made the default for a silo, any existing default will remain linked to the silo, but will no longer be the default.",
@@ -5738,7 +5738,7 @@
       },
       "delete": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Unlink IP pool from silo",
         "description": "Will fail if there are any outstanding IPs allocated in the silo.",
@@ -5777,7 +5777,7 @@
     "/v1/system/ip-pools/{pool}/utilization": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Fetch IP pool utilization",
         "operationId": "ip_pool_utilization_view",
@@ -5815,7 +5815,7 @@
     "/v1/system/ip-pools-service": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Fetch Oxide service IP pool",
         "operationId": "ip_pool_service_view",
@@ -5842,7 +5842,7 @@
     "/v1/system/ip-pools-service/ranges": {
       "get": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "List IP ranges for the Oxide service pool",
         "description": "Ranges are ordered by their first address.",
@@ -5895,7 +5895,7 @@
     "/v1/system/ip-pools-service/ranges/add": {
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Add IP range to Oxide service pool",
         "description": "IPv6 ranges are not allowed yet.",
@@ -5933,7 +5933,7 @@
     "/v1/system/ip-pools-service/ranges/remove": {
       "post": {
         "tags": [
-          "system/networking"
+          "system/ip-pools"
         ],
         "summary": "Remove IP range from Oxide service pool",
         "operationId": "ip_pool_service_range_remove",
@@ -21462,6 +21462,13 @@
       "description": "These operations pertain to hardware inventory and management. Racks are the unit of expansion of an Oxide deployment. Racks are in turn composed of sleds, switches, power supplies, and a cabled backplane.",
       "externalDocs": {
         "url": "http://docs.oxide.computer/api/system-hardware"
+      }
+    },
+    {
+      "name": "system/ip-pools",
+      "description": "IP pools are collections of external IPs that can be assigned to silos. When a pool is linked to a silo, users in that silo can allocate IPs from the pool for their instances.",
+      "externalDocs": {
+        "url": "http://docs.oxide.computer/api/system-ip-pools"
       }
     },
     {


### PR DESCRIPTION
This is entirely out of hand 😄 (and getting worse). Note that this requires a small docs site change to make the tag name nice:

```diff
diff --git a/app/routes/api.tsx b/app/routes/api.tsx
index eef6505..bc0d3e8 100644
--- a/app/routes/api.tsx
+++ b/app/routes/api.tsx
@@ -136,7 +136,11 @@ const MethodLink = ({ method }: { method: MethodLite }) => (
   </SidebarLinks.Item>
 )
 
-const tagMap: Record<string, string> = { vpcs: 'VPCs', 'floating-ips': 'Floating IPs' }
+const tagMap: Record<string, string> = {
+  vpcs: 'VPCs',
+  'floating-ips': 'Floating IPs',
+  'system/ip-pools': 'IP Pools',
+}
 
 function mapTitle(label: string) {
   return tagMap[label] || titleCase(label.replace('system/', ''))
```

| Before | After |
| --- | --- |
| <img width="282" alt="image" src="https://github.com/user-attachments/assets/f38eeb33-61ce-4119-bd1e-e8ad1ee2fd60"> | <img width="268" alt="image" src="https://github.com/user-attachments/assets/e1e801b5-dae8-4b27-9449-fdf189a786b0"> |
