### PR TITLE
Bump samael to v0.17 to pick up samael#53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8308,9 +8308,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "0ca7dd09b5f4a9029c35e323b086d0a68acdc673317b9c4d002c6f1d4a7278c6"
 dependencies = [
  "memchr",
  "serde",
@@ -9194,9 +9194,9 @@ dependencies = [
 
 [[package]]
 name = "samael"
-version = "0.0.15"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da862a2115c0767681e28309a367dbd0a2366026948aae0272787e582d71eaf"
+checksum = "6c3e9664150c82db0eba06db746594e1e8e092c5c91986ee0fe46c0619fb159f"
 dependencies = [
  "base64 0.22.1",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -528,7 +528,7 @@ rustfmt-wrapper = "0.2"
 rustls = "0.22.2"
 rustls-pemfile = "2.1.3"
 rustyline = "14.0.0"
-samael = { version = "0.0.15", features = ["xmlsec"] }
+samael = { version = "0.0.17", features = ["xmlsec"] }
 schemars = "0.8.21"
 secrecy = "0.8.0"
 semver = { version = "1.0.23", features = ["std", "serde"] }


### PR DESCRIPTION
This change bumps samael to v0.17 so that we can pick up njaremko/samael#53. 
The fix submitted by @jmpesp fixes #5604.
