### PR TITLE
bump to v11; API to estimated release date

### DIFF
--- a/dev-tools/openapi-manager/src/spec.rs
+++ b/dev-tools/openapi-manager/src/spec.rs
@@ -81,7 +81,7 @@ pub fn all_apis() -> Vec<ApiSpec> {
         },
         ApiSpec {
             title: "Oxide Region API",
-            version: "20240821.0",
+            version: "20241009.0",
             description: "API for interacting with the Oxide control plane",
             boundary: ApiBoundary::External,
             api_description:

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -41,7 +41,7 @@ use crate::job::Jobs;
 /// to as "v8", "version 8", or "release 8" to customers). The use of semantic
 /// versioning is mostly to hedge for perhaps wanting something more granular in
 /// the future.
-const BASE_VERSION: Version = Version::new(10, 0, 0);
+const BASE_VERSION: Version = Version::new(11, 0, 0);
 
 const RETRY_ATTEMPTS: usize = 3;
 

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -23,7 +23,7 @@ use omicron_common::api::external::{
 use openapi_manager_types::ValidationContext;
 use openapiv3::OpenAPI;
 
-pub const API_VERSION: &str = "20240821.0";
+pub const API_VERSION: &str = "20241009.0";
 
 // API ENDPOINT FUNCTION NAMING CONVENTIONS
 //

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "20240821.0"
+    "version": "20241009.0"
   },
   "paths": {
     "/device/auth": {


### PR DESCRIPTION
[![image](https://github.com/user-attachments/assets/5448f57a-8f3b-4070-b708-c0fde58f91ea)](https://en.wikipedia.org/wiki/Up_to_eleven)