### PR TITLE
[nexus] Mark VMMs on `Expunged` sleds as `Failed`

### DIFF
--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -516,7 +516,11 @@ impl BackgroundTask for InstanceWatcher {
                         CheckOutcome::Failure(reason) => {
                             *check_failures.entry(reason.as_str().into_owned()).or_default() += 1;
                         }
-                        CheckOutcome::Unknown => {}
+                        CheckOutcome::Unknown => {
+                            if let Err(reason) = check.result {
+                                *check_errors.entry(reason.as_str().into_owned()).or_default() += 1;
+                            }
+                        }
                     }
                     if check.update_saga_queued {
                         update_sagas_queued += 1;

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -15,6 +15,7 @@ use nexus_db_model::Vmm;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::pagination::Paginator;
 use nexus_db_queries::db::DataStore;
+use nexus_types::external_api::views::SledPolicy;
 use nexus_types::identity::Asset;
 use nexus_types::identity::Resource;
 use omicron_common::api::external::Error;
@@ -87,6 +88,7 @@ impl InstanceWatcher {
         client: SledAgentClient,
         target: VirtualMachine,
         vmm: Vmm,
+        sled: Sled,
     ) -> impl Future<Output = Check> + Send + 'static {
         let datastore = self.datastore.clone();
         let sagas = self.sagas.clone();
@@ -99,6 +101,7 @@ impl InstanceWatcher {
                 target.instance_id.to_string(),
             );
             meta.insert("vmm_id".to_string(), vmm_id.to_string());
+            meta.insert("sled_id".to_string(), sled.id().to_string());
             opctx.child(meta)
         };
 
@@ -107,92 +110,123 @@ impl InstanceWatcher {
                 opctx.log, "checking on VMM"; "propolis_id" => %vmm_id
             );
 
-            let rsp = client
-                .vmm_get_state(&vmm_id)
-                .await
-                .map_err(SledAgentInstanceError);
-
             let mut check = Check {
                 target,
                 outcome: Default::default(),
                 result: Ok(()),
                 update_saga_queued: false,
             };
