### PR TITLE
don't run GHA workflows on tag pushes

### DIFF
--- a/.github/workflows/hakari.yml
+++ b/.github/workflows/hakari.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+      - 'rel/**'
+  pull_request: {}
 
 name: cargo hakari
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,12 @@
 #
 name: Rust
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+      - 'rel/**'
+  pull_request: {}
 
 jobs:
   check-style:


### PR DESCRIPTION
Per the branching experiment review we are about to begin in the control plane huddle.

1. For the rust.yml workflow, only run the `push` mode when pushing to `main` or any branch matching the glob `rel/**`.
2. For the hakari.yml workflow, apply the same rules. This has the effect of enabling them for the release branches, and also enabling them for pull requests that do not target the `main` branch.

~~This is a draft because we cannot merge it until `Rust / clippy-lint (push)` and `Rust / check-style (push)` are removed from the required checks. (The `pull_request` versions should remain required.)~~ **EDIT**: Maybe this isn't a thing? GitHub confuses me.