### PR TITLE
SAML relay state shouldn't result in internal server error

### DIFF
--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -317,15 +317,12 @@ pub(crate) async fn login_saml(
                 }
             };
 
-        let relay_state = if let Some(value) = relay_state_string {
-            // We used to return an internal server error if we failed to parse
-            // the relay state from the IDP. Since an IDP can technically put
-            // anything it wants here it's better to ignore the parse error and
-            // continue on with the login flow.
-            RelayState::from_encoded(value).ok()
-        } else {
-            None
-        };
+        // We used to return an internal server error if we failed to parse the
+        // relay state from the IDP. Since an IDP can technically put anything
+        // it wants here it's better to ignore the parse error and continue on
+        // with the login flow.
+        let relay_state =
+            relay_state_string.and_then(|v| RelayState::from_encoded(v).ok());
 
         let user = nexus
             .silo_user_from_authenticated_subject(


### PR DESCRIPTION
Fixes #5607

The relay state can be set by an IDP to some string value.  Nexus itself is expecting that string to be in the form of JSON that serializes/deserializes to our `RelayState` type. With this fix we now attempt to parse this value so that we know where to redirect the user upon successful authentication, however if we can't we just send the user to the root aka `/`.