-            let state: SledVmmState = match rsp {
-                Ok(rsp) => rsp.into_inner().into(),
-                // Oh, this error indicates that the VMM should transition to
-                // `Failed`. Let's synthesize a `SledInstanceState` that does
-                // that.
-                Err(e) if e.vmm_gone() => {
-                    slog::info!(
-                        opctx.log,
-                        "sled-agent error indicates that this instance's \
-                         VMM has failed!";
-                        "error" => %e,
-                    );
-                    check.outcome =
-                        CheckOutcome::Failure(Failure::NoSuchInstance);
-                    // TODO(eliza): it would be nicer if this used the same
-                    // code path as `mark_instance_failed`...
-                    SledVmmState {
-                        vmm_state: nexus::VmmRuntimeState {
-                            r#gen: vmm.runtime.r#gen.0.next(),
-                            state: nexus::VmmState::Failed,
-                            time_updated: chrono::Utc::now(),
-                        },
-                        // It's fine to synthesize `None`s here because a `None`
-                        // just means "don't update the migration state", not
-                        // "there is no migration".
-                        migration_in: None,
-                        migration_out: None,
-                    }
-                }
-                Err(SledAgentInstanceError(ClientError::ErrorResponse(
-                    rsp,
-                ))) => {
-                    let status = rsp.status();
-                    if status.is_client_error() {
-                        slog::warn!(opctx.log, "check incomplete due to client error";
-                            "status" => ?status, "error" => ?rsp.into_inner());
-                    } else {
-                        slog::info!(opctx.log, "check incomplete due to server error";
-                        "status" => ?status, "error" => ?rsp.into_inner());
-                    }
 
-                    check.result =
-                        Err(Incomplete::SledAgentHttpError(status.as_u16()));
-                    return check;
+            let state = if sled.policy() == SledPolicy::Expunged {
+                // If the sled has been expunged, any VMMs still on that sled
+                // should be marked as `Failed`.
+                slog::info!(
+                    opctx.log,
+                    "instance is assigned to a VMM on an Expunged sled; \
+                     marking it as Failed";
+                );
+                check.outcome = CheckOutcome::Failure(Failure::SledExpunged);
+                // TODO(eliza): it would be nicer if this used the same
+                // code path as `mark_instance_failed`...
+                SledVmmState {
+                    vmm_state: nexus::VmmRuntimeState {
+                        r#gen: vmm.runtime.r#gen.0.next(),
+                        state: nexus::VmmState::Failed,
+                        time_updated: chrono::Utc::now(),
+                    },
+                    // It's fine to synthesize `None`s here because a `None`
+                    // just means "don't update the migration state", not
+                    // "there is no migration".
+                    migration_in: None,
+                    migration_out: None,
                 }
-                Err(SledAgentInstanceError(
-                    ClientError::CommunicationError(e),
-                )) => {
-                    // TODO(eliza): eventually, we may want to transition the
-                    // instance to the `Failed` state if the sled-agent has been
-                    // unreachable for a while. We may also want to take other
-                    // corrective actions or alert an operator in this case.
-                    //
-                    // TODO(eliza): because we have the preported IP address
-                    // of the instance's VMM from our databse query, we could
-                    // also ask the VMM directly when the sled-agent is
-                    // unreachable. We should start doing that here at some
-                    // point.
-                    slog::info!(opctx.log, "sled agent is unreachable"; "error" => ?e);
-                    check.result = Err(Incomplete::SledAgentUnreachable);
-                    return check;
-                }
-                Err(SledAgentInstanceError(e)) => {
-                    slog::warn!(
-                        opctx.log,
-                        "error checking up on instance";
-                        "error" => ?e,
-                        "status" => ?e.status(),
-                    );
-                    check.result = Err(Incomplete::ClientError);
-                    return check;
+            } else {
+                // Otherwise, ask the sled-agent what it has to say for itself.
+                let rsp = client
+                    .vmm_get_state(&vmm_id)
+                    .await
+                    .map_err(SledAgentInstanceError);
+                match rsp {
+                    Ok(rsp) => {
+                        let state: SledVmmState = rsp.into_inner().into();
+                        check.outcome =
+                            CheckOutcome::Success(state.vmm_state.state.into());
+                        state
+                    }
+                    // Oh, this error indicates that the VMM should transition to
+                    // `Failed`. Let's synthesize a `SledInstanceState` that does
+                    // that.
+                    Err(e) if e.vmm_gone() => {
+                        slog::info!(
+                            opctx.log,
+                            "sled-agent error indicates that this instance's \
+                             VMM has failed!";
+                            "error" => %e,
+                        );
+                        check.outcome =
+                            CheckOutcome::Failure(Failure::NoSuchInstance);
+                        // TODO(eliza): it would be nicer if this used the same
+                        // code path as `mark_instance_failed`...
+                        SledVmmState {
+                            vmm_state: nexus::VmmRuntimeState {
+                                r#gen: vmm.runtime.r#gen.0.next(),
+                                state: nexus::VmmState::Failed,
+                                time_updated: chrono::Utc::now(),
+                            },
+                            // It's fine to synthesize `None`s here because a `None`
+                            // just means "don't update the migration state", not
+                            // "there is no migration".
+                            migration_in: None,
+                            migration_out: None,
+                        }
+                    }
+                    Err(SledAgentInstanceError(
+                        ClientError::ErrorResponse(rsp),
+                    )) => {
+                        let status = rsp.status();
+                        if status.is_client_error() {
+                            slog::warn!(opctx.log, "check incomplete due to client error";
+                            "status" => ?status, "error" => ?rsp.into_inner());
+                        } else {
+                            slog::info!(opctx.log, "check incomplete due to server error";
+                        "status" => ?status, "error" => ?rsp.into_inner());
+                        }
+
+                        check.result = Err(Incomplete::SledAgentHttpError(
+                            status.as_u16(),
+                        ));
+                        return check;
+                    }
+                    Err(SledAgentInstanceError(
+                        ClientError::CommunicationError(e),
+                    )) => {
+                        // TODO(eliza): eventually, we may want to transition the
+                        // instance to the `Failed` state if the sled-agent has been
+                        // unreachable for a while. We may also want to take other
+                        // corrective actions or alert an operator in this case.
+                        //
+                        // TODO(eliza): because we have the preported IP address
+                        // of the instance's VMM from our databse query, we could
+                        // also ask the VMM directly when the sled-agent is
+                        // unreachable. We should start doing that here at some
+                        // point.
+                        slog::info!(opctx.log, "sled agent is unreachable"; "error" => ?e);
+                        check.result = Err(Incomplete::SledAgentUnreachable);
+                        return check;
+                    }
+                    Err(SledAgentInstanceError(e)) => {
+                        slog::warn!(
+                            opctx.log,
+                            "error checking up on instance";
+                            "error" => ?e,
+                            "status" => ?e.status(),
+                        );
+                        check.result = Err(Incomplete::ClientError);
+                        return check;
+                    }
                 }
             };
 
-            check.outcome = CheckOutcome::Success(state.vmm_state.state.into());
             debug!(
                 opctx.log,
                 "updating instance state";
@@ -328,12 +362,16 @@ enum Failure {
     /// we believe it *should* know about. This probably means the sled-agent,
     /// and potentially the whole sled, has been restarted.
     NoSuchInstance,
+    /// The instance was assigned to a sled that was expunged. Its VMM has been
+    /// marked as `Failed`, since the sled is no longer present.
+    SledExpunged,
 }
 
 impl Failure {
     fn as_str(&self) -> Cow<'static, str> {
         match self {
             Self::NoSuchInstance => "no_such_instance".into(),
+            Self::SledExpunged => "sled_expunged".into(),
         }
     }
 }
@@ -455,9 +493,8 @@ impl BackgroundTask for InstanceWatcher {
                         },
                     };
 
-
                     let target = VirtualMachine::new(self.id, &sled, &instance, &vmm, &project);
-                    tasks.spawn(self.check_instance(opctx, client, target, vmm));
+                    tasks.spawn(self.check_instance(opctx, client, target, vmm, sled));
                 }
 
                 // Now, wait for the check results to come back.
@@ -480,9 +517,6 @@ impl BackgroundTask for InstanceWatcher {
                             *check_failures.entry(reason.as_str().into_owned()).or_default() += 1;
                         }
                         CheckOutcome::Unknown => {}
-                    }
-                    if let Err(ref reason) = check.result {
-                        *check_errors.entry(reason.as_str().into_owned()).or_default() += 1;
                     }
                     if check.update_saga_queued {
                         update_sagas_queued += 1;

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -205,8 +205,8 @@ impl InstanceWatcher {
                         // unreachable for a while. We may also want to take other
                         // corrective actions or alert an operator in this case.
                         //
-                        // TODO(eliza): because we have the preported IP address
-                        // of the instance's VMM from our databse query, we could
+                        // TODO(eliza): because we have the purported IP address
+                        // of the instance's VMM from our database query, we could
                         // also ask the VMM directly when the sled-agent is
                         // unreachable. We should start doing that here at some
                         // point.

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1278,13 +1278,6 @@ async fn test_instance_failed_when_on_expunged_sled(
         .await
         .unwrap();
 
-    // Activate the instance-watcher task.
-    nexus_test_utils::background::activate_background_task(
-        &cptestctx.internal_client,
-        "instance_watcher",
-    )
-    .await;
-
     // Wait for both instances to transition to Failed.
     instance_wait_for_state(client, instance1_id, InstanceState::Failed).await;
     instance_wait_for_state(client, instance2_id, InstanceState::Failed).await;


### PR DESCRIPTION
When a sled is expunged, any VMMs previously believed to be on that sled
are definitely no longer present. Currently, expunging a sled will not
do anything to VMMs resident on that sled, and the instances will remain
in the `Running` state...but it won't be possible to stop them, as their
sled-agent will probably no longer be reachable. In conjunction with 
#6503, this commit will implement most of the behavior described in 
issue #4872; see [this comment][1] for details.

This commit updates the `instance-watcher` background task to mark any
VMMs on `Expunged` sleds as `Failed`, so that those VMMs' instances can
transition to `Failed` and be restarted or deleted normally. It seems
better to do this in the `instance-watcher` background task, rather than
in the code paths for actually marking a sled as expunged, because
transitioning a VMM to failed triggers an instance-update saga to move
the instance to failed, and doing all of that in the transaction that
expunges the sled seems unfortunate --- expunging the sled would be a
much longer-running operation, and we'd have to be careful to not roll
it back if one update saga fails or whatever. So, instead, I think it's
nicer to just mark the sled as expunged and then let the background task
do the remaining work. And, the `instance-watcher` background task
already queries for all instances *and their associated sleds*, so it
makes sense to do the transition there rather than in the
`instance-updater` background task, since we'd have to add an additional
JOIN to look at sleds, which seems unfortunate. Also, this way,
VMMs that are marked as `Failed` due to sled expungement can also be
reflected in the metrics, which seems nice.

This was, overall, pretty straightforward: I've just removed the
`SledFilter::InService` from the `instance_and_vmm_list_by_sled_agent`
query,[^1], passed the `Sled` into the `check_instance` function, and
added a code path to skip the actual HTTP health check if the sled is
`Expunged` and just go ahead and mark the VMM as `Failed`. I think it
still makes sense to spawn a task for these VMMs, even though they don't
actually do HTTP requests to the sled-agent, because they will attempt
to run a whole `instance-update` saga to transition the instance to
`Failed`, which can take a bit of time. It seems nice to just keep
starting other health checks while that runs, instead of doing it
sequentially.

In addition, commit e238d563357c0a1cd620925e5406ceb6aec1237a
changes the `instance-watcher` task to only increment the metrics for
`InstanceState::Failed` when a VMM has _actually_ transitioned to `Failed`.
Error responses from sled-agent that don't mark a VMM as failed are now
considered "incomplete" checks. It seemed wrong to me to increment 
metrics with `instance_state="failed"` when the instance's state is not 
actually `Failed`.

[1]: https://github.com/oxidecomputer/omicron/issues/4872#issuecomment-2327552935
[^1]: Apparently there were actually *two* separate
    `SledFilter::InService` calls, which tripped  me up for longer than
    I would like to admit...