### PR TITLE
Add planner code for replicated clickhouse processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,6 +5412,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clickhouse-admin-types",
  "debug-ignore",
  "expectorate",
  "gateway-client",
@@ -5583,6 +5584,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "clickhouse-admin-types",
  "cookie 0.18.1",
  "derive-where",
  "derive_more",

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -2155,7 +2155,8 @@ impl DataStore {
             rot_pages_found,
             sled_agents,
             omicron_zones,
-            // currently unused
+            // Currently unused
+            // See: https://github.com/oxidecomputer/omicron/issues/6578
             clickhouse_keeper_cluster_membership: BTreeMap::new(),
         })
     }

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -2155,6 +2155,8 @@ impl DataStore {
             rot_pages_found,
             sled_agents,
             omicron_zones,
+            // currently unused
+            clickhouse_keeper_cluster_membership: BTreeMap::new(),
         })
     }
 }

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -147,6 +147,8 @@ impl CollectionBuilder {
             rot_pages_found: self.rot_pages_found,
             sled_agents: self.sleds,
             omicron_zones: self.omicron_zones,
+            // Currently unused
+            clickhouse_keeper_cluster_membership: BTreeMap::new(),
         }
     }
 

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -148,6 +148,7 @@ impl CollectionBuilder {
             sled_agents: self.sleds,
             omicron_zones: self.omicron_zones,
             // Currently unused
+            // See: https://github.com/oxidecomputer/omicron/issues/6578
             clickhouse_keeper_cluster_membership: BTreeMap::new(),
         }
     }

