### PR TITLE
[reconfigurator] change_sled_zones no longer automatically bumps generation number

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1339,8 +1339,11 @@ impl<'a> BlueprintZonesBuilder<'a> {
     /// Returns a mutable reference to a sled's Omicron zones *because* we're
     /// going to change them.
     ///
-    /// This method should generally only be called if the caller is going to
-    /// change the zones, but is safe to call otherwise.
+    /// This updates internal data structures, and it is recommended that it be
+    /// called only when the caller actually wishes to make changes to zones.
+    /// But making no changes after calling this does not result in a changed
+    /// blueprint. (In particular, the generation number is only updated if
+    /// the state of any zones was updated.)
     pub fn change_sled_zones(
         &mut self,
         sled_id: SledUuid,
@@ -1447,9 +1450,11 @@ impl<'a> BlueprintDisksBuilder<'a> {
     }
 
     /// Returns a mutable reference to a sled's Omicron disks *because* we're
-    /// going to change them.  It's essential that the caller _does_ change them
-    /// because we will have bumped the generation number and we don't want to
-    /// do that if no changes are being made.
+    /// going to change them.
+    ///
+    /// Unlike [`BlueprintZonesBuilder::change_sled_zones`], it is essential
+    /// that the caller _does_ change them, because constructing this bumps the
+    /// generation number unconditionally.
     pub fn change_sled_disks(
         &mut self,
         sled_id: SledUuid,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1337,9 +1337,10 @@ impl<'a> BlueprintZonesBuilder<'a> {
     }
 
     /// Returns a mutable reference to a sled's Omicron zones *because* we're
-    /// going to change them.  It's essential that the caller _does_ change them
-    /// because we will have bumped the generation number and we don't want to
-    /// do that if no changes are being made.
+    /// going to change them.
+    ///
+    /// This method should generally only be called if the caller is going to
+    /// change the zones, but is safe to call otherwise.
     pub fn change_sled_zones(
         &mut self,
         sled_id: SledUuid,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/zones.rs
@@ -132,13 +132,19 @@ impl BuilderZonesConfig {
     }
 
     pub(super) fn build(self) -> BlueprintZonesConfig {
+        // Only bump the generation if any zones have been changed.
+        let generation = if self
+            .zones
+            .iter()
+            .any(|z| z.state != BuilderZoneState::Unchanged)
+        {
+            self.generation.next()
+        } else {
+            self.generation
+        };
+
         let mut ret = BlueprintZonesConfig {
-            // Something we could do here is to check if any zones have
-            // actually been modified, and if not, return the parent's
-            // generation. For now, we depend on callers to only call
-            // `BlueprintZonesBuilder::change_sled_zones` when they really
-            // mean it.
-            generation: self.generation.next(),
+            generation,
             zones: self.zones.into_iter().map(|z| z.zone).collect(),
         };
         ret.sort();
@@ -288,6 +294,12 @@ mod tests {
             (new_sled_id, input.build())
         };
 
+        let existing_sled_id = example
+            .input
+            .all_sled_ids(SledFilter::Commissioned)
+            .next()
+            .expect("at least one sled present");
+
         let mut builder = BlueprintBuilder::new_based_on(
             &logctx.log,
             &blueprint_initial,
@@ -321,11 +333,6 @@ mod tests {
 
         // Now, test adding a new zone (Oximeter, picked arbitrarily) to an
         // existing sled.
-        let existing_sled_id = example
-            .input
-            .all_sled_ids(SledFilter::Commissioned)
-            .next()
-            .expect("at least one sled present");
         let change = builder.zones.change_sled_zones(existing_sled_id);
 
         let new_zone_id = OmicronZoneUuid::new_v4();
@@ -460,6 +467,30 @@ mod tests {
             assert_eq!(modified.zones.len(), 1);
             let modified_zone = &modified.zones[0];
             assert_eq!(modified_zone.zone.id(), existing_zone_id);
+        }
+
+        // Test a no-op change.
+        {
+            let mut builder = BlueprintBuilder::new_based_on(
+                &logctx.log,
+                &blueprint,
+                &input2,
+                "the_test",
+            )
+            .expect("creating blueprint builder");
+            builder.set_rng_seed((TEST_NAME, "bp2"));
+
+            // This call by itself shouldn't bump the generation number.
+            builder.zones.change_sled_zones(existing_sled_id);
+
+            let blueprint_noop = builder.build();
+            verify_blueprint(&blueprint_noop);
+            let diff = blueprint_noop.diff_since_blueprint(&blueprint);
+            println!("expecting a noop:\n{}", diff.display());
+
+            assert!(diff.sleds_modified.is_empty(), "no sleds modified");
+            assert!(diff.sleds_added.is_empty(), "no sleds added");
+            assert!(diff.sleds_removed.is_empty(), "no sleds removed");
         }
 
         logctx.cleanup_successful();


### PR DESCRIPTION
Once we start garbage collecting zones, we're going to be making modifications
to it that don't bump the generation number (since they don't have any impact
on what's presented to sled-agent.) Make it so that `change_sled_zones` _by
itself_ doesn't bump the generation number: only actually changing a zone does.
