### PR TITLE
[ci] update nextest, enable colors in buildomat

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.77", recommended = "0.9.77" }
+nextest-version = { required = "0.9.77", recommended = "0.9.78" }
 
 experimental = ["setup-scripts"]
 

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
+# Color the output for easier readability.
+export CARGO_TERM_COLOR=always
+
 target_os=$1
 
 # NOTE: This version should be in sync with the recommended version in

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -12,7 +12,7 @@ target_os=$1
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.77'
+NEXTEST_VERSION='0.9.78'
 
 cargo --version
 rustc --version

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -560,8 +560,6 @@ mod test {
             .expect("failed to deploy last round of zones");
         s1.verify_and_clear();
         s2.verify_and_clear();
-
-        panic!("something failed");
     }
 
     #[nexus_test]

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -560,6 +560,8 @@ mod test {
             .expect("failed to deploy last round of zones");
         s1.verify_and_clear();
         s2.verify_and_clear();
+
+        panic!("something failed");
     }
 
     #[nexus_test]


### PR DESCRIPTION
With https://github.com/oxidecomputer/buildomat/pull/63 in place, we can now turn on colors in our Buildomat jobs, making outputs so much easier to read.

Also bump nextest to 0.9.78, which adds support for highlighting the specific lines in tests that failed ([example](https://buildomat.eng.oxide.computer/wg/0/details/01J726JZ4451WYRQ4XB33CPCBV/XjTtwUi3qlm6mtfCBItXhPzx93PlglKiGIHHOWnE3I9VKYLP/01J726KRGC5ZBRCAMBZ1CJ0RR7#S4723)).