--- a/nexus/reconfigurator/planning/Cargo.toml
+++ b/nexus/reconfigurator/planning/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clickhouse-admin-types.workspace = true
 chrono.workspace = true
 debug-ignore.workspace = true
 gateway-client.workspace = true

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -193,7 +193,7 @@ impl ClickhouseAllocator {
             // This should always succeed eventually, barring a bug in
             // clickhouse.
             //
-            if added_keepers.len() == 0 {
+            if added_keepers.is_empty() {
                 return bump_gen_if_necessary(new_config);
             }
 
@@ -670,7 +670,7 @@ pub mod test {
         assert_eq!(new_config.keepers.len(), 4);
 
         // Let's make sure that the right keeper was expunged.
-        assert!(new_config.keepers.get(&zone_to_expunge).is_none());
+        assert!(!new_config.keepers.contains_key(&zone_to_expunge));
 
         // Adding a new zone should allow a new keeper to get provisioned as
         // long as the inventory reflects the last one is gone. Let's set the
@@ -745,7 +745,7 @@ pub mod test {
         allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
         let new_config = allocator.plan().unwrap();
         assert_eq!(new_config.keepers.len(), 4);
-        assert!(new_config.keepers.get(&zone_to_expunge).is_none());
+        assert!(!new_config.keepers.contains_key(&zone_to_expunge));
     }
 
     #[test]
@@ -778,7 +778,7 @@ pub mod test {
         };
 
         let zone_to_expunge =
-            allocator.parent_config.servers.keys().next().unwrap().clone();
+            *allocator.parent_config.servers.keys().next().unwrap();
 
         allocator.in_service_clickhouse_zones.servers.remove(&zone_to_expunge);
 
@@ -792,7 +792,7 @@ pub mod test {
 
         // Let's ensure that the zone to expunge isn't actually in the new
         // config
-        assert!(new_config.servers.get(&zone_to_expunge).is_none());
+        assert!(!new_config.servers.contains_key(&zone_to_expunge));
 
         // We can add a new keeper and server at the same time
         let new_keeper_zone = OmicronZoneUuid::new_v4();

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 // the `BlueprintBuilder` in the current planning iteration.
 //
 // Will be removed once the planner starts using this code
+// See: https://github.com/oxidecomputer/omicron/issues/6577
 #[allow(unused)]
 struct InServiceClickhouseZones {
     keepers: BTreeSet<OmicronZoneUuid>,
@@ -59,6 +60,7 @@ impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
 /// allocated.
 //
 // Will be removed once the planner starts using this code
+// See: https://github.com/oxidecomputer/omicron/issues/6577
 #[allow(unused)]
 pub struct ClickhouseAllocator {
     log: Logger,
@@ -69,7 +71,9 @@ pub struct ClickhouseAllocator {
 }
 
 /// Errors encountered when trying to plan keeper deployments
+//
 // Will be removed once the planner starts using this code
+// See: https://github.com/oxidecomputer/omicron/issues/6577
 #[allow(unused)]
 #[derive(Debug, Error)]
 pub enum KeeperAllocationError {
@@ -82,6 +86,7 @@ pub enum KeeperAllocationError {
 }
 
 // Will be removed once the planner starts using this code
+// https://github.com/oxidecomputer/omicron/issues/6577
 #[allow(unused)]
 impl ClickhouseAllocator {
     pub fn new(
@@ -151,12 +156,12 @@ impl ClickhouseAllocator {
             return bump_gen_if_necessary(new_config);
         }
 
-        // Save the log index for next ime
+        // Save the log index for next time
         new_config.highest_seen_keeper_leader_committed_log_index =
             inventory_membership.leader_committed_log_index;
 
         if current_keepers != inventory_membership.raft_config {
-            // We're still trying to reach our desired state We want to ensure
+            // We're still trying to reach our desired state. We want to ensure,
             // however, that if we are currently trying to add a node, that we
             // have not expunged the zone of the keeper that we are trying to
             // add. This can happen for a number of reasons, and without this
@@ -182,7 +187,7 @@ impl ClickhouseAllocator {
                 });
             }
 
-            // If we are not adding a keeper than we are done.
+            // If we are not adding a keeper then we are done.
             // The executor is trying to remove one from the cluster.
             //
             // This should always succeed eventually, barring a bug in

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -35,7 +35,7 @@ impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
     ) -> Self {
         let mut keepers = BTreeSet::new();
         let mut servers = BTreeSet::new();
-        for (_, bp_zone_config) in Blueprint::all_bp_zones(
+        for (_, bp_zone_config) in Blueprint::filtered_zones(
             zones_by_sled_id,
             BlueprintZoneFilter::ShouldBeRunning,
         ) {

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -7,8 +7,8 @@
 
 use clickhouse_admin_types::KeeperId;
 use nexus_types::deployment::{
-    all_omicron_zones, BlueprintZoneFilter, BlueprintZoneType,
-    BlueprintZonesConfig, ClickhouseClusterConfig,
+    Blueprint, BlueprintZoneFilter, BlueprintZoneType, BlueprintZonesConfig,
+    ClickhouseClusterConfig,
 };
 use nexus_types::inventory::ClickhouseKeeperClusterMembership;
 use omicron_uuid_kinds::{OmicronZoneUuid, SledUuid};
@@ -35,7 +35,7 @@ impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
     ) -> Self {
         let mut keepers = BTreeSet::new();
         let mut servers = BTreeSet::new();
-        for (_, bp_zone_config) in all_omicron_zones(
+        for (_, bp_zone_config) in Blueprint::all_bp_zones(
             zones_by_sled_id,
             BlueprintZoneFilter::ShouldBeRunning,
         ) {

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -1,0 +1,843 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A mechanism for allocating clickhouse keeper and server nodes for clustered
+//! clickhouse setups during blueprint planning
+
+use clickhouse_admin_types::KeeperId;
+use nexus_types::deployment::{
+    all_omicron_zones, BlueprintZoneFilter, BlueprintZoneType,
+    BlueprintZonesConfig, ClickhouseClusterConfig,
+};
+use nexus_types::inventory::ClickhouseKeeperClusterMembership;
+use omicron_uuid_kinds::{OmicronZoneUuid, SledUuid};
+use slog::{error, Logger};
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+// The set of in service clickhouse server and keeper zones as constructed by
+// the `BlueprintBuilder` in the current planning iteration.
+//
+// Will be removed once the planner starts using this code
+#[allow(unused)]
+struct InServiceClickhouseZones {
+    keepers: BTreeSet<OmicronZoneUuid>,
+    servers: BTreeSet<OmicronZoneUuid>,
+}
+
+impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
+    for InServiceClickhouseZones
+{
+    fn from(
+        zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+    ) -> Self {
+        let mut keepers = BTreeSet::new();
+        let mut servers = BTreeSet::new();
+        for (_, bp_zone_config) in all_omicron_zones(
+            zones_by_sled_id,
+            BlueprintZoneFilter::ShouldBeRunning,
+        ) {
+            match bp_zone_config.zone_type {
+                BlueprintZoneType::ClickhouseKeeper(_) => {
+                    keepers.insert(bp_zone_config.id);
+                }
+                BlueprintZoneType::ClickhouseServer(_) => {
+                    servers.insert(bp_zone_config.id);
+                }
+                _ => (),
+            }
+        }
+        InServiceClickhouseZones { keepers, servers }
+    }
+}
+
+/// A mechanism for allocating clickhouse server and keeper processes
+/// to zones
+///
+/// This is to be used as part of the `BlueprintBuilder` after zones have been
+/// allocated.
+//
+// Will be removed once the planner starts using this code
+#[allow(unused)]
+pub struct ClickhouseAllocator {
+    log: Logger,
+    in_service_clickhouse_zones: InServiceClickhouseZones,
+    parent_config: ClickhouseClusterConfig,
+    // The latest clickhouse cluster membership from inventory
+    inventory: Option<ClickhouseKeeperClusterMembership>,
+}
+
+/// Errors encountered when trying to plan keeper deployments
+// Will be removed once the planner starts using this code
+#[allow(unused)]
+#[derive(Debug, Error)]
+pub enum KeeperAllocationError {
+    #[error("a clickhouse cluster configuration has not been created")]
+    NoConfig,
+    #[error("failed to retrieve clickhouse keeper membership from inventory")]
+    NoInventory,
+    #[error("cannot add more than one keeper at a time: {added_keepers:?}")]
+    BadMembershipChange { added_keepers: BTreeSet<KeeperId> },
+}
+
+// Will be removed once the planner starts using this code
+#[allow(unused)]
+impl ClickhouseAllocator {
+    pub fn new(
+        log: Logger,
+        zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+        clickhouse_cluster_config: ClickhouseClusterConfig,
+        inventory: Option<ClickhouseKeeperClusterMembership>,
+    ) -> ClickhouseAllocator {
+        ClickhouseAllocator {
+            log,
+            in_service_clickhouse_zones: zones_by_sled_id.into(),
+            parent_config: clickhouse_cluster_config,
+            inventory,
+        }
+    }
+
+    /// Return a new clickhouse cluster configuration based
+    /// on the parent blueprint and inventory
+    pub fn plan(
+        &self,
+    ) -> Result<ClickhouseClusterConfig, KeeperAllocationError> {
+        let mut new_config = self.parent_config.clone();
+
+        // Bump the generation number if the config has changed
+        // and return the new configuration.
+        let bump_gen_if_necessary =
+            |mut new_config: ClickhouseClusterConfig| {
+                if new_config.needs_generation_bump(&self.parent_config) {
+                    new_config.generation = new_config.generation.next();
+                }
+                Ok(new_config)
+            };
+
+        // First, remove the clickhouse servers that are no longer in service
+        new_config.servers.retain(|zone_id, _| {
+            self.in_service_clickhouse_zones.servers.contains(zone_id)
+        });
+        // Next, add any new clickhouse servers
+        for zone_id in &self.in_service_clickhouse_zones.servers {
+            if !new_config.servers.contains_key(zone_id) {
+                // Allocate a new `ServerId` and map it to the server zone
+                new_config.max_used_server_id += 1.into();
+                new_config
+                    .servers
+                    .insert(*zone_id, new_config.max_used_server_id);
+            }
+        }
+
+        // Now we need to configure the keepers. We can only add or remove
+        // one keeper at a time.
+        //
+        // We need to see if we have any keeper inventory so we can compare it
+        // with our current configuration and see if any changes are required.
+        // If we fail to retrieve any inventory for keepers in the current
+        // collection than we must not modify our keeper config, as we don't
+        // know whether a configuration is ongoing or not.
+        let current_keepers: BTreeSet<_> =
+            self.parent_config.keepers.values().cloned().collect();
+        let Some(inventory_membership) = &self.inventory else {
+            return bump_gen_if_necessary(new_config);
+        };
+
+        // If we've already seen this inventory then skip keeper planning
+        if inventory_membership.leader_committed_log_index
+            <= self.parent_config.highest_seen_keeper_leader_committed_log_index
+        {
+            return bump_gen_if_necessary(new_config);
+        }
+
+        // Save the log index for next ime
+        new_config.highest_seen_keeper_leader_committed_log_index =
+            inventory_membership.leader_committed_log_index;
+
+        if current_keepers != inventory_membership.raft_config {
+            // We're still trying to reach our desired state We want to ensure
+            // however, that if we are currently trying to add a node, that we
+            // have not expunged the zone of the keeper that we are trying to
+            // add. This can happen for a number of reasons, and without this
+            // check we would not be able to make forward progress.
+            let mut added_keepers: BTreeSet<_> = current_keepers
+                .difference(&inventory_membership.raft_config)
+                .cloned()
+                .collect();
+
+            // We should only be adding or removing 1 keeper at a time
+            if added_keepers.len() > 1 {
+                error!(
+                    self.log,
+                    concat!(
+                        "Keeper membership error: attempting to add",
+                        "more than one keeper to cluster: {:?}.",
+                        "Did keeper membership change out from under us?"
+                    ),
+                    added_keepers
+                );
+                return Err(KeeperAllocationError::BadMembershipChange {
+                    added_keepers,
+                });
+            }
+
+            // If we are not adding a keeper than we are done.
+            // The executor is trying to remove one from the cluster.
+            //
+            // This should always succeed eventually, barring a bug in
+            // clickhouse.
+            //
+            if added_keepers.len() == 0 {
+                return bump_gen_if_necessary(new_config);
+            }
+
+            // Let's find the matching zone id for the keeper we are adding
+            //
+            // Unwrap is fine, because we know we have exactly one added keeper
+            // at this point, and it is present in our config.
+            let added_keeper_id = added_keepers.pop_first().unwrap();
+            let (added_zone_id, _) = self
+                .parent_config
+                .keepers
+                .iter()
+                .find(|(_, &keeper_id)| keeper_id == added_keeper_id)
+                .unwrap();
+
+            // Let's ensure that this zone has not been expunged yet. If it has that means
+            // that adding the keeper will never succeed.
+            if !self.in_service_clickhouse_zones.keepers.contains(added_zone_id)
+            {
+                // The zone has been expunged, so we must remove it from our configuration.
+                new_config.keepers.remove(added_zone_id);
+
+                // We are now done. We'll fall through to the return below.
+                //
+                // We only want to make one change to our keeper config at a
+                // time. It is possible that there is a race where the keeper
+                // was actually added to the rust configuration after the
+                // inventory was read but before the zone was expunged. In that
+                // case, we'll want the executor to go ahead and remove it from
+                // the keeper cluster membershp when it runs next.
+            }
+
+            // We are done
+            return bump_gen_if_necessary(new_config);
+        }
+
+        // Our desired membership from the parent blueprint matches the
+        // inventory.
+
+        // Do we need to remove any nodes for zones that have been expunged?
+        //
+        // We remove first, because the zones are already gone and therefore
+        // don't help our quorum.
+        for (zone_id, _) in &self.parent_config.keepers {
+            if !self.in_service_clickhouse_zones.keepers.contains(&zone_id) {
+                // Remove the keeper for the first expunged zone we see.
+                // Remember, we only do one keeper membership change at time.
+                new_config.keepers.remove(zone_id);
+                return bump_gen_if_necessary(new_config);
+            }
+        }
+
+        // Do we need to add any nodes to in service zones that don't have them
+        for zone_id in &self.in_service_clickhouse_zones.keepers {
+            if !new_config.keepers.contains_key(zone_id) {
+                // Allocate a new `KeeperId` and map it to the server zone
+                new_config.max_used_keeper_id += 1.into();
+                new_config
+                    .keepers
+                    .insert(*zone_id, new_config.max_used_keeper_id);
+                return bump_gen_if_necessary(new_config);
+            }
+        }
+
+        // We possibly added or removed clickhouse servers, but not keepers.
+        bump_gen_if_necessary(new_config)
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use clickhouse_admin_types::ServerId;
+    use omicron_common::api::external::Generation;
+    use omicron_test_utils::dev::test_setup_log;
+
+    fn initial_config(
+        n_keeper_zones: u64,
+        n_server_zones: u64,
+        n_keepers: u64,
+        n_servers: u64,
+    ) -> (InServiceClickhouseZones, ClickhouseClusterConfig) {
+        // Generate the maximum number of (`ZoneId`, `KeeperId`) pairs
+        // Note that we order by `KeeperId` so that we have determinism during
+        // tests
+        let all_keepers: BTreeMap<KeeperId, OmicronZoneUuid> =
+            (1..=u64::max(n_keeper_zones, n_keepers))
+                .map(|i| (KeeperId(i), OmicronZoneUuid::new_v4()))
+                .collect();
+
+        // Generate the maximum number of (`ZoneId`, `ServerId`) pairs
+        let all_servers: BTreeMap<ServerId, OmicronZoneUuid> =
+            (1..=u64::max(n_server_zones, n_servers))
+                .map(|i| (ServerId(i), OmicronZoneUuid::new_v4()))
+                .collect();
+
+        // Pare the zones down to the actual number we want
+        let keeper_zone_ids: BTreeSet<_> = all_keepers
+            .values()
+            .take(n_keeper_zones as usize)
+            .cloned()
+            .collect();
+        let server_zone_ids: BTreeSet<_> = all_servers
+            .values()
+            .take(n_server_zones as usize)
+            .cloned()
+            .collect();
+
+        let in_service_clickhouse_zones = InServiceClickhouseZones {
+            keepers: keeper_zone_ids.clone(),
+            servers: server_zone_ids.clone(),
+        };
+
+        // Pare the keeper and server configs down to the actual number we want
+        let keepers: BTreeMap<_, _> = all_keepers
+            .into_iter()
+            .take(n_keepers as usize)
+            .map(|(k, z)| (z, k))
+            .collect();
+        let servers = all_servers
+            .into_iter()
+            .take(n_servers as usize)
+            .map(|(s, z)| (z, s))
+            .collect();
+
+        let parent_clickhouse_cluster_config = ClickhouseClusterConfig {
+            generation: Generation::new(),
+            max_used_server_id: ServerId(n_servers),
+            max_used_keeper_id: KeeperId(n_keepers),
+            cluster_name: "test_cluster".to_string(),
+            cluster_secret: "test_secret".to_string(),
+            highest_seen_keeper_leader_committed_log_index: 1,
+            keepers,
+            servers,
+        };
+
+        (in_service_clickhouse_zones, parent_clickhouse_cluster_config)
+    }
+
+    #[test]
+    fn no_changes_needed() {
+        static TEST_NAME: &str = "clickhouse_allocator_no_changes_needed";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (3, 2, 3, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config: parent_config.clone(),
+            inventory,
+        };
+
+        // Our clickhouse cluster config should not have changed
+        let new_config = allocator.plan().unwrap();
+
+        // Note that we cannot directly check equality here and
+        // in a bunch of the test cases below, because we bump the
+        // `highest_seen_keeper_leader_committed_log_index` in the `new_config`
+        // during `plan` calls, even though no configuration has actually
+        // changed.
+        assert!(!new_config.needs_generation_bump(&parent_config));
+
+        // Running again without changing the inventory should be idempotent
+        allocator.parent_config = new_config;
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config, allocator.parent_config);
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn move_from_3_to_5_keepers() {
+        static TEST_NAME: &str =
+            "clickhouse_allocator_move_from_3_to_5_keepers";
+        let logctx = test_setup_log(TEST_NAME);
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (5, 2, 3, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        // We have 5 in service keeper zones, but only three keepers in our
+        // cluster configuration. All three show up in inventory, therefore the
+        // allocator should allocate one more keeper.
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config: parent_config.clone(),
+            inventory,
+        };
+
+        // Did our new config change as we expect?
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.generation, Generation::from_u32(2));
+        assert_eq!(new_config.generation, parent_config.generation.next());
+        assert_eq!(new_config.max_used_keeper_id, 4.into());
+        assert_eq!(
+            new_config.max_used_keeper_id,
+            parent_config.max_used_keeper_id + 1.into()
+        );
+        assert_eq!(new_config.keepers.len(), 4);
+        assert_eq!(new_config.keepers.len(), parent_config.keepers.len() + 1);
+        assert_eq!(new_config.servers.len(), 2);
+        assert_eq!(new_config.servers.len(), parent_config.servers.len());
+
+        // Let's allocate again, but with the config output from our last round.
+        // Our inventory still hasn't changed, and so the output from this round
+        // should be identical to the last.
+        //
+        // Note that We mutate the allocator here and in subsequent tests, as
+        // this is the shortest way to test what we want. However, planning
+        // itself does not modify  the allocator and a new one is created by the
+        // `BlueprintBuilder` on each planning round.
+        allocator.parent_config = new_config;
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config, allocator.parent_config);
+
+        // Now let's update our inventory to reflect the new keeper. This should
+        // trigger the planner to add a 5th keeper.
+        allocator.inventory.as_mut().unwrap().raft_config.insert(4.into());
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.generation, Generation::from_u32(3));
+        assert_eq!(
+            new_config.generation,
+            allocator.parent_config.generation.next()
+        );
+        assert_eq!(new_config.max_used_keeper_id, 5.into());
+        assert_eq!(
+            new_config.max_used_keeper_id,
+            allocator.parent_config.max_used_keeper_id + 1.into()
+        );
+        assert_eq!(new_config.keepers.len(), 5);
+        assert_eq!(
+            new_config.keepers.len(),
+            allocator.parent_config.keepers.len() + 1
+        );
+        assert_eq!(new_config.servers.len(), 2);
+        assert_eq!(
+            new_config.servers.len(),
+            allocator.parent_config.servers.len()
+        );
+
+        // Let's run that plan aginst the new config without changing the
+        // inventory raft config. We should end up with the same config.
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+
+        // Now let's modify the inventory to reflect that the 5th keeper node
+        // was added to the cluster.
+        //
+        // We should see that the configuration doesn't change because all of
+        // our keeper zones have a keeper that is part of the cluster.
+        allocator.inventory.as_mut().unwrap().raft_config.insert(5.into());
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+    }
+
+    #[test]
+    fn expunge_2_of_5_keeper_zones() {
+        static TEST_NAME: &str = "clickhouse_allocator_expunge_2_of_5_keepers";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (5, 2, 5, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config: parent_config.clone(),
+            inventory,
+        };
+
+        // Our clickhouse cluster config should not have changed
+        // We have 5 keepers and 5 zones and all of them are in the inventory
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&parent_config));
+
+        // Now expunge 2 of the 5 keeper zones by removing them from the
+        // in-service zones
+        allocator.in_service_clickhouse_zones.keepers.pop_first();
+        allocator.in_service_clickhouse_zones.keepers.pop_first();
+        // Bump the inventory index so that we get to this check
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+
+        // Running the planner should remove one of the keepers from the new config
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.generation, Generation::from_u32(2));
+        assert_eq!(
+            new_config.generation,
+            allocator.parent_config.generation.next()
+        );
+        assert_eq!(new_config.max_used_keeper_id, 5.into());
+        assert_eq!(
+            new_config.max_used_keeper_id,
+            allocator.parent_config.max_used_keeper_id
+        );
+        assert_eq!(new_config.keepers.len(), 4);
+        assert_eq!(
+            new_config.keepers.len(),
+            allocator.parent_config.keepers.len() - 1
+        );
+        assert_eq!(new_config.servers.len(), 2);
+        assert_eq!(
+            new_config.servers.len(),
+            allocator.parent_config.servers.len()
+        );
+
+        // Planning with the new config should result in the same output,
+        // since the inventory hasn't reflected the change
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+
+        // Reflecting the new config in inventory should remove another keeper
+        allocator.inventory.as_mut().unwrap().raft_config =
+            new_config.keepers.values().cloned().collect();
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+
+        assert_eq!(new_config.generation, Generation::from_u32(3));
+        assert_eq!(
+            new_config.generation,
+            allocator.parent_config.generation.next()
+        );
+        assert_eq!(new_config.max_used_keeper_id, 5.into());
+        assert_eq!(
+            new_config.max_used_keeper_id,
+            allocator.parent_config.max_used_keeper_id
+        );
+        assert_eq!(new_config.keepers.len(), 3);
+        assert_eq!(
+            new_config.keepers.len(),
+            allocator.parent_config.keepers.len() - 1
+        );
+        assert_eq!(new_config.servers.len(), 2);
+        assert_eq!(
+            new_config.servers.len(),
+            allocator.parent_config.servers.len()
+        );
+
+        // Running with the same inventory and new config will result in no
+        // change, because the inventory doesn't reflect the removed keeper
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+
+        // Reflecting the keeper removal in inventory should also result in no
+        // change since the number of keepers matches the number of zones
+        allocator.inventory.as_mut().unwrap().raft_config =
+            new_config.keepers.values().cloned().collect();
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        allocator.parent_config = new_config;
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+    }
+
+    #[test]
+    fn expunge_a_different_keeper_while_adding_keeper() {
+        static TEST_NAME: &str =
+            "clickhouse_allocator_expunge_a_different_keeper_while_adding_keeper";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (5, 2, 4, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config,
+            inventory,
+        };
+
+        // First run the planner to add a 5th keeper to our config
+        assert_eq!(allocator.parent_config.keepers.len(), 4);
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.keepers.len(), 5);
+
+        // Pick one of the keepers currently in our inventory, find the zone
+        // for it, and expunge it
+        let keeper_to_expunge = allocator
+            .inventory
+            .as_ref()
+            .unwrap()
+            .raft_config
+            .first()
+            .cloned()
+            .unwrap();
+        let zone_to_expunge = allocator
+            .parent_config
+            .keepers
+            .iter()
+            .find(|(_, &keeper_id)| keeper_id == keeper_to_expunge)
+            .map(|(zone_id, _)| *zone_id)
+            .unwrap();
+        allocator.in_service_clickhouse_zones.keepers.remove(&zone_to_expunge);
+
+        // Bump the inventory commit index so we guarantee we perform the keeper
+        // checks
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+
+        // Use our last new configuration as the parent
+        allocator.parent_config = new_config;
+
+        // Run the plan. Our configuration should stay the same because we can
+        // only add or remove one keeper node from the cluster at a time and we
+        // are already in the process of adding a node.
+        let new_config = allocator.plan().unwrap();
+        assert!(!new_config.needs_generation_bump(&allocator.parent_config));
+
+        // Now we change the inventory to reflect the addition of the node to
+        // the cluster. This should result in the expunged zone removing the
+        // keeper from configuration.
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        allocator.inventory.as_mut().unwrap().raft_config.insert(5.into());
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.keepers.len(), 4);
+
+        // Let's make sure that the right keeper was expunged.
+        assert!(new_config.keepers.get(&zone_to_expunge).is_none());
+
+        // Adding a new zone should allow a new keeper to get provisioned as
+        // long as the inventory reflects the last one is gone. Let's set the
+        // replicator to reflect that there are 4 keepers and the inventory
+        // knows that, and that there is a new zone without a keeper;
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        allocator
+            .inventory
+            .as_mut()
+            .unwrap()
+            .raft_config
+            .remove(&keeper_to_expunge);
+        let new_zone_id = OmicronZoneUuid::new_v4();
+        allocator.in_service_clickhouse_zones.keepers.insert(new_zone_id);
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.keepers.len(), 5);
+        assert_eq!(*new_config.keepers.get(&new_zone_id).unwrap(), KeeperId(6));
+        assert_eq!(new_config.max_used_keeper_id, 6.into());
+    }
+
+    #[test]
+    fn expunge_keeper_being_added() {
+        static TEST_NAME: &str =
+            "clickhouse_allocator_expunge_keeper_being_added";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (5, 2, 4, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config,
+            inventory,
+        };
+
+        // First run the planner to add a 5th keeper to our config
+        assert_eq!(allocator.parent_config.keepers.len(), 4);
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.keepers.len(), 5);
+
+        // Find the zone for our new keeper and expunge it before it is
+        // reflected in inventory. An expunged zone in most cases will not be
+        // succesfully added. There can be a race here, but that is also ok,
+        // because the next run of the executor will then remove the added
+        // keeper.
+        let zone_to_expunge = new_config
+            .keepers
+            .iter()
+            .find(|(_, &keeper_id)| keeper_id == 5.into())
+            .map(|(zone_id, _)| *zone_id)
+            .unwrap();
+        allocator.parent_config = new_config;
+        allocator.in_service_clickhouse_zones.keepers.remove(&zone_to_expunge);
+
+        // Bump the inventory commit index so we guarantee we perform the keeper
+        // checks
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.keepers.len(), 4);
+        assert!(new_config.keepers.get(&zone_to_expunge).is_none());
+    }
+
+    #[test]
+    fn add_3_servers_and_expunge_one_simultaneously() {
+        static TEST_NAME: &str =
+            "clickhouse_allocator_add_3_servers_and_expunge_one_simultaneously";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (3, 5, 3, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: parent_config.keepers.values().cloned().collect(),
+        });
+
+        let mut allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config,
+            inventory,
+        };
+
+        let zone_to_expunge =
+            allocator.parent_config.servers.keys().next().unwrap().clone();
+
+        allocator.in_service_clickhouse_zones.servers.remove(&zone_to_expunge);
+
+        // After running the planner we should see 4 servers:
+        // Start with 2, expunge 1, add 3 to reach the number of zones we have.
+        assert_eq!(allocator.parent_config.servers.len(), 2);
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.servers.len(), 4);
+        assert_eq!(new_config.max_used_server_id, 5.into());
+        assert_eq!(new_config.generation, Generation::from_u32(2));
+
+        // Let's ensure that the zone to expunge isn't actually in the new
+        // config
+        assert!(new_config.servers.get(&zone_to_expunge).is_none());
+
+        // We can add a new keeper and server at the same time
+        let new_keeper_zone = OmicronZoneUuid::new_v4();
+        let new_server_id = OmicronZoneUuid::new_v4();
+        allocator.in_service_clickhouse_zones.keepers.insert(new_keeper_zone);
+        allocator.in_service_clickhouse_zones.servers.insert(new_server_id);
+        allocator.parent_config = new_config;
+        allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
+        let new_config = allocator.plan().unwrap();
+        assert_eq!(new_config.generation, Generation::from_u32(3));
+        assert_eq!(new_config.max_used_server_id, 6.into());
+        assert_eq!(new_config.max_used_keeper_id, 4.into());
+        assert_eq!(new_config.keepers.len(), 4);
+        assert_eq!(new_config.servers.len(), 5);
+    }
+
+    #[test]
+    fn inventory_returns_unexpected_membership() {
+        static TEST_NAME: &str =
+            "clickhouse_allocator_inventory_returns_unexpected_membership";
+        let logctx = test_setup_log(TEST_NAME);
+
+        let (n_keeper_zones, n_server_zones, n_keepers, n_servers) =
+            (3, 2, 3, 2);
+
+        let (in_service_clickhouse_zones, parent_config) = initial_config(
+            n_keeper_zones,
+            n_server_zones,
+            n_keepers,
+            n_servers,
+        );
+
+        // Let's show an incorrect inventory, where either there
+        // was a keeper bug or someone manually removed an extra node.
+        let inventory = Some(ClickhouseKeeperClusterMembership {
+            queried_keeper: KeeperId(1),
+            leader_committed_log_index: 2,
+            raft_config: [KeeperId(1)].into_iter().collect(),
+        });
+
+        let allocator = ClickhouseAllocator {
+            log: logctx.log.clone(),
+            in_service_clickhouse_zones,
+            parent_config,
+            inventory,
+        };
+
+        // We expect to get an error back. This can be used by higher level
+        // software to trigger alerts, etc... In practice the `BlueprintBuilder`
+        // should not change it's config when it receives an error.
+        assert!(allocator.plan().is_err());
+    }
+}

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -200,7 +200,7 @@ impl ClickhouseAllocator {
             // Let's find the matching zone id for the keeper we are adding
             //
             // Unwrap is fine, because we know we have exactly one added keeper
-            // at this point, and it is present in our config.
+            // at this point, and it is present in our `parent_config`.
             let added_keeper_id = added_keepers.pop_first().unwrap();
             let (added_zone_id, _) = self
                 .parent_config

--- a/nexus/reconfigurator/planning/src/blueprint_builder/mod.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/mod.rs
@@ -5,6 +5,7 @@
 //! Low-level facility for generating Blueprints
 
 mod builder;
+mod clickhouse;
 mod external_networking;
 mod internal_dns;
 mod zones;

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -13,6 +13,7 @@ async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 clap.workspace = true
+clickhouse-admin-types.workspace = true
 cookie.workspace = true
 derive-where.workspace = true
 derive_more.workspace = true

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -199,7 +199,24 @@ impl Blueprint {
         &self,
         filter: BlueprintZoneFilter,
     ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-        all_omicron_zones(&self.blueprint_zones, filter)
+        Blueprint::all_bp_zones(&self.blueprint_zones, filter)
+    }
+
+    /// Iterate over the [`BlueprintZoneConfig`] instances that match the
+    /// provided filter, along with the associated sled id.
+    //
+    // Ths was moved to a free function so that it could be used in the
+    // `BlueprintBuilder` during planning as well as in the `Blueprint`.
+    pub fn all_bp_zones(
+        zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+        filter: BlueprintZoneFilter,
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
+        zones_by_sled_id.iter().flat_map(move |(sled_id, z)| {
+            z.zones
+                .iter()
+                .filter(move |z| z.disposition.matches(filter))
+                .map(|z| (*sled_id, z))
+        })
     }
 
     /// Iterate over the [`BlueprintZoneConfig`] instances in the blueprint
@@ -342,23 +359,6 @@ impl BpSledSubtableData for BlueprintOrCollectionZonesConfig {
             )
         })
     }
