### PR TITLE
Rip `InstanceRuntimeState` out of the internal API

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -86,22 +86,6 @@ impl omicron_common::api::external::ClientError for types::Error {
     }
 }
 
-impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
-    for types::InstanceRuntimeState
-{
-    fn from(
-        s: omicron_common::api::internal::nexus::InstanceRuntimeState,
-    ) -> Self {
-        Self {
-            propolis_id: s.propolis_id,
-            dst_propolis_id: s.dst_propolis_id,
-            migration_id: s.migration_id,
-            gen: s.gen,
-            time_updated: s.time_updated,
-        }
-    }
-}
-
 impl From<omicron_common::api::internal::nexus::VmmState> for types::VmmState {
     fn from(s: omicron_common::api::internal::nexus::VmmState) -> Self {
         use omicron_common::api::internal::nexus::VmmState as Input;
@@ -123,20 +107,6 @@ impl From<omicron_common::api::external::InstanceCpuCount>
 {
     fn from(s: omicron_common::api::external::InstanceCpuCount) -> Self {
         Self(s.0)
-    }
-}
-
-impl From<types::InstanceRuntimeState>
-    for omicron_common::api::internal::nexus::InstanceRuntimeState
-{
-    fn from(s: types::InstanceRuntimeState) -> Self {
-        Self {
-            propolis_id: s.propolis_id,
-            dst_propolis_id: s.dst_propolis_id,
-            migration_id: s.migration_id,
-            gen: s.gen,
-            time_updated: s.time_updated,
-        }
     }
 }
 

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -10,7 +10,6 @@ use crate::api::external::{
 };
 use chrono::{DateTime, Utc};
 use omicron_uuid_kinds::DownstairsRegionKind;
-use omicron_uuid_kinds::PropolisUuid;
 use omicron_uuid_kinds::TypedUuid;
 use omicron_uuid_kinds::UpstairsRepairKind;
 use omicron_uuid_kinds::UpstairsSessionKind;
@@ -58,23 +57,6 @@ pub struct InstanceProperties {
     pub memory: ByteCount,
     /// RFC1035-compliant hostname for the instance.
     pub hostname: Hostname,
-}
-
-/// The dynamic runtime properties of an instance: its current VMM ID (if any),
-/// migration information (if any), and the instance state to report if there is
-/// no active VMM.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceRuntimeState {
-    /// The instance's currently active VMM ID.
-    pub propolis_id: Option<PropolisUuid>,
-    /// If a migration is active, the ID of the target VMM.
-    pub dst_propolis_id: Option<PropolisUuid>,
-    /// If a migration is active, the ID of that migration.
-    pub migration_id: Option<Uuid>,
-    /// Generation number for this state.
-    pub gen: Generation,
-    /// Timestamp for this information.
-    pub time_updated: DateTime<Utc>,
 }
 
 /// One of the states that a VMM can be in.

--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -223,28 +223,3 @@ impl InstanceRuntimeState {
         }
     }
 }
-
-impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
-    for InstanceRuntimeState
-{
-    fn from(
-        state: omicron_common::api::internal::nexus::InstanceRuntimeState,
-    ) -> Self {
-        let nexus_state = if state.propolis_id.is_some() {
-            InstanceState::Vmm
-        } else {
-            InstanceState::NoVmm
-        };
-
-        Self {
-            nexus_state,
-            time_updated: state.time_updated,
-            gen: state.gen.into(),
-            propolis_id: state.propolis_id.map(|id| id.into_untyped_uuid()),
-            dst_propolis_id: state
-                .dst_propolis_id
-                .map(|id| id.into_untyped_uuid()),
-            migration_id: state.migration_id,
-        }
-    }
-}

--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -11,7 +11,7 @@ use crate::schema::{disk, external_ip, instance};
 use chrono::{DateTime, Utc};
 use db_macros::Resource;
 use nexus_types::external_api::params;
-use omicron_uuid_kinds::{GenericUuid, InstanceUuid, PropolisUuid};
+use omicron_uuid_kinds::{GenericUuid, InstanceUuid};
 use serde::Deserialize;
 use serde::Serialize;
 use uuid::Uuid;
@@ -245,22 +245,6 @@ impl From<omicron_common::api::internal::nexus::InstanceRuntimeState>
                 .dst_propolis_id
                 .map(|id| id.into_untyped_uuid()),
             migration_id: state.migration_id,
