### PR TITLE
[reconfigurator] Retrieve keeper lgif information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,9 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "slog",
+ "slog-async",
+ "slog-term",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,6 +5929,7 @@ dependencies = [
  "clap",
  "clickhouse-admin-api",
  "clickhouse-admin-types",
+ "clickward",
  "dropshot 0.10.2-dev",
  "expectorate",
  "http 0.2.12",
@@ -5940,6 +5941,8 @@ dependencies = [
  "omicron-workspace-hack",
  "openapi-lint",
  "openapiv3",
+ "oximeter-db",
+ "oximeter-test-utils",
  "schemars",
  "serde",
  "serde_json",
@@ -7241,10 +7244,14 @@ dependencies = [
 name = "oximeter-test-utils"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
+ "clickward",
+ "omicron-test-utils",
  "omicron-workspace-hack",
  "oximeter-macro-impl",
  "oximeter-types",
+ "slog",
  "uuid",
 ]
 

--- a/clickhouse-admin/Cargo.toml
+++ b/clickhouse-admin/Cargo.toml
@@ -30,9 +30,13 @@ toml.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+clickward.workspace = true
+dropshot.workspace = true
 expectorate.workspace = true
 nexus-test-utils.workspace = true
 omicron-test-utils.workspace = true
+oximeter-db.workspace = true
+oximeter-test-utils.workspace = true
 openapi-lint.workspace = true
 openapiv3.workspace = true
 serde_json.workspace = true

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
 use clickhouse_admin_types::{KeeperSettings, ServerSettings};
-use dropshot::{HttpError, HttpResponseCreated, RequestContext, TypedBody};
+use dropshot::{HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody};
 use omicron_common::api::external::Generation;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -50,4 +50,16 @@ pub trait ClickhouseAdminApi {
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<KeeperConfigurableSettings>,
     ) -> Result<HttpResponseCreated<KeeperConfig>, HttpError>;
+
+    /// Retrieve a logically grouped information file from a keeper node.
+    /// This information is used internally by ZooKeeper to manage snapshots
+    /// and logs for consistency and recovery.
+    #[endpoint {
+        method = GET,
+        path = "/keeper/lgif",
+    }]
+    async fn lgif(
+        rqctx: RequestContext<Self::Context>,
+        // TODO: Actually return something useful
+    ) -> Result<HttpResponseOk<String>, HttpError>;
 }

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -3,8 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
-use clickhouse_admin_types::{KeeperSettings, ServerSettings};
-use dropshot::{HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody};
+use clickhouse_admin_types::{KeeperSettings, Lgif, ServerSettings};
+use dropshot::{
+    HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody,
+};
 use omicron_common::api::external::Generation;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -60,6 +62,5 @@ pub trait ClickhouseAdminApi {
     }]
     async fn lgif(
         rqctx: RequestContext<Self::Context>,
-        // TODO: Actually return something useful
-    ) -> Result<HttpResponseOk<String>, HttpError>;
+    ) -> Result<HttpResponseOk<Lgif>, HttpError>;
 }

