### PR TITLE
Remove unused `name_or_id` query param on bgp announce set list

### DIFF
--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -444,7 +444,7 @@ impl DataStore {
             .transaction(&conn, |conn| {
                 let err = err.clone();
                 async move {
-                    let name_or_id = sel.name_or_id.clone();
+                    let name_or_id = sel.announce_set.clone();
 
                     let announce_id: Uuid = match name_or_id {
                         NameOrId::Id(id) => announce_set_dsl::bgp_announce_set
@@ -700,7 +700,7 @@ impl DataStore {
         use db::schema::bgp_config::dsl as bgp_config_dsl;
 
         let conn = self.pool_connection_authorized(opctx).await?;
-        let name_or_id = sel.name_or_id.clone();
+        let name_or_id = sel.announce_set.clone();
 
         let err = OptionalError::new();
         self.transaction_retry_wrapper("bgp_delete_announce_set")

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -181,10 +181,10 @@ networking_allow_list_view               GET      /v1/system/networking/allow-li
 networking_bfd_disable                   POST     /v1/system/networking/bfd-disable
 networking_bfd_enable                    POST     /v1/system/networking/bfd-enable
 networking_bfd_status                    GET      /v1/system/networking/bfd-status
-networking_bgp_announce_set_delete       DELETE   /v1/system/networking/bgp-announce-set/{name_or_id}
+networking_bgp_announce_set_delete       DELETE   /v1/system/networking/bgp-announce-set/{announce_set}
 networking_bgp_announce_set_list         GET      /v1/system/networking/bgp-announce-set
 networking_bgp_announce_set_update       PUT      /v1/system/networking/bgp-announce-set
-networking_bgp_announcement_list         GET      /v1/system/networking/bgp-announce-set/{name_or_id}/announcement
+networking_bgp_announcement_list         GET      /v1/system/networking/bgp-announce-set/{announce_set}/announcement
 networking_bgp_config_create             POST     /v1/system/networking/bgp
 networking_bgp_config_delete             DELETE   /v1/system/networking/bgp
 networking_bgp_config_list               GET      /v1/system/networking/bgp

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -1565,9 +1565,7 @@ pub trait NexusExternalApi {
     }]
     async fn networking_bgp_announce_set_list(
         rqctx: RequestContext<Self::Context>,
-        query_params: Query<
-            PaginatedByNameOrId<params::OptionalBgpAnnounceSetSelector>,
-        >,
+        query_params: Query<PaginatedByNameOrId>,
     ) -> Result<HttpResponseOk<Vec<BgpAnnounceSet>>, HttpError>;
 
     /// Delete BGP announce set

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -1571,7 +1571,7 @@ pub trait NexusExternalApi {
     /// Delete BGP announce set
     #[endpoint {
         method = DELETE,
-        path = "/v1/system/networking/bgp-announce-set/{name_or_id}",
+        path = "/v1/system/networking/bgp-announce-set/{announce_set}",
         tags = ["system/networking"],
     }]
     async fn networking_bgp_announce_set_delete(
@@ -1584,7 +1584,7 @@ pub trait NexusExternalApi {
     /// Get originated routes for a specified BGP announce set
     #[endpoint {
         method = GET,
-        path = "/v1/system/networking/bgp-announce-set/{name_or_id}/announcement",
+        path = "/v1/system/networking/bgp-announce-set/{announce_set}/announcement",
         tags = ["system/networking"],
     }]
     async fn networking_bgp_announcement_list(

--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -568,7 +568,7 @@ impl BackgroundTask for SwitchPortSettingsManager {
                                 .bgp_announcement_list(
                                     opctx,
                                     &params::BgpAnnounceSetSelector {
-                                        name_or_id: bgp_config
+                                        announce_set: bgp_config
                                             .bgp_announce_set_id
                                             .into(),
                                     },

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -3139,9 +3139,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
 
     async fn networking_bgp_announce_set_list(
         rqctx: RequestContext<ApiContext>,
-        query_params: Query<
-            PaginatedByNameOrId<params::OptionalBgpAnnounceSetSelector>,
-        >,
+        query_params: Query<PaginatedByNameOrId>,
     ) -> Result<HttpResponseOk<Vec<BgpAnnounceSet>>, HttpError> {
         let apictx = rqctx.context();
         let handler = async {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1675,13 +1675,6 @@ pub struct BgpAnnounceSetCreate {
     pub announcement: Vec<BgpAnnouncementCreate>,
 }
 
-/// Optionally select a BGP announce set by a name or id.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct OptionalBgpAnnounceSetSelector {
-    /// A name or id to use when s electing BGP port settings
-    pub name_or_id: Option<NameOrId>,
-}
-
 /// Select a BGP announce set by a name or id.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct BgpAnnounceSetSelector {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1678,15 +1678,15 @@ pub struct BgpAnnounceSetCreate {
 /// Select a BGP announce set by a name or id.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct BgpAnnounceSetSelector {
-    /// A name or id to use when selecting BGP port settings
-    pub name_or_id: NameOrId,
+    /// Name or ID of the announce set
+    pub announce_set: NameOrId,
 }
 
 /// List BGP announce set with an optional name or id.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
 pub struct BgpAnnounceListSelector {
-    /// A name or id to use when selecting BGP config.
-    pub name_or_id: Option<NameOrId>,
+    /// Name or ID of the announce set
+    pub announce_set: Option<NameOrId>,
 }
 
 /// Selector used for querying imported BGP routes.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6556,14 +6556,6 @@
           },
           {
             "in": "query",
-            "name": "name_or_id",
-            "description": "A name or id to use when s electing BGP port settings",
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          },
-          {
-            "in": "query",
             "name": "page_token",
             "description": "Token returned by previous call to retrieve the subsequent page",
             "schema": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6634,7 +6634,7 @@
         }
       }
     },
-    "/v1/system/networking/bgp-announce-set/{name_or_id}": {
+    "/v1/system/networking/bgp-announce-set/{announce_set}": {
       "delete": {
         "tags": [
           "system/networking"
@@ -6644,8 +6644,8 @@
         "parameters": [
           {
             "in": "path",
-            "name": "name_or_id",
-            "description": "A name or id to use when selecting BGP port settings",
+            "name": "announce_set",
+            "description": "Name or ID of the announce set",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
@@ -6665,7 +6665,7 @@
         }
       }
     },
-    "/v1/system/networking/bgp-announce-set/{name_or_id}/announcement": {
+    "/v1/system/networking/bgp-announce-set/{announce_set}/announcement": {
       "get": {
         "tags": [
           "system/networking"
@@ -6675,8 +6675,8 @@
         "parameters": [
           {
             "in": "path",
-            "name": "name_or_id",
-            "description": "A name or id to use when selecting BGP port settings",
+            "name": "announce_set",
+            "description": "Name or ID of the announce set",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"


### PR DESCRIPTION
Closes #6467 

Happy to throw this out @internet-diglett if it conflicts with anything you're doing, but it's small enough that I think you might be able to just merge it into yours.