-        }
-    }
-}
-
-impl From<InstanceRuntimeState>
-    for sled_agent_client::types::InstanceRuntimeState
-{
-    fn from(state: InstanceRuntimeState) -> Self {
-        Self {
-            dst_propolis_id: state
-                .dst_propolis_id
-                .map(PropolisUuid::from_untyped_uuid),
-            gen: state.gen.into(),
-            migration_id: state.migration_id,
-            propolis_id: state.propolis_id.map(PropolisUuid::from_untyped_uuid),
-            time_updated: state.time_updated,
         }
     }
 }

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1199,7 +1199,7 @@ impl super::Nexus {
                 propolis_id,
                 &sled_agent_client::types::InstanceEnsureBody {
                     hardware: instance_hardware,
-                    instance_runtime: db_instance.runtime().clone().into(),
+                    migration_id: db_instance.runtime().migration_id,
                     vmm_runtime,
                     instance_id,
                     propolis_addr: SocketAddr::new(

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3137,14 +3137,6 @@
               }
             ]
           },
-          "instance_runtime": {
-            "description": "The instance runtime state for the instance being registered.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/InstanceRuntimeState"
-              }
-            ]
-          },
           "metadata": {
             "description": "Metadata used to track instance statistics.",
             "allOf": [
@@ -3152,6 +3144,12 @@
                 "$ref": "#/components/schemas/InstanceMetadata"
               }
             ]
+          },
+          "migration_id": {
+            "nullable": true,
+            "description": "The ID of the migration in to this VMM, if this VMM is being ensured s part of a migration in. If this is `None`, the VMM is not being created due to a migration.",
+            "type": "string",
+            "format": "uuid"
           },
           "propolis_addr": {
             "description": "The address at which this VMM should serve a Propolis server API.",
@@ -3169,7 +3167,6 @@
         "required": [
           "hardware",
           "instance_id",
-          "instance_runtime",
           "metadata",
           "propolis_addr",
           "vmm_runtime"
@@ -3337,53 +3334,6 @@
           "hostname",
           "memory",
           "ncpus"
-        ]
-      },
-      "InstanceRuntimeState": {
-        "description": "The dynamic runtime properties of an instance: its current VMM ID (if any), migration information (if any), and the instance state to report if there is no active VMM.",
-        "type": "object",
-        "properties": {
-          "dst_propolis_id": {
-            "nullable": true,
-            "description": "If a migration is active, the ID of the target VMM.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForPropolisKind"
-              }
-            ]
-          },
-          "gen": {
-            "description": "Generation number for this state.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Generation"
-              }
-            ]
-          },
-          "migration_id": {
-            "nullable": true,
-            "description": "If a migration is active, the ID of that migration.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "propolis_id": {
-            "nullable": true,
-            "description": "The instance's currently active VMM ID.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForPropolisKind"
-              }
-            ]
-          },
-          "time_updated": {
-            "description": "Timestamp for this information.",
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "gen",
-          "time_updated"
         ]
       },
       "Inventory": {
@@ -5133,10 +5083,6 @@
         "type": "string",
         "format": "uuid"
       },
-      "TypedUuidForPropolisKind": {
-        "type": "string",
-        "format": "uuid"
-      },
       "TypedUuidForZpoolKind": {
         "type": "string",
         "format": "uuid"
@@ -5769,6 +5715,10 @@
           "A",
           "B"
         ]
