### PR TITLE
omicron-ddm-admin-client does not need build dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6046,24 +6046,17 @@ dependencies = [
 name = "omicron-ddm-admin-client"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "ddm-admin-client",
  "either",
  "omicron-common",
  "omicron-workspace-hack",
- "omicron-zone-package",
- "progenitor",
  "progenitor-client",
- "quote",
  "reqwest",
- "rustfmt-wrapper",
  "serde",
- "serde_json",
  "sled-hardware-types",
  "slog",
  "thiserror",
  "tokio",
- "toml 0.8.19",
  "uuid",
 ]
 

--- a/clients/ddm-admin-client/Cargo.toml
+++ b/clients/ddm-admin-client/Cargo.toml
@@ -20,12 +20,3 @@ sled-hardware-types.workspace = true
 omicron-workspace-hack.workspace = true
 ddm-admin-client.workspace = true
 uuid.workspace = true
-
-[build-dependencies]
-anyhow.workspace = true
-omicron-zone-package.workspace = true
-progenitor.workspace = true
-quote.workspace = true
-rustfmt-wrapper.workspace = true
-serde_json.workspace = true
-toml.workspace = true


### PR DESCRIPTION
I think this is a follow up to #5271, in that PR removed the build script in this package but there are still some build dependencies.  This removes those.