### PR TITLE
Return Volume's own regions when soft-deleting

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(96, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(97, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(97, "lookup-region-snapshot-by-region-id"),
         KnownVersion::new(96, "inv-dataset"),
         KnownVersion::new(95, "turn-boot-on-fault-into-auto-restart"),
         KnownVersion::new(94, "put-back-creating-vmm-state"),

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -644,9 +644,13 @@ CREATE TABLE IF NOT EXISTS omicron.public.region_snapshot (
     PRIMARY KEY (dataset_id, region_id, snapshot_id)
 );
 
-/* Index for use during join with region table */
+/* Indexes for use during join with region table */
 CREATE INDEX IF NOT EXISTS lookup_region_by_dataset on omicron.public.region_snapshot (
     dataset_id, region_id
+);
+
+CREATE INDEX IF NOT EXISTS lookup_region_snapshot_by_region_id on omicron.public.region_snapshot (
+    region_id
 );
 
 /*
@@ -4284,7 +4288,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '96.0.0', NULL)
+    (TRUE, NOW(), NOW(), '97.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/lookup-region-snapshot-by-region-id/up.sql
+++ b/schema/crdb/lookup-region-snapshot-by-region-id/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS lookup_region_snapshot_by_region_id on omicron.public.region_snapshot (
+    region_id
+);


### PR DESCRIPTION
Correctly populate the "regions" field in the section of the DecreaseCrucibleResourceCountAndSoftDeleteVolume CTE that constructs the V3 version of the CrucibleResources object. Previously this would almost never return the Volume's regions, causing those to be picked up later by `find_deleted_volume_regions` and cleaned up there.

This bug did not result in any leaked regions that this author knows about, but did cause a lot of confusion when examining another unrelated issue.