### PR TITLE
omdb: Add sled state to blueprint displays and diffs

### DIFF
--- a/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
+++ b/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
@@ -2,7 +2,7 @@ from: collection 094d362b-7d79-49e7-a244-134276cca8fe
 to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
  UNCHANGED SLEDS:
 
-  sled 08c7046b-c9c4-4368-881f-19a72df22143:
+  sled 08c7046b-c9c4-4368-881f-19a72df22143 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -39,7 +39,7 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     nexus          b2573120-9c91-4ed7-8b4f-a7bfe8dbc807   in service    fd00:1122:3344:103::22
 
 
-  sled 84ac367e-9b03-4e9d-a846-df1a08deee6c:
+  sled 84ac367e-9b03-4e9d-a846-df1a08deee6c (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -76,7 +76,7 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     nexus          a9a6a974-8953-4783-b815-da46884f2c02   in service    fd00:1122:3344:101::22
 
 
-  sled be7f4375-2a6b-457f-b1a4-3074a715e5fe:
+  sled be7f4375-2a6b-457f-b1a4-3074a715e5fe (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -3,7 +3,7 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
  UNCHANGED SLEDS:
 
-  sled 41f45d9f-766e-4ca6-a881-61ee45c80f57:
+  sled 41f45d9f-766e-4ca6-a881-61ee45c80f57 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -40,7 +40,7 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     nexus          cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
 
 
-  sled 43677374-8d2f-4deb-8a41-eeea506db8e0:
+  sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -77,7 +77,7 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     nexus          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:101::22
 
 
-  sled 590e3034-d946-4166-b0e5-2d0034197a07:
+  sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -116,7 +116,7 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
  ADDED SLEDS:
 
-  sled b59ec570-2abb-4017-80ce-129d94e7a025:
+  sled b59ec570-2abb-4017-80ce-129d94e7a025 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -3,7 +3,7 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
  UNCHANGED SLEDS:
 
-  sled 41f45d9f-766e-4ca6-a881-61ee45c80f57:
+  sled 41f45d9f-766e-4ca6-a881-61ee45c80f57 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -40,7 +40,7 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     nexus          cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
 
 
-  sled 43677374-8d2f-4deb-8a41-eeea506db8e0:
+  sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -77,7 +77,7 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     nexus          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:101::22
 
 
-  sled 590e3034-d946-4166-b0e5-2d0034197a07:
+  sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -116,7 +116,7 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
  MODIFIED SLEDS:
 
-  sled b59ec570-2abb-4017-80ce-129d94e7a025:
+  sled b59ec570-2abb-4017-80ce-129d94e7a025 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -3,7 +3,7 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
  MODIFIED SLEDS:
 
-  sled a1b477db-b629-48eb-911d-1ccdafca75b9:
+  sled a1b477db-b629-48eb-911d-1ccdafca75b9 (active -> decommissioned):
 
     physical disks from generation 1:
     ----------------------------------------------------------------------
@@ -53,7 +53,7 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
      └─                                                   + expunged                           
 
 
-  sled d67ce8f0-a691-4010-b414-420d82e80527:
+  sled d67ce8f0-a691-4010-b414-420d82e80527 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -91,7 +91,7 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 +   nexus          ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:101::2d
 
 
-  sled fefcf4cf-f7e7-46b3-b629-058526ce440e:
+  sled fefcf4cf-f7e7-46b3-b629-058526ce440e (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -1,7 +1,7 @@
 blueprint  1ac2d88f-27dd-4506-8585-6b2be832528e
 parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
-  sled: d67ce8f0-a691-4010-b414-420d82e80527
+  sled: d67ce8f0-a691-4010-b414-420d82e80527 (active)
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -40,7 +40,7 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 
 
-  sled: fefcf4cf-f7e7-46b3-b629-058526ce440e
+  sled: fefcf4cf-f7e7-46b3-b629-058526ce440e (active)
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -3,7 +3,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
  UNCHANGED SLEDS:
 
-  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9:
+  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -42,7 +42,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
  MODIFIED SLEDS:
 
-  sled 48d95fef-bc9f-4f50-9a53-1e075836291d:
+  sled 48d95fef-bc9f-4f50-9a53-1e075836291d (active -> decommissioned):
 
     physical disks from generation 1:
     ----------------------------------------------------------------------
@@ -92,7 +92,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
      └─                                                   + expunged                           
 
 
-  sled 68d24ac5-f341-49ea-a92a-0381b52ab387:
+  sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (active):
 
     physical disks from generation 1:
     ----------------------------------------------------------------------
@@ -129,7 +129,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     nexus          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::22
 
 
-  sled 75bc286f-2b4b-482c-9431-59272af529da:
+  sled 75bc286f-2b4b-482c-9431-59272af529da (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -169,7 +169,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 +   nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
 
 
-  sled affab35f-600a-4109-8ea0-34a067a4e0bc:
+  sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -3,7 +3,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
  UNCHANGED SLEDS:
 
-  sled 75bc286f-2b4b-482c-9431-59272af529da:
+  sled 75bc286f-2b4b-482c-9431-59272af529da (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -43,7 +43,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
 
 
-  sled affab35f-600a-4109-8ea0-34a067a4e0bc:
+  sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -83,32 +83,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
 
 
- REMOVED SLEDS:
-
-  sled 68d24ac5-f341-49ea-a92a-0381b52ab387:
-
-    omicron zones from generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
--   crucible       3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::29
--   crucible       57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::2a
--   crucible       6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::26
--   crucible       8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::28
--   crucible       9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::23
--   crucible       b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::24
--   crucible       b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::2b
--   crucible       b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:102::25
--   crucible       c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::27
--   crucible       e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::2c
--   internal_dns   878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:3::1   
--   internal_ntp   47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:102::21
--   nexus          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::22
-
-
  MODIFIED SLEDS:
 
-  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9:
+  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active):
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -144,7 +121,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
      └─                                                   + quiesced                           
 
 
-  sled 48d95fef-bc9f-4f50-9a53-1e075836291d:
+  sled 48d95fef-bc9f-4f50-9a53-1e075836291d (decommissioned):
 
     omicron zones generation 3 -> 4:
     ------------------------------------------------------------------------------------------
@@ -163,6 +140,27 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   internal_dns   56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:2::1   
 -   internal_ntp   2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   expunged      fd00:1122:3344:103::21
 -   nexus          67622d61-2df4-414d-aa0e-d1277265f405   expunged      fd00:1122:3344:103::22
+
+
+  sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (active):
+
+    omicron zones from generation 2:
+    ------------------------------------------------------------------------------------------
+    zone type      zone id                                disposition   underlay IP           
+    ------------------------------------------------------------------------------------------
+-   crucible       3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::29
+-   crucible       57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::2a
+-   crucible       6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::26
+-   crucible       8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::28
+-   crucible       9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::23
+-   crucible       b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::24
+-   crucible       b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::2b
+-   crucible       b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:102::25
+-   crucible       c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::27
+-   crucible       e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::2c
+-   internal_dns   878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:3::1   
+-   internal_ntp   47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:102::21
+-   nexus          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::22
 
 
 ERRORS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -1,7 +1,7 @@
 blueprint  9f71f5d3-a272-4382-9154-6ea2e171a6c6
 parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
-  sled: 2d1cb4f2-cf44-40fc-b118-85036eb732a9
+  sled: 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active)
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -39,7 +39,7 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 
 
-  sled: 75bc286f-2b4b-482c-9431-59272af529da
+  sled: 75bc286f-2b4b-482c-9431-59272af529da (active)
 
     physical disks at generation 1:
     ----------------------------------------------------------------------
@@ -80,7 +80,7 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 
 
-  sled: affab35f-600a-4109-8ea0-34a067a4e0bc
+  sled: affab35f-600a-4109-8ea0-34a067a4e0bc (active)
 
     physical disks at generation 1:
     ----------------------------------------------------------------------

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -438,6 +438,16 @@ impl<'a> fmt::Display for BlueprintDisplay<'a> {
                 disks.rows(BpDiffState::Unchanged).collect(),
             );
 
+            // Look up the sled state
+            let sled_state = self
+                .blueprint
+                .sled_state
+                .get(sled_id)
+                .map(|state| state.to_string())
+                .unwrap_or_else(|| {
+                    "blueprint error: unknown sled state".to_string()
+                });
+
             // Construct the zones subtable
             match self.blueprint.blueprint_zones.get(sled_id) {
                 Some(zones) => {
@@ -450,10 +460,13 @@ impl<'a> fmt::Display for BlueprintDisplay<'a> {
                     );
                     writeln!(
                         f,
-                        "\n  sled: {sled_id}\n\n{disks_table}\n\n{zones_tab}\n"
+                        "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n\n{zones_tab}\n"
                     )?;
                 }
-                None => writeln!(f, "\n  sled: {sled_id}\n\n{disks_table}\n")?,
+                None => writeln!(
+                    f,
+                    "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n"
+                )?,
             }
             seen_sleds.insert(sled_id);
         }


### PR DESCRIPTION
On `main`, omdb shows this for the confusing blueprint on dogfood from oxidecomputer/product-assurance#52:

```
root@oxz_switch0:/var/tmp/john# omdb nexus blueprints diff 430f5c6b-3156-4921-8ddc-74560989c8f4 3eb67393-bdbc-4957-98c2-36cc60e3e901
... snip unchanged sleds ...

 MODIFIED SLEDS:

  sled 1efda86b-caef-489f-9792-589d7677e59a:

    physical disks from generation 1:
    -----------------------------------
    vendor   model             serial
    -----------------------------------
-   1b96     WUS4C6432DSP3X3   A079DDFD
-   1b96     WUS4C6432DSP3X3   A079DE08
-   1b96     WUS4C6432DSP3X3   A079DE11
-   1b96     WUS4C6432DSP3X3   A079DEA7
-   1b96     WUS4C6432DSP3X3   A079DEAF
-   1b96     WUS4C6432DSP3X3   A079DF11
-   1b96     WUS4C6432DSP3X3   A079DFA7
-   1b96     WUS4C6432DSP3X3   A079DFCA
-   1b96     WUS4C6432DSP3X3   A079E02E
-   1b96     WUS4C6432DSP3X3   A079E076


    omicron zones generation 3 -> 4:
    -------------------------------------------------------------------------------------------
    zone type      zone id                                disposition    underlay IP
    -------------------------------------------------------------------------------------------
*   crucible       09f14045-df78-447a-b7d8-217e0ca8ee09   - in service   fd00:1122:3344:124::24
     └─                                                   + expunged
*   crucible       3ec0e848-39de-495e-be0e-88241e11d0fb   - in service   fd00:1122:3344:124::22
     └─                                                   + expunged
*   crucible       562c58dc-2408-415e-a005-eb80d1769d10   - in service   fd00:1122:3344:124::28
     └─                                                   + expunged
*   crucible       568f842d-3cd3-4901-97f8-94991c2e9938   - in service   fd00:1122:3344:124::25
     └─                                                   + expunged
*   crucible       5f3fbd1c-5513-4527-88b5-d07c8fbf71e0   - in service   fd00:1122:3344:124::29
     └─                                                   + expunged
*   crucible       6632cd6f-ade4-415f-ad65-b510d4ead12d   - in service   fd00:1122:3344:124::23
     └─                                                   + expunged
*   crucible       6ca6aa76-c32b-402c-a1ac-751f12d5bdd9   - in service   fd00:1122:3344:124::2b
     └─                                                   + expunged
*   crucible       9a475569-439c-4749-b78f-eba2096b2131   - in service   fd00:1122:3344:124::26
     └─                                                   + expunged
*   crucible       bac40327-4eeb-429d-94e1-d3c0525266a2   - in service   fd00:1122:3344:124::2a
     └─                                                   + expunged
*   crucible       eb71bb55-37fb-4fc4-bdee-a5382a480271   - in service   fd00:1122:3344:124::27
     └─                                                   + expunged
*   internal_ntp   bfea30f1-9ea6-496d-aeb9-ae126ea4f686   - in service   fd00:1122:3344:124::21
     └─                                                   + expunged


 ADDED SLEDS:

  sled 05652dc1-b811-4cac-95e1-d32633f2ba75:

 COCKROACHDB SETTINGS:
    state fingerprint:::::::::::::::::   d4d87aa2ad877a4cc2fddd0573952362739110de (unchanged)
    cluster.preserve_downgrade_option:   "22.1" (unchanged)

 METADATA:
*   internal DNS version:   5 -> 6
    external DNS version:   31 (unchanged)
```

As of this branch, we get parenthetical state information on the `sled $SLED_ID:` lines:

```
 MODIFIED SLEDS:

  sled 1efda86b-caef-489f-9792-589d7677e59a (active -> decommissioned):

    physical disks from generation 1:
    -----------------------------------
    vendor   model             serial
    -----------------------------------
-   1b96     WUS4C6432DSP3X3   A079DDFD
-   1b96     WUS4C6432DSP3X3   A079DE08
-   1b96     WUS4C6432DSP3X3   A079DE11
-   1b96     WUS4C6432DSP3X3   A079DEA7
-   1b96     WUS4C6432DSP3X3   A079DEAF
-   1b96     WUS4C6432DSP3X3   A079DF11
-   1b96     WUS4C6432DSP3X3   A079DFA7
-   1b96     WUS4C6432DSP3X3   A079DFCA
-   1b96     WUS4C6432DSP3X3   A079E02E
-   1b96     WUS4C6432DSP3X3   A079E076


    omicron zones generation 3 -> 4:
    -------------------------------------------------------------------------------------------
    zone type      zone id                                disposition    underlay IP
    -------------------------------------------------------------------------------------------
*   crucible       09f14045-df78-447a-b7d8-217e0ca8ee09   - in service   fd00:1122:3344:124::24
     └─                                                   + expunged
*   crucible       3ec0e848-39de-495e-be0e-88241e11d0fb   - in service   fd00:1122:3344:124::22
     └─                                                   + expunged
*   crucible       562c58dc-2408-415e-a005-eb80d1769d10   - in service   fd00:1122:3344:124::28
     └─                                                   + expunged
*   crucible       568f842d-3cd3-4901-97f8-94991c2e9938   - in service   fd00:1122:3344:124::25
     └─                                                   + expunged
*   crucible       5f3fbd1c-5513-4527-88b5-d07c8fbf71e0   - in service   fd00:1122:3344:124::29
     └─                                                   + expunged
*   crucible       6632cd6f-ade4-415f-ad65-b510d4ead12d   - in service   fd00:1122:3344:124::23
     └─                                                   + expunged
*   crucible       6ca6aa76-c32b-402c-a1ac-751f12d5bdd9   - in service   fd00:1122:3344:124::2b
     └─                                                   + expunged
*   crucible       9a475569-439c-4749-b78f-eba2096b2131   - in service   fd00:1122:3344:124::26
     └─                                                   + expunged
*   crucible       bac40327-4eeb-429d-94e1-d3c0525266a2   - in service   fd00:1122:3344:124::2a
     └─                                                   + expunged
*   crucible       eb71bb55-37fb-4fc4-bdee-a5382a480271   - in service   fd00:1122:3344:124::27
     └─                                                   + expunged
*   internal_ntp   bfea30f1-9ea6-496d-aeb9-ae126ea4f686   - in service   fd00:1122:3344:124::21
     └─                                                   + expunged


 ADDED SLEDS:

  sled 05652dc1-b811-4cac-95e1-d32633f2ba75 (decommissioned):

 COCKROACHDB SETTINGS:
    state fingerprint:::::::::::::::::   d4d87aa2ad877a4cc2fddd0573952362739110de (unchanged)
    cluster.preserve_downgrade_option:   "22.1" (unchanged)

 METADATA:
*   internal DNS version:   5 -> 6
    external DNS version:   31 (unchanged)
```

The empty sled added block is still kinda confusing, but I think the note that the added sled is starting out in the `decommissioned` state is at least a reasonable pointer to an explanation of what's going on.

Fixes #6544.