### PR TITLE
include backtrace from omdb panic from within omdb tests

### DIFF
--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -502,11 +502,11 @@ async fn do_run_extra<F>(
         tokio::task::spawn_blocking(move || {
             let exec = modexec(
                 Exec::cmd(cmd_path)
-                    // Set RUST_BACKTRACE for consistency between CI and
-                    // developers' local runs.  We set it to 0 only to match
-                    // what someone would see who wasn't debugging it, but we
-                    // could as well use 1 or "full" to store that instead.
-                    .env("RUST_BACKTRACE", "0")
+                    // Set RUST_BACKTRACE explicitly for consistency between CI
+                    // and developers' local runs.  We set it to 1 so that in
+                    // the event of a panic, particularly in CI, we have more
+                    // information about what went wrong.
+                    .env("RUST_BACKTRACE", "1")
                     .args(&owned_args),
             );
             run_command(exec)

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -505,8 +505,12 @@ async fn do_run_extra<F>(
                     // Set RUST_BACKTRACE explicitly for consistency between CI
                     // and developers' local runs.  We set it to 1 so that in
                     // the event of a panic, particularly in CI, we have more
-                    // information about what went wrong.
+                    // information about what went wrong.  But we set
+                    // RUST_LIB_BACKTRACE=1 so that we don't get a dump to
+                    // stderr for all the Errors that get created and handled
+                    // gracefully.
                     .env("RUST_BACKTRACE", "1")
+                    .env("RUST_LIB_BACKTRACE", "0")
                     .args(&owned_args),
             );
             run_command(exec)


### PR DESCRIPTION
This is basically to help debug issues like #6505.