### PR TITLE
Use a status struct for RegionReplacementDetector

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1112,8 +1112,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
             Ok(status) => {
                 println!(
-                    "    number of region replacement requests created ok: \
-                    {}",
+                    "    region replacement requests created ok: {}",
                     status.requests_created_ok.len()
                 );
                 for line in &status.requests_created_ok {
@@ -1121,15 +1120,14 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 }
 
                 println!(
-                    "    number of region replacement start sagas started \
-                    ok: {}",
+                    "    region replacement start sagas started ok: {}",
                     status.start_invoked_ok.len()
                 );
                 for line in &status.start_invoked_ok {
                     println!("    > {line}");
                 }
 
-                println!("    number of errors: {}", status.errors.len());
+                println!("    errors: {}", status.errors.len());
                 for line in &status.errors {
                     println!("    > {line}");
                 }
@@ -1311,8 +1309,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
 
             Ok(status) => {
                 println!(
-                    "    number of region replacement drive sagas started ok: \
-                    {}",
+                    "    region replacement drive sagas started ok: {}",
                     status.drive_invoked_ok.len()
                 );
                 for line in &status.drive_invoked_ok {
@@ -1320,15 +1317,14 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 }
 
                 println!(
-                    "    number of region replacement finish sagas started \
-                    ok: {}",
+                    "    region replacement finish sagas started ok: {}",
                     status.finish_invoked_ok.len()
                 );
                 for line in &status.finish_invoked_ok {
                     println!("    > {line}");
                 }
 
-                println!("    number of errors: {}", status.errors.len());
+                println!("    errors: {}", status.errors.len());
                 for line in &status.errors {
                     println!("    > {line}");
                 }

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -589,18 +589,18 @@ task: "region_replacement"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacement requests created ok: 0
-    number of region replacement start sagas started ok: 0
-    number of errors: 0
+    region replacement requests created ok: 0
+    region replacement start sagas started ok: 0
+    errors: 0
 
 task: "region_replacement_driver"
   configured period: every <REDACTED_DURATION>s
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacement drive sagas started ok: 0
-    number of region replacement finish sagas started ok: 0
-    number of errors: 0
+    region replacement drive sagas started ok: 0
+    region replacement finish sagas started ok: 0
+    errors: 0
 
 task: "region_snapshot_replacement_finish"
   configured period: every <REDACTED_DURATION>s
@@ -1019,18 +1019,18 @@ task: "region_replacement"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacement requests created ok: 0
-    number of region replacement start sagas started ok: 0
-    number of errors: 0
+    region replacement requests created ok: 0
+    region replacement start sagas started ok: 0
+    errors: 0
 
 task: "region_replacement_driver"
   configured period: every <REDACTED_DURATION>s
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacement drive sagas started ok: 0
-    number of region replacement finish sagas started ok: 0
-    number of errors: 0
+    region replacement drive sagas started ok: 0
+    region replacement finish sagas started ok: 0
+    errors: 0
 
 task: "region_snapshot_replacement_finish"
   configured period: every <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -589,8 +589,9 @@ task: "region_replacement"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacements started ok: 0
-    number of region replacement start errors: 0
+    number of region replacement requests created ok: 0
+    number of region replacement start sagas started ok: 0
+    number of errors: 0
 
 task: "region_replacement_driver"
   configured period: every <REDACTED_DURATION>s
@@ -1018,8 +1019,9 @@ task: "region_replacement"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    number of region replacements started ok: 0
-    number of region replacement start errors: 0
+    number of region replacement requests created ok: 0
+    number of region replacement start sagas started ok: 0
+    number of errors: 0
 
 task: "region_replacement_driver"
   configured period: every <REDACTED_DURATION>s

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -6,6 +6,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use uuid::Uuid;
 
+/// The status of a `region_replacement` background task activation
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct RegionReplacementStatus {
+    pub requests_created_ok: Vec<String>,
+    pub start_invoked_ok: Vec<String>,
+    pub errors: Vec<String>,
+}
+
 /// The status of a `region_replacement_drive` background task activation
 #[derive(Serialize, Deserialize, Default)]
 pub struct RegionReplacementDriverStatus {


### PR DESCRIPTION
Like the other replacement related background tasks, use a struct for the return value of the RegionReplacementDetector background task.