### PR TITLE
[nexus] remove unnecessary `name_or_id` param from bgp config list endpoint

### DIFF
--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -1484,7 +1484,7 @@ pub trait NexusExternalApi {
     }]
     async fn networking_bgp_config_list(
         rqctx: RequestContext<Self::Context>,
-        query_params: Query<PaginatedByNameOrId<params::BgpConfigListSelector>>,
+        query_params: Query<PaginatedByNameOrId>,
     ) -> Result<HttpResponseOk<ResultsPage<BgpConfig>>, HttpError>;
 
     //TODO pagination? the normal by-name/by-id stuff does not work here

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2991,7 +2991,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
 
     async fn networking_bgp_config_list(
         rqctx: RequestContext<ApiContext>,
-        query_params: Query<PaginatedByNameOrId<params::BgpConfigListSelector>>,
+        query_params: Query<PaginatedByNameOrId>,
     ) -> Result<HttpResponseOk<ResultsPage<BgpConfig>>, HttpError> {
         let apictx = rqctx.context();
         let handler = async {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1653,13 +1653,6 @@ pub struct BgpConfigSelector {
     pub name_or_id: NameOrId,
 }
 
-/// List BGP configs with an optional name or id.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct BgpConfigListSelector {
-    /// A name or id to use when selecting BGP config.
-    pub name_or_id: Option<NameOrId>,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct BgpPeerConfig {
     pub peers: Vec<BgpPeer>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -6425,14 +6425,6 @@
           },
           {
             "in": "query",
-            "name": "name_or_id",
-            "description": "A name or id to use when selecting BGP config.",
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          },
-          {
-            "in": "query",
             "name": "page_token",
             "description": "Token returned by previous call to retrieve the subsequent page",
             "schema": {


### PR DESCRIPTION
Missed this in #6498. Closes #6467 (again).