--- a/clickhouse-admin/src/bin/clickhouse-admin.rs
+++ b/clickhouse-admin/src/bin/clickhouse-admin.rs
@@ -54,11 +54,12 @@ async fn main_impl() -> Result<(), CmdError> {
                 .map_err(|err| CmdError::Failure(anyhow!(err)))?;
             config.dropshot.bind_address = SocketAddr::V6(http_address);
             let clickward = Clickward::new();
-            let keeper_client = ClickhouseCli::new(binary_path, listen_address);
+            let clickhouse_cli =
+                ClickhouseCli::new(binary_path, listen_address);
 
             let server = omicron_clickhouse_admin::start_server(
                 clickward,
-                keeper_client,
+                clickhouse_cli,
                 config,
             )
             .await

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -82,7 +82,7 @@ impl ClickhouseCli {
         .await
     }
 
-    async fn keeper_client_non_interactive<'a, F, T>(
+    async fn keeper_client_non_interactive<F, T>(
         &self,
         query: &str,
         subcommand_description: &'static str,
@@ -103,15 +103,15 @@ impl ClickhouseCli {
             .arg(query);
 
         let output = command.output().await.map_err(|err| {
-            let args: Vec<&OsStr> = command.as_std().get_args().collect();
-            let args_parsed: Vec<String> = args
+            let err_args: Vec<&OsStr> = command.as_std().get_args().collect();
+            let err_args_parsed: Vec<String> = err_args
                 .iter()
-                .map(|&os_str| os_str.to_str().unwrap().to_owned())
+                .map(|&os_str| os_str.to_string_lossy().into_owned())
                 .collect();
-            let args_str = args_parsed.join(" ");
+            let err_args_str = err_args_parsed.join(" ");
             ClickhouseCliError::Run {
                 description: subcommand_description,
-                subcommand: args_str,
+                subcommand: err_args_str,
                 err,
             }
         })?;

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use dropshot::HttpError;
+use illumos_utils::{ExecutionError, output_to_exec_error};
+use slog_error_chain::{InlineErrorChain, SlogInlineError};
+use std::ffi::OsStr;
+use std::io;
+use std::net::SocketAddrV6;
+use tokio::process::Command;
+
+#[derive(Debug, thiserror::Error, SlogInlineError)]
+pub enum ClickhouseCliError {
+    #[error("failed to run `clickhouse {subcommand}`")]
+    Run {
+        description: &'static str,
+        subcommand: String,
+        #[source]
+        err: io::Error,
+    },
+    #[error(transparent)]
+    ExecutionError(#[from] ExecutionError),
+}
+
+impl From<ClickhouseCliError> for HttpError {
+    fn from(err: ClickhouseCliError) -> Self {
+        match err {
+            ClickhouseCliError::Run { .. }
+            | ClickhouseCliError::ExecutionError(_) => {
+                let message = InlineErrorChain::new(&err).to_string();
+                HttpError {
+                    status_code: http::StatusCode::INTERNAL_SERVER_ERROR,
+                    error_code: Some(String::from("Internal")),
+                    external_message: message.clone(),
+                    internal_message: message,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ClickhouseCli {
+    /// Path to where the clickhouse binary is located
+    pub binary_path: Utf8PathBuf,
+    /// Address on where the clickhouse keeper is listening on
+    pub listen_address: SocketAddrV6,
+}
+
+impl ClickhouseCli {
+    pub fn new (binary_path: Utf8PathBuf, listen_address: SocketAddrV6) -> Self {
+        Self {binary_path, listen_address}
+    }
+
+    pub async fn lgif(&self) -> Result<String, ClickhouseCliError> {
+        self.keeper_client_non_interactive(
+            ["lgif"].into_iter(),
+            "Retrieve logically grouped information file",
+        )
+        .await
+    }
+
+    async fn keeper_client_non_interactive<'a, I>(
+        &self,
+        subcommand_args: I,
+        subcommand_description: &'static str,
+    ) -> Result<String, ClickhouseCliError>
+    where
+        I: Iterator<Item = &'a str>,
+    {
+        let mut command = Command::new(&self.binary_path);
+        command
+            .arg("keeper-client")
+            .arg("--host")
+            .arg(&format!("[{}]", self.listen_address.ip()))
+            .arg("--port")
+            .arg(&format!("{}", self.listen_address.port()))
+            .arg("--query");
+
+        let args: Vec<&'a str> = subcommand_args.collect();
+        let query = args.join(" ");
+        command.arg(query);
+
+        let output = command.output().await.map_err(|err| {
+            let args: Vec<&OsStr> = command.as_std().get_args().collect();
+            let args_parsed: Vec<String> = args
+                .iter()
+                .map(|&os_str| os_str.to_string_lossy().into_owned())
+                .collect();
+            let args_str = args_parsed.join(" ");
+            ClickhouseCliError::Run {
+                description: subcommand_description,
+                subcommand: args_str,
+                err,
+            }
+        })?;
+
+        if !output.status.success() {
+            return Err(output_to_exec_error(command.as_std(), &output).into());
+        }
+
+        // TODO: Actually parse this
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -74,7 +74,7 @@ impl ClickhouseCli {
 
     pub async fn lgif(&self) -> Result<Lgif, ClickhouseCliError> {
         self.keeper_client_non_interactive(
-            ["lgif"].into_iter(),
+            "lgif",
             "Retrieve logically grouped information file",
             Lgif::parse,
             self.log.clone().unwrap(),
@@ -82,15 +82,14 @@ impl ClickhouseCli {
         .await
     }
 
-    async fn keeper_client_non_interactive<'a, I, F, T>(
+    async fn keeper_client_non_interactive<'a, F, T>(
         &self,
-        subcommand_args: I,
+        query: &str,
         subcommand_description: &'static str,
         parse: F,
         log: Logger,
     ) -> Result<T, ClickhouseCliError>
     where
-        I: Iterator<Item = &'a str>,
         F: FnOnce(&Logger, &[u8]) -> Result<T>,
     {
         let mut command = Command::new(&self.binary_path);
@@ -100,11 +99,8 @@ impl ClickhouseCli {
             .arg(&format!("[{}]", self.listen_address.ip()))
             .arg("--port")
             .arg(&format!("{}", self.listen_address.port()))
-            .arg("--query");
-
-        let args: Vec<&'a str> = subcommand_args.collect();
-        let query = args.join(" ");
-        command.arg(query);
+            .arg("--query")
+            .arg(query);
 
         let output = command.output().await.map_err(|err| {
             let args: Vec<&OsStr> = command.as_std().get_args().collect();

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -39,7 +39,6 @@ impl From<ClickhouseCliError> for HttpError {
     fn from(err: ClickhouseCliError) -> Self {
         match err {
             ClickhouseCliError::Run { .. }
-            // TODO: Can I make this message better?
             | ClickhouseCliError::Parse { .. }
             | ClickhouseCliError::ExecutionError(_) => {
                 let message = InlineErrorChain::new(&err).to_string();

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -110,7 +110,7 @@ impl ClickhouseCli {
             let args: Vec<&OsStr> = command.as_std().get_args().collect();
             let args_parsed: Vec<String> = args
                 .iter()
-                .map(|&os_str| os_str.to_string_lossy().into_owned())
+                .map(|&os_str| os_str.to_str().unwrap().to_owned())
                 .collect();
             let args_str = args_parsed.join(" ");
             ClickhouseCliError::Run {

--- a/clickhouse-admin/src/context.rs
+++ b/clickhouse-admin/src/context.rs
@@ -2,20 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::Clickward;
+use crate::{ClickhouseCli, Clickward};
 use slog::Logger;
 
 pub struct ServerContext {
     clickward: Clickward,
+    clickhouse_cli: ClickhouseCli,
     _log: Logger,
 }
 
 impl ServerContext {
-    pub fn new(clickward: Clickward, _log: Logger) -> Self {
-        Self { clickward, _log }
+    pub fn new(
+        clickward: Clickward,
+        clickhouse_cli: ClickhouseCli,
+        _log: Logger,
+    ) -> Self {
+        Self { clickward, clickhouse_cli, _log }
     }
 
     pub fn clickward(&self) -> &Clickward {
         &self.clickward
+    }
+
+    pub fn clickhouse_cli(&self) -> &ClickhouseCli {
+        &self.clickhouse_cli
     }
 }

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -5,7 +5,7 @@
 use crate::context::ServerContext;
 use clickhouse_admin_api::*;
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
-use dropshot::{HttpError, HttpResponseCreated, RequestContext, TypedBody};
+use dropshot::{HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody};
 use std::sync::Arc;
 
 type ClickhouseApiDescription = dropshot::ApiDescription<Arc<ServerContext>>;
@@ -43,5 +43,13 @@ impl ClickhouseAdminApi for ClickhouseAdminImpl {
         // with the generation number `keeper.generation`
         let output = ctx.clickward().generate_keeper_config(keeper.settings)?;
         Ok(HttpResponseCreated(output))
+    }
+
+    async fn lgif(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<String>, HttpError> {
+        let ctx = rqctx.context();
+        let output = ctx.clickhouse_cli().lgif().await?;
+        Ok(HttpResponseOk(output))
     }
 }

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -5,7 +5,10 @@
 use crate::context::ServerContext;
 use clickhouse_admin_api::*;
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
-use dropshot::{HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody};
+use clickhouse_admin_types::Lgif;
+use dropshot::{
+    HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody,
+};
 use std::sync::Arc;
 
 type ClickhouseApiDescription = dropshot::ApiDescription<Arc<ServerContext>>;
@@ -47,7 +50,7 @@ impl ClickhouseAdminApi for ClickhouseAdminImpl {
 
     async fn lgif(
         rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<String>, HttpError> {
+    ) -> Result<HttpResponseOk<Lgif>, HttpError> {
         let ctx = rqctx.context();
         let output = ctx.clickhouse_cli().lgif().await?;
         Ok(HttpResponseOk(output))

--- a/clickhouse-admin/src/lib.rs
+++ b/clickhouse-admin/src/lib.rs
@@ -11,11 +11,13 @@ use std::error::Error;
 use std::io;
 use std::sync::Arc;
 
+mod clickhouse_cli;
 mod clickward;
 mod config;
 mod context;
 mod http_entrypoints;
 
+pub use clickhouse_cli::ClickhouseCli;
 pub use clickward::Clickward;
 pub use config::Config;
 
@@ -34,6 +36,7 @@ pub type Server = dropshot::HttpServer<Arc<ServerContext>>;
 /// Start the dropshot server
 pub async fn start_server(
     clickward: Clickward,
+    keeper_client: ClickhouseCli,
     server_config: Config,
 ) -> Result<Server, StartError> {
     let (drain, registration) = slog_dtrace::with_drain(
@@ -56,6 +59,7 @@ pub async fn start_server(
 
     let context = ServerContext::new(
         clickward,
+        keeper_client,
         log.new(slog::o!("component" => "ServerContext")),
     );
     let http_server_starter = dropshot::HttpServerStarter::new(

--- a/clickhouse-admin/src/lib.rs
+++ b/clickhouse-admin/src/lib.rs
@@ -36,7 +36,7 @@ pub type Server = dropshot::HttpServer<Arc<ServerContext>>;
 /// Start the dropshot server
 pub async fn start_server(
     clickward: Clickward,
-    keeper_client: ClickhouseCli,
+    clickhouse_cli: ClickhouseCli,
     server_config: Config,
 ) -> Result<Server, StartError> {
     let (drain, registration) = slog_dtrace::with_drain(
@@ -59,7 +59,8 @@ pub async fn start_server(
 
     let context = ServerContext::new(
         clickward,
-        keeper_client,
+        clickhouse_cli
+            .with_log(log.new(slog::o!("component" => "ClickhouseCli"))),
         log.new(slog::o!("component" => "ServerContext")),
     );
     let http_server_starter = dropshot::HttpServerStarter::new(

--- a/clickhouse-admin/tests/integration_test.rs
+++ b/clickhouse-admin/tests/integration_test.rs
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::Context;
+use camino::Utf8PathBuf;
+use clickward::{BasePorts, Deployment, DeploymentConfig, KeeperId};
+use dropshot::test_util::log_prefix_for_test;
+use omicron_clickhouse_admin::ClickhouseCli;
+use omicron_test_utils::dev::test_setup_log;
+use oximeter_test_utils::wait_for_keepers;
+use slog::info;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::str::FromStr;
+
+#[tokio::test]
+async fn test_lgif_parsing() -> anyhow::Result<()> {
+    let logctx = test_setup_log("test_lgif_parsing");
+    let log = logctx.log.clone();
+
+    let (parent_dir, prefix) = log_prefix_for_test(logctx.test_name());
+    let path = parent_dir.join(format!("{prefix}-oximeter-clickward-test"));
+    std::fs::create_dir(&path)?;
+
+    // We use the default ports in `test_schemas_disjoint` and must use a
+    // separate set here in case the two tests run concurrently.
+    let base_ports = BasePorts {
+        keeper: 29000,
+        raft: 29100,
+        clickhouse_tcp: 29200,
+        clickhouse_http: 29300,
+        clickhouse_interserver_http: 29400,
+    };
+
+    let config = DeploymentConfig {
+        path: path.clone(),
+        base_ports,
+        cluster_name: "oximeter_cluster".to_string(),
+    };
+
+    let mut deployment = Deployment::new(config);
+
+    // We only need a single keeper to test the lgif command
+    let num_keepers = 1;
+    let num_replicas = 1;
+    deployment
+        .generate_config(num_keepers, num_replicas)
+        .context("failed to generate config")?;
+    deployment.deploy().context("failed to deploy")?;
+
+    wait_for_keepers(&log, &deployment, vec![KeeperId(1)]).await?;
+
+    let clickhouse_cli = ClickhouseCli::new(
+        Utf8PathBuf::from_str("clickhouse").unwrap(),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, 29001, 0, 0),
+    )
+    .with_log(log.clone());
+
+    let lgif = clickhouse_cli.lgif().await.unwrap();
+
+    // The first log index from a newly created cluster should always be 1
+    assert_eq!(lgif.first_log_idx, 1);
+
+    info!(&log, "Cleaning up test");
+    deployment.teardown()?;
+    std::fs::remove_dir_all(path)?;
+    logctx.cleanup_successful();
+    Ok(())
+}

--- a/clickhouse-admin/types/Cargo.toml
+++ b/clickhouse-admin/types/Cargo.toml
@@ -18,4 +18,9 @@ omicron-workspace-hack.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+slog.workspace = true
 expectorate.workspace = true
+
+[dev-dependencies]
+slog-async.workspace = true
+slog-term.workspace = true

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -8,6 +8,7 @@ use camino::Utf8PathBuf;
 use derive_more::{Add, AddAssign, Display, From};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::create_dir;
 use std::io::{ErrorKind, Write};
 use std::net::Ipv6Addr;
@@ -224,18 +225,30 @@ impl Lgif {
     pub fn parse(data: &[u8]) -> Result<Self> {
         let binding = String::from_utf8_lossy(data);
         let output = binding.as_ref();
-        let p: Vec<&str> = output.split(|c| c == '\t' || c == '\n').collect();
+        let mut p: Vec<&str> = output.split(|c| c == '\t' || c == '\n').collect();
+
+        let mut lgif: HashMap<&str, &str> = HashMap::new();
+
+        // TODO: First I need to make sure it's an even number?
+        let items_to_add = p.len()/2;
+        // Create a hashmap with the vec
+        for _ in 0..items_to_add {
+            let key = p.remove(0);
+            let value = p.remove(0);
+
+            lgif.insert(key, value);
+        }
 
         // TODO: Make this not suck
         Ok(Self {
-            first_log_idx: u64::from_str(p[1]).unwrap(),
-            first_log_term: u64::from_str(p[3]).unwrap(),
-            last_log_idx: u64::from_str(p[5]).unwrap(),
-            last_log_term: u64::from_str(p[7]).unwrap(),
-            last_committed_log_idx: u64::from_str(p[9]).unwrap(),
-            leader_committed_log_idx: u64::from_str(p[11]).unwrap(),
-            target_committed_log_idx: u64::from_str(p[13]).unwrap(),
-            last_snapshot_idx: u64::from_str(p[15]).unwrap(),
+            first_log_idx: u64::from_str(lgif.get("first_log_idx").unwrap()).unwrap(),
+            first_log_term: u64::from_str(lgif.get("first_log_term").unwrap()).unwrap(),
+            last_log_idx: u64::from_str(lgif.get("last_log_idx").unwrap()).unwrap(),
+            last_log_term: u64::from_str(lgif.get("last_log_term").unwrap()).unwrap(),
+            last_committed_log_idx: u64::from_str(lgif.get("last_committed_log_idx").unwrap()).unwrap(),
+            leader_committed_log_idx: u64::from_str(lgif.get("leader_committed_log_idx").unwrap()).unwrap(),
+            target_committed_log_idx: u64::from_str(lgif.get("target_committed_log_idx").unwrap()).unwrap(),
+            last_snapshot_idx: u64::from_str(lgif.get("last_snapshot_idx").unwrap()).unwrap(),
         })
     }
 }

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -231,7 +231,7 @@ macro_rules! define_struct_and_set_values {
 
         impl $name {
             // Check if a field name matches a given key and set its value
-            pub fn set_field_value(&mut self, key: &str, value: Option<u128>) -> Result<()> {
+            pub fn set_field_value(&mut self, key: &str, value: Option<u64>) -> Result<()> {
                 match key {
                     $(
                         stringify!($field_name) => {
@@ -257,21 +257,21 @@ define_struct_and_set_values! {
     /// Logically grouped information file from a keeper node
     struct Lgif {
         /// Index of the first log entry in the current log segment
-        first_log_idx: Option<u128>,
+        first_log_idx: Option<u64>,
         /// Term of the leader when the first log entry was created
-        first_log_term: Option<u128>,
+        first_log_term: Option<u64>,
         /// Index of the last log entry in the current log segment
-        last_log_idx: Option<u128>,
+        last_log_idx: Option<u64>,
         /// Term of the leader when the last log entry was created
-        last_log_term: Option<u128>,
+        last_log_term: Option<u64>,
         /// Index of the last committed log entry
-        last_committed_log_idx: Option<u128>,
+        last_committed_log_idx: Option<u64>,
         /// Index of the last committed log entry from the leader's perspective
-        leader_committed_log_idx: Option<u128>,
+        leader_committed_log_idx: Option<u64>,
         /// Target index for log commitment during replication or recovery
-        target_committed_log_idx: Option<u128>,
+        target_committed_log_idx: Option<u64>,
         /// Index of the most recent snapshot taken
-        last_snapshot_idx: Option<u128>,
+        last_snapshot_idx: Option<u64>,
     }
 }
 
@@ -310,18 +310,18 @@ impl Lgif {
         //
         // 1. Create an iterator over the lines of a string. These are split at newlines.
         // 2. Each line is split by the tab, and we make sure that the key and value are
-        //    valid. If a value is not valid, we ignore it and mode on. We want to keep
+        //    valid. If a value is not valid, we ignore it and move on. We want to keep
         //    other key-value pairs if they are valid.
         // 3. Once we have a HashMap of valid key-value pairs, we set the fields of the
         //    Lgif struct with the retrieved data. To do this we make sure that the name
-        //    of each HasMap key matches one of the field names and then we set the
+        //    of each HashMap key matches one of the field names and then we set the
         //    corresponding value. If a key does not match any of the struct's fields we
         //    log an error, but continue populating all valid key-value pairs.
         // 4. We return an error only if the response had no valid key-value pairs.
         //
         let binding = String::from_utf8_lossy(data);
         let lines = binding.lines();
-        let mut lgif: HashMap<String, u128> = HashMap::new();
+        let mut lgif: HashMap<String, u64> = HashMap::new();
 
         for line in lines {
             let line = line.trim();
@@ -339,12 +339,12 @@ impl Lgif {
 
                 let key = l[0].to_string();
                 let raw_value = l[1];
-                let value = match u128::from_str(raw_value) {
+                let value = match u64::from_str(raw_value) {
                     Ok(v) => v,
                     Err(e) => {
                         error!(
                             log,
-                            "Unable to convert value into u128";
+                            "Unable to convert value into u64";
                             "value" => ?raw_value,
                             "error" => ?e,
                         );
@@ -549,7 +549,7 @@ mod tests {
     }
 
     #[test]
-    fn test_non_u128_value_lgif_parse_success() {
+    fn test_non_u64_value_lgif_parse_success() {
         let log = log();
         let data =
             "first_log_idx\t1\nfirst_log_term\tBOB\nlast_log_idx\t4386\nlast_log_term\t1\nlast_committed_log_idx\t4386

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -225,7 +225,7 @@ macro_rules! define_struct_and_set_values {
         pub struct $name {
             $(
                 #[$doc_field]
-                $field_name: $field_type
+                pub $field_name: $field_type
             ),*
         }
 

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -288,7 +288,7 @@ impl Lgif {
 
                 lgif.insert(key, value);
             }
-        };
+        }
 
         let mut parsed_data = Lgif::new();
         for (key, value) in lgif {
@@ -297,7 +297,6 @@ impl Lgif {
                 Err(e) => {
                     // TODO: Log the error
                     println!("{e}");
-                    ();
                 }
             };
         }

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -224,31 +224,40 @@ pub struct Lgif {
 impl Lgif {
     pub fn parse(data: &[u8]) -> Result<Self> {
         let binding = String::from_utf8_lossy(data);
-        let output = binding.as_ref();
-        let mut p: Vec<&str> = output.split(|c| c == '\t' || c == '\n').collect();
+        let lines = binding.lines();
+        let mut lgif: HashMap<String, u64> = HashMap::new();
 
-        let mut lgif: HashMap<&str, &str> = HashMap::new();
+        for line in lines {
+            let line = line.trim();
+            if !line.is_empty() {
+                let l: Vec<&str> = line.split('\t').collect();
 
-        // TODO: First I need to make sure it's an even number?
-        let items_to_add = p.len()/2;
-        // Create a hashmap with the vec
-        for _ in 0..items_to_add {
-            let key = p.remove(0);
-            let value = p.remove(0);
+                if l.len() != 2 {
+                    // TODO: Log that there was an empty line
+                    continue;
+                }
 
-            lgif.insert(key, value);
-        }
+                // println!("Vec: {:#?}", l);
+                let key = l[0].to_string();
+                let value = match u64::from_str(l[1]) {
+                    Ok(v) => v,
+                    // TODO: Log error
+                    Err(_) => continue,
+                };
 
-        // TODO: Make this not suck
+                lgif.insert(key, value);
+            }
+        }; 
+
         Ok(Self {
-            first_log_idx: u64::from_str(lgif.get("first_log_idx").unwrap()).unwrap(),
-            first_log_term: u64::from_str(lgif.get("first_log_term").unwrap()).unwrap(),
-            last_log_idx: u64::from_str(lgif.get("last_log_idx").unwrap()).unwrap(),
-            last_log_term: u64::from_str(lgif.get("last_log_term").unwrap()).unwrap(),
-            last_committed_log_idx: u64::from_str(lgif.get("last_committed_log_idx").unwrap()).unwrap(),
-            leader_committed_log_idx: u64::from_str(lgif.get("leader_committed_log_idx").unwrap()).unwrap(),
-            target_committed_log_idx: u64::from_str(lgif.get("target_committed_log_idx").unwrap()).unwrap(),
-            last_snapshot_idx: u64::from_str(lgif.get("last_snapshot_idx").unwrap()).unwrap(),
+            first_log_idx: lgif.remove("first_log_idx").unwrap(),
+            first_log_term: lgif.remove("first_log_term").unwrap(),
+            last_log_idx: lgif.remove("last_log_idx").unwrap(),
+            last_log_term: lgif.remove("last_log_term").unwrap(),
+            last_committed_log_idx: lgif.remove("last_committed_log_idx").unwrap(),
+            leader_committed_log_idx: lgif.remove("leader_committed_log_idx").unwrap(),
+            target_committed_log_idx: lgif.remove("target_committed_log_idx").unwrap(),
+            last_snapshot_idx: lgif.remove("last_snapshot_idx").unwrap(),
         })
     }
 }

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -383,62 +383,64 @@
         "type": "object",
         "properties": {
           "first_log_idx": {
-            "nullable": true,
             "description": "Index of the first log entry in the current log segment",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "first_log_term": {
-            "nullable": true,
             "description": "Term of the leader when the first log entry was created",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "last_committed_log_idx": {
-            "nullable": true,
             "description": "Index of the last committed log entry",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "last_log_idx": {
-            "nullable": true,
             "description": "Index of the last log entry in the current log segment",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "last_log_term": {
-            "nullable": true,
             "description": "Term of the leader when the last log entry was created",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "last_snapshot_idx": {
-            "nullable": true,
             "description": "Index of the most recent snapshot taken",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "leader_committed_log_idx": {
-            "nullable": true,
             "description": "Index of the last committed log entry from the leader's perspective",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "target_committed_log_idx": {
-            "nullable": true,
             "description": "Target index for log commitment during replication or recovery",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           }
-        }
+        },
+        "required": [
+          "first_log_idx",
+          "first_log_term",
+          "last_committed_log_idx",
+          "last_log_idx",
+          "last_log_term",
+          "last_snapshot_idx",
+          "leader_committed_log_idx",
+          "target_committed_log_idx"
+        ]
       },
       "LogConfig": {
         "type": "object",

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -386,56 +386,56 @@
             "nullable": true,
             "description": "Index of the first log entry in the current log segment",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "first_log_term": {
             "nullable": true,
             "description": "Term of the leader when the first log entry was created",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "last_committed_log_idx": {
             "nullable": true,
             "description": "Index of the last committed log entry",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "last_log_idx": {
             "nullable": true,
             "description": "Index of the last log entry in the current log segment",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "last_log_term": {
             "nullable": true,
             "description": "Term of the leader when the last log entry was created",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "last_snapshot_idx": {
             "nullable": true,
             "description": "Index of the most recent snapshot taken",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "leader_committed_log_idx": {
             "nullable": true,
             "description": "Index of the last committed log entry from the leader's perspective",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           },
           "target_committed_log_idx": {
             "nullable": true,
             "description": "Target index for log commitment during replication or recovery",
             "type": "integer",
-            "format": "uint128",
+            "format": "uint64",
             "minimum": 0
           }
         }

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -56,8 +56,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "String",
-                  "type": "string"
+                  "$ref": "#/components/schemas/Lgif"
                 }
               }
             }
@@ -377,6 +376,61 @@
           "id",
           "listen_addr",
           "raft_servers"
+        ]
+      },
+      "Lgif": {
+        "type": "object",
+        "properties": {
+          "first_log_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "first_log_term": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_committed_log_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_log_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_log_term": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_snapshot_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "leader_committed_log_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "target_committed_log_idx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_log_idx",
+          "first_log_term",
+          "last_committed_log_idx",
+          "last_log_idx",
+          "last_log_term",
+          "last_snapshot_idx",
+          "leader_committed_log_idx",
+          "target_committed_log_idx"
         ]
       },
       "LogConfig": {

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -379,52 +379,61 @@
         ]
       },
       "Lgif": {
+        "description": "Logically grouped information file from a keeper node",
         "type": "object",
         "properties": {
           "first_log_idx": {
             "nullable": true,
+            "description": "Index of the first log entry in the current log segment",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "first_log_term": {
             "nullable": true,
+            "description": "Term of the leader when the first log entry was created",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "last_committed_log_idx": {
             "nullable": true,
+            "description": "Index of the last committed log entry",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "last_log_idx": {
             "nullable": true,
+            "description": "Index of the last log entry in the current log segment",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "last_log_term": {
             "nullable": true,
+            "description": "Term of the leader when the last log entry was created",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "last_snapshot_idx": {
             "nullable": true,
+            "description": "Index of the most recent snapshot taken",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "leader_committed_log_idx": {
             "nullable": true,
+            "description": "Index of the last committed log entry from the leader's perspective",
             "type": "integer",
             "format": "uint128",
             "minimum": 0
           },
           "target_committed_log_idx": {
             "nullable": true,
+            "description": "Target index for log commitment during replication or recovery",
             "type": "integer",
             "format": "uint128",
             "minimum": 0

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -382,56 +382,54 @@
         "type": "object",
         "properties": {
           "first_log_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "first_log_term": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "last_committed_log_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "last_log_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "last_log_term": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "last_snapshot_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "leader_committed_log_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           },
           "target_committed_log_idx": {
+            "nullable": true,
             "type": "integer",
-            "format": "uint64",
+            "format": "uint128",
             "minimum": 0
           }
-        },
-        "required": [
-          "first_log_idx",
-          "first_log_term",
-          "last_committed_log_idx",
-          "last_log_idx",
-          "last_log_term",
-          "last_snapshot_idx",
-          "leader_committed_log_idx",
-          "target_committed_log_idx"
-        ]
+        }
       },
       "LogConfig": {
         "type": "object",

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -45,6 +45,32 @@
         }
       }
     },
+    "/keeper/lgif": {
+      "get": {
+        "summary": "Retrieve a logically grouped information file from a keeper node.",
+        "description": "This information is used internally by ZooKeeper to manage snapshots and logs for consistency and recovery.",
+        "operationId": "lgif",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "String",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/server/config": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a server node on a specified",

--- a/oximeter/test-utils/Cargo.toml
+++ b/oximeter/test-utils/Cargo.toml
@@ -8,8 +8,12 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
+anyhow.workspace = true
 chrono.workspace = true
+clickward.workspace = true
 omicron-workspace-hack.workspace = true
+omicron-test-utils.workspace = true
 oximeter-macro-impl.workspace = true
 oximeter-types.workspace = true
+slog.workspace =true
 uuid.workspace = true

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -128,6 +128,12 @@ const IPV6_UNSPECIFIED: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
 
 const COCKROACH: &str = "/opt/oxide/cockroachdb/bin/cockroach";
 
+const CLICKHOUSE_SERVER_BINARY: &str =
+    "/opt/oxide//opt/oxide/clickhouse_server/clickhouse";
+const CLICKHOUSE_KEEPER_BINARY: &str =
+    "/opt/oxide//opt/oxide/clickhouse_keeper/clickhouse";
+const CLICKHOUSE_BINARY: &str = "/opt/oxide//opt/oxide/clickhouse/clickhouse";
+
 pub const SWITCH_ZONE_BASEBOARD_FILE: &str = "/opt/oxide/baseboard.json";
 
 #[derive(thiserror::Error, Debug, slog_error_chain::SlogInlineError)]
@@ -1579,12 +1585,21 @@ impl ServiceManager {
                 )
                 .to_string();
 
+                let ch_address = SocketAddr::new(
+                    IpAddr::V6(listen_addr),
+                    CLICKHOUSE_HTTP_PORT,
+                )
+                .to_string();
+
                 let clickhouse_admin_config =
-                    PropertyGroupBuilder::new("config").add_property(
-                        "http_address",
-                        "astring",
-                        admin_address,
-                    );
+                    PropertyGroupBuilder::new("config")
+                        .add_property("http_address", "astring", admin_address)
+                        .add_property("ch_address", "astring", ch_address)
+                        .add_property(
+                            "ch_binary",
+                            "astring",
+                            CLICKHOUSE_BINARY,
+                        );
                 let clickhouse_admin_service =
                     ServiceBuilder::new("oxide/clickhouse-admin").add_instance(
                         ServiceInstanceBuilder::new("default")
@@ -1652,12 +1667,21 @@ impl ServiceManager {
                 )
                 .to_string();
 
+                let ch_address = SocketAddr::new(
+                    IpAddr::V6(listen_addr),
+                    CLICKHOUSE_HTTP_PORT,
+                )
+                .to_string();
+
                 let clickhouse_admin_config =
-                    PropertyGroupBuilder::new("config").add_property(
-                        "http_address",
-                        "astring",
-                        admin_address,
-                    );
+                    PropertyGroupBuilder::new("config")
+                        .add_property("http_address", "astring", admin_address)
+                        .add_property("ch_address", "astring", ch_address)
+                        .add_property(
+                            "ch_binary",
+                            "astring",
+                            CLICKHOUSE_SERVER_BINARY,
+                        );
                 let clickhouse_admin_service =
                     ServiceBuilder::new("oxide/clickhouse-admin").add_instance(
                         ServiceInstanceBuilder::new("default")
@@ -1728,12 +1752,21 @@ impl ServiceManager {
                 )
                 .to_string();
 
+                let ch_address = SocketAddr::new(
+                    IpAddr::V6(listen_addr),
+                    CLICKHOUSE_KEEPER_TCP_PORT,
+                )
+                .to_string();
+
                 let clickhouse_admin_config =
-                    PropertyGroupBuilder::new("config").add_property(
-                        "http_address",
-                        "astring",
-                        admin_address,
-                    );
+                    PropertyGroupBuilder::new("config")
+                        .add_property("http_address", "astring", admin_address)
+                        .add_property("ch_address", "astring", ch_address)
+                        .add_property(
+                            "ch_binary",
+                            "astring",
+                            CLICKHOUSE_KEEPER_BINARY,
+                        );
                 let clickhouse_admin_service =
                     ServiceBuilder::new("oxide/clickhouse-admin").add_instance(
                         ServiceInstanceBuilder::new("default")

--- a/smf/clickhouse-admin/manifest.xml
+++ b/smf/clickhouse-admin/manifest.xml
@@ -17,12 +17,14 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/clickhouse-admin/bin/clickhouse-admin run -c /var/svc/manifest/site/clickhouse-admin/config.toml -a %{config/http_address} &amp;'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/clickhouse-admin/bin/clickhouse-admin run -c /var/svc/manifest/site/clickhouse-admin/config.toml -a %{config/http_address} -l %{config/ch_address} -b %{config/ch_binary}  &amp;'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 
   <property_group name='config' type='application'>
     <propval name='http_address' type='astring' value='unknown' />
+    <propval name='ch_address' type='astring' value='unknown' />
+    <propval name='ch_binary' type='astring' value='unknown' />
   </property_group>
 
   <property_group name='startd' type='framework'>


### PR DESCRIPTION
## Overview

This commit introduces a new `clickhouse-admin` API endpoint: `/keeper/lgif`.

This endpoint uses the ClickHouse CLI internally to retrieve and parse the logically grouped information file from the ClickHouse keepers.

## Purpose

Reconfigurator will need this information to reliably manage and operate a ClickHouse replicated cluster. Additional endpoints to retrieve other information from ClickHouse servers or keepers will be added in follow up PRs.

## Testing

In addition to the unit tests, I have manually tested with the following results:

```console
$ cargo run --bin=clickhouse-admin -- run -c ./smf/clickhouse-admin/config.toml -a [::1]:8888 -l [::1]:20001 -b /Users/karcar/src/omicron/out/clickhouse/clickhouse
   Compiling omicron-clickhouse-admin v0.1.0 (/Users/karcar/src/omicron/clickhouse-admin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.46s
     Running `target/debug/clickhouse-admin run -c ./smf/clickhouse-admin/config.toml -a '[::1]:8888' -l '[::1]:20001' -b /Users/karcar/src/omicron/out/clickhouse/clickhouse`
note: configured to log to "/dev/stdout"
{"msg":"listening","v":0,"name":"clickhouse-admin","level":30,"time":"2024-09-12T02:37:19.383597Z","hostname":"ixchel","pid":3115,"local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/git/checkouts/dropshot-a4a923d29dccc492/06c8dab/dropshot/src/server.rs:205"}
{"msg":"accepted connection","v":0,"name":"clickhouse-admin","level":30,"time":"2024-09-12T02:37:23.843325Z","hostname":"ixchel","pid":3115,"local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/git/checkouts/dropshot-a4a923d29dccc492/06c8dab/dropshot/src/server.rs:775","remote_addr":"[::1]:54455"}
{"msg":"request completed","v":0,"name":"clickhouse-admin","level":30,"time":"2024-09-12T02:37:24.302588Z","hostname":"ixchel","pid":3115,"uri":"/keeper/lgif","method":"GET","req_id":"64b232d0-d6ac-4cae-8f0a-f14cf6d1dfba","remote_addr":"[::1]:54455","local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/git/checkouts/dropshot-a4a923d29dccc492/06c8dab/dropshot/src/server.rs:914","latency_us":458301,"response_code":"200"}
```

```console
$ curl http://[::1]:8888/keeper/lgif
{"first_log_idx":1,"first_log_term":1,"last_log_idx":11717,"last_log_term":20,"last_committed_log_idx":11717,"leader_committed_log_idx":11717,"target_committed_log_idx":11717,"last_snapshot_idx":9465}
```

Related: https://github.com/oxidecomputer/omicron/issues/5999