### PR TITLE
live-tests readme: add omdb step, clarify tests run from switch zone

### DIFF
--- a/dev-tools/xtask/src/live_tests.rs
+++ b/dev-tools/xtask/src/live_tests.rs
@@ -128,9 +128,11 @@ pub fn run_cmd(_args: Args) -> Result<()> {
             .subsequent_indent("              "),
     );
     eprintln!("{}\n", text.join("\n"));
-    eprintln!("3. On that system, unpack the tarball with:\n");
+    eprintln!(
+        "3. From the switch zone on that system, unpack the tarball with:\n"
+    );
     eprintln!("     tar xzf {}\n", final_tarball.file_name().unwrap());
-    eprintln!("4. On that system, run tests with:\n");
+    eprintln!("4. From the switch zone on that system, run tests with:\n");
     // TMPDIR=/var/tmp puts stuff on disk, cached as needed, rather than the
     // default /tmp which requires that stuff be in-memory.  That can lead to
     // great sadness if the tests wind up writing a lot of data.

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -20,6 +20,12 @@ These tests are not currently run automatically (though they are _built_ in CI).
 
 You can run them yourself.  First, deploy Omicron using `a4x2` or one of the hardware test rigs.  In your Omicron workspace, run `cargo xtask live-tests` to build an archive and then follow the instructions:
 
+The live tests require that the system's target blueprint is enabled. This is to avoid a case where the live tests generate blueprints based on a target blueprint that is not current and then wind up making a bunch of unrelated changes to the system. On a fresh system, you will have to enable the target blueprint yourself:
+
+    omdb --destructive nexus blueprints target enable current
+
+This essentially enables reconfigurator, causing it to constantly try to make the system match its target blueprint. You only need to do this once in the lifetime of the system, not every time you re-run the live tests.
+
 ```
 $ cargo xtask live-tests
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
@@ -51,21 +57,11 @@ To use this:
               $(which cargo-nextest) \
               root@YOUR_SCRIMLET_GZ_IP:/zone/oxz_switch/root/root
 
-3. Copy omdb as well.
-
-     e.g., scp \
-              /home/dap/omicron-work/target/debug/omdb \
-              root@YOUR_SCRIMLET_GZ_IP:/zone/oxz_switch/root/root
-
-4. On that system, enable target blueprint:
-
-     ./omdb --destructive nexus blueprints target enable current
-
-5. From the switch zone on that system, unpack the tarball with:
+3. From the switch zone on that system, unpack the tarball with:
 
      tar xzf live-tests-archive.tgz
 
-6. From the switch zone on that system, run tests with:
+4. From the switch zone on that system, run tests with:
 
      TMPDIR=/var/tmp ./cargo-nextest nextest run --profile=live-tests \
          --archive-file live-tests-archive/omicron-live-tests.tar.zst \

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -25,7 +25,7 @@ Ensure the system's target blueprint is enabled. The live tests require this to 
 On a fresh system, you will have to enable the target blueprint yourself:
 
 ```
-    omdb --destructive nexus blueprints target enable current
+omdb --destructive nexus blueprints target enable current
 ```
 
 This essentially enables reconfigurator, causing it to constantly try to make the system match its target blueprint. You only need to do this once in the lifetime of the system, not every time you re-run the live tests.

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -16,15 +16,21 @@ There are some safeguards so that these tests won't run on production systems: t
 
 == Usage
 
-These tests are not currently run automatically (though they are _built_ in CI).
+These tests are not currently run automatically (though they are _built_ in CI). You can run them yourself.
 
-You can run them yourself.  First, deploy Omicron using `a4x2` or one of the hardware test rigs.  In your Omicron workspace, run `cargo xtask live-tests` to build an archive and then follow the instructions:
+First, deploy Omicron using `a4x2` or one of the hardware test rigs.
 
-The live tests require that the system's target blueprint is enabled. This is to avoid a case where the live tests generate blueprints based on a target blueprint that is not current and then wind up making a bunch of unrelated changes to the system. On a fresh system, you will have to enable the target blueprint yourself:
+Ensure the system's target blueprint is enabled. The live tests require this to avoid a case where the live tests generate blueprints based on a target blueprint that is not current, and then make a bunch of changes to the system unrelated to the tests.
 
+On a fresh system, you will have to enable the target blueprint yourself:
+
+```
     omdb --destructive nexus blueprints target enable current
+```
 
 This essentially enables reconfigurator, causing it to constantly try to make the system match its target blueprint. You only need to do this once in the lifetime of the system, not every time you re-run the live tests.
+
+At this point the system is prepared for testing. In your Omicron workspace, run `cargo xtask live-tests` to build an archive and then follow the instructions:
 
 ```
 $ cargo xtask live-tests

--- a/live-tests/README.adoc
+++ b/live-tests/README.adoc
@@ -51,11 +51,21 @@ To use this:
               $(which cargo-nextest) \
               root@YOUR_SCRIMLET_GZ_IP:/zone/oxz_switch/root/root
 
-3. On that system, unpack the tarball with:
+3. Copy omdb as well.
+
+     e.g., scp \
+              /home/dap/omicron-work/target/debug/omdb \
+              root@YOUR_SCRIMLET_GZ_IP:/zone/oxz_switch/root/root
+
+4. On that system, enable target blueprint:
+
+     ./omdb --destructive nexus blueprints target enable current
+
+5. From the switch zone on that system, unpack the tarball with:
 
      tar xzf live-tests-archive.tgz
 
-4. On that system, run tests with:
+6. From the switch zone on that system, run tests with:
 
      TMPDIR=/var/tmp ./cargo-nextest nextest run --profile=live-tests \
          --archive-file live-tests-archive/omicron-live-tests.tar.zst \


### PR DESCRIPTION
Based on my experience getting live-tests running in a4x2. after omdb command, everything works

```
info: experimental features enabled: setup-scripts
------------
 Nextest run ID 54e6aeb1-3c56-4ead-a272-c7858f87b1e2 with nextest profile: live-tests
    Starting 1 test across 1 binary
        SLOW [> 60.000s] omicron-live-tests::test_nexus_add_remove test_nexus_add_remove
        PASS [  76.842s] omicron-live-tests::test_nexus_add_remove test_nexus_add_remove
------------
     Summary [  76.846s] 1 test run: 1 passed (1 slow), 0 skipped
```