### PR TITLE
[nexus] Add `instance_watcher` concurrency limit

### DIFF
--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -46,14 +46,14 @@ pub(crate) struct InstanceWatcher {
 
 /// Determines how many instance checks and their subsequent update sagas (if
 /// the instance's state has changed) can execute concurrently.  If this
-/// numberis too high, there's risk that this task could starve other Nexus
+/// number is too high, there's risk that this task could starve other Nexus
 /// activities or overload the database or overload one or more sled agents.
 ///
 /// The only consequence of the number being too low is that it may take longer
 /// for the system to notice an instance's VMM state requires an instance state
 /// transition, which translates to increased latency between when events (like
 /// a VMM crash or a completed migration) occur, and when the necessary actions
-/// are (like releasing unused resource allocations or allowing an instance to
+/// (like releasing unused resource allocations or allowing an instance to
 /// be restarted or deleted) are performed.  However, in the happy path, instance
 /// update sagas execute immediately upon receipt of a VMM state update pushed
 /// by a sled-agent in `cpapi_instances_put`.  Therefore, discovering a needed

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -388,7 +388,7 @@ impl BackgroundTask for InstanceWatcher {
             let mut check_errors: BTreeMap<String, usize> = BTreeMap::new();
 
             // A `reqwest` client is a reference-counted handle to a connection
-            // poll that can be reused by multiple requests. Making a new client
+            // pool that can be reused by multiple requests. Making a new client
             // is fairly expensive, but cloning one is cheap, and cloning it
             // allows reusing pooled TCP connections. Therefore, we will order
             // the database query by sled ID, and reuse the same sled-agent


### PR DESCRIPTION
The `instance_watcher` background task follows a pattern where it
queries the database for instances, and then spawns a big pile of Tokio
tasks to concurrently perform health checks for those instances. As
suggested by @davepacheco in [this comment][1], there should probably be
a limit on the number of concurrently running health checks to avoid
clobbering the sled-agents with a giant pile of HTTP requests.

This branch sets a global concurrency limit of 16 health checks (which
is fairly conservative, but we can turn it up later if it turns out to
be a bottleneck). The concurrency limit is implemented using the
database query's batch size. Previously, this code was written in a
slightly-weird dual-loop structure, which was intended specifically to
*avoid* the size of the database query batch acting as a concurrency
limit: we would read a page of sleds from CRDB, spawn a bunch of health
check tasks, and then read the next batch, waiting for the tasks to
complete only once all instance records had been read from the database.
Now, we can implement a concurrency limit by just...not doing that. We
now wait to read the next page of query results until we've run health
checks for every instance in the batch, limiting the number of
concurrently in flight checks. 

This has a nice advantage over the naïve approach of using a
`tokio::sync::Semaphore` or similar, which each health check task must
acquire before proceeding, as the concurrency limit: it also bounds the
amount of Nexus' memory used by the instance watcher. If we spawned all
the tasks immediately but made them wait to acquire a semaphore permit,
there would be a bunch of tasks in memory sitting around doing nothing
until the currently in flight tasks completed. With the batch size as
concurrency limit approach, we can instead avoid spawning those tasks at all
(and, avoid reading stuff from CRDB until we actually need it).

[1]:
    https://github.com/oxidecomputer/omicron/pull/6519#pullrequestreview-2283593739