### PR TITLE
[nexus] nicer OMDB status for `instance_updater`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1476,7 +1476,10 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 saga_errors.len()
             );
             for (instance_id, error) in &saga_errors {
-                println!("      > {instance_id}: {error}");
+                match instance_id {
+                    Some(id) => println!("      > {id}: {error}"),
+                    None => println!("      > {error}"),
+                }
             }
         }
 

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -32,6 +32,7 @@ use nexus_client::types::UninitializedSledId;
 use nexus_db_queries::db::lookup::LookupPath;
 use nexus_saga_recovery::LastPass;
 use nexus_types::deployment::Blueprint;
+use nexus_types::internal_api::background::AbandonedVmmReaperStatus;
 use nexus_types::internal_api::background::LookupRegionPortStatus;
 use nexus_types::internal_api::background::RegionReplacementDriverStatus;
 use nexus_types::internal_api::background::RegionSnapshotReplacementFinishStatus;
@@ -1165,54 +1166,61 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
             }
         };
     } else if name == "abandoned_vmm_reaper" {
-        #[derive(Deserialize)]
-        struct TaskSuccess {
-            /// total number of abandoned VMMs found
-            found: usize,
-
-            /// number of abandoned VMM records that were deleted
-            vmms_deleted: usize,
-
-            /// number of abandoned VMM records that were already deleted when
-            /// we tried to delete them.
-            vmms_already_deleted: usize,
-
-            /// sled resource reservations that were released
-            sled_reservations_deleted: usize,
-
-            /// number of errors that occurred during the activation
-            error_count: usize,
-
-            /// the last error that occurred during execution.
-            error: Option<String>,
-        }
-        match serde_json::from_value::<TaskSuccess>(details.clone()) {
+        match serde_json::from_value::<AbandonedVmmReaperStatus>(
+            details.clone(),
+        ) {
             Err(error) => eprintln!(
                 "warning: failed to interpret task details: {:?}: {:?}",
                 error, details
             ),
-            Ok(TaskSuccess {
-                found,
+            Ok(AbandonedVmmReaperStatus {
+                vmms_found,
                 vmms_deleted,
                 vmms_already_deleted,
                 sled_reservations_deleted,
-                error_count,
-                error,
+                errors,
             }) => {
-                if let Some(error) = error {
-                    println!("    task did not complete successfully!");
-                    println!("      total errors: {error_count}");
-                    println!("      most recent error: {error}");
+                if !errors.is_empty() {
+                    println!(
+                        "    task did not complete successfully! ({} errors)",
+                        errors.len()
+                    );
+                    for error in errors {
+                        println!("    > {error}");
+                    }
                 }
 
-                println!("    total abandoned VMMs found: {found}");
-                println!("      VMM records deleted: {vmms_deleted}");
+                const VMMS_FOUND: &'static str = "total abandoned VMMs found:";
+                const VMMS_DELETED: &'static str = "  VMM records deleted:";
+                const VMMS_ALREADY_DELETED: &'static str =
+                    "  VMMs already deleted by another Nexus:";
+                const SLED_RESERVATIONS_DELETED: &'static str =
+                    "sled resource reservations deleted:";
+                // To align the number column, figure out the length of the
+                // longest line of text and add one (so that there's a space).
+                //
+                // Yes, I *could* just count the number of characters in each
+                // line myself, but why do something by hand when you could make
+                // the computer do it for you? And, this way, if we change the
+                // text, we won't need to figure it out again.
+                const WIDTH: usize = const_max_len(&[
+                    VMMS_FOUND,
+                    VMMS_DELETED,
+                    VMMS_ALREADY_DELETED,
+                    SLED_RESERVATIONS_DELETED,
+                ]) + 1;
+                const NUM_WIDTH: usize = 3;
+
+                println!("    {VMMS_FOUND:<WIDTH$}{vmms_found:>NUM_WIDTH$}");
                 println!(
-                    "      VMM records already deleted by another Nexus: {}",
-                    vmms_already_deleted,
+                    "    {VMMS_DELETED:<WIDTH$}{vmms_deleted:>NUM_WIDTH$}"
                 );
                 println!(
-                    "    sled resource reservations deleted: {}",
+                    "    {VMMS_ALREADY_DELETED:<WIDTH$}{:>NUM_WIDTH$}",
+                    vmms_already_deleted
+                );
+                println!(
+                    "    {SLED_RESERVATIONS_DELETED:<WIDTH$}{:>NUM_WIDTH$}",
                     sled_reservations_deleted,
                 );
             }
@@ -2577,4 +2585,17 @@ async fn cmd_nexus_sled_expunge_disk(
         .context("expunging disk")?;
     eprintln!("expunged disk {}", args.physical_disk_id);
     Ok(())
+}
+
+const fn const_max_len(strs: &[&str]) -> usize {
+    let mut max = 0;
+    let mut i = 0;
+    while i < strs.len() {
+        let len = strs[i].len();
+        if len > max {
+            max = len;
+        }
+        i += 1;
+    }
+    max
 }

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -33,6 +33,7 @@ use nexus_db_queries::db::lookup::LookupPath;
 use nexus_saga_recovery::LastPass;
 use nexus_types::deployment::Blueprint;
 use nexus_types::internal_api::background::AbandonedVmmReaperStatus;
+use nexus_types::internal_api::background::InstanceUpdaterStatus;
 use nexus_types::internal_api::background::LookupRegionPortStatus;
 use nexus_types::internal_api::background::RegionReplacementDriverStatus;
 use nexus_types::internal_api::background::RegionSnapshotReplacementFinishStatus;
@@ -1408,85 +1409,87 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
             ),
         }
     } else if name == "instance_updater" {
-        #[derive(Deserialize)]
-        struct UpdaterStatus {
-            /// number of instances found with destroyed active VMMs
-            destroyed_active_vmms: usize,
-
-            /// number of instances found with failed active VMMs
-            failed_active_vmms: usize,
-
-            /// number of instances found with terminated active migrations
-            terminated_active_migrations: usize,
-
-            /// number of update sagas started.
-            sagas_started: usize,
-
-            /// number of sagas completed successfully
-            sagas_completed: usize,
-
-            /// number of sagas which failed
-            sagas_failed: usize,
-
-            /// number of sagas which could not be started
-            saga_start_failures: usize,
-
-            /// the last error that occurred during execution.
-            error: Option<String>,
-        }
-        match serde_json::from_value::<UpdaterStatus>(details.clone()) {
-            Err(error) => eprintln!(
-                "warning: failed to interpret task details: {:?}: {:?}",
-                error, details
-            ),
-            Ok(UpdaterStatus {
-                destroyed_active_vmms,
-                failed_active_vmms,
-                terminated_active_migrations,
-                sagas_started,
-                sagas_completed,
-                sagas_failed,
-                saga_start_failures,
-                error,
-            }) => {
-                if let Some(error) = error {
-                    println!("    task did not complete successfully!");
-                    println!("      most recent error: {error}");
-                }
-
-                println!(
-                    "    total instances in need of updates: {}",
-                    destroyed_active_vmms + terminated_active_migrations
+        let status = match serde_json::from_value::<InstanceUpdaterStatus>(
+            details.clone(),
+        ) {
+            Err(error) => {
+                eprintln!(
+                    "warning: failed to interpret task details: {:?}: {:?}",
+                    error, details,
                 );
-                println!(
-                    "      instances with Destroyed active VMMs: {}",
-                    destroyed_active_vmms,
-                );
-                println!(
-                    "      instances with Failed active VMMs: {}",
-                    failed_active_vmms,
-                );
-                println!(
-                    "      instances with terminated active migrations: {}",
-                    terminated_active_migrations,
-                );
-                println!("    update sagas started: {sagas_started}");
-                println!(
-                    "    update sagas completed successfully: {}",
-                    sagas_completed,
-                );
-
-                let total_failed = sagas_failed + saga_start_failures;
-                if total_failed > 0 {
-                    println!("    unsuccessful update sagas: {total_failed}");
-                    println!(
-                        "      sagas which could not be started: {}",
-                        saga_start_failures
-                    );
-                    println!("      sagas failed: {sagas_failed}");
-                }
+                return;
             }
+            Ok(status) => status,
         };
+        let errors = status.errors();
+        let instances_found = status.total_instances_found();
+        let InstanceUpdaterStatus {
+            disabled,
+            destroyed_active_vmms,
+            failed_active_vmms,
+            terminated_active_migrations,
+            sagas_started,
+            sagas_completed,
+            saga_errors,
+            query_errors,
+        } = status;
+
+        if disabled {
+            println!("    task explicitly disabled by config!")
+        }
+
+        const FOUND: &'static str = "instances in need of updates:";
+        const DESTROYED: &'static str =
+            "  instances with Destroyed active VMMs:";
+        const FAILED: &'static str = "  instances with Failed active VMMs:";
+        const MIGRATIONS: &'static str =
+            "  instances with terminated migrations:";
+        const SAGAS_STARTED: &'static str = "update sagas started:";
+        const SAGAS_COMPLETED: &'static str =
+            "  update sagas completed successfully:";
+        const SAGA_ERRORS: &'static str = "  update sagas failed:";
+        const QUERY_ERRORS: &'static str =
+            "  errors finding instances to update:";
+        const WIDTH: usize = const_max_len(&[
+            FOUND,
+            DESTROYED,
+            FAILED,
+            MIGRATIONS,
+            SAGAS_STARTED,
+            SAGA_ERRORS,
+            QUERY_ERRORS,
+        ]) + 1;
+        const NUM_WIDTH: usize = 3;
+        if errors > 0 {
+            println!(
+                "    task did not complete successfully! ({errors} errors)"
+            );
+            println!(
+                "      {QUERY_ERRORS:<WIDTH$}{:>NUM_WIDTH$}",
+                query_errors.len()
+            );
+            for error in query_errors {
+                println!("     > {error}");
+            }
+            println!(
+                "      {SAGA_ERRORS:<WIDTH$}{:>NUM_WIDTH$}",
+                saga_errors.len()
+            );
+            for (instance_id, error) in &saga_errors {
+                println!("      > {instance_id}: {error}");
+            }
+        }
+
+        println!("    {FOUND:<WIDTH$}{instances_found:>NUM_WIDTH$}");
+        println!("    {DESTROYED:<WIDTH$}{destroyed_active_vmms:>NUM_WIDTH$}",);
+        println!("    {FAILED:<WIDTH$}{failed_active_vmms:>NUM_WIDTH$}");
+        println!(
+            "    {MIGRATIONS:<WIDTH$}{:>NUM_WIDTH$}",
+            terminated_active_migrations,
+        );
+        println!("    {SAGAS_STARTED:<WIDTH$}{sagas_started:>NUM_WIDTH$}");
+        println!("    {SAGAS_COMPLETED:<WIDTH$}{sagas_completed:>NUM_WIDTH$}",);
+        println!("    {SAGA_ERRORS:<WIDTH$}{:>NUM_WIDTH$}", saga_errors.len());
     } else if name == "region_snapshot_replacement_start" {
         match serde_json::from_value::<RegionSnapshotReplacementStartStatus>(
             details.clone(),

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -475,10 +475,10 @@ task: "abandoned_vmm_reaper"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    total abandoned VMMs found: 0
-      VMM records deleted: 0
-      VMM records already deleted by another Nexus: 0
-    sled resource reservations deleted: 0
+    total abandoned VMMs found:                0
+      VMM records deleted:                     0
+      VMMs already deleted by another Nexus:   0
+    sled resource reservations deleted:        0
 
 task: "bfd_manager"
   configured period: every <REDACTED_DURATION>s
@@ -902,10 +902,10 @@ task: "abandoned_vmm_reaper"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    total abandoned VMMs found: 0
-      VMM records deleted: 0
-      VMM records already deleted by another Nexus: 0
-    sled resource reservations deleted: 0
+    total abandoned VMMs found:                0
+      VMM records deleted:                     0
+      VMMs already deleted by another Nexus:   0
+    sled resource reservations deleted:        0
 
 task: "bfd_manager"
   configured period: every <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -523,12 +523,14 @@ task: "instance_updater"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    total instances in need of updates: 0
-      instances with Destroyed active VMMs: 0
-      instances with Failed active VMMs: 0
-      instances with terminated active migrations: 0
-    update sagas started: 0
-    update sagas completed successfully: 0
+    task explicitly disabled by config!
+    instances in need of updates:             0
+      instances with Destroyed active VMMs:   0
+      instances with Failed active VMMs:      0
+      instances with terminated migrations:   0
+    update sagas started:                     0
+      update sagas completed successfully:    0
+      update sagas failed:                    0
 
 task: "instance_watcher"
   configured period: every <REDACTED_DURATION>s
@@ -950,12 +952,14 @@ task: "instance_updater"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    total instances in need of updates: 0
-      instances with Destroyed active VMMs: 0
-      instances with Failed active VMMs: 0
-      instances with terminated active migrations: 0
-    update sagas started: 0
-    update sagas completed successfully: 0
+    task explicitly disabled by config!
+    instances in need of updates:             0
+      instances with Destroyed active VMMs:   0
+      instances with Failed active VMMs:      0
+      instances with terminated migrations:   0
+    update sagas started:                     0
+      update sagas completed successfully:    0
+      update sagas failed:                    0
 
 task: "instance_watcher"
   configured period: every <REDACTED_DURATION>s

--- a/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
@@ -40,21 +40,13 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::datastore::SQL_BATCH_SIZE;
 use nexus_db_queries::db::pagination::Paginator;
 use nexus_db_queries::db::DataStore;
+use nexus_types::internal_api::background::AbandonedVmmReaperStatus;
 use omicron_uuid_kinds::{GenericUuid, PropolisUuid};
 use std::sync::Arc;
 
 /// Background task that searches for abandoned VMM records and deletes them.
 pub struct AbandonedVmmReaper {
     datastore: Arc<DataStore>,
-}
-
-#[derive(Debug, Default)]
-struct ActivationResults {
-    found: usize,
-    sled_reservations_deleted: usize,
-    vmms_deleted: usize,
-    vmms_already_deleted: usize,
-    error_count: usize,
 }
 
 impl AbandonedVmmReaper {
@@ -65,13 +57,10 @@ impl AbandonedVmmReaper {
     /// List abandoned VMMs and clean up all of their database records.
     async fn reap_all(
         &mut self,
-        results: &mut ActivationResults,
+        status: &mut AbandonedVmmReaperStatus,
         opctx: &OpContext,
     ) -> Result<(), anyhow::Error> {
-        slog::info!(opctx.log, "Abandoned VMM reaper running");
-
         let mut paginator = Paginator::new(SQL_BATCH_SIZE);
-        let mut last_err = Ok(());
         while let Some(p) = paginator.next() {
             let vmms = self
                 .datastore
@@ -79,10 +68,10 @@ impl AbandonedVmmReaper {
                 .await
                 .context("failed to list abandoned VMMs")?;
             paginator = p.found_batch(&vmms, &|vmm| vmm.id);
-            self.reap_batch(results, &mut last_err, opctx, &vmms).await;
+            self.reap_batch(status, opctx, &vmms).await;
         }
 
-        last_err
+        Ok(())
     }
 
     /// Clean up a batch of abandoned VMMs.
@@ -95,13 +84,17 @@ impl AbandonedVmmReaper {
     /// than doing it all in one go. Thus, this is factored out.
     async fn reap_batch(
         &mut self,
-        results: &mut ActivationResults,
-        last_err: &mut Result<(), anyhow::Error>,
+        status: &mut AbandonedVmmReaperStatus,
         opctx: &OpContext,
         vmms: &[Vmm],
     ) {
-        results.found += vmms.len();
-        slog::debug!(opctx.log, "Found abandoned VMMs"; "count" => vmms.len());
+        status.vmms_found += vmms.len();
+        slog::debug!(
+            opctx.log,
+            "Found abandoned VMMs";
+            "count" => vmms.len(),
+            "total" => status.vmms_found,
+        );
 
         for vmm in vmms {
             let vmm_id = PropolisUuid::from_untyped_uuid(vmm.id);
@@ -118,22 +111,18 @@ impl AbandonedVmmReaper {
                         "Deleted abandoned VMM's sled reservation";
                         "vmm" => %vmm_id,
                     );
-                    results.sled_reservations_deleted += 1;
+                    status.sled_reservations_deleted += 1;
                 }
                 Err(e) => {
+                    const ERR_MSG: &'static str =
+                        "Failed to delete sled reservation";
                     slog::warn!(
                         opctx.log,
-                        "Failed to delete sled reservation for abandoned VMM";
+                        "{ERR_MSG} for abandoned VMM";
                         "vmm" => %vmm_id,
                         "error" => %e,
                     );
-                    results.error_count += 1;
-                    *last_err = Err(e).with_context(|| {
-                        format!(
-                            "failed to delete sled reservation for VMM \
-                             {vmm_id}"
-                        )
-                    });
+                    status.errors.push(format!("{ERR_MSG} for {vmm_id}: {e}"));
                 }
             }
 
@@ -145,7 +134,7 @@ impl AbandonedVmmReaper {
                         "Deleted abandoned VMM";
                         "vmm" => %vmm_id,
                     );
-                    results.vmms_deleted += 1;
+                    status.vmms_deleted += 1;
                 }
                 Ok(false) => {
                     slog::trace!(
@@ -153,19 +142,17 @@ impl AbandonedVmmReaper {
                         "Abandoned VMM was already deleted";
                         "vmm" => %vmm_id,
                     );
-                    results.vmms_already_deleted += 1;
+                    status.vmms_already_deleted += 1;
                 }
                 Err(e) => {
+                    const ERR_MSG: &'static str = "Failed to delete";
                     slog::warn!(
                         opctx.log,
-                        "Failed to mark abandoned VMM as deleted";
+                        "{ERR_MSG} abandoned VMM";
                         "vmm" => %vmm_id,
                         "error" => %e,
                     );
-                    results.error_count += 1;
-                    *last_err = Err(e).with_context(|| {
-                        format!("failed to mark VMM {vmm_id} as deleted")
-                    });
+                    status.errors.push(format!("{ERR_MSG} {vmm_id}: {e}"))
                 }
             }
         }
@@ -178,36 +165,28 @@ impl BackgroundTask for AbandonedVmmReaper {
         opctx: &'a OpContext,
     ) -> BoxFuture<'a, serde_json::Value> {
         async move {
-            let mut results = ActivationResults::default();
-            let error = match self.reap_all(&mut results, opctx).await {
+            let mut status = AbandonedVmmReaperStatus::default();
+            match self.reap_all(&mut status, opctx).await {
                 Ok(_) => {
                     slog::info!(opctx.log, "Abandoned VMMs reaped";
-                        "found" => results.found,
-                        "sled_reservations_deleted" => results.sled_reservations_deleted,
-                        "vmms_deleted" => results.vmms_deleted,
-                        "vmms_already_deleted" => results.vmms_already_deleted,
+                        "vmms_found" => status.vmms_found,
+                        "sled_reservations_deleted" => status.sled_reservations_deleted,
+                        "vmms_deleted" => status.vmms_deleted,
+                        "vmms_already_deleted" => status.vmms_already_deleted,
                     );
-                    None
                 }
                 Err(err) => {
                     slog::error!(opctx.log, "Abandoned VMM reaper activation failed";
                         "error" => %err,
-                        "found" => results.found,
-                        "sled_reservations_deleted" => results.sled_reservations_deleted,
-                        "vmms_deleted" => results.vmms_deleted,
-                        "vmms_already_deleted" => results.vmms_already_deleted,
+                        "vmms_found" => status.vmms_found,
+                        "sled_reservations_deleted" => status.sled_reservations_deleted,
+                        "vmms_deleted" => status.vmms_deleted,
+                        "vmms_already_deleted" => status.vmms_already_deleted,
                     );
-                    Some(err.to_string())
+                    status.errors.push(err.to_string());
                 }
             };
-            serde_json::json!({
-                "found": results.found,
-                "vmms_deleted": results.vmms_deleted,
-                "vmms_already_deleted": results.vmms_already_deleted,
-                "sled_reservations_deleted": results.sled_reservations_deleted,
-                "error_count": results.error_count,
-                "error": error,
-            })
+            serde_json::json!(status)
         }
         .boxed()
     }
@@ -356,15 +335,16 @@ mod tests {
 
         let mut task = AbandonedVmmReaper::new(datastore.clone());
 
-        let mut results = ActivationResults::default();
-        dbg!(task.reap_all(&mut results, &opctx,).await)
+        let mut status = AbandonedVmmReaperStatus::default();
+        dbg!(task.reap_all(&mut status, &opctx,).await)
             .expect("activation completes successfully");
-        dbg!(&results);
+        dbg!(&status);
 
-        assert_eq!(results.vmms_deleted, 1);
-        assert_eq!(results.sled_reservations_deleted, 1);
-        assert_eq!(results.vmms_already_deleted, 0);
-        assert_eq!(results.error_count, 0);
+        assert_eq!(status.vmms_found, 1);
+        assert_eq!(status.vmms_deleted, 1);
+        assert_eq!(status.sled_reservations_deleted, 1);
+        assert_eq!(status.vmms_already_deleted, 0);
+        assert_eq!(status.errors, Vec::<String>::new());
         fixture.assert_reaped(datastore).await;
     }
 
@@ -385,7 +365,7 @@ mod tests {
         // order to simulate a condition where the VMM record was deleted
         // between when the listing query was run and when the bg task attempted
         // to delete the VMM record.
-        let paginator = Paginator::new(MAX_BATCH);
+        let paginator = Paginator::new(SQL_BATCH_SIZE);
         let p = paginator.next().unwrap();
         let abandoned_vmms = datastore
             .vmm_list_abandoned(&opctx, &p.current_pagparams())
@@ -399,19 +379,16 @@ mod tests {
             .await
             .expect("simulate another nexus marking the VMM deleted");
 
-        let mut results = ActivationResults::default();
-        let mut last_err = Ok(());
+        let mut status = AbandonedVmmReaperStatus::default();
         let mut task = AbandonedVmmReaper::new(datastore.clone());
-        task.reap_batch(&mut results, &mut last_err, &opctx, &abandoned_vmms)
-            .await;
-        dbg!(last_err).expect("should not have errored");
-        dbg!(&results);
+        task.reap_batch(&mut status, &opctx, &abandoned_vmms).await;
+        dbg!(&status);
 
-        assert_eq!(results.found, 1);
-        assert_eq!(results.vmms_deleted, 0);
-        assert_eq!(results.sled_reservations_deleted, 1);
-        assert_eq!(results.vmms_already_deleted, 1);
-        assert_eq!(results.error_count, 0);
+        assert_eq!(status.vmms_found, 1);
+        assert_eq!(status.vmms_deleted, 0);
+        assert_eq!(status.sled_reservations_deleted, 1);
+        assert_eq!(status.vmms_already_deleted, 1);
+        assert_eq!(status.errors, Vec::<String>::new());
 
         fixture.assert_reaped(datastore).await
     }
@@ -435,7 +412,7 @@ mod tests {
         // order to simulate a condition where the sled reservation record was
         // deleted between when the listing query was run and when the bg task
         // attempted to delete the sled reservation..
-        let paginator = Paginator::new(MAX_BATCH);
+        let paginator = Paginator::new(SQL_BATCH_SIZE);
         let p = paginator.next().unwrap();
         let abandoned_vmms = datastore
             .vmm_list_abandoned(&opctx, &p.current_pagparams())
@@ -454,19 +431,16 @@ mod tests {
                 "simulate another nexus marking the sled reservation deleted",
             );
 
-        let mut results = ActivationResults::default();
-        let mut last_err = Ok(());
+        let mut status = AbandonedVmmReaperStatus::default();
         let mut task = AbandonedVmmReaper::new(datastore.clone());
-        task.reap_batch(&mut results, &mut last_err, &opctx, &abandoned_vmms)
-            .await;
-        dbg!(last_err).expect("should not have errored");
-        dbg!(&results);
+        task.reap_batch(&mut status, &opctx, &abandoned_vmms).await;
+        dbg!(&status);
 
-        assert_eq!(results.found, 1);
-        assert_eq!(results.vmms_deleted, 1);
-        assert_eq!(results.sled_reservations_deleted, 1);
-        assert_eq!(results.vmms_already_deleted, 0);
-        assert_eq!(results.error_count, 0);
+        assert_eq!(status.vmms_found, 1);
+        assert_eq!(status.vmms_deleted, 1);
+        assert_eq!(status.sled_reservations_deleted, 1);
+        assert_eq!(status.vmms_already_deleted, 0);
+        assert_eq!(status.errors, Vec::<String>::new());
 
         fixture.assert_reaped(datastore).await
     }

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -70,9 +70,7 @@ impl InstanceUpdater {
                         "{ERR_MSG} {what}";
                         "error" => &error,
                     );
-                    status
-                        .query_errors
-                        .push(format!("{ERR_MSG} {what}: {error}"));
+                    status.errors.push(format!("{ERR_MSG} {what}: {error}"));
                     Vec::new()
                 }
             }
@@ -134,6 +132,9 @@ impl InstanceUpdater {
                      `JoinSet`, a `JoinError` should never be observed!";
                     debug_assert!(false, "{MSG}");
                     error!(opctx.log, "{MSG}"; "error" => ?err);
+                    status
+                        .saga_errors
+                        .push((None, format!("unexpected JoinError: {err}")));
                 }
                 Ok(Err((instance_id, err))) => {
                     const MSG: &'static str = "update saga failed";
@@ -143,7 +144,9 @@ impl InstanceUpdater {
                         "instance_id" => %instance_id,
                         "error" => &err,
                     );
-                    status.saga_errors.push((instance_id, err.to_string()));
+                    status
+                        .saga_errors
+                        .push((Some(instance_id), err.to_string()));
                 }
                 Ok(Ok(())) => status.sagas_completed += 1,
             }
@@ -195,7 +198,7 @@ impl InstanceUpdater {
                     );
                     status
                         .saga_errors
-                        .push((instance_id, format!("{ERR_MSG}: {err}")));
+                        .push((Some(instance_id), format!("{ERR_MSG}: {err}")));
                 }
             }
         }

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -8,7 +8,6 @@ use crate::app::background::BackgroundTask;
 use crate::app::saga::StartSaga;
 use crate::app::sagas::instance_update;
 use crate::app::sagas::NexusSaga;
-use anyhow::Context;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use nexus_db_model::Instance;
@@ -18,11 +17,14 @@ use nexus_db_queries::db::lookup::LookupPath;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::{authn, authz};
 use nexus_types::identity::Resource;
+use nexus_types::internal_api::background::InstanceUpdaterStatus;
+use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
 use serde_json::json;
 use std::future::Future;
 use std::sync::Arc;
 use tokio::task::JoinSet;
+use uuid::Uuid;
 
 pub struct InstanceUpdater {
     datastore: Arc<DataStore>,
@@ -42,12 +44,12 @@ impl InstanceUpdater {
     async fn actually_activate(
         &mut self,
         opctx: &OpContext,
-        stats: &mut ActivationStats,
-    ) -> Result<(), anyhow::Error> {
+        status: &mut InstanceUpdaterStatus,
+    ) {
         async fn find_instances(
             what: &'static str,
             log: &slog::Logger,
-            last_err: &mut Result<(), anyhow::Error>,
+            status: &mut InstanceUpdaterStatus,
             query: impl Future<Output = ListResultVec<Instance>>,
         ) -> Vec<Instance> {
             slog::debug!(&log, "looking for instances with {what}...");
@@ -61,20 +63,21 @@ impl InstanceUpdater {
                     list
                 }
                 Err(error) => {
+                    const ERR_MSG: &'static str =
+                        "failed to list instances with ";
                     slog::error!(
                         &log,
-                        "failed to list instances with {what}";
-                        "error" => %error,
+                        "{ERR_MSG} {what}";
+                        "error" => &error,
                     );
-                    *last_err = Err(error).with_context(|| {
-                        format!("failed to find instances with {what}",)
-                    });
+                    status
+                        .query_errors
+                        .push(format!("{ERR_MSG} {what}: {error}"));
                     Vec::new()
                 }
             }
         }
 
-        let mut last_err = Ok(());
         let mut sagas = JoinSet::new();
 
         // NOTE(eliza): These don't, strictly speaking, need to be two separate
@@ -84,52 +87,39 @@ impl InstanceUpdater {
         let destroyed_active_vmms = find_instances(
             "destroyed active VMMs",
             &opctx.log,
-            &mut last_err,
+            status,
             self.datastore
                 .find_instances_by_active_vmm_state(opctx, VmmState::Destroyed),
         )
         .await;
-        stats.destroyed_active_vmms = destroyed_active_vmms.len();
-        self.start_sagas(
-            &opctx,
-            stats,
-            &mut last_err,
-            &mut sagas,
-            destroyed_active_vmms,
-        )
-        .await;
+        status.destroyed_active_vmms = destroyed_active_vmms.len();
+        self.start_sagas(&opctx, status, &mut sagas, destroyed_active_vmms)
+            .await;
 
         let failed_active_vmms = find_instances(
             "failed active VMMs",
             &opctx.log,
-            &mut last_err,
+            status,
             self.datastore
                 .find_instances_by_active_vmm_state(opctx, VmmState::Failed),
         )
         .await;
-        stats.failed_active_vmms = failed_active_vmms.len();
-        self.start_sagas(
-            &opctx,
-            stats,
-            &mut last_err,
-            &mut sagas,
-            failed_active_vmms,
-        )
-        .await;
+        status.failed_active_vmms = failed_active_vmms.len();
+        self.start_sagas(&opctx, status, &mut sagas, failed_active_vmms).await;
 
         let terminated_active_migrations = find_instances(
             "terminated active migrations",
             &opctx.log,
-            &mut last_err,
+            status,
             self.datastore
                 .find_instances_with_terminated_active_migrations(opctx),
         )
         .await;
-        stats.terminated_active_migrations = terminated_active_migrations.len();
+        status.terminated_active_migrations =
+            terminated_active_migrations.len();
         self.start_sagas(
             &opctx,
-            stats,
-            &mut last_err,
+            status,
             &mut sagas,
             terminated_active_migrations,
         )
@@ -139,33 +129,32 @@ impl InstanceUpdater {
         while let Some(saga_result) = sagas.join_next().await {
             match saga_result {
                 Err(err) => {
-                    debug_assert!(
-                        false,
-                        "since nexus is compiled with `panic=\"abort\"`, and \
-                         we never cancel the tasks on the `JoinSet`, a \
-                         `JoinError` should never be observed!",
+                    const MSG: &'static str = "since nexus is compiled with \
+                     `panic=\"abort\"`, and we never cancel the tasks on the \
+                     `JoinSet`, a `JoinError` should never be observed!";
+                    debug_assert!(false, "{MSG}");
+                    error!(opctx.log, "{MSG}"; "error" => ?err);
+                }
+                Ok(Err((instance_id, err))) => {
+                    const MSG: &'static str = "update saga failed";
+                    warn!(
+                        opctx.log,
+                        "{MSG}!";
+                        "instance_id" => %instance_id,
+                        "error" => &err,
                     );
-                    stats.sagas_failed += 1;
-                    last_err = Err(err.into());
+                    status.saga_errors.push((instance_id, err.to_string()));
                 }
-                Ok(Err(err)) => {
-                    warn!(opctx.log, "update saga failed!"; "error" => %err);
-                    stats.sagas_failed += 1;
-                    last_err = Err(err);
-                }
-                Ok(Ok(())) => stats.sagas_completed += 1,
+                Ok(Ok(())) => status.sagas_completed += 1,
             }
         }
-
-        last_err
     }
 
     async fn start_sagas(
         &self,
         opctx: &OpContext,
-        stats: &mut ActivationStats,
-        last_err: &mut Result<(), anyhow::Error>,
-        sagas: &mut JoinSet<Result<(), anyhow::Error>>,
+        status: &mut InstanceUpdaterStatus,
+        sagas: &mut JoinSet<Result<(), (Uuid, Error)>>,
         instances: impl IntoIterator<Item = Instance>,
     ) {
         let serialized_authn = authn::saga::Serialized::for_opctx(opctx);
@@ -183,45 +172,34 @@ impl InstanceUpdater {
                         authz_instance,
                     },
                 )
-                .with_context(|| {
-                    format!("failed to prepare instance-update saga for {instance_id}")
-                })
             }
             .await;
             match saga {
                 Ok(saga) => {
                     let start_saga = self.sagas.clone();
                     sagas.spawn(async move {
-                        start_saga.saga_start(saga).await.with_context(|| {
-                            format!("update saga for {instance_id} failed")
-                        })
+                        start_saga
+                            .saga_start(saga)
+                            .await
+                            .map_err(|e| (instance_id, e))
                     });
-                    stats.sagas_started += 1;
+                    status.sagas_started += 1;
                 }
                 Err(err) => {
+                    const ERR_MSG: &str = "failed to start update saga";
                     warn!(
                         opctx.log,
-                        "failed to start instance-update saga!";
+                        "{ERR_MSG}!";
                         "instance_id" => %instance_id,
                         "error" => %err,
                     );
-                    stats.saga_start_failures += 1;
-                    *last_err = Err(err);
+                    status
+                        .saga_errors
+                        .push((instance_id, format!("{ERR_MSG}: {err}")));
                 }
             }
         }
     }
-}
-
-#[derive(Default)]
-struct ActivationStats {
-    destroyed_active_vmms: usize,
-    failed_active_vmms: usize,
-    terminated_active_migrations: usize,
-    sagas_started: usize,
-    sagas_completed: usize,
-    sagas_failed: usize,
-    saga_start_failures: usize,
 }
 
 impl BackgroundTask for InstanceUpdater {
@@ -230,64 +208,40 @@ impl BackgroundTask for InstanceUpdater {
         opctx: &'a OpContext,
     ) -> BoxFuture<'a, serde_json::Value> {
         async {
-            let mut stats = ActivationStats::default();
+            let mut status = InstanceUpdaterStatus::default();
 
-            let error = if self.disable {
+            if self.disable {
                 slog::info!(&opctx.log, "background instance updater explicitly disabled");
-                None
+                status.disabled = true;
+                return json!(status);
+            }
+
+            self.actually_activate(opctx, &mut status).await;
+            if status.errors() == 0 {
+                slog::info!(
+                    &opctx.log,
+                    "instance updater activation completed";
+                    "destroyed_active_vmms" => status.destroyed_active_vmms,
+                    "failed_active_vmms" => status.failed_active_vmms,
+                    "terminated_active_migrations" => status.terminated_active_migrations,
+                    "update_sagas_started" => status.sagas_started,
+                    "update_sagas_completed" => status.sagas_completed,
+                );
             } else {
-                match self.actually_activate(opctx, &mut stats).await {
-                    Ok(()) => {
-                        slog::info!(
-                            &opctx.log,
-                            "instance updater activation completed";
-                            "destroyed_active_vmms" => stats.destroyed_active_vmms,
-                            "failed_active_vmms" => stats.failed_active_vmms,
-                            "terminated_active_migrations" => stats.terminated_active_migrations,
-                            "update_sagas_started" => stats.sagas_started,
-                            "update_sagas_completed" => stats.sagas_completed,
-                        );
-                        debug_assert_eq!(
-                            stats.sagas_failed,
-                            0,
-                            "if the task completed successfully, then no sagas \
-                            should have failed",
-                        );
-                        debug_assert_eq!(
-                            stats.saga_start_failures,
-                            0,
-                            "if the task completed successfully, all sagas \
-                            should have started successfully"
-                        );
-                        None
-                    }
-                    Err(error) => {
-                        slog::warn!(
-                            &opctx.log,
-                            "instance updater activation failed!";
-                            "error" => %error,
-                            "destroyed_active_vmms" => stats.destroyed_active_vmms,
-                            "failed_active_vmms" => stats.failed_active_vmms,
-                            "terminated_active_migrations" => stats.terminated_active_migrations,
-                            "update_sagas_started" => stats.sagas_started,
-                            "update_sagas_completed" => stats.sagas_completed,
-                            "update_sagas_failed" => stats.sagas_failed,
-                            "update_saga_start_failures" => stats.saga_start_failures,
-                        );
-                        Some(error.to_string())
-                    }
-                }
+                slog::error!(
+                    &opctx.log,
+                    "instance updater activation failed!";
+                    "query_errors" => status.query_errors.len(),
+                    "saga_errors" => status.saga_errors.len(),
+                    "destroyed_active_vmms" => status.destroyed_active_vmms,
+                    "failed_active_vmms" => status.failed_active_vmms,
+                    "terminated_active_migrations" => status.terminated_active_migrations,
+                    "update_sagas_started" => status.sagas_started,
+                    "update_sagas_completed" => status.sagas_completed,
+                );
             };
-            json!({
-                "destroyed_active_vmms": stats.destroyed_active_vmms,
-                "failed_active_vmms": stats.failed_active_vmms,
-                "terminated_active_migrations": stats.terminated_active_migrations,
-                "sagas_started": stats.sagas_started,
-                "sagas_completed": stats.sagas_completed,
-                "sagas_failed": stats.sagas_failed,
-                "saga_start_failures": stats.saga_start_failures,
-                "error": error,
-            })
+
+            json!(status)
         }
         .boxed()
     }

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -70,7 +70,9 @@ impl InstanceUpdater {
                         "{ERR_MSG} {what}";
                         "error" => &error,
                     );
-                    status.errors.push(format!("{ERR_MSG} {what}: {error}"));
+                    status
+                        .query_errors
+                        .push(format!("{ERR_MSG} {what}: {error}"));
                     Vec::new()
                 }
             }

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -88,7 +88,7 @@ pub struct InstanceUpdaterStatus {
 
     /// errors returned by instance update sagas which failed, and the UUID of
     /// the instance which could not be updated.
-    pub saga_errors: Vec<(Uuid, String)>,
+    pub saga_errors: Vec<(Option<Uuid>, String)>,
 
     /// errors which occurred while querying the database for instances in need
     /// of updates.

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -53,3 +53,13 @@ pub struct RegionSnapshotReplacementFinishStatus {
     pub records_set_to_done: Vec<String>,
     pub errors: Vec<String>,
 }
+
+/// The status of an `abandoned_vmm_reaper` background task activation.
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
+pub struct AbandonedVmmReaperStatus {
+    pub vmms_found: usize,
+    pub sled_reservations_deleted: usize,
+    pub vmms_deleted: usize,
+    pub vmms_already_deleted: usize,
+    pub errors: Vec<String>,
+}


### PR DESCRIPTION
Depends on #6541.

Similarly to #6541, this commit refactors the `instance_updater`
background task's OMDB status implementation to use a shared Rust struct
in `nexus-types` to represent the status JSON object. I also changed the
status message to include a full list of errors that occurred, instead
of just the most recent one and a count, and I made some tweaks to the
output alignment in OMDB.