+      },
+      "TypedUuidForPropolisKind": {
+        "type": "string",
+        "format": "uuid"
       }
     },
     "responses": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3147,7 +3147,7 @@
           },
           "migration_id": {
             "nullable": true,
-            "description": "The ID of the migration in to this VMM, if this VMM is being ensured s part of a migration in. If this is `None`, the VMM is not being created due to a migration.",
+            "description": "The ID of the migration in to this VMM, if this VMM is being ensured is part of a migration in. If this is `None`, the VMM is not being created due to a migration.",
             "type": "string",
             "format": "uuid"
           },

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -320,16 +320,7 @@ impl SledAgentApi for SledAgentImpl {
         let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
         Ok(HttpResponseOk(
-            sa.instance_ensure_registered(
-                body_args.instance_id,
-                propolis_id,
-                body_args.migration_id,
-                body_args.hardware,
-                body_args.vmm_runtime,
-                body_args.propolis_addr,
-                body_args.metadata,
-            )
-            .await?,
+            sa.instance_ensure_registered(propolis_id, body_args).await?,
         ))
     }
 

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -323,8 +323,8 @@ impl SledAgentApi for SledAgentImpl {
             sa.instance_ensure_registered(
                 body_args.instance_id,
                 propolis_id,
+                body_args.migration_id,
                 body_args.hardware,
-                body_args.instance_runtime,
                 body_args.vmm_runtime,
                 body_args.propolis_addr,
                 body_args.metadata,

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1594,9 +1594,7 @@ mod tests {
     use omicron_common::api::external::{
         ByteCount, Generation, Hostname, InstanceCpuCount,
     };
-    use omicron_common::api::internal::nexus::{
-        InstanceProperties, InstanceRuntimeState, VmmState,
-    };
+    use omicron_common::api::internal::nexus::{InstanceProperties, VmmState};
     use omicron_common::api::internal::shared::{DhcpConfig, SledIdentifiers};
     use omicron_common::FileKv;
     use sled_agent_types::zone_bundle::CleanupContext;
@@ -2251,21 +2249,16 @@ mod tests {
             serial: "fake-serial".into(),
         };
 
-        let instance_runtime = InstanceRuntimeState {
-            propolis_id: Some(propolis_id),
-            dst_propolis_id: None,
-            migration_id: None,
-            gen: Generation::new(),
-            time_updated: Default::default(),
-        };
-
         mgr.ensure_registered(
-            instance_id,
             propolis_id,
-            hardware,
-            instance_runtime,
-            vmm_runtime,
-            propolis_addr,
+            InstanceEnsureBody {
+                instance_id,
+                migration_id: None,
+                hardware,
+                vmm_runtime,
+                propolis_addr,
+                metadata,
+            },
             sled_identifiers,
             metadata,
         )

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2260,7 +2260,6 @@ mod tests {
                 metadata,
             },
             sled_identifiers,
-            metadata,
         )
         .await
         .unwrap();

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -20,9 +20,7 @@ use illumos_utils::opte::PortManager;
 use illumos_utils::running_zone::ZoneBuilderFactory;
 use omicron_common::api::external::Generation;
 use omicron_common::api::internal::nexus::SledVmmState;
-use omicron_common::api::internal::nexus::VmmRuntimeState;
 use omicron_common::api::internal::shared::SledIdentifiers;
-use omicron_uuid_kinds::InstanceUuid;
 use omicron_uuid_kinds::PropolisUuid;
 use sled_agent_types::instance::*;
 use sled_agent_types::zone_bundle::ZoneBundleMetadata;
@@ -30,7 +28,6 @@ use sled_storage::manager::StorageHandle;
 use sled_storage::resources::AllDisks;
 use slog::Logger;
 use std::collections::{BTreeMap, HashSet};
-use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
@@ -138,30 +135,19 @@ impl InstanceManager {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn ensure_registered(
         &self,
-        instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
-        migration_id: Option<Uuid>,
-        hardware: InstanceHardware,
-        vmm_runtime: VmmRuntimeState,
-        propolis_addr: SocketAddr,
+        instance: InstanceEnsureBody,
         sled_identifiers: SledIdentifiers,
-        metadata: InstanceMetadata,
     ) -> Result<SledVmmState, Error> {
         let (tx, rx) = oneshot::channel();
         self.inner
             .tx
             .send(InstanceManagerRequest::EnsureRegistered {
-                instance_id,
                 propolis_id,
-                migration_id,
-                hardware,
-                vmm_runtime,
-                propolis_addr,
+                instance,
                 sled_identifiers: Box::new(sled_identifiers),
-                metadata,
                 tx,
             })
             .await
@@ -338,19 +324,14 @@ impl InstanceManager {
 #[derive(strum::Display)]
 enum InstanceManagerRequest {
     EnsureRegistered {
-        instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
-        migration_id: Option<Uuid>,
-        hardware: InstanceHardware,
-        vmm_runtime: VmmRuntimeState,
-        propolis_addr: SocketAddr,
+        instance: InstanceEnsureBody,
         // These are boxed because they are, apparently, quite large, and Clippy
         // whinges about the overall size of this variant relative to the
         // others. Since we will generally send `EnsureRegistered` requests much
         // less frequently than most of the others, boxing this seems like a
         // reasonable choice...
         sled_identifiers: Box<SledIdentifiers>,
-        metadata: InstanceMetadata,
         tx: oneshot::Sender<Result<SledVmmState, Error>>,
     },
     EnsureUnregistered {
@@ -463,26 +444,12 @@ impl InstanceManagerRunner {
                     let request_variant = request.as_ref().map(|r| r.to_string());
                     let result = match request {
                         Some(EnsureRegistered {
-                            instance_id,
                             propolis_id,
-                            migration_id,
-                            hardware,
-                            vmm_runtime,
-                            propolis_addr,
+                            instance,
                             sled_identifiers,
-                            metadata,
                             tx,
                         }) => {
-                            tx.send(self.ensure_registered(
-                                instance_id,
-                                propolis_id,
-                                migration_id,
-                                hardware,
-                                vmm_runtime,
-                                propolis_addr,
-                                *sled_identifiers,
-                                metadata
-                            ).await).map_err(|_| Error::FailedSendClientClosed)
+                            tx.send(self.ensure_registered(propolis_id, instance, *sled_identifiers).await).map_err(|_| Error::FailedSendClientClosed)
                         },
                         Some(EnsureUnregistered { propolis_id, tx }) => {
                             self.ensure_unregistered(tx, propolis_id).await
@@ -538,14 +505,15 @@ impl InstanceManagerRunner {
     }
 
     /// Ensures that the instance manager contains a registered instance with
-    /// the supplied instance ID and the Propolis ID specified in
-    /// `initial_hardware`.
+    /// the supplied Propolis ID and the instance spec provided in `instance`.
     ///
     /// # Arguments
     ///
-    /// * instance_id: The ID of the instance to register.
-    /// * initial_hardware: The initial hardware manifest and runtime state of
-    ///   the instance, to be used if the instance does not already exist.
+    /// * `propolis_id`: The ID of the VMM to ensure exists.
+    /// * `instance`: The initial hardware manifest, runtime state, and metadata
+    ///   of the instance, to be used if the instance does not already exist.
+    /// * `sled_identifiers`: This sled's [`SledIdentifiers`] --- you know, like
+    ///   it says on the tin....
     ///
     /// # Return value
     ///
@@ -554,18 +522,20 @@ impl InstanceManagerRunner {
     /// (instance ID, Propolis ID) pair multiple times, but will fail if the
     /// instance is registered with a Propolis ID different from the one the
     /// caller supplied.
-    #[allow(clippy::too_many_arguments)]
     pub async fn ensure_registered(
         &mut self,
-        instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
-        migration_id: Option<Uuid>,
-        hardware: InstanceHardware,
-        vmm_runtime: VmmRuntimeState,
-        propolis_addr: SocketAddr,
+        instance: InstanceEnsureBody,
         sled_identifiers: SledIdentifiers,
-        metadata: InstanceMetadata,
     ) -> Result<SledVmmState, Error> {
+        let InstanceEnsureBody {
+            instance_id,
+            migration_id,
+            propolis_addr,
+            hardware,
+            vmm_runtime,
+            metadata,
+        } = instance;
         info!(
             &self.log,
             "ensuring instance is registered";

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -96,8 +96,8 @@ impl SledAgentApi for SledAgentSimImpl {
             sa.instance_register(
                 body_args.instance_id,
                 propolis_id,
+                body_args.migration_id,
                 body_args.hardware,
-                body_args.instance_runtime,
                 body_args.vmm_runtime,
                 body_args.metadata,
             )

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -92,17 +92,7 @@ impl SledAgentApi for SledAgentSimImpl {
         let sa = rqctx.context();
         let propolis_id = path_params.into_inner().propolis_id;
         let body_args = body.into_inner();
-        Ok(HttpResponseOk(
-            sa.instance_register(
-                body_args.instance_id,
-                propolis_id,
-                body_args.migration_id,
-                body_args.hardware,
-                body_args.vmm_runtime,
-                body_args.metadata,
-            )
-            .await?,
-        ))
+        Ok(HttpResponseOk(sa.instance_register(propolis_id, body_args).await?))
     }
 
     async fn vmm_unregister(

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -24,11 +24,9 @@ use nexus_sled_agent_shared::inventory::{
 use omicron_common::api::external::{
     ByteCount, DiskState, Error, Generation, ResourceType,
 };
+use omicron_common::api::internal::nexus::VmmRuntimeState;
 use omicron_common::api::internal::nexus::{
     DiskRuntimeState, MigrationRuntimeState, MigrationState, SledVmmState,
-};
-use omicron_common::api::internal::nexus::{
-    InstanceRuntimeState, VmmRuntimeState,
 };
 use omicron_common::api::internal::shared::{
     RackNetworkConfig, ResolvedVpcRoute, ResolvedVpcRouteSet,
@@ -262,8 +260,8 @@ impl SledAgent {
         self: &Arc<Self>,
         instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
+        migration_id: Option<Uuid>,
         hardware: InstanceHardware,
-        instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
         metadata: InstanceMetadata,
     ) -> Result<SledVmmState, Error> {
@@ -362,14 +360,13 @@ impl SledAgent {
             }
         }
 
-        let migration_in = instance_runtime.migration_id.map(|migration_id| {
-            MigrationRuntimeState {
+        let migration_in =
+            migration_id.map(|migration_id| MigrationRuntimeState {
                 migration_id,
                 state: MigrationState::Pending,
                 gen: Generation::new(),
                 time_updated: chrono::Utc::now(),
-            }
-        });
+            });
 
         let instance_run_time_state = self
             .vmms

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -46,8 +46,7 @@ use omicron_common::api::internal::shared::{
     VirtualNetworkInterfaceHost,
 };
 use omicron_common::api::{
-    internal::nexus::DiskRuntimeState, internal::nexus::InstanceRuntimeState,
-    internal::nexus::UpdateArtifactId,
+    internal::nexus::DiskRuntimeState, internal::nexus::UpdateArtifactId,
 };
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
@@ -986,8 +985,8 @@ impl SledAgent {
         &self,
         instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
+        migration_id: Option<Uuid>,
         hardware: InstanceHardware,
-        instance_runtime: InstanceRuntimeState,
         vmm_runtime: VmmRuntimeState,
         propolis_addr: SocketAddr,
         metadata: InstanceMetadata,
@@ -997,8 +996,8 @@ impl SledAgent {
             .ensure_registered(
                 instance_id,
                 propolis_id,
+                migration_id,
                 hardware,
-                instance_runtime,
                 vmm_runtime,
                 propolis_addr,
                 self.sled_identifiers(),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -39,7 +39,7 @@ use omicron_common::address::{
     get_sled_address, get_switch_zone_address, Ipv6Subnet, SLED_PREFIX,
 };
 use omicron_common::api::external::{ByteCount, ByteCountRangeError, Vni};
-use omicron_common::api::internal::nexus::{SledVmmState, VmmRuntimeState};
+use omicron_common::api::internal::nexus::SledVmmState;
 use omicron_common::api::internal::shared::{
     HostPortConfig, RackNetworkConfig, ResolvedVpcFirewallRule,
     ResolvedVpcRouteSet, ResolvedVpcRouteState, SledIdentifiers,
@@ -56,13 +56,13 @@ use omicron_common::disk::{
     OmicronPhysicalDisksConfig,
 };
 use omicron_ddm_admin_client::Client as DdmAdminClient;
-use omicron_uuid_kinds::{InstanceUuid, PropolisUuid};
+use omicron_uuid_kinds::PropolisUuid;
 use sled_agent_api::Zpool;
 use sled_agent_types::disk::DiskStateRequested;
 use sled_agent_types::early_networking::EarlyNetworkConfig;
 use sled_agent_types::instance::{
-    InstanceExternalIpBody, InstanceHardware, InstanceMetadata,
-    VmmPutStateResponse, VmmStateRequested, VmmUnregisterResponse,
+    InstanceEnsureBody, InstanceExternalIpBody, VmmPutStateResponse,
+    VmmStateRequested, VmmUnregisterResponse,
 };
 use sled_agent_types::sled::{BaseboardId, StartSledAgentRequest};
 use sled_agent_types::time_sync::TimeSync;
@@ -77,7 +77,7 @@ use sled_storage::dataset::{CRYPT_DATASET, ZONE_DATASET};
 use sled_storage::manager::StorageHandle;
 use slog::Logger;
 use std::collections::BTreeMap;
-use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -980,29 +980,14 @@ impl SledAgent {
     /// Idempotently ensures that a given instance is registered with this sled,
     /// i.e., that it can be addressed by future calls to
     /// [`Self::instance_ensure_state`].
-    #[allow(clippy::too_many_arguments)]
     pub async fn instance_ensure_registered(
         &self,
-        instance_id: InstanceUuid,
         propolis_id: PropolisUuid,
-        migration_id: Option<Uuid>,
-        hardware: InstanceHardware,
-        vmm_runtime: VmmRuntimeState,
-        propolis_addr: SocketAddr,
-        metadata: InstanceMetadata,
+        instance: InstanceEnsureBody,
     ) -> Result<SledVmmState, Error> {
         self.inner
             .instances
-            .ensure_registered(
-                instance_id,
-                propolis_id,
-                migration_id,
-                hardware,
-                vmm_runtime,
-                propolis_addr,
-                self.sled_identifiers(),
-                metadata,
-            )
+            .ensure_registered(propolis_id, instance, self.sled_identifiers())
             .await
             .map_err(|e| Error::Instance(e))
     }

--- a/sled-agent/types/src/instance.rs
+++ b/sled-agent/types/src/instance.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 use omicron_common::api::internal::{
-    nexus::{
-        InstanceProperties, InstanceRuntimeState, SledVmmState, VmmRuntimeState,
-    },
+    nexus::{InstanceProperties, SledVmmState, VmmRuntimeState},
     shared::{
         DhcpConfig, NetworkInterface, ResolvedVpcFirewallRule, SourceNatConfig,
     },
@@ -31,14 +29,16 @@ pub struct InstanceEnsureBody {
     /// state this sled agent should store for this incarnation of the instance.
     pub hardware: InstanceHardware,
 
-    /// The instance runtime state for the instance being registered.
-    pub instance_runtime: InstanceRuntimeState,
-
     /// The initial VMM runtime state for the VMM being registered.
     pub vmm_runtime: VmmRuntimeState,
 
     /// The ID of the instance for which this VMM is being created.
     pub instance_id: InstanceUuid,
+
+    /// The ID of the migration in to this VMM, if this VMM is being
+    /// ensured s part of a migration in. If this is `None`, the VMM is not
+    /// being created due to a migration.
+    pub migration_id: Option<Uuid>,
 
     /// The address at which this VMM should serve a Propolis server API.
     pub propolis_addr: SocketAddr,

--- a/sled-agent/types/src/instance.rs
+++ b/sled-agent/types/src/instance.rs
@@ -36,7 +36,7 @@ pub struct InstanceEnsureBody {
     pub instance_id: InstanceUuid,
 
     /// The ID of the migration in to this VMM, if this VMM is being
-    /// ensured s part of a migration in. If this is `None`, the VMM is not
+    /// ensured is part of a migration in. If this is `None`, the VMM is not
     /// being created due to a migration.
     pub migration_id: Option<Uuid>,
 


### PR DESCRIPTION
The `omicron_common::api::internal::InstanceRuntimeState` type was once
a key component of how Nexus and sled-agents communicated about
instances. Now, however, it's outlived its usefulness: #5749 changed
Nexus' `cpapi_instances_put` and sled-agent's `instance_get` APIs to
operate exclusively on `VmmRuntimeState`s rather than
`InstanceRuntimeState`, with the sled-agent almost completely unaware of
`InstanceRuntimeState`.

At present, the `InstanceRuntimeState` type remains in the internal API
just because it's used in the `InstanceEnsureBody` type, which is sent
to sled-agent's `instance_ensure_registered` API when a new VMM is
registered. However, looking at the code that
`instance_ensure_registered` calls into in sled-agent, we see that the
only thing from the `InstanceRuntimeState` that the sled-agent actually
*uses* is the migration ID of the current migration (if the instance is
migrating in). Soooo...we can just replace the whole
`InstanceRuntimeState` there with a `migration_id: Option<Uuid>`. Once
that's done, there are now no longer any internal APIs in Nexus or in
sled-agent that actually use `InstanceRuntimeState`, so the type can be
removed from the internal API entirely. All of the code in Nexus that
deals with instance runtime states already has changed to operate
exclusively on the `nexus_db_model` version of the struct, so removing
the API type is actually quite straightforward.

In addition, I've refactored the sled-agent `instance_ensure_registered`
code paths a little bit to pass around the `InstanceEnsureBody`, rather
than unpacking its fields at the HTTP entrypoint and then passing them
all through the chain of method calls that actually gets it to the
instance-runner task. Just passing the struct around means we can remove
a bunch of `#[allow(clippy::too_many_arguments)]` attributes. It also
makes changing the contents of the instance-ensure payload a bit easier,
as we'll no longer need to change the arguments list in the whole maze
of tiny little functions, all alike, that pass around all the pieces of
the `InstanceEnsureBody`.