-}
-
-/// Iterate over the [`BlueprintZoneConfig`] instances that match the
-/// provided filter, along with the associated sled id.
-//
-// Ths was moved to a free function so that it could be used in the
-// `BlueprintBuilder` during planning as well as in the `Blueprint`.
-pub fn all_omicron_zones(
-    zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
-    filter: BlueprintZoneFilter,
-) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-    zones_by_sled_id.iter().flat_map(move |(sled_id, z)| {
-        z.zones
-            .iter()
-            .filter(move |z| z.disposition.matches(filter))
-            .map(|z| (*sled_id, z))
-    })
 }
 
 /// Wrapper to allow a [`Blueprint`] to be displayed with information.

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -205,7 +205,7 @@ impl Blueprint {
     /// Iterate over the [`BlueprintZoneConfig`] instances that match the
     /// provided filter, along with the associated sled id.
     //
-    // Ths was moved to a free function so that it could be used in the
+    // This is a scoped function so that it can be used in the
     // `BlueprintBuilder` during planning as well as in the `Blueprint`.
     pub fn all_bp_zones(
         zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -199,7 +199,7 @@ impl Blueprint {
         &self,
         filter: BlueprintZoneFilter,
     ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-        Blueprint::all_bp_zones(&self.blueprint_zones, filter)
+        Blueprint::filtered_zones(&self.blueprint_zones, filter)
     }
 
     /// Iterate over the [`BlueprintZoneConfig`] instances that match the
@@ -207,7 +207,7 @@ impl Blueprint {
     //
     // This is a scoped function so that it can be used in the
     // `BlueprintBuilder` during planning as well as in the `Blueprint`.
-    pub fn all_bp_zones(
+    pub fn filtered_zones(
         zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
         filter: BlueprintZoneFilter,
     ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {

--- a/nexus/types/src/deployment/clickhouse.rs
+++ b/nexus/types/src/deployment/clickhouse.rs
@@ -23,7 +23,7 @@ pub struct ClickhouseClusterConfig {
     /// Clickhouse Server IDs must be unique and are handed out monotonically.
     /// Keep track of the last used one.
     pub max_used_server_id: ServerId,
-    /// CLickhouse Keeper ids must be unique and are handed out monotonically.
+    /// CLickhouse Keeper IDss must be unique and are handed out monotonically.
     /// Keep track of the last used one.
     pub max_used_keeper_id: KeeperId,
     /// An arbitrary name for the Clickhouse cluster shared by all nodes
@@ -64,21 +64,23 @@ pub struct ClickhouseClusterConfig {
     ///   1. We start with 3 keeper nodes in 3 deployed keeper zones and need to
     ///      add two to reach our desired policy of 5 keepers
     ///   2. The planner adds 2 new keeper zones to the blueprint
-    ///   3. The planner will also add **one** new keeper process that matches
-    ///      one of the deployed zones to the desired keeper cluster.
-    ///   4. The executor will start the new keeper process, attempt to add it
-    ///      to the keeper cluster by pushing configuration updates to the other
-    ///      keepers, and then updating the clickhouse server configurations to
-    ///      know about the new keeper.
-    ///   5. If the keeper is successfully added, as reflected in inventory, then
-    ///      steps 3 and 4 above will be retried for the next keeper process.
+    ///   3. The planner will also add **one** new keeper to the `keepers` field
+    ///      below that matches one of the deployed zones.
+    ///   4. The executor will start the new keeper process that was added
+    ///      to the `keepers` field, attempt to add it to the keeper cluster
+    ///      by pushing configuration updates to the other keepers, and then
+    ///      updating the clickhouse server configurations to know about the
+    ///      new keeper.
+    ///   5. If the keeper is successfully added, as reflected in inventory,
+    ///      then steps 3 and 4 above will be repeated for the next keeper
+    ///      process.
     ///   6. If the keeper is not successfully added by the executor it will
     ///      continue to retry indefinitely.
     ///   7. If the zone is expunged while the planner has it as part of its
-    ///      desired state, and the executor is trying to add it, the keeper
-    ///      will be removed from the desired state in the next blueprint. If it
-    ///      has been added by an executor in the meantime it will be removed on
-    ///      the next iteration of an executor.
+    ///      desired state in `keepers`, and the executor is trying to add it,
+    ///      the keeper will be removed from `keepers` in the next blueprint.
+    ///      If it has been added to the actual cluster by an executor in the
+    ///      meantime it will be removed on the next iteration of an executor.
     pub keepers: BTreeMap<OmicronZoneUuid, KeeperId>,
 
     /// The desired state of clickhouse server processes on the rack

--- a/nexus/types/src/deployment/clickhouse.rs
+++ b/nexus/types/src/deployment/clickhouse.rs
@@ -23,7 +23,7 @@ pub struct ClickhouseClusterConfig {
     /// Clickhouse Server IDs must be unique and are handed out monotonically.
     /// Keep track of the last used one.
     pub max_used_server_id: ServerId,
-    /// CLickhouse Keeper IDss must be unique and are handed out monotonically.
+    /// Clickhouse Keeper IDs must be unique and are handed out monotonically.
     /// Keep track of the last used one.
     pub max_used_keeper_id: KeeperId,
     /// An arbitrary name for the Clickhouse cluster shared by all nodes

--- a/nexus/types/src/deployment/clickhouse.rs
+++ b/nexus/types/src/deployment/clickhouse.rs
@@ -20,7 +20,7 @@ pub struct ClickhouseClusterConfig {
     /// This is used by `clickhouse-admin` in the clickhouse server and keeper
     /// zones to discard old configurations.
     pub generation: Generation,
-    /// Clickhouse Server ids must be unique and are handed out monotonically.
+    /// Clickhouse Server IDs must be unique and are handed out monotonically.
     /// Keep track of the last used one.
     pub max_used_server_id: ServerId,
     /// CLickhouse Keeper ids must be unique and are handed out monotonically.

--- a/nexus/types/src/deployment/clickhouse.rs
+++ b/nexus/types/src/deployment/clickhouse.rs
@@ -74,7 +74,7 @@ pub struct ClickhouseClusterConfig {
     ///      steps 3 and 4 above will be retried for the next keeper process.
     ///   6. If the keeper is not successfully added by the executor it will
     ///      continue to retry indefinitely.
-    ///   7. If the zone is expunged while the planner is has it as part of its
+    ///   7. If the zone is expunged while the planner has it as part of its
     ///      desired state, and the executor is trying to add it, the keeper
     ///      will be removed from the desired state in the next blueprint. If it
     ///      has been added by an executor in the meantime it will be removed on

--- a/nexus/types/src/deployment/clickhouse.rs
+++ b/nexus/types/src/deployment/clickhouse.rs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Types used in blueprints related to clickhouse configuration
+
+use clickhouse_admin_types::{KeeperId, ServerId};
+use omicron_common::api::external::Generation;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+/// Global configuration for all clickhouse servers (replicas) and keepers
+#[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+pub struct ClickhouseClusterConfig {
+    /// The last update to the clickhouse cluster configuration
+    ///
+    /// This is used by `clickhouse-admin` in the clickhouse server and keeper
+    /// zones to discard old configurations.
+    pub generation: Generation,
+    /// Clickhouse Server ids must be unique and are handed out monotonically.
+    /// Keep track of the last used one.
+    pub max_used_server_id: ServerId,
+    /// CLickhouse Keeper ids must be unique and are handed out monotonically.
+    /// Keep track of the last used one.
+    pub max_used_keeper_id: KeeperId,
+    /// An arbitrary name for the Clickhouse cluster shared by all nodes
+    pub cluster_name: String,
+    /// An arbitrary string shared by all nodes used at runtime to determine
+    /// whether nodes are part of the same cluster.
+    pub cluster_secret: String,
+
+    /// This is used as a marker to tell if the raft configuration
+    /// in a new inventory collection is newer than the last collection.
+    //
+    /// This serves as a surrogate for the log index of the last committed
+    /// configuration, which clickhouse keeper doesn't expose.
+    ///
+    /// This is necesssary because during inventory collection we poll
+    /// multiple keeper nodes, and each returns their local knowledge of the
+    /// configuration. But we may reach different nodes in different attempts,
+    /// and some nodes in a following attempt may reflect stale configuration.
+    /// Due to timing, we can always query old information. That is just normal
+    /// polling. However, we never want to use old configuration if we have
+    /// already seen and acted on newer configuration.
+    pub highest_seen_keeper_leader_committed_log_index: u64,
+
+    /// The desired state of the clickhouse keeper cluster
+    ///
+    /// We decouple deployment of zones that should contain clickhouse keeper
+    /// processes from actually starting or stopping those processes, adding or
+    /// removing them to/from the keeper cluster, and reconfiguring other keeper
+    /// and clickhouse server nodes to reflect the new configuration.
+    ///
+    /// As part of this decoupling, we keep track of the intended zone
+    /// deployment in the blueprint, but that is not enough to track the desired
+    /// state of the keeper cluster. We are only allowed to add or remove one
+    /// keeper node at a time, and therefore we must track the desired state of
+    /// the keeper cluster which may change multiple times until the keepers in
+    /// the cluster match the deployed zones. An example may help:
+    ///
+    ///   1. We start with 3 keeper nodes in 3 deployed keeper zones and need to
+    ///      add two to reach our desired policy of 5 keepers
+    ///   2. The planner adds 2 new keeper zones to the blueprint
+    ///   3. The planner will also add **one** new keeper process that matches
+    ///      one of the deployed zones to the desired keeper cluster.
+    ///   4. The executor will start the new keeper process, attempt to add it
+    ///      to the keeper cluster by pushing configuration updates to the other
+    ///      keepers, and then updating the clickhouse server configurations to
+    ///      know about the new keeper.
+    ///   5. If the keeper is successfully added, as reflected in inventory, then
+    ///      steps 3 and 4 above will be retried for the next keeper process.
+    ///   6. If the keeper is not successfully added by the executor it will
+    ///      continue to retry indefinitely.
+    ///   7. If the zone is expunged while the planner is has it as part of its
+    ///      desired state, and the executor is trying to add it, the keeper
+    ///      will be removed from the desired state in the next blueprint. If it
+    ///      has been added by an executor in the meantime it will be removed on
+    ///      the next iteration of an executor.
+    pub keepers: BTreeMap<OmicronZoneUuid, KeeperId>,
+
+    /// The desired state of clickhouse server processes on the rack
+    ///
+    /// Clickhouse servers do not have the same limitations as keepers
+    /// and can be deployed all at once.
+    pub servers: BTreeMap<OmicronZoneUuid, ServerId>,
+}
+
+impl ClickhouseClusterConfig {
+    pub fn new(cluster_name: String) -> ClickhouseClusterConfig {
+        ClickhouseClusterConfig {
+            generation: Generation::new(),
+            max_used_server_id: 0.into(),
+            max_used_keeper_id: 0.into(),
+            cluster_name,
+            cluster_secret: Uuid::new_v4().to_string(),
+            highest_seen_keeper_leader_committed_log_index: 0,
+            keepers: BTreeMap::new(),
+            servers: BTreeMap::new(),
+        }
+    }
+
+    // Has the configuration changed such that the executor needs to update
+    // servers or keepers in the clickhouse zones?
+    //
+    // We specifically ignore `highest_seen_keeper_leader_committed_log_index`
+    // because that should be regularly changing without the actual keeper
+    // membership actually changing. We don't want to push on each committed
+    // raft log commit.
+    pub fn needs_generation_bump(
+        &self,
+        parent: &ClickhouseClusterConfig,
+    ) -> bool {
+        self.keepers != parent.keepers || self.servers != parent.servers
+    }
+}

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -13,6 +13,7 @@ use crate::external_api::params::PhysicalDiskKind;
 use crate::external_api::params::UninitializedSledId;
 use chrono::DateTime;
 use chrono::Utc;
+use clickhouse_admin_types::KeeperId;
 pub use gateway_client::types::PowerState;
 pub use gateway_client::types::RotImageError;
 pub use gateway_client::types::RotSlot;
@@ -30,6 +31,7 @@ pub use omicron_common::api::internal::shared::SourceNatConfig;
 pub use omicron_common::zpool_name::ZpoolName;
 use omicron_uuid_kinds::CollectionUuid;
 use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use serde::{Deserialize, Serialize};
@@ -117,6 +119,12 @@ pub struct Collection {
 
     /// Omicron zones found, by *sled* id
     pub omicron_zones: BTreeMap<SledUuid, OmicronZonesFound>,
+
+    /// The raft configuration (cluster membership) of the clickhouse keeper
+    /// cluster as returned from each available keeper via `clickhouse-admin` in
+    /// the `ClickhouseKeeper` zone
+    pub clickhouse_keeper_cluster_membership:
+        BTreeMap<OmicronZoneUuid, ClickhouseKeeperClusterMembership>,
 }
 
 impl Collection {
@@ -153,6 +161,27 @@ impl Collection {
             .iter()
             .filter(|(_, inventory)| inventory.sled_role == SledRole::Scrimlet)
             .map(|(sled_id, _)| *sled_id)
+    }
+
+    /// Return the latest clickhouse keeper configuration in this last collection, if there is one.
+    pub fn latest_clickhouse_keeper_membership(
+        &self,
+    ) -> Option<(OmicronZoneUuid, ClickhouseKeeperClusterMembership)> {
+        let mut latest = None;
+        for (zone_id, membership) in &self.clickhouse_keeper_cluster_membership
+        {
+            match &latest {
+                None => latest = Some((*zone_id, membership.clone())),
+                Some((_, latest_membership)) => {
+                    if membership.leader_committed_log_index
+                        > latest_membership.leader_committed_log_index
+                    {
+                        latest = Some((*zone_id, membership.clone()));
+                    }
+                }
+            }
+        }
+        latest
     }
 }
 
@@ -467,4 +496,18 @@ pub struct OmicronZonesFound {
     pub source: String,
     pub sled_id: SledUuid,
     pub zones: OmicronZonesConfig,
+}
+
+/// The configuration of the clickhouse keeper raft cluster returned from a
+/// single keeper node
+///
+/// Each keeper is asked for its known raft configuration via `clickhouse-admin`
+/// dropshot servers running in `ClickhouseKeeper` zones. state. We include the
+/// leader committed log index known to the current keeper node (whether or not
+/// it is the leader) to determine which configuration is newest.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ClickhouseKeeperClusterMembership {
+    pub queried_keeper: KeeperId,
+    pub leader_committed_log_index: u64,
+    pub raft_config: BTreeSet<KeeperId>,
 }

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -163,25 +163,15 @@ impl Collection {
             .map(|(sled_id, _)| *sled_id)
     }
 
-    /// Return the latest clickhouse keeper configuration in this last collection, if there is one.
+    /// Return the latest clickhouse keeper configuration in this collection, if
+    /// there is one.
     pub fn latest_clickhouse_keeper_membership(
         &self,
     ) -> Option<(OmicronZoneUuid, ClickhouseKeeperClusterMembership)> {
-        let mut latest = None;
-        for (zone_id, membership) in &self.clickhouse_keeper_cluster_membership
-        {
-            match &latest {
-                None => latest = Some((*zone_id, membership.clone())),
-                Some((_, latest_membership)) => {
-                    if membership.leader_committed_log_index
-                        > latest_membership.leader_committed_log_index
-                    {
-                        latest = Some((*zone_id, membership.clone()));
-                    }
-                }
-            }
-        }
-        latest
+        self.clickhouse_keeper_cluster_membership
+            .iter()
+            .max_by_key(|(_, membership)| membership.leader_committed_log_index)
+            .map(|(zone_id, membership)| (*zone_id, membership.clone()))
     }
 }
 


### PR DESCRIPTION
Primarily, this commit includes a planning mechanism to allocate clickhouse keepers and servers to their in-service zones. This `ClickhouseAllocator` is intended to be created by the `BlueprintBuilder` after zones are added and expunged. It very carefully manages adding or removing only one keeper node at a time and there are a bunch of tests regarding this  behavior.

In order to know when to continue allocating new keepers or servers or expunging them, the allocator takes in the set of zones from the current builder run, the parent configuration from the last blueprint, and any inventory updates related to clickhouse keepers. We only pass in the `latest_clickhouse_keeper_membership` from the inventory. This is all that the allocator needs and also simplifies testing by precluding having to build a complete `Collection` just to test. While we pass in all `blueprint_zones` from the `BlueprintBuilder` to the `ClickhouseAllocator::new` constructor, to make production code simpler and safer to write, we mnaually manipulate the allocator to keep the tests simple, and not have to worry about generating `BlueprintZonesConfig` that we don't actually use.

None of this code is wired up to run, but all the planning logic should be capable of being hooked in easily. We'll also need to add DB models and queries, and write the executor, and inventory collection